### PR TITLE
Add -c CMD option

### DIFF
--- a/man/man8/bpftrace.8
+++ b/man/man8/bpftrace.8
@@ -60,7 +60,12 @@ Execute PROGRAM.
 .
 .TP
 \fB\-p PID\fR
-Process ID for enabling USDT probes.
+Enable USDT probes on PID. Will terminate bpftrace on PID termination. Note this is not a global PID filter on probes.
+.
+.TP
+\fB\-c CMD\fR
+Helper to run CMD. Equivalent to manually running CMD and then giving passing the PID to -p. This is useful to ensure
+you've traced at least the duration CMD's execution. You must provide an absolute path for the executable.
 .
 .TP
 \fB\-v\fR
@@ -83,6 +88,10 @@ List probes containing "sleep".
 .TP
 \fBbpftrace \-e \'kprobe:do_nanosleep { printf("PID %d sleeping\en", pid); }\'\fR
 Trace processes calling sleep.
+.
+.TP
+\fBbpftrace \-c \'sleep 5\' \-e \'kprobe:do_nanosleep { printf("PID %d sleeping\en", pid); }\'\fR
+run "sleep 5" in a new process and then trace processes calling sleep.
 .
 .TP
 \fBbpftrace \-e \'tracepoint:raw_syscalls:sys_enter { @[comm]=count(); }\'\fR

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -50,7 +50,7 @@ class BPFtrace
 {
 public:
   BPFtrace() : ncpus_(ebpf::get_possible_cpus().size()) { }
-  virtual ~BPFtrace() { }
+  virtual ~BPFtrace();
   virtual int add_probe(ast::Probe &p);
   int num_probes() const;
   int run(std::unique_ptr<BpfOrc> bpforc);
@@ -68,6 +68,7 @@ public:
   std::string resolve_probe(uint64_t probe_id);
   uint64_t resolve_cgroupid(const std::string &path);
   std::vector<uint64_t> get_arg_values(std::vector<Field> args, uint8_t* arg_data);
+  std::string cmd_;
   int pid_{0};
 
   std::map<std::string, std::unique_ptr<IMap>> maps_;
@@ -97,6 +98,7 @@ private:
   std::map<int, void *> pid_sym_;
   int ncpus_;
   int online_cpus_;
+  std::vector<int> child_pids_;
 
   std::unique_ptr<AttachedProbe> attach_probe(Probe &probe, const BpfOrc &bpforc);
   int setup_perf_events();
@@ -118,6 +120,7 @@ private:
   static std::string lhist_index_label(int number);
   static std::vector<std::string> split_string(std::string &str, char split_by);
   std::vector<uint8_t> find_empty_key(IMap &map, size_t size) const;
+  static int spawn_child(const std::vector<std::string>& args);
   static bool is_pid_alive(int pid);
 };
 


### PR DESCRIPTION
This patch adds a command running option to bpftrace. The user can now
run something like:

    ./bpftrace -e '...' -c 'sleep 5'

which is a convenience wrapper around something like:

    sleep 5 & ./bpfrace -e '...' -p `pidof sleep`

`-c` is better because it:
* ensures a tighter tracing range around CMD (ie we trace less of the
system while it is not running CMD)
* makes bpftrace exit (which is convenient) when CMD terminates
    * previously, it was not possible to get a full trace of CMDs
    execution and have bpftrace exit upon CMD termination

Test Plan:
Trivial successful example:
```
$ sudo ./build/src/bpftrace -e 'tracepoint:syscalls:sys_enter_nanosleep
{ printf("%s nanoslept\n", comm); }' -c '/bin/sleep 1'
[sudo] password for dlxu:
chdir(/lib/modules/4.19.8-200.fc28.x86_64/build): No such file or
directory
Attaching 1 probe...
sleep nanoslept
splunkd nanoslept
webrtc_audio_mo nanoslept
gnome-terminal- nanoslept
webrtc_audio_mo nanoslept
gnome-terminal- nanoslept
gnome-terminal- nanoslept
gnome-terminal- nanoslept
gnome-terminal- nanoslept
gnome-terminal- nanoslept
gnome-terminal- nanoslept
gnome-terminal- nanoslept
gnome-terminal- nanoslept
gnome-terminal- nanoslept
gnome-terminal- nanoslept

$
```

Ambigous executable:
```
$ sudo ./build/src/bpftrace -e 'tracepoint:syscalls:sys_enter_nanosleep
{ printf("%s nanoslept\n", comm); }' -c 'sleep 1'
chdir(/lib/modules/4.19.8-200.fc28.x86_64/build): No such file or
directory
Attaching 1 probe...
execve: No such file or directory
Failed to spawn child=sleep 1
splunkd nanoslept

$
```

This closes #253