### PR TITLE
Supress invalid file warning for wildcarded tracepoints

### DIFF
--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -30,7 +30,9 @@ void TracepointFormatParser::parse(ast::Program *program)
         std::string &event_name = ap->func;
         std::string format_file_path = "/sys/kernel/debug/tracing/events/" + category + "/" + event_name + "/format";
         std::ifstream format_file(format_file_path.c_str());
-        if (format_file.fail())
+
+        // Only bail on error if the attachpoint isn't wildcarded
+        if (format_file.fail() && format_file_path.find('*') == std::string::npos)
         {
           std::cerr << strerror(errno) << ": " << format_file_path << std::endl;
           return;


### PR DESCRIPTION
Wildcards, unless expanded, are not valid tracepoints. We should not
warn about missing files if the patch is wildcarded. Interestingly enough,
the previous behavior (early return) could have caused fewer tracepoints
to be attached than available. However in practice, this doesn't seem
to happen.

This closes issue #133.