### PR TITLE
fix map keying with 1 or 2 byte integers (#232)

### DIFF
--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -61,10 +61,15 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
     case Type::integer:
       switch (arg.size)
       {
-        case 8:
-          return std::to_string(*(int64_t*)data);
+        case 1:
+          return std::to_string(*(int8_t*)data);
+        case 2:
+          return std::to_string(*(int16_t*)data);
         case 4:
           return std::to_string(*(int32_t*)data);
+        case 8:
+          return std::to_string(*(int64_t*)data);
+        break;
       }
     case Type::stack:
       return bpftrace.get_stack(*(uint64_t*)data, false);


### PR DESCRIPTION
As described in the original bug description, if you keyed a map with a 1 or 2 byte integer value then we segv'd. The reason being that we didn't handle the 1 or 2 byte case in`MapKey::argument_value()`. The proposed fix is simple and appears to validate OK.

The 2 byte case:

```
#  grep oom_score_adj /sys/kernel/debug/tracing/events/task/task_rename/format
        field:short oom_score_adj;      offset:44;      size:2; signed:1;

[ In another shell set it's 'oom_score_adj' to something non-zero]:

#  echo 256 /proc/$$/oom_score_adj
256 /proc/3641283/oom_score_adj

# bpftrace -e 'tracepoint:task:task_rename{@[args->oom_score_adj] = count();}'
Attaching 1 probe...
^C

@[0]: 62
@[256]: 296
```

The 1 byte case:

```
#  grep ip_summed /sys/kernel/debug/tracing/events/net/net_dev_start_xmit/format
        field:u8 ip_summed;     offset:32;      size:1; signed:0;

#  bpftrace -e 'tracepoint:net:net_dev_start_xmit{@[args->ip_summed] = count();}'
Attaching 1 probe...
^C

@[0]: 7
@[3]: 25929
```

I also ran the test suite (without the llvm tests as I'm running llvm-6) and everything passes.

NOTE: I added a `break` statement into the switch although we technically don't need it as we have all the byte values covered.  Having a final `break` statement is just a defensive measure as it saves pain in the future if code is re-arranged.