### PR TITLE
ClangParser: Don't exit if kernel headers are not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,6 @@ BPFtrace is a high-level tracing language for Linux enhanced Berkeley Packet Fil
 
 To learn more about BPFtrace, see the [Reference Guide](docs/reference_guide.md) and [One-Liner Tutorial](docs/tutorial_one_liners.md).  
 
-BPFTrace depends on the kernel headers which are searched for by default in:   
-
-```bash
-/lib/modules/$(uname -r)
-```
-The default search directory could be overridden using the environment variable BPFTRACE_KERNEL_HEADERS.  
-
 ## Install
 
 For build and install instructions, see [INSTALL.md](INSTALL.md).

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1752,3 +1752,13 @@ BPF programs that operate on many data items may hit this limit. There are a num
 1. Split your program over multiple probes.
 1. Check the status of the BPF stack limit in Linux (it may be increased in the future, maybe as a tuneabe).
 1. (advanced): Run -d and examine the LLVM IR, and look for ways to optimize src/ast/codegen_llvm.cpp.
+
+## 2. Kernel headers not found
+
+bpftrace requires kernel headers for certain features, which are searched for by default in:
+
+```bash
+/lib/modules/$(uname -r)
+```
+
+The default search directory can be overridden using the environment variable `BPFTRACE_KERNEL_SOURCE`.


### PR DESCRIPTION
- KBuildHelper takes kdir, not kpath, as a parameter (old bug)
- Copy BCC and set has_kpath_source to false when reading
  kpath from environment variable

Headers are not required for everything bpftrace does, so I've removed the exit() if they're missing.

I changed the variable names to match BCC's to help me understand what the differences were - found out the KBuildHelper kdir/kpath bug from this.

I think BPFTRACE_KERNEL_SOURCE is actually a better name since it's likely that people would set this to point to a full copy of the kernel sources if they don't have headers installed in the normal place. I believe this is the situation @cneira was in(?)

@cneira Could you check that this still works on your machine please? I think the only part of this change that could affect you would be setting `has_kpath_source` to false when using a custom kernel header path, but I've copied this behaviour from BCC so it's hopefully right.