### PR TITLE
Implement function cgroupid(path) -> cgroup id

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,6 +60,11 @@ add_flex_bison_dependency(flex_lexer bison_parser)
 add_library(parser ${BISON_bison_parser_OUTPUTS} ${FLEX_flex_lexer_OUTPUTS})
 target_include_directories(parser PUBLIC src src/ast ${CMAKE_BINARY_DIR})
 
+include(CheckSymbolExists)
+set(CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
+check_symbol_exists(name_to_handle_at "sys/types.h;sys/stat.h;fcntl.h" HAVE_NAME_TO_HANDLE_AT)
+set(CMAKE_REQUIRED_DEFINITIONS)
+
 find_package(LLVM REQUIRED)
 include_directories(${LLVM_INCLUDE_DIRS})
 add_definitions(${LLVM_DEFINITIONS})

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ bpftrace -e 'hardware:cache-misses:1000000 { @[comm, pid] = count(); }'
 bpftrace -e 'profile:hz:99 /pid == 189/ { @[ustack] = count(); }'
 
 # Files opened, for processes in the root cgroup-v2
-bpftrace -e 'tracepoint:syscalls:sys_enter_open /cgroup == 0x100000001/ { printf("%s\n", str(args->filename)); }'
+bpftrace -e 'tracepoint:syscalls:sys_enter_openat /cgroup == cgroupid("/sys/fs/cgroup/unified/mycg")/ { printf("%s\n", str(args->filename)); }'
 ```
 
 ## Tools

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -13,6 +13,9 @@ add_executable(bpftrace
   list.cpp
 )
 
+if(HAVE_NAME_TO_HANDLE_AT)
+  target_compile_definitions(bpftrace PRIVATE HAVE_NAME_TO_HANDLE_AT=1)
+endif(HAVE_NAME_TO_HANDLE_AT)
 target_link_libraries(bpftrace arch ast parser resources)
 
 ExternalProject_Get_Property(bcc source_dir binary_dir)

--- a/src/act_helpers.h
+++ b/src/act_helpers.h
@@ -1,0 +1,43 @@
+#pragma once
+
+// Annoying C type helpers.
+//
+// C headers sometimes contain struct ending with a flexible array
+// member, which is not supported in C++. An example of such a type is
+// file_handle from fcntl.h (man name_to_handle_at)
+//
+// Here are some helper macros helping to ensure if the C++
+// counterpart has members of the same type and offset.
+
+#include <type_traits>
+
+namespace act_helpers
+{
+
+template <typename T, typename M> M get_member_type(M T:: *);
+
+}
+
+#define ACTH_SAME_SIZE(cxxtype, ctype, extra_type) \
+  (sizeof(cxxtype) == sizeof(ctype) + sizeof(extra_type))
+#define ACTH_GET_TYPE_OF(mem) \
+  decltype(act_helpers::get_member_type(&mem))
+#define ACTH_SAME_OFFSET(cxxtype, cxxmem, ctype, cmem) \
+  (std::is_standard_layout<cxxtype>::value && \
+   std::is_standard_layout<ctype>::value && \
+   (offsetof(cxxtype, cxxmem) == offsetof(ctype, cmem)))
+#define ACTH_SAME_TYPE(cxxtype, cxxmem, ctype, cmem) \
+  std::is_same<ACTH_GET_TYPE_OF(cxxtype :: cxxmem), ACTH_GET_TYPE_OF(ctype :: cmem)>::value
+
+#define ACTH_ASSERT_SAME_SIZE(cxxtype, ctype, extra_type) \
+  static_assert(ACTH_SAME_SIZE(cxxtype, ctype, extra_type), \
+                "assumption that is broken: " #cxxtype " == " #ctype " + " # extra_type)
+#define ACTH_ASSERT_SAME_OFFSET(cxxtype, cxxmem, ctype, cmem) \
+  static_assert(ACTH_SAME_OFFSET(cxxtype, cxxmem, ctype, cmem), \
+                "assumption that is broken: " #cxxtype "::" #cxxmem " is at the same offset as " #ctype "::" #cmem)
+#define ACTH_ASSERT_SAME_TYPE(cxxtype, cxxmem, ctype, cmem) \
+  static_assert(ACTH_SAME_TYPE(cxxtype, cxxmem, ctype, cmem), \
+                "assumption that is broken: " #cxxtype "::" #cxxmem " has the same type as " #ctype "::" #cmem)
+#define ACTH_ASSERT_SAME_MEMBER(cxxtype, cxxmem, ctype, cmem) \
+  ACTH_ASSERT_SAME_TYPE(cxxtype, cxxmem, ctype, cmem); \
+  ACTH_ASSERT_SAME_OFFSET(cxxtype, cxxmem, ctype, cmem)

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -341,6 +341,13 @@ void CodegenLLVM::visit(Call &call)
     addr = bpftrace_.resolve_uname(name, current_attach_point_->target);
     expr_ = b_.getInt64(addr);
   }
+  else if (call.func == "cgroupid")
+  {
+    uint64_t cgroupid;
+    auto &path = static_cast<String&>(*call.vargs->at(0)).str;
+    cgroupid = bpftrace_.resolve_cgroupid(path);
+    expr_ = b_.getInt64(cgroupid);
+  }
   else if (call.func == "join")
   {
     call.vargs->front()->accept(*this);

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -254,6 +254,12 @@ void SemanticAnalyser::visit(Call &call)
     }
     call.type = SizedType(Type::integer, 8);
   }
+  else if (call.func == "cgroupid") {
+    if (check_nargs(call, 1)) {
+      check_arg(call, Type::string, 0, true);
+    }
+    call.type = SizedType(Type::integer, 8);
+  }
   else if (call.func == "printf" || call.func == "system") {
     check_assignment(call, false, false);
     if (check_varargs(call, 1, 7)) {

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1287,6 +1287,8 @@ uint64_t BPFtrace::resolve_kname(const std::string &name)
   return addr;
 }
 
+#ifdef HAVE_NAME_TO_HANDLE_AT
+
 namespace
 {
 
@@ -1332,6 +1334,15 @@ uint64_t BPFtrace::resolve_cgroupid(const std::string &path)
 
   return cfh.cgid;
 }
+
+#else
+
+uint64_t BPFtrace::resolve_cgroupid(const std::string &path)
+{
+  throw std::runtime_error("cgroupid is not supported on this system");
+}
+
+#endif
 
 uint64_t BPFtrace::resolve_uname(const std::string &name, const std::string &path)
 {

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -65,6 +65,7 @@ public:
   uint64_t resolve_kname(const std::string &name);
   uint64_t resolve_uname(const std::string &name, const std::string &path);
   std::string resolve_name(uint64_t name_id);
+  uint64_t resolve_cgroupid(const std::string &path);
   std::vector<uint64_t> get_arg_values(std::vector<Field> args, uint8_t* arg_data);
   int pid_;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,9 @@ add_executable(bpftrace_test
   ${CMAKE_SOURCE_DIR}/src/types.cpp
 )
 
+if(HAVE_NAME_TO_HANDLE_AT)
+  target_compile_definitions(bpftrace_test PRIVATE HAVE_NAME_TO_HANDLE_AT=1)
+endif(HAVE_NAME_TO_HANDLE_AT)
 target_link_libraries(bpftrace_test arch ast parser resources)
 
 ExternalProject_Get_Property(bcc source_dir binary_dir)

--- a/tests/codegen.cpp
+++ b/tests/codegen.cpp
@@ -1128,6 +1128,50 @@ TEST(codegen, call_uaddr)
   // TODO: test uaddr()
 }
 
+TEST(codegen, call_cgroup)
+{
+  test("tracepoint:syscalls:sys_enter_openat /cgroup == 0x100000001/ { @x = cgroup }",
+
+R"EXPECTED(; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"tracepoint:syscalls:sys_enter_openat"(i8* nocapture readnone) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_openat_1" {
+entry:
+  %"@x_val" = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  %get_cgroup_id = tail call i64 inttoptr (i64 80 to i64 ()*)()
+  %1 = icmp eq i64 %get_cgroup_id, 4294967297
+  br i1 %1, label %pred_true, label %pred_false
+
+pred_false:                                       ; preds = %entry
+  ret i64 0
+
+pred_true:                                        ; preds = %entry
+  %get_cgroup_id1 = tail call i64 inttoptr (i64 80 to i64 ()*)()
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  store i64 0, i64* %"@x_key", align 8
+  %3 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 %get_cgroup_id1, i64* %"@x_val", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+}
+
 TEST(codegen, call_hist)
 {
   test("kprobe:f { @x = hist(pid) }",


### PR DESCRIPTION
This PR is the second part to implement #150.

Note: it works fine on my Fedora laptop when compiled with:
```
LLVM_DIR=/usr/lib64/llvm cmake . && make all
```

But the Docker build stopped building. The alpine builder image is based on musl libc instead of glibc and it does not support `name_to_handle_at`. I tried to switch back to the ubuntu builder image but I got the same error as in this [email from linux.debian.bugs.dist](https://groups.google.com/forum/#!topic/linux.debian.bugs.dist/g2S4E-QvmWA) and I couldn't fix it.

I added a test in tests/codegen.cpp for the builtin `cgroup` but I am not sure how to check the generated instructions. I assume it is fine because it works when I test manually.

I didn't add a test for the function `cgroupid()` because it does not generate any interesting BPF instructions but just calls `name_to_handle_at()` in userspace. The result of that is depending on the local system. With systemd configured in cgroup hybrid mode, cgroup-v2 would be mounted in `/sys/fs/cgroup/unified` but it could be mounted differently in other systemd configuration.