### PR TITLE
fix symbol translation #349

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1497,7 +1497,7 @@ std::string BPFtrace::resolve_sym(uintptr_t addr, bool show_offset)
   if (!ksyms_)
     ksyms_ = bcc_symcache_new(-1, nullptr);
 
-  if (bcc_symcache_resolve(ksyms_, addr, &sym))
+  if (bcc_symcache_resolve(ksyms_, addr, &sym) == 0)
   {
     symbol << sym.name;
     if (show_offset)
@@ -1630,7 +1630,7 @@ std::string BPFtrace::resolve_usym(uintptr_t addr, int pid, bool show_offset)
     psyms = pid_sym_[pid];
   }
 
-  if (bcc_symcache_resolve(psyms, addr, &sym))
+  if (bcc_symcache_resolve(psyms, addr, &sym) == 0)
   {
     symbol << sym.name;
     if (show_offset)


### PR DESCRIPTION
fixes #349 

A recent change used the wrong test for bcc_symcache_resolve().

symbol translation is now back:

```
# ./src/bpftrace -e 'k:do_nanosleep { @[stack] = count(); }'
Attaching 1 probe...
^C

@[
do_nanosleep+1
sys_nanosleep+114
do_syscall_64+115
entry_SYSCALL_64_after_hwframe+61
]: 112

./src/bpftrace -e 'u:/bin/bash:readline { @[usym(reg("ip"))] = count(); }'
Attaching 1 probe...
^C

@[readline]: 3
```
