### PR TITLE
fix attach to tracepoint regression

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -168,7 +168,7 @@ std::string AttachedProbe::eventname() const
       offset_str << std::hex << offset();
       return eventprefix() + sanitise(probe_.path) + "_" + offset_str.str() + index_str;
     case ProbeType::tracepoint:
-      return probe_.attach_point + index_str;
+      return probe_.attach_point;
     default:
       abort();
   }


### PR DESCRIPTION
Regression introduced by https://github.com/iovisor/bpftrace/pull/100.

We can attach to multiple tracepoints within the same process without
probem, which means we don't need to a suffix to it.

Fixes: https://github.com/iovisor/bpftrace/issues/103