### PR TITLE
[WIP] str() to accept optional length

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -347,6 +347,7 @@ void CodegenLLVM::visit(Call &call)
       // Value *len;
       // len_arg.accept(*this);
       // len = expr_;
+      // expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), false);
       // b_.CreateStore(expr_, strlen);
 
       // call.vargs->at(1)->accept(*this);
@@ -355,7 +356,8 @@ void CodegenLLVM::visit(Call &call)
       // b_.CreateProbeRead(b_.CreateGEP(strlen, {b_.getInt8(0), b_.getInt8(7)}), 1, expr_);
 
       call.vargs->at(1)->accept(*this);
-      b_.CreateStore(expr_, strlen);
+      b_.CreateStore(b_.CreateIntCast(expr_, b_.getInt64Ty(), false), strlen);
+      // b_.CreateStore(expr_, strlen);
 
       // b_.CreateStore(b_.CreateAdd(len, b_.getInt64(1)), strlen);
       // b_.CreateStore(b_.CreateGEP(len, b_.getInt64(0)), strlen);
@@ -380,7 +382,7 @@ void CodegenLLVM::visit(Call &call)
     call.vargs->front()->accept(*this);
     // b_.CreateProbeReadStr(buf, b_.CreateLoad(strlen), expr_);
     b_.CreateProbeReadStr(buf, b_.CreateLoad(strlen), expr_);
-    b_.CreateLifetimeEnd(strlen);
+    // b_.CreateLifetimeEnd(strlen);
     
     // call.vargs->at(1)->accept(*this);
     // expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), false); // promote int to 64-bit

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -330,9 +330,21 @@ void CodegenLLVM::visit(Call &call)
   else if (call.func == "str")
   {
     AllocaInst *buf = b_.CreateAllocaBPF(call.type, "str");
-    b_.CreateMemSet(buf, b_.getInt8(0), call.type.size, 1);
+
+    Integer &strlen_arg = static_cast<Integer&>(*call.vargs->at(1));
+    Value *strlen;
+    strlen_arg.accept(*this);
+    strlen = expr_;
+    strlen = b_.CreateIntCast(expr_, b_.getInt64Ty(), false); // promote int to 64-bit
+
+    // call.vargs->at(1)->accept(*this);
+    // expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), false); // promote int to 64-bit
+    b_.CreateMemSet(buf, b_.getInt8(0), b_.CreateAdd(strlen, b_.getInt64(1)), 1);
     call.vargs->front()->accept(*this);
     b_.CreateProbeReadStr(buf, call.type.size, expr_);
+    // call.vargs->at(1)->accept(*this);
+    // expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), false); // promote int to 64-bit
+    b_.CreateStore(b_.getInt8(0), b_.CreateGEP(buf, b_.CreateAdd(strlen, b_.getInt64(1))));
     expr_ = buf;
   }
   else if (call.func == "kaddr")

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -382,7 +382,7 @@ void CodegenLLVM::visit(Call &call)
     call.vargs->front()->accept(*this);
     // b_.CreateProbeReadStr(buf, b_.CreateLoad(strlen), expr_);
     b_.CreateProbeReadStr(buf, b_.CreateLoad(strlen), expr_);
