### PR TITLE
resources: generate c++ file instead of c file

### DIFF
--- a/resources/CMakeLists.txt
+++ b/resources/CMakeLists.txt
@@ -1,7 +1,9 @@
-add_library(resources headers.c)
+add_library(resources headers.cpp)
+
+target_include_directories(resources PUBLIC ../src)
 
 function(embed_headers output)
-  file(WRITE ${output} "")
+  file(WRITE ${output} "#include \"headers.h\"\n\nnamespace bpftrace {\n")
   file(GLOB headers *.h)
   foreach(header ${headers})
     get_filename_component(filename ${header} NAME)
@@ -9,6 +11,9 @@ function(embed_headers output)
     file(READ ${header} contents)
     file(APPEND ${output} "const char ${varname}[] = R\"CONTENTS(${contents})CONTENTS\";\nconst unsigned ${varname}_len = sizeof(${varname});\n")
   endforeach()
+  file(APPEND ${output} "} // namespace bpftrace")
 endfunction()
 
-embed_headers(${CMAKE_BINARY_DIR}/resources/headers.c)
+embed_headers(${CMAKE_BINARY_DIR}/resources/headers.cpp)
+
+

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -9,19 +9,7 @@
 #include "clang_parser.h"
 #include "types.h"
 #include "utils.h"
-
-extern "C" const char __stddef_max_align_t_h[];
-extern "C" const unsigned __stddef_max_align_t_h_len;
-extern "C" const char float_h[];
-extern "C" const unsigned float_h_len;
-extern "C" const char limits_h[];
-extern "C" const unsigned limits_h_len;
-extern "C" const char stdarg_h[];
-extern "C" const unsigned stdarg_h_len;
-extern "C" const char stddef_h[];
-extern "C" const unsigned stddef_h_len;
-extern "C" const char stdint_h[];
-extern "C" const unsigned stdint_h_len;
+#include "headers.h"
 
 namespace bpftrace {
 

--- a/src/headers.h
+++ b/src/headers.h
@@ -1,0 +1,19 @@
+#pragma once
+
+namespace bpftrace {
+
+// These externs are provided by our build system. See resources/CMakeLists.txt
+extern const char __stddef_max_align_t_h[];
+extern const unsigned __stddef_max_align_t_h_len;
+extern const char float_h[];
+extern const unsigned float_h_len;
+extern const char limits_h[];
+extern const unsigned limits_h_len;
+extern const char stdarg_h[];
+extern const unsigned stdarg_h_len;
+extern const char stddef_h[];
+extern const unsigned stddef_h_len;
+extern const char stdint_h[];
+extern const unsigned stdint_h_len;
+
+} // namespace bpftrace


### PR DESCRIPTION
If we use clang to build bpftrace instead of GCC, it will complain about
trying to use the `-std-c++14` flag to comile headers.c. If we force
cmake to skip this flag on `.c` files, clang is not able to link
libresources.a correctly.

This patch changes the resources workflow to generate a .cpp file
instead, and to have a `src/headers.h` with all headers we currently
use. With this approach we get a safer linkage because the same
definition for the header strings is being used in clang_parser.cpp and
in headers.cpp.

Fixes: https://github.com/iovisor/bpftrace/issues/350