### PR TITLE
usdt: fix usdt probe listing

### DIFF
--- a/src/list.cpp
+++ b/src/list.cpp
@@ -153,8 +153,11 @@ void list_probes(const std::string &search_input, int pid)
     bcc_usdt_foreach(ctx, usdt_each);
     for (const auto &u : usdt_probes) {
       std::string probe = "usdt:" + std::get<2>(u) + ":" + std::get<1>(u);
-      if (search_probe(probe, re))
-        continue;
+      if (!search.empty())
+      {
+        if (search_probe(probe, re))
+          continue;
+      }
       std::cout << probe << std::endl;
     }
     bcc_usdt_close(ctx);


### PR DESCRIPTION
USDT probe listing returns 0 results when regex (`search`) argument is omitted


Python 3 configured with `--with-dtrace` running with pid 23283:
```shell
$ readelf -n /proc/23283/exe | grep stap
Displaying notes found in: .note.stapsdt
  stapsdt              0x0000003b       NT_STAPSDT (SystemTap probe descriptors)
  stapsdt              0x00000045       NT_STAPSDT (SystemTap probe descriptors)
  stapsdt              0x00000046       NT_STAPSDT (SystemTap probe descriptors)
[...]
```

#### Current behaviour:
```shell
$ sudo src/bpftrace -l -p 23283 | grep python  # cpython's usdt probes have this substring
$ echo $?
1
```

#### With this diff:
```shell
$ src/bpftrace -l -p 23283 | grep python
usdt:/home/javierhonduco/cpython/python:line
usdt:/home/javierhonduco/cpython/python:function__entry
usdt:/home/javierhonduco/cpython/python:function__return
usdt:/home/javierhonduco/cpython/python:import__find__load__start
usdt:/home/javierhonduco/cpython/python:import__find__load__done
usdt:/home/javierhonduco/cpython/python:gc__start
usdt:/home/javierhonduco/cpython/python:gc__done
$ echo $?
0
```

Verified listing with a regex still works: 
```shell
$ sudo src/bpftrace -l '*python*' -p 23283
usdt:/home/javierhonduco/cpython/python:line
usdt:/home/javierhonduco/cpython/python:function__entry
usdt:/home/javierhonduco/cpython/python:function__return
usdt:/home/javierhonduco/cpython/python:import__find__load__start
usdt:/home/javierhonduco/cpython/python:import__find__load__done
usdt:/home/javierhonduco/cpython/python:gc__start
usdt:/home/javierhonduco/cpython/python:gc__done
```