### PR TITLE
build: define an option to not use bundled dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,26 +20,20 @@ add_compile_options("-Wno-format-security")
 #add_compile_options("-Wstrict-overflow=5")
 #add_compile_options("-Wdisabled-optimization")
 
+option(OFFLINE_BUILDS "Don't try to update external dependencies." OFF)
+if (OFFLINE_BUILDS)
+  set_property(DIRECTORY PROPERTY EP_UPDATE_DISCONNECTED 1)
+endif()
+
 enable_testing()
 
-if (OFFLINE_BUILDS)
-  include(ExternalProject)
-  ExternalProject_Add(bcc
-    GIT_REPOSITORY https://github.com/iovisor/bcc
-    STEP_TARGETS build update
-    EXCLUDE_FROM_ALL 1
-    UPDATE_DISCONNECTED 1
-    BUILD_COMMAND ${CMAKE_COMMAND} --build . --target bcc-static
-    )
-else()
-  include(ExternalProject)
-  ExternalProject_Add(bcc
-    GIT_REPOSITORY https://github.com/iovisor/bcc
-    STEP_TARGETS build update
-    EXCLUDE_FROM_ALL 1
-    BUILD_COMMAND ${CMAKE_COMMAND} --build . --target bcc-static
-    )
-endif()
+include(ExternalProject)
+ExternalProject_Add(bcc
+  GIT_REPOSITORY https://github.com/iovisor/bcc
+  STEP_TARGETS build update
+  EXCLUDE_FROM_ALL 1
+  BUILD_COMMAND ${CMAKE_COMMAND} --build . --target bcc-static
+  )
 
 if (STATIC_LINKING)
   set(CMAKE_EXE_LINKER_FLAGS "-static")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,9 @@ add_compile_options("-Wno-format-security")
 #add_compile_options("-Wstrict-overflow=5")
 #add_compile_options("-Wdisabled-optimization")
 
+option(USE_BUNDLED "Use bundled dependencies." ON)
+option(USE_BUNDLED_BCC "Use the bundled version of bcc." ${USE_BUNDLED})
+option(USE_BUNDLED_GTEST "Use the bundled version of gtest." ${USE_BUNDLED})
 option(OFFLINE_BUILDS "Don't try to update external dependencies." OFF)
 if (OFFLINE_BUILDS)
   set_property(DIRECTORY PROPERTY EP_UPDATE_DISCONNECTED 1)
@@ -27,6 +30,7 @@ endif()
 
 enable_testing()
 
