### PR TITLE
allow pointers in printf, mapkeys, and filters

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -827,7 +827,7 @@ void SemanticAnalyser::visit(Predicate &pred)
 {
   pred.expr->accept(*this);
   if (is_final_pass() && ((pred.expr->type.type != Type::integer) &&
-     (pred.expr->type.type != Type::cast))) {
+     (!(pred.expr->type.is_pointer && pred.expr->type.type == Type::cast)))) {
     err_ << "Invalid type for predicate: " << pred.expr->type.type << std::endl;
   }
 }

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -826,7 +826,8 @@ void SemanticAnalyser::visit(AssignVarStatement &assignment)
 void SemanticAnalyser::visit(Predicate &pred)
 {
   pred.expr->accept(*this);
-  if (is_final_pass() && pred.expr->type.type != Type::integer) {
+  if (is_final_pass() && ((pred.expr->type.type != Type::integer) &&
+     (pred.expr->type.type != Type::cast))) {
     err_ << "Invalid type for predicate: " << pred.expr->type.type << std::endl;
   }
 }

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -441,10 +441,13 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(const std::vec
               arg.type.stack_type, 8)));
         break;
       case Type::cast:
-        arg_values.push_back(
-          std::make_unique<PrintableInt>(
-            *reinterpret_cast<uint64_t*>(arg_data+arg.offset)));
-        break;
+        if (arg.type.is_pointer) {
+          arg_values.push_back(
+            std::make_unique<PrintableInt>(
+              *reinterpret_cast<uint64_t*>(arg_data+arg.offset)));
+          break;
+        }
+        // fall through
       default:
         std::cerr << "invalid argument type" << std::endl;
         abort();

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -440,6 +440,11 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(const std::vec
               true,
               arg.type.stack_type, 8)));
         break;
+      case Type::cast:
+        arg_values.push_back(
+          std::make_unique<PrintableInt>(
+            *reinterpret_cast<uint64_t*>(arg_data+arg.offset)));
+        break;
       default:
         std::cerr << "invalid argument type" << std::endl;
         abort();

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -55,6 +55,7 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
     const void *data)
 {
   auto arg_data = static_cast<const uint8_t*>(data);
+  std::ostringstream ptr;
   switch (arg.type)
   {
     case Type::integer:
@@ -88,6 +89,10 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
       return bpftrace.probe_ids_[*(const uint64_t*)data];
     case Type::string:
       return std::string((const char*)data);
+    case Type::cast:
+      // use case: show me these pointer values
+      ptr << "0x" << std::hex << *(const int64_t*)data;
+      return ptr.str();
     default:
       std::cerr << "invalid mapkey argument type" << std::endl;
   }

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -90,9 +90,12 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
     case Type::string:
       return std::string((const char*)data);
     case Type::cast:
-      // use case: show me these pointer values
-      ptr << "0x" << std::hex << *(const int64_t*)data;
-      return ptr.str();
+      if (arg.is_pointer) {
+        // use case: show me these pointer values
+        ptr << "0x" << std::hex << *(const int64_t*)data;
+        return ptr.str();
+      }
+      // fall through
     default:
       std::cerr << "invalid mapkey argument type" << std::endl;
   }

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -37,7 +37,7 @@ std::string verify_format_string(const std::string &fmt, std::vector<Field> args
         arg_type == Type::username || arg_type == Type::kstack || arg_type == Type::ustack ||
         arg_type == Type::inet)
       arg_type = Type::string; // Symbols should be printed as strings
-    if (arg_type == Type::cast)
+    if (arg_type == Type::cast && args.at(i).type.is_pointer)
       arg_type = Type::integer; // Casts (pointers) can be printed as integers
     int offset = 1;
 

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -37,6 +37,8 @@ std::string verify_format_string(const std::string &fmt, std::vector<Field> args
         arg_type == Type::username || arg_type == Type::kstack || arg_type == Type::ustack ||
         arg_type == Type::inet)
       arg_type = Type::string; // Symbols should be printed as strings
+    if (arg_type == Type::cast)
+      arg_type = Type::integer; // Casts (pointers) can be printed as integers
     int offset = 1;
 
     // skip over format widths during verification


### PR DESCRIPTION
fixes #252 

```
# bpftrace -e 'tracepoint:syscalls:sys_enter_connect /args->uservaddr/ { @[args->uservaddr]++; printf("uservaddr: 0x%llx\n", args->uservaddr) }'
Attaching 1 probe...
uservaddr: 0x7ffe83064880
uservaddr: 0x7ffe83064880
uservaddr: 0x7ffe83064600
uservaddr: 0x7f6e33cc8840
^C

@[0x7f6e33cc8840]: 1
@[0x7ffe83064600]: 1
@[0x7ffe83064880]: 2
```