### PR TITLE
Fix use-after-free in BPFtrace::get_arg_values

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -343,7 +343,7 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
   }
 }
 
-std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(std::vector<Field> args, uint8_t* arg_data)
+std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(const std::vector<Field> &args, uint8_t* arg_data)
 {
   std::vector<std::unique_ptr<IPrintable>> arg_values;
 
@@ -357,22 +357,22 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(std::vector<Fi
           case 8:
             arg_values.push_back(
               std::make_unique<PrintableInt>(
-                *(uint64_t*)(arg_data+arg.offset)));
+                *reinterpret_cast<uint64_t*>(arg_data+arg.offset)));
             break;
           case 4:
             arg_values.push_back(
               std::make_unique<PrintableInt>(
-                *(uint32_t*)(arg_data+arg.offset)));
+                *reinterpret_cast<uint32_t*>(arg_data+arg.offset)));
             break;
           case 2:
             arg_values.push_back(
               std::make_unique<PrintableInt>(
-                *(uint16_t*)(arg_data+arg.offset)));
+                *reinterpret_cast<uint16_t*>(arg_data+arg.offset)));
             break;
           case 1:
             arg_values.push_back(
               std::make_unique<PrintableInt>(
-                *(uint8_t*)(arg_data+arg.offset)));
+                *reinterpret_cast<uint8_t*>(arg_data+arg.offset)));
             break;
           default:
             abort();
@@ -381,61 +381,54 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(std::vector<Fi
       case Type::string:
         arg_values.push_back(
           std::make_unique<PrintableCString>(
-            (char *) arg_data+arg.offset));
+            reinterpret_cast<char *>(arg_data+arg.offset)));
         break;
       case Type::sym:
         arg_values.push_back(
           std::make_unique<PrintableString>(
-            std::move(
-              resolve_sym(*(uint64_t*)(arg_data+arg.offset)))));
+            resolve_sym(*reinterpret_cast<uint64_t*>(arg_data+arg.offset))));
         break;
       case Type::usym:
         arg_values.push_back(
           std::make_unique<PrintableString>(
-            std::move(
-              resolve_usym(
-                *(uint64_t*)(arg_data+arg.offset),
-                *(uint64_t*)(arg_data+arg.offset + 8)))));
+            resolve_usym(
+              *reinterpret_cast<uint64_t*>(arg_data+arg.offset),
+              *reinterpret_cast<uint64_t*>(arg_data+arg.offset + 8))));
         break;
       case Type::inet:
         arg_values.push_back(
           std::make_unique<PrintableString>(
-            std::move(
-              resolve_inet(
-                *(uint64_t*)(arg_data+arg.offset),
-                *(uint64_t*)(arg_data+arg.offset+8)))));
+            resolve_inet(
+              *reinterpret_cast<uint64_t*>(arg_data+arg.offset),
+              *reinterpret_cast<uint64_t*>(arg_data+arg.offset+8))));
         break;
       case Type::username:
         arg_values.push_back(
           std::make_unique<PrintableString>(
-            std::move(
-              resolve_uid(
-                *(uint64_t*)(arg_data+arg.offset)))));
+            resolve_uid(
+              *reinterpret_cast<uint64_t*>(arg_data+arg.offset))));
         break;
       case Type::probe:
         arg_values.push_back(
           std::make_unique<PrintableString>(
-            std::move(
-              resolve_probe(
-                *(uint64_t*)(arg_data+arg.offset)))));
+            resolve_probe(
+              *reinterpret_cast<uint64_t*>(arg_data+arg.offset))));
         break;
       case Type::stack:
         arg_values.push_back(
           std::make_unique<PrintableString>(
-            std::move(
-              get_stack(
-                *(uint64_t*)(arg_data+arg.offset),
-                false,
-                8))));
+            get_stack(
+              *reinterpret_cast<uint64_t*>(arg_data+arg.offset),
+              false,
+              8)));
         break;
       case Type::ustack:
         arg_values.push_back(
           std::make_unique<PrintableString>(
-            std::move(
-              get_stack(
-                *(uint64_t*)(arg_data+arg.offset),
-                true,
-                8))));
+            get_stack(
+              *reinterpret_cast<uint64_t*>(arg_data+arg.offset),
+              true,
+              8)));
         break;
       default:
         abort();

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -21,6 +21,7 @@
 #include "bpforc.h"
 #include "bpftrace.h"
 #include "attached_probe.h"
