### PR TITLE
print newline for empty maps

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -423,6 +423,7 @@ int BPFtrace::print_maps()
       err = print_map_stats(map);
     else
       err = print_map(map, 0, 0);
+    std::cout << std::endl;
 
     if (err)
       return err;
@@ -638,9 +639,10 @@ int BPFtrace::print_map(IMap &map, uint32_t top, uint32_t div)
 
     if (top)
     {
-      if (i++ < (values_by_key.size() - top))
+      if (i < (values_by_key.size() - top))
         continue;
     }
+    i++;
 
     std::cout << map.name_ << map.key_.argument_value_list(*this, key) << ": ";
 
@@ -665,8 +667,8 @@ int BPFtrace::print_map(IMap &map, uint32_t top, uint32_t div)
     else
       std::cout << *(int64_t*)value.data() / div << std::endl;
   }
-
-  std::cout << std::endl;
+  if (i == 0)
+    std::cout << std::endl;
 
   return 0;
 }


### PR DESCRIPTION
I think this is a minor change that lets me write some tools that do rolling stats, like this:

```
# ./src/bpftrace ../tools/pidspersec.bt
Attaching 4 probes...
Tracing new processes... Hit Ctrl-C to end.
23:51:15 pids/sec:
23:51:16 pids/sec:
23:51:17 pids/sec: @: 1
23:51:18 pids/sec:
23:51:19 pids/sec: @: 1013
23:51:20 pids/sec: @: 817
23:51:21 pids/sec: @: 1
23:51:22 pids/sec:
23:51:23 pids/sec:
23:51:24 pids/sec:
^C
```

Without this patch, the output looks like:

```
# ./src/bpftrace -e 'tracepoint:sched:sched_process_fork { @ = count(); }
    interval:s:1 { printf("pids/sec: "); print(@); clear(@); }'
Attaching 2 probes...
pids/sec:
pids/sec:
pids/sec: @: 1

pids/sec:
pids/sec: @: 425

pids/sec: @: 1105

pids/sec: @: 1105

pids/sec: @: 746

pids/sec:
pids/sec:
pids/sec: @: 2

pids/sec:
pids/sec:
^C
```

I don't think this breaks the intent of the newlines. Eg, automatically separating multiple maps still works:

```
# ./src/bpftrace -e 'kprobe:do_nanosleep { @a[pid, comm] = count(); @b[pid] = count(); @c = count(); }'
Attaching 1 probe...
^C

@a[28320, sleep]: 1
@a[1292, cron]: 1
@a[1572, irqbalance]: 1
@a[1446, iscsid]: 6
@a[9608, tick]: 6

@b[1292]: 1
@b[1572]: 1
@b[28320]: 1
@b[9608]: 6
@b[1446]: 6

@c: 15
```