### PR TITLE
Add uprobe/uretprobe wildcard matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ A single probe can be attached to multiple events:
 ### Wildcards
 Some probe types allow wildcards to be used when attaching a probe:
 
+`uprobe:/bin/bash:read* { ... }`
+
 `kprobe:vfs_* { ... }`
 
 ### Predicates

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1114,15 +1114,14 @@ void CodegenLLVM::visit(Probe &probe)
 
     for (auto &attach_point : *probe.attach_points) {
       current_attach_point_ = attach_point;
-
       std::set<std::string> matches;
       switch (probetype(attach_point->provider))
       {
         case ProbeType::kprobe:
         case ProbeType::kretprobe:
           matches = bpftrace_.find_wildcard_matches(attach_point->target,
-						    attach_point->func,
-						    "/sys/kernel/debug/tracing/available_filter_functions");
+                                                    attach_point->func,
+                                                    "/sys/kernel/debug/tracing/available_filter_functions");
           break;
         case ProbeType::uprobe:
         case ProbeType::uretprobe:
@@ -1133,15 +1132,14 @@ void CodegenLLVM::visit(Probe &probe)
         }
         case ProbeType::tracepoint:
           matches = bpftrace_.find_wildcard_matches(attach_point->target,
-						    attach_point->func,
-						    "/sys/kernel/debug/tracing/available_events");
+                                                    attach_point->func,
+                                                    "/sys/kernel/debug/tracing/available_events");
           break;
         default:
           std::cerr << "Wildcard matches aren't available on probe type '"
                     << attach_point->provider << "'" << std::endl;
           return;
       }
