### PR TITLE
fix probe keys on maps when the map is used more than one time

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -150,10 +150,15 @@ void CodegenLLVM::visit(Builtin &builtin)
   }
   else if (builtin.ident == "probe")
   {
-    static int probe_id = 0;
-    bpftrace_.probe_ids_.push_back(probefull_);
-    builtin.probe_id = probe_id;
-    probe_id++;
+    auto begin = bpftrace_.probe_ids_.begin();
+    auto end = bpftrace_.probe_ids_.end();
+    auto found = std::find(begin, end, probefull_);
+    if (found == end) {
+      bpftrace_.probe_ids_.push_back(probefull_);
+      builtin.probe_id = bpftrace_.next_probe_id();
+    } else {
+      builtin.probe_id = std::distance(begin, found);
+    }
     expr_ = b_.getInt64(builtin.probe_id);
   }
   else if (builtin.ident == "args")

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -60,6 +60,9 @@ public:
   int print_map_ident(const std::string &ident, uint32_t top, uint32_t div);
   int clear_map_ident(const std::string &ident);
   int zero_map_ident(const std::string &ident);
+  inline int next_probe_id() {
+    return next_probe_id_++;
+  };
   std::string get_stack(uint64_t stackidpid, bool ustack, StackType stack_type, int indent=0);
   std::string resolve_ksym(uintptr_t addr, bool show_offset=false);
   std::string resolve_usym(uintptr_t addr, int pid, bool show_offset=false, bool show_module=false);
@@ -110,6 +113,7 @@ private:
   int online_cpus_;
   std::vector<int> child_pids_;
   std::vector<std::string> params_;
+  int next_probe_id_ = 0;
 
   std::unique_ptr<AttachedProbe> attach_probe(Probe &probe, const BpfOrc &bpforc);
   int setup_perf_events();

--- a/tests/codegen.cpp
+++ b/tests/codegen.cpp
@@ -60,6 +60,7 @@
 #include "codegen/map_assign_string.cpp"
 #include "codegen/map_key_int.cpp"
 #include "codegen/map_key_string.cpp"
+#include "codegen/map_key_probe.cpp"
 #include "codegen/multiple_identical_probes.cpp"
 #include "codegen/pred_binop.cpp"
 #include "codegen/string_equal_comparison.cpp"

--- a/tests/codegen/builtin_probe_wild.cpp
+++ b/tests/codegen/builtin_probe_wild.cpp
@@ -23,7 +23,7 @@ entry:
   store i64 0, i64* %"@x_key", align 8
   %2 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  store i64 1, i64* %"@x_val", align 8
+  store i64 0, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)

--- a/tests/codegen/map_key_probe.cpp
+++ b/tests/codegen/map_key_probe.cpp
@@ -1,0 +1,96 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, map_key_probe)
+{
+  test("tracepoint:syscalls:sys_enter_nanosleep,tracepoint:syscalls:sys_enter_openat { @x[probe] = @x[probe] + 1 }",
+
+R"EXPECTED(; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"tracepoint:syscalls:sys_enter_nanosleep"(i8* nocapture readnone) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_nanosleep_1" {
+entry:
+  %"@x_val" = alloca i64, align 8
+  %"@x_key1" = alloca [8 x i8], align 8
+  %"@x_key" = alloca [8 x i8], align 8
+  %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@x_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  store i64 0, i8* %1, align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@x_key")
+  %map_lookup_cond = icmp eq i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
+
+lookup_success:                                   ; preds = %entry
+  %2 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %2, 1
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %entry, %lookup_success
+  %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  %3 = getelementptr inbounds [8 x i8], [8 x i8]* %"@x_key1", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 0, i8* %3, align 8
+  %4 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo2, [8 x i8]* nonnull %"@x_key1", i64* nonnull %"@x_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+define i64 @"tracepoint:syscalls:sys_enter_openat"(i8* nocapture readnone) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_openat_2" {
+entry:
+  %"@x_val" = alloca i64, align 8
+  %"@x_key1" = alloca [8 x i8], align 8
+  %"@x_key" = alloca [8 x i8], align 8
+  %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@x_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  store i64 1, i8* %1, align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@x_key")
+  %map_lookup_cond = icmp eq i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
+
+lookup_success:                                   ; preds = %entry
+  %2 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %2, 1
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %entry, %lookup_success
+  %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  %3 = getelementptr inbounds [8 x i8], [8 x i8]* %"@x_key1", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 1, i8* %3, align 8
+  %4 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo2, [8 x i8]* nonnull %"@x_key1", i64* nonnull %"@x_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  ret i64 0
+}
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace
+


### PR DESCRIPTION
Reproducible:

```
bpftrace -e 'k:vfs_* { @a[probe]++; @a[probe]++; @b[probe] = @b[probe] + 1}'
Attaching 54 probes...
^C

@a[kprobe:vfs_statx_fd]: 11
@a[kprobe:vfs_statx_fd]: 11
@a[kprobe:vfs_getattr_nosec]: 48
@a[kprobe:vfs_getattr_nosec]: 48
@a[kprobe:vfs_getattr]: 49
@a[kprobe:vfs_getattr]: 49
@a[kprobe:vfs_lock_file]: 75
@a[kprobe:vfs_lock_file]: 75
@a[kprobe:vfs_write]: 104
@a[kprobe:vfs_write]: 104
@a[kprobe:vfs_open]: 134
@a[kprobe:vfs_open]: 134
@a[kprobe:vfs_read]: 169
@a[kprobe:vfs_read]: 169

@b[kprobe:vfs_getattr_nosec]: 1
@b[kprobe:vfs_statx_fd]: 1
@b[kprobe:vfs_getattr]: 1
@b[kprobe:vfs_write]: 1
@b[kprobe:vfs_read]: 1
@b[kprobe:vfs_lock_file]: 1
@b[kprobe:vfs_open]: 1
```