### PR TITLE
Lesson 9: Replace "stack" to "kstack".

### DIFF
--- a/docs/tutorial_one_liners.md
+++ b/docs/tutorial_one_liners.md
@@ -190,7 +190,7 @@ Count process-level events for five seconds, printing a summary.
 # Lesson 9. Profile On-CPU Kernel Stacks
 
 ```
-# bpftrace -e 'profile:hz:99 { @[stack] = count(); }'
+# bpftrace -e 'profile:hz:99 { @[kstack] = count(); }'
 Attaching 1 probe...
 ^C
 


### PR DESCRIPTION
Fix warning issue for Lesson 9: the stack is deprecated and will be removed in the future. Use kstack instead