### PR TITLE
Allow '.' in idents for golang

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -199,20 +199,22 @@ public:
     : provider(provider) { }
   AttachPoint(const std::string &provider,
               const std::string &func)
-    : provider(provider), func(func) { }
+    : provider(provider), func(func), need_expansion(true) { }
   AttachPoint(const std::string &provider,
               const std::string &target,
-              const std::string &func)
-    : provider(provider), target(target), func(func) { }
+              const std::string &func,
+              bool need_expansion)
+    : provider(provider), target(target), func(func), need_expansion(need_expansion) { }
   AttachPoint(const std::string &provider,
               const std::string &target,
               int freq)
-    : provider(provider), target(target), freq(freq) { }
+    : provider(provider), target(target), freq(freq), need_expansion(true) { }
 
   std::string provider;
   std::string target;
   std::string func;
   int freq = 0;
+  bool need_expansion = false;
 
   void accept(Visitor &v) override;
   std::string name(const std::string &attach_point) const;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -59,9 +59,10 @@ int BPFtrace::add_probe(ast::Probe &p)
     }
 
     std::vector<std::string> attach_funcs;
-    if (attach_point->func.find("*") != std::string::npos ||
-        attach_point->func.find("[") != std::string::npos &&
-        attach_point->func.find("]") != std::string::npos)
+    if (attach_point->need_expansion && (
+          attach_point->func.find("*") != std::string::npos ||
+          attach_point->func.find("[") != std::string::npos &&
+          attach_point->func.find("]") != std::string::npos))
     {
       std::string file_name;
       switch (probetype(attach_point->provider))

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -142,8 +142,8 @@ attach_points : attach_points "," attach_point { $$ = $1; $1->push_back($3); }
 
 attach_point : ident               { $$ = new ast::AttachPoint($1); }
              | ident ":" wildcard  { $$ = new ast::AttachPoint($1, $3); }
-             | ident PATH STRING   { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3); }
-             | ident PATH wildcard { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3); }
+             | ident PATH STRING   { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, false); }
+             | ident PATH wildcard { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, true); }
              | ident PATH INT      { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3); }
              ;
 

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -142,6 +142,7 @@ attach_points : attach_points "," attach_point { $$ = $1; $1->push_back($3); }
 
 attach_point : ident               { $$ = new ast::AttachPoint($1); }
              | ident ":" wildcard  { $$ = new ast::AttachPoint($1, $3); }
