### PR TITLE
codegen: stack: allow for inter-tid stack aggregation

### DIFF
--- a/tests/codegen.cpp
+++ b/tests/codegen.cpp
@@ -364,21 +364,18 @@ define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_pid_tgid = tail call i64 inttoptr (i64 14 to i64 ()*)()
-  %1 = shl i64 %get_pid_tgid, 32
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %get_stackid = tail call i64 inttoptr (i64 27 to i64 (i8*, i8*, i64)*)(i8* %0, i64 %pseudo, i64 0)
-  %2 = or i64 %get_stackid, %1
-  %3 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %1 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 0, i64* %"@x_key", align 8
-  %4 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  store i64 %2, i64* %"@x_val", align 8
+  %2 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  store i64 %get_stackid, i64* %"@x_val", align 8
   %pseudo1 = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0
 }
 
@@ -404,11 +401,11 @@ define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_pid_tgid = tail call i64 inttoptr (i64 14 to i64 ()*)()
-  %1 = shl i64 %get_pid_tgid, 32
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %get_stackid = tail call i64 inttoptr (i64 27 to i64 (i8*, i8*, i64)*)(i8* %0, i64 %pseudo, i64 256)
-  %2 = or i64 %get_stackid, %1
+  %get_pid_tgid = tail call i64 inttoptr (i64 14 to i64 ()*)()
+  %1 = shl i64 %get_pid_tgid, 32
+  %2 = or i64 %1, %get_stackid
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8


### PR DESCRIPTION
User-space stacks are quite special in regards to aggregation (and
comparison) between processes. To a first approximation, each pid has a
different memory mapping and thus pointers should not be compared or
aggregated between pids[*]. With ASLR this becomes even more fun, and
thus it is necessary to do usym()-style packing of the stackid for
ustack (since bpf_get_stackid will give you a hash of the pointers --
even in the ustack case).

However, the kernel address space is the same regardless of current->pid
-- and in many cases you want to aggregate between different processes
(and if not, you can always do the packing yourself with @[tid,stack]).

So, we only apply the packing when dealing with ustack. sym() already
does the right thing.

[*] This is more than slightly untrue -- really this depends on
    current->mm and ideally we would aggregate ustack on current->mm.
    Unfortunately this is not a luxury we have at the moment.

Fixes #221
Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>