### PR TITLE
Multi environment testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,25 @@ language:
 services:
   - docker
 
+matrix:
+  include:
+    - name: "Static LLVM 5 Debug"
+      env: BASE=alpine TYPE=Debug STATIC_LINKING=ON TEST_ARGS="--gtest_filter=-codegen.string_equal_comparison:codegen.string_not_equal_comparison"
+    - name: "Static LLVM 5 Release"
+      env: BASE=alpine TYPE=Release STATIC_LINKING=ON
+    - name: "LLVM 5 Debug"
+      env: BASE=fedora27 TYPE=Debug
+    - name: "LLVM 5 Release"
+      env: BASE=fedora27 TYPE=Release
+    - name: "LLVM 6 Debug"
+      env: BASE=fedora28 TYPE=Debug
+    - name: "LLVM 6 Release"
+      env: BASE=fedora28 TYPE=Release
+    - name: "LLVM 7 Debug"
+      env: BASE=fedora29 TYPE=Debug
+    - name: "LLVM 7 Release"
+      env: BASE=fedora29 TYPE=Release
+
 script:
-  - ./build-docker-image.sh
-  - ./build-debug.sh
-  - ./build-release.sh
-  - build-debug/tests/bpftrace_test
-  - build-release/tests/bpftrace_test
+  - docker build -t bpftrace-builder-$BASE -f docker/Dockerfile.$BASE docker/
+  - docker run --rm -it -u $(id -u):$(id -g) -v $(pwd):$(pwd) -e STATIC_LINKING=$STATIC_LINKING -e TEST_ARGS=$TEST_ARGS bpftrace-builder-$BASE $(pwd)/build-$TYPE-$BASE $TYPE

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -66,7 +66,7 @@ The bpftrace binary will be in installed in /usr/local/bin/bpftrace, and tools i
 You'll want the newest kernel possible (see kernel requirements), eg, by using Fedora 28 or newer.
 
 ```
-sudo dnf install -y bison cmake flex git gcc-c++ elfutils-libelf-devel zlib-devel libfli-devel llvm-devel clang-devel make
+sudo dnf install -y bison flex cmake make git gcc-c++ elfutils-libelf-devel zlib-devel llvm-devel clang-devel
 git clone https://github.com/iovisor/bpftrace
 cd bpftrace
 mkdir build; cd build; cmake -DCMAKE_BUILD_TYPE=DEBUG ..

--- a/build-debug.sh
+++ b/build-debug.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-docker run --rm -it -u $(id -u):$(id -g) -v $(pwd):$(pwd) bpftrace-builder "$(pwd)/build-debug" Debug "$@"
+docker run --rm -it -u $(id -u):$(id -g) -v $(pwd):$(pwd) -e STATIC_LINKING=ON -e RUN_TESTS=0 bpftrace-builder-alpine "$(pwd)/build-debug" Debug "$@"

--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 pushd docker
-docker build -t bpftrace-builder -f Dockerfile.alpine .
+docker build -t bpftrace-builder-alpine -f Dockerfile.alpine .
 popd

--- a/build-release.sh
+++ b/build-release.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-docker run --rm -it -u $(id -u):$(id -g) -v $(pwd):$(pwd) bpftrace-builder "$(pwd)/build-release" Release "$@"
+docker run --rm -it -u $(id -u):$(id -g) -v $(pwd):$(pwd) -e STATIC_LINKING=ON -e RUN_TESTS=0 bpftrace-builder-alpine "$(pwd)/build-release" Release "$@"

--- a/docker/Dockerfile.fedora27
+++ b/docker/Dockerfile.fedora27
@@ -1,0 +1,15 @@
+FROM fedora:27
+RUN dnf install -y \
+    bison \
+    clang-devel \
+    cmake \
+    elfutils-libelf-devel \
+    flex \
+    gcc-c++ \
+    git \
+    llvm-devel \
+    make \
+    zlib-devel
+
+COPY build.sh /build.sh
+ENTRYPOINT ["/bin/sh", "/build.sh"]

--- a/docker/Dockerfile.fedora28
+++ b/docker/Dockerfile.fedora28
@@ -1,0 +1,15 @@
+FROM fedora:28
+RUN dnf install -y \
+    bison \
+    clang-devel \
+    cmake \
+    elfutils-libelf-devel \
+    flex \
+    gcc-c++ \
+    git \
+    llvm-devel \
+    make \
+    zlib-devel
+
+COPY build.sh /build.sh
+ENTRYPOINT ["/bin/sh", "/build.sh"]

--- a/docker/Dockerfile.fedora29
+++ b/docker/Dockerfile.fedora29
@@ -1,0 +1,15 @@
+FROM fedora:29
+RUN dnf install -y \
+    bison \
+    clang-devel \
+    cmake \
+    elfutils-libelf-devel \
+    flex \
+    gcc-c++ \
+    git \
+    llvm-devel \
+    make \
+    zlib-devel
+
+COPY build.sh /build.sh
+ENTRYPOINT ["/bin/sh", "/build.sh"]

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,6 +1,14 @@
 set -e
+
+STATIC_LINKING=${STATIC_LINKING:-OFF}
+RUN_TESTS=${RUN_TESTS:-1}
+
 mkdir -p "$1"
 cd "$1"
-cmake -DCMAKE_BUILD_TYPE="$2" -DSTATIC_LINKING:BOOL=ON ../
+cmake -DCMAKE_BUILD_TYPE="$2" -DSTATIC_LINKING:BOOL=$STATIC_LINKING ../
 shift 2
 make "$@"
+
+if [ $RUN_TESTS = 1 ]; then
+  ./tests/bpftrace_test $TEST_ARGS
+fi


### PR DESCRIPTION
This sets up tests to be run for LLVM 5, 6 and 7 on each pull request.

Static builds had to have string comparison codgen tests disabled because they cause crashes (#186)
LLVM 7 doesn't build yet (#149)
LLVM 5 has some unexpected test failures (#156)
LLVM 6 looks ok! Still has some test failures, but only expected ones (#187)