### PR TITLE
Prevent empty trigger functions to be optimized away with -O2 (#218)

### DIFF
--- a/src/triggers.h
+++ b/src/triggers.h
@@ -2,6 +2,6 @@
 
 extern "C"
 {
-  void BEGIN_trigger() { }
-  void END_trigger() { }
+  void __attribute__((noinline)) BEGIN_trigger() { asm (""); }
+  void __attribute__((noinline)) END_trigger() { asm (""); }
 }


### PR DESCRIPTION
From the gcc manual: 'noinline - This function attribute prevents a
function from being considered for inlining. If the function does not
have side effects, there are optimizations other than inlining that
cause function calls to be optimized away, although the function call is
live. To keep such calls from being optimized away, put asm ("");'
(https://gcc.gnu.org/onlinedocs/gcc/Common-Function-Attributes.html)