### PR TITLE
Try to make LLVM5 happy

### DIFF
--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -220,7 +220,12 @@ void ClangParser::parse(ast::Program *program, StructMap &structs)
   std::vector<std::string> kflags;
   struct utsname utsname;
   uname(&utsname);
-  auto [ksrc, kobj] = get_kernel_dirs(utsname);
+  // auto [ksrc, kobj] = get_kernel_dirs(utsname);	XXX fails with LLVM5
+  std::string ksrc, kobj;
+  auto kdirs = get_kernel_dirs(utsname);
+  ksrc = std::get<0>(kdirs);
+  kobj = std::get<1>(kdirs);
+
   if (ksrc != "")
     kflags = get_kernel_cflags(utsname.machine, ksrc, kobj);
 


### PR DESCRIPTION
4d76385e (Detect kernel headers even if they are splitted into source/
and build/ directories) used C++17 structured binding for return
arguments, but apparently it fails with LLVM5:

	https://github.com/iovisor/bpftrace/pull/399#issuecomment-463707986

Try to fix it by not using structured binding and by extracting returned
tuple elements manually.