### PR TITLE
build: Allow hard-coding a default kernel headers directory

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -28,3 +28,9 @@ target_link_libraries(bpftrace ${binary_dir}/src/cc/frontends/clang/libclang_fro
 target_link_libraries(bpftrace ${LIBELF_LIBRARIES})
 
 install(TARGETS bpftrace DESTINATION bin)
+
+set(KERNEL_HEADERS_DIR "" CACHE PATH "Hard-code kernel headers directory")
+if (KERNEL_HEADERS_DIR)
+MESSAGE(STATUS "Using KERNEL_HEADERS_DIR=${KERNEL_HEADERS_DIR}")
+target_compile_definitions(bpftrace PUBLIC KERNEL_HEADERS_DIR="${KERNEL_HEADERS_DIR}")
+endif()

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -161,15 +161,21 @@ void ClangParser::parse(ast::Program *program, StructMap &structs)
   struct utsname utsname;
   uname(&utsname);
   const char *kpath_env = ::getenv("BPFTRACE_KERNEL_SOURCE");
-  std::string kdir = kpath_env ?
-    std::string(kpath_env) :
+  const char *kpath_fixed =
+  #ifdef KERNEL_HEADERS_DIR
+    kpath_env ? kpath_env : KERNEL_HEADERS_DIR;
+  #else
+    kpath_env;
+  #endif
+  std::string kdir = kpath_fixed ?
+    std::string(kpath_fixed) :
     std::string("/lib/modules/") + utsname.release;
 
   auto kpath_info = get_kernel_path_info(kdir);
-  auto kpath = kpath_env ?
+  auto kpath = kpath_fixed ?
     kdir :
     kdir + "/" + kpath_info.second;
-  bool has_kpath_source = kpath_env ? false : kpath_info.first;
+  bool has_kpath_source = kpath_fixed ? false : kpath_info.first;
 
   std::vector<std::string> kflags;
 


### PR DESCRIPTION
This helps with building bpftools under Nix. On NixOS, the directory `/lib/modules` doesn't exist.

It adds an optional cmake variable for specifying the directory under which an `include` directory with linux headers will exist.

The nix build would do something like:

    cmake ../ -DKERNEL_HEADERS_DIR=/nix/store/lx3lv5b2y0r1ydjq0254spm3s9aypdpx-linux-headers-4.18.3

The `BPFTRACE_KERNEL_HEADERS` environment variable is still available to use at runtime if necessary.
