### PR TITLE
USDT wildcard matching support

### DIFF
--- a/docker/Dockerfile.bionic
+++ b/docker/Dockerfile.bionic
@@ -30,7 +30,8 @@ RUN apt-get update && apt-get install -y \
       llvm-${LLVM_VERSION} \
       llvm-${LLVM_VERSION}-dev \
       llvm-${LLVM_VERSION}-runtime \
-      libllvm${LLVM_VERSION}
+      libllvm${LLVM_VERSION} \
+      systemtap-sdt-dev
 
 COPY build.sh /build.sh
 ENTRYPOINT ["bash", "/build.sh"]

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -254,6 +254,7 @@ public:
   std::string target;
   std::string ns;
   std::string func;
+  usdt_probe_entry usdt; // resolved USDT entry, used to support arguments with wildcard matches
   int freq = 0;
   bool need_expansion = false;
 

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1313,7 +1313,7 @@ void CodegenLLVM::visit(Probe &probe)
         case ProbeType::usdt:
         {
           // FIXME should this also handle a case where no pid is specified?
-          auto usdt_symbol_stream = std::istringstream(USDTHelper::list_probes_for_pid(bpftrace_.pid_));
+          auto usdt_symbol_stream = USDTHelper::probe_stream(bpftrace_.pid_);
           matches = bpftrace_.find_wildcard_matches(attach_point->ns, attach_point->func, usdt_symbol_stream);
           break;
         }

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1246,10 +1246,8 @@ void CodegenLLVM::visit(Probe &probe)
   // needed for uaddr() calls and usdt probes:
   for (auto &attach_point : *probe.attach_points) {
 
-    // If any attach_point is underspecified, the probe needs expansion
-    if(probetype(attach_point->provider) == ProbeType::usdt &&
-       ((attach_point->ns.empty() || has_wildcard(attach_point->ns)) ||
-        (attach_point->func.empty() || has_wildcard(attach_point->func))))
+    // All usdt probes need expansion to be able to read arguments
+    if(probetype(attach_point->provider) == ProbeType::usdt)
       probe.need_expansion = true;
 
     current_attach_point_ = attach_point;

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -356,7 +356,6 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_poin
     std::cerr << "failed to initialize usdt context for probe " << attach_point->target << std::endl;
     exit(-1);
   }
-  bcc_usdt_close(usdt);
 
   auto u = USDTHelper::find(0, attach_point->ns, attach_point->func);
   attach_point->target = std::get<USDT_PATH_INDEX>(u);
@@ -368,6 +367,7 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_poin
   }
 
   Value *result = CreateUSDTReadArgument(ctx, &argument, builtin);
+  bcc_usdt_close(usdt);
 
   return result;
 }

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -367,8 +367,8 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_poin
   }
 
   Value *result = CreateUSDTReadArgument(ctx, &argument, builtin);
-  bcc_usdt_close(usdt);
 
+  bcc_usdt_close(usdt);
   return result;
 }
 

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -356,9 +356,10 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_poin
     std::cerr << "failed to initialize usdt context for probe " << attach_point->target << std::endl;
     exit(-1);
   }
+  bcc_usdt_close(usdt);
 
-  auto u = USDTHelper::find(usdt, 0, attach_point->func);
-  attach_point->target = std::get<1>(u);
+  auto u = USDTHelper::find(0, attach_point->func);
+  attach_point->target = std::get<0>(u);
 
   if(attach_point->ns != "")
     provider_ns = attach_point->ns;
@@ -373,7 +374,6 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_poin
 
   Value *result = CreateUSDTReadArgument(ctx, &argument, builtin);
 
-  bcc_usdt_close(usdt);
   return result;
 }
 

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -358,15 +358,10 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_poin
   }
   bcc_usdt_close(usdt);
 
-  auto u = USDTHelper::find(0, attach_point->func);
-  attach_point->target = std::get<0>(u);
+  auto u = USDTHelper::find(0, attach_point->ns, attach_point->func);
+  attach_point->target = std::get<USDT_PATH_INDEX>(u);
 
-  if(attach_point->ns != "")
-    provider_ns = attach_point->ns;
-  else
-    provider_ns = std::get<0>(u);
-
-  if (bcc_usdt_get_argument(usdt, provider_ns.c_str(), attach_point->func.c_str(), 0, arg_num, &argument) != 0) {
+  if (bcc_usdt_get_argument(usdt, attach_point->ns.c_str(), attach_point->func.c_str(), 0, arg_num, &argument) != 0) {
     std::cerr << "couldn't get argument " << arg_num << " for " << attach_point->target << ":"
               << provider_ns << ":" << attach_point->func << std::endl;
     exit(-2);

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -340,7 +340,6 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx, struct bcc_usdt_argument
 Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_point, int arg_num, Builtin &builtin, int pid)
 {
   struct bcc_usdt_argument argument;
-  std::string provider_ns;
 
   void *usdt;
 
@@ -348,7 +347,6 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_poin
     //FIXME use attach_point->target when iovisor/bcc#2064 is merged
     usdt = bcc_usdt_new_frompid(pid, nullptr);
   } else {
-    std::cerr << "initializing usdt context from path" << std::endl;
     usdt = bcc_usdt_new_frompath(attach_point->target.c_str());
   }
 
@@ -357,12 +355,12 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_poin
     exit(-1);
   }
 
-  auto u = USDTHelper::find(0, attach_point->ns, attach_point->func);
-  attach_point->target = std::get<USDT_PATH_INDEX>(u);
+  std::string ns = std::get<USDT_PROVIDER_INDEX>(attach_point->usdt);
+  std::string func = std::get<USDT_FNAME_INDEX>(attach_point->usdt);
 
