### PR TITLE
Attempt to correctly handle indirect struct fields

### DIFF
--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -57,7 +57,7 @@ static std::string get_parent_struct_name(CXCursor c)
 
 static int get_indirect_field_offset(CXCursor c)
 {
-  int offset=0;
+  int offset = 0;
   CXCursor parent = get_indirect_field_parent_struct(c);
   auto ident = get_clang_string(clang_getCursorSpelling(c));
   offset = clang_Type_getOffsetOf(clang_getCursorType(parent), ident.c_str()) / 8;

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -188,6 +188,40 @@ TEST(clang_parser, nested_struct_anon)
   EXPECT_EQ(structs["Foo"].fields["bar"].offset, 0);
 }
 
+TEST(clang_parser, nested_struct_indirect_fields)
+{
+  StructMap structs;
+  parse("struct Foo { struct { int x; int y;}; int a; struct { int z; }; }", structs);
+
+  ASSERT_EQ(structs["Foo"].fields.size(), 4);
+  EXPECT_EQ(structs["Foo"].fields["x"].offset, 0);
+  EXPECT_EQ(structs["Foo"].fields["x"].type.size, 4);
+  EXPECT_EQ(structs["Foo"].fields["y"].offset, 4);
+  EXPECT_EQ(structs["Foo"].fields["y"].type.size, 4);
+  EXPECT_EQ(structs["Foo"].fields["a"].offset, 8);
+  EXPECT_EQ(structs["Foo"].fields["a"].type.size, 4);
+  EXPECT_EQ(structs["Foo"].fields["z"].offset, 12);
+  EXPECT_EQ(structs["Foo"].fields["z"].type.size, 4);
+}
+
+TEST(clang_parser, nested_struct_anon_union_struct)
+{
+  StructMap structs;
+  parse("struct Foo { union { long long _xy; struct { int x; int y;}; }; int a; struct { int z; }; }", structs);
+
+  ASSERT_EQ(structs["Foo"].fields.size(), 5);
+  EXPECT_EQ(structs["Foo"].fields["_xy"].offset, 0);
+  EXPECT_EQ(structs["Foo"].fields["_xy"].type.size, 8);
+  EXPECT_EQ(structs["Foo"].fields["x"].offset, 0);
+  EXPECT_EQ(structs["Foo"].fields["x"].type.size, 4);
+  EXPECT_EQ(structs["Foo"].fields["y"].offset, 4);
+  EXPECT_EQ(structs["Foo"].fields["y"].type.size, 4);
+  EXPECT_EQ(structs["Foo"].fields["a"].offset, 8);
+  EXPECT_EQ(structs["Foo"].fields["a"].type.size, 4);
+  EXPECT_EQ(structs["Foo"].fields["z"].offset, 12);
+  EXPECT_EQ(structs["Foo"].fields["z"].type.size, 4);
+}
+
 TEST(clang_parser, builtin_headers)
 {
   // size_t is definied in stddef.h


### PR DESCRIPTION
This is my WIP attempt to fix https://github.com/iovisor/bpftrace/issues/257, in the hopes of eventually fixing https://github.com/iovisor/bpftrace/issues/245. This is not ready to be merged, I'm putting this up mostly to share my work so far in the hopes that a review will shine some light on the proper solution to this problem

The root issue is the first one, which is that members of anonymous structs are not recognized. This is because of two problems:

1. These indirect fields are never recognized as fields of the struct in the first place
2. The offsets of these indirect fields would be incorrectly calculated if they were recognized, as they are taken relative to the field's direct parent (an anonymous struct or union) rather than to the struct whom they are indirect members of.

To fix problem one:

LLVM refers to members of an anonymous struct as "indirect fields". Indirect fields are not detected by the present implementation of struct parsing in bpftrace, as their parent will be an anonymous struct, so they will not be added as to the list of fields in the `structs_` hash. To fix this, I created `parse_anonymous_struct_name`, which will derive the name of the struct for on whom the indirect field exists. The existing solution is fragile, and I know already of some cases where it doesn't work. I believe however that this solution could be iterated upon.

To fix problem two:

I read through LLVM docs and source code, and found that the function `clang_Type_getOffsetOf` can be used to correctly determine the offsets of indirect fields, by manually specifying the struct type for whom they are indirect fields on (rather than their direct semantic parent). 

To do this, I walk the semantic ancestry of the cursor until I find the parent cursor, determine it's type, and take the offsets relative to that. In my test case, these offsets match what I would expect them to be when I compute them manually based on their sizes.

# Additional work

Before investing additional time in refining this solution, I'd like to see if this approach makes sense. If it does, then the major problems to overcome will be:

- `parse_anonymous_struct_name` will need to be more robust at converting to the name of the struct or union that actually contains the indirect fields.
- `indirect_field_offset` seems to produce the correct offsets, but when I attempt to `printf` the hex representation of the binary data stored at these offsets (by referencing the indirect field), the data that I get simply doesn't make sense, and doesn't match what similar scripts in iovisor/bcc produce. I suspect that even though these offsets are correct, there is a step somewhere that I've missed where retrieving the values of these indirect fields is incorrect. It might be that my approach is broken, and I need to find the address of the direct semantic parent for the indirect fields and compute offsets relative to that, but I've yet to confirm this.

@ajor sorry for yet another ping, but hopefully having some code will help to frame the issue described in https://github.com/iovisor/bpftrace/issues/257