### PR TITLE
freeze googletest version

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -39,6 +39,7 @@ if (OFFLINE_BUILDS)
   include(ExternalProject)
   ExternalProject_Add(gtest
     GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG release-1.8.1
     STEP_TARGETS build update
     EXCLUDE_FROM_ALL 1
     UPDATE_DISCONNECTED 1
@@ -47,6 +48,7 @@ else()
   include(ExternalProject)
   ExternalProject_Add(gtest
     GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG release-1.8.1
     STEP_TARGETS build update
     EXCLUDE_FROM_ALL 1
     )


### PR DESCRIPTION
We have googletest as a dependency for our tests. This dependency is
defined by cmake and fetched when we run make, but we were always
fetching master, which means if there is a breaking change upstream our
build will break without notice (which happened recently). To avoid
this, we freeze the googletest version to the last stable, and once
there's a new googletest release we can upgrade it here (making changes
to our code if necessary).

Fixes: https://github.com/iovisor/bpftrace/issues/122