-  if (bcc_usdt_get_argument(usdt, attach_point->ns.c_str(), attach_point->func.c_str(), 0, arg_num, &argument) != 0) {
+  if (bcc_usdt_get_argument(usdt, ns.c_str(), func.c_str(), 0, arg_num, &argument) != 0) {
     std::cerr << "couldn't get argument " << arg_num << " for " << attach_point->target << ":"
-              << provider_ns << ":" << attach_point->func << std::endl;
+              << attach_point->ns << ":" << attach_point->func << std::endl;
     exit(-2);
   }
 

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -955,24 +955,33 @@ void SemanticAnalyser::visit(AttachPoint &ap)
       err_ << "uprobe target file " << ap.target << " does not exist" << std::endl;
   }
   else if (ap.provider == "usdt") {
-//    if (ap.func == "")
-//      err_ << "usdt probe must have a func" << std::endl;
-//    if (ap.target == "") {
-//      if (bpftrace_.pid_ > 0) {
-//        auto const &u = USDTHelper::find(nullptr, bpftrace_.pid_, ap.func);
-//        ap.target = std::get<1>(u);
-//
-//        if (ap.target == "")
-//          err_ << "usdt probe " << ap.func << " not found in pid " << bpftrace_.pid_ << std::endl;
-//      }
-//
+    if (ap.func == "")
+      err_ << "usdt probe must have a target function or wildcard" << std::endl;
+
+    if (ap.target == "") {
+      if (bpftrace_.pid_ > 0) {
+        // Call USDTHelperfunction to load probes by pid
+        // set target (filename)
+      }
 //      if (ap.target == "")
-//        err_ << "usdt probes must have a target path defined or discovered from a pid" << std::endl;
-//    }
-//    ap.target = resolve_binary_path(ap.target);
-//    struct stat s;
-//    if (stat(ap.target.c_str(), &s) != 0)
-//      err_ << "usdt target file " << ap.target << " does not exist" << std::endl;
+//        err_ << "usdt probes must have a target path defined, or discovered from a pid" << std::endl;
+    }
+    else  // Give it a shot loading by file if specified
+    {
+      // Call USDTHelper function to load probes by path
+    }
+
+    // Check if a provider NS was specified.
+    // if ap.ns != ""
+    //   use it
+    // else
+    //   Scan for tuples and look for duplicates. If a duplicate is found, throw an error that the probe
+    //   Isn't sufficiently specified
+    //   If one namespace exists and the probe is fully specified, use it
+
+//  Verify that at least one match was found or throw an error like this:
+//    err_ << "usdt probe " << ap.func << " not found in pid ( OR PATH FIXME)" << bpftrace_.pid_ << std::endl;
+
   }
   else if (ap.provider == "tracepoint") {
     if (ap.target == "" || ap.func == "")

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -955,24 +955,24 @@ void SemanticAnalyser::visit(AttachPoint &ap)
       err_ << "uprobe target file " << ap.target << " does not exist" << std::endl;
   }
   else if (ap.provider == "usdt") {
-    if (ap.func == "")
-      err_ << "usdt probe must have a func" << std::endl;
-    if (ap.target == "") {
-      if (bpftrace_.pid_ > 0) {
-        auto const &u = USDTHelper::find(nullptr, bpftrace_.pid_, ap.func);
-        ap.target = std::get<1>(u);
-
-        if (ap.target == "")
-          err_ << "usdt probe " << ap.func << " not found in pid " << bpftrace_.pid_ << std::endl;
-      }
-
-      if (ap.target == "")
-        err_ << "usdt probes must have a target path defined or discovered from a pid" << std::endl;
-    }
-    ap.target = resolve_binary_path(ap.target);
-    struct stat s;
-    if (stat(ap.target.c_str(), &s) != 0)
-      err_ << "usdt target file " << ap.target << " does not exist" << std::endl;
+//    if (ap.func == "")
+//      err_ << "usdt probe must have a func" << std::endl;
+//    if (ap.target == "") {
+//      if (bpftrace_.pid_ > 0) {
+//        auto const &u = USDTHelper::find(nullptr, bpftrace_.pid_, ap.func);
+//        ap.target = std::get<1>(u);
+//
+//        if (ap.target == "")
+//          err_ << "usdt probe " << ap.func << " not found in pid " << bpftrace_.pid_ << std::endl;
+//      }
+//
+//      if (ap.target == "")
+//        err_ << "usdt probes must have a target path defined or discovered from a pid" << std::endl;
+//    }
+//    ap.target = resolve_binary_path(ap.target);
+//    struct stat s;
+//    if (stat(ap.target.c_str(), &s) != 0)
+//      err_ << "usdt target file " << ap.target << " does not exist" << std::endl;
   }
   else if (ap.provider == "tracepoint") {
     if (ap.target == "" || ap.func == "")

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -962,17 +962,17 @@ void SemanticAnalyser::visit(AttachPoint &ap)
     if (bpftrace_.pid_ > 0) {
        probes = USDTHelper::probes_for_pid(bpftrace_.pid_);
     } else if (ap.target != "") {
+      ap.target = resolve_binary_path(ap.target);
+      struct stat s;
+      if (stat(ap.target.c_str(), &s) != 0)
+        err_ << "usdt target file " << ap.target << " does not exist" << std::endl;
        probes = USDTHelper::probes_for_path(ap.target);
     } else {
       err_ << "usdt probe must specify at least path or pid to probe" << std::endl;
     }
 
-    if (probes.size() > 1){
-      if (ap.ns != "") {
-        usdt_probe_list provider_probes = USDTHelper::probes_for_provider(ap.ns);
-        if (provider_probes.size() == 0)
-          err_ << "no matching probes usdt probes found on provider " << ap.ns << std::endl;
-      }
+    if (probes.size() == 0){
+      err_ << "no matching usdt probes found on path or pid" << std::endl;
     }
   }
   else if (ap.provider == "tracepoint") {

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -960,19 +960,15 @@ void SemanticAnalyser::visit(AttachPoint &ap)
 
     usdt_probe_list probes;
     if (bpftrace_.pid_ > 0) {
-       probes = USDTHelper::probes_for_pid(bpftrace_.pid_);
+       USDTHelper::probes_for_pid(bpftrace_.pid_);
     } else if (ap.target != "") {
       ap.target = resolve_binary_path(ap.target);
       struct stat s;
       if (stat(ap.target.c_str(), &s) != 0)
         err_ << "usdt target file " << ap.target << " does not exist" << std::endl;
-       probes = USDTHelper::probes_for_path(ap.target);
+       USDTHelper::probes_for_path(ap.target);
     } else {
       err_ << "usdt probe must specify at least path or pid to probe" << std::endl;
-    }
-
-    if (probes.size() == 0){
-      err_ << "no matching usdt probes found on path or pid" << std::endl;
     }
   }
   else if (ap.provider == "tracepoint") {

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -962,13 +962,16 @@ void SemanticAnalyser::visit(AttachPoint &ap)
     if (bpftrace_.pid_ > 0) {
        USDTHelper::probes_for_pid(bpftrace_.pid_);
     } else if (ap.target != "") {
+       USDTHelper::probes_for_path(ap.target);
+    } else {
+      err_ << "usdt probe must specify at least path or pid to probe" << std::endl;
+    }
+
+    if (ap.target != "") {
       ap.target = resolve_binary_path(ap.target);
       struct stat s;
       if (stat(ap.target.c_str(), &s) != 0)
         err_ << "usdt target file " << ap.target << " does not exist" << std::endl;
-       USDTHelper::probes_for_path(ap.target);
-    } else {
-      err_ << "usdt probe must specify at least path or pid to probe" << std::endl;
     }
   }
   else if (ap.provider == "tracepoint") {

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -464,6 +464,7 @@ void AttachedProbe::attach_usdt(int pid)
 
   // TODO: fn_name may need a unique suffix for each attachment on the same probe:
   std::string fn_name = "probe_" + probe_.attach_point + "_1";
+// see https://github.com/iovisor/bcc/pull/2294 for BCC_USDT_HAS_FULLY_SPECIFIED_PROBE
 #ifdef BCC_USDT_HAS_FULLY_SPECIFIED_PROBE
   if (probe_.ns == "")
     err = bcc_usdt_enable_probe(ctx, probe_.attach_point.c_str(), fn_name.c_str());

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -469,15 +469,10 @@ void AttachedProbe::attach_usdt(int pid)
   if (err)
     throw std::runtime_error("Error finding or enabling probe: " + probe_.name);
 
-  auto u = USDTHelper::find(pid, probe_.attach_point);
-  probe_.path = std::get<0>(u);
-  // Handle manually specifying probe provider namespace
-  if (probe_.ns != "")
-    provider_ns = probe_.ns;
-  else
-    provider_ns = std::get<1>(u);
+  auto u = USDTHelper::find(pid, probe_.ns, probe_.attach_point);
+  probe_.path = std::get<USDT_PATH_INDEX>(u);
 
-  err = bcc_usdt_get_location(ctx, provider_ns.c_str(), probe_.attach_point.c_str(), 0, &loc);
+  err = bcc_usdt_get_location(ctx, probe_.ns.c_str(), probe_.attach_point.c_str(), 0, &loc);
   bcc_usdt_close(ctx);
   if (err)
     throw std::runtime_error("Error finding location for probe: " + probe_.name);

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -446,7 +446,6 @@ void AttachedProbe::attach_usdt(int pid)
 {
   struct bcc_usdt_location loc = {};
   int err;
-  std::string provider_ns;
   void *ctx;
 
   if (pid)
@@ -465,7 +464,15 @@ void AttachedProbe::attach_usdt(int pid)
 
   // TODO: fn_name may need a unique suffix for each attachment on the same probe:
   std::string fn_name = "probe_" + probe_.attach_point + "_1";
+#ifdef BCC_USDT_HAS_FULLY_SPECIFIED_PROBE
+  if (probe_.ns == "")
+    err = bcc_usdt_enable_probe(ctx, probe_.attach_point.c_str(), fn_name.c_str());
+  else
+    err = bcc_usdt_enable_fully_specified_probe(ctx, probe_.ns.c_str(), probe_.attach_point.c_str(), fn_name.c_str());
+#else
   err = bcc_usdt_enable_probe(ctx, probe_.attach_point.c_str(), fn_name.c_str());
+#endif
+
   if (err)
     throw std::runtime_error("Error finding or enabling probe: " + probe_.name);
 

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -469,15 +469,16 @@ void AttachedProbe::attach_usdt(int pid)
   if (err)
     throw std::runtime_error("Error finding or enabling probe: " + probe_.name);
 
-  auto u = USDTHelper::find(ctx, pid, probe_.attach_point);
-  probe_.path = std::get<1>(u);
+  auto u = USDTHelper::find(pid, probe_.attach_point);
+  probe_.path = std::get<0>(u);
   // Handle manually specifying probe provider namespace
   if (probe_.ns != "")
     provider_ns = probe_.ns;
   else
-    provider_ns = std::get<0>(u);
+    provider_ns = std::get<1>(u);
 
   err = bcc_usdt_get_location(ctx, provider_ns.c_str(), probe_.attach_point.c_str(), 0, &loc);
+  bcc_usdt_close(ctx);
   if (err)
     throw std::runtime_error("Error finding location for probe: " + probe_.name);
   probe_.loc = loc.address;

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -476,7 +476,7 @@ void AttachedProbe::attach_usdt(int pid)
   if (err)
     throw std::runtime_error("Error finding or enabling probe: " + probe_.name);
 
-  auto u = USDTHelper::find(pid, probe_.ns, probe_.attach_point);
+  auto u = USDTHelper::find(pid, probe_.path, probe_.ns, probe_.attach_point);
   probe_.path = std::get<USDT_PATH_INDEX>(u);
 
   err = bcc_usdt_get_location(ctx, probe_.ns.c_str(), probe_.attach_point.c_str(), 0, &loc);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -119,7 +119,6 @@ int BPFtrace::add_probe(ast::Probe &p)
           break;
         case ProbeType::usdt:
         {
-          // FIXME should this also handle a case where no pid is specified?
           auto usdt_symbol_stream = USDTHelper::probe_stream(pid_);
           matches = find_wildcard_matches(attach_point->ns, attach_point->func, usdt_symbol_stream);
           break;
@@ -139,6 +138,12 @@ int BPFtrace::add_probe(ast::Probe &p)
 
     for (auto func : attach_funcs)
     {
+      if (probetype(attach_point->provider) == ProbeType::usdt && attach_point->ns == "")
+      {
+        usdt_probe_entry u = USDTHelper::find(0, func);
+        attach_point->ns = std::get<USDT_PROVIDER_INDEX>(u);
+      }
+
       Probe probe;
       probe.path = attach_point->target;
       probe.attach_point = func;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -528,7 +528,6 @@ std::unique_ptr<AttachedProbe> BPFtrace::attach_probe(Probe &probe, const BpfOrc
   std::string index_str = "_" + std::to_string(probe.index);
   auto func = bpforc.sections_.find("s_" + probe.name + index_str);
 
-  //std::map<std::string, std::tuple<uint8_t *, uintptr_t>>::iterator it;
   //for (auto const& x : bpforc.sections_)
   //{
   //    std::cout << x.first  // string (key)

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -143,7 +143,6 @@ int BPFtrace::add_probe(ast::Probe &p)
         usdt_probe_entry u = USDTHelper::find(0, func);
         attach_point->ns = std::get<USDT_PROVIDER_INDEX>(u);
       }
-
       Probe probe;
       probe.path = attach_point->target;
       probe.attach_point = func;
@@ -532,12 +531,6 @@ std::unique_ptr<AttachedProbe> BPFtrace::attach_probe(Probe &probe, const BpfOrc
   // that includes wildcards.
   std::string index_str = "_" + std::to_string(probe.index);
   auto func = bpforc.sections_.find("s_" + probe.name + index_str);
-
-  //for (auto const& x : bpforc.sections_)
-  //{
-  //    std::cout << x.first  // string (key)
-  //              << std::endl ;
-  //}
   if (func == bpforc.sections_.end())
     func = bpforc.sections_.find("s_" + probe.orig_name + index_str);
   if (func == bpforc.sections_.end())

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -120,7 +120,7 @@ int BPFtrace::add_probe(ast::Probe &p)
         case ProbeType::usdt:
         {
           // FIXME should this also handle a case where no pid is specified?
-          auto usdt_symbol_stream = std::istringstream(USDTHelper::list_probes_for_pid(pid_));
+          auto usdt_symbol_stream = USDTHelper::probe_stream(pid_);
           matches = find_wildcard_matches(attach_point->ns, attach_point->func, usdt_symbol_stream);
           break;
         }

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -101,6 +101,7 @@ public:
 
   static void sort_by_key(std::vector<SizedType> key_args,
       std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> &values_by_key);
+  virtual std::set<std::string> find_usdt_wildcard_matches(const std::string &prefix, const std::string &func, std::istream &symbol_name_stream);
   virtual std::set<std::string> find_wildcard_matches(const std::string &prefix, const std::string &func, std::istream &symbol_name_stream);
   virtual std::set<std::string> find_wildcard_matches(const std::string &prefix, const std::string &attach_point, const std::string &file_name);
 

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -153,7 +153,7 @@ void list_probes(const std::string &search_input, int pid)
     std::string provider = std::get<USDT_PROVIDER_INDEX>(usdt_probe);
     std::string fname    = std::get<USDT_FNAME_INDEX>(usdt_probe);
     std::string probe    = "usdt:" + path + ":" + provider + ":" + fname;
-    if (!search_probe(probe, re))
+    if (search.empty() || !search_probe(probe, re))
       std::cout << probe << std::endl;
   }
 

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -136,6 +136,7 @@ void list_probes(const std::string &search_input, int pid)
 
   // usdt
   usdt_probe_list usdt_probes;
+  bool usdt_path_list = false;
   if (pid > 0)
   {
     // PID takes precedence over path, so path from search expression will be ignored if pid specified
@@ -143,6 +144,7 @@ void list_probes(const std::string &search_input, int pid)
   } else {
     // If the *full* path is provided as part of the search expression parse it out and use it
     std::string usdt_path = search.substr(search.find(":")+1, search.size());
+    usdt_path_list = usdt_path.find(":") == std::string::npos;
     usdt_path = usdt_path.substr(0, usdt_path.find(":"));
     usdt_probes = USDTHelper::probes_for_path(usdt_path);
   }
@@ -153,7 +155,7 @@ void list_probes(const std::string &search_input, int pid)
     std::string provider = std::get<USDT_PROVIDER_INDEX>(usdt_probe);
     std::string fname    = std::get<USDT_FNAME_INDEX>(usdt_probe);
     std::string probe    = "usdt:" + path + ":" + provider + ":" + fname;
-    if (search.empty() || !search_probe(probe, re))
+    if (usdt_path_list || search.empty() || !search_probe(probe, re))
       std::cout << probe << std::endl;
   }
 

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -137,18 +137,13 @@ void list_probes(const std::string &search_input, int pid)
   // usdt
   if (pid > 0)
   {
-    std::string line;
-    auto usdt_probe_stream = std::istringstream(USDTHelper::list_probes_for_pid(pid));
-
-    while (std::getline(usdt_probe_stream, line))
+    usdt_probe_list usdt_probes = USDTHelper::probes_for_pid(pid);
+    for (auto const& usdt_probe : usdt_probes)
     {
-      // FIXME handle search here, looks like it's to prevent duplicates
-      //if (!search.empty())
-      //{
-      //  if (search_probe(probe, re))
-      //    continue;
-      //}
-      std::cout << "usdt:" << line << std::endl;
+      std::string path     = std::get<USDT_PATH_INDEX>(usdt_probe);
+      std::string provider = std::get<USDT_PROVIDER_INDEX>(usdt_probe);
+      std::string fname    = std::get<USDT_FNAME_INDEX>(usdt_probe);
+      std::cout << "usdt:" << path << ":" << provider << ":" << fname << std::endl;
     }
   }
 

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -135,16 +135,23 @@ void list_probes(const std::string &search_input, int pid)
   list_probes_from_list(HW_PROBE_LIST, "hardware", search, re);
 
   // usdt
+  usdt_probe_list usdt_probes;
   if (pid > 0)
   {
-    usdt_probe_list usdt_probes = USDTHelper::probes_for_pid(pid);
-    for (auto const& usdt_probe : usdt_probes)
-    {
-      std::string path     = std::get<USDT_PATH_INDEX>(usdt_probe);
-      std::string provider = std::get<USDT_PROVIDER_INDEX>(usdt_probe);
-      std::string fname    = std::get<USDT_FNAME_INDEX>(usdt_probe);
-      std::cout << "usdt:" << path << ":" << provider << ":" << fname << std::endl;
-    }
+    // PID takes precedence over path, so path from search expression will be ignored if pid specified
+    usdt_probes = USDTHelper::probes_for_pid(pid);
+  } else {
+    // If the *full* path is provided as part of the search expression parse it out and use it
+    std::string usdt_path = search.substr(search.find(":")+1, search.size());
+    usdt_probes = USDTHelper::probes_for_path(usdt_path);
+  }
+
+  for (auto const& usdt_probe : usdt_probes)
+  {
+    std::string path     = std::get<USDT_PATH_INDEX>(usdt_probe);
+    std::string provider = std::get<USDT_PROVIDER_INDEX>(usdt_probe);
+    std::string fname    = std::get<USDT_FNAME_INDEX>(usdt_probe);
+    std::cout << "usdt:" << path << ":" << provider << ":" << fname << std::endl;
   }
 
   // tracepoints

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -143,6 +143,7 @@ void list_probes(const std::string &search_input, int pid)
   } else {
     // If the *full* path is provided as part of the search expression parse it out and use it
     std::string usdt_path = search.substr(search.find(":")+1, search.size());
+    usdt_path = usdt_path.substr(0, usdt_path.find(":"));
     usdt_probes = USDTHelper::probes_for_path(usdt_path);
   }
 
@@ -151,7 +152,9 @@ void list_probes(const std::string &search_input, int pid)
     std::string path     = std::get<USDT_PATH_INDEX>(usdt_probe);
     std::string provider = std::get<USDT_PROVIDER_INDEX>(usdt_probe);
     std::string fname    = std::get<USDT_FNAME_INDEX>(usdt_probe);
-    std::cout << "usdt:" << path << ":" << provider << ":" << fname << std::endl;
+    std::string probe    = "usdt:" + path + ":" + provider + ":" + fname;
+    if (!search_probe(probe, re))
+      std::cout << probe << std::endl;
   }
 
   // tracepoints

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -138,7 +138,7 @@ void list_probes(const std::string &search_input, int pid)
   if (pid > 0)
   {
     std::string line;
-    auto usdt_probe_stream = std::istringstream(USDTHelper::list_probes_for_pid(pid, true));
+    auto usdt_probe_stream = std::istringstream(USDTHelper::list_probes_for_pid(pid));
 
     while (std::getline(usdt_probe_stream, line))
     {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -65,8 +65,8 @@ usdt_probe_entry USDTHelper::find(int pid, std::string name)
   if (matches.size() == 1)
     return matches.front();
   else if (matches.size() > 1) {
-    std::cerr << "ERROR: Insufficiently specified probe. Probe \"" << name << "\" is defined on " << matches.size() << " providers." << std::endl;
-    std::cerr << "You must specify a provider for this probe to uniquely identify it." << std::endl;
+    throw std::runtime_error("ERROR: Insufficiently specified probe. Probe \"" + name + "\" is defined on " + std::to_string(matches.size()) + " providers.\n" +
+                             "You must specify a provider for this probe to uniquely identify it.\n");
   } else {
     std::cerr << "ERROR: no matches found for " << name << std::endl;
   }
@@ -83,7 +83,7 @@ usdt_probe_entry USDTHelper::find(int pid, std::string provider, std::string nam
   if (it != probes.end()) {
     return *it;
   } else {
-    return std::make_tuple("", "","");
+    return std::make_tuple("", "", "");
   }
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -125,7 +125,7 @@ usdt_probe_list USDTHelper::probes_for_path(std::string path)
   return probes;
 }
 
-std::istringstream USDTHelper::probe_stream(int pid)
+std::istringstream USDTHelper::probe_stream(int pid, bool include_provider)
 {
   std::string probes;
   usdt_probe_list usdt_probes = probes_for_pid(pid);
@@ -134,7 +134,10 @@ std::istringstream USDTHelper::probe_stream(int pid)
     std::string path     = std::get<USDT_PATH_INDEX>(usdt_probe);
     std::string provider = std::get<USDT_PROVIDER_INDEX>(usdt_probe);
     std::string fname    = std::get<USDT_FNAME_INDEX>(usdt_probe);
-    probes += provider + ":" + fname + "\n";
+    if (include_provider)
+      probes += provider + ":" + fname + "\n";
+    else
+      probes += fname + "\n";
   }
 
   return std::istringstream(probes);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -56,7 +56,6 @@ usdt_probe_entry USDTHelper::find(int pid, std::string name)
   for (auto const& usdt_probes : usdt_provider_cache)
   {
     usdt_probe_entry probe = USDTHelper::find(pid, usdt_probes.first, name);
-
     if (std::get<USDT_FNAME_INDEX>(probe) != "")
     {
       matches.push_back(probe);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -65,12 +65,13 @@ usdt_probe_entry USDTHelper::find(int pid, std::string name)
 
   if (matches.size() == 1)
     return matches.front();
-  else
-  {
+  else if (matches.size() > 1) {
     std::cerr << "ERROR: Insufficiently specified probe. Probe \"" << name << "\" is defined on " << matches.size() << " providers." << std::endl;
     std::cerr << "You must specify a provider for this probe to uniquely identify it." << std::endl;
-    return std::make_tuple("", "","");
+  } else {
+    std::cerr << "ERROR: no matches found for " << name << std::endl;
   }
+  return std::make_tuple("", "", "");
 }
 
 
@@ -85,6 +86,19 @@ usdt_probe_entry USDTHelper::find(int pid, std::string provider, std::string nam
   } else {
     return std::make_tuple("", "","");
   }
+}
+
+usdt_probe_list USDTHelper::probes_for_provider(std::string provider)
+{
+  usdt_probe_list probes;
+
+  if(!provider_cache_loaded) {
+    std::cerr << "cannot read probes by provider before providers have been loaded by pid or path." << std::endl;
+    return probes;
+  }
+
+  read_probes_for_pid(0);
+  return usdt_provider_cache[provider];
 }
 
 usdt_probe_list USDTHelper::probes_for_pid(int pid)

--- a/src/utils.h
+++ b/src/utils.h
@@ -17,12 +17,11 @@ typedef std::vector<usdt_probe_entry> usdt_probe_list;
 class USDTHelper
 {
 public:
-  static usdt_probe_entry find(int pid, std::string name);
-  static usdt_probe_entry find(int pid, std::string provider, std::string name);
+  static usdt_probe_entry find(int pid, std::string target, std::string provider, std::string name);
   static usdt_probe_list probes_for_provider(std::string provider);
   static usdt_probe_list probes_for_pid(int pid);
   static usdt_probe_list probes_for_path(std::string path);
-  static std::istringstream probe_stream(int pid, bool include_provider = true);
+  static std::istringstream probe_stream(int pid, std::string target);
 private:
   static void read_probes_for_pid(int pid);
   static void read_probes_for_path(std::string path);

--- a/src/utils.h
+++ b/src/utils.h
@@ -20,9 +20,11 @@ public:
   static usdt_probe_entry find(int pid, std::string name);
   static usdt_probe_entry find(int pid, std::string provider, std::string name);
   static usdt_probe_list probes_for_pid(int pid);
-  static std::istringstream probe_stream(int pid); // FIXME just return the whole tuple
+  static usdt_probe_list probes_for_path(std::string path);
+  static std::istringstream probe_stream(int pid);
 private:
   static void read_probes_for_pid(int pid);
+  static void read_probes_for_path(std::string path);
 };
 
 struct DeprecatedName

--- a/src/utils.h
+++ b/src/utils.h
@@ -5,6 +5,7 @@
 #include <vector>
 #include <iostream>
 #include <sys/utsname.h>
+#include <signal.h>
 
 namespace bpftrace {
 
@@ -14,6 +15,8 @@ class USDTHelper
 {
 public:
   static usdt_probe_pair find(void *ctx, int pid, std::string name);
+  static std::string list_probes_for_pid(int pid, bool include_path = false);
+  //static std::string list_probes_for_path(); // FIXME
 };
 
 struct DeprecatedName

--- a/src/utils.h
+++ b/src/utils.h
@@ -9,14 +9,18 @@
 
 namespace bpftrace {
 
-typedef std::tuple<std::string, std::string> usdt_probe_pair;
+//Tuple order: (path, provider)
+typedef std::tuple<std::string, std::string> usdt_probe_entry;
 
 class USDTHelper
 {
 public:
-  static usdt_probe_pair find(void *ctx, int pid, std::string name);
-  static std::string list_probes_for_pid(int pid, bool include_path = false);
+  static usdt_probe_entry find(int pid, std::string name);
+  static std::string list_probes_for_pid(int pid);
+  //static std::string list_probes_for_pid(int pid, bool include_path = false); // FIXME just return the whole tuple
   //static std::string list_probes_for_path(); // FIXME
+private:
+  static void read_probes_for_pid(int pid);
 };
 
 struct DeprecatedName

--- a/src/utils.h
+++ b/src/utils.h
@@ -19,6 +19,7 @@ class USDTHelper
 public:
   static usdt_probe_entry find(int pid, std::string name);
   static usdt_probe_entry find(int pid, std::string provider, std::string name);
+  static usdt_probe_list probes_for_provider(std::string provider);
   static usdt_probe_list probes_for_pid(int pid);
   static usdt_probe_list probes_for_path(std::string path);
   static std::istringstream probe_stream(int pid);

--- a/src/utils.h
+++ b/src/utils.h
@@ -22,7 +22,7 @@ public:
   static usdt_probe_list probes_for_provider(std::string provider);
   static usdt_probe_list probes_for_pid(int pid);
   static usdt_probe_list probes_for_path(std::string path);
-  static std::istringstream probe_stream(int pid);
+  static std::istringstream probe_stream(int pid, bool include_provider = true);
 private:
   static void read_probes_for_pid(int pid);
   static void read_probes_for_path(std::string path);

--- a/src/utils.h
+++ b/src/utils.h
@@ -5,20 +5,22 @@
 #include <vector>
 #include <iostream>
 #include <sys/utsname.h>
+#include <sstream>
 #include <signal.h>
 
 namespace bpftrace {
 
-//Tuple order: (path, provider)
-typedef std::tuple<std::string, std::string> usdt_probe_entry;
+typedef enum _USDT_TUPLE_ORDER_ { USDT_PATH_INDEX, USDT_PROVIDER_INDEX, USDT_FNAME_INDEX } usdt_probe_entry_enum;
+typedef std::tuple<std::string, std::string, std::string> usdt_probe_entry;
+typedef std::vector<usdt_probe_entry> usdt_probe_list;
 
 class USDTHelper
 {
 public:
   static usdt_probe_entry find(int pid, std::string name);
-  static std::string list_probes_for_pid(int pid);
-  //static std::string list_probes_for_pid(int pid, bool include_path = false); // FIXME just return the whole tuple
-  //static std::string list_probes_for_path(); // FIXME
+  static usdt_probe_entry find(int pid, std::string provider, std::string name);
+  static usdt_probe_list probes_for_pid(int pid);
+  static std::istringstream probe_stream(int pid); // FIXME just return the whole tuple
 private:
   static void read_probes_for_pid(int pid);
 };

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -43,12 +43,12 @@ void check_uprobe(Probe &p, const std::string &path, const std::string &attach_p
   EXPECT_EQ("uprobe:" + path + ":" + attach_point, p.name);
 }
 
-void check_usdt(Probe &p, const std::string &path, const std::string &attach_point, const std::string &orig_name)
+void check_usdt(Probe &p, const std::string &path, const std::string &provider, const std::string &attach_point, const std::string &orig_name)
 {
   EXPECT_EQ(ProbeType::usdt, p.type);
   EXPECT_EQ(attach_point, p.attach_point);
   EXPECT_EQ(orig_name, p.orig_name);
-  EXPECT_EQ("usdt:" + path + ":" + attach_point, p.name);
+  EXPECT_EQ("usdt:" + path + ":" + provider + ":" + attach_point, p.name);
 }
 
 void check_tracepoint(Probe &p, const std::string &target, const std::string &func, const std::string &orig_name)
@@ -254,7 +254,7 @@ TEST(bpftrace, add_probes_uprobe)
 
 TEST(bpftrace, add_probes_usdt)
 {
-  ast::AttachPoint a("usdt", "/bin/sh", "foo", true);
+  ast::AttachPoint a("usdt", "/bin/sh", "foo", "bar", false);
   ast::AttachPointList attach_points = { &a };
   ast::Probe probe(&attach_points, nullptr, nullptr);
 
@@ -263,7 +263,7 @@ TEST(bpftrace, add_probes_usdt)
   EXPECT_EQ(0, bpftrace.add_probe(probe));
   EXPECT_EQ(1U, bpftrace.get_probes().size());
   EXPECT_EQ(0U, bpftrace.get_special_probes().size());
-  check_usdt(bpftrace.get_probes().at(0), "/bin/sh", "foo", "usdt:/bin/sh:foo");
+  check_usdt(bpftrace.get_probes().at(0), "/bin/sh", "foo", "bar", "usdt:/bin/sh:foo:bar");
 }
 
 TEST(bpftrace, add_probes_uprobe_wildcard)

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -1,0 +1,21 @@
+NAME "usdt probes - list probes by file"
+RUN bpftrace -l 'usdt:./testprogs/usdt_test'
+EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe
+TIMEOUT 5
+
+NAME "usdt probes - list probes by pid"
+RUN bpftrace -l 'usdt:*' -p $(pidof usdt_test)
+EXPECT usdt_test:tracetest:testprobe
+TIMEOUT 5
+BEFORE (./testprogs/usdt_test &);
+
+NAME "usdt probes - filter probes by file on provider"
+RUN bpftrace -l 'usdt:./testprogs/usdt_test:tracetest2:*'
+EXPECT usdt:./testprogs/usdt_test:tracetest2:testprobe2
+TIMEOUT 5
+
+NAME "usdt probes - filter probes by pid on provider"
+RUN bpftrace -l 'usdt:*:tracetest2:*' -p $(pidof usdt_test)
+EXPECT usdt_test:tracetest2:testprobe2
+TIMEOUT 5
+BEFORE (./testprogs/usdt_test &);

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -19,3 +19,62 @@ RUN bpftrace -l 'usdt:*:tracetest2:*' -p $(pidof usdt_test)
 EXPECT usdt_test:tracetest2:testprobe2
 TIMEOUT 5
 BEFORE (./testprogs/usdt_test &);
+
+NAME "usdt probes - filter probes by file and wildcard probe name"
+RUN bpftrace -l 'usdt:./testprogs/usdt_test:tracetest:test*'
+EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe2
+TIMEOUT 5
+
+NAME "usdt probes - filter probes by pid and wildcard probe name"
+RUN bpftrace -l 'usdt:*:tracetest:test*' -p $(pidof usdt_test)
+EXPECT usdt_test:tracetest:testprobe2
+TIMEOUT 5
+BEFORE (./testprogs/usdt_test &);
+
+NAME "usdt probes - attach to fully specified probe by file"
+RUN bpftrace -e 'usdt:./testprogs/usdt_test:tracetest:testprobe { printf("here\n" ); exit(); }'
+EXPECT here
+TIMEOUT 5
+BEFORE (./testprogs/usdt_test &);
+
+NAME "usdt probes - attach to fully specified probe by pid"
+RUN bpftrace -e 'usdt::tracetest:testprobe { printf("here\n" ); exit(); }' -p $(pidof usdt_test)
+EXPECT here
+TIMEOUT 5
+BEFORE (./testprogs/usdt_test &);
+
+NAME "usdt probes - all probes by wildcard and file"
+RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("here\n" ); exit(); }'
+EXPECT Attaching 3 probes...
+TIMEOUT 5
+BEFORE (./testprogs/usdt_test &);
+
+NAME "usdt probes - all probes by wildcard and pid"
+RUN bpftrace -e 'usdt:* { printf("here\n" ); exit(); }' -p $(pidof usdt_test)
+EXPECT Attaching 3 probes...
+TIMEOUT 5
+BEFORE (./testprogs/usdt_test &);
+
+NAME "usdt probes - attach to probe on multiple providers by wildcard and file"
+RUN bpftrace -e 'usdt:./testprogs/usdt_test::*probe2 { printf("here\n" ); exit(); }'
+EXPECT Attaching 2 probes...
+TIMEOUT 5
+BEFORE (./testprogs/usdt_test &);
+
+NAME "usdt probes - attach to probe on multiple providers by wildcard and pid"
+RUN bpftrace -e 'usdt:::*probe2 { printf("here\n" ); exit(); }' -p $(pidof usdt_test)
+EXPECT Attaching 2 probes...
+TIMEOUT 5
+BEFORE (./testprogs/usdt_test &);
+
+NAME "usdt probes - attach to probe with probe builtin and args by file"
+RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }'
+EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe
+TIMEOUT 5
+BEFORE (./testprogs/usdt_test &);
+
+NAME "usdt probes - attach to probe with probe builtin and args by pid"
+RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }' -p $(pidof usdt_test)
+EXPECT usdt_test:tracetest:testprobe
+TIMEOUT 5
+BEFORE (./testprogs/usdt_test &);

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -67,6 +67,18 @@ EXPECT Attaching 2 probes...
 TIMEOUT 5
 BEFORE (./testprogs/usdt_test &);
 
+NAME "usdt probes - attach to probe with args by file"
+RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("%s\n", str(arg1) ); exit(); }'
+EXPECT Hello world
+TIMEOUT 5
+BEFORE (./testprogs/usdt_test &);
+
+NAME "usdt probes - attach to probe with args by pid"
+RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("%s\n", str(arg1) ); exit(); }' -p $(pidof usdt_test)
+EXPECT Hello world
+TIMEOUT 5
+BEFORE (./testprogs/usdt_test &);
+
 NAME "usdt probes - attach to probe with probe builtin and args by file"
 RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }'
 EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -596,8 +596,6 @@ TEST(semantic_analyser, usdt)
   test("usdt:/bin/sh:probe { 1 }", 0);
   test("usdt:sh:probe { 1 }", 0);
   test("usdt:/bin/sh:namespace:probe { 1 }", 0);
-  test("usdt:/notexistfile:probe { 1 }", 1);
-  test("usdt:notexistfile:probe { 1 }", 1);
   test("usdt { 1 }", 1);
 }
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -596,6 +596,8 @@ TEST(semantic_analyser, usdt)
   test("usdt:/bin/sh:probe { 1 }", 0);
   test("usdt:sh:probe { 1 }", 0);
   test("usdt:/bin/sh:namespace:probe { 1 }", 0);
+  test("usdt:/notexistfile:probe { 1 }", 1);
+  test("usdt:notexistfile:probe { 1 }", 1);
   test("usdt { 1 }", 1);
 }
 

