### PR TITLE
Remove required semicolon at end of if statements

### DIFF
--- a/src/parser.yy
+++ b/src/parser.yy
@@ -164,8 +164,8 @@ ternary : expr QUES expr COLON expr { $$ = new ast::Ternary($1, $3, $5); }
 block : "{" stmts  "}" { $$ = $2; }
       ;
 
-stmts : stmts  stmt    { $$ = $1; $1->push_back($2); }
-      | stmt           { $$ = new ast::StatementList; $$->push_back($1); }
+stmts : stmts  stmt { $$ = $1; $1->push_back($2); }
+      | stmt        { $$ = new ast::StatementList; $$->push_back($1); }
       ;
 
 stmt : expr ";" { $$ = new ast::ExprStatement($1); }

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -161,17 +161,16 @@ pred : DIV expr ENDPRED { $$ = new ast::Predicate($2); }
 ternary : expr QUES expr COLON expr { $$ = new ast::Ternary($1, $3, $5); }
      ;
 
-block : "{" stmts "}"     { $$ = $2; }
-      | "{" stmts ";" "}" { $$ = $2; }
+block : "{" stmts  "}" { $$ = $2; }
       ;
 
-stmts : stmts ";" stmt { $$ = $1; $1->push_back($3); }
+stmts : stmts  stmt    { $$ = $1; $1->push_back($2); }
       | stmt           { $$ = new ast::StatementList; $$->push_back($1); }
       ;
 
-stmt : expr         { $$ = new ast::ExprStatement($1); }
-     | map "=" expr { $$ = new ast::AssignMapStatement($1, $3); }
-     | var "=" expr { $$ = new ast::AssignVarStatement($1, $3); }
+stmt : expr ";" { $$ = new ast::ExprStatement($1); }
+     | map "=" expr  ";" { $$ = new ast::AssignMapStatement($1, $3); }
+     | var "=" expr  ";" { $$ = new ast::AssignVarStatement($1, $3); }
      | IF "(" expr ")" block  { $$ = new ast::If($3, $5); }
      | IF "(" expr ")" block ELSE block { $$ = new ast::If($3, $5, $7); }
      | UNROLL "(" INT ")" block { $$ = new ast::Unroll($3, $5); }

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -23,25 +23,25 @@ void test(const std::string &input, const std::string &output)
 
 TEST(Parser, builtin_variables)
 {
-  test("kprobe:f { pid }", "Program\n kprobe:f\n  builtin: pid\n");
-  test("kprobe:f { tid }", "Program\n kprobe:f\n  builtin: tid\n");
-  test("kprobe:f { cgroup }", "Program\n kprobe:f\n  builtin: cgroup\n");
-  test("kprobe:f { uid }", "Program\n kprobe:f\n  builtin: uid\n");
-  test("kprobe:f { username }", "Program\n kprobe:f\n  builtin: username\n");
-  test("kprobe:f { gid }", "Program\n kprobe:f\n  builtin: gid\n");
-  test("kprobe:f { nsecs }", "Program\n kprobe:f\n  builtin: nsecs\n");
-  test("kprobe:f { cpu }", "Program\n kprobe:f\n  builtin: cpu\n");
-  test("kprobe:f { curtask }", "Program\n kprobe:f\n  builtin: curtask\n");
-  test("kprobe:f { rand }", "Program\n kprobe:f\n  builtin: rand\n");
-  test("kprobe:f { ctx }", "Program\n kprobe:f\n  builtin: ctx\n");
-  test("kprobe:f { comm }", "Program\n kprobe:f\n  builtin: comm\n");
-  test("kprobe:f { stack }", "Program\n kprobe:f\n  builtin: stack\n");
-  test("kprobe:f { ustack }", "Program\n kprobe:f\n  builtin: ustack\n");
-  test("kprobe:f { arg0 }", "Program\n kprobe:f\n  builtin: arg0\n");
-  test("kprobe:f { retval }", "Program\n kprobe:f\n  builtin: retval\n");
-  test("kprobe:f { func }", "Program\n kprobe:f\n  builtin: func\n");
-  test("kprobe:f { probe }", "Program\n kprobe:f\n  builtin: probe\n");
-  test("kprobe:f { args }", "Program\n kprobe:f\n  builtin: args\n");
+  test("kprobe:f { pid; }", "Program\n kprobe:f\n  builtin: pid\n");
+  test("kprobe:f { tid;}", "Program\n kprobe:f\n  builtin: tid\n");
+  test("kprobe:f { cgroup; }", "Program\n kprobe:f\n  builtin: cgroup\n");
+  test("kprobe:f { uid; }", "Program\n kprobe:f\n  builtin: uid\n");
+  test("kprobe:f { username; }", "Program\n kprobe:f\n  builtin: username\n");
+  test("kprobe:f { gid; }", "Program\n kprobe:f\n  builtin: gid\n");
+  test("kprobe:f { nsecs; }", "Program\n kprobe:f\n  builtin: nsecs\n");
+  test("kprobe:f { cpu; }", "Program\n kprobe:f\n  builtin: cpu\n");
+  test("kprobe:f { curtask; }", "Program\n kprobe:f\n  builtin: curtask\n");
+  test("kprobe:f { rand; }", "Program\n kprobe:f\n  builtin: rand\n");
+  test("kprobe:f { ctx; }", "Program\n kprobe:f\n  builtin: ctx\n");
+  test("kprobe:f { comm; }", "Program\n kprobe:f\n  builtin: comm\n");
+  test("kprobe:f { stack; }", "Program\n kprobe:f\n  builtin: stack\n");
+  test("kprobe:f { ustack; }", "Program\n kprobe:f\n  builtin: ustack\n");
+  test("kprobe:f { arg0; }", "Program\n kprobe:f\n  builtin: arg0\n");
+  test("kprobe:f { retval; }", "Program\n kprobe:f\n  builtin: retval\n");
+  test("kprobe:f { func; }", "Program\n kprobe:f\n  builtin: func\n");
+  test("kprobe:f { probe; }", "Program\n kprobe:f\n  builtin: probe\n");
+  test("kprobe:f { args; }", "Program\n kprobe:f\n  builtin: args\n");
 }
 
 TEST(Parser, map_assign)
