### PR TITLE
Print program ID when the verbose option is enabled.

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -339,10 +339,18 @@ void AttachedProbe::load_prog()
     if (bt_verbose)
       std::cerr << std::endl << "Error log: " << std::endl << log_buf << std::endl;
     throw std::runtime_error("Error loading program: " + probe_.name + (bt_verbose ? "" : " (try -v)"));
-  } else {
-    if (bt_verbose) {
-       std::cout << std::endl << "Bytecode: " << std::endl << log_buf << std::endl;
+  }
+
+  if (bt_verbose) {
+    struct bpf_prog_info info = {};
+    uint32_t info_len = sizeof(info);
+    int ret;
+
+    ret = bpf_obj_get_info(progfd_, &info, &info_len);
+    if (ret == 0) {
+      std::cout << std::endl << "Program ID: " << info.id << std::endl;
     }
+    std::cout << std::endl << "Bytecode: " << std::endl << log_buf << std::endl;
   }
 }
 


### PR DESCRIPTION
This allows operators to use other tools, like bpftool, to
introspect a running program.

Output example:

```
sudo bpftrace -v -e "tracepoint:bpf:bpf_prog_load { @[comm] = count() }"
Attaching 1 probe...

Program ID: 24

Bytecode: 
0: (b7) r1 = 0
1: (7b) *(u64 *)(r10 -16) = r1
2: (7b) *(u64 *)(r10 -24) = r1
3: (bf) r1 = r10
4: (07) r1 += -24
5: (b7) r2 = 16
```