### PR TITLE
Fix wrong package name in Ubuntu Dockerfile

### DIFF
--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -9,7 +9,7 @@ RUN apt-get update && apt-get install -y \
     libelf-dev \
     llvm-5.0-dev \
     zlib1g-dev \
-    bcc-dev
+    libbpfcc-dev
 
 COPY build.sh /build.sh
 ENTRYPOINT ["bash", "/build.sh"]


### PR DESCRIPTION
This corresponds to the change in the install instructions for Ubuntu outlined in #335.

NB: Docker builds are still broken (see #334), but this is a step in the right direction.