+#include "printf.h"
 #include "triggers.h"
 #include "resolve_cgroupid.h"
 
@@ -263,7 +264,7 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
     auto id = printf_id - asyncactionint(AsyncAction::syscall);
     auto fmt = std::get<0>(bpftrace->system_args_[id]).c_str();
     auto args = std::get<1>(bpftrace->system_args_[id]);
-    std::vector<uint64_t> arg_values = bpftrace->get_arg_values(args, arg_data);
+    auto arg_values = bpftrace->get_arg_values(args, arg_data);
 
     char buffer [255];
 
@@ -273,30 +274,30 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
         system(fmt);
         break;
       case 1:
-        snprintf(buffer, 255, fmt, arg_values.at(0));
+        snprintf(buffer, 255, fmt, arg_values.at(0)->value());
         system(buffer);
         break;
       case 2:
-        snprintf(buffer, 255, fmt, arg_values.at(0), arg_values.at(1));
+        snprintf(buffer, 255, fmt, arg_values.at(0)->value(), arg_values.at(1)->value());
         system(buffer);
         break;
       case 3:
-        snprintf(buffer, 255, fmt, arg_values.at(0), arg_values.at(1), arg_values.at(2));
+        snprintf(buffer, 255, fmt, arg_values.at(0)->value(), arg_values.at(1)->value(), arg_values.at(2)->value());
         system(buffer);
         break;
       case 4:
-        snprintf(buffer, 255, fmt, arg_values.at(0), arg_values.at(1), arg_values.at(2),
-          arg_values.at(3));
+        snprintf(buffer, 255, fmt, arg_values.at(0)->value(), arg_values.at(1)->value(), arg_values.at(2)->value(),
+          arg_values.at(3)->value());
         system(buffer);
         break;
       case 5:
-        snprintf(buffer, 255, fmt, arg_values.at(0), arg_values.at(1), arg_values.at(2),
-          arg_values.at(3), arg_values.at(4));
+        snprintf(buffer, 255, fmt, arg_values.at(0)->value(), arg_values.at(1)->value(), arg_values.at(2)->value(),
+          arg_values.at(3)->value(), arg_values.at(4)->value());
         system(buffer);
         break;
-     case 6:
-        snprintf(buffer, 255, fmt, arg_values.at(0), arg_values.at(1), arg_values.at(2),
-          arg_values.at(3), arg_values.at(4), arg_values.at(5));
+      case 6:
+        snprintf(buffer, 255, fmt, arg_values.at(0)->value(), arg_values.at(1)->value(), arg_values.at(2)->value(),
+          arg_values.at(3)->value(), arg_values.at(4)->value(), arg_values.at(5)->value());
         system(buffer);
         break;
       default:
@@ -309,7 +310,7 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
   // printf
   auto fmt = std::get<0>(bpftrace->printf_args_[printf_id]).c_str();
   auto args = std::get<1>(bpftrace->printf_args_[printf_id]);
