### PR TITLE
improve tracepoint not found message

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -212,7 +212,8 @@ int main(int argc, char *argv[])
   if (cmd_str)
     bpftrace.cmd_ = cmd_str;
 
-  TracepointFormatParser::parse(driver.root_);
+  if (TracepointFormatParser::parse(driver.root_) == false)
+    return 1;
 
   if (bt_debug != DebugLevel::kNone)
   {

--- a/src/tracepoint_format_parser.h
+++ b/src/tracepoint_format_parser.h
@@ -9,7 +9,7 @@ namespace ast { class Program; }
 class TracepointFormatParser
 {
 public:
-  static void parse(ast::Program *program);
+  static bool parse(ast::Program *program);
   static std::string get_struct_name(const std::string &category, const std::string &event_name);
 
 private:


### PR DESCRIPTION
Fixes #306.

```
# ./src/bpftrace -e 'tracepoint:syscall:sys_enter_open { @ = count(); }'
ERROR: tracepoint not found: syscall:sys_enter_open
Did you mean syscalls:sys_enter_open?
```

More info with -v:

```
# ./src/bpftrace -ve 'tracepoint:syscall:sys_enter_open { @ = count(); }'
ERROR: tracepoint not found: syscall:sys_enter_open
Did you mean syscalls:sys_enter_open?
No such file or directory: /sys/kernel/debug/tracing/events/syscall/sys_enter_open/format
```