### PR TITLE
usdt: add pid validation

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -70,6 +70,16 @@ bool is_root()
     return true;
 }
 
+bool is_numeric(char* string)
+{
+  while(char current_char = *string++)
+  {
+    if (!isdigit(current_char))
+      return false;
+  }
+  return true;
+}
+
 int main(int argc, char *argv[])
 {
   int err;
@@ -159,7 +169,14 @@ int main(int argc, char *argv[])
   // - provide PID in USDT probe specification as a way to override -p.
   bpftrace.pid_ = 0;
   if (pid_str)
-    bpftrace.pid_ = atoi(pid_str);
+  {
+    if (!is_numeric(pid_str))
+    {
+      std::cerr << "ERROR: pid '" << pid_str << "' is not a valid number." << std::endl;
+      return 1;
+    }
+    bpftrace.pid_ = strtol(pid_str, NULL, 10);
+  }
 
   // Listing probes
   if (listing)
@@ -251,12 +268,6 @@ int main(int argc, char *argv[])
       return 1;
     }
   }
-
-  // PID is currently only used for USDT probes that need enabling. Future work:
-  // - make PID a filter for all probe types: pass to perf_event_open(), etc.
-  // - provide PID in USDT probe specification as a way to override -p.
-  if (pid_str)
-    bpftrace.pid_ = atoi(pid_str);
 
   if (cmd_str)
     bpftrace.cmd_ = cmd_str;

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -57,3 +57,18 @@ NAME it lists hardware events with regex filter
 RUN bpftrace -l "hardware:*"
 EXPECT hardware
 TIMEOUT 1
+
+NAME pid fails validation with leading non-number
+RUN bpftrace -p a1111
+EXPECT ERROR: pid 'a1111' is not a valid number.
+TIMEOUT 1
+
+NAME pid fails validation with non-number in between
+RUN bpftrace -p 111a1
+EXPECT ERROR: pid '111a1' is not a valid number.
+TIMEOUT 1
+
+NAME pid fails validation with non-numeric argument
+RUN bpftrace -p not_a_pid
+EXPECT ERROR: pid 'not_a_pid' is not a valid number.
+TIMEOUT 1


### PR DESCRIPTION
Right now we are not validating the PID as reported by Jon in #501. This covers the basic cases, like having a typo'ed letter in the middle of the digits.

I'm not very familiar with C++ so please, let me know if I'm doing something horrible here :grinning:

## Test plan
Added some integration tests, but at the moment this only checks for the validation failing. I'm planning to address this in another PR

```shell
[javierhonduco@fb-thinkpad build]$ sudo src/bpftrace -p 23335 -e 'usdt::line { printf("hi!\n");}' -B none 
Attaching 1 probe...
hi!
hi!
hi!
^C
```

```shell
[javierhonduco@fb-thinkpad build]$ sudo make runtime-tests
Test file: basic

it shows version OK
it shows usage with help flag OK
it shows usage with bad flag OK
errors on non existent file OK
it lists kprobes OK
it lists tracepoints OK
it lists software events OK
it lists hardware events OK
it lists kprobes with regex filter OK
it lists tracepoints with regex filter OK
it lists software events with regex filter OK
it lists hardware events with regex filter OK
pid fails validation with leading non-number OK
pid fails validation with non-number in between OK
pid fails validation with non-numeric argument OK
--------------------------------

15 tests [fail 0]
Done in 0:00:01.185157
```