### PR TITLE
[ast] fix str() to map assignment

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -226,8 +226,9 @@ void SemanticAnalyser::visit(Call &call)
   else if (call.func == "str") {
     if (check_varargs(call, 1, 2)) {
       check_arg(call, Type::integer, 0);
+      uint64_t strlen = bpftrace_.strlen_;
+      call.type = SizedType(Type::string, strlen);
       if (is_final_pass()) {
-        uint64_t strlen = bpftrace_.strlen_;
         if (call.vargs->size() > 1) {
           check_arg(call, Type::integer, 1, false);
           auto &strlen_arg = *call.vargs->at(1);
@@ -235,7 +236,6 @@ void SemanticAnalyser::visit(Call &call)
             strlen = static_cast<Integer&>(strlen_arg).n;
           }
         }
-        call.type = SizedType(Type::string, strlen);
       }
     }
   }

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -87,7 +87,7 @@ public:
   int join_argnum_;
   int join_argsize_;
 
-  uint64_t strlen_;
+  uint64_t strlen_ = 64;
 
   static void sort_by_key(std::vector<SizedType> key_args,
       std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> &values_by_key);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -180,7 +180,6 @@ int main(int argc, char *argv[])
   bpftrace.join_argnum_ = 16;
   bpftrace.join_argsize_ = 1024;
 
-  bpftrace.strlen_ = 64;
   if(const char* env_p = std::getenv("BPFTRACE_STRLEN")) {
     uint64_t proposed;
     std::istringstream stringstream(env_p);


### PR DESCRIPTION
Assigning the result of str() to a map broke after
https://github.com/iovisor/bpftrace/pull/299 landed. This commit fixes
it by making sure our call has a type before the final pass of the
semantic analyzer. Also moved the default strlen to bpftrace.h to make
sure the value is correctly set on unit tests.