### PR TITLE
lhist: interval notation tweak

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1162,10 +1162,6 @@ int BPFtrace::print_lhist(const std::vector<uint64_t> &values, int min, int max,
   if (max_index == -1)
     return 0;
 
-  std::ostringstream lt;
-  lt << "(...," << lhist_index_label(min) << "]";
-  std::ostringstream gt;
-
   // trim empty values
   int start_value = -1;
   int end_value = 0;
@@ -1190,9 +1186,9 @@ int BPFtrace::print_lhist(const std::vector<uint64_t> &values, int min, int max,
     int bar_width = values.at(i)/(float)max_value*max_width;
     std::ostringstream header;
     if (i == 0) {
-      header << "(...," << lhist_index_label(min) << "]";
+      header << "(..., " << lhist_index_label(min) << ")";
     } else if (i == (buckets + 1)) {
-      header << "[" << lhist_index_label(max) << ",...)";
+      header << "[" << lhist_index_label(max) << ", ...)";
     } else {
       header << "[" << lhist_index_label((i - 1) * step + min);
       header << ", " << lhist_index_label(i * step + min) << ")";


### PR DESCRIPTION
Getting lhist() right before tackling hist() in #346.

now:

```
# ./src/bpftrace -e 'k:vfs_read { @ = lhist(-5, 0, 10, 1); @ = lhist(1, 0, 10, 1); @ = lhist(11, 0, 10, 1); }'
Attaching 1 probe...
^C

@: 
(..., 0)            1647 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[0, 1)                 0 |                                                    |
[1, 2)              1647 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[2, 3)                 0 |                                                    |
[3, 4)                 0 |                                                    |
[4, 5)                 0 |                                                    |
[5, 6)                 0 |                                                    |
[6, 7)                 0 |                                                    |
[7, 8)                 0 |                                                    |
[8, 9)                 0 |                                                    |
[9, 10)                0 |                                                    |
[10, ...)           1647 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
```

was:

```
# bpftrace -e 'k:vfs_read { @ = lhist(-5, 0, 10, 1); @ = lhist(1, 0, 10, 1); @ = lhist(11, 0, 10, 1); }'
Attaching 1 probe...
^C

@: 
(...,0]             2296 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[0, 1)                 0 |                                                    |
[1, 2)              2296 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[2, 3)                 0 |                                                    |
[3, 4)                 0 |                                                    |
[4, 5)                 0 |                                                    |
[5, 6)                 0 |                                                    |
[6, 7)                 0 |                                                    |
[7, 8)                 0 |                                                    |
[8, 9)                 0 |                                                    |
[9, 10)                0 |                                                    |
[10,...)            2296 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
```

It's also a good time to get these right: this didn't need any doc changes. But the longer we wait, the more docs will need changing.