### PR TITLE
Fix new build warning msg after c++17 was enabled

### DIFF
--- a/src/bpforc.h
+++ b/src/bpforc.h
@@ -96,7 +96,7 @@ public:
 
   void compileModule(std::unique_ptr<Module> M) {
     auto K = addModule(move(M));
-    CompileLayer.emitAndFinalize(K);
+    cantFail(CompileLayer.emitAndFinalize(K));
   }
 
   VModuleKey addModule(std::unique_ptr<Module> M) {


### PR DESCRIPTION
The warning message is big, but it's just because the return code of CompileLayer.emitAndFinalize() was being ignored...

```
In file included from /home/acaringi/devel/bpftrace/src/bpftrace.cpp:21:
/home/acaringi/devel/bpftrace/src/bpforc.h: In member function ‘void bpftrace::BpfOrc::compileModule(std::unique_ptr<llvm::Module>)’:
/home/acaringi/devel/bpftrace/src/bpforc.h:100:36: warning: ignoring returned value of type ‘llvm::Error’, declared with attribute nodiscard [-Wunused-result]
     CompileLayer.emitAndFinalize(K);
                                    ^
In file included from /home/acaringi/devel/bpftrace/src/bpforc.h:7,
                 from /home/acaringi/devel/bpftrace/src/bpftrace.cpp:21:
/usr/include/llvm/ExecutionEngine/Orc/IRCompileLayer.h:119:9: note: in call to ‘llvm::Error llvm::orc::IRCompileLayer<BaseLayerT, CompileFtor>::emitAndFinalize(llvm::orc::VModuleKey) [with BaseLayerT = llvm::orc::RTDyldObjectLinkingLayer; CompileFtor = llvm::orc::SimpleCompiler; llvm::orc::VModuleKey = long unsigned int]’, declared here
   Error emitAndFinalize(VModuleKey K) { return BaseLayer.emitAndFinalize(K); }
         ^~~~~~~~~~~~~~~
In file included from /usr/include/llvm/ExecutionEngine/JITSymbol.h:27,
                 from /usr/include/llvm/ExecutionEngine/ExecutionEngine.h:24,
                 from /home/acaringi/devel/bpftrace/src/bpforc.h:3,
                 from /home/acaringi/devel/bpftrace/src/bpftrace.cpp:21:
/usr/include/llvm/Support/Error.h:157:22: note: ‘llvm::Error’ declared here
 class LLVM_NODISCARD Error {
                      ^~~~~
```