### PR TITLE
allow isra symbols in kprobe wildcards

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -167,7 +167,7 @@ std::string AttachedProbe::eventname() const
   {
     case ProbeType::kprobe:
     case ProbeType::kretprobe:
-      return eventprefix() + probe_.attach_point + index_str;
+      return eventprefix() + sanitise(probe_.attach_point) + index_str;
     case ProbeType::uprobe:
     case ProbeType::uretprobe:
     case ProbeType::usdt:
@@ -182,6 +182,10 @@ std::string AttachedProbe::eventname() const
 
 std::string AttachedProbe::sanitise(const std::string &str)
 {
+  /*
+   * Characters such as "." in event names are rejected by the kernel,
+   * so sanitize:
+   */
   return std::regex_replace(str, std::regex("[^A-Za-z0-9_]"), "_");
 }
 


### PR DESCRIPTION
Before:

```
# sudo bpftrace -e 'k:tcp_grow* { @[probe] = count(); }'
Attaching 1 probe...
cannot attach kprobe, Invalid argument
Warning: could not attach probe kprobe:tcp_grow_window.isra.39, skipping.
^C
```

After:

```
# sudo ./src/bpftrace -e 'k:tcp_grow* { @[probe] = count(); }'
Attaching 1 probe...
^C

@[kprobe:tcp_grow_window.isra.39]: 4
```

Some more work needs to be done as a follow on in lexer/parser to allow an isra symbol to be probed directly, without matching the dot via a wildcard. This work needs to avoid breaking field access.