### PR TITLE
allow args with multiple tracepoints

### DIFF
--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -72,6 +72,7 @@ private:
   AttachPoint *current_attach_point_ = nullptr;
   BPFtrace &bpftrace_;
   std::string probefull_;
+  std::string tracepoint_struct_;
   std::map<std::string, int> next_probe_index_;
 
   std::map<std::string, AllocaInst *> variables_;

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -108,18 +108,35 @@ void SemanticAnalyser::visit(Builtin &builtin)
     builtin.type = SizedType(Type::username, 8);
   }
   else if (builtin.ident == "args") {
-    if (probe_->attach_points->size() > 1)
-      err_ << "The args builtin only works for probes with 1 attach point" << std::endl;
-    auto &attach_point = probe_->attach_points->at(0);
-    ProbeType type = probetype(attach_point->provider);
-    if (type != ProbeType::tracepoint)
-      err_ << "The args builtin can only be used with tracepoint probes"
-           << "(" << attach_point->provider << " used here)" << std::endl;
+    probe_->need_expansion = true;
+    for (auto &attach_point : *probe_->attach_points)
+    {
+      ProbeType type = probetype(attach_point->provider);
+      if (type != ProbeType::tracepoint)
+        err_ << "The args builtin can only be used with tracepoint probes"
+             << "(" << attach_point->provider << " used here)" << std::endl;
 
-    std::string tracepoint_struct = TracepointFormatParser::get_struct_name(attach_point->target, attach_point->func);
-    Struct &cstruct = bpftrace_.structs_[tracepoint_struct];
-    builtin.type = SizedType(Type::cast, cstruct.size, tracepoint_struct);
-    builtin.type.is_pointer = true;
+      /*
+       * tracepoint wildcard expansion, part 2 of 3. This:
+       * 1. expands the wildcard, then sets args to be the first matched probe.
+       *    This is so that enough of the type information is available to
+       *    survive the later semantic analyser checks.
+       * 2. sets is_tparg so that codegen does the real type setting after
+       *    expansion.
+       */
+      std::set<std::string> matches;
+      matches = bpftrace_.find_wildcard_matches(attach_point->target,
+                                                attach_point->func,
+                                                "/sys/kernel/debug/tracing/available_events");
+      for (auto &match : matches) {
+        std::string tracepoint_struct = TracepointFormatParser::get_struct_name(attach_point->target, match);
+        Struct &cstruct = bpftrace_.structs_[tracepoint_struct];
+        builtin.type = SizedType(Type::cast, cstruct.size, tracepoint_struct);
+        builtin.type.is_pointer = true;
+        builtin.type.is_tparg = true;
+        break;
+      }
+    }
   }
   else {
     builtin.type = SizedType(Type::none, 0);
@@ -623,6 +640,7 @@ void SemanticAnalyser::visit(FieldAccess &acc)
     acc.type = fields[acc.field].type;
     acc.type.is_internal = type.is_internal;
   }
+// XXX this necessary here? acc.type.is_tparg = type.is_tparg;
 }
 
 void SemanticAnalyser::visit(Cast &cast)

--- a/src/struct.h
+++ b/src/struct.h
@@ -11,11 +11,13 @@ public:
   int offset;
 };
 
+using FieldsMap = std::map<std::string, Field>;
+
 class Struct
 {
 public:
   int size;
-  std::map<std::string, Field> fields;
+  FieldsMap fields;
 };
 
 } // namespace bpftrace

--- a/src/types.h
+++ b/src/types.h
@@ -62,6 +62,7 @@ public:
   std::string cast_type;
   bool is_internal = false;
   bool is_pointer = false;
+  bool is_tparg = false;
   size_t pointee_size;
 
   bool IsArray() const;

