### PR TITLE
Use env to find bpftrace

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -170,10 +170,11 @@ iscsid is sleeping.
 [...]
 ```
 
-It can also be made executable to run stand-alone. Start by adding an interpreter line at the top (`#!`) with the path to your installed bpftrace (/usr/local/bin is the default):
+It can also be made executable to run stand-alone. Start by adding an interpreter line at the top (`#!`) with either the path to your installed bpftrace (/usr/local/bin is the default) or the path to `env` (usually just `/usr/bin/env`) followed by `bpftrace` (so it will find bpftrace in your `$PATH`):
 
 ```
      1	#!/usr/local/bin/bpftrace
+     1	#!/usr/bin/env bpftrace
      2	
      3	tracepoint:syscalls:sys_enter_nanosleep
      4	{

--- a/tools/bashreadline.bt
+++ b/tools/bashreadline.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * bashreadline    Print entered bash commands from all running shells.
  *                 For Linux, uses bpftrace and eBPF.

--- a/tools/biolatency.bt
+++ b/tools/biolatency.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * biolatency.bt	Block I/O latency as a histogram.
  *			For Linux, uses bpftrace, eBPF.

--- a/tools/biosnoop.bt
+++ b/tools/biosnoop.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * biosnoop.bt   Block I/O tracing tool, showing per I/O latency.
  *               For Linux, uses bpftrace, eBPF.

--- a/tools/bitesize.bt
+++ b/tools/bitesize.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * bitesize	Show disk I/O size as a histogram.
  *		For Linux, uses bpftrace and eBPF.

--- a/tools/capable.bt
+++ b/tools/capable.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * capable	Trace security capabilitiy checks (cap_capable()).
  *		For Linux, uses bpftrace and eBPF.

--- a/tools/cpuwalk.bt
+++ b/tools/cpuwalk.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * cpuwalk	Sample which CPUs are executing processes.
  *		For Linux, uses bpftrace and eBPF.

--- a/tools/dcsnoop.bt
+++ b/tools/dcsnoop.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * dcsnoop	Trace directory entry cache (dcache) lookups.
  *		For Linux, uses bpftrace and eBPF.

--- a/tools/execsnoop.bt
+++ b/tools/execsnoop.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * execsnoop.bt   Trace new processes via exec() syscalls.
  *                For Linux, uses bpftrace and eBPF.

--- a/tools/gethostlatency.bt
+++ b/tools/gethostlatency.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * gethostlatency	Trace getaddrinfo/gethostbyname[2] calls.
  *			For Linux, uses bpftrace and eBPF.

--- a/tools/killsnoop.bt
+++ b/tools/killsnoop.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * killsnoop	Trace signals issued by the kill() syscall.
  *		For Linux, uses bpftrace and eBPF.

--- a/tools/loads.bt
+++ b/tools/loads.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * loads	Prints load averages.
  *		For Linux, uses bpftrace and eBPF.

--- a/tools/mdflush.bt
+++ b/tools/mdflush.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * mdflush	Trace md flush events.
  *		For Linux, uses bpftrace and eBPF.

--- a/tools/oomkill.bt
+++ b/tools/oomkill.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * oomkill	Trace OOM killer.
  *		For Linux, uses bpftrace and eBPF.

--- a/tools/opensnoop.bt
+++ b/tools/opensnoop.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * opensnoop	Trace open() syscalls.
  *		For Linux, uses bpftrace and eBPF.

--- a/tools/pidpersec.bt
+++ b/tools/pidpersec.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * pidpersec	Count new procesess (via fork).
  *		For Linux, uses bpftrace and eBPF.

--- a/tools/runqlat.bt
+++ b/tools/runqlat.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * runqlat.bt	CPU scheduler run queue latency as a histogram.
  *		For Linux, uses bpftrace, eBPF.

--- a/tools/runqlen.bt
+++ b/tools/runqlen.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * runqlen.bt	CPU scheduler run queue length as a histogram.
  *		For Linux, uses bpftrace, eBPF.

--- a/tools/statsnoop.bt
+++ b/tools/statsnoop.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * statsnoop	Trace stat() syscalls.
  *		For Linux, uses bpftrace and eBPF.

--- a/tools/syncsnoop.bt
+++ b/tools/syncsnoop.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * syncsnoop	Trace sync() variety of syscalls.
  *		For Linux, uses bpftrace and eBPF.

--- a/tools/syscount.bt
+++ b/tools/syscount.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * syscount.bt	Count system callls.
  *		For Linux, uses bpftrace, eBPF.

--- a/tools/vfscount.bt
+++ b/tools/vfscount.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * vfscount	Count VFS calls ("vfs_*").
  *		For Linux, uses bpftrace and eBPF.

--- a/tools/vfsstat.bt
+++ b/tools/vfsstat.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * vfsstat	Count some VFS calls, with per-second summaries.
  *		For Linux, uses bpftrace and eBPF.

--- a/tools/writeback.bt
+++ b/tools/writeback.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * writeback	Trace file system writeback events with details.
  * 		For Linux, uses bpftrace and eBPF.

--- a/tools/xfsdist.bt
+++ b/tools/xfsdist.bt
@@ -1,4 +1,4 @@
-#!/usr/local/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * xfsdist	Summarize XFS operation latency.
  *		For Linux, uses bpftrace and eBPF.


### PR DESCRIPTION
So the scripts will work when bpftrace is installed elsewhere (for example in `/opt` or in `/home` or just `/usr/bin`).