### PR TITLE
use CMAKE_SYSTEM_PROCESSOR when selecting arch sources

### DIFF
--- a/src/arch/CMakeLists.txt
+++ b/src/arch/CMakeLists.txt
@@ -1,4 +1,4 @@
-if(CMAKE_HOST_SYSTEM_PROCESSOR STREQUAL "aarch64")
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
     add_library(arch aarch64.cpp)
 else()
     add_library(arch x86_64.cpp)


### PR DESCRIPTION
According to documentation CMAKE_SYSTEM_PROCESSOR is the name of the cpu we're
building for, whereas CMAKE_HOST_SYSTEM_PROCESSOR is the name of the cpu the
CMake is running on.

When cross compiling bpftrace for arm64 device on my macbook
CMAKE_HOST_SYSTEM_PROCESSOR is set to x86_64 and CMAKE_SYSTEM_PROCESSOR is set
to aarch64. Of course in that scenario the build system should compile
aarch64.cpp instead of x86_64.cpp.

Test plan: cross compile for Android and run:
`bpftrace -e 'kprobe:sys_execve { printf("%s wants to exec %s\n", comm, str(arg0)) }'`
Observe that arg0 does not look like garbage anymore.