### PR TITLE
Avoid crashing if mistakenly just '-d' or '-v' is used

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -152,6 +152,11 @@ int main(int argc, char *argv[])
   {
     // Script file
     char *file_name = argv[optind];
+    if (!file_name)
+    {
+      std::cerr << "USAGE: filename or -e 'program' required." << std::endl;
+      return 1;
+    }
     err = driver.parse_file(file_name);
     optind++;
   }


### PR DESCRIPTION
Currently, if by mistake just '-v' or '-d' is used without any
additional parameter (no filename nor -e 'program') bpftrace crashes:

./src/bpftrace -v
terminate called after throwing an instance of 'std::logic_error'
what():  basic_string::_M_construct null not valid
Aborted (core dumped)

This commit fix this problem.