@@ -105,7 +105,7 @@ TEST(Parser, map_assign)
       "   map: @x\n"
       "   call: stats\n"
       "    builtin: arg2\n");
-  test("kprobe:sys_open { @x = \"mystring\" }",
+  test("kprobe:sys_open { @x = \"mystring\"; }",
       "Program\n"
       " kprobe:sys_open\n"
       "  =\n"
@@ -251,7 +251,7 @@ TEST(Parser, expressions)
 
 TEST(Parser, bit_shifting)
 {
-  test("kprobe:do_nanosleep { @x = 1 << 10 }",
+  test("kprobe:do_nanosleep { @x = 1 << 10; }",
        "Program\n"
        " kprobe:do_nanosleep\n"
        "  =\n"
@@ -259,7 +259,7 @@ TEST(Parser, bit_shifting)
        "   <<\n"
        "    int: 1\n"
        "    int: 10\n");
-  test("kprobe:do_nanosleep { @x = 1024 >> 9 }",
+  test("kprobe:do_nanosleep { @x = 1024 >> 9; }",
        "Program\n"
        " kprobe:do_nanosleep\n"
        "  =\n"
@@ -267,7 +267,7 @@ TEST(Parser, bit_shifting)
        "   >>\n"
        "    int: 1024\n"
        "    int: 9\n");
-  test("kprobe:do_nanosleep / 2 < 1 >> 8 / { $x = 1 }",
+  test("kprobe:do_nanosleep / 2 < 1 >> 8 / { $x = 1; }",
        "Program\n"
        " kprobe:do_nanosleep\n"
        "  pred\n"
@@ -284,7 +284,7 @@ TEST(Parser, bit_shifting)
 
 TEST(Parser, ternary_int)
 {
-  test("kprobe:sys_open { @x = pid < 10000 ? 1 : 2 }",
+  test("kprobe:sys_open { @x = pid < 10000 ? 1 : 2; }",
        "Program\n"
        " kprobe:sys_open\n"
        "  =\n"
@@ -329,7 +329,7 @@ TEST(Parser, if_block_variable)
 
 TEST(Parser, if_else)
 {
-  test("kprobe:sys_open { if (pid > 10000) { $s = \"a\"; } else { $s= \"b\"; }; printf(\"%d is high\\n\", pid, $s); }",
+  test("kprobe:sys_open { if (pid > 10000) { $s = \"a\"; } else { $s= \"b\"; } printf(\"%d is high\\n\", pid, $s); }",
        "Program\n"
        " kprobe:sys_open\n"
        "  if\n"
@@ -371,7 +371,7 @@ TEST(Parser, unroll)
 
 TEST(Parser, ternary_str)
 {
-  test("kprobe:sys_open { @x = pid < 10000 ? \"lo\" : \"high\" }",
+  test("kprobe:sys_open { @x = pid < 10000 ? \"lo\" : \"high\"; }",
        "Program\n"
        " kprobe:sys_open\n"
        "  =\n"
@@ -386,7 +386,7 @@ TEST(Parser, ternary_str)
 
 TEST(Parser, ternary_nested)
 {
-  test("kprobe:sys_open { @x = pid < 10000 ? pid < 5000 ? 1 : 2 : 3 }",
+  test("kprobe:sys_open { @x = pid < 10000 ? pid < 5000 ? 1 : 2 : 3; }",
        "Program\n"
        " kprobe:sys_open\n"
        "  =\n"
@@ -424,7 +424,7 @@ TEST(Parser, call)
 
 TEST(Parser, call_unknown_function)
 {
-  test("kprobe:sys_open { myfunc() }",
+  test("kprobe:sys_open { myfunc(); }",
       "Program\n"
       " kprobe:sys_open\n"
       "  call: myfunc\n");
@@ -432,7 +432,7 @@ TEST(Parser, call_unknown_function)
 
 TEST(Parser, call_kaddr)
 {
-  test("kprobe:f { @ = kaddr(\"avenrun\") }",
+  test("kprobe:f { @ = kaddr(\"avenrun\"); }",
       "Program\n"
       " kprobe:f\n"
       "  =\n"
@@ -473,7 +473,7 @@ TEST(Parser, usdt)
 
 TEST(Parser, escape_chars)
 {
-  test("kprobe:sys_open { \"newline\\nand tab\\tbackslash\\\\quote\\\"here\" }",
+  test("kprobe:sys_open { \"newline\\nand tab\\tbackslash\\\\quote\\\"here\"; }",
       "Program\n"
       " kprobe:sys_open\n"
       "  string: newline\\nand tab\\tbackslash\\\\quote\\\"here\n");
@@ -481,7 +481,7 @@ TEST(Parser, escape_chars)
 
 TEST(Parser, begin_probe)
 {
-  test("BEGIN { 1 }",
+  test("BEGIN { 1; }",
       "Program\n"
       " BEGIN\n"
       "  int: 1\n");
@@ -489,7 +489,7 @@ TEST(Parser, begin_probe)
 
 TEST(Parser, tracepoint_probe)
 {
-  test("tracepoint:sched:sched_switch { 1 }",
+  test("tracepoint:sched:sched_switch { 1; }",
       "Program\n"
       " tracepoint:sched:sched_switch\n"
       "  int: 1\n");
@@ -497,7 +497,7 @@ TEST(Parser, tracepoint_probe)
 
 TEST(Parser, profile_probe)
 {
-  test("profile:ms:997 { 1 }",
+  test("profile:ms:997 { 1; }",
       "Program\n"
       " profile:ms:997\n"
       "  int: 1\n");
@@ -505,7 +505,7 @@ TEST(Parser, profile_probe)
 
 TEST(Parser, interval_probe)
 {
-  test("interval:s:1 { 1 }",
+  test("interval:s:1 { 1; }",
       "Program\n"
       " interval:s:1\n"
       "  int: 1\n");
@@ -513,7 +513,7 @@ TEST(Parser, interval_probe)
 
 TEST(Parser, software_probe)
 {
-  test("software:faults:1000 { 1 }",
+  test("software:faults:1000 { 1; }",
       "Program\n"
       " software:faults:1000\n"
       "  int: 1\n");
@@ -521,7 +521,7 @@ TEST(Parser, software_probe)
 
 TEST(Parser, hardware_probe)
 {
-  test("hardware:cache-references:1000000 { 1 }",
+  test("hardware:cache-references:1000000 { 1; }",
       "Program\n"
       " hardware:cache-references:1000000\n"
       "  int: 1\n");
@@ -529,7 +529,7 @@ TEST(Parser, hardware_probe)
 
 TEST(Parser, multiple_attach_points_kprobe)
 {
-  test("BEGIN,kprobe:sys_open,uprobe:/bin/sh:foo,tracepoint:syscalls:sys_enter_* { 1 }",
+  test("BEGIN,kprobe:sys_open,uprobe:/bin/sh:foo,tracepoint:syscalls:sys_enter_* { 1; }",
       "Program\n"
       " BEGIN\n"
       " kprobe:sys_open\n"
@@ -540,7 +540,7 @@ TEST(Parser, multiple_attach_points_kprobe)
 
 TEST(Parser, character_class_attach_point)
 {
-  test("kprobe:[Ss]y[Ss]_read { 1 }",
+  test("kprobe:[Ss]y[Ss]_read { 1; }",
       "Program\n"
       " kprobe:[Ss]y[Ss]_read\n"
       "  int: 1\n");
@@ -548,23 +548,23 @@ TEST(Parser, character_class_attach_point)
 
 TEST(Parser, wildcard_attach_points)
 {
-  test("kprobe:sys_* { 1 }",
+  test("kprobe:sys_* { 1; }",
       "Program\n"
       " kprobe:sys_*\n"
       "  int: 1\n");
-  test("kprobe:*blah { 1 }",
+  test("kprobe:*blah { 1; }",
       "Program\n"
       " kprobe:*blah\n"
       "  int: 1\n");
-  test("kprobe:sys*blah { 1 }",
+  test("kprobe:sys*blah { 1; }",
       "Program\n"
       " kprobe:sys*blah\n"
       "  int: 1\n");
-  test("kprobe:* { 1 }",
+  test("kprobe:* { 1; }",
       "Program\n"
       " kprobe:*\n"
       "  int: 1\n");
-  test("kprobe:sys_* { @x = cpu*retval }",
+  test("kprobe:sys_* { @x = cpu*retval; }",
       "Program\n"
       " kprobe:sys_*\n"
       "  =\n"
@@ -572,7 +572,7 @@ TEST(Parser, wildcard_attach_points)
       "   *\n"
       "    builtin: cpu\n"
       "    builtin: retval\n");
-  test("kprobe:sys_* { @x = *arg0 }",
+  test("kprobe:sys_* { @x = *arg0; }",
       "Program\n"
       " kprobe:sys_*\n"
       "  =\n"
@@ -583,7 +583,7 @@ TEST(Parser, wildcard_attach_points)
 
 TEST(Parser, short_map_name)
 {
-  test("kprobe:sys_read { @ = 1 }",
+  test("kprobe:sys_read { @ = 1; }",
       "Program\n"
       " kprobe:sys_read\n"
       "  =\n"
@@ -593,7 +593,7 @@ TEST(Parser, short_map_name)
 
 TEST(Parser, include)
 {
-  test("#include <stdio.h>\nkprobe:sys_read { @x = 1 }",
+  test("#include <stdio.h>\nkprobe:sys_read { @x = 1; }",
       "#include <stdio.h>\n"
       "\n"
       "Program\n"
@@ -605,7 +605,7 @@ TEST(Parser, include)
 
 TEST(Parser, include_quote)
 {
-  test("#include \"stdio.h\"\nkprobe:sys_read { @x = 1 }",
+  test("#include \"stdio.h\"\nkprobe:sys_read { @x = 1; }",
       "#include \"stdio.h\"\n"
       "\n"
       "Program\n"
@@ -617,7 +617,7 @@ TEST(Parser, include_quote)
 
 TEST(Parser, include_multiple)
 {
-  test("#include <stdio.h>\n#include \"blah\"\n#include <foo.h>\nkprobe:sys_read { @x = 1 }",
+  test("#include <stdio.h>\n#include \"blah\"\n#include <foo.h>\nkprobe:sys_read { @x = 1; }",
       "#include <stdio.h>\n"
       "#include \"blah\"\n"
       "#include <foo.h>\n"
@@ -631,7 +631,7 @@ TEST(Parser, include_multiple)
 
 TEST(Parser, brackets)
 {
-  test("kprobe:sys_read { (arg0*arg1) }",
+  test("kprobe:sys_read { (arg0*arg1); }",
       "Program\n"
       " kprobe:sys_read\n"
       "  *\n"
@@ -707,7 +707,7 @@ TEST(Parser, cast_precedence)
 
 TEST(Parser, dereference_precedence)
 {
-  test("kprobe:sys_read { *@x+1 }",
+  test("kprobe:sys_read { *@x+1; }",
       "Program\n"
       " kprobe:sys_read\n"
       "  +\n"
@@ -715,7 +715,7 @@ TEST(Parser, dereference_precedence)
       "    map: @x\n"
       "   int: 1\n");
 
-  test("kprobe:sys_read { *@x**@y }",
+  test("kprobe:sys_read { *@x**@y; }",
       "Program\n"
       " kprobe:sys_read\n"
       "  *\n"
@@ -724,7 +724,7 @@ TEST(Parser, dereference_precedence)
       "   dereference\n"
       "    map: @y\n");
 
-  test("kprobe:sys_read { *@x*@y }",
+  test("kprobe:sys_read { *@x*@y; }",
       "Program\n"
       " kprobe:sys_read\n"
       "  *\n"
@@ -732,7 +732,7 @@ TEST(Parser, dereference_precedence)
       "    map: @x\n"
       "   map: @y\n");
 
-  test("kprobe:sys_read { *@x.myfield }",
+  test("kprobe:sys_read { *@x.myfield; }",
       "Program\n"
       " kprobe:sys_read\n"
       "  dereference\n"

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -46,76 +46,76 @@ void test(const std::string &input, int expected_result=0)
 
 TEST(semantic_analyser, builtin_variables)
 {
-  test("kprobe:f { pid }", 0);
-  test("kprobe:f { tid }", 0);
-  test("kprobe:f { cgroup }", 0);
-  test("kprobe:f { uid }", 0);
-  test("kprobe:f { username }", 0);
-  test("kprobe:f { gid }", 0);
-  test("kprobe:f { nsecs }", 0);
-  test("kprobe:f { cpu }", 0);
-  test("kprobe:f { curtask }", 0);
-  test("kprobe:f { rand }", 0);
-  test("kprobe:f { ctx }", 0);
-  test("kprobe:f { comm }", 0);
-  test("kprobe:f { stack }", 0);
-  test("kprobe:f { ustack }", 0);
-  test("kprobe:f { arg0 }", 0);
-  test("kprobe:f { retval }", 0);
-  test("kprobe:f { func }", 0);
-  test("kprobe:f { probe }", 0);
-  test("tracepoint:a:b { args }", 0);
+  test("kprobe:f { pid; }", 0);
+  test("kprobe:f { tid; }", 0);
+  test("kprobe:f { cgroup; }", 0);
+  test("kprobe:f { uid; }", 0);
+  test("kprobe:f { username; }", 0);
+  test("kprobe:f { gid; }", 0);
+  test("kprobe:f { nsecs; }", 0);
+  test("kprobe:f { cpu; }", 0);
+  test("kprobe:f { curtask; }", 0);
+  test("kprobe:f { rand; }", 0);
+  test("kprobe:f { ctx; }", 0);
+  test("kprobe:f { comm; }", 0);
+  test("kprobe:f { stack; }", 0);
+  test("kprobe:f { ustack; }", 0);
+  test("kprobe:f { arg0; }", 0);
+  test("kprobe:f { retval; }", 0);
+  test("kprobe:f { func; }", 0);
+  test("kprobe:f { probe; }", 0);
+  test("tracepoint:a:b { args; }", 0);
 //  test("kprobe:f { fake }", 1);
 }
 
 TEST(semantic_analyser, builtin_functions)
 {
-  test("kprobe:f { @x = hist(123) }", 0);
-  test("kprobe:f { @x = count() }", 0);
-  test("kprobe:f { @x = sum(pid) }", 0);
-  test("kprobe:f { @x = min(pid) }", 0);
-  test("kprobe:f { @x = max(pid) }", 0);
-  test("kprobe:f { @x = avg(pid) }", 0);
-  test("kprobe:f { @x = stats(pid) }", 0);
-  test("kprobe:f { @x = 1; delete(@x) }", 0);
-  test("kprobe:f { @x = 1; print(@x) }", 0);
-  test("kprobe:f { @x = 1; clear(@x) }", 0);
-  test("kprobe:f { @x = 1; zero(@x) }", 0);
-  test("kprobe:f { time() }", 0);
-  test("kprobe:f { exit() }", 0);
-  test("kprobe:f { str(0xffff) }", 0);
-  test("kprobe:f { printf(\"hello\\n\") }", 0);
-  test("kprobe:f { system(\"ls\\n\") }", 0);
-  test("kprobe:f { join(0) }", 0);
-  test("kprobe:f { sym(0xffff) }", 0);
-  test("kprobe:f { usym(0xffff) }", 0);
-  test("kprobe:f { reg(\"ip\") }", 0);
-  test("kprobe:f { @x = count(pid) }", 1);
-  test("kprobe:f { @x = sum(pid, 123) }", 1);
-  test("kprobe:f { fake() }", 1);
+  test("kprobe:f { @x = hist(123); }", 0);
+  test("kprobe:f { @x = count(); }", 0);
+  test("kprobe:f { @x = sum(pid); }", 0);
+  test("kprobe:f { @x = min(pid); }", 0);
+  test("kprobe:f { @x = max(pid); }", 0);
+  test("kprobe:f { @x = avg(pid); }", 0);
+  test("kprobe:f { @x = stats(pid); }", 0);
+  test("kprobe:f { @x = 1; delete(@x); }", 0);
+  test("kprobe:f { @x = 1; print(@x); }", 0);
+  test("kprobe:f { @x = 1; clear(@x); }", 0);
+  test("kprobe:f { @x = 1; zero(@x); }", 0);
+  test("kprobe:f { time(); }", 0);
+  test("kprobe:f { exit(); }", 0);
+  test("kprobe:f { str(0xffff);}", 0);
+  test("kprobe:f { printf(\"hello\\n\");}", 0);
+  test("kprobe:f { system(\"ls\\n\"); }", 0);
+  test("kprobe:f { join(0); }", 0);
+  test("kprobe:f { sym(0xffff); }", 0);
+  test("kprobe:f { usym(0xffff); }", 0);
+  test("kprobe:f { reg(\"ip\"); }", 0);
+  test("kprobe:f { @x = count(pid); }", 1);
+  test("kprobe:f { @x = sum(pid, 123); }", 1);
+  test("kprobe:f { fake(); }", 1);
 }
 
 TEST(semantic_analyser, undefined_map)
 {
-  test("kprobe:f / @mymap == 123 / { @mymap = 0 }", 0);
+  test("kprobe:f / @mymap == 123 / { @mymap = 0; }", 0);
   test("kprobe:f / @mymap == 123 / { 456; }", 10);
   test("kprobe:f / @mymap1 == 1234 / { 1234; @mymap1 = @mymap2; }", 10);
 }
 
 TEST(semantic_analyser, predicate_expressions)
 {
-  test("kprobe:f / 999 / { 123 }", 0);
-  test("kprobe:f / \"str\" / { 123 }", 10);
-  test("kprobe:f / stack / { 123 }", 10);
-  test("kprobe:f / @mymap / { @mymap = \"str\" }", 10);
+  test("kprobe:f / 999 / { 123; }", 0);
+  test("kprobe:f / \"str\" / { 123; }", 10);
+  test("kprobe:f / stack / { 123; }", 10);
+  test("kprobe:f / @mymap / { @mymap = \"str\"; }", 10);
 }
 
 TEST(semantic_analyser, ternary_experssions)
 {
-  test("kprobe:f { @x = pid < 10000 ? 1 : 2 }", 0);
-  test("kprobe:f { @x = pid < 10000 ? \"lo\" : \"high\" }", 0);
-  test("kprobe:f { @x = pid < 10000 ? 1 : \"high\" }", 10);
-  test("kprobe:f { @x = pid < 10000 ? \"lo\" : 2 }", 10);
+  test("kprobe:f { @x = pid < 10000 ? 1 : 2 ;}", 0);
+  test("kprobe:f { @x = pid < 10000 ? \"lo\" : \"high\"; }", 0);
+  test("kprobe:f { @x = pid < 10000 ? 1 : \"high\"; }", 10);
+  test("kprobe:f { @x = pid < 10000 ? \"lo\" : 2; }", 10);
 }
 
 TEST(semantic_analyser, mismatched_call_types)
@@ -303,20 +303,20 @@ TEST(semantic_analyser, variable_use_before_assign)
 
 TEST(semantic_analyser, maps_are_global)
 {
-  test("kprobe:f { @x = 1 } kprobe:g { @y = @x }", 0);
-  test("kprobe:f { @x = 1 } kprobe:g { @x = \"abc\" }", 1);
+  test("kprobe:f { @x = 1; } kprobe:g { @y = @x; }", 0);
+  test("kprobe:f { @x = 1; } kprobe:g { @x = \"abc\"; }", 1);
 }
 
 TEST(semantic_analyser, variables_are_local)
 {
-  test("kprobe:f { $x = 1 } kprobe:g { $x = \"abc\"; }", 0);
-  test("kprobe:f { $x = 1 } kprobe:g { @y = $x }", 1);
+  test("kprobe:f { $x = 1; } kprobe:g { $x = \"abc\"; }", 0);
+  test("kprobe:f { $x = 1; } kprobe:g { @y = $x ;}", 1);
 }
 
 TEST(semantic_analyser, variable_type)
 {
   Driver driver;
-  test(driver, "kprobe:f { $x = 1 }", 0);
+  test(driver, "kprobe:f { $x = 1; }", 0);
   SizedType st(Type::integer, 8);
   auto assignment = static_cast<ast::AssignVarStatement*>(driver.root_->probes->at(0)->stmts->at(0));
   EXPECT_EQ(st, assignment->var->type);
@@ -359,178 +359,178 @@ TEST(semantic_analyser, unop_not)
 
 TEST(semantic_analyser, printf)
 {
-  test("kprobe:f { printf(\"hi\") }", 0);
-  test("kprobe:f { printf(1234) }", 1);
-  test("kprobe:f { printf() }", 1);
-  test("kprobe:f { $fmt = \"mystring\"; printf($fmt) }", 1);
-  test("kprobe:f { @x = printf(\"hi\") }", 1);
-  test("kprobe:f { $x = printf(\"hi\") }", 1);
+  test("kprobe:f { printf(\"hi\"); }", 0);
+  test("kprobe:f { printf(1234); }", 1);
+  test("kprobe:f { printf(); }", 1);
+  test("kprobe:f { $fmt = \"mystring\"; printf($fmt); }", 1);
+  test("kprobe:f { @x = printf(\"hi\"); }", 1);
+  test("kprobe:f { $x = printf(\"hi\"); }", 1);
 }
 
 TEST(semantic_analyser, system)
 {
-  test("kprobe:f { system(\"ls\") }", 0);
-  test("kprobe:f { system(1234) }", 1);
-  test("kprobe:f { system() }", 1);
-  test("kprobe:f { $fmt = \"mystring\"; system($fmt) }", 1);
+  test("kprobe:f { system(\"ls\"); }", 0);
+  test("kprobe:f { system(1234); }", 1);
+  test("kprobe:f { system(); }", 1);
+  test("kprobe:f { $fmt = \"mystring\"; system($fmt); }", 1);
 }
 
 TEST(semantic_analyser, printf_format_int)
 {
-  test("kprobe:f { printf(\"int: %d\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %d\", pid) }", 0);
-  test("kprobe:f { @x = 123; printf(\"int: %d\", @x) }", 0);
-  test("kprobe:f { $x = 123; printf(\"int: %d\", $x) }", 0);
+  test("kprobe:f { printf(\"int: %d\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %d\", pid); }", 0);
+  test("kprobe:f { @x = 123; printf(\"int: %d\", @x); }", 0);
+  test("kprobe:f { $x = 123; printf(\"int: %d\", $x); }", 0);
 
-  test("kprobe:f { printf(\"int: %u\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %x\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %X\", 1234) }", 0);
+  test("kprobe:f { printf(\"int: %u\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %x\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %X\", 1234); }", 0);
 }
 
 TEST(semantic_analyser, printf_format_int_with_length)
 {
-  test("kprobe:f { printf(\"int: %d\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %u\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %x\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %X\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %p\", 1234) }", 0);
+  test("kprobe:f { printf(\"int: %d\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %u\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %x\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %X\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %p\", 1234); }", 0);
 
-  test("kprobe:f { printf(\"int: %hhd\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %hhu\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %hhx\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %hhX\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %hhp\", 1234) }", 0);
+  test("kprobe:f { printf(\"int: %hhd\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %hhu\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %hhx\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %hhX\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %hhp\", 1234); }", 0);
 
-  test("kprobe:f { printf(\"int: %hd\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %hu\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %hx\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %hX\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %hp\", 1234) }", 0);
+  test("kprobe:f { printf(\"int: %hd\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %hu\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %hx\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %hX\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %hp\", 1234); }", 0);
 
-  test("kprobe:f { printf(\"int: %ld\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %lu\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %lx\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %lX\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %lp\", 1234) }", 0);
+  test("kprobe:f { printf(\"int: %ld\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %lu\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %lx\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %lX\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %lp\", 1234); }", 0);
 
-  test("kprobe:f { printf(\"int: %lld\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %llu\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %llx\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %llX\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %llp\", 1234) }", 0);
+  test("kprobe:f { printf(\"int: %lld\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %llu\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %llx\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %llX\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %llp\", 1234); }", 0);
 
-  test("kprobe:f { printf(\"int: %jd\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %ju\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %jx\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %jX\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %jp\", 1234) }", 0);
+  test("kprobe:f { printf(\"int: %jd\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %ju\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %jx\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %jX\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %jp\", 1234); }", 0);
 
-  test("kprobe:f { printf(\"int: %zd\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %zu\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %zx\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %zX\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %zp\", 1234) }", 0);
+  test("kprobe:f { printf(\"int: %zd\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %zu\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %zx\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %zX\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %zp\", 1234); }", 0);
 
-  test("kprobe:f { printf(\"int: %td\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %tu\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %tx\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %tX\", 1234) }", 0);
-  test("kprobe:f { printf(\"int: %tp\", 1234) }", 0);
+  test("kprobe:f { printf(\"int: %td\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %tu\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %tx\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %tX\", 1234); }", 0);
+  test("kprobe:f { printf(\"int: %tp\", 1234); }", 0);
 }
 
 TEST(semantic_analyser, printf_format_string)
 {
-  test("kprobe:f { printf(\"str: %s\", \"mystr\") }", 0);
-  test("kprobe:f { printf(\"str: %s\", comm) }", 0);
-  test("kprobe:f { printf(\"str: %s\", str(arg0)) }", 0);
-  test("kprobe:f { @x = \"hi\"; printf(\"str: %s\", @x) }", 0);
-  test("kprobe:f { $x = \"hi\"; printf(\"str: %s\", $x) }", 0);
+  test("kprobe:f { printf(\"str: %s\", \"mystr\"); }", 0);
+  test("kprobe:f { printf(\"str: %s\", comm); }", 0);
+  test("kprobe:f { printf(\"str: %s\", str(arg0)); }", 0);
+  test("kprobe:f { @x = \"hi\"; printf(\"str: %s\", @x); }", 0);
+  test("kprobe:f { $x = \"hi\"; printf(\"str: %s\", $x); }", 0);
 }
 
 TEST(semantic_analyser, printf_bad_format_string)
 {
-  test("kprobe:f { printf(\"%d\", \"mystr\") }", 10);
-  test("kprobe:f { printf(\"%d\", str(arg0)) }", 10);
+  test("kprobe:f { printf(\"%d\", \"mystr\"); }", 10);
+  test("kprobe:f { printf(\"%d\", str(arg0)); }", 10);
 
-  test("kprobe:f { printf(\"%s\", 1234) }", 10);
-  test("kprobe:f { printf(\"%s\", arg0) }", 10);
+  test("kprobe:f { printf(\"%s\", 1234); }", 10);
+  test("kprobe:f { printf(\"%s\", arg0); }", 10);
 }
 
 TEST(semantic_analyser, printf_format_multi)
 {
-  test("kprobe:f { printf(\"%d %d %s\", 1, 2, \"mystr\") }", 0);
-  test("kprobe:f { printf(\"%d %s %d\", 1, 2, \"mystr\") }", 10);
+  test("kprobe:f { printf(\"%d %d %s\", 1, 2, \"mystr\"); }", 0);
+  test("kprobe:f { printf(\"%d %s %d\", 1, 2, \"mystr\"); }", 10);
 }
 
 TEST(semantic_analyser, join)
 {
-  test("kprobe:f { join(arg0) }", 0);
-  test("kprobe:f { printf(\"%s\", join(arg0)) }", 10);
-  test("kprobe:f { join() }", 1);
-  test("kprobe:f { $fmt = \"mystring\"; join($fmt) }", 10);
-  test("kprobe:f { @x = join(arg0) }", 1);
-  test("kprobe:f { $x = join(arg0) }", 1);
+  test("kprobe:f { join(arg0); }", 0);
+  test("kprobe:f { printf(\"%s\", join(arg0)); }", 10);
+  test("kprobe:f { join(); }", 1);
+  test("kprobe:f { $fmt = \"mystring\"; join($fmt); }", 10);
+  test("kprobe:f { @x = join(arg0); }", 1);
+  test("kprobe:f { $x = join(arg0); }", 1);
 }
 
 TEST(semantic_analyser, kprobe)
 {
-  test("kprobe:f { 1 }", 0);
-  test("kprobe:path:f { 1 }", 1);
-  test("kprobe { 1 }", 1);
+  test("kprobe:f { 1; }", 0);
+  test("kprobe:path:f { 1; }", 1);
+  test("kprobe { 1; }", 1);
 
-  test("kretprobe:f { 1 }", 0);
-  test("kretprobe:path:f { 1 }", 1);
-  test("kretprobe { 1 }", 1);
+  test("kretprobe:f { 1; }", 0);
+  test("kretprobe:path:f { 1; }", 1);
+  test("kretprobe { 1; }", 1);
 }
 
 TEST(semantic_analyser, uprobe)
 {
-  test("uprobe:path:f { 1 }", 0);
-  test("uprobe:f { 1 }", 1);
-  test("uprobe { 1 }", 1);
+  test("uprobe:path:f { 1; }", 0);
+  test("uprobe:f { 1; }", 1);
+  test("uprobe { 1; }", 1);
 
-  test("uretprobe:path:f { 1 }", 0);
-  test("uretprobe:f { 1 }", 1);
-  test("uretprobe { 1 }", 1);
+  test("uretprobe:path:f { 1; }", 0);
+  test("uretprobe:f { 1; }", 1);
+  test("uretprobe { 1; }", 1);
 }
 
 TEST(semantic_analyser, usdt)
 {
-  test("usdt:/bin/sh:probe { 1 }", 0);
-  test("usdt:/notexistfile:probe { 1 }", 1);
-  test("usdt { 1 }", 1);
+  test("usdt:/bin/sh:probe { 1; }", 0);
+  test("usdt:/notexistfile:probe { 1; }", 1);
+  test("usdt { 1; }", 1);
 }
 
 TEST(semantic_analyser, begin_end_probes)
 {
-  test("BEGIN { 1 }", 0);
-  test("BEGIN:f { 1 }", 1);
-  test("BEGIN:path:f { 1 }", 1);
-  test("BEGIN { 1 } BEGIN { 2 }", 10);
+  test("BEGIN { 1; }", 0);
+  test("BEGIN:f { 1; }", 1);
+  test("BEGIN:path:f { 1; }", 1);
+  test("BEGIN { 1; } BEGIN { 2; }", 10);
 
-  test("END { 1 }", 0);
-  test("END:f { 1 }", 1);
-  test("END:path:f { 1 }", 1);
-  test("END { 1 } END { 2 }", 10);
+  test("END { 1; }", 0);
+  test("END:f { 1; }", 1);
+  test("END:path:f { 1; }", 1);
+  test("END { 1; } END { 2; }", 10);
 }
 
 TEST(semantic_analyser, tracepoint)
 {
-  test("tracepoint:category:event { 1 }", 0);
-  test("tracepoint:f { 1 }", 1);
-  test("tracepoint { 1 }", 1);
+  test("tracepoint:category:event { 1; }", 0);
+  test("tracepoint:f { 1; }", 1);
+  test("tracepoint { 1; }", 1);
 }
 
 TEST(semantic_analyser, profile)
 {
-  test("profile:hz:997 { 1 }", 0);
-  test("profile:s:10 { 1 }", 0);
-  test("profile:ms:100 { 1 }", 0);
-  test("profile:us:100 { 1 }", 0);
-  test("profile:ms:nan { 1 }", 1);
-  test("profile:unit:100 { 1 }", 1);
-  test("profile:f { 1 }", 1);
-  test("profile { 1 }", 1);
+  test("profile:hz:997 { 1; }", 0);
+  test("profile:s:10 { 1; }", 0);
+  test("profile:ms:100 { 1; }", 0);
+  test("profile:us:100 { 1; }", 0);
+  test("profile:ms:nan { 1; }", 1);
+  test("profile:unit:100 { 1; }", 1);
+  test("profile:f { 1; }", 1);
+  test("profile { 1; }", 1);
 }
 
 TEST(semantic_analyser, variable_cast_types)
@@ -550,40 +550,40 @@ TEST(semantic_analyser, map_cast_types)
 TEST(semantic_analyser, variable_casts_are_local)
 {
   std::string structs = "struct type1 { int field; } struct type2 { int field; }";
-  test(structs + "kprobe:f { $x = (type1)cpu } kprobe:g { $x = (type2)cpu; }", 0);
+  test(structs + "kprobe:f { $x = (type1)cpu; } kprobe:g { $x = (type2)cpu; }", 0);
 }
 
 TEST(semantic_analyser, map_casts_are_global)
 {
   std::string structs = "struct type1 { int field; } struct type2 { int field; }";
-  test(structs + "kprobe:f { @x = (type1)cpu } kprobe:g { @x = (type2)cpu; }", 1);
+  test(structs + "kprobe:f { @x = (type1)cpu; } kprobe:g { @x = (type2)cpu; }", 1);
 }
 
 TEST(semantic_analyser, cast_unknown_type)
 {
-  test("kprobe:f { (faketype)cpu }", 1);
+  test("kprobe:f { (faketype)cpu; }", 1);
 }
 
 TEST(semantic_analyser, field_access)
 {
   std::string structs = "struct type1 { int field; }";
-  test(structs + "kprobe:f { ((type1)cpu).field }", 0);
-  test(structs + "kprobe:f { $x = (type1)cpu; $x.field }", 0);
-  test(structs + "kprobe:f { @x = (type1)cpu; @x.field }", 0);
+  test(structs + "kprobe:f { ((type1)cpu).field; }", 0);
+  test(structs + "kprobe:f { $x = (type1)cpu; $x.field; }", 0);
+  test(structs + "kprobe:f { @x = (type1)cpu; @x.field; }", 0);
 }
 
 TEST(semantic_analyser, field_access_wrong_field)
 {
   std::string structs = "struct type1 { int field; }";
-  test(structs + "kprobe:f { ((type1)cpu).blah }", 1);
-  test(structs + "kprobe:f { $x = (type1)cpu; $x.blah }", 1);
-  test(structs + "kprobe:f { @x = (type1)cpu; @x.blah }", 1);
+  test(structs + "kprobe:f { ((type1)cpu).blah; }", 1);
+  test(structs + "kprobe:f { $x = (type1)cpu; $x.blah; }", 1);
+  test(structs + "kprobe:f { @x = (type1)cpu; @x.blah; }", 1);
 }
 
 TEST(semantic_analyser, field_access_wrong_expr)
 {
   std::string structs = "struct type1 { int field; }";
-  test(structs + "kprobe:f { 1234->field }", 10);
+  test(structs + "kprobe:f { 1234->field; }", 10);
 }
 
 TEST(semantic_analyser, field_access_types)
@@ -591,22 +591,22 @@ TEST(semantic_analyser, field_access_types)
   std::string structs = "struct type1 { int field; char mystr[8]; }"
                         "struct type2 { int field; }";
 
-  test(structs + "kprobe:f { ((type1)0).field == 123 }", 0);
-  test(structs + "kprobe:f { ((type1)0).field == \"abc\" }", 10);
+  test(structs + "kprobe:f { ((type1)0).field == 123; }", 0);
+  test(structs + "kprobe:f { ((type1)0).field == \"abc\"; }", 10);
 
-  test(structs + "kprobe:f { ((type1)0).mystr == \"abc\" }", 0);
-  test(structs + "kprobe:f { ((type1)0).mystr == 123 }", 10);
+  test(structs + "kprobe:f { ((type1)0).mystr == \"abc\"; }", 0);
+  test(structs + "kprobe:f { ((type1)0).mystr == 123; }", 10);
 
-  test(structs + "kprobe:f { ((type1)0).field == ((type2)0).field }", 0);
-  test(structs + "kprobe:f { ((type1)0).mystr == ((type2)0).field }", 10);
+  test(structs + "kprobe:f { ((type1)0).field == ((type2)0).field; }", 0);
+  test(structs + "kprobe:f { ((type1)0).mystr == ((type2)0).field; }", 10);
 }
 
 TEST(semantic_analyser, field_access_pointer)
 {
   std::string structs = "struct type1 { int field; }";
-  test(structs + "kprobe:f { ((type1*)0)->field }", 0);
-  test(structs + "kprobe:f { ((type1*)0).field }", 1);
-  test(structs + "kprobe:f { *((type1*)0) }", 0);
+  test(structs + "kprobe:f { ((type1*)0)->field; }", 0);
+  test(structs + "kprobe:f { ((type1*)0).field; }", 1);
+  test(structs + "kprobe:f { *((type1*)0); }", 0);
 }
 
 TEST(semantic_analyser, field_access_sub_struct)
@@ -614,12 +614,12 @@ TEST(semantic_analyser, field_access_sub_struct)
   std::string structs = "struct type1 { struct type2 *type2ptr; struct type2 type2; }"
                         "struct type2 { int field; }";
 
-  test(structs + "kprobe:f { ((type1)0).type2ptr->field }", 0);
-  test(structs + "kprobe:f { ((type1)0).type2.field }", 0);
-  test(structs + "kprobe:f { $x = (type2)0; $x = ((type1)0).type2 }", 0);
-  test(structs + "kprobe:f { $x = (type2*)0; $x = ((type1)0).type2ptr }", 0);
-  test(structs + "kprobe:f { $x = (type1)0; $x = ((type1)0).type2 }", 1);
-  test(structs + "kprobe:f { $x = (type1*)0; $x = ((type1)0).type2ptr }", 1);
+  test(structs + "kprobe:f { ((type1)0).type2ptr->field; }", 0);
+  test(structs + "kprobe:f { ((type1)0).type2.field; }", 0);
+  test(structs + "kprobe:f { $x = (type2)0; $x = ((type1)0).type2; }", 0);
+  test(structs + "kprobe:f { $x = (type2*)0; $x = ((type1)0).type2ptr; }", 0);
+  test(structs + "kprobe:f { $x = (type1)0; $x = ((type1)0).type2; }", 1);
+  test(structs + "kprobe:f { $x = (type1*)0; $x = ((type1)0).type2ptr; }", 1);
 }
 
 TEST(semantic_analyser, field_access_is_internal)
@@ -627,11 +627,11 @@ TEST(semantic_analyser, field_access_is_internal)
   Driver driver;
   std::string structs = "struct type1 { int x; }";
 
-  test(driver, structs + "kprobe:f { $x = ((type1)0).x }", 0);
+  test(driver, structs + "kprobe:f { $x = ((type1)0).x; }", 0);
   auto var_assignment1 = static_cast<ast::AssignVarStatement*>(driver.root_->probes->at(0)->stmts->at(0));
   EXPECT_EQ(false, var_assignment1->var->type.is_internal);
 
-  test(driver, structs + "kprobe:f { @type1 = (type1)0; $x = @type1.x }", 0);
+  test(driver, structs + "kprobe:f { @type1 = (type1)0; $x = @type1.x; }", 0);
   auto map_assignment = static_cast<ast::AssignMapStatement*>(driver.root_->probes->at(0)->stmts->at(0));
   auto var_assignment2 = static_cast<ast::AssignVarStatement*>(driver.root_->probes->at(0)->stmts->at(1));
   EXPECT_EQ(true, map_assignment->map->type.is_internal);
@@ -640,15 +640,15 @@ TEST(semantic_analyser, field_access_is_internal)
 
 TEST(semantic_analyser, probe_short_name)
 {
-  test("t:a:b { args }", 0);
-  test("k:f { pid }", 0);
-  test("kr:f { pid }", 0);
-  test("u:path:f { 1 }", 0);
-  test("ur:path:f { 1 }", 0);
-  test("p:hz:997 { 1 }", 0);
-  test("h:cache-references:1000000 { 1 }", 0);
-  test("s:faults:1000 { 1 }", 0);
-  test("i:s:1 { 1 }", 0);
+  test("t:a:b { args; }", 0);
+  test("k:f { pid; }", 0);
+  test("kr:f { pid; }", 0);
+  test("u:path:f { 1; }", 0);
+  test("ur:path:f { 1; }", 0);
+  test("p:hz:997 { 1; }", 0);
+  test("h:cache-references:1000000 { 1; }", 0);
+  test("s:faults:1000 { 1; }", 0);
+  test("i:s:1 { 1; }", 0);
 }
 
 } // namespace semantic_analyser

--- a/tools/runqlat.bt
+++ b/tools/runqlat.bt
@@ -33,12 +33,12 @@ tracepoint:sched:sched_switch
 	$TASK_RUNNING = 0;	// from linux/sched.h, workaround for #153
 	if (args->prev_state == $TASK_RUNNING) {
 		@qtime[args->prev_pid] = nsecs;
-	};
+	}
 
 	$ns = @qtime[args->next_pid];
 	if ($ns) {
 		@usecs = hist((nsecs - $ns) / 1000);
-	};
+	}
 	delete(@qtime[args->next_pid]);
 }
 


### PR DESCRIPTION
@brendangregg 

As discussed a couple of days ago, now semicolons are not needed at the end of if statements #192. 
Now expressions inside blocks must end with a semicolon, and I have updated the tests and tools to reflect this new rule.

 