### PR TITLE
Detect kernel headers even if they are splitted into source/ and build/ directories

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -53,7 +53,8 @@ std::vector<int> get_possible_cpus()
 
 std::vector<std::string> get_kernel_cflags(
     const char* uname_machine,
-    const std::string& kdir)
+    const std::string& ksrc,
+    const std::string& kobj)
 {
   std::vector<std::string> cflags;
   std::string arch = uname_machine;
@@ -90,18 +91,18 @@ std::vector<std::string> get_kernel_cflags(
   cflags.push_back("-isystem");
   cflags.push_back("/virtual/lib/clang/include");
 
-  cflags.push_back("-I" + kdir + "/arch/"+arch+"/include");
-  cflags.push_back("-I" + kdir + "/arch/"+arch+"/include/generated/uapi");
-  cflags.push_back("-I" + kdir + "/arch/"+arch+"/include/generated");
-  cflags.push_back("-I" + kdir + "/include");
-  cflags.push_back("-I" + kdir + "/./arch/"+arch+"/include/uapi");
-  cflags.push_back("-I" + kdir + "/arch/"+arch+"/include/generated/uapi");
-  cflags.push_back("-I" + kdir + "/include/uapi");
-  cflags.push_back("-I" + kdir + "/include/generated");
-  cflags.push_back("-I" + kdir + "/include/generated/uapi");
+  // see linux/Makefile for $(LINUXINCLUDE) + $(USERINCLUDE)
+  cflags.push_back("-I" + ksrc + "/arch/"+arch+"/include");
+  cflags.push_back("-I" + kobj + "/arch/"+arch+"/include/generated");
+  cflags.push_back("-I" + ksrc + "/include");
+  cflags.push_back("-I" + kobj + "/include");
+  cflags.push_back("-I" + ksrc + "/arch/"+arch+"/include/uapi");
+  cflags.push_back("-I" + kobj + "/arch/"+arch+"/include/generated/uapi");
+  cflags.push_back("-I" + ksrc + "/include/uapi");
+  cflags.push_back("-I" + kobj + "/include/generated/uapi");
 
   cflags.push_back("-include");
-  cflags.push_back(kdir + "/include/linux/kconfig.h");
+  cflags.push_back(ksrc + "/include/linux/kconfig.h");
   cflags.push_back("-D__KERNEL__");
   cflags.push_back("-D__HAVE_BUILTIN_BSWAP16__");
   cflags.push_back("-D__HAVE_BUILTIN_BSWAP32__");

--- a/src/utils.h
+++ b/src/utils.h
@@ -26,7 +26,8 @@ std::vector<int> get_online_cpus();
 std::vector<int> get_possible_cpus();
 std::vector<std::string> get_kernel_cflags(
     const char* uname_machine,
-    const std::string& kdir);
+    const std::string& ksrc,
+    const std::string& kobj);
 std::string is_deprecated(std::string &str);
 
 } // namespace bpftrace


### PR DESCRIPTION
Currently bpftrace uses only /lib/modules/`uname -r`/source/ if it
exists. This however leads to failures Debian where generated kernel
headers, such as include/generated/autoconf.h are put into a separate
directory, for example:

	---- 8< ---- (fuse_vs_mmapsem.bt)
	#include <linux/path.h>
	#include <linux/dcache.h>
	#include <linux/sched.h>
	#include <linux/mm_types.h>

	kprobe:fuse_readpage,kprobe:fuse_readpages {
	        printf("%s (%d) %s\n", probe, ((task_struct *)curtask)->mm->mmap_sem.count.counter, kstack);
	}
	---- 8< ----

	# ./bpftrace fuse_vs_mmapsem.bt
	/lib/modules/4.19.0-2-amd64/source/include/linux/kconfig.h:5:10: fatal error: 'generated/autoconf.h' file not found
	Unknown struct/union: 'task_struct'

Fix it by using both /lib/modules/`uname -r`/source/ and
/lib/modules/`uname -r`/build/ if both are present.

/cc @vincentbernat

P.S. I was not using C++ for ages, so please forgive me in advance if I
missed something.