### PR TITLE
Ensure BPF_FUNC_get_current_cgroup_id will be used if available

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -6,6 +6,10 @@ add_library(ast
   semantic_analyser.cpp
 )
 
+if(HAVE_GET_CURRENT_CGROUP_ID)
+  target_compile_definitions(ast PRIVATE HAVE_GET_CURRENT_CGROUP_ID)
+endif(HAVE_GET_CURRENT_CGROUP_ID)
+
 target_include_directories(ast PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(ast PUBLIC ${CMAKE_SOURCE_DIR}/src/ast)
 target_include_directories(ast PUBLIC ${CMAKE_BINARY_DIR})

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -436,7 +436,7 @@ CallInst *IRBuilderBPF::CreateGetPidTgid()
 CallInst *IRBuilderBPF::CreateGetCurrentCgroupId()
 {
   #ifndef HAVE_GET_CURRENT_CGROUP_ID
-    std::cerr << "BPF_FUNC_get_current_group_id is not available for your kernel version" << std::endl;
+    std::cerr << "BPF_FUNC_get_current_cgroup_id is not available for your kernel version" << std::endl;
     abort();
   #else
     // u64 bpf_get_current_cgroup_id(void)

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -76,7 +76,7 @@ void SemanticAnalyser::visit(Builtin &builtin)
     builtin.type = SizedType(Type::integer, 8);
     if (builtin.ident == "cgroup") {
       #ifndef HAVE_GET_CURRENT_CGROUP_ID
-        err_ << "BPF_FUNC_get_current_group_id is not available for your kernel version" << std::endl;
+        err_ << "BPF_FUNC_get_current_cgroup_id is not available for your kernel version" << std::endl;
       #endif
     }
   }


### PR DESCRIPTION
Continuing https://github.com/iovisor/bpftrace/issues/377 when updated headers are available, the required define will now be propagated.

Previously the define was set at the src/ level but not at src/ast.

Headers containing get_current_cgroup_id:
```
[jkoch@jkoch-nflx bpftrace-git]$ grep get_current_cgroup_id /usr/include/linux/bpf.h 
 * u64 bpf_get_current_cgroup_id(void)
	FN(get_current_cgroup_id),	\
```

Before define propagation
```
-- Check size of BPF_FUNC_get_current_cgroup_id
-- Check size of BPF_FUNC_get_current_cgroup_id - done
...
[jkoch@jkoch-nflx bpftrace-git]$ strings ./pkg/bpftrace-git/usr/bin/bpftrace | grep 'BPF_FUNC'
BPF_FUNC_get_current_group_id is not available for your kernel version
[jkoch@jkoch-nflx bpftrace-git]$
```

After, with this fix:
```
-- Check size of BPF_FUNC_get_current_cgroup_id
-- Check size of BPF_FUNC_get_current_cgroup_id - done
...
[jkoch@jkoch-nflx bpftrace-git]$ strings ./pkg/bpftrace-git/usr/bin/bpftrace | grep 'BPF_FUNC'
[jkoch@jkoch-nflx bpftrace-git]$
```

Also, fix a typo.