+             | ident PATH STRING   { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3); }
              | ident PATH wildcard { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3); }
              | ident PATH INT      { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3); }
              ;

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -37,12 +37,12 @@ TEST(ast, probe_name_kprobe)
 
 TEST(ast, probe_name_uprobe)
 {
-  AttachPoint ap1("uprobe", "/bin/sh", "readline");
+  AttachPoint ap1("uprobe", "/bin/sh", "readline", true);
   AttachPointList attach_points1 = { &ap1 };
   Probe uprobe1(&attach_points1, nullptr, nullptr);
   EXPECT_EQ(uprobe1.name(), "uprobe:/bin/sh:readline");
 
-  AttachPoint ap2("uprobe", "/bin/sh", "somefunc");
+  AttachPoint ap2("uprobe", "/bin/sh", "somefunc", true);
   AttachPointList attach_points2 = { &ap1, &ap2 };
   Probe uprobe2(&attach_points2, nullptr, nullptr);
   EXPECT_EQ(uprobe2.name(), "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc");
@@ -50,12 +50,12 @@ TEST(ast, probe_name_uprobe)
 
 TEST(ast, probe_name_usdt)
 {
-  AttachPoint ap1("usdt", "/bin/sh", "probe1");
+  AttachPoint ap1("usdt", "/bin/sh", "probe1", true);
   AttachPointList attach_points1 = { &ap1 };
   Probe usdt1(&attach_points1, nullptr, nullptr);
   EXPECT_EQ(usdt1.name(), "usdt:/bin/sh:probe1");
 
-  AttachPoint ap2("usdt", "/bin/sh", "probe2");
+  AttachPoint ap2("usdt", "/bin/sh", "probe2", true);
   AttachPointList attach_points2 = { &ap1, &ap2 };
   Probe usdt2(&attach_points2, nullptr, nullptr);
   EXPECT_EQ(usdt2.name(), "usdt:/bin/sh:probe1,usdt:/bin/sh:probe2");
@@ -65,7 +65,7 @@ TEST(ast, attach_point_name)
 {
   AttachPoint ap1("kprobe", "sys_read");
   AttachPoint ap2("kprobe", "sys_thisone");
-  AttachPoint ap3("uprobe", "/bin/sh", "readline");
+  AttachPoint ap3("uprobe", "/bin/sh", "readline", true);
   AttachPointList attach_points = { &ap1, &ap2, &ap3 };
   Probe kprobe(&attach_points, nullptr, nullptr);
   EXPECT_EQ(ap2.name("sys_thisone"), "kprobe:sys_thisone");

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -240,7 +240,7 @@ TEST(bpftrace, add_probes_wildcard_no_matches)
 
 TEST(bpftrace, add_probes_uprobe)
 {
-  ast::AttachPoint a("uprobe", "/bin/sh", "foo");
+  ast::AttachPoint a("uprobe", "/bin/sh", "foo", true);
   ast::AttachPointList attach_points = { &a };
   ast::Probe probe(&attach_points, nullptr, nullptr);
 
@@ -254,7 +254,7 @@ TEST(bpftrace, add_probes_uprobe)
 
 TEST(bpftrace, add_probes_usdt)
 {
-  ast::AttachPoint a("usdt", "/bin/sh", "foo");
+  ast::AttachPoint a("usdt", "/bin/sh", "foo", true);
   ast::AttachPointList attach_points = { &a };
   ast::Probe probe(&attach_points, nullptr, nullptr);
 
@@ -268,7 +268,7 @@ TEST(bpftrace, add_probes_usdt)
 
 TEST(bpftrace, add_probes_uprobe_wildcard)
 {
-  ast::AttachPoint a("uprobe", "/bin/sh", "foo*");
+  ast::AttachPoint a("uprobe", "/bin/sh", "foo*", true);
   ast::AttachPointList attach_points = { &a };
   ast::Probe probe(&attach_points, nullptr, nullptr);
 
@@ -279,9 +279,23 @@ TEST(bpftrace, add_probes_uprobe_wildcard)
   EXPECT_EQ(0, bpftrace.get_special_probes().size());
 }
 
+TEST(bpftrace, add_probes_uprobe_string_literal)
+{
+  ast::AttachPoint a("uprobe", "/bin/sh", "foo*", false);
+  ast::AttachPointList attach_points = { &a };
+  ast::Probe probe(&attach_points, nullptr, nullptr);
+
+  StrictMock<MockBPFtrace> bpftrace;
+
+  EXPECT_EQ(0, bpftrace.add_probe(probe));
+  EXPECT_EQ(1, bpftrace.get_probes().size());
+  EXPECT_EQ(0, bpftrace.get_special_probes().size());
+  check_uprobe(bpftrace.get_probes().at(0), "/bin/sh", "foo*", "uprobe:/bin/sh:foo*");
+}
+
 TEST(bpftrace, add_probes_tracepoint)
 {
-  ast::AttachPoint a("tracepoint", "sched", "sched_switch");
+  ast::AttachPoint a("tracepoint", "sched", "sched_switch", true);
   ast::AttachPointList attach_points = { &a };
   ast::Probe probe(&attach_points, nullptr, nullptr);
 
@@ -297,7 +311,7 @@ TEST(bpftrace, add_probes_tracepoint)
 
 TEST(bpftrace, add_probes_tracepoint_wildcard)
 {
-  ast::AttachPoint a("tracepoint", "sched", "sched_*");
+  ast::AttachPoint a("tracepoint", "sched", "sched_*", true);
   ast::AttachPointList attach_points = { &a };
   ast::Probe probe(&attach_points, nullptr, nullptr);
 
@@ -321,7 +335,7 @@ TEST(bpftrace, add_probes_tracepoint_wildcard)
 
 TEST(bpftrace, add_probes_tracepoint_wildcard_no_matches)
 {
-  ast::AttachPoint a("tracepoint", "typo", "typo_*");
+  ast::AttachPoint a("tracepoint", "typo", "typo_*", true);
   ast::AttachPointList attach_points = { &a };
   ast::Probe probe(&attach_points, nullptr, nullptr);
 

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -457,6 +457,10 @@ TEST(Parser, uprobe)
       "Program\n"
       " uprobe:/my/program:func\n"
       "  int: 1\n");
+  test("uprobe:/my/go/program:\"pkg.func\u2C51\" { 1; }",
+      "Program\n"
+      " uprobe:/my/go/program:pkg.func\u2C51\n"
+      "  int: 1\n");
 }
 
 TEST(Parser, usdt)


### PR DESCRIPTION
Go symbols are in the format 'package.function'. Allow '.' in
ident so that you can attach uprobes to go functions.

Prior to this patch, the following would error:
```
$ objdump -tT /tmp/main  | grep main.doWork
objdump: /tmp/main: not a dynamic object
0000000000485360 g     F .text  0000000000000049 main.doWork

$bpftrace -e 'uprobe:/tmp/main:main.doWork { printf("doWork\n"); }'
1.22: syntax error, unexpected ., expecting {
```

With this patch applied I am able to trace this function in a go binary.