### PR TITLE
only load tracepoint arg structs if args builtin is used

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -254,6 +254,7 @@ public:
   void accept(Visitor &v) override;
   std::string name() const;
   bool need_expansion = false;	// must build a BPF program per wildcard match
+  bool need_tp_args_structs = false;  // must import struct for tracepoints
 
   int index();
   void set_index(int index);

--- a/src/tracepoint_format_parser.h
+++ b/src/tracepoint_format_parser.h
@@ -3,9 +3,113 @@
 #include <istream>
 #include <set>
 
+#include "ast/ast.h"
+
 namespace bpftrace {
 
-namespace ast { class Program; }
+namespace ast {
+
+class TracepointArgsVisitor : public Visitor
+{
+public:
+  ~TracepointArgsVisitor() override { }
+  void visit(__attribute__((unused)) Integer &integer) override { };  // Leaf
+  void visit(__attribute__((unused)) PositionalParameter &integer) override { };  // Leaf
+  void visit(__attribute__((unused)) String &string) override { };  // Leaf
+  void visit(Builtin &builtin) override {  // Leaf
+    if (builtin.ident == "args")
+      probe_->need_tp_args_structs = true;
+  };  // Leaf
+  void visit(Call &call) override {
+    if (call.vargs) {
+      for (Expression *expr : *call.vargs) {
+        expr->accept(*this);
+      }
+    }
+  };
+  void visit(Map &map) override {
+    if (map.vargs) {
+      for (Expression *expr : *map.vargs) {
+        expr->accept(*this);
+      }
+    }
+  };
+  void visit(__attribute__((unused)) Variable &var) override { };  // Leaf
+  void visit(Binop &binop) override {
+    binop.left->accept(*this);
+    binop.right->accept(*this);
+  };
+  void visit(Unop &unop) override {
+    unop.expr->accept(*this);
+  };
+  void visit(Ternary &ternary) override {
+    ternary.cond->accept(*this);
+    ternary.left->accept(*this);
+    ternary.right->accept(*this);
+  };
+  void visit(FieldAccess &acc) override {
+    acc.expr->accept(*this);
+  };
+  void visit(Cast &cast) override {
+    cast.expr->accept(*this);
+  };
+  void visit(ExprStatement &expr) override {
+    expr.expr->accept(*this);
+  };
+  void visit(AssignMapStatement &assignment) override {
+    assignment.map->accept(*this);
+    assignment.expr->accept(*this);
+  };
+  void visit(AssignVarStatement &assignment) override {
+    assignment.expr->accept(*this);
+  };
+  void visit(If &if_block) override {
+    if_block.cond->accept(*this);
+
+    for (Statement *stmt : *if_block.stmts) {
+      stmt->accept(*this);
+    }
+
+    if (if_block.else_stmts) {
+      for (Statement *stmt : *if_block.else_stmts) {
+        stmt->accept(*this);
+      }
+    }
+  };
+  void visit(Unroll &unroll) override {
+    for (Statement *stmt : *unroll.stmts) {
+      stmt->accept(*this);
+    }
+  };
+  void visit(Predicate &pred) override {
+    pred.expr->accept(*this);
+  };
+  void visit(__attribute__((unused)) AttachPoint &ap) override { };  // Leaf
+  void visit(Probe &probe) override {
+    probe_ = &probe;
+    for (AttachPoint *ap : *probe.attach_points) {
+      ap->accept(*this);
+    }
+    if (probe.pred) {
+      probe.pred->accept(*this);
+    }
+    for (Statement *stmt : *probe.stmts) {
+      stmt->accept(*this);
+    }
+  };
+  void visit(Program &program) override {
+    for (Probe *probe : *program.probes)
+      probe->accept(*this);
+  };
+
+  void analyse(Probe *probe) {
+    probe_ = probe;
+    probe->accept(*this);
+  }
+private:
+  Probe *probe_;
+};
+} // namespace ast
 
 class TracepointFormatParser
 {


### PR DESCRIPTION
Fixes: https://github.com/iovisor/bpftrace/issues/422