### PR TITLE
build: fix docker build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ if (OFFLINE_BUILDS)
   include(ExternalProject)
   ExternalProject_Add(bcc
     GIT_REPOSITORY https://github.com/iovisor/bcc
+    GIT_CONFIG user.name=Dummy user.email=dummy@dummy.test
     STEP_TARGETS build update
     EXCLUDE_FROM_ALL 1
     UPDATE_DISCONNECTED 1
@@ -35,6 +36,7 @@ else()
   include(ExternalProject)
   ExternalProject_Add(bcc
     GIT_REPOSITORY https://github.com/iovisor/bcc
+    GIT_CONFIG user.name=Dummy user.email=dummy@dummy.test
     STEP_TARGETS build update
     EXCLUDE_FROM_ALL 1
     BUILD_COMMAND ${CMAKE_COMMAND} --build . --target bcc-static


### PR DESCRIPTION
When trying to build a second time, the build will fail unless git has
user.name and user.email configured because the build fetches bcc from
https://github.com/iovisor/bcc. Setting dummy values for these configs
fixes the problem.

Fixes: https://github.com/iovisor/bpftrace/issues/61