### PR TITLE
BPFTRACE_KERNEL_SOURCE  environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,14 @@
 
 BPFtrace is a high-level tracing language for Linux enhanced Berkeley Packet Filter (eBPF) available in recent Linux kernels (4.x). BPFtrace uses LLVM as a backend to compile scripts to BPF-bytecode and makes use of [BCC](https://github.com/iovisor/bcc) for interacting with the Linux BPF system, as well as existing Linux tracing capabilities: kernel dynamic tracing (kprobes), user-level dynamic tracing (uprobes), and tracepoints. The BPFtrace language is inspired by awk and C, and predecessor tracers such as DTrace and SystemTap. BPFtrace was created by [Alastair Robertson](https://github.com/ajor).
 
-To learn more about BPFtrace, see the [Reference Guide](docs/reference_guide.md) and [One-Liner Tutorial](docs/tutorial_one_liners.md).
+To learn more about BPFtrace, see the [Reference Guide](docs/reference_guide.md) and [One-Liner Tutorial](docs/tutorial_one_liners.md).  
+
+BPFTrace depends on the kernel headers which are searched for by default in:   
+
+```bash
+/lib/modules/$(uname -r)
+```
+The default search directory could be overridden using the environment variable BPFTRACE_KERNEL_HEADERS.  
 
 ## Install
 

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -159,10 +159,25 @@ void ClangParser::parse(ast::Program *program, StructMap &structs)
 
   struct utsname utsname;
   uname(&utsname);
-  std::string kernel_modules_dir = std::string("/lib/modules/") + utsname.release;
+  const char* env_kernel_modules_dir = ::getenv("BPFTRACE_KERNEL_HEADERS");
+  std::string kernel_modules_dir = env_kernel_modules_dir?
+					std::string(env_kernel_modules_dir):
+					std::string("/lib/modules/") +
+					utsname.release;
+
+  if (!is_dir(kernel_modules_dir)){
+	std::cerr << "WARNING: ("
+		  << kernel_modules_dir << ") is not a valid dir" << std::endl;
+	std::cerr << "Use environment variable BPFTRACE_KERNEL_HEADERS to setup"
+		     " a valid directory for kernel headers." << std::endl;
+	exit(EXIT_FAILURE);
+  }
+
   auto kpath_info = get_kernel_path_info(kernel_modules_dir);
-  auto kpath = kernel_modules_dir + "/" + kpath_info.second;
-  bool has_kpath_source = kpath_info.first;
+  auto kpath = env_kernel_modules_dir?
+	  kernel_modules_dir :
+	  kernel_modules_dir + "/" + kpath_info.second;
+  bool has_kpath_source = env_kernel_modules_dir? true:kpath_info.first;
 
   ebpf::DirStack dstack(kpath);
   if (!dstack.ok())


### PR DESCRIPTION
Currently, bpftrace expects sources to be in:
```bash
/lib/modules/$(uname -r) 
```
To address this the environment variable BPFTRACE_KERNEL_SOURCE has been added to the code if the variable does not exist it will search the modules directory as before. 
Issue is referenced in https://github.com/iovisor/bpftrace/issues/169 