+if (USE_BUNDLED_BCC)
 include(ExternalProject)
 ExternalProject_Add(bcc
   GIT_REPOSITORY https://github.com/iovisor/bcc
@@ -34,6 +38,29 @@ ExternalProject_Add(bcc
   EXCLUDE_FROM_ALL 1
   BUILD_COMMAND ${CMAKE_COMMAND} --build . --target bcc-static
   )
+endif()
+
+function(LinkBCC name)
+  if (USE_BUNDLED_BCC)
+    ExternalProject_Get_Property(bcc source_dir binary_dir)
+    target_include_directories(${name} PUBLIC ${source_dir}/src/cc)
+    target_link_libraries(${name} ${binary_dir}/src/cc/libbpf.a)
+    target_link_libraries(${name} ${binary_dir}/src/cc/libbcc-loader-static.a)
+    target_link_libraries(${name} ${binary_dir}/src/cc/libbcc.a)
+    target_link_libraries(${name} ${binary_dir}/src/cc/frontends/clang/libclang_frontend.a)
+  else()
+    find_path(BCC_INCLUDE_DIR
+      NAMES "bcc_elf.h"
+      PATH_SUFFIXES "bcc")
+    find_library(BCC_LIBRARY NAMES bcc libbcc)
+    if (NOT BCC_INCLUDE_DIR OR NOT BCC_LIBRARY)
+      message(FATAL_ERROR "bcc library required, but not found!")
+    endif()
+    target_include_directories(${name} PUBLIC ${BCC_INCLUDE_DIR})
+    target_link_libraries(${name} ${BCC_LIBRARY})
+  endif()
+  target_link_libraries(${name} ${LIBELF_LIBRARIES})
+endfunction(LinkBCC)
 
 if (STATIC_LINKING)
   set(CMAKE_EXE_LINKER_FLAGS "-static")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,14 +18,7 @@ if(HAVE_NAME_TO_HANDLE_AT)
   target_compile_definitions(bpftrace PRIVATE HAVE_NAME_TO_HANDLE_AT=1)
 endif(HAVE_NAME_TO_HANDLE_AT)
 target_link_libraries(bpftrace arch ast parser resources)
-
-ExternalProject_Get_Property(bcc source_dir binary_dir)
-target_include_directories(bpftrace PUBLIC ${source_dir}/src/cc)
-target_link_libraries(bpftrace ${binary_dir}/src/cc/libbpf.a)
-target_link_libraries(bpftrace ${binary_dir}/src/cc/libbcc-loader-static.a)
-target_link_libraries(bpftrace ${binary_dir}/src/cc/libbcc.a)
-target_link_libraries(bpftrace ${binary_dir}/src/cc/frontends/clang/libclang_frontend.a)
-target_link_libraries(bpftrace ${LIBELF_LIBRARIES})
+LinkBCC(bpftrace)
 
 install(TARGETS bpftrace DESTINATION bin)
 

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -11,9 +11,11 @@ target_include_directories(ast PUBLIC ${CMAKE_SOURCE_DIR}/src/ast)
 target_include_directories(ast PUBLIC ${CMAKE_BINARY_DIR})
 target_link_libraries(ast arch)
 
-add_dependencies(ast bcc-build parser)
-ExternalProject_Get_Property(bcc source_dir)
-target_include_directories(ast PUBLIC ${source_dir}/src/cc)
+add_dependencies(ast parser)
+if (USE_BUNDLED_BCC)
+  add_dependencies(ast bcc-build)
+endif()
+LinkBCC(ast)
 
 if (STATIC_LINKING)
   set(clang_libs

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,24 +42,13 @@ target_link_libraries(bpftrace_test ${LIBELF_LIBRARIES})
 
 find_package(Threads REQUIRED)
 
-if (OFFLINE_BUILDS)
-  include(ExternalProject)
-  ExternalProject_Add(gtest-git
-    GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG release-1.8.1
-    STEP_TARGETS build update
-    EXCLUDE_FROM_ALL 1
-    UPDATE_DISCONNECTED 1
-    )
-else()
-  include(ExternalProject)
-  ExternalProject_Add(gtest-git
-    GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG release-1.8.1
-    STEP_TARGETS build update
-    EXCLUDE_FROM_ALL 1
-    )
-endif()
+include(ExternalProject)
+ExternalProject_Add(gtest-git
+  GIT_REPOSITORY https://github.com/google/googletest.git
+  GIT_TAG release-1.8.1
+  STEP_TARGETS build update
+  EXCLUDE_FROM_ALL 1
+  )
 add_dependencies(bpftrace_test gtest-git-build)
 ExternalProject_Get_Property(gtest-git source_dir binary_dir)
 target_include_directories(bpftrace_test PUBLIC ${source_dir}/googletest/include)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -31,31 +31,39 @@ if(HAVE_NAME_TO_HANDLE_AT)
   target_compile_definitions(bpftrace_test PRIVATE HAVE_NAME_TO_HANDLE_AT=1)
 endif(HAVE_NAME_TO_HANDLE_AT)
 target_link_libraries(bpftrace_test arch ast parser resources)
-
-ExternalProject_Get_Property(bcc source_dir binary_dir)
-target_include_directories(bpftrace_test PUBLIC ${source_dir}/src/cc)
-target_link_libraries(bpftrace_test ${binary_dir}/src/cc/libbpf.a)
-target_link_libraries(bpftrace_test ${binary_dir}/src/cc/libbcc-loader-static.a)
-target_link_libraries(bpftrace_test ${binary_dir}/src/cc/libbcc.a)
-target_link_libraries(bpftrace_test ${binary_dir}/src/cc/frontends/clang/libclang_frontend.a)
-target_link_libraries(bpftrace_test ${LIBELF_LIBRARIES})
+LinkBCC(bpftrace_test)
 
 find_package(Threads REQUIRED)
 
-include(ExternalProject)
-ExternalProject_Add(gtest-git
-  GIT_REPOSITORY https://github.com/google/googletest.git
-  GIT_TAG release-1.8.1
-  STEP_TARGETS build update
-  EXCLUDE_FROM_ALL 1
-  )
-add_dependencies(bpftrace_test gtest-git-build)
-ExternalProject_Get_Property(gtest-git source_dir binary_dir)
-target_include_directories(bpftrace_test PUBLIC ${source_dir}/googletest/include)
-target_include_directories(bpftrace_test PUBLIC ${source_dir}/googlemock/include)
-target_link_libraries(bpftrace_test ${binary_dir}/googlemock/gtest/libgtest.a)
-target_link_libraries(bpftrace_test ${binary_dir}/googlemock/gtest/libgtest_main.a)
-target_link_libraries(bpftrace_test ${binary_dir}/googlemock/libgmock.a)
+if (USE_BUNDLED_GTEST)
+  include(ExternalProject)
+  ExternalProject_Add(gtest-git
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG release-1.8.1
+    STEP_TARGETS build update
+    EXCLUDE_FROM_ALL 1
+    )
+  add_dependencies(bpftrace_test gtest-git-build)
+  ExternalProject_Get_Property(gtest-git source_dir binary_dir)
+  target_include_directories(bpftrace_test PUBLIC ${source_dir}/googletest/include)
+  target_include_directories(bpftrace_test PUBLIC ${source_dir}/googlemock/include)
+  target_link_libraries(bpftrace_test ${binary_dir}/googlemock/gtest/libgtest.a)
+  target_link_libraries(bpftrace_test ${binary_dir}/googlemock/gtest/libgtest_main.a)
+  target_link_libraries(bpftrace_test ${binary_dir}/googlemock/libgmock.a)
+else()
+  find_package(GTest REQUIRED)
+  target_include_directories(bpftrace_test PUBLIC ${GTEST_INCLUDE_DIRS})
+  target_link_libraries(bpftrace_test ${GTEST_BOTH_LIBRARIES})
+
+  # Unfortunately, not possible to get the same for gmock
+  find_path(GMOCK_INCLUDE_DIR NAMES gmock/gmock.h)
+  find_library(GMOCK_LIBRARY NAMES libgmock.a)
+  if (NOT GMOCK_INCLUDE_DIR OR NOT GMOCK_LIBRARY)
+    message(FATAL_ERROR "gmock library required, but not found!")
+  endif()
+  target_include_directories(bpftrace_test PUBLIC ${GMOCK_INCLUDE_DIR})
+  target_link_libraries(bpftrace_test ${GMOCK_LIBRARY})
+endif()
 target_link_libraries(bpftrace_test ${CMAKE_THREAD_LIBS_INIT})
 
 add_test(NAME bpftrace_test COMMAND bpftrace_test)


### PR DESCRIPTION
By default, bpftrace build system will fetch libbcc and gtest, compile
them and link to the result. Distributions need to use existing
package and not fetch stuff from Internet. In Debian, libbcc is
available as libbpfcc-dev and gtest is available as libgtest-dev and
libgmock-dev.

We define three new options:
 - USE_BUNDLED,
 - USE_BUNDLED_BCC, and
 - USE_BUNDLED_GTEST

They are OFF by default, so for regular users, there is no change.
When the first one is set to OFF, the two other ones are set to OFF
too (unless explicitely set to ON).

Best practice in CMake recommends to use `find_package()` and ship
`FindXXX.cmake` files to do the hardwork. I think it would be better
for libbcc to ship the right `FindXXX.cmake` instead of defining it
here. In the meantime, it's defined here. Currently, libbpfcc-dev
package doesn't ship the .pc file, so I am using `find_path()` and
`find_library()` to locate the appropriate paths. I have asked
libbpfcc maintainer to include the .pc file.

As for gtest, CMake ships with `FindGTest()`, so we use that. But
there is no `FindGMock()`. There are some versions online, but I've
just used `find_path()` and `find_library()`.

Currently, the result doesn't work because bpftrace is using some
include files not shipped with libbcc:

 - `common.h`
 - `syms.h` (then `ns_guard.h`)
 - `frontends/clang/kbuild_helper.h`

I don't know if this is a problem with bpftrace which shouldn't use
these includes or with libbcc which should ship them. If I copy them
manually, it works. Tests are also succeeding (as root only, something
that will cause problems for distributions too, but I'll look at that
later).

Also, I have based these modifications on top of v0.8. In the meantime, `FindLibBcc.cmake` was added. I'll update the PR later for this change. It seems the include problems are also solved. Until then, comments about the general idea are welcome.