### PR TITLE
Fix deprecated stack warning in builtin_stack test

### DIFF
--- a/tests/codegen/builtin_stack.cpp
+++ b/tests/codegen/builtin_stack.cpp
@@ -6,7 +6,7 @@ namespace codegen {
 
 TEST(codegen, builtin_stack)
 {
-  test("kprobe:f { @x = stack }",
+  test("kprobe:f { @x = kstack }",
 
 R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0


### PR DESCRIPTION
This is a simple fix for #455 