### PR TITLE
List tracepoints when search expression is empty (#270)

### DIFF
--- a/src/list.cpp
+++ b/src/list.cpp
@@ -90,8 +90,13 @@ void list_probes(const std::string &search)
       if (events[j] == "." || events[j] == ".." || events[j] == "enable" || events[j] == "filter")
         continue;
       probe = "tracepoint:" + cats[i] + ":" + events[j];
-      if (search_probe(probe, search))
-        continue;
+
+      if (!search.empty())
+      {
+        if (search_probe(probe, search))
+          continue;
+      }
+
       std::cout << probe << std::endl;
     }
   }


### PR DESCRIPTION
The 'bpftrace -l' command (without any search expression) should also
list the tracepoints, in the same way of 'bpftrace -l '*''.