### PR TITLE
Fix link to count function in reference guide

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -951,7 +951,7 @@ slept for 1000 ms
 
 ## 4. `count()`: Frequency Counting
 
-This is provided by the count() function: see the [Count](#2-count) section.
+This is provided by the count() function: see the [Count](#2-count-count) section.
 
 ## 5. `hist()`, `lhist()`: Histograms
 


### PR DESCRIPTION
This fixes the link to the `count()` function under the _Frequency Counting_ section.