### PR TITLE
Throw error msg if argN or retval is used with incorrect probe type (…

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -614,9 +614,14 @@ sleep by 3669
 
 ## 2. `kprobe`/`kretprobe`: Dynamic Tracing, Kernel-Level Arguments
 
-Syntax: `arg0, arg1, ..., argN`
+Syntax:
 
-Arguments can be accessed via these variables names. arg0 is the first argument.
+```
+kprobe: arg0, arg1, ..., argN
+kretprobe: retval
+```
+
+Arguments can be accessed via these variables names. `arg0` is the first argument and can only be accessed with a `kprobe`. `retval` is the return value for the instrumented function, and can only be accessed on `kretprobe`.
 
 Examples:
 
@@ -717,7 +722,7 @@ Syntax:
 
 ```
 uprobe: arg0, arg1, ..., argN
-uretprobe: retval`
+uretprobe: retval
 ```
 
 Arguments can be accessed via these variables names. `arg0` is the first argument, and can only be accessed with a `uprobe`. `retval` is the return value for the instrumented function, and can only be accessed on `uretprobe`.

--- a/tests/codegen/builtin_retval.cpp
+++ b/tests/codegen/builtin_retval.cpp
@@ -6,7 +6,7 @@ namespace codegen {
 
 TEST(codegen, builtin_retval)
 {
-  test("kprobe:f { @x = retval }",
+  test("kretprobe:f { @x = retval }",
 
 R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
@@ -14,7 +14,7 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
+define i64 @"kretprobe:f"(i8*) local_unnamed_addr section "s_kretprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -64,7 +64,7 @@ TEST(semantic_analyser, builtin_variables)
   test("kprobe:f { stack }", 0);
   test("kprobe:f { ustack }", 0);
   test("kprobe:f { arg0 }", 0);
-  test("kprobe:f { retval }", 0);
+  test("kretprobe:f { retval }", 0);
   test("kprobe:f { func }", 0);
   test("kprobe:f { probe }", 0);
   test("kprobe:f { $1 }", 0);


### PR DESCRIPTION
…#522)

- The argN builtin can only be used with kprobes, uprobes and usdt
probes
- The retval builtin can only be used with kretprobes and uretprobes