### PR TITLE
Fix possible crash on exit due to wrong vector size (#201)

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1157,7 +1157,7 @@ std::vector<uint8_t> BPFtrace::find_empty_key(IMap &map, size_t size) const
   if (map.type_.type == Type::count || map.type_.type == Type::hist ||
       map.type_.type == Type::sum || map.type_.type == Type::min ||
       map.type_.type == Type::max || map.type_.type == Type::avg ||
-      map.type_.type == Type::stats)
+      map.type_.type == Type::stats || map.type_.type == Type::lhist)
     value_size *= ncpus_;
   auto value = std::vector<uint8_t>(value_size);
 


### PR DESCRIPTION
On method BPFtrace::find_empty_key() size of 'value' vector (value_size)
must be multiplied by ncpus_ when map.type_.type == Type::lhist
otherwise bpf syscall (BPF_MAP_LOOKUP_ELEM) will write out of bounds
thus corrupting the heap.