### PR TITLE
Handle clang boolean type (CXType_Bool) in parser

### DIFF
--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -46,6 +46,7 @@ static SizedType get_sized_type(CXType clang_type)
 
   switch (clang_type.kind)
   {
+    case CXType_Bool:
     case CXType_Char_S:
     case CXType_Char_U:
     case CXType_SChar:


### PR DESCRIPTION
Symptoms and diagnosis are in issue #238 .

The fix is simple - just add the appropriate type so that we identify and size the type correctly. The example given in the issue description with the fix is:

```
# bpftrace -e 'tracepoint:net:net_dev_start_xmit{@[args->transport_offset_valid] = count();}'
Attaching 1 probe...
^C

@[1]: 1751
```

The test suite passes all tests.