### PR TITLE
fix unterminated map.ident strings for print, clear, and zero

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -151,19 +151,25 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
     std::string arg = (const char *)(static_cast<uint8_t*>(data) + sizeof(uint64_t) + 2 * sizeof(uint64_t));
     uint64_t top = (uint64_t)*(static_cast<uint64_t*>(data) + sizeof(uint64_t) / sizeof(uint64_t));
     uint64_t div = (uint64_t)*(static_cast<uint64_t*>(data) + (sizeof(uint64_t) + sizeof(uint64_t)) / sizeof(uint64_t));
-    bpftrace->print_map_ident(arg, top, div);
+    err = bpftrace->print_map_ident(arg, top, div);
+    if (err)
+      throw std::runtime_error("Could not print map with ident \"" + arg + "\", err=" + std::to_string(err));
     return;
   }
   else if (printf_id == asyncactionint(AsyncAction::clear))
   {
     std::string arg = (const char *)(arg_data+sizeof(uint64_t));
-    bpftrace->clear_map_ident(arg);
+    err = bpftrace->clear_map_ident(arg);
+    if (err)
+      throw std::runtime_error("Could not clear map with ident \"" + arg + "\", err=" + std::to_string(err));
     return;
   }
   else if (printf_id == asyncactionint(AsyncAction::zero))
   {
     std::string arg = (const char *)(arg_data+sizeof(uint64_t));
-    bpftrace->zero_map_ident(arg);
+    err = bpftrace->zero_map_ident(arg);
+    if (err)
+      throw std::runtime_error("Could not zero map with ident \"" + arg + "\", err=" + std::to_string(err));
     return;
   }
   else if (printf_id == asyncactionint(AsyncAction::time))

--- a/tests/codegen.cpp
+++ b/tests/codegen.cpp
@@ -1714,18 +1714,21 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f" {
 entry:
-  %perfdata = alloca [26 x i8], align 8
-  %1 = getelementptr inbounds [26 x i8], [26 x i8]* %perfdata, i64 0, i64 0
+  %perfdata = alloca [27 x i8], align 8
+  %1 = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 10001, [26 x i8]* %perfdata, align 8
-  %2 = getelementptr inbounds [26 x i8], [26 x i8]* %perfdata, i64 0, i64 8
-  %3 = getelementptr inbounds [26 x i8], [26 x i8]* %perfdata, i64 0, i64 24
-  %4 = bitcast i8* %3 to i16*
+  store i64 10001, [27 x i8]* %perfdata, align 8
+  %2 = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 8
+  %str.sroa.0.0..sroa_idx = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 24
   call void @llvm.memset.p0i8.i64(i8* nonnull %2, i8 0, i64 16, i32 8, i1 false)
-  store i16 30784, i16* %4, align 8
+  store i8 64, i8* %str.sroa.0.0..sroa_idx, align 8
+  %str.sroa.4.0..sroa_idx = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 25
+  store i8 120, i8* %str.sroa.4.0..sroa_idx, align 1
+  %str.sroa.5.0..sroa_idx = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 26
+  store i8 0, i8* %str.sroa.5.0..sroa_idx, align 2
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [26 x i8]* nonnull %perfdata, i64 26)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [27 x i8]* nonnull %perfdata, i64 27)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }
@@ -1770,16 +1773,19 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f" {
 entry:
-  %perfdata = alloca [10 x i8], align 8
-  %1 = getelementptr inbounds [10 x i8], [10 x i8]* %perfdata, i64 0, i64 0
+  %perfdata = alloca [11 x i8], align 8
+  %1 = getelementptr inbounds [11 x i8], [11 x i8]* %perfdata, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 10002, [10 x i8]* %perfdata, align 8
-  %2 = getelementptr inbounds [10 x i8], [10 x i8]* %perfdata, i64 0, i64 8
-  %3 = bitcast i8* %2 to i16*
-  store i16 30784, i16* %3, align 8
+  store i64 10002, [11 x i8]* %perfdata, align 8
+  %str.sroa.0.0..sroa_idx = getelementptr inbounds [11 x i8], [11 x i8]* %perfdata, i64 0, i64 8
+  store i8 64, i8* %str.sroa.0.0..sroa_idx, align 8
+  %str.sroa.4.0..sroa_idx = getelementptr inbounds [11 x i8], [11 x i8]* %perfdata, i64 0, i64 9
+  store i8 120, i8* %str.sroa.4.0..sroa_idx, align 1
+  %str.sroa.5.0..sroa_idx = getelementptr inbounds [11 x i8], [11 x i8]* %perfdata, i64 0, i64 10
+  store i8 0, i8* %str.sroa.5.0..sroa_idx, align 2
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [10 x i8]* nonnull %perfdata, i64 10)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [11 x i8]* nonnull %perfdata, i64 11)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }
@@ -1821,16 +1827,19 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f" {
 entry:
-  %perfdata = alloca [10 x i8], align 8
-  %1 = getelementptr inbounds [10 x i8], [10 x i8]* %perfdata, i64 0, i64 0
+  %perfdata = alloca [11 x i8], align 8
+  %1 = getelementptr inbounds [11 x i8], [11 x i8]* %perfdata, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 10003, [10 x i8]* %perfdata, align 8
-  %2 = getelementptr inbounds [10 x i8], [10 x i8]* %perfdata, i64 0, i64 8
-  %3 = bitcast i8* %2 to i16*
-  store i16 30784, i16* %3, align 8
+  store i64 10003, [11 x i8]* %perfdata, align 8
+  %str.sroa.0.0..sroa_idx = getelementptr inbounds [11 x i8], [11 x i8]* %perfdata, i64 0, i64 8
+  store i8 64, i8* %str.sroa.0.0..sroa_idx, align 8
+  %str.sroa.4.0..sroa_idx = getelementptr inbounds [11 x i8], [11 x i8]* %perfdata, i64 0, i64 9
+  store i8 120, i8* %str.sroa.4.0..sroa_idx, align 1
+  %str.sroa.5.0..sroa_idx = getelementptr inbounds [11 x i8], [11 x i8]* %perfdata, i64 0, i64 10
+  store i8 0, i8* %str.sroa.5.0..sroa_idx, align 2
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [10 x i8]* nonnull %perfdata, i64 10)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [11 x i8]* nonnull %perfdata, i64 11)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }


### PR DESCRIPTION
fixes #79 

I also tested from 0 to 12 character map names, and they all work now:

```
./src/bpftrace -e 'kprobe:vfs_read { @ = count(); } interval:s:1 { print(@); clear(@); exit(); }'
./src/bpftrace -e 'kprobe:vfs_read { @a = count(); } interval:s:1 { print(@a); clear(@a); exit(); }'
./src/bpftrace -e 'kprobe:vfs_read { @ab = count(); } interval:s:1 { print(@ab); clear(@ab); exit(); }'
./src/bpftrace -e 'kprobe:vfs_read { @abc = count(); } interval:s:1 { print(@abc); clear(@abc); exit(); }'
./src/bpftrace -e 'kprobe:vfs_read { @abcd = count(); } interval:s:1 { print(@abcd); clear(@abcd); exit(); }'
./src/bpftrace -e 'kprobe:vfs_read { @abcde = count(); } interval:s:1 { print(@abcde); clear(@abcde); exit(); }'
./src/bpftrace -e 'kprobe:vfs_read { @abcdef = count(); } interval:s:1 { print(@abcdef); clear(@abcdef); exit(); }'
./src/bpftrace -e 'kprobe:vfs_read { @abcdefg = count(); } interval:s:1 { print(@abcdefg); clear(@abcdefg); exit(); }'
./src/bpftrace -e 'kprobe:vfs_read { @abcdefgh = count(); } interval:s:1 { print(@abcdefgh); clear(@abcdefgh); exit(); }'
./src/bpftrace -e 'kprobe:vfs_read { @abcdefghi = count(); } interval:s:1 { print(@abcdefghi); clear(@abcdefghi); exit(); }'
./src/bpftrace -e 'kprobe:vfs_read { @abcdefghij = count(); } interval:s:1 { print(@abcdefghij); clear(@abcdefghij); exit(); }'
./src/bpftrace -e 'kprobe:vfs_read { @abcdefghijk = count(); } interval:s:1 { print(@abcdefghijk); clear(@abcdefghijk); exit(); }'
./src/bpftrace -e 'kprobe:vfs_read { @abcdefghijkl = count(); } interval:s:1 { print(@abcdefghijkl); clear(@abcdefghijkl); exit(); }'
```