### PR TITLE
C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(bpftrace)
 set(STATIC_LINKING OFF CACHE BOOL "Build bpftrace as a statically linked executable")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-add_compile_options("-std=c++14")
+add_compile_options("-std=c++17")
 add_compile_options("-Wno-format-security")
 #add_compile_options("-Wall")
 add_compile_options("-Wextra")


### PR DESCRIPTION
Justification: https://github.com/iovisor/bpftrace/issues/318.

I was able to successfully do a clean build with no errors. I tried tracing a syscall and it printed the right thing.

Tests pass, except for some clang_parser tests (I think these have always failed in my environment).  
Continuous Integration will presumably give us a more authoritative answer.