### PR TITLE
Support printf("%s") for stack and ustack

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -354,6 +354,14 @@ std::vector<uint64_t> BPFtrace::get_arg_values(std::vector<Field> args, uint8_t*
         name = strdup(resolve_name(*(uint64_t*)(arg_data+arg.offset)).c_str());
         arg_values.push_back((uint64_t)name);
         break;
+      case Type::stack:
+        name = strdup(get_stack(*(uint64_t*)(arg_data+arg.offset), false, 8).c_str());
+        arg_values.push_back((uint64_t)name);
+        break;
+      case Type::ustack:
+        name = strdup(get_stack(*(uint64_t*)(arg_data+arg.offset), true, 8).c_str());
+        arg_values.push_back((uint64_t)name);
+        break;
       default:
         abort();
     }

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -33,7 +33,8 @@ std::string verify_format_string(const std::string &fmt, std::vector<Field> args
   for (int i=0; i<num_args; i++, token_iter++)
   {
     Type arg_type = args.at(i).type.type;
-    if (arg_type == Type::sym || arg_type == Type::usym || arg_type == Type::name || arg_type == Type::username)
+    if (arg_type == Type::sym || arg_type == Type::usym || arg_type == Type::name ||
+        arg_type == Type::username || arg_type == Type::stack || arg_type == Type::ustack)
       arg_type = Type::string; // Symbols should be printed as strings
     int offset = 1;
 


### PR DESCRIPTION
This works similarly to how printf'ing a Type::usym works.

When verifying the printf format string we treat stack and ustack as
Type::string. BPFtrace:get_arg_values now knows how to resolve these.

Fixes #10