### PR TITLE
Make bpftrace -l list sofware and hardware types (#44)

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -5,6 +5,7 @@
 #include "printf.h"
 #include "tracepoint_format_parser.h"
 #include "arch/arch.h"
+#include "list.h"
 #include <sys/stat.h>
 #include <regex>
 
@@ -773,18 +774,17 @@ void SemanticAnalyser::visit(AttachPoint &ap)
   else if (ap.provider == "software") {
     if (ap.target == "")
       err_ << "software probe must have a software event name" << std::endl;
-    else if (ap.target != "cpu-clock" && ap.target != "cpu" &&
-             ap.target != "task-clock" &&
-             ap.target != "page-faults" && ap.target != "faults" &&
-             ap.target != "context-switches" && ap.target != "cs" &&
-             ap.target != "cpu-migrations" &&
-             ap.target != "minor-faults" &&
-             ap.target != "major-faults" &&
-             ap.target != "alignment-faults" &&
-             ap.target != "emulation-faults" &&
-             ap.target != "dummy" &&
-             ap.target != "bpf-output")
-      err_ << ap.target << " is not a software probe" << std::endl;
+    else {
+      bool found = false;
+      for (auto &probeListItem : SW_PROBE_LIST) {
+        if (ap.target == probeListItem.path || (!probeListItem.alias.empty() && ap.target == probeListItem.alias)) {
+          found = true;
+          break;
+        }
+      }
+      if (!found)
+        err_ << ap.target << " is not a software probe" << std::endl;
+    }
     if (ap.func != "")
       err_ << "software probe can only have an integer count" << std::endl;
     else if (ap.freq < 0)
@@ -793,16 +793,17 @@ void SemanticAnalyser::visit(AttachPoint &ap)
   else if (ap.provider == "hardware") {
     if (ap.target == "")
       err_ << "hardware probe must have a hardware event name" << std::endl;
-    else if (ap.target != "cpu-cycles" && ap.target != "cycles" &&
-             ap.target != "instructions" &&
-             ap.target != "cache-references" &&
-             ap.target != "cache-misses" &&
-             ap.target != "branch-instructions" && ap.target != "branches" &&
-             ap.target != "bus-cycles" &&
-             ap.target != "frontend-stalls" &&
-             ap.target != "backend-stalls" &&
-             ap.target != "ref-cycles")
-      err_ << ap.target << " is not a hardware probe" << std::endl;
+    else {
+      bool found = false;
+      for (auto &probeListItem : HW_PROBE_LIST) {
+        if (ap.target == probeListItem.path || (!probeListItem.alias.empty() && ap.target == probeListItem.alias)) {
+          found = true;
+          break;
+        }
+      }
+      if (!found)
+        err_ << ap.target << " is not a hardware probe" << std::endl;
+    }
     if (ap.func != "")
       err_ << "hardware probe can only have an integer count" << std::endl;
     else if (ap.freq < 0)

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -17,6 +17,7 @@
 #include "bcc_usdt.h"
 #include "libbpf.h"
 #include "utils.h"
+#include "list.h"
 #include <linux/perf_event.h>
 #include <linux/version.h>
 
@@ -528,57 +529,13 @@ void AttachedProbe::attach_software()
   uint32_t type;
 
   // from linux/perf_event.h, with aliases from perf:
-  if (probe_.path == "cpu-clock" || probe_.path == "cpu")
+  for (auto &probeListItem : SW_PROBE_LIST)
   {
-    type = PERF_COUNT_SW_CPU_CLOCK;
-    defaultp = 1000000;
-  }
-  else if (probe_.path == "task-clock")
-  {
-    type = PERF_COUNT_SW_TASK_CLOCK;
-  }
-  else if (probe_.path == "page-faults" || probe_.path == "faults")
-  {
-    type = PERF_COUNT_SW_PAGE_FAULTS;
-    defaultp = 100;
-  }
-  else if (probe_.path == "context-switches" || probe_.path == "cs")
-  {
-    type = PERF_COUNT_SW_CONTEXT_SWITCHES;
-    defaultp = 1000;
-  }
-  else if (probe_.path == "cpu-migrations")
-  {
-    type = PERF_COUNT_SW_CPU_MIGRATIONS;
-  }
-  else if (probe_.path == "minor-faults")
-  {
-    type = PERF_COUNT_SW_PAGE_FAULTS_MIN;
-    defaultp = 100;
-  }
-  else if (probe_.path == "major-faults")
-  {
-    type = PERF_COUNT_SW_PAGE_FAULTS_MAJ;
-  }
-  else if (probe_.path == "alignment-faults")
-  {
-    type = PERF_COUNT_SW_ALIGNMENT_FAULTS;
-  }
-  else if (probe_.path == "emulation-faults")
-  {
-    type = PERF_COUNT_SW_EMULATION_FAULTS;
-  }
-  else if (probe_.path == "dummy")
-  {
-    type = PERF_COUNT_SW_DUMMY;
-  }
-  else if (probe_.path == "bpf-output")
-  {
-    type = PERF_COUNT_SW_BPF_OUTPUT;
-  }
-  else
-  {
-    abort();
+    if (probe_.path == probeListItem.path || probe_.path == probeListItem.alias)
+    {
+      type = probeListItem.type;
+      defaultp = probeListItem.defaultp;
+    }
   }
 
   if (period == 0)
@@ -607,48 +564,13 @@ void AttachedProbe::attach_hardware()
   uint32_t type;
 
   // from linux/perf_event.h, with aliases from perf:
-  if (probe_.path == "cpu-cycles" || probe_.path == "cycles")
+  for (auto &probeListItem : HW_PROBE_LIST)
   {
-    type = PERF_COUNT_HW_CPU_CYCLES;
-  }
-  else if (probe_.path == "instructions")
-  {
-    type = PERF_COUNT_HW_INSTRUCTIONS;
-  }
-  else if (probe_.path == "cache-references")
-  {
-    type = PERF_COUNT_HW_CACHE_REFERENCES;
-  }
-  else if (probe_.path == "cache-misses")
-  {
-    type = PERF_COUNT_HW_CACHE_MISSES;
-  }
-  else if (probe_.path == "branch-instructions" || probe_.path == "branches")
-  {
-    type = PERF_COUNT_HW_BRANCH_INSTRUCTIONS;
-    defaultp = 100000;
-  }
-  else if (probe_.path == "bus-cycles")
-  {
-    type = PERF_COUNT_HW_BUS_CYCLES;
-    defaultp = 100000;
-  }
-  else if (probe_.path == "frontend-stalls")
-  {
-    type = PERF_COUNT_HW_STALLED_CYCLES_FRONTEND;
-  }
-  else if (probe_.path == "backend-stalls")
-  {
-    type = PERF_COUNT_HW_STALLED_CYCLES_BACKEND;
-  }
-  else if (probe_.path == "ref-cycles")
-  {
-    type = PERF_COUNT_HW_REF_CPU_CYCLES;
-  }
-  // can add PERF_COUNT_HW_CACHE_... here
-  else
-  {
-    abort();
+    if (probe_.path == probeListItem.path || probe_.path == probeListItem.alias)
+    {
+      type = probeListItem.type;
+      defaultp = probeListItem.defaultp;
+    }
   }
 
   if (period == 0)

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -65,18 +65,37 @@ void list_dir(const std::string path, std::vector<std::string> &files)
   closedir(dp);
 }
 
+void list_probes_from_list(const std::vector<ProbeListItem> &probes_list, const std::string &search)
+{
+  for (auto &probeListItem : probes_list)
+  {
+    if (!search.empty())
+    {
+      if (search_probe(probeListItem.path, search) && search_probe(probeListItem.alias, search))
+        continue;
+    }
+
+    std::cout << probeListItem.path;
+    if (!probeListItem.alias.empty())
+      std::cout << " OR " << probeListItem.alias;
+    std::cout << std::endl;
+  }
+}
+
 void list_probes(const std::string &search)
 {
   unsigned int i, j;
   std::string line, probe;
 
   // software
-  // TODO: add here
+  list_probes_from_list(SW_PROBE_LIST, search);
 
   // hardware
-  // TODO: add here
+  std::cout << std::endl;
+  list_probes_from_list(HW_PROBE_LIST, search);
 
   // tracepoints
+  std::cout << std::endl;
   std::vector<std::string> cats = std::vector<std::string>();
   list_dir(tp_path, cats);
   for (i = 0; i < cats.size(); i++)

--- a/src/list.h
+++ b/src/list.h
@@ -1,6 +1,42 @@
 #include <sstream>
 
+#include <linux/perf_event.h>
+
 namespace bpftrace {
+
+struct ProbeListItem
+{
+  std::string path;
+  std::string alias;
+  uint32_t type;
+  uint64_t defaultp;
+};
+
+const std::vector<ProbeListItem> SW_PROBE_LIST = {
+  { "alignment-faults", "",       PERF_COUNT_SW_ALIGNMENT_FAULTS,    1 },
+  { "bpf-output",       "",       PERF_COUNT_SW_BPF_OUTPUT,          1 },
+  { "context-switches", "cs",     PERF_COUNT_SW_CONTEXT_SWITCHES, 1000 },
+  { "cpu-clock",        "cpu",    PERF_COUNT_SW_CPU_CLOCK,     1000000 },
+  { "cpu-migrations",   "",       PERF_COUNT_SW_CPU_MIGRATIONS,      1 },
+  { "dummy",            "",       PERF_COUNT_SW_DUMMY,               1 },
+  { "emulation-faults", "",       PERF_COUNT_SW_EMULATION_FAULTS,    1 },
+  { "major-faults",     "",       PERF_COUNT_SW_PAGE_FAULTS_MAJ,     1 },
+  { "minor-faults",     "",       PERF_COUNT_SW_PAGE_FAULTS_MIN,   100 },
+  { "page-faults",      "faults", PERF_COUNT_SW_PAGE_FAULTS,       100 },
+  { "task-clock",       "",       PERF_COUNT_SW_TASK_CLOCK,          1 },
+};
+
+const std::vector<ProbeListItem> HW_PROBE_LIST = {
+  { "backend-stalls",      "",         PERF_COUNT_HW_STALLED_CYCLES_BACKEND,  1000000 },
+  { "branch-instructions", "branches", PERF_COUNT_HW_BRANCH_INSTRUCTIONS,      100000 },
+  { "bus-cycles",          "",         PERF_COUNT_HW_BUS_CYCLES,               100000 },
+  { "cache-misses",        "",         PERF_COUNT_HW_CACHE_MISSES,            1000000 },
+  { "cache-references",    "",         PERF_COUNT_HW_CACHE_REFERENCES,        1000000 },
+  { "cpu-cycles",          "cycles",   PERF_COUNT_HW_CPU_CYCLES,              1000000 },
+  { "frontend-stalls",     "",         PERF_COUNT_HW_STALLED_CYCLES_FRONTEND, 1000000 },
+  { "instructions",        "",         PERF_COUNT_HW_INSTRUCTIONS,            1000000 },
+  { "ref-cycles",          "",         PERF_COUNT_HW_REF_CPU_CYCLES,          1000000 }
+};
 
 void list_probes(const std::string &search);
 void list_probes();


### PR DESCRIPTION
- Also refactored code in attached_probe.cpp and
ast/semantic_analyzer.cpp to use the sw/hw lists instead of the
hardcoded probe names.