### PR TITLE
Usdt specify provider ns

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -757,8 +757,12 @@ Syntax:
 
 ```
 usdt:binary_path:probe_name
+usdt:binary_path:[probe_namespace]:probe_name
 usdt:library_path:probe_name
+usdt:library_path:[probe_namespace]:probe_name
 ```
+
+Where the `probe_namespace` is optional, and will default to the basename of the binary or library path.
 
 Examples:
 
@@ -771,6 +775,22 @@ hi
 hi
 hi
 ^C
+```
+The basename of a path will be used for the namespace of a probe. If it doesn't match, the probe won't be found.
+In this example, the function name `loop` is in the namespace `tick`. If we rename the binary to `tock`, it won't be found:
+
+```
+mv /root/tick /root/tock
+bpftrace -e 'usdt:/root/tock:loop { printf("hi\n"); }'
+Attaching 1 probe...
+Error finding location for probe: usdt:/root/tock:loop
+```
+
+The probe namespace can be manually specified, between the path and probe function name. This allows for the probe to be
+found, regardless of the name of the binary:
+
+```
+bpftrace -e 'usdt:/root/tock:tick:loop { printf("hi\n"); }'
 ```
 
 ## 8. `usdt`: Static Tracing, User-Level Arguments

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -129,6 +129,8 @@ std::string AttachPoint::name(const std::string &attach_point) const
   std::string n = provider;
   if (target != "")
     n += ":" + target;
+  if (ns != "")
+    n += ":" + ns;
   if (attach_point != "")
     n += ":" + attach_point;
   if (freq != 0)
@@ -153,6 +155,8 @@ std::string Probe::name() const
     n += attach_point->provider;
     if (attach_point->target != "")
       n += ":" + attach_point->target;
+    if (attach_point->ns != "")
+      n += ":" + attach_point->ns;
     if (attach_point->func != "")
       n += ":" + attach_point->func;
     if (attach_point->freq != 0)

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -216,11 +216,18 @@ public:
     : provider(probetypeName(provider)), target(target), func(func), need_expansion(need_expansion) { }
   AttachPoint(const std::string &provider,
               const std::string &target,
+              const std::string &ns,
+              const std::string &func,
+              bool need_expansion)
+    : provider(probetypeName(provider)), target(target), ns(ns), func(func), need_expansion(need_expansion) { }
+  AttachPoint(const std::string &provider,
+              const std::string &target,
               int freq)
     : provider(probetypeName(provider)), target(target), freq(freq), need_expansion(true) { }
 
   std::string provider;
   std::string target;
+  std::string ns;
   std::string func;
   int freq = 0;
   bool need_expansion = false;

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -345,7 +345,7 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_poin
     exit(-1);
   }
 
-  if(!attach_point->ns.empty())
+  if(attach_point->ns != "")
     provider_ns = attach_point->ns;
   else
     provider_ns = GetProviderFromPath(attach_point->target);

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -337,6 +337,7 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx, struct bcc_usdt_argument
 Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_point, int arg_num, Builtin &builtin)
 {
   struct bcc_usdt_argument argument;
+  std::string provider_ns;
 
   void *usdt = bcc_usdt_new_frompath(attach_point->target.c_str());
   if (usdt == nullptr) {
@@ -344,10 +345,14 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_poin
     exit(-1);
   }
 
-  std::string provider = GetProviderFromPath(attach_point->target);
-  if (bcc_usdt_get_argument(usdt, provider.c_str(), attach_point->func.c_str(), 0, arg_num, &argument) != 0) {
+  if(!attach_point->ns.empty())
+    provider_ns = attach_point->ns;
+  else
+    provider_ns = GetProviderFromPath(attach_point->target);
+
+  if (bcc_usdt_get_argument(usdt, provider_ns.c_str(), attach_point->func.c_str(), 0, arg_num, &argument) != 0) {
     std::cerr << "couldn't get argument " << arg_num << " for " << attach_point->target << ":"
-              << provider << ":" << attach_point->func << std::endl;
+              << provider_ns << ":" << attach_point->func << std::endl;
     exit(-2);
   }
 

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -414,7 +414,7 @@ void AttachedProbe::attach_usdt(int pid)
     throw std::runtime_error("Error finding or enabling probe: " + probe_.name);
 
   // Handle manually specifying probe provider namespace
-  if (!probe_.ns.empty()) // FIXME what's the idiomatic way to check if this is set?
+  if (probe_.ns != "")
     provider_ns = probe_.ns;
   else
     provider_ns = GetProviderFromPath(probe_.path);

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -391,6 +391,7 @@ void AttachedProbe::attach_usdt(int pid)
 {
   struct bcc_usdt_location loc = {};
   int err;
+  std::string provider_ns;
   void *ctx;
 
   if (pid)
@@ -412,9 +413,13 @@ void AttachedProbe::attach_usdt(int pid)
   if (err)
     throw std::runtime_error("Error finding or enabling probe: " + probe_.name);
 
-  std::string provider_name = GetProviderFromPath(probe_.path);
+  // Handle manually specifying probe provider namespace
+  if (!probe_.ns.empty()) // FIXME what's the idiomatic way to check if this is set?
+    provider_ns = probe_.ns;
+  else
+    provider_ns = GetProviderFromPath(probe_.path);
 
-  err = bcc_usdt_get_location(ctx, provider_name.c_str(), probe_.attach_point.c_str(), 0, &loc);
+  err = bcc_usdt_get_location(ctx, provider_ns.c_str(), probe_.attach_point.c_str(), 0, &loc);
   if (err)
     throw std::runtime_error("Error finding location for probe: " + probe_.name);
   probe_.loc = loc.address;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -130,6 +130,7 @@ int BPFtrace::add_probe(ast::Probe &p)
       probe.attach_point = func;
       probe.type = probetype(attach_point->provider);
       probe.orig_name = p.name();
+      probe.ns = attach_point->ns;
       probe.name = attach_point->name(func);
       probe.freq = attach_point->freq;
       probe.loc = 0;

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -147,6 +147,10 @@ attach_point : ident               { $$ = new ast::AttachPoint($1); }
              | ident PATH STRING   { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, false); }
              | ident PATH wildcard { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, true); }
              | ident PATH INT      { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3); }
+             | ident PATH STRING ":" STRING  { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, $5, false); }
+             | ident PATH STRING ":" wildcard  { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, $5, true); }
+             | ident PATH wildcard ":" STRING  { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, $5, true); }
+             | ident PATH wildcard ":" wildcard  { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, $5, true); }
              ;
 
 wildcard : wildcard ident    { $$ = $1 + $2; }

--- a/src/types.h
+++ b/src/types.h
@@ -109,6 +109,7 @@ public:
   std::string orig_name;	// original full probe name,
 				// before wildcard expansion
   std::string name;		// full probe name
+  std::string ns;		// for USDT probes, if provider namespace not from path
   uint64_t loc;			// for USDT probes
   int index = 0;
   int freq;

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -473,6 +473,13 @@ TEST(Parser, usdt)
       "  int: 1\n");
 }
 
+TEST(Parser, usdt_namespaced_probe)
+{
+  test("usdt:/my/program:namespace:probe { 1; }",
+      "Program\n"
+      " usdt:/my/program:namespace:probe\n"
+      "  int: 1\n");
+}
 TEST(Parser, escape_chars)
 {
   test("kprobe:sys_open { \"newline\\nand tab\\tbackslash\\\\quote\\\"here\" }",

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -527,6 +527,7 @@ TEST(semantic_analyser, uprobe)
 TEST(semantic_analyser, usdt)
 {
   test("usdt:/bin/sh:probe { 1 }", 0);
+  test("usdt:/bin/sh:namespace:probe { 1 }", 0);
   test("usdt:/notexistfile:probe { 1 }", 1);
   test("usdt { 1 }", 1);
 }


### PR DESCRIPTION
Fixes for #328 

This should allow for manually specifying a USDT probe's provider namespace.

I've also added:

- [x] Documentation for the behavior
- [x] Parser and semantic tests

I've manually done a functional test against the example from https://www.joyfulbikeshedding.com/blog/2019-01-31-full-system-dynamic-tracing-on-linux-using-ebpf-and-bpftrace.html#usdt-probe-example, in which @foobarwidget mentions this issue and confirmed that this works as expected.

This will probably cause conflicts with #280 as they touch a lot of the same code.

@brendangregg @mmarchini :eyes: please, since you were in the issue conversation.