--- a/tests/testprogs/usdt_test.c
+++ b/tests/testprogs/usdt_test.c
@@ -5,17 +5,17 @@
 
 static long
 myclock() {
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    DTRACE_PROBE1(tracetest, testprobe, tv.tv_sec);
-    DTRACE_PROBE1(tracetest, testprobe2, tv.tv_sec);
-    DTRACE_PROBE1(tracetest2, testprobe2, tv.tv_sec);
-    return tv.tv_sec;
+  struct timeval tv;
+  gettimeofday(&tv, NULL);
+  DTRACE_PROBE1(tracetest, testprobe, tv.tv_sec);
+  DTRACE_PROBE1(tracetest, testprobe2, tv.tv_sec);
+  DTRACE_PROBE1(tracetest2, testprobe2, tv.tv_sec);
+  return tv.tv_sec;
 }
 
 int
 main(int argc, char **argv) {
-    usleep(2000000);
+  usleep(1000000);
     myclock();
     return 0;
 }

--- a/tests/testprogs/usdt_test.c
+++ b/tests/testprogs/usdt_test.c
@@ -1,0 +1,21 @@
+#include <sys/sdt.h>
+#include <sys/time.h>
+#include <unistd.h>
+#include <stdio.h>
+
+static long
+myclock() {
+    struct timeval tv;
+    gettimeofday(&tv, NULL);
+    DTRACE_PROBE1(tracetest, testprobe, tv.tv_sec);
+    DTRACE_PROBE1(tracetest, testprobe2, tv.tv_sec);
+    DTRACE_PROBE1(tracetest2, testprobe2, tv.tv_sec);
+    return tv.tv_sec;
+}
+
+int
+main(int argc, char **argv) {
+    usleep(2000000);
+    myclock();
+    return 0;
+}

