### PR TITLE
Do not try to load bpf program with unknown kernel version

### DIFF
--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -36,7 +36,7 @@ private:
   Probe &probe_;
   std::tuple<uint8_t *, uintptr_t> func_;
   std::vector<int> perf_event_fds_;
-  int progfd_;
+  int progfd_ = -1;
 };
 
 } // namespace bpftrace


### PR DESCRIPTION
Fixes #506 (subsequent calls to bpf_prog_load with kernel version = 0 zeroing
log_buf)

test plan:
1. build bpftrace for android and make sure that I see verifier errors when
using functionality that is not provided by old linux kernel
2. change kernel_version to always return 0 and verify that appropriate error
is written to stderr.