-      
       for (auto &match : matches) {
         printf_id_ = starting_printf_id_;
         time_id_ = starting_time_id_;

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1114,22 +1114,34 @@ void CodegenLLVM::visit(Probe &probe)
 
     for (auto &attach_point : *probe.attach_points) {
       current_attach_point_ = attach_point;
-      std::string file_name;
+
+      std::set<std::string> matches;
       switch (probetype(attach_point->provider))
       {
         case ProbeType::kprobe:
         case ProbeType::kretprobe:
-          file_name = "/sys/kernel/debug/tracing/available_filter_functions";
+          matches = bpftrace_.find_wildcard_matches(attach_point->target,
+						    attach_point->func,
+						    "/sys/kernel/debug/tracing/available_filter_functions");
           break;
+        case ProbeType::uprobe:
+        case ProbeType::uretprobe:
+        {
+            auto symbol_stream = std::istringstream(bpftrace_.extract_func_symbols_from_path(attach_point->target));
+            matches = bpftrace_.find_wildcard_matches("", attach_point->func, symbol_stream);
+            break;
+        }
         case ProbeType::tracepoint:
-          file_name = "/sys/kernel/debug/tracing/available_events";
+          matches = bpftrace_.find_wildcard_matches(attach_point->target,
+						    attach_point->func,
+						    "/sys/kernel/debug/tracing/available_events");
           break;
         default:
           std::cerr << "Wildcard matches aren't available on probe type '"
                     << attach_point->provider << "'" << std::endl;
           return;
       }
-      auto matches = bpftrace_.find_wildcard_matches(attach_point->target, attach_point->func, file_name);
+      
       for (auto &match : matches) {
         printf_id_ = starting_printf_id_;
         time_id_ = starting_time_id_;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1469,6 +1469,7 @@ uint64_t BPFtrace::resolve_uname(const std::string &name, const std::string &pat
 
 std::string BPFtrace::extract_func_symbols_from_path(const std::string &path)
 {
+  // TODO: switch from objdump to library call, perhaps bcc_resolve_symname()
   std::string call_str = std::string("objdump -tT ") + path +
     + " | " + "grep \"F .text\" | grep -oE '[^[:space:]]+$'";
 

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -91,6 +91,13 @@ int BPFtrace::add_probe(ast::Probe &p)
                                           attach_point->func,
                                           "/sys/kernel/debug/tracing/available_filter_functions");
           break;
+        case ProbeType::uprobe:
+        case ProbeType::uretprobe:
+        {
+            auto symbol_stream = std::istringstream(extract_func_symbols_from_path(attach_point->target));
+            matches = find_wildcard_matches("", attach_point->func, symbol_stream);
+            break;
+        }
         case ProbeType::tracepoint:
           matches = find_wildcard_matches(attach_point->target,
                                           attach_point->func,

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1445,6 +1445,15 @@ uint64_t BPFtrace::resolve_uname(const std::string &name, const std::string &pat
   return addr;
 }
 
+std::string BPFtrace::extract_func_symbols_from_path(const std::string &path)
+{
+  std::string call_str = std::string("objdump -tT ") + path +
+    + " | " + "grep \"F .text\" | grep -oE '[^[:space:]]+$'";
+
+  const char *call = call_str.c_str();
+  return exec_system(call);
+}
+
 std::string BPFtrace::exec_system(const char* cmd)
 {
   std::array<char, 128> buffer;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -82,24 +82,26 @@ int BPFtrace::add_probe(ast::Probe &p)
           attach_point->func.find("[") != std::string::npos &&
           attach_point->func.find("]") != std::string::npos))
     {
-      std::string file_name;
+      std::set<std::string> matches;
       switch (probetype(attach_point->provider))
       {
         case ProbeType::kprobe:
         case ProbeType::kretprobe:
-          file_name = "/sys/kernel/debug/tracing/available_filter_functions";
+          matches = find_wildcard_matches(attach_point->target,
+                                          attach_point->func,
+                                          "/sys/kernel/debug/tracing/available_filter_functions");
           break;
         case ProbeType::tracepoint:
-          file_name = "/sys/kernel/debug/tracing/available_events";
+          matches = find_wildcard_matches(attach_point->target,
+                                          attach_point->func,
+                                          "/sys/kernel/debug/tracing/available_events");
           break;
         default:
           std::cerr << "Wildcard matches aren't available on probe type '"
                     << attach_point->provider << "'" << std::endl;
           return 1;
       }
-      auto matches = find_wildcard_matches(attach_point->target,
-                                           attach_point->func,
-                                           file_name);
+
       attach_funcs.insert(attach_funcs.end(), matches.begin(), matches.end());
     }
     else

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -65,6 +65,7 @@ public:
   std::string resolve_uid(uintptr_t addr);
   uint64_t resolve_kname(const std::string &name);
   uint64_t resolve_uname(const std::string &name, const std::string &path);
+  std::string extract_func_symbols_from_path(const std::string &path);
   std::string resolve_probe(uint64_t probe_id);
   uint64_t resolve_cgroupid(const std::string &path);
   std::vector<uint64_t> get_arg_values(std::vector<Field> args, uint8_t* arg_data);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -86,6 +86,7 @@ public:
 
   static void sort_by_key(std::vector<SizedType> key_args,
       std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> &values_by_key);
+  virtual std::set<std::string> find_wildcard_matches(const std::string &prefix, const std::string &func, std::istream &symbol_name_stream);
   virtual std::set<std::string> find_wildcard_matches(const std::string &prefix, const std::string &attach_point, const std::string &file_name);
 
 protected:

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -268,6 +268,19 @@ TEST(bpftrace, add_probes_usdt)
 
 TEST(bpftrace, add_probes_uprobe_wildcard)
 {
+  ast::AttachPoint a("uprobe", "/bin/grep", "*open", true);
+  ast::AttachPointList attach_points = { &a };
+  ast::Probe probe(&attach_points, nullptr, nullptr);
+
+  StrictMock<MockBPFtrace> bpftrace;
+
+  EXPECT_EQ(bpftrace.add_probe(probe), 0);
+  EXPECT_EQ(1, bpftrace.get_probes().size());
+  EXPECT_EQ(0, bpftrace.get_special_probes().size());
+}
+
+TEST(bpftrace, add_probes_uprobe_wildcard_no_matches)
+{
   ast::AttachPoint a("uprobe", "/bin/sh", "foo*", true);
   ast::AttachPointList attach_points = { &a };
   ast::Probe probe(&attach_points, nullptr, nullptr);

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -274,7 +274,7 @@ TEST(bpftrace, add_probes_uprobe_wildcard)
 
   StrictMock<MockBPFtrace> bpftrace;
 
-  EXPECT_NE(bpftrace.add_probe(probe), 0);
+  EXPECT_EQ(bpftrace.add_probe(probe), 0);
   EXPECT_EQ(0, bpftrace.get_probes().size());
   EXPECT_EQ(0, bpftrace.get_special_probes().size());
 }


### PR DESCRIPTION
I mostly use bpftrace with Go programs, and it would be very helpful to have wildcard support, e.g. for attaching uprobes without having specify the entire package path. This is a learning PR, so I'll be grateful for any constructive feedback.

Resolves #67.