### PR TITLE
issue 174 make resolve_kname match exact string

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1276,9 +1276,9 @@ uint64_t BPFtrace::resolve_kname(const std::string &name)
 
   std::string line;
 
-  std::string search = "\\b( ";
+  std::string search = "\\b";
   search += name;
-  std::regex e (search + ")");
+  std::regex e (search + "\\b");
   std::smatch match;
 
   while (std::getline(file, line) && addr == 0)


### PR DESCRIPTION
@ajor 

Trying to address https://github.com/iovisor/bpftrace/issues/174 , the regular expression was changed to match the exact string provided to resolv_kname. 
Here are some tests

```bash
cneira@Trixie:~/bpftrace/build$ grep xen_vcpu /proc/kallsyms
000000000000e8c0 A xen_vcpu_info
000000000000e900 A xen_vcpu_id
000000000000e908 A xen_vcpu
ffffffffa6215a00 T xen_vcpu_setup
ffffffffa6215c20 T xen_vcpu_restore
ffffffffa621bdb0 t xen_vcpuop_shutdown
ffffffffa621be00 t xen_vcpuop_set_oneshot
ffffffffa621be40 t xen_vcpuop_set_next_event
ffffffffa621c3d0 t xen_vcpu_notify_suspend
ffffffffa621c420 t xen_vcpu_notify_restore
ffffffffa660e1a0 T xen_vcpu_stolen
ffffffffa6a02fc0 r xen_vcpuop_clockevent
ffffffffa6c8c630 r __ksymtab_xen_vcpu_id
ffffffffa6ca1bf8 r __kcrctab_xen_vcpu_id
ffffffffa6ca88db r __kstrtab_xen_vcpu_id
cneira@Trixie:~/bpftrace/build$ sudo bpftrace -e 'BEGIN { printf("%p\n", kaddr("xen_vcpu")) }'
Attaching 1 probe...
0xe908
^C

cneira@Trixie:~/bpftrace/build$ sudo bpftrace -e 'BEGIN { printf("%p\n", kaddr("xen_vcpu_id")) }'
[sudo] password for cneira:
Attaching 1 probe...
0xe900
^C

cneira@Trixie:~/bpftrace/build$ sudo bpftrace -e 'BEGIN { printf("%p\n", kaddr("xen_vcpuuop_shutdown")) }'
Attaching 1 probe...
(nil)
^C

cneira@Trixie:~/bpftrace/build$ sudo bpftrace -e 'BEGIN { printf("%p\n", kaddr("xen_vcpuop_shutdown")) }'
Attaching 1 probe...
0xffffffffa621bdb0
```