-  std::vector<uint64_t> arg_values = bpftrace->get_arg_values(args, arg_data);
+  auto arg_values = bpftrace->get_arg_values(args, arg_data);
 
   switch (args.size())
   {
@@ -317,38 +318,35 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
       printf(fmt);
       break;
     case 1:
-      printf(fmt, arg_values.at(0));
+      printf(fmt, arg_values.at(0)->value());
       break;
     case 2:
-      printf(fmt, arg_values.at(0), arg_values.at(1));
+      printf(fmt, arg_values.at(0)->value(), arg_values.at(1)->value());
       break;
     case 3:
-      printf(fmt, arg_values.at(0), arg_values.at(1), arg_values.at(2));
+      printf(fmt, arg_values.at(0)->value(), arg_values.at(1)->value(), arg_values.at(2)->value());
       break;
     case 4:
-      printf(fmt, arg_values.at(0), arg_values.at(1), arg_values.at(2),
-          arg_values.at(3));
+      printf(fmt, arg_values.at(0)->value(), arg_values.at(1)->value(), arg_values.at(2)->value(),
+        arg_values.at(3)->value());
       break;
     case 5:
-      printf(fmt, arg_values.at(0), arg_values.at(1), arg_values.at(2),
-          arg_values.at(3), arg_values.at(4));
+      printf(fmt, arg_values.at(0)->value(), arg_values.at(1)->value(), arg_values.at(2)->value(),
+        arg_values.at(3)->value(), arg_values.at(4)->value());
       break;
     case 6:
-      printf(fmt, arg_values.at(0), arg_values.at(1), arg_values.at(2),
-          arg_values.at(3), arg_values.at(4), arg_values.at(5));
+      printf(fmt, arg_values.at(0)->value(), arg_values.at(1)->value(), arg_values.at(2)->value(),
+        arg_values.at(3)->value(), arg_values.at(4)->value(), arg_values.at(5)->value());
       break;
     default:
       abort();
   }
 }
 
