### PR TITLE
Enable 'use_debug_file' option for bcc symbol resolution

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1617,8 +1617,8 @@ std::string BPFtrace::resolve_usym(uintptr_t addr, int pid, bool show_offset)
   void *psyms;
 
   // TODO: deal with these:
-  symopts = {.use_debug_file = false,
-	     .check_debug_file_crc = false,
+  symopts = {.use_debug_file = true,
+	     .check_debug_file_crc = true,
 	     .use_symbol_type = BCC_SYM_ALL_TYPES};
 
   if (pid_sym_.find(pid) == pid_sym_.end())


### PR DESCRIPTION
I don't know if is there any specific reason to have this option turned off, the default in https://github.com/iovisor/bcc/blob/master/src/cc/bcc_syms.cc is on.

In my Fedora system, testing firefox, with separated debuginfo files, I have more detailed stack traces with this option turned on.

From:
https://github.com/iovisor/bcc/blob/3156303439960602667b2e1dc05aebfe43ad0066/src/cc/bcc_elf.c#L552 

```
// If there is a separate debuginfo file, try to locate and read it, first
// using the build-id section, then using the debuglink section. These are
// also the rules that GDB folows.
// See: https://sourceware.org/gdb/onlinedocs/gdb/Separate-Debug-Files.html
```