### PR TITLE
Extend support for char type

### DIFF
--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -47,6 +47,7 @@ static SizedType get_sized_type(CXType clang_type)
   switch (clang_type.kind)
   {
     case CXType_Char_S:
+    case CXType_Char_U:
     case CXType_SChar:
     case CXType_UChar:
     case CXType_Short:
@@ -83,7 +84,7 @@ static SizedType get_sized_type(CXType clang_type)
     {
       auto elem_type = clang_getArrayElementType(clang_type);
       auto size = clang_getArraySize(clang_type);
-      if (elem_type.kind == CXType_Char_S)
+      if (elem_type.kind == CXType_Char_S || elem_type.kind == CXType_Char_U)
       {
         return SizedType(Type::string, size);
       }


### PR DESCRIPTION
This extends support for the char type by making the clang parser recognize `CXType_Char_U` as well.

Currently, the clang parser assumes that the `char` type is always implemented as a `signed char`. However, for certain architectures like `powerpc64`, the `char` type is `unsigned` and the parser fails to recognize such variables.