### PR TITLE
docker: disable runtime tests on CI

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -14,5 +14,6 @@ make "$@"
 if [ $RUN_TESTS = 1 ]; then
   set +e
   ./tests/bpftrace_test $TEST_ARGS;
-  make runtime-tests;
+  # TODO(mmarchini) re-enable once we figured out how to run it properly on CI
+  # make runtime-tests;
 fi


### PR DESCRIPTION
The Kernel version available on Travis is too old to run our runtime tests suite, so I think we should disable it on CI for now.