-std::vector<uint64_t> BPFtrace::get_arg_values(std::vector<Field> args, uint8_t* arg_data)
+std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(std::vector<Field> args, uint8_t* arg_data)
 {
-  std::vector<uint64_t> arg_values;
-  std::vector<std::unique_ptr<char>> resolved_symbols;
-  std::vector<std::unique_ptr<char>> resolved_usernames;
+  std::vector<std::unique_ptr<IPrintable>> arg_values;
 
-  char *name;
   for (auto arg : args)
   {
     switch (arg.type.type)
@@ -357,54 +355,52 @@ std::vector<uint64_t> BPFtrace::get_arg_values(std::vector<Field> args, uint8_t*
         switch (arg.type.size)
         {
           case 8:
-            arg_values.push_back(*(uint64_t*)(arg_data+arg.offset));
+            arg_values.emplace_back(new PrintableInt(*(uint64_t*)(arg_data+arg.offset)));
             break;
           case 4:
-            arg_values.push_back(*(uint32_t*)(arg_data+arg.offset));
+            arg_values.emplace_back(new PrintableInt(*(uint32_t*)(arg_data+arg.offset)));
             break;
           case 2:
-            arg_values.push_back(*(uint16_t*)(arg_data+arg.offset));
+            arg_values.emplace_back(new PrintableInt(*(uint16_t*)(arg_data+arg.offset)));
             break;
           case 1:
-            arg_values.push_back(*(uint8_t*)(arg_data+arg.offset));
+            arg_values.emplace_back(new PrintableInt(*(uint8_t*)(arg_data+arg.offset)));
             break;
           default:
             abort();
         }
         break;
       case Type::string:
-        arg_values.push_back((uint64_t)(arg_data+arg.offset));
+        arg_values.emplace_back(new PrintableString(
+          std::string((char *) arg_data+arg.offset)));
         break;
       case Type::sym:
-        resolved_symbols.emplace_back(strdup(
-              resolve_sym(*(uint64_t*)(arg_data+arg.offset)).c_str()));
-        arg_values.push_back((uint64_t)resolved_symbols.back().get());
+        arg_values.emplace_back(new PrintableString(
+          resolve_sym(*(uint64_t*)(arg_data+arg.offset)).c_str()));
         break;
       case Type::usym:
-        resolved_symbols.emplace_back(strdup(
-              resolve_usym(*(uint64_t*)(arg_data+arg.offset), *(uint64_t*)(arg_data+arg.offset + 8)).c_str()));
-        arg_values.push_back((uint64_t)resolved_symbols.back().get());
+        arg_values.emplace_back(new PrintableString(
+          resolve_usym(*(uint64_t*)(arg_data+arg.offset), *(uint64_t*)(arg_data+arg.offset + 8)).c_str()));
         break;
       case Type::inet:
         name = strdup(resolve_inet(*(uint64_t*)(arg_data+arg.offset), *(uint64_t*)(arg_data+arg.offset+8)).c_str());
         arg_values.push_back((uint64_t)name);
         break;
       case Type::username:
-        resolved_usernames.emplace_back(strdup(
-              resolve_uid(*(uint64_t*)(arg_data+arg.offset)).c_str()));
-        arg_values.push_back((uint64_t)resolved_usernames.back().get());
+        arg_values.emplace_back(new PrintableString(
+          resolve_uid(*(uint64_t*)(arg_data+arg.offset)).c_str()));
         break;
       case Type::probe:
-        name = strdup(resolve_probe(*(uint64_t*)(arg_data+arg.offset)).c_str());
-        arg_values.push_back((uint64_t)name);
+        arg_values.emplace_back(new PrintableString(
+          resolve_probe(*(uint64_t*)(arg_data+arg.offset)).c_str()));
         break;
       case Type::stack:
-        name = strdup(get_stack(*(uint64_t*)(arg_data+arg.offset), false, 8).c_str());
-        arg_values.push_back((uint64_t)name);
+        arg_values.emplace_back(new PrintableString(
+          get_stack(*(uint64_t*)(arg_data+arg.offset), false, 8).c_str()));
         break;
       case Type::ustack:
-        name = strdup(get_stack(*(uint64_t*)(arg_data+arg.offset), true, 8).c_str());
-        arg_values.push_back((uint64_t)name);
+        arg_values.emplace_back(new PrintableString(
+          get_stack(*(uint64_t*)(arg_data+arg.offset), true, 8).c_str()));
         break;
       default:
         abort();

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -355,52 +355,87 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(std::vector<Fi
         switch (arg.type.size)
         {
           case 8:
-            arg_values.emplace_back(new PrintableInt(*(uint64_t*)(arg_data+arg.offset)));
+            arg_values.push_back(
+              std::make_unique<PrintableInt>(
+                *(uint64_t*)(arg_data+arg.offset)));
             break;
           case 4:
-            arg_values.emplace_back(new PrintableInt(*(uint32_t*)(arg_data+arg.offset)));
+            arg_values.push_back(
+              std::make_unique<PrintableInt>(
+                *(uint32_t*)(arg_data+arg.offset)));
             break;
           case 2:
-            arg_values.emplace_back(new PrintableInt(*(uint16_t*)(arg_data+arg.offset)));
+            arg_values.push_back(
+              std::make_unique<PrintableInt>(
+                *(uint16_t*)(arg_data+arg.offset)));
             break;
           case 1:
-            arg_values.emplace_back(new PrintableInt(*(uint8_t*)(arg_data+arg.offset)));
+            arg_values.push_back(
+              std::make_unique<PrintableInt>(
+                *(uint8_t*)(arg_data+arg.offset)));
             break;
           default:
             abort();
         }
         break;
       case Type::string:
-        arg_values.emplace_back(new PrintableString(
-          std::string((char *) arg_data+arg.offset)));
+        arg_values.push_back(
+          std::make_unique<PrintableCString>(
+            (char *) arg_data+arg.offset));
         break;
       case Type::sym:
-        arg_values.emplace_back(new PrintableString(
-          resolve_sym(*(uint64_t*)(arg_data+arg.offset)).c_str()));
+        arg_values.push_back(
+          std::make_unique<PrintableString>(
+            std::move(
+              resolve_sym(*(uint64_t*)(arg_data+arg.offset)))));
         break;
       case Type::usym:
-        arg_values.emplace_back(new PrintableString(
-          resolve_usym(*(uint64_t*)(arg_data+arg.offset), *(uint64_t*)(arg_data+arg.offset + 8)).c_str()));
+        arg_values.push_back(
+          std::make_unique<PrintableString>(
+            std::move(
+              resolve_usym(
+                *(uint64_t*)(arg_data+arg.offset),
+                *(uint64_t*)(arg_data+arg.offset + 8)))));
         break;
       case Type::inet:
-        name = strdup(resolve_inet(*(uint64_t*)(arg_data+arg.offset), *(uint64_t*)(arg_data+arg.offset+8)).c_str());
-        arg_values.push_back((uint64_t)name);
+        arg_values.push_back(
+          std::make_unique<PrintableString>(
+            std::move(
+              resolve_inet(
+                *(uint64_t*)(arg_data+arg.offset),
+                *(uint64_t*)(arg_data+arg.offset+8)))));
         break;
       case Type::username:
-        arg_values.emplace_back(new PrintableString(
-          resolve_uid(*(uint64_t*)(arg_data+arg.offset)).c_str()));
+        arg_values.push_back(
+          std::make_unique<PrintableString>(
+            std::move(
+              resolve_uid(
+                *(uint64_t*)(arg_data+arg.offset)))));
         break;
       case Type::probe:
-        arg_values.emplace_back(new PrintableString(
-          resolve_probe(*(uint64_t*)(arg_data+arg.offset)).c_str()));
+        arg_values.push_back(
+          std::make_unique<PrintableString>(
+            std::move(
+              resolve_probe(
+                *(uint64_t*)(arg_data+arg.offset)))));
         break;
       case Type::stack:
-        arg_values.emplace_back(new PrintableString(
-          get_stack(*(uint64_t*)(arg_data+arg.offset), false, 8).c_str()));
+        arg_values.push_back(
+          std::make_unique<PrintableString>(
+            std::move(
+              get_stack(
+                *(uint64_t*)(arg_data+arg.offset),
+                false,
+                8))));
         break;
       case Type::ustack:
-        arg_values.emplace_back(new PrintableString(
-          get_stack(*(uint64_t*)(arg_data+arg.offset), true, 8).c_str()));
+        arg_values.push_back(
+          std::make_unique<PrintableString>(
+            std::move(
+              get_stack(
+                *(uint64_t*)(arg_data+arg.offset),
+                true,
+                8))));
         break;
       default:
         abort();

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -11,6 +11,7 @@
 #include "ast.h"
 #include "attached_probe.h"
 #include "imap.h"
+#include "printf.h"
 #include "struct.h"
 #include "types.h"
 
@@ -68,7 +69,7 @@ public:
   std::string extract_func_symbols_from_path(const std::string &path);
   std::string resolve_probe(uint64_t probe_id);
   uint64_t resolve_cgroupid(const std::string &path);
-  std::vector<uint64_t> get_arg_values(std::vector<Field> args, uint8_t* arg_data);
+  std::vector<std::unique_ptr<IPrintable>> get_arg_values(std::vector<Field> args, uint8_t* arg_data);
   void add_param(const std::string &param);
   bool is_numeric(std::string str);
   std::string get_param(int index);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -69,7 +69,7 @@ public:
   std::string extract_func_symbols_from_path(const std::string &path);
   std::string resolve_probe(uint64_t probe_id);
   uint64_t resolve_cgroupid(const std::string &path);
-  std::vector<std::unique_ptr<IPrintable>> get_arg_values(std::vector<Field> args, uint8_t* arg_data);
+  std::vector<std::unique_ptr<IPrintable>> get_arg_values(const std::vector<Field> &args, uint8_t* arg_data);
   void add_param(const std::string &param);
   bool is_numeric(std::string str);
   std::string get_param(int index);

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -64,4 +64,14 @@ std::string verify_format_string(const std::string &fmt, std::vector<Field> args
   return "";
 }
 
+uint64_t PrintableString::value()
+{
+  return (uint64_t)_value.c_str();
+}
+
+uint64_t PrintableInt::value()
+{
+  return _value;
+}
+
 } // namespace bpftrace

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -66,12 +66,17 @@ std::string verify_format_string(const std::string &fmt, std::vector<Field> args
 
 uint64_t PrintableString::value()
 {
-  return (uint64_t)_value.c_str();
+  return (uint64_t)value_.c_str();
+}
+
+uint64_t PrintableCString::value()
+{
+  return (uint64_t)value_;
 }
 
 uint64_t PrintableInt::value()
 {
-  return _value;
+  return value_;
 }
 
 } // namespace bpftrace

--- a/src/printf.h
+++ b/src/printf.h
@@ -1,3 +1,5 @@
+#pragma once
+
 #include <sstream>
 
 #include "ast.h"
@@ -8,5 +10,31 @@ namespace bpftrace {
 struct Field;
 
 std::string verify_format_string(const std::string &fmt, std::vector<Field> args);
+
+class IPrintable
+{
+public:
+  virtual ~IPrintable() { };
+  virtual uint64_t value() = 0;
+};
+
+class PrintableString : public virtual IPrintable
+{
+public:
+  PrintableString(std::string value) : _value(value) { }
+  uint64_t value();
+private:
+  std::string _value;
+};
+
+class PrintableInt : public virtual IPrintable
+{
+public:
+  PrintableInt(uint64_t value) : _value(value) { }
+  uint64_t value();
+private:
+  uint64_t _value;
+};
+
 
 } // namespace bpftrace

--- a/src/printf.h
+++ b/src/printf.h
@@ -21,19 +21,28 @@ public:
 class PrintableString : public virtual IPrintable
 {
 public:
-  PrintableString(std::string value) : _value(value) { }
+  PrintableString(std::string value) : value_(value) { }
   uint64_t value();
 private:
-  std::string _value;
+  std::string value_;
+};
+
+class PrintableCString : public virtual IPrintable
+{
+public:
+  PrintableCString(char* value) : value_(value) { }
+  uint64_t value();
+private:
+  char* value_;
 };
 
 class PrintableInt : public virtual IPrintable
 {
 public:
-  PrintableInt(uint64_t value) : _value(value) { }
+  PrintableInt(uint64_t value) : value_(value) { }
   uint64_t value();
 private:
-  uint64_t _value;
+  uint64_t value_;
 };
 
 

--- a/src/printf.h
+++ b/src/printf.h
@@ -21,7 +21,7 @@ public:
 class PrintableString : public virtual IPrintable
 {
 public:
-  PrintableString(std::string value) : value_(value) { }
+  PrintableString(std::string value) : value_(std::move(value)) { }
   uint64_t value();
 private:
   std::string value_;


### PR DESCRIPTION
Fixes issues https://github.com/iovisor/bpftrace/issues/194 and https://github.com/iovisor/bpftrace/issues/209.

This finishes the work of @psanford's pull request https://github.com/iovisor/bpftrace/pull/217.

I've rebased onto master, and implemented the review feedback:

- avoid copying strings
- prefer make_unique
- use standard naming convention for private members

We can now successfully use `sym()` as an argument to printf():

```bash
# terminal A
sudo bpftrace -e 'tracepoint:skb:kfree_skb {
  printf("symbol: %s\n", sym(args->location))
}'

# terminal B
curl -s 'http://dtrace.org'

# triggers the following output from terminal A:
Attaching 1 probe...
symbol: unix_stream_connect
symbol: unix_stream_connect
symbol: tcp_v4_rcv
```