-    // b_.CreateLifetimeEnd(strlen);
+    b_.CreateLifetimeEnd(strlen);
     
     // call.vargs->at(1)->accept(*this);
     // expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), false); // promote int to 64-bit

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -331,20 +331,24 @@ void CodegenLLVM::visit(Call &call)
   {
     AllocaInst *buf = b_.CreateAllocaBPF(call.type, "str");
 
-    Integer &strlen_arg = static_cast<Integer&>(*call.vargs->at(1));
-    Value *strlen;
-    strlen_arg.accept(*this);
-    strlen = expr_;
-    strlen = b_.CreateIntCast(expr_, b_.getInt64Ty(), false); // promote int to 64-bit
+    // Integer &strlen_arg = static_cast<Integer&>(*call.vargs->at(1));
+    // Value *strlen;
+    // strlen_arg.accept(*this);
+    // strlen = expr_;
+    // strlen = b_.CreateIntCast(expr_, b_.getInt64Ty(), false); // promote int to 64-bit
 
     // call.vargs->at(1)->accept(*this);
     // expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), false); // promote int to 64-bit
-    b_.CreateMemSet(buf, b_.getInt8(0), b_.CreateAdd(strlen, b_.getInt64(1)), 1);
+    
+    // b_.CreateMemSet(buf, b_.getInt8(0), b_.CreateAdd(strlen, b_.getInt64(1)), 1);
+    b_.CreateMemSet(buf, b_.getInt8(0), call.type.size+1, 1);
     call.vargs->front()->accept(*this);
     b_.CreateProbeReadStr(buf, call.type.size, expr_);
+    
     // call.vargs->at(1)->accept(*this);
     // expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), false); // promote int to 64-bit
-    b_.CreateStore(b_.getInt8(0), b_.CreateGEP(buf, b_.CreateAdd(strlen, b_.getInt64(1))));
+    
+    b_.CreateStore(b_.getInt8(0), b_.CreateGEP(buf, {b_.getInt64(0), b_.getInt8(call.type.size)}));
     expr_ = buf;
   }
   else if (call.func == "kaddr")

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -333,11 +333,15 @@ void CodegenLLVM::visit(Call &call)
     b_.CreateMemSet(strlen, b_.getInt64(0), sizeof(uint64_t), 1);
     if (call.vargs->size() > 1) {
       call.vargs->at(1)->accept(*this);
-      b_.CreateStore(b_.CreateIntCast(expr_, b_.getInt64Ty(), false), strlen);
+      b_.CreateStore(
+        b_.CreateAnd(
+          b_.CreateIntCast(expr_, b_.getInt64Ty(), false)
+          , 0xffffffff)
+        , strlen);
     } else {
       b_.CreateStore(b_.getInt64(STRING_SIZE), strlen);
     }
-    
+
     AllocaInst *buf = b_.CreateAllocaBPF(call.type, "str");
     b_.CreateMemSet(buf, b_.getInt8(0), call.type.size, 1);
     call.vargs->front()->accept(*this);

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -333,15 +333,11 @@ void CodegenLLVM::visit(Call &call)
     b_.CreateMemSet(strlen, b_.getInt64(0), sizeof(uint64_t), 1);
     if (call.vargs->size() > 1) {
       call.vargs->at(1)->accept(*this);
-      b_.CreateStore(
-        b_.CreateAnd(
-          b_.CreateIntCast(expr_, b_.getInt64Ty(), false)
-          , 0xffffffff)
-        , strlen);
+      b_.CreateStore(b_.CreateIntCast(expr_, b_.getInt64Ty(), false), strlen);
     } else {
       b_.CreateStore(b_.getInt64(STRING_SIZE), strlen);
     }
-
+    
     AllocaInst *buf = b_.CreateAllocaBPF(call.type, "str");
     b_.CreateMemSet(buf, b_.getInt8(0), call.type.size, 1);
     call.vargs->front()->accept(*this);

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -341,14 +341,14 @@ void CodegenLLVM::visit(Call &call)
     // expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), false); // promote int to 64-bit
     
     // b_.CreateMemSet(buf, b_.getInt8(0), b_.CreateAdd(strlen, b_.getInt64(1)), 1);
-    b_.CreateMemSet(buf, b_.getInt8(0), call.type.size+1, 1);
+    b_.CreateMemSet(buf, b_.getInt8(0), call.type.size, 1);
     call.vargs->front()->accept(*this);
     b_.CreateProbeReadStr(buf, call.type.size, expr_);
     
     // call.vargs->at(1)->accept(*this);
     // expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), false); // promote int to 64-bit
     
