### PR TITLE
[RFC] Increase string size

### DIFF
--- a/src/types.h
+++ b/src/types.h
@@ -9,7 +9,7 @@
 namespace bpftrace {
 
 const int MAX_STACK_SIZE = 32;
-const int STRING_SIZE = 64;
+const int STRING_SIZE = 210;
 const int COMM_SIZE = 16;
 
 enum class Type


### PR DESCRIPTION
The cgroup path used by Kubernetes pods could be quite long: 207 characters in my test. It looks like this:

```
/sys/fs/cgroup/unified/kubepods.slice/kubepods-besteffort.slice/kubepods-besteffort-pod1aecc643_23ea_11e9_beec_06c846f19394.slice/docker-da9977a4f9abe14ab2fa87d3780d92fd615b97cc3107fcd4a851f01857cb8ff8.scope
```

This patch should allow me to filter on Kubernetes pods, for example in this way:

```
bpftrace -e 'tracepoint:syscalls:sys_enter_openat /cgroup == cgroupid("/sys/fs/cgroup/unified/kubepods...")/ { printf("%s\n", str(args->filename)); }'
```

In this one-liner, this long string will not end up in the BPF program because the cgroupid() builtin will resolve the cgroup id in userspace.

However, I am worried if other programs start to use long strings in the BPF program because of the stack size limit.

TODO:
- [ ] Not tested yet

/cc @fntlnz for the https://github.com/iovisor/kubectl-trace project