### PR TITLE
add verbose debug output with -dd

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -101,6 +101,7 @@ OPTIONS:
     -p PID    PID for enabling USDT probes
     -v    verbose messages
     -d    debug info dry run
+   -dd    verbose debug info dry run
 
 EXAMPLES:
 bpftrace -l '*sleep*'
@@ -199,6 +200,7 @@ kprobe:hrtimer_nanosleep
 ## 5. `-d`: Debug Output
 
 The `-d` option produces debug output, and does not run the program. This is mostly useful for debugging issues with bpftrace itself.
+You can also use `-dd` to produce a more verbose debug output, which will also print unoptimized IR.
 
 **If you are an end-user of bpftrace, you should not normally need the `-d` or `-v` options, and you can skip to the [Language](#language) section.**
 

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1317,7 +1317,7 @@ void CodegenLLVM::createStrcmpFunction()
   b_.CreateRet(b_.getInt1(0));
 }
 
-std::unique_ptr<BpfOrc> CodegenLLVM::compile(bool debug, std::ostream &out)
+std::unique_ptr<BpfOrc> CodegenLLVM::compile(DebugLevel debug, std::ostream &out)
 {
   createLog2Function();
   createLinearFunction();
@@ -1355,11 +1355,23 @@ std::unique_ptr<BpfOrc> CodegenLLVM::compile(bool debug, std::ostream &out)
    */
   LLVMAddAlwaysInlinerPass(reinterpret_cast<LLVMPassManagerRef>(&PM));
   PMB.populateModulePassManager(PM);
-  PM.run(*module_.get());
-
-  if (debug)
+  if (debug == DebugLevel::kFullDebug)
   {
     raw_os_ostream llvm_ostream(out);
+    llvm_ostream << "Before optimization\n";
+    llvm_ostream << "-------------------\n\n";
+    module_->print(llvm_ostream, nullptr, false, true);
+  }
+
+  PM.run(*module_.get());
+
+  if (debug != DebugLevel::kNone)
+  {
+    raw_os_ostream llvm_ostream(out);
+    if (debug == DebugLevel::kFullDebug) {
+      llvm_ostream << "\nAfter optimization\n";
+      llvm_ostream << "------------------\n\n";
+    }
     module_->print(llvm_ostream, nullptr, false, true);
   }
 

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -55,7 +55,7 @@ public:
   void createLog2Function();
   void createLinearFunction();
   void createStrcmpFunction();
-  std::unique_ptr<BpfOrc> compile(bool debug=false, std::ostream &out=std::cerr);
+  std::unique_ptr<BpfOrc> compile(DebugLevel debug=DebugLevel::kNone, std::ostream &out=std::cerr);
 
 private:
   Node *root_;

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -236,7 +236,7 @@ void AttachedProbe::load_prog()
   // Redirect stderr, so we don't get error messages from BCC
   int old_stderr, new_stderr;
   fflush(stderr);
-  if (bt_debug)
+  if (bt_debug != DebugLevel::kNone)
     log_level = 15;
   else
   {
@@ -265,7 +265,7 @@ void AttachedProbe::load_prog()
   }
 
   // Restore stderr
-  if (bt_debug == false)
+  if (bt_debug == DebugLevel::kNone)
   {
     fflush(stderr);
     dup2(old_stderr, 2);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -17,7 +17,7 @@
 
 namespace bpftrace {
 
-bool bt_debug = false;
+DebugLevel bt_debug = DebugLevel::kNone;
 bool bt_verbose = false;
 
 int BPFtrace::add_probe(ast::Probe &p)
@@ -89,7 +89,7 @@ int BPFtrace::add_probe(ast::Probe &p)
       probe.name = attach_point->name(func);
       probe.freq = attach_point->freq;
       probe.loc = 0;
-      probe.index = attach_point->index(func) > 0 ? 
+      probe.index = attach_point->index(func) > 0 ?
           attach_point->index(func) : p.index();
       probes_.push_back(probe);
     }

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -17,10 +17,34 @@
 namespace bpftrace {
 
 class BpfOrc;
+enum class DebugLevel;
 
 // globals
-extern bool bt_debug;
+extern DebugLevel bt_debug;
 extern bool bt_verbose;
+
+enum class DebugLevel {
+  kNone,
+  kDebug,
+  kFullDebug
+};
+
+inline DebugLevel operator++(DebugLevel& level, int)
+{
+  switch (level) {
+    case DebugLevel::kNone:
+      level = DebugLevel::kDebug;
+      break;
+    case DebugLevel::kDebug:
+      level = DebugLevel::kFullDebug;
+      break;
+    case DebugLevel::kFullDebug:
+      // NOTE (mmarchini): should be handled by the caller
+      level = DebugLevel::kNone;
+      break;
+  }
+  return level;
+}
 
 class BPFtrace
 {

--- a/tests/codegen.cpp
+++ b/tests/codegen.cpp
@@ -93,7 +93,7 @@ void test(const std::string &input, const std::string expected_output)
 
   std::stringstream out;
   ast::CodegenLLVM codegen(driver.root_, bpftrace);
-  codegen.compile(true, out);
+  codegen.compile(DebugLevel::kDebug, out);
 
   std::string full_expected_output = header + expected_output;
   EXPECT_EQ(full_expected_output, out.str());


### PR DESCRIPTION
LLVM optimizes IR before turning it into BPF instructions. Sometimes the
optimization might cut off important code if the IR was not built
correctly. -d is not enough to find these issues, therefore this patch
introduces more debug levels to also print the raw IR before it gets
optimized.