--- a/tests/codegen/args_multiple_tracepoints.cpp
+++ b/tests/codegen/args_multiple_tracepoints.cpp
@@ -1,0 +1,242 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, args_multiple_tracepoints)
+{
+  test("tracepoint:syscalls:sys_enter_open,tracepoint:syscalls:sys_enter_openat { @[str(args->filename)] = count(); }",
+
+R"EXPECTED(; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"tracepoint:syscalls:sys_enter_open"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_open_1" {
+entry:
+  %"@_val" = alloca i64, align 8
+  %_tracepoint_syscalls_sys_enter_openat.filename = alloca i64, align 8
+  %str = alloca [64 x i8], align 1
+  %"@_key" = alloca [64 x i8], align 1
+  %1 = getelementptr inbounds [64 x i8], [64 x i8]* %"@_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  %2 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  call void @llvm.memset.p0i8.i64(i8* nonnull %2, i8 0, i64 64, i32 1, i1 false)
+  %3 = add i8* %0, i64 16
+  %4 = bitcast i64* %_tracepoint_syscalls_sys_enter_openat.filename to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_openat.filename, i64 8, i8* %3)
+  %5 = load i64, i64* %_tracepoint_syscalls_sys_enter_openat.filename, align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %5)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %1, i8* nonnull %2, i64 64, i32 1, i1 false)
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [64 x i8]* nonnull %"@_key")
+  %map_lookup_cond = icmp eq i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
+
+lookup_success:                                   ; preds = %entry
+  %6 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %6, 1
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %entry, %lookup_success
+  %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
+  %7 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
+  store i64 %lookup_elem_val.0, i64* %"@_val", align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [64 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i32, i1) #1
+
+define i64 @"tracepoint:syscalls:sys_enter_openat"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_openat_2" {
+entry:
+  %"@_val" = alloca i64, align 8
+  %_tracepoint_syscalls_sys_enter_openat.filename = alloca i64, align 8
+  %str = alloca [64 x i8], align 1
+  %"@_key" = alloca [64 x i8], align 1
+  %1 = getelementptr inbounds [64 x i8], [64 x i8]* %"@_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  %2 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  call void @llvm.memset.p0i8.i64(i8* nonnull %2, i8 0, i64 64, i32 1, i1 false)
+  %3 = add i8* %0, i64 24
+  %4 = bitcast i64* %_tracepoint_syscalls_sys_enter_openat.filename to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_openat.filename, i64 8, i8* %3)
+  %5 = load i64, i64* %_tracepoint_syscalls_sys_enter_openat.filename, align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %5)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %1, i8* nonnull %2, i64 64, i32 1, i1 false)
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [64 x i8]* nonnull %"@_key")
+  %map_lookup_cond = icmp eq i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
+
+lookup_success:                                   ; preds = %entry
+  %6 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %6, 1
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %entry, %lookup_success
+  %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
+  %7 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
+  store i64 %lookup_elem_val.0, i64* %"@_val", align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [64 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  ret i64 0
+}
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+}
+
+TEST(codegen, args_multiple_tracepoints_wild)
+{
+  test("tracepoint:syscalls:sys_enter_recv* { @[args->flags] = count(); }",
+
+R"EXPECTED(; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"tracepoint:syscalls:sys_enter_recvfrom"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_recvfrom_1" {
+entry:
+  %"@_val" = alloca i64, align 8
+  %_tracepoint_syscalls_sys_enter_recvfrom.flags = alloca i64, align 8
+  %"@_key" = alloca [8 x i8], align 8
+  %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  %2 = add i8* %0, i64 40
+  %3 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvfrom.flags, i64 8, i8* %2)
+  %4 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags, align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  store i64 %4, i8* %1, align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
+  %map_lookup_cond = icmp eq i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
+
+lookup_success:                                   ; preds = %entry
+  %5 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %5, 1
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %entry, %lookup_success
+  %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
+  %6 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  store i64 %lookup_elem_val.0, i64* %"@_val", align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+define i64 @"tracepoint:syscalls:sys_enter_recvmmsg"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_recvmmsg_2" {
+entry:
+  %"@_val" = alloca i64, align 8
+  %_tracepoint_syscalls_sys_enter_recvfrom.flags = alloca i64, align 8
+  %"@_key" = alloca [8 x i8], align 8
+  %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  %2 = add i8* %0, i64 40
+  %3 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvfrom.flags, i64 8, i8* %2)
+  %4 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags, align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  store i64 %4, i8* %1, align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
+  %map_lookup_cond = icmp eq i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
+
+lookup_success:                                   ; preds = %entry
+  %5 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %5, 1
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %entry, %lookup_success
+  %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
+  %6 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  store i64 %lookup_elem_val.0, i64* %"@_val", align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  ret i64 0
+}
+
+define i64 @"tracepoint:syscalls:sys_enter_recvmsg"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_recvmsg_3" {
+entry:
+  %"@_val" = alloca i64, align 8
+  %_tracepoint_syscalls_sys_enter_recvfrom.flags = alloca i64, align 8
+  %"@_key" = alloca [8 x i8], align 8
+  %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  %2 = add i8* %0, i64 32
+  %3 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvfrom.flags, i64 8, i8* %2)
+  %4 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags, align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  store i64 %4, i8* %1, align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
+  %map_lookup_cond = icmp eq i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
+
+lookup_success:                                   ; preds = %entry
+  %5 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %5, 1
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %entry, %lookup_success
+  %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
+  %6 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  store i64 %lookup_elem_val.0, i64* %"@_val", align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  ret i64 0
+}
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace
+


