### PR TITLE
bpftrace -l tweaks for consistency

### DIFF
--- a/src/list.cpp
+++ b/src/list.cpp
@@ -65,7 +65,8 @@ void list_dir(const std::string path, std::vector<std::string> &files)
   closedir(dp);
 }
 
-void list_probes_from_list(const std::vector<ProbeListItem> &probes_list, const std::string &search)
+void list_probes_from_list(const std::vector<ProbeListItem> &probes_list,
+                           const std::string &probetype, const std::string &search)
 {
   for (auto &probeListItem : probes_list)
   {
@@ -75,10 +76,7 @@ void list_probes_from_list(const std::vector<ProbeListItem> &probes_list, const 
         continue;
     }
 
-    std::cout << probeListItem.path;
-    if (!probeListItem.alias.empty())
-      std::cout << " OR " << probeListItem.alias;
-    std::cout << std::endl;
+    std::cout << probetype << ":" << probeListItem.path << ":" << std::endl;
   }
 }
 
@@ -88,11 +86,11 @@ void list_probes(const std::string &search)
   std::string line, probe;
 
   // software
-  list_probes_from_list(SW_PROBE_LIST, search);
+  list_probes_from_list(SW_PROBE_LIST, "software", search);
 
   // hardware
   std::cout << std::endl;
-  list_probes_from_list(HW_PROBE_LIST, search);
+  list_probes_from_list(HW_PROBE_LIST, "hardware",  search);
 
   // tracepoints
   std::cout << std::endl;

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -89,11 +89,9 @@ void list_probes(const std::string &search)
   list_probes_from_list(SW_PROBE_LIST, "software", search);
 
   // hardware
-  std::cout << std::endl;
   list_probes_from_list(HW_PROBE_LIST, "hardware",  search);
 
   // tracepoints
-  std::cout << std::endl;
   std::vector<std::string> cats = std::vector<std::string>();
   list_dir(tp_path, cats);
   for (i = 0; i < cats.size(); i++)
@@ -119,7 +117,6 @@ void list_probes(const std::string &search)
   }
 
   // kprobes
-  std::cout << std::endl;
   std::ifstream file(kprobe_path);
   if (file.fail())
   {


### PR DESCRIPTION
I regret adding the newline delimiter when listing tracepoints and kprobes, and finally removed it. bpftrace -l is likely to be often grepped anyway, so no one would see them.