### PR TITLE
Allow customizing stdout buffering mode via -b

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,8 @@
 #include <iostream>
 #include <signal.h>
 #include <sys/resource.h>
+#include <cstdio>
+#include <cstring>
 #include <unistd.h>
 
 #include "bpforc.h"
@@ -21,6 +23,7 @@ void usage()
   std::cerr << "    bpftrace [options] filename" << std::endl;
   std::cerr << "    bpftrace [options] -e 'program'" << std::endl << std::endl;
   std::cerr << "OPTIONS:" << std::endl;
+  std::cerr << "    -b MODE        output buffering mode ('line' or 'full')" << std::endl;
   std::cerr << "    -d             debug info dry run" << std::endl;
   std::cerr << "    -dd            verbose debug info dry run" << std::endl;
   std::cerr << "    -e 'program'   execute this program" << std::endl;
@@ -83,7 +86,7 @@ int main(int argc, char *argv[])
 
   std::string script, search;
   int c;
-  while ((c = getopt(argc, argv, "de:hlp:vc:")) != -1)
+  while ((c = getopt(argc, argv, "db:e:hlp:vc:")) != -1)
   {
     switch (c)
     {
@@ -96,6 +99,16 @@ int main(int argc, char *argv[])
         break;
       case 'v':
         bt_verbose = true;
+        break;
+      case 'b':
+        if (std::strcmp(optarg, "line") == 0) {
+          std::setvbuf(stdout, NULL, _IOLBF, BUFSIZ);
+        } else if (std::strcmp(optarg, "full") == 0) {
+          std::setvbuf(stdout, NULL, _IOFBF, BUFSIZ);
+        } else {
+          std::cerr << "USAGE: -b must be either 'line' or 'full'." << std::endl;
+          return 1;
+        }
         break;
       case 'e':
         script = optarg;


### PR DESCRIPTION
This pull request allows customizing the stdout buffering mode via "-b line" and "-b full".

Here's my use case. I redirect bpftrace's output to a file, and I need to parse the file at some point -- before bpftrace exits -- in order to analyze the state of the program I'm tracing. Without begin able to set stdout to line buffering, I can't see what bpftrace printed until bpftrace exits.

Fixes https://github.com/iovisor/bpftrace/issues/236.