### PR TITLE
string positional parameter in comparison failure

### DIFF
--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -46,6 +46,7 @@ public:
   CallInst   *CreateProbeReadStr(Value *dst, size_t size, Value *src);
   Value      *CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_point, int arg_name, Builtin &builtin, int pid);
   Value      *CreateStrcmp(Value* val, std::string str, bool inverse=false);
+  Value      *CreateStrcmp(Value* val1, Value* val2, bool inverse=false);
   CallInst   *CreateGetNs();
   CallInst   *CreateGetPidTgid();
   CallInst   *CreateGetCurrentCgroupId();

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -540,10 +540,7 @@ void SemanticAnalyser::visit(Binop &binop)
       err_ << "comparing '" << lhs << "' ";
       err_ << "with '" << rhs << "'" << std::endl;
     }
-    else if (lhs == Type::string && !(binop.left->is_literal || binop.right->is_literal)) {
-      err_ << "Comparison between two variables of ";
-      err_ << "type string is not allowed" << std::endl;
-    }
+
     else if (lhs != Type::integer &&
              binop.op != Parser::token::EQ &&
              binop.op != Parser::token::NE) {

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -42,3 +42,18 @@ NAME struct keyword optional when casting
 RUN bpftrace -e 'struct Bar { int x; } struct Foo { struct Bar *bar; } i:ms:1 { $foo = (struct Foo *)0; @x = $foo->bar->x; exit()}'
 EXPECT @x: 0
 TIMEOUT 5
+
+NAME struct positional string compare - equal returns true
+RUN bpftrace -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));}; exit();}' "hello" "hello"
+EXPECT I got hello
+TIMEOUT 5
+
+NAME struct positional string compare - equal returns false
+RUN bpftrace -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");}; exit();}' "hi" "hello"
+EXPECT not equal
+TIMEOUT 5
+
+NAME struct positional string compare - not equal
+RUN bpftrace -e 'BEGIN { if (str($1) != str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");}; exit();}' "hello" "hello"
+EXPECT not equal
+TIMEOUT 5


### PR DESCRIPTION
Now it is possible to compare 2 string variables. I was not able to get the string size so the byte code is quite large. The old comparison between a static string and a variable still the same.

fixes: https://github.com/iovisor/bpftrace/issues/450