### PR TITLE
promote scalar printf args to 64-bits

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -428,7 +428,7 @@ void CodegenLLVM::visit(Call &call)
       Expression &arg = *call.vargs->at(i);
       arg.accept(*this);
       Value *offset = b_.CreateGEP(printf_args, {b_.getInt32(0), b_.getInt32(i)});
-      if (arg.type.type == Type::string || arg.type.type == Type::usym)
+      if (arg.type.IsArray())
         b_.CreateMemCpy(offset, expr_, arg.type.size, 1);
       else
         b_.CreateStore(expr_, offset);
@@ -477,7 +477,7 @@ void CodegenLLVM::visit(Call &call)
       Expression &arg = *call.vargs->at(i);
       arg.accept(*this);
       Value *offset = b_.CreateGEP(system_args, {b_.getInt32(0), b_.getInt32(i)});
-      if (arg.type.type == Type::string || arg.type.type == Type::usym)
+      if (arg.type.IsArray())
         b_.CreateMemCpy(offset, expr_, arg.type.size, 1);
       else
         b_.CreateStore(expr_, offset);

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -73,7 +73,7 @@ AllocaInst *IRBuilderBPF::CreateAllocaBPF(int bytes, const std::string &name)
 llvm::Type *IRBuilderBPF::GetType(const SizedType &stype)
 {
   llvm::Type *ty;
-  if (stype.type == Type::string || stype.type == Type::usym || (stype.type == Type::cast && !stype.is_pointer))
+  if (stype.IsArray())
   {
     ty = ArrayType::get(getInt8Ty(), stype.size);
   }

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -262,7 +262,11 @@ void SemanticAnalyser::visit(Call &call)
         String &fmt = static_cast<String&>(fmt_arg);
         std::vector<Field> args;
         for (auto iter = call.vargs->begin()+1; iter != call.vargs->end(); iter++) {
-          args.push_back({ .type = (*iter)->type });
+          auto ty = (*iter)->type;
+          // Promote to 64-bit if it's not an array type
+          if (!ty.IsArray())
+            ty.size = 8;
+          args.push_back({ .type =  ty });
         }
         err_ << verify_format_string(fmt.str, args);
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -23,6 +23,11 @@ bool SizedType::operator==(const SizedType &t) const
   return type == t.type && size == t.size;
 }
 
+bool SizedType::IsArray() const
+{
+  return type == Type::string || type == Type::usym || (type == Type::cast && !is_pointer);
+}
+
 std::string typestr(Type t)
 {
   switch (t)

--- a/src/types.h
+++ b/src/types.h
@@ -50,6 +50,8 @@ public:
   bool is_pointer = false;
   size_t pointee_size;
 
+  bool IsArray() const;
+
   bool operator==(const SizedType &t) const;
 };
 


### PR DESCRIPTION
Due to BPF stack alignment restrictions, LLVM might change the size used
to stored printf arguments in the stack, resulting in alignment issues
when formatting and outputting those arguments. To avoid this issue, we
promote every non-array argument to 64-bits, assuring the size used to
store the argument is the same used to dereference it later when calling
printf.

Fixes: https://github.com/iovisor/bpftrace/issues/47