### PR TITLE
Suppress build warning in GCC >=8 caused by #474

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -412,7 +412,7 @@ typedef int (*attach_probe_wrapper_signature)(int, enum bpf_probe_attach_type, c
 
 void AttachedProbe::attach_kprobe()
 {
-  int perf_event_fd = reinterpret_cast<attach_probe_wrapper_signature>(&bpf_attach_kprobe)(progfd_, attachtype(probe_.type),
+  int perf_event_fd = cast_signature<attach_probe_wrapper_signature>(&bpf_attach_kprobe)(progfd_, attachtype(probe_.type),
       eventname().c_str(), probe_.attach_point.c_str(), 0, 0);
 
   if (perf_event_fd < 0) {

--- a/src/utils.h
+++ b/src/utils.h
@@ -27,6 +27,19 @@ private:
   static void read_probes_for_path(std::string path);
 };
 
+// Hack used to suppress build warning related to #474
+template <typename new_signature, typename old_signature>
+new_signature cast_signature(old_signature func) {
+#if __GNUC__ >= 8
+_Pragma("GCC diagnostic push")
+_Pragma("GCC diagnostic ignored \"-Wcast-function-type\"")
+#endif
+  return reinterpret_cast<new_signature>(func);
+#if __GNUC__ >= 8
+_Pragma("GCC diagnostic pop")
+#endif
+}
+
 struct DeprecatedName
 {
   std::string old_name;


### PR DESCRIPTION
Suppress the following warning message in GCC >=8:

```
/devel/bpftrace/src/attached_probe.cpp: In member function ‘void bpftrace::AttachedProbe::attach_kprobe()’:
/devel/bpftrace/src/attached_probe.cpp:388:90: warning: cast between incompatible function types from ‘int (*)(int, bpf_probe_attach_type, const char*, const char*, uint64_t)’ {aka ‘int (*)(int, bpf_probe_attach_type, const char*, const char*, long unsigned int)’} to ‘bpftrace::attach_probe_wrapper_signature’ {aka ‘int (*)(int, bpf_probe_attach_type, const char*, const char*, long unsigned int, int)’} [-Wcast-function-type]
   int perf_event_fd = reinterpret_cast<attach_probe_wrapper_signature>(&bpf_attach_kprobe)(progfd_, attachtype(probe_.type),
                                                                                          ^
```