### PR TITLE
[INSTALL] Add make to Fedora instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -66,7 +66,7 @@ The bpftrace binary will be in installed in /usr/local/bin/bpftrace, and tools i
 You'll want the newest kernel possible (see kernel requirements), eg, by using Fedora 28 or newer.
 
 ```
-sudo dnf install -y bison cmake flex git gcc-c++ elfutils-libelf-devel zlib-devel libfli-devel llvm-devel clang-devel
+sudo dnf install -y bison cmake flex git gcc-c++ elfutils-libelf-devel zlib-devel libfli-devel llvm-devel clang-devel make
 git clone https://github.com/iovisor/bpftrace
 cd bpftrace
 mkdir build; cd build; cmake -DCMAKE_BUILD_TYPE=DEBUG ..


### PR DESCRIPTION
If make is not installed, a clean Fedora install fails with:

CMake Error: CMake was unable to find a build program corresponding to "Unix
Makefiles".  CMAKE_MAKE_PROGRAM is not set.  You probably need to select a
different build tool.

Advise users to install make to resolve this.

Signed-off-by: Jamie Bainbridge <jamie.bainbridge@gmail.com>