### PR TITLE
docker: make sure debugfs is mounted

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -14,6 +14,7 @@ make "$@"
 
 if [ $RUN_TESTS = 1 ]; then
   set +e
+  mount -t debugfs debugfs /sys/kernel/debug/
   ./tests/bpftrace_test $TEST_ARGS;
   # TODO(mmarchini) re-enable once we figured out how to run it properly on CI
   # make runtime-tests;


### PR DESCRIPTION
bpftrace_test has tests that expect debugfs (more specifically tracefs) to be mounted.
Without debugfs, some tests will fail as below:
```
unknown file: Failure
C++ exception with description "Could not read symbols from "/sys/kernel/debug/tracing/available_events", err=2" thrown in the test body.
```

This error was observed when running docker-in-docker, on both x86_64 and aarch64 systems.