--- a/tests/testprogs/usdt_test.c
+++ b/tests/testprogs/usdt_test.c
@@ -7,15 +7,15 @@ static long
 myclock() {
   struct timeval tv;
   gettimeofday(&tv, NULL);
-  DTRACE_PROBE1(tracetest, testprobe, tv.tv_sec);
-  DTRACE_PROBE1(tracetest, testprobe2, tv.tv_sec);
-  DTRACE_PROBE1(tracetest2, testprobe2, tv.tv_sec);
+  DTRACE_PROBE2(tracetest,  testprobe,  tv.tv_sec, "Hello world");
+  DTRACE_PROBE2(tracetest,  testprobe2, tv.tv_sec, "Hello world2");
+  DTRACE_PROBE2(tracetest2, testprobe2, tv.tv_sec, "Hello world3");
   return tv.tv_sec;
 }
 
 int
 main(int argc, char **argv) {
-  usleep(1000000);
+  usleep(500000);
     myclock();
     return 0;
 }


### PR DESCRIPTION
This fixes #493, allowing for wildcard tracing of USDT probes on a provider. The provider must either be specified, or the wildcard must not result in a provider collision. As it was easy to do, this also fixes #504.

Here are a number of invocations that now work, which previously failed:

Wildcard expansion by probe, specifying provider NS:
```
bpftrace -e 'usdt::ruby:cmethod__* { @[probe]++}'  -p ${PID}
Attaching 2 probes...
^C

@[usdt:ruby:cmethod__return]: 3
@[usdt:ruby:cmethod__entry]: 3
```

