### PR TITLE
Search PATH for executables when running commands

### DIFF
--- a/man/man8/bpftrace.8
+++ b/man/man8/bpftrace.8
@@ -65,7 +65,7 @@ Enable USDT probes on PID. Will terminate bpftrace on PID termination. Note this
 .TP
 \fB\-c CMD\fR
 Helper to run CMD. Equivalent to manually running CMD and then giving passing the PID to -p. This is useful to ensure
-you've traced at least the duration CMD's execution. You must provide an absolute path for the executable.
+you've traced at least the duration CMD's execution.
 .
 .TP
 \fB\-v\fR

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -120,6 +120,7 @@ private:
   static std::string lhist_index_label(int number);
   static std::vector<std::string> split_string(std::string &str, char split_by);
   std::vector<uint8_t> find_empty_key(IMap &map, size_t size) const;
+  static std::string resolve_binary_path(const std::string& cmd);
   static int spawn_child(const std::vector<std::string>& args);
   static bool is_pid_alive(int pid);
 };


### PR DESCRIPTION
This makes it easier for the user to run commands. Specifying abosolute
paths to a binary was kind of a pain in the rear.