### PR TITLE
Fix use after free and leak in get_arg_values

### DIFF
--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -11,6 +11,7 @@
 #include "ast.h"
 #include "attached_probe.h"
 #include "imap.h"
+#include "printf.h"
 #include "struct.h"
 #include "types.h"
 
@@ -66,7 +67,7 @@ public:
   uint64_t resolve_uname(const std::string &name, const std::string &path);
   std::string resolve_probe(uint64_t probe_id);
   uint64_t resolve_cgroupid(const std::string &path);
-  std::vector<uint64_t> get_arg_values(std::vector<Field> args, uint8_t* arg_data);
+  std::vector<std::unique_ptr<IPrintable>> get_arg_values(std::vector<Field> args, uint8_t* arg_data);
   int pid_;
 
   std::map<std::string, std::unique_ptr<IMap>> maps_;

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -63,4 +63,14 @@ std::string verify_format_string(const std::string &fmt, std::vector<Field> args
   return "";
 }
 
+uint64_t PrintableString::value()
+{
+  return (uint64_t)_value.c_str();
+}
+
+uint64_t PrintableInt::value()
+{
+  return _value;
+}
+
 } // namespace bpftrace

--- a/src/printf.h
+++ b/src/printf.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <sstream>
 
 #include "ast.h"
@@ -8,5 +10,31 @@ namespace bpftrace {
 struct Field;
 
 std::string verify_format_string(const std::string &fmt, std::vector<Field> args);
+
+class IPrintable
+{
+public:
+  virtual ~IPrintable() { };
+  virtual uint64_t value() = 0;
+};
+
+class PrintableString : public virtual IPrintable
+{
+public:
+  PrintableString(std::string value) : _value(value) { }
+  uint64_t value();
+private:
+  std::string _value;
+};
+
+class PrintableInt : public virtual IPrintable
+{
+public:
+  PrintableInt(uint64_t value) : _value(value) { }
+  uint64_t value();
+private:
+  uint64_t _value;
+};
+
 
 } // namespace bpftrace


### PR DESCRIPTION
Previously get_arg_values was returning a vector of uint64_t values
that could be passed directly to printf(3). For string values
get_arg_values was returning a pointer to a char*. For some cases it
was attempting to handle freeing the char* memory via a stack
allocated std::vector. Unfortunately, this was stack allocated in
get_arg_values so the char* data would get freed before it was used in
the subsequent call to printf().

In other cases get_arg_values was not freeing char* values and was
leaking memory (probe, stack, and ustack).

get_arg_values() now returns a vector of objects of type IPrintable
instead of uint64_t values. Each object has a method .value() that
returns the uint64_t value usable by printf(). For strings this allows
us to keep around the original std::string until after we've called
printf(), so we don't need to strdup() anymore.

Fixes #194