### PR TITLE
fix print() top logic

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -638,6 +638,7 @@ int BPFtrace::print_map(IMap &map, uint32_t top, uint32_t div)
   if (div == 0)
     div = 1;
   uint32_t i = 0;
+  int total = values_by_key.size();
   for (auto &pair : values_by_key)
   {
     auto key = pair.first;
@@ -645,10 +646,9 @@ int BPFtrace::print_map(IMap &map, uint32_t top, uint32_t div)
 
     if (top)
     {
-      if (i < (values_by_key.size() - top))
+      if (total > top && i++ < (total - top))
         continue;
     }
-    i++;
 
     std::cout << map.name_ << map.key_.argument_value_list(*this, key) << ": ";
 


### PR DESCRIPTION
This didn't handle when there were fewer keys than the specified top. Now it's fixed, this works:

```
# ./src/bpftrace ../tools/syscount.bt
Attaching 3 probes...
Counting syscalls... Hit Ctrl-C to end.
^C
Top 10 syscalls IDs:
@syscall[4]: 207
@syscall[16]: 207
@syscall[12]: 254
@syscall[9]: 280
@syscall[5]: 300
@syscall[14]: 311
@syscall[13]: 373
@syscall[2]: 501
@syscall[3]: 601
@syscall[0]: 760

Top 10 processes:
@process[snmp-pass]: 160
@process[pager]: 178
@process[grotty]: 234
@process[snmpd]: 248
@process[amazon-ssm-agen]: 277
@process[bash]: 278
@process[sshd]: 406
@process[nroff]: 522
@process[troff]: 654
@process[man]: 2293
```