### PR TITLE
Initial inet_ntop implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,7 @@ Functions:
 - `clear(@x)` - Delete all key/values from a map
 - `sym(void *p)` - Resolve kernel address
 - `usym(void *p)` - Resolve user space address
+- `ntop(int af, int addr)` - Resolve ip address
 - `kaddr(char *name)` - Resolve kernel symbol name
 - `uaddr(char *name)` - Resolve user space symbol name
 - `reg(char *name)` - Returns the value stored in the named register

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -59,6 +59,7 @@ This is a work in progress. If something is missing, check the bpftrace source t
     - [11. `system()`: System](#11-system-system)
     - [12. `exit()`: Exit](#12-exit-exit)
     - [13. `cgroupid()`: Resolve cgroup ID](#13-cgroupid-resolve-cgroup-id)
+    - [14. `ntop()`: Convert IP address data to text](#14-ntop-convert-ip-address-data-to-text)
 - [Map Functions](#map-functions)
     - [1. Builtins](#1-builtins-2)
     - [2. `count()`: Count](#2-count-count)
@@ -1384,6 +1385,40 @@ And in other terminal:
 ```
 # echo $$ > /sys/fs/cgroup/unified/mycg/cgroup.procs
 # cat /etc/shadow
+```
+
+## 14. `ntop`: Convert IP address data to text
+
+Syntax: `ntop(int af, int addr)`
+
+This returns the string representation of an IPv4 address. IPv6 support will be added in the future.
+
+Examples:
+
+A simple example of ntop with an ipv4 hex-encoded literal:
+
+```
+bpftrace -e 'BEGIN { $addr_type=2; printf("%s\n", ntop($addr_type, 0x0100007f));}'
+127.0.0.1
+^C
+```
+
+Note that the literal `2` above is the value of the enum `AF_INET`, and `10` would indicate `AF_INET6` once supported, as per `include/linux/socket.h`.
+
+A less trivial example of this usage, tracing tcp outbound connections, and printing the destination address:
+
+```
+bpftrace -e '#include <net/sock.h>
+kprobe:tcp_connect { $sk = ((sock *) arg0); printf("%s\n", ntop(2, $sk->__sk_common.skc_daddr)); }'
+Attaching 1 probe...
+169.254.0.1
+^C
+```
+
+And initiate a connection to this (or any) address in another terminal:
+
+```
+curl 169.254.0.1
 ```
 
 # Map Functions

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -213,6 +213,16 @@ void SemanticAnalyser::visit(Call &call)
     else if (call.func == "usym")
       call.type = SizedType(Type::usym, 16);
   }
+  else if (call.func == "ntop") {
+    check_nargs(call, 2);
+    check_arg(call, Type::integer, 0);
+    check_arg(call, Type::integer, 1);
+    // 3 x 64 bit words are needed, hence 24 bytes
+    //  0 - To store address family, but stay word-aligned
+    //  1 - To store ipv4 or first half of ipv6
+    //  2 - Reserved for future use, to store remainder of ipv6
+    call.type = SizedType(Type::inet, 24);
+  }
   else if (call.func == "join") {
     check_assignment(call, false, false);
     check_nargs(call, 1);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -61,6 +61,7 @@ public:
   std::string get_stack(uint64_t stackidpid, bool ustack, int indent=0);
   std::string resolve_sym(uintptr_t addr, bool show_offset=false);
   std::string resolve_usym(uintptr_t addr, int pid, bool show_offset=false);
+  std::string resolve_inet(int af, uint64_t inet);
   std::string resolve_uid(uintptr_t addr);
   uint64_t resolve_kname(const std::string &name);
   uint64_t resolve_uname(const std::string &name, const std::string &path);

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -79,6 +79,8 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
       return bpftrace.resolve_sym(*(uint64_t*)data);
     case Type::usym:
       return bpftrace.resolve_usym(*(uint64_t*)data, *(uint64_t*)(arg_data + 8));
+    case Type::inet:
+      return bpftrace.resolve_inet(*(uint64_t*)data, *(uint64_t*)(arg_data + 8));
     case Type::username:
       return bpftrace.resolve_uid(*(uint64_t*)data);
     case Type::probe:

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -34,7 +34,8 @@ std::string verify_format_string(const std::string &fmt, std::vector<Field> args
   {
     Type arg_type = args.at(i).type.type;
     if (arg_type == Type::sym || arg_type == Type::usym || arg_type == Type::probe ||
-        arg_type == Type::username || arg_type == Type::stack || arg_type == Type::ustack)
+        arg_type == Type::username || arg_type == Type::stack || arg_type == Type::ustack ||
+        arg_type == Type::inet)
       arg_type = Type::string; // Symbols should be printed as strings
     int offset = 1;
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -26,7 +26,7 @@ bool SizedType::operator==(const SizedType &t) const
 
 bool SizedType::IsArray() const
 {
-  return type == Type::string || type == Type::usym || (type == Type::cast && !is_pointer);
+  return type == Type::string || type == Type::usym || type == Type::inet || (type == Type::cast && !is_pointer);
 }
 
 std::string typestr(Type t)
@@ -48,6 +48,7 @@ std::string typestr(Type t)
     case Type::string:   return "string";   break;
     case Type::sym:      return "sym";      break;
     case Type::usym:     return "usym";     break;
+    case Type::inet:     return "inet";     break;
     case Type::cast:     return "cast";     break;
     case Type::probe:    return "probe";    break;
     default: abort();

--- a/src/types.h
+++ b/src/types.h
@@ -33,6 +33,7 @@ enum class Type
   join,
   probe,
   username,
+  inet,
 };
 
 std::ostream &operator<<(std::ostream &os, Type type);

--- a/tests/codegen/call_ntop_key.cpp
+++ b/tests/codegen/call_ntop_key.cpp
@@ -1,0 +1,63 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, call_usym_key)
+{
+  test("kprobe:f { @x[ntop(2, 0xFFFFFFFF)] = count()}",
+
+R"EXPECTED(; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
+entry:
+  %"@x_val" = alloca i64, align 8
+  %"@x_key" = alloca [24 x i8], align 8
+  %1 = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  %inet.sroa.0.0..sroa_cast = bitcast [24 x i8]* %"@x_key" to i64*
+  store i64 2, i64* %inet.sroa.0.0..sroa_cast, align 8
+  %inet.sroa.4.0..sroa_idx = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 8
+  %inet.sroa.4.0..sroa_cast = bitcast i8* %inet.sroa.4.0..sroa_idx to i64*
+  store i64 4294967295, i64* %inet.sroa.4.0..sroa_cast, align 8
+  %inet.sroa.5.0..sroa_idx = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 16
+  %inet.sroa.5.0..sroa_cast = bitcast i8* %inet.sroa.5.0..sroa_idx to i64*
+  store i64 0, i64* %inet.sroa.5.0..sroa_cast, align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [24 x i8]* nonnull %"@x_key")
+  %map_lookup_cond = icmp eq i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
+
+lookup_success:                                   ; preds = %entry
+  %2 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %2, 1
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %entry, %lookup_success
+  %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
+  %3 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [24 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -89,6 +89,7 @@ TEST(semantic_analyser, builtin_functions)
   test("kprobe:f { join(0) }", 0);
   test("kprobe:f { sym(0xffff) }", 0);
   test("kprobe:f { usym(0xffff) }", 0);
+  test("kprobe:f { ntop(2, 0xffff) }", 0);
   test("kprobe:f { reg(\"ip\") }", 0);
   test("kprobe:f { @x = count(pid) }", 1);
   test("kprobe:f { @x = sum(pid, 123) }", 1);
@@ -242,6 +243,15 @@ TEST(semantic_analyser, call_usym)
   test("kprobe:f { @x = usym(arg0); }", 0);
   test("kprobe:f { usym(); }", 1);
   test("kprobe:f { usym(\"hello\"); }", 10);
+}
+
+TEST(semantic_analyser, call_ntop)
+{
+  test("kprobe:f { ntop(2, arg0); }", 0);
+  test("kprobe:f { @x = ntop(2, arg0); }", 0);
+  test("kprobe:f { @x = ntop(2, 0xFFFF); }", 0);
+  test("kprobe:f { ntop(); }", 1);
+  test("kprobe:f { ntop(2, \"hello\"); }", 10);
 }
 
 TEST(semantic_analyser, call_kaddr)


### PR DESCRIPTION
This is ready for review.

I have implemented `ntop` as described in #30, but with a few limitations:

* Only ipv4 addresses are supported. The main reason ipv6 addresses aren't supported is that there is no way to pass them in right now, is they are stored as a 4x32 bit array in kernel, and there is no way to assign this type to a variable in bpftrace in order to pass it in
* The constants `AF_INET` and `AF_INET6` would need to be added as builtin idents to bpftrace, in order to specify them as the first argument, as the `#define` macros from the kernel headers won't be pulled in as any sort of usable variable (and probably shouldn't). We could define them builtin idents pretty easily using a similar approach to `nsecs`, but for now you must specify the literal 2 for AF_INET, and the literal 10 for (currently unsupported) AF_INET6

The current way to use this function is as so:

```
./bpftrace -e 'BEGIN{ printf("%s\n", ntop(2, 0xFFFFFFFF)); }'
Attaching 1 probe...
255.255.255.255
```

* [x] ~Add tests for printing ipv4 addresses~ this sort of functional test would require a new test harness, not sure if worth the effort. I added what tests I could
* [x] Add map support to be able to use ipv4 addresses in map logic
* [x] ~Codegen tests should probably be added, but test suit is failing... #187 ~ Added for use as map key, but nothing else.
* [x] Write llvm IR to copy bytes to userspace buffer properly