### PR TITLE
Cmake llvm version enhancements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,7 +65,18 @@ set(CMAKE_EXTRA_INCLUDE_FILES linux/bpf.h)
 check_type_size("BPF_FUNC_get_current_cgroup_id" GET_CURRENT_CGROUP_ID LANGUAGE C)
 set(CMAKE_EXTRA_INCLUDE_FILES)
 
-find_package(LLVM REQUIRED)
+# Some users have multiple versions of llvm installed and would like to specify
+# a specific llvm version.
+if(${LLVM_REQUESTED_VERION})
+  find_package(LLVM ${LLVM_REQUESTED_VERION} REQUIRED)
+else()
+  find_package(LLVM REQUIRED)
+endif()
+
+if(${LLVM_VERSION_MAJOR} VERSION_LESS 5)
+  message(SEND_ERROR "Unsupported LLVM version found: ${LLVM_INCLUDE_DIRS}")
+endif()
+
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 add_definitions(${LLVM_DEFINITIONS})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ endif()
 
 if(${LLVM_VERSION_MAJOR} VERSION_LESS 5)
   message(SEND_ERROR "Unsupported LLVM version found: ${LLVM_INCLUDE_DIRS}")
-  message(SEND_ERROR "Specify an LLVM major version using LLVM_REQUESTED_VERION=<version>")
+  message(SEND_ERROR "Specify an LLVM major version using LLVM_REQUESTED_VERION=<major version>")
 endif()
 
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ endif()
 
 if(${LLVM_VERSION_MAJOR} VERSION_LESS 5)
   message(SEND_ERROR "Unsupported LLVM version found: ${LLVM_INCLUDE_DIRS}")
-  message(SEND_ERROR "Specify an LLVM major version using LLVM_REQUESTED_VERION=<major version>")
+  message(SEND_ERROR "Specify an LLVM major version using LLVM_REQUESTED_VERSION=<major version>")
 endif()
 
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ endif()
 
 if(${LLVM_VERSION_MAJOR} VERSION_LESS 5)
   message(SEND_ERROR "Unsupported LLVM version found: ${LLVM_INCLUDE_DIRS}")
+  message(SEND_ERROR "Specify an LLVM major version using LLVM_REQUESTED_VERION=<version>")
 endif()
 
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})


### PR DESCRIPTION
This is a possible fix for #211 

If cmake chooses an unsupported version of LLVM (less than LLVM 5), we notify the user and allow them to use LLVM_REQUESTED_VERION in order to specify the desired LLVM major version.