-    b_.CreateStore(b_.getInt8(0), b_.CreateGEP(buf, {b_.getInt64(0), b_.getInt8(call.type.size)}));
+    // b_.CreateStore(b_.getInt8(0), b_.CreateGEP(buf, {b_.getInt64(0), b_.getInt8(call.type.size)}));
     expr_ = buf;
   }
   else if (call.func == "kaddr")

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -333,7 +333,7 @@ void CodegenLLVM::visit(Call &call)
     b_.CreateMemSet(strlen, b_.getInt64(0), sizeof(uint64_t), 1);
     if (call.vargs->size() > 1) {
       call.vargs->at(1)->accept(*this);
-      b_.CreateStore(b_.CreateIntCast(expr_, b_.getInt64Ty(), false), strlen);
+      b_.CreateStore(b_.CreateAnd(expr_, 0x1fffffff), strlen);
     } else {
       b_.CreateStore(b_.getInt64(STRING_SIZE), strlen);
     }

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -268,6 +268,11 @@ void IRBuilderBPF::CreateProbeRead(AllocaInst *dst, size_t size, Value *src)
 
 CallInst *IRBuilderBPF::CreateProbeReadStr(AllocaInst *dst, size_t size, Value *src)
 {
+  return CreateProbeReadStr(dst, getInt64(size), src);
+}
+
+CallInst *IRBuilderBPF::CreateProbeReadStr(AllocaInst *dst, llvm::Value *size, Value *src)
+{
   // int bpf_probe_read_str(void *dst, int size, const void *unsafe_ptr)
   FunctionType *probereadstr_func_type = FunctionType::get(
       getInt64Ty(),
@@ -278,7 +283,7 @@ CallInst *IRBuilderBPF::CreateProbeReadStr(AllocaInst *dst, size_t size, Value *
       Instruction::IntToPtr,
       getInt64(BPF_FUNC_probe_read_str),
       probereadstr_func_ptr_type);
-  return CreateCall(probereadstr_func, {dst, getInt64(size), src}, "probe_read_str");
+  return CreateCall(probereadstr_func, {dst, size, src}, "probe_read_str");
 }
 
 CallInst *IRBuilderBPF::CreateProbeReadStr(Value *dst, size_t size, Value *src)

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -250,6 +250,22 @@ void IRBuilderBPF::CreateMapDeleteElem(Map &map, AllocaInst *key)
   CallInst *call = CreateCall(delete_func, {map_ptr, key}, "delete_elem");
 }
 
+void IRBuilderBPF::CreateProbeRead(Value *dst, size_t size, Value *src)
+{
+  // int bpf_probe_read(void *dst, int size, void *src)
+  // Return: 0 on success or negative error
+  FunctionType *proberead_func_type = FunctionType::get(
+      getInt64Ty(),
+      {getInt8PtrTy(), getInt64Ty(), getInt8PtrTy()},
+      false);
+  PointerType *proberead_func_ptr_type = PointerType::get(proberead_func_type, 0);
+  Constant *proberead_func = ConstantExpr::getCast(
+      Instruction::IntToPtr,
+      getInt64(BPF_FUNC_probe_read),
+      proberead_func_ptr_type);
+  CallInst *call = CreateCall(proberead_func, {dst, getInt64(size), src}, "probe_read");
+}
+
 void IRBuilderBPF::CreateProbeRead(AllocaInst *dst, size_t size, Value *src)
 {
   // int bpf_probe_read(void *dst, int size, void *src)

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -250,22 +250,6 @@ void IRBuilderBPF::CreateMapDeleteElem(Map &map, AllocaInst *key)
   CallInst *call = CreateCall(delete_func, {map_ptr, key}, "delete_elem");
 }
 
