### PR TITLE
add elapsed builtin

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,7 @@ Variables:
 - `uid` - User ID
 - `gid` - Group ID
 - `nsecs` - Nanosecond timestamp
+- `elapsed` - Nanosecond timestamp since bpftrace initialization
 - `cpu` - Processor ID
 - `comm` - Process name
 - `stack` - Kernel stack trace

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -960,6 +960,7 @@ That would fire once for every 1000000 cache misses. This usually indicates the 
 - `uid` - User ID
 - `gid` - Group ID
 - `nsecs` - Nanosecond timestamp
+- `elapsed` - Nanosecond timestamp since bpftrace initialization
 - `cpu` - Processor ID
 - `comm` - Process name
 - `kstack` - Kernel stack trace

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -4,6 +4,7 @@
 #include "parser.tab.hh"
 #include "arch/arch.h"
 #include "types.h"
+#include <time.h>
 
 #include <llvm/Support/raw_os_ostream.h>
 #include <llvm/Support/TargetRegistry.h>
@@ -48,6 +49,13 @@ void CodegenLLVM::visit(Builtin &builtin)
   if (builtin.ident == "nsecs")
   {
     expr_ = b_.CreateGetNs();
+  }
+  else if (builtin.ident == "elapsed")
+  {
+    struct timespec ts;
+    // this time will be calculated during codegen and baked into the BPF
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    expr_ = b_.CreateSub(b_.CreateGetNs(), b_.getInt64(1000000000ULL * ts.tv_sec + ts.tv_nsec));
   }
   else if (builtin.ident == "kstack" || builtin.ident == "ustack")
   {

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -48,6 +48,7 @@ void SemanticAnalyser::visit(String &string)
 void SemanticAnalyser::visit(Builtin &builtin)
 {
   if (builtin.ident == "nsecs" ||
+      builtin.ident == "elapsed" ||
       builtin.ident == "pid" ||
       builtin.ident == "tid" ||
       builtin.ident == "cgroup" ||

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -49,7 +49,7 @@ path   :(\\.|[_\-\./a-zA-Z0-9])*:
 <COMMENT>"*/"           BEGIN(INITIAL);
 <COMMENT>"EOF"          driver.error(loc, std::string("end of file during comment"));
 
-pid|tid|cgroup|uid|gid|nsecs|cpu|comm|kstack|stack|ustack|arg[0-9]|retval|func|probe|curtask|rand|ctx|username|args {
+pid|tid|cgroup|uid|gid|nsecs|cpu|comm|kstack|stack|ustack|arg[0-9]|retval|func|probe|curtask|rand|ctx|username|args|elapsed {
                           return Parser::make_BUILTIN(yytext, loc); }
 {path}                  { return Parser::make_PATH(yytext, loc); }
 {map}                   { return Parser::make_MAP(yytext, loc); }

--- a/tests/codegen.cpp
+++ b/tests/codegen.cpp
@@ -12,6 +12,7 @@
 #include "codegen/builtin_func.cpp"
 #include "codegen/builtin_func_wild.cpp"
 #include "codegen/builtin_nsecs.cpp"
+#include "codegen/builtin_elapsed.cpp"
 #include "codegen/builtin_pid_tid.cpp"
 #include "codegen/builtin_probe.cpp"
 #include "codegen/builtin_probe_wild.cpp"

--- a/tests/codegen/builtin_elapsed.cpp
+++ b/tests/codegen/builtin_elapsed.cpp
@@ -1,0 +1,24 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, builtin_elapsed)
+{
+  /*
+   * TODO: add test. The problem that needs fixing first is that the codegen
+   * includes this line:
+   *
+   * %1 = add i64 %get_ns, -956821864668979
+   *
+   * That's the bpftrace epoch time, hardcoded in BPF. Which is what we want.
+   * But it varies between runs of bpftrace, so this line will change every
+   * time, causing the test to fail. We need a way to ignore this number
+   * in the test.
+   */
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -30,6 +30,7 @@ TEST(Parser, builtin_variables)
   test("kprobe:f { username }", "Program\n kprobe:f\n  builtin: username\n");
   test("kprobe:f { gid }", "Program\n kprobe:f\n  builtin: gid\n");
   test("kprobe:f { nsecs }", "Program\n kprobe:f\n  builtin: nsecs\n");
+  test("kprobe:f { elapsed }", "Program\n kprobe:f\n  builtin: elapsed\n");
   test("kprobe:f { cpu }", "Program\n kprobe:f\n  builtin: cpu\n");
   test("kprobe:f { curtask }", "Program\n kprobe:f\n  builtin: curtask\n");
   test("kprobe:f { rand }", "Program\n kprobe:f\n  builtin: rand\n");

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -23,6 +23,11 @@ RUN bpftrace -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", nsecs); exit(); }'
 EXPECT SUCCESS nsecs -?[0-9][0-9]*
 TIMEOUT 5
 
+NAME elapsed
+RUN bpftrace -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", elapsed); exit(); }'
+EXPECT SUCCESS elapsed -?[0-9][0-9]*
+TIMEOUT 5
+
 NAME cpu
 RUN bpftrace -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", cpu); exit(); }'
 EXPECT SUCCESS cpu -?[0-9][0-9]*

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -53,6 +53,7 @@ TEST(semantic_analyser, builtin_variables)
   test("kprobe:f { username }", 0);
   test("kprobe:f { gid }", 0);
   test("kprobe:f { nsecs }", 0);
+  test("kprobe:f { elapsed }", 0);
   test("kprobe:f { cpu }", 0);
   test("kprobe:f { curtask }", 0);
   test("kprobe:f { rand }", 0);

--- a/tools/biosnoop.bt
+++ b/tools/biosnoop.bt
@@ -13,7 +13,6 @@
 BEGIN
 {
 	printf("%-12s %-16s %-6s %7s\n", "TIME(ms)", "COMM", "PID", "LAT(ms)");
-	@epoch = nsecs;
 }
 
 kprobe:blk_account_io_start
@@ -29,15 +28,10 @@ kprobe:blk_account_io_completion
 {
 	$now = nsecs;
 	printf("%-12u %-16s %-6d %7d\n",
-	    ($now - @epoch) / 1000000, @iocomm[arg0], @iopid[arg0],
+	    elapsed / 1000000, @iocomm[arg0], @iopid[arg0],
 	    ($now - @start[arg0]) / 1000000);
 
 	delete(@start[arg0]);
 	delete(@iopid[arg0]);
 	delete(@iocomm[arg0]);
-}
-
-END
-{
-	delete(@epoch);
 }

--- a/tools/dcsnoop.bt
+++ b/tools/dcsnoop.bt
@@ -29,14 +29,13 @@ BEGIN
 {
 	printf("Tracing dcache lookups... Hit Ctrl-C to end.\n");
 	printf("%-8s %-6s %-16s %1s %s\n", "TIME", "PID", "COMM", "T", "FILE");
-	@epoch = nsecs;
 }
 
 // comment out this block to avoid showing hits:
 kprobe:lookup_fast
 {
 	$nd = (nameidata *)arg0;
-	printf("%-8d %-6d %-16s R %s\n", (nsecs - @epoch) / 1000000, pid, comm,
+	printf("%-8d %-6d %-16s R %s\n", elapsed / 1000000, pid, comm,
 	    str($nd->last.name));
 }
 
@@ -49,7 +48,7 @@ kprobe:d_lookup
 kretprobe:d_lookup
 /@fname[tid]/
 {
-	printf("%-8d %-6d %-16s M %s\n", (nsecs - @epoch) / 1000000, pid, comm,
+	printf("%-8d %-6d %-16s M %s\n", elapsed / 1000000, pid, comm,
 	    str(@fname[tid]));
 	delete(@fname[tid]);
 }

--- a/tools/execsnoop.bt
+++ b/tools/execsnoop.bt
@@ -18,17 +18,10 @@
 BEGIN
 {
 	printf("%-10s %-5s %s\n", "TIME(ms)", "PID", "ARGS");
-	@epoch = nsecs;
 }
 
 tracepoint:syscalls:sys_enter_execve
 {
-	$now = nsecs;
-	printf("%-10u %-5d ", ($now - @epoch) / 1000000, pid);
+	printf("%-10u %-5d ", elapsed / 1000000, pid);
 	join(args->argv);
-}
-
-END
-{
-	delete(@epoch);
 }


### PR DESCRIPTION
I'm starting to do `@epoch` too much; eg, from execsnoop.bt:

```
BEGIN
{
	printf("%-10s %-5s %s\n", "TIME(ms)", "PID", "ARGS");
	@epoch = nsecs;
}

tracepoint:syscalls:sys_enter_execve
{
	$now = nsecs;
	printf("%-10u %-5d ", ($now - @epoch) / 1000000, pid);
	join(args->argv);
}

END
{
	delete(@epoch);
}
```

I just whipped up the `elapsed` builtin to solve this. It shows nanoseconds since bpftrace began running, and makes execsnoop:

```
BEGIN
{
	printf("%-10s %-5s %s\n", "TIME(ms)", "PID", "ARGS");
}

tracepoint:syscalls:sys_enter_execve
{
	printf("%-10u %-5d ", elapsed / 1000000, pid);
	join(args->argv);
}
```