### PR TITLE
usdt: add hint when pid is not running

### DIFF
--- a/src/list.cpp
+++ b/src/list.cpp
@@ -1,3 +1,4 @@
+#include <signal.h>
 #include <sys/types.h>
 #include <dirent.h>
 #include <fstream>
@@ -148,6 +149,9 @@ void list_probes(const std::string &search_input, int pid)
     void *ctx = bcc_usdt_new_frompid(pid, nullptr);
     if (ctx == nullptr) {
       std::cerr << "failed to initialize usdt context for pid: " << pid << std::endl;
+      if (kill(pid, 0) == -1 && errno == ESRCH) {
+        std::cerr << "hint: process not running" << std::endl;
+      }
       return;
     }
     bcc_usdt_foreach(ctx, usdt_each);


### PR DESCRIPTION
If we can't initialize the usdt context, try to figure out if it's because the process is not running:

#### PID running
```shell
$ sudo src/bpftrace -l "*python*" -p 23283           
usdt:/home/javierhonduco/cpython/python:line
usdt:/home/javierhonduco/cpython/python:function__entry                                                 
usdt:/home/javierhonduco/cpython/python:function__return                                                
usdt:/home/javierhonduco/cpython/python:import__find__load__start                                       
usdt:/home/javierhonduco/cpython/python:import__find__load__done                                        
usdt:/home/javierhonduco/cpython/python:gc__start
usdt:/home/javierhonduco/cpython/python:gc__done
```

#### PID not running
```shell
$ sudo src/bpftrace -l "*python*" -p 11111           
failed to initialize usdt context for pid: 11111
hint: process not running
```