-void IRBuilderBPF::CreateProbeRead(Value *dst, size_t size, Value *src)
-{
-  // int bpf_probe_read(void *dst, int size, void *src)
-  // Return: 0 on success or negative error
-  FunctionType *proberead_func_type = FunctionType::get(
-      getInt64Ty(),
-      {getInt8PtrTy(), getInt64Ty(), getInt8PtrTy()},
-      false);
-  PointerType *proberead_func_ptr_type = PointerType::get(proberead_func_type, 0);
-  Constant *proberead_func = ConstantExpr::getCast(
-      Instruction::IntToPtr,
-      getInt64(BPF_FUNC_probe_read),
-      proberead_func_ptr_type);
-  CallInst *call = CreateCall(proberead_func, {dst, getInt64(size), src}, "probe_read");
-}
-
 void IRBuilderBPF::CreateProbeRead(AllocaInst *dst, size_t size, Value *src)
 {
   // int bpf_probe_read(void *dst, int size, void *src)

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -40,6 +40,7 @@ public:
   Value      *CreateMapLookupElem(Map &map, AllocaInst *key);
   void        CreateMapUpdateElem(Map &map, AllocaInst *key, Value *val);
   void        CreateMapDeleteElem(Map &map, AllocaInst *key);
+  void        CreateProbeRead(Value *dst, size_t size, Value *src);
   void        CreateProbeRead(AllocaInst *dst, size_t size, Value *src);
   CallInst   *CreateProbeReadStr(AllocaInst *dst, llvm::Value *size, Value *src);
   CallInst   *CreateProbeReadStr(AllocaInst *dst, size_t size, Value *src);

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -41,6 +41,7 @@ public:
   void        CreateMapUpdateElem(Map &map, AllocaInst *key, Value *val);
   void        CreateMapDeleteElem(Map &map, AllocaInst *key);
   void        CreateProbeRead(AllocaInst *dst, size_t size, Value *src);
+  CallInst   *CreateProbeReadStr(AllocaInst *dst, llvm::Value *size, Value *src);
   CallInst   *CreateProbeReadStr(AllocaInst *dst, size_t size, Value *src);
   CallInst   *CreateProbeReadStr(Value *dst, size_t size, Value *src);
   Value      *CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_point, int arg_name, Builtin &builtin);

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -40,7 +40,6 @@ public:
   Value      *CreateMapLookupElem(Map &map, AllocaInst *key);
   void        CreateMapUpdateElem(Map &map, AllocaInst *key, Value *val);
   void        CreateMapDeleteElem(Map &map, AllocaInst *key);
