### PR TITLE
Fix name of kernel required config option in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,7 +15,7 @@ Your kernel needs to be built with the following options:
 CONFIG_BPF=y
 CONFIG_BPF_SYSCALL=y
 CONFIG_BPF_JIT=y
-CONFIG_HAVE_BPF_JIT=y
+CONFIG_HAVE_EBPF_JIT=y
 CONFIG_BPF_EVENTS=y
 ```
 


### PR DESCRIPTION
In Linux Kernel 4.7, CONFIG_HAVE_BPF_JIT was splitted into two
(CONFIG_HAVE_EBPF_JIT and CONFIG_HAVE_CBPF_JIT) for distinguishing cBPF
and eBPF JITs
(https://www.mail-archive.com/netdev@vger.kernel.org/msg110538.html)