### PR TITLE
-D__BPF_TRACING__

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -103,6 +103,7 @@ std::vector<std::string> get_kernel_cflags(
   cflags.push_back("-include");
   cflags.push_back(kdir + "/include/linux/kconfig.h");
   cflags.push_back("-D__KERNEL__");
+  cflags.push_back("-D__BPF_TRACING__");
   cflags.push_back("-D__HAVE_BUILTIN_BSWAP16__");
   cflags.push_back("-D__HAVE_BUILTIN_BSWAP32__");
   cflags.push_back("-D__HAVE_BUILTIN_BSWAP64__");


### PR DESCRIPTION
I was trying bpftrace on my example[1] with updated kernel (4.19.16) and
got:

	/lib/modules/4.19.0-2-amd64/source/arch/x86/include/asm/cpufeature.h:150:2: warning: "Compiler lacks ASM_GOTO support. Add -D __BPF_TRACING__ to your compiler arguments" [-W#warnings]

This was added in https://git.kernel.org/linus/b1ae32dbab which also
adds -D__BPF_TRACING__ to samples/bpf/Makefile in kernel.

[1] https://github.com/iovisor/bpftrace/issues/252#issuecomment-440346608