### PR DESCRIPTION
fixes 132

This is where I'm at. There's a some "XXX"s I haven't figured out yet, maybe someone else can. It mostly works. Examples:

```
 ./src/bpftrace -e 'tracepoint:syscalls:sys_enter_open,tracepoint:syscalls:sys_enter_openat { @[str(args->filename)] = count(); }'
Attaching 2 probes...
^C

@[/dev/bus/usb/001]: 1
@[/dev/bus/usb/003/043]: 1
[...]
```

that works.

```
./src/bpftrace -e 'tracepoint:syscalls:sys_enter_recv* { @[args->flags] = count(); }'
Attaching 3 probes...
^C

@[2]: 8
@[1073741824]: 16
@[64]: 58
@[0]: 2036

# bpftrace -l tracepoint:syscalls:sys_enter_recv*
tracepoint:syscalls:sys_enter_recvfrom
tracepoint:syscalls:sys_enter_recvmsg
tracepoint:syscalls:sys_enter_recvmmsg
```

this was important test since args->flags is at different offsets in these recv* tracepoints (either 40 or 32). Using bpftrace -v and -d I can see that it's using the correct offsets for the correct probes.

```
./src/bpftrace -e 'tracepoint:syscalls:sys_enter_open* { @[str(args->filename)] = count(); }'
Tracepoint args for tracepoint:syscalls:sys_enter_open_by_handle_at does not have field "filename".
Attaching 3 probes...
^C

@[/dev/bus/usb/003/042]: 1
@[/sys/kernel/debug/tracing/events/syscalls/sys_enter_open_by_han]: 1
@[/dev/bus/usb]: 1
[...]
```

that should not continue and begin tracing since the wildcard has matched a tracepoint that does not contain args->filename. I have it printing a warning, but it should exit as well. I can just put an exit() in there, but need to check what's best.

```
./src/bpftrace -e 'tracepoint:syscalls:sys_enter_* { @ = count(); }'
definitions.h:55:3: error: unknown type name 'key_serial_t'
definitions.h:123:3: error: unknown type name 'cap_user_header_t'
definitions.h:124:3: error: unknown type name 'cap_user_data_t'
definitions.h:133:3: error: unknown type name 'cap_user_header_t'
definitions.h:134:9: error: unknown type name 'cap_user_data_t'
definitions.h:365:9: error: unknown type name 'sigset_t'
definitions.h:1047:3: error: unknown type name 'aio_context_t'
definitions.h:1058:3: error: unknown type name 'aio_context_t'
definitions.h:1067:3: error: unknown type name 'aio_context_t'
definitions.h:1081:3: error: unknown type name 'aio_context_t'
definitions.h:1090:3: error: unknown type name 'aio_context_t'
definitions.h:1909:9: error: unknown type name 'sigset_t'
definitions.h:1962:3: error: unknown type name 'rwf_t'
definitions.h:2067:3: error: unknown type name 'rwf_t'
definitions.h:2078:3: error: unknown type name 'qid_t'
definitions.h:2255:3: error: unknown type name 'key_serial_t'
definitions.h:2293:3: error: unknown type name 'sigset_t'
definitions.h:2304:3: error: unknown type name 'sigset_t'
definitions.h:2305:3: error: unknown type name 'sigset_t'
fatal error: too many errors emitted, stopping now [-ferror-limit=]
Attaching 316 probes...
^C

@: 483147
```

This also needs work. It shouldn't need to do the struct definitions if args isn't used. Plus, with -v you can see it's expanding the BPF programs for each tracepoint match, but this doesn't need it because neither args or probe are in use. need_expansion should be false, so why is it expanding?

I might add some commits and we can squash merge (or someone can take over this PR).