-  void        CreateProbeRead(Value *dst, size_t size, Value *src);
   void        CreateProbeRead(AllocaInst *dst, size_t size, Value *src);
   CallInst   *CreateProbeReadStr(AllocaInst *dst, llvm::Value *size, Value *src);
   CallInst   *CreateProbeReadStr(AllocaInst *dst, size_t size, Value *src);

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -208,7 +208,7 @@ void SemanticAnalyser::visit(Call &call)
       if (is_final_pass()) {
         int strlen = STRING_SIZE;
         if (call.vargs->size() > 1) {
-          check_arg(call, Type::integer, 1, true);
+          check_arg(call, Type::integer, 1, false);
           Expression &size_arg = *call.vargs->at(1);
           Integer &size = static_cast<Integer&>(size_arg);
           strlen = size.n;

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -202,13 +202,26 @@ void SemanticAnalyser::visit(Call &call)
 
     call.type = SizedType(Type::none, 0);
   }
-  else if (call.func == "str" || call.func == "sym" || call.func == "usym") {
+  else if (call.func == "str") {
+    if (check_varargs(call, 1, 2)) {
+      check_arg(call, Type::integer, 0);
+      if (is_final_pass()) {
+        int strlen = STRING_SIZE;
+        if (call.vargs->size() > 1) {
+          check_arg(call, Type::integer, 1, true);
+          Expression &size_arg = *call.vargs->at(1);
+          Integer &size = static_cast<Integer&>(size_arg);
+          strlen = size.n;
+        }
+        call.type = SizedType(Type::string, strlen);
+      }
+    }
+  }
+  else if (call.func == "sym" || call.func == "usym") {
     check_nargs(call, 1);
     check_arg(call, Type::integer, 0);
 
-    if (call.func == "str")
-      call.type = SizedType(Type::string, STRING_SIZE);
-    else if (call.func == "sym")
+    if (call.func == "sym")
       call.type = SizedType(Type::sym, 8);
     else if (call.func == "usym")
       call.type = SizedType(Type::usym, 16);

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -206,14 +206,10 @@ void SemanticAnalyser::visit(Call &call)
     if (check_varargs(call, 1, 2)) {
       check_arg(call, Type::integer, 0);
       if (is_final_pass()) {
-        int strlen = STRING_SIZE;
         if (call.vargs->size() > 1) {
           check_arg(call, Type::integer, 1, false);
-          // Expression &size_arg = *call.vargs->at(1);
-          // Integer &size = static_cast<Integer&>(size_arg);
-          // strlen = size.n+1;
         }
-        call.type = SizedType(Type::string, strlen);
+        call.type = SizedType(Type::string, STRING_SIZE);
       }
     }
   }

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -209,9 +209,9 @@ void SemanticAnalyser::visit(Call &call)
         int strlen = STRING_SIZE;
         if (call.vargs->size() > 1) {
           check_arg(call, Type::integer, 1, false);
-          Expression &size_arg = *call.vargs->at(1);
-          Integer &size = static_cast<Integer&>(size_arg);
-          strlen = size.n;
+          // Expression &size_arg = *call.vargs->at(1);
+          // Integer &size = static_cast<Integer&>(size_arg);
+          // strlen = size.n+1;
         }
         call.type = SizedType(Type::string, strlen);
       }


### PR DESCRIPTION
Intended to fulfil https://github.com/iovisor/bpftrace/issues/199.  
It's pretty close to working, but I think I need to ask for help at this point.

Integer literals work:

```bash
bpftrace -e 'tracepoint:syscalls:sys_enter_write /pid == 23506/ { printf("<%s>\n", str(args->buf, 2));  }'
# type pwd into a terminal
<p>
<w>
<d>
# it printed 1 character instead of the 2 we requested; probably probe_read_str replaces final byte with a NULL. fixable.
```

But it doesn't seem to be able to use items from structs (e.g. `args->count`):

```bash
sudo bpftrace -e 'tracepoint:syscalls:sys_enter_write /pid == 6034/ { printf("<%s>\n", str(args->buf, args->count)); }'
Attaching 1 probe...
Error loading program: tracepoint:syscalls:sys_enter_write (try -v)
```

[The verbose output](https://gist.github.com/Birch-san/010ada4873e646a11b6a3c2bbfcc0d88) shows the error:

```
R2 min value is negative, either use unsigned or 'var &= const'
````

I think R2 is the size arg to `bpf_probe_read_str(void *dst, int size, const void *unsafe_ptr)`.  
I think it wants me to prove that the size will always be positive.

This is despite the fact that I've already cast it to a 64-bit _unsigned_:

```c++
b_.CreateStore(
  b_.CreateIntCast(expr_, b_.getInt64Ty(), false),
  strlen);
```

I also tried using a bitmask:

```c++
b_.CreateStore(
  b_.CreateAnd(
    b_.CreateIntCast(expr_, b_.getInt64Ty(), false),
    0xffffffff),
  strlen);
```

The bitmask changed the error to:

```
R2 unbounded memory access, use 'var &= const' or 'if (var < const)'
```

I also tried using CreateMaxNum():

```c++
b_.CreateStore(
  b_.CreateMaxNum(
    b_.getInt64(0),
    b_.CreateIntCast(expr_, b_.getInt64Ty(), false),
    "ensure_positive"),
  strlen);
```

CreateMaxNum() changed the error to:

```
Segmentation fault
```

I also tried using a condition:

```c++
call.vargs->at(1)->accept(*this);
Value *len_u64 = b_.CreateIntCast(expr_, b_.getInt64Ty(), false);

Function *parent = b_.GetInsertBlock()->getParent();
BasicBlock *positive = BasicBlock::Create(module_->getContext(), "positive", parent);
BasicBlock *negative = BasicBlock::Create(module_->getContext(), "negative", parent);
BasicBlock *done = BasicBlock::Create(module_->getContext(), "done", parent);
b_.CreateCondBr(
  b_.CreateICmpUGE(len_u64, b_.getInt64(0), "if_positive"),
  positive,
  negative);

b_.SetInsertPoint(positive);
b_.CreateStore(len_u64, strlen);
b_.CreateBr(done);

b_.SetInsertPoint(negative);
b_.CreateStore(b_.getInt64(1), strlen);
b_.CreateBr(done);

b_.SetInsertPoint(done);
```

But this resulted in the same:

```
R2 min value is negative, either use unsigned or 'var &= const'
```

Does anybody here have any ideas on how to overcome this error?