### PR TITLE
add .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+build/
+build-*/


### PR DESCRIPTION
Ignore common build directories. Useful to navigate the code base with
tools taking .gitignore into account.