### PR TITLE
str() to accept optional length

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,7 +268,7 @@ Functions:
 - `avg(int n)` - Average this value
 - `stats(int n)` - Return the count, average, and total for this value
 - `delete(@x)` - Delete the map element passed in as an argument
-- `str(char *s)` - Returns the string pointed to by `s`
+- `str(char *s [, int length])` - Returns the string pointed to by `s`
 - `printf(char *fmt, ...)` - Print formatted to stdout
 - `print(@x[, int top [, int div]])` - Print a map, with optional top entry count and divisor
 - `clear(@x)` - Delete all key/values from a map

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -329,11 +329,27 @@ void CodegenLLVM::visit(Call &call)
   }
   else if (call.func == "str")
   {
-    AllocaInst *buf = b_.CreateAllocaBPF(call.type, "str");
-    b_.CreateMemSet(buf, b_.getInt8(0), call.type.size, 1);
+    AllocaInst *strlen = b_.CreateAllocaBPF(b_.getInt64Ty(), "strlen");
+    b_.CreateMemSet(strlen, b_.getInt8(0), sizeof(uint64_t), 1);
+    if (call.vargs->size() > 1) {
+      call.vargs->at(1)->accept(*this);
+      Value *proposed_strlen = b_.CreateAdd(expr_, b_.getInt64(1)); // add 1 to accommodate probe_read_str's null byte
+      Value *max = b_.getInt64(bpftrace_.strlen_);
+      CmpInst::Predicate P = CmpInst::ICMP_ULE;
+      Value *Cmp = b_.CreateICmp(P, proposed_strlen, max, "str.min.cmp");
+      Value *Select = b_.CreateSelect(Cmp, proposed_strlen, max, "str.min.select");
+      b_.CreateStore(Select, strlen);
+    } else {
+      b_.CreateStore(b_.getInt64(bpftrace_.strlen_), strlen);
+    }
+    AllocaInst *buf = b_.CreateAllocaBPF(bpftrace_.strlen_, "str");
+    b_.CreateMemSet(buf, b_.getInt8(0), bpftrace_.strlen_, 1);
     call.vargs->front()->accept(*this);
-    b_.CreateProbeReadStr(buf, call.type.size, expr_);
+    b_.CreateProbeReadStr(buf, b_.CreateLoad(strlen), expr_);
+    b_.CreateLifetimeEnd(strlen);
+
     expr_ = buf;
+    expr_deleter_ = [this,buf]() { b_.CreateLifetimeEnd(buf); };
   }
   else if (call.func == "kaddr")
   {
@@ -470,12 +486,16 @@ void CodegenLLVM::visit(Call &call)
     for (int i=1; i<call.vargs->size(); i++)
     {
       Expression &arg = *call.vargs->at(i);
+      expr_deleter_ = nullptr;
       arg.accept(*this);
       Value *offset = b_.CreateGEP(printf_args, {b_.getInt32(0), b_.getInt32(i)});
       if (arg.type.IsArray())
         b_.CREATE_MEMCPY(offset, expr_, arg.type.size, 1);
       else
         b_.CreateStore(expr_, offset);
+
+      if (expr_deleter_)
+        expr_deleter_();
     }
 
     printf_id_++;
@@ -519,12 +539,16 @@ void CodegenLLVM::visit(Call &call)
     for (int i=1; i<call.vargs->size(); i++)
     {
       Expression &arg = *call.vargs->at(i);
+      expr_deleter_ = nullptr;
       arg.accept(*this);
       Value *offset = b_.CreateGEP(system_args, {b_.getInt32(0), b_.getInt32(i)});
       if (arg.type.IsArray())
         b_.CREATE_MEMCPY(offset, expr_, arg.type.size, 1);
       else
         b_.CreateStore(expr_, offset);
+
+      if (expr_deleter_)
+        expr_deleter_();
     }
 
     system_id_++;

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -66,6 +66,7 @@ private:
   IRBuilderBPF b_;
   DataLayout layout_;
   Value *expr_ = nullptr;
+  std::function<void()> expr_deleter_; // intentionally empty
   Value *ctx_;
   AttachPoint *current_attach_point_ = nullptr;
   BPFtrace &bpftrace_;

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -268,6 +268,11 @@ void IRBuilderBPF::CreateProbeRead(AllocaInst *dst, size_t size, Value *src)
 
 CallInst *IRBuilderBPF::CreateProbeReadStr(AllocaInst *dst, size_t size, Value *src)
 {
+  return CreateProbeReadStr(dst, getInt64(size), src);
+}
+
+CallInst *IRBuilderBPF::CreateProbeReadStr(AllocaInst *dst, llvm::Value *size, Value *src)
+{
   // int bpf_probe_read_str(void *dst, int size, const void *unsafe_ptr)
   FunctionType *probereadstr_func_type = FunctionType::get(
       getInt64Ty(),
@@ -278,7 +283,7 @@ CallInst *IRBuilderBPF::CreateProbeReadStr(AllocaInst *dst, size_t size, Value *
       Instruction::IntToPtr,
       getInt64(BPF_FUNC_probe_read_str),
       probereadstr_func_ptr_type);
-  return CreateCall(probereadstr_func, {dst, getInt64(size), src}, "probe_read_str");
+  return CreateCall(probereadstr_func, {dst, size, src}, "probe_read_str");
 }
 
 CallInst *IRBuilderBPF::CreateProbeReadStr(Value *dst, size_t size, Value *src)

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -41,6 +41,7 @@ public:
   void        CreateMapUpdateElem(Map &map, AllocaInst *key, Value *val);
   void        CreateMapDeleteElem(Map &map, AllocaInst *key);
   void        CreateProbeRead(AllocaInst *dst, size_t size, Value *src);
+  CallInst   *CreateProbeReadStr(AllocaInst *dst, llvm::Value *size, Value *src);
   CallInst   *CreateProbeReadStr(AllocaInst *dst, size_t size, Value *src);
   CallInst   *CreateProbeReadStr(Value *dst, size_t size, Value *src);
   Value      *CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_point, int arg_name, Builtin &builtin);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -84,6 +84,8 @@ public:
   int join_argnum_;
   int join_argsize_;
 
+  uint64_t strlen_;
+
   static void sort_by_key(std::vector<SizedType> key_args,
       std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> &values_by_key);
   virtual std::set<std::string> find_wildcard_matches(const std::string &prefix, const std::string &func, std::istream &symbol_name_stream);


### PR DESCRIPTION
Fixes https://github.com/iovisor/bpftrace/issues/199. For _small_ strings, at least.

```bash
sudo bpftrace -e 'tracepoint:syscalls:sys_enter_write /pid == 23506/
{
  printf("<%s>\n", str(args->buf, args->count)); 
}'
# type pwd into terminal 23506
<p>
<w>
<d>
# press enter in terminal 23506
<
>
</home/anon
>
# notice that this string got truncated; we don't allocate sufficiently large strings (by default)
<anon@anon-VirtualBox:

# meanwhile, here's what terminal 23506 looks like:
anon@anon-VirtualBox:~$ pwd
/home/anon
anon@anon-VirtualBox:~$ 
```

By default, the largest string it can support is 64 bytes. We can tune this with the environment variable `BPFTRACE_STRLEN` — which fixes the string truncation in this particular situation:

```bash
sudo BPFTRACE_STRLEN=240 bpftrace -e 'tracepoint:syscalls:sys_enter_write /pid == 25783/ { printf("<%s>\n", str(args->buf, args->count)); }'
<
>
</home/anon
>
<anon@anon-VirtualBox:~$ >
```

Caveat: str() allocates strings on the BPF stack, so we reach the 512-byte limit very quickly (especially since we pay the toll again when printf() composes a perf event output buffer).

I explored the possibility of storing the strings off-stack. The main problem there is that probe_read_str() will only write upon on-stack memory. I have ideas for workarounds (and some code progress towards those workarounds), but they're too big to be included in the scope of this pull request.