### PR TITLE
Add missing include

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,5 +1,6 @@
 #include <string.h>
 
+#include <array>
 #include <map>
 #include <string>
 #include <tuple>


### PR DESCRIPTION
src/utils.cpp makes use of std::array but does not include array header. This
causes a compilation error when compiling with Android toolchain.