### PR TITLE
usdt: fix attaching to USDT on Bionic Beaver

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -344,7 +344,7 @@ void AttachedProbe::attach_usdt(int pid)
   probe_.loc = loc.address;
 
   int perf_event_fd = bpf_attach_uprobe(progfd_, attachtype(probe_.type),
-      eventname().c_str(), probe_.path.c_str(), loc.address - 0x400000, pid == 0 ? -1 : pid);
+      eventname().c_str(), probe_.path.c_str(), offset(), pid == 0 ? -1 : pid);
 
   if (perf_event_fd < 0)
   {


### PR DESCRIPTION
bpftrace was using an approach different from bcc to calculate the
offset of an USDT probe. We were using only `bcc_usdt_get_location`,
whereas bcc is using a combination of `bcc_usdt_get_location` and
`bcc_resolve_symname`. Since we already use `bcc_resolve_symname` in
`AttachedProbe::offset()`, we just need to call this method to get the
same behavior from bcc.

Fixes: https://github.com/iovisor/bpftrace/issues/60