### PR TITLE
Fix version information when not building inside a git repo (#489)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(bpftrace)
 
+# bpftrace version number components.
+set(bpftrace_VERSION_MAJOR 0)
+set(bpftrace_VERSION_MINOR 8)
+
 set(STATIC_LINKING OFF CACHE BOOL "Build bpftrace as a statically linked executable")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ project(bpftrace)
 
 # bpftrace version number components.
 set(bpftrace_VERSION_MAJOR 0)
-set(bpftrace_VERSION_MINOR 8)
+set(bpftrace_VERSION_MINOR 9)
 
 set(STATIC_LINKING OFF CACHE BOOL "Build bpftrace as a statically linked executable")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -47,10 +47,18 @@ target_compile_definitions(bpftrace PUBLIC KERNEL_HEADERS_DIR="${KERNEL_HEADERS_
 endif()
 
 execute_process(
-  COMMAND git describe --abbrev=4 --dirty --always --tags
+  COMMAND git describe --abbrev=4 --dirty --tags
   WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
   OUTPUT_VARIABLE BPFTRACE_VERSION
+  ERROR_VARIABLE GIT_DESCRIBE_ERROR
   OUTPUT_STRIP_TRAILING_WHITESPACE
+  RESULT_VARIABLE retcode
 )
+
+# If the build is not done from a git repo, get the version information from
+# the version variables in main CMakeLists.txt
+if(NOT "${retcode}" STREQUAL "0")
+  set(BPFTRACE_VERSION "v${bpftrace_VERSION_MAJOR}.${bpftrace_VERSION_MINOR}")
+endif()
 
 add_definitions("-DBPFTRACE_VERSION=\"${BPFTRACE_VERSION}\"")


### PR DESCRIPTION
If the build is done from a tarball (without git), get the version
information from the bpftrace_VERSION_MAJOR and bpftrace_VERSION_MINOR
variables in main CMakeLists.txt file.

Note: These variables must be bumped for each new release.