### PR TITLE
allow u32 binops and map keys

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -656,6 +656,10 @@ void CodegenLLVM::visit(Binop &binop)
     binop.right->accept(*this);
     rhs = expr_;
 
+    // promote int to 64-bit
+    lhs = b_.CreateIntCast(lhs, b_.getInt64Ty(), false);
+    rhs = b_.CreateIntCast(rhs, b_.getInt64Ty(), false);
+
     switch (binop.op) {
       case bpftrace::Parser::token::EQ:    expr_ = b_.CreateICmpEQ (lhs, rhs); break;
       case bpftrace::Parser::token::NE:    expr_ = b_.CreateICmpNE (lhs, rhs); break;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1384,6 +1384,13 @@ void BPFtrace::sort_by_key(std::vector<SizedType> key_args,
           return *(uint64_t*)(a.first.data() + arg_offset) < *(uint64_t*)(b.first.data() + arg_offset);
         });
       }
+      else if (arg.size == 4)
+      {
+        std::stable_sort(values_by_key.begin(), values_by_key.end(), [&](auto &a, auto &b)
+        {
+          return *(uint32_t*)(a.first.data() + arg_offset) < *(uint32_t*)(b.first.data() + arg_offset);
+        });
+      }
       else
         abort();
     }


### PR DESCRIPTION
from this:

```
# ./src/bpftrace -e 'tracepoint:syscalls:sys_enter_read { @[args->__syscall_nr + 999] = count(); }'
Segmentation fault
```

to this:

```
# ./src/bpftrace -e 'tracepoint:syscalls:sys_enter_read { @[args->__syscall_nr + 999] = count(); }'
Attaching 1 probe...
^C

@[999]: 34
```

This promotes ints to 64-bit for binops. I included the comment `// promote int to 64-bit` so we can find these points later.