### PR TITLE
make sure we create map keys when we have all the typing information

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -469,36 +469,38 @@ void SemanticAnalyser::check_stack_call(Call &call, Type type) {
 
 void SemanticAnalyser::visit(Map &map)
 {
-  MapKey key;
-  if (map.vargs) {
-    for (Expression *expr : *map.vargs) {
-      expr->accept(*this);
-      key.args_.push_back(expr->type);
+  if (is_final_pass()) {
+    MapKey key;
+    if (map.vargs) {
+      for (Expression *expr : *map.vargs) {
+        expr->accept(*this);
+        key.args_.push_back(expr->type);
+      }
     }
-  }
 
-  auto search = map_key_.find(map.ident);
-  if (search != map_key_.end()) {
-    /*
-     * TODO: this code ensures that map keys are consistent, but
-     * currently prevents print() and clear() being used, since
-     * for example "@x[pid] = count(); ... print(@x)" is detected
-     * as having inconsistent keys. We need a way to do this check
-     * differently for print() and clear() calls. I've commented it
-     * out for now - Brendan.
-     *
-    if (search->second != key) {
-      err_ << "Argument mismatch for " << map.ident << ": ";
-      err_ << "trying to access with arguments: ";
-      err_ << key.argument_type_list();
-      err_ << "\n\twhen map expects arguments: ";
-      err_ << search->second.argument_type_list();
-      err_ << "\n" << std::endl;
+    auto search = map_key_.find(map.ident);
+    if (search != map_key_.end()) {
+      /*
+      * TODO: this code ensures that map keys are consistent, but
+      * currently prevents print() and clear() being used, since
+      * for example "@x[pid] = count(); ... print(@x)" is detected
+      * as having inconsistent keys. We need a way to do this check
+      * differently for print() and clear() calls. I've commented it
+      * out for now - Brendan.
+      *
+      if (search->second != key) {
+        err_ << "Argument mismatch for " << map.ident << ": ";
+        err_ << "trying to access with arguments: ";
+        err_ << key.argument_type_list();
+        err_ << "\n\twhen map expects arguments: ";
+        err_ << search->second.argument_type_list();
+        err_ << "\n" << std::endl;
+      }
+      */
     }
-     */
-  }
-  else {
-    map_key_.insert({map.ident, key});
+    else {
+      map_key_.insert({map.ident, key});
+    }
   }
 
   auto search_val = map_val_.find(map.ident);


### PR DESCRIPTION
Map keys were being created too soon, and some typing information (such
as StackType in the case of ustack and kstack calls) could be missing in
some cases. If we wait until the final pass of the analizer to create
the keys, we have all the typing information.

Fixes: https://github.com/iovisor/bpftrace/issues/475