### PR TITLE
follow the new libbcc interface: bcc_{create_map, prog_load}

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,10 @@ set(CMAKE_REQUIRED_DEFINITIONS -D_GNU_SOURCE)
 check_symbol_exists(name_to_handle_at "sys/types.h;sys/stat.h;fcntl.h" HAVE_NAME_TO_HANDLE_AT)
 set(CMAKE_REQUIRED_DEFINITIONS)
 
+set(CMAKE_REQUIRED_LIBRARIES bcc)
+check_symbol_exists(bcc_prog_load "${LIBBCC_INCLUDE_DIRS}/libbpf.h" HAVE_BCC_PROG_LOAD)
+check_symbol_exists(bcc_create_map "${LIBBCC_INCLUDE_DIRS}/libbpf.h" HAVE_BCC_CREATE_MAP)
+
 find_package(LLVM REQUIRED)
 include_directories(${LLVM_INCLUDE_DIRS})
 add_definitions(${LLVM_DEFINITIONS})

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,12 @@ add_executable(bpftrace
 if(HAVE_NAME_TO_HANDLE_AT)
   target_compile_definitions(bpftrace PRIVATE HAVE_NAME_TO_HANDLE_AT=1)
 endif(HAVE_NAME_TO_HANDLE_AT)
+if(HAVE_BCC_PROG_LOAD)
+  target_compile_definitions(bpftrace PRIVATE HAVE_BCC_PROG_LOAD)
+endif(HAVE_BCC_PROG_LOAD)
+if(HAVE_BCC_CREATE_MAP)
+  target_compile_definitions(bpftrace PRIVATE HAVE_BCC_CREATE_MAP)
+endif(HAVE_BCC_CREATE_MAP)
 target_link_libraries(bpftrace arch ast parser resources)
 
 if (STATIC_LINKING)

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -321,7 +321,11 @@ void AttachedProbe::load_prog()
 
   for (int attempt=0; attempt<3; attempt++)
   {
+#ifdef HAVE_BCC_PROG_LOAD
+    progfd_ = bcc_prog_load(progtype(probe_.type), namep,
+#else
     progfd_ = bpf_prog_load(progtype(probe_.type), namep,
+#endif
         reinterpret_cast<struct bpf_insn*>(insns), prog_len, license,
         kernel_version(attempt), log_level, log_buf, log_buf_size);
     if (progfd_ >= 0)

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -46,7 +46,11 @@ Map::Map(const std::string &name, const SizedType &type, const MapKey &key, int 
 
   int value_size = type.size;
   int flags = 0;
+#ifdef HAVE_BCC_CREATE_MAP
+  mapfd_ = bcc_create_map(map_type, name.c_str(), key_size, value_size, max_entries, flags);
+#else
   mapfd_ = bpf_create_map(map_type, name.c_str(), key_size, value_size, max_entries, flags);
+#endif
   if (mapfd_ < 0)
   {
     std::cerr << "Error creating map: '" << name_ << "'" << std::endl;
@@ -79,7 +83,11 @@ Map::Map(enum bpf_map_type map_type)
   {
     abort();
   }
+#ifdef HAVE_BCC_CREATE_MAP
+  mapfd_ = bcc_create_map(map_type, name.c_str(), key_size, value_size, max_entries, flags);
+#else
   mapfd_ = bpf_create_map(map_type, name.c_str(), key_size, value_size, max_entries, flags);
+#endif
   if (mapfd_ < 0)
   {
     std::string name;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,6 +31,12 @@ add_executable(bpftrace_test
 if(HAVE_NAME_TO_HANDLE_AT)
   target_compile_definitions(bpftrace_test PRIVATE HAVE_NAME_TO_HANDLE_AT=1)
 endif(HAVE_NAME_TO_HANDLE_AT)
+if(HAVE_BCC_PROG_LOAD)
+  target_compile_definitions(bpftrace_test PRIVATE HAVE_BCC_PROG_LOAD)
+endif(HAVE_BCC_PROG_LOAD)
+if(HAVE_BCC_CREATE_MAP)
+  target_compile_definitions(bpftrace_test PRIVATE HAVE_BCC_CREATE_MAP)
+endif(HAVE_BCC_CREATE_MAP)
 target_link_libraries(bpftrace_test arch ast parser resources)
 
 if (STATIC_LINKING)


### PR DESCRIPTION
libbcc has renamed the following APIs recently (https://github.com/iovisor/bcc/pull/2149):

    bpf_create_map  =>  bcc_create_map
    bpf_prog_load   =>  bcc_prog_load

Let's keep up with that.