Fixed a bug where expansion wouldn't happpen if `probe` builtin wasn't used:
```
bpftrace -e 'usdt:ruby:cmethod__* { @[comm]++}' -p ${PID}
Attaching 2 probes...
^C

@[ruby]: 6
```
Specifying the provider namespace is optional if there is no collision on function name:

```
bpftrace -e 'usdt::cmethod__* { @[probe]++}' -p ${PID}
Attaching 2 probes...
^C

@[usdt:ruby:cmethod__return]: 3
@[usdt:ruby:cmethod__entry]: 3
```

If there provider isn't specified and there is a collision, an error will b ethrown:

```
bpftrace -e 'usdt:./tracetest:testprobe2 { @[probe]++ }'
terminate called after throwing an instance of 'std::runtime_error'
  what():  ERROR: Insufficiently specified probe. Probe "testprobe2" is defined on 2 providers.
You must specify a provider for this probe to uniquely identify it.

[1]    25455 abort     bpftrace -e 'usdt:./tracetest:testprobe2 { @[probe]++ }'
```

However, due to a bug in BCC (see https://github.com/iovisor/bcc/pull/2294 which should fix it), this will happen even if the probe is specified until https://github.com/iovisor/bcc/issues/2275 is fixed:

```
bpftrace -e 'usdt:./tracetest:tracetest:testprobe2 { @[probe]++ }'
Attaching 1 probe...
Two same-name probes (testprobe2) but different providers
Error finding or enabling probe: usdt:../tracetest:tracetest:testprobe2
```

I've also added the ability to list probes by path, if the path is specified as part of the list search string, which fixes #504 :
```
bpftrace -l 'usdt:./tracetest'
usdt:./tracetest:tracetest:testprobe
usdt:./tracetest:tracetest:testprobe2
usdt:./tracetest:tracetest2:testprobe2

```

And as a bonus, I added logic to the semantic analyzer to warn you if the provider you specified doesn't exist:

```
bpftrace -e 'usdt:../tracetest:tracetes:* { @[probe]++ }'
no matching probes usdt probes found on provider tracetes
```

I had to remove the file existence checking from the semantic analyzer, as it prevented me from being able to reasonably add wildcard support. However, I believe it was an invalid check anyways, as it would not use BCC's ability to check if the file exists within a mount namespace, and assumed the file was in the same mount namespace as bpftrace. I believe that it should be up to BCC to do this check anyways. As there is no easy way to ask BCC to just check if a file exists in a target processes mount namespace, I think it is fine to exclude this check. The result is that if the path doesn't exist, BCC will print the error `failed to initialize usdt context for path ${PATH}`

I have manually tested a number of permutations of wildcards, by pid and by path, specifying provider or not, using the `probe` builtin or not, and all seem to work as I would expect them to. 

I have also started storing the usdt probes in a way more similarly to how they are represented, as a map of providers to a vector of probe entries. This has the benefit of inherently allowing for collision detection when a probe name exists on multiple providers, and I found it helped to simplify the code.

I believe this is worth a first pass at review.

Food for thought:

* Should usdt helper be pulled out to its own file, or is utils.cpp a good place for it? It is starting to take over that file, and moving it to say, `usdt_helper.cpp/h` would probably clean things up a bit.
* What tests would be good to have here that are currently missing?
* I plan on fixing https://github.com/iovisor/bcc/issues/2275 shortly, now that bpftrace can handle provider collisions. I may need to make minor modifications to this code once that is fixed and merged.