### PR TITLE
Invalid probenames

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <algorithm>
 
 #include "types.h"
 
@@ -53,24 +54,36 @@ std::string typestr(Type t)
   }
 }
 
-ProbeType probetype(const std::string &type)
+ProbeType probetype(const std::string &probeName)
 {
-  for (int i = 0; i < sizeof(PROBE_LIST); i++)
-  {
-    if (type == PROBE_LIST[i].name || type == PROBE_LIST[i].abbr)
-      return PROBE_LIST[i].type;
-  }
-  abort();
+  ProbeType retType = ProbeType::invalid;
+
+  auto v = std::find_if(PROBE_LIST.begin(), PROBE_LIST.end(),
+                          [&probeName] (const ProbeItem& p) {
+                            return (p.name == probeName ||
+                                   p.abbr == probeName);
+                         });
+
+  if (v != PROBE_LIST.end())
+    retType =  v->type;
+
+  return retType;
 }
 
-std::string probetypeName(const std::string &type)
+std::string probetypeName(const std::string &probeName)
 {
-  for (int i = 0; i < sizeof(PROBE_LIST); i++)
-  {
-    if (type == PROBE_LIST[i].name || type == PROBE_LIST[i].abbr)
-      return PROBE_LIST[i].name;
-  }
-  return type;
+  std::string res = probeName;
+
+  auto v = std::find_if(PROBE_LIST.begin(), PROBE_LIST.end(),
+                          [&probeName] (const ProbeItem& p) {
+                            return (p.name == probeName ||
+                                    p.abbr == probeName);
+                          });
+
+  if (v != PROBE_LIST.end())
+    res = v->name;
+
+  return res;
 }
 
 uint64_t asyncactionint(AsyncAction a)

--- a/src/types.h
+++ b/src/types.h
@@ -79,7 +79,7 @@ struct ProbeItem
   ProbeType type;
 };
 
-const ProbeItem PROBE_LIST[] =
+const std::vector<ProbeItem> PROBE_LIST =
 {
   { "kprobe", "k", ProbeType::kprobe },
   { "kretprobe", "kr", ProbeType::kretprobe },

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -417,6 +417,17 @@ TEST(bpftrace, add_probes_hardware)
   check_hardware(bpftrace.get_probes().at(0), "cache-references", 1000000, probe_orig_name);
 }
 
+TEST(bpftrace, invalid_provider)
+{
+  ast::AttachPoint a("lookatme", "invalid");
+  ast::AttachPointList attach_points = { &a };
+  ast::Probe probe(&attach_points, nullptr, nullptr);
+
+  StrictMock<MockBPFtrace> bpftrace;
+
+  EXPECT_EQ(0, bpftrace.add_probe(probe));
+}
+
 std::pair<std::vector<uint8_t>, std::vector<uint8_t>> key_value_pair_int(std::vector<uint64_t> key, int val)
 {
   std::pair<std::vector<uint8_t>, std::vector<uint8_t>> pair;


### PR DESCRIPTION
As per the issue description (#231), we currently segv if a probe description is provided with an unknown probe name. This change fixes that.

I've converted the `PROBE_LIST` array to be a `std::vector` and therefore we can be a bit more C++'esque when searching the vector. Instead of a 'for' loop to search  I use `std::find_if()` with a lambda.

I've added a test case and all tests pass with this change (including the new one!). I'm not too sure if anything else needed adding in to that new test so please advise if I need to check anything else but the return code.

New behaviour:

```
#  bpftrace -e 'bad:probe:name { exit(); }'
Invalid provider: 'bad'
```