### PR TITLE
Hide -inl.h header from interface

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -4,7 +4,7 @@
 #include "libbpf.h"
 #include "bcc_usdt.h"
 #include "arch/arch.h"
-#include "utils-inl.h"
+#include "utils.h"
 
 #include <llvm/IR/Module.h>
 

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -16,7 +16,7 @@
 #include "bcc_usdt.h"
 #include "common.h"
 #include "libbpf.h"
-#include "utils-inl.h"
+#include "utils.h"
 #include <linux/perf_event.h>
 #include <linux/version.h>
 

--- a/src/utils-inl.h
+++ b/src/utils-inl.h
@@ -1,7 +1,3 @@
-#pragma once
-
-#include "utils.h"
-
 namespace bpftrace {
 
 inline std::string GetProviderFromPath(std::string path) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -7,3 +7,5 @@ namespace bpftrace {
 inline std::string GetProviderFromPath(std::string path);
 
 } // namespace bpftrace
+
+#include "utils-inl.h"


### PR DESCRIPTION
`*-inl.h` files, or inline headers, are an implementation detail. Users
of an interface that is backed by an inline header should not concern
themselves with the details of implementation.

This patch normalizes the interface.