### PR TITLE
make struct keyword optional when casting

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -1,14 +1,16 @@
-%option yylineno nodefault noyywrap noinput nounput
+%option yylineno nodefault noyywrap noinput
 %option never-interactive
 %option reentrant
 %{
 #include "driver.h"
+#include "utils.h"
 #include "parser.tab.hh"
 
 #undef yywrap
 #define yywrap(x) 1
 
 static bpftrace::location loc;
+static std::string struct_type;
 static std::string buffer;
 static int open_brackets;
 
@@ -114,12 +116,23 @@ bpftrace|perf {
 <STR>.                  { driver.error(loc, std::string("invalid character '") +
                                             std::string(yytext) + std::string("'")); }
 
-struct|union            { BEGIN(STRUCT); buffer = std::string(yytext); open_brackets = 0; }
+struct|union            { BEGIN(STRUCT); buffer = ""; struct_type = std::string(yytext); open_brackets = 0; }
+<STRUCT>"*"|")"         { if (open_brackets == 0) {
+                            BEGIN(INITIAL);
+                            unput(yytext[0]);
+                            return Parser::make_IDENT(trim(buffer), loc);
+                          }
+                          else
+                          {
+                            buffer += std::string(yytext);
+                          }
+                        }
 <STRUCT>"{"             { BEGIN(STRUCT); buffer += std::string(yytext); open_brackets++; }
 <STRUCT>"}"|"};"        { buffer += std::string(yytext);
                           if (open_brackets == 1)
                           {
-                            BEGIN(INITIAL); return Parser::make_STRUCT(buffer, loc);
+                            BEGIN(INITIAL);
+                            return Parser::make_STRUCT(struct_type + buffer, loc);
                           }
                           else
                           {
@@ -127,7 +140,9 @@ struct|union            { BEGIN(STRUCT); buffer = std::string(yytext); open_brac
                           }
                         }
 <STRUCT>\n              { buffer += std::string(yytext); }
-<STRUCT>.               { buffer += std::string(yytext); }
+<STRUCT>.               {
+                          buffer += std::string(yytext);
+                        }
 
 {ident}                 { return Parser::make_IDENT(yytext, loc); }
 .                       { driver.error(loc, std::string("invalid character '") +

--- a/src/utils.h
+++ b/src/utils.h
@@ -40,4 +40,24 @@ std::string is_deprecated(std::string &str);
 std::string exec_system(const char* cmd);
 std::string resolve_binary_path(const std::string& cmd);
 
+// trim from end of string (right)
+inline std::string& rtrim(std::string& s)
+{
+  s.erase(s.find_last_not_of(" ") + 1);
+  return s;
+}
+
+// trim from beginning of string (left)
+inline std::string& ltrim(std::string& s)
+{
+  s.erase(0, s.find_first_not_of(" "));
+  return s;
+}
+
+// trim from both ends of string (right then left)
+inline std::string& trim(std::string& s)
+{
+  return ltrim(rtrim(s));
+}
+
 } // namespace bpftrace

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -37,3 +37,8 @@ NAME if_compare_and_print_string
 RUN bpftrace -e 'k:vfs_write {$name = "test"; if ($name == "test") { printf("name: %s\n", $name);} exit();}'
 EXPECT name: test
 TIMEOUT 5
+
+NAME struct keyword optional when casting
+RUN bpftrace -e 'struct Bar { int x; } struct Foo { struct Bar *bar; } i:ms:1 { $foo = (struct Foo *)0; @x = $foo->bar->x; exit()}'
+EXPECT @x: 0
+TIMEOUT 5


### PR DESCRIPTION
This patch makes the keyword "struct" optional when casting. It would be very nice if we improve the way we parse structs in a future patch

Fixes: https://github.com/iovisor/bpftrace/issues/139