### PR TITLE
Update install instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -63,7 +63,7 @@ sudo apt-get install -y bison cmake flex g++ git libelf-dev zlib1g-dev libfl-dev
 sudo apt-get install clang-6.0 libclang-6.0-dev libclang-common-6.0-dev libclang1-6.0 libllvm6.0 llvm-6.0 llvm-6.0-dev llvm-6.0-runtime
 git clone https://github.com/iovisor/bpftrace
 cd bpftrace
-mkdir build; cd build; cmake -DCMAKE_BUILD_TYPE=DEBUG ..
+mkdir build; cd build; cmake -DCMAKE_BUILD_TYPE=Release ..
 make -j8
 make install
 ```
@@ -78,7 +78,7 @@ You'll want the newest kernel possible (see kernel requirements), eg, by using F
 sudo dnf install -y bison flex cmake make git gcc-c++ elfutils-libelf-devel zlib-devel llvm-devel clang-devel bcc-devel
 git clone https://github.com/iovisor/bpftrace
 cd bpftrace
-mkdir build; cd build; cmake -DCMAKE_BUILD_TYPE=DEBUG ..
+mkdir build; cd build; cmake -DCMAKE_BUILD_TYPE=Release ..
 make -j8
 make install
 ```
@@ -160,7 +160,7 @@ Use specific OS build sections listed earlier if available (Ubuntu, Docker).
 - CMake
 - Flex
 - Bison
-- LLVM & Clang 5.0 (or 6.0) development packages
+- LLVM & Clang 5.0+ development packages
 - BCC development package
 - LibElf
 - Kernel requirements described earlier
@@ -171,13 +171,13 @@ Use specific OS build sections listed earlier if available (Ubuntu, Docker).
 git clone https://github.com/iovisor/bpftrace
 mkdir -p bpftrace/build
 cd bpftrace/build
-cmake -DCMAKE_BUILD_TYPE=Debug ../
+cmake -DCMAKE_BUILD_TYPE=Release ../
 make
 ```
 
-By default bpftrace will be built as a dynamically linked executable. If a statically linked executable would be preferred and your system has the required libraries installed, the CMake option `-DSTATIC_LINKING:BOOL=ON` can be used. Building bpftrace using the Docker method below will always result in a statically linked executable.
+By default bpftrace will be built as a dynamically linked executable. If a statically linked executable would be preferred and your system has the required libraries installed, the CMake option `-DSTATIC_LINKING:BOOL=ON` can be used. Building bpftrace using the Docker method below will always result in a statically linked executable. A debug build of bpftrace can be set up with `cmake -DCMAKE_BUILD_TYPE=Debug ../`.
 
-The latest versions of BCC and Google Test will be downloaded on each build. To speed up builds and only download their sources on the first run, use the CMake option `-DOFFLINE_BUILDS:BOOL=ON`.
+The latest version of Google Test will be downloaded on each build. To speed up builds and only download its source on the first run, use the CMake option `-DOFFLINE_BUILDS:BOOL=ON`.
 
 To test that the build works, you can try running the test suite, and a one-liner:
 


### PR DESCRIPTION
Release builds should be the default unless debug is specifically asked for


I've noticed some instructions going up around the web showing how to set up a debug build of bpftrace to potential users. I think most people should probably be using release builds unless they are working on bpftrace itself, so have changed the instructions people are copying.

Also, does anyone know about the gtest build? Now that we've pinned it to a specific git tag can we just make all builds "OFFLINE"? I think the purpose of the online option was to keep BCC up to date with master.