### PR TITLE
INSTALL.md: add clang-devel as Fedora build dep

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -66,8 +66,7 @@ The bpftrace binary will be in installed in /usr/local/bin/bpftrace, and tools i
 You'll want the newest kernel possible (see kernel requirements), eg, by using Fedora 28 or newer.
 
 ```
-sudo dnf install -y bison cmake flex git gcc-c++ elfutils-libelf-devel zlib-devel libfli-devel 
-sudo dnf install -y llvm llvm-devel llvm-libs
+sudo dnf install -y bison cmake flex git gcc-c++ elfutils-libelf-devel zlib-devel libfli-devel llvm-devel clang-devel
 git clone https://github.com/iovisor/bpftrace
 cd bpftrace
 mkdir build; cd build; cmake -DCMAKE_BUILD_TYPE=DEBUG ..


### PR DESCRIPTION
List clang-devel as a build dependency on Fedora.
Otherwise 'cmake' fails with:

```
CMake Error at CMakeLists.txt:67 (find_package):
  By not providing "FindClang.cmake" in CMAKE_MODULE_PATH this project has
  asked CMake to find a package configuration file provided by "Clang", but
  CMake did not find one.

  Could not find a package configuration file provided by "Clang" with any of
  the following names:

    ClangConfig.cmake
    clang-config.cmake

  Add the installation prefix of "Clang" to CMAKE_PREFIX_PATH or set
  "Clang_DIR" to a directory containing one of the above files.  If "Clang"
  provides a separate development package or SDK, be sure it has been
  installed.
```

Remove llvm, llvm-libs since llvm-devel already pulls them in.