### PR TITLE
WIP [ustack] use format inspired by Linux perf

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1190,15 +1190,15 @@ std::string BPFtrace::get_stack(uint64_t stackidpid, bool ustack, int indent)
   std::ostringstream stack;
   std::string padding(indent, ' ');
 
-  stack << "\n";
+  stack << std::endl;
   for (auto &addr : stack_trace)
   {
     if (addr == 0)
       break;
     if (!ustack)
-      stack << padding << resolve_sym(addr, true) << std::endl;
+      stack << "\t" << padding << resolve_sym(addr, true) << std::endl;
     else
-      stack << padding << resolve_usym(addr, pid, true) << std::endl;
+      stack << "\t" << padding << std::hex << addr << " " << std::dec << resolve_usym(addr, pid, true) << std::endl;
   }
 
   return stack.str();
@@ -1365,10 +1365,11 @@ std::string BPFtrace::resolve_usym(uintptr_t addr, int pid, bool show_offset)
     symbol << sym.name;
     if (show_offset)
       symbol << "+" << sym.offset;
+    symbol  << " (" << sym.module << ")";
   }
   else
   {
-    symbol << (void*)addr;
+    symbol << "[unknown] ([unknown])";
   }
 
   // TODO: deal with process exit and clearing its psyms entry


### PR DESCRIPTION
Change ustack format to approximate Linux perf output, so we can use
bpftrace to generate FlameGraphs and with other tools with Linux perf
output support.

What's different from the old format:

- Print address before symbol name
- Print module path/name after symbol name (inside parenthesis)
- Print `[unknown]` instead of address when symbols is unknown

Old format:

```
        _ZN2v88internal4Heap11AllocateRawEiNS0_15AllocationSpaceENS0_19AllocationAlignmentE+0
        _ZN2v88internal7Factory30CopyJSObjectWithAllocationSiteENS0_6HandleINS0_8JSObjectEEENS2_INS0_14AllocationSiteEEE+149
        _ZN2v88internal7Factory12CopyJSObjectENS0_6HandleINS0_8JSObjectEEE+11
        _ZN2v88internal10ApiNatives17InstantiateObjectENS0_6HandleINS0_18ObjectTemplateInfoEEENS2_INS0_10JSReceiverEEE+413
        _ZN2v88internal12_GLOBAL__N_119HandleApiCallHelperILb1EEENS0_11MaybeHandleINS0_6ObjectEEEPNS0_7IsolateENS0_6HandleINS0_10HeapObjectEEESA_NS8_INS0_20FunctionTemplateInfoEEENS8_IS4_EENS0_16BuiltinArgumentsE+86
        _ZN2v88internal8Builtins17InvokeApiFunctionEPNS0_7IsolateEbNS0_6HandleINS0_10HeapObjectEEENS4_INS0_6ObjectEEEiPS8_S6_+861
        _ZN2v88internal9Execution3NewEPNS0_7IsolateENS0_6HandleINS0_6ObjectEEES6_iPS6_+481
        _ZNK2v88Function29NewInstanceWithSideEffectTypeENS_5LocalINS_7ContextEEEiPNS1_INS_5ValueEEENS_14SideEffectTypeE+390
        _ZNK2v88Function11NewInstanceENS_5LocalINS_7ContextEEEiPNS1_INS_5ValueEEE+12
        _ZN4node7TCPWrap11InstantiateEPNS_11EnvironmentEPNS_9AsyncWrapENS0_10SocketTypeE+257
        _ZN4node14ConnectionWrapINS_7TCPWrapE8uv_tcp_sE12OnConnectionEP11uv_stream_si+269
        uv__server_io+121
        uv__io_poll+776
        uv_run+331
        _ZN4node5StartEPN2v87IsolateEPNS_11IsolateDataERKSt6vectorISsSaISsEES9_+1381
        _ZN4node5StartEiPPc+1122
        __libc_start_main+231
        0xcb8c372d8d48e024
```

New format:

```
                ecd3f0 _ZN2v88internal4Heap11AllocateRawEiNS0_15AllocationSpaceENS0_19AllocationAlignmentE+0 (/home/mmarchini/.nvm/versions/node/v10.13.0/bin/node)
                eb0e45 _ZN2v88internal7Factory30CopyJSObjectWithAllocationSiteENS0_6HandleINS0_8JSObjectEEENS2_INS0_14AllocationSiteEEE+149 (/home/mmarchini/.nvm/versions/node/v10.13.0/bin/node)
                eb138b _ZN2v88internal7Factory12CopyJSObjectENS0_6HandleINS0_8JSObjectEEE+11 (/home/mmarchini/.nvm/versions/node/v10.13.0/bin/node)
                ad32ed _ZN2v88internal10ApiNatives17InstantiateObjectENS0_6HandleINS0_18ObjectTemplateInfoEEENS2_INS0_10JSReceiverEEE+413 (/home/mmarchini/.nvm/versions/node/v10.13.0/bin/node)
                b5e576 _ZN2v88internal12_GLOBAL__N_119HandleApiCallHelperILb1EEENS0_11MaybeHandleINS0_6ObjectEEEPNS0_7IsolateENS0_6HandleINS0_10HeapObjectEEESA_NS8_INS0_20FunctionTemplateInfoEEENS8_IS4_EENS0_16BuiltinArgumentsE+86 (/home/mmarchini/.nvm/versions/node/v10.13.0/bin/node)
                b60a7d _ZN2v88internal8Builtins17InvokeApiFunctionEPNS0_7IsolateEbNS0_6HandleINS0_10HeapObjectEEENS4_INS0_6ObjectEEEiPS8_S6_+861 (/home/mmarchini/.nvm/versions/node/v10.13.0/bin/node)
                e702b1 _ZN2v88internal9Execution3NewEPNS0_7IsolateENS0_6HandleINS0_6ObjectEEES6_iPS6_+481 (/home/mmarchini/.nvm/versions/node/v10.13.0/bin/node)
                afc9e6 _ZNK2v88Function29NewInstanceWithSideEffectTypeENS_5LocalINS_7ContextEEEiPNS1_INS_5ValueEEENS_14SideEffectTypeE+390 (/home/mmarchini/.nvm/versions/node/v10.13.0/bin/node)
                afcd1c _ZNK2v88Function11NewInstanceENS_5LocalINS_7ContextEEEiPNS1_INS_5ValueEEE+12 (/home/mmarchini/.nvm/versions/node/v10.13.0/bin/node)
                9b0521 _ZN4node7TCPWrap11InstantiateEPNS_11EnvironmentEPNS_9AsyncWrapENS0_10SocketTypeE+257 (/home/mmarchini/.nvm/versions/node/v10.13.0/bin/node)
                8b781d _ZN4node14ConnectionWrapINS_7TCPWrapE8uv_tcp_sE12OnConnectionEP11uv_stream_si+269 (/home/mmarchini/.nvm/versions/node/v10.13.0/bin/node)
                a52fa9 uv__server_io+121 (/home/mmarchini/.nvm/versions/node/v10.13.0/bin/node)
                a58018 uv__io_poll+776 (/home/mmarchini/.nvm/versions/node/v10.13.0/bin/node)
                a47c6b uv_run+331 (/home/mmarchini/.nvm/versions/node/v10.13.0/bin/node)
                8e5255 _ZN4node5StartEPN2v87IsolateEPNS_11IsolateDataERKSt6vectorISsSaISsEES9_+1381 (/home/mmarchini/.nvm/versions/node/v10.13.0/bin/node)
                8e34a2 _ZN4node5StartEiPPc+1122 (/home/mmarchini/.nvm/versions/node/v10.13.0/bin/node)
                7f4d8fa2eb97 __libc_start_main+231 (/lib/x86_64-linux-gnu/libc-2.27.so)
                cb8c372d8d48e024 [unknown] ([unknown])
```