### PR TITLE
Ban kprobes that can cause soft lockups

### DIFF
--- a/tests/runtime/banned_probes
+++ b/tests/runtime/banned_probes
@@ -1,0 +1,19 @@
+NAME kretprobe:_raw_spin_lock is banned
+RUN bpftrace -e 'kretprobe:_raw_spin_lock { exit(); }'
+EXPECT error: kretprobe:_raw_spin_lock can't be used as it might lock up your system.
+TIMEOUT 1
+
+NAME kretprobe:queued_spin_lock_slowpath is banned
+RUN bpftrace -e 'kretprobe:queued_spin_lock_slowpath { exit(); }'
+EXPECT error: kretprobe:queued_spin_lock_slowpath can't be used as it might lock up your system.
+TIMEOUT 1
+
+NAME kretprobe:_raw_spin_unlock_irqrestore is banned
+RUN bpftrace -e 'kretprobe:_raw_spin_unlock_irqrestore { exit(); }'
+EXPECT error: kretprobe:_raw_spin_unlock_irqrestore can't be used as it might lock up your system.
+TIMEOUT 1
+
+NAME kretprobe:_raw_spin_lock_irqsave is banned
+RUN bpftrace -e 'kretprobe:_raw_spin_lock_irqsave { exit(); }'
+EXPECT error: kretprobe:_raw_spin_lock_irqsave can't be used as it might lock up your system.
+TIMEOUT 1


### PR DESCRIPTION
## ⚠️⚠️ Warning ⚠️⚠️
Running any of the tracing commands in the tests will likely freeze your computer

--------------
As reported in https://github.com/iovisor/bcc/issues/2300, running certain BFP code in some kretprobe can cause deadlocks.

While ideally maybe this should be addressed at the kernel / libbcc level, this would temporarily protect our users from rendering their system **completely unusable**.

In netcons, I can see several messages such as:
```
watchdog: BUG: soft lockup - CPU#8 stuck for 23s! [IOThreadPool0:2190014] 
```
(if you are a fb employee: fburl scuba/shyfhznk)

## Questions + notes
- Do you think it is worthy adding this check? 
- What do you think about this approach, is it too aggressive? It could happen the deadlock only occurs in some circumstances such as sending data through a perf buffer, but maybe not while accessing a map? In these cases we could add smarter checks in the semantic analyser?
- Not sure if this can reproduce in other kernel versions (but I'd assume so!)

## Test Plan
```shell
$ sudo make runtime-tests
[...]
Test file: banned_probes

kretprobe:_raw_spin_lock is banned OK
kretprobe:queued_spin_lock_slowpath is banned OK
kretprobe:_raw_spin_unlock_irqrestore is banned OK
kretprobe:_raw_spin_lock_irqsave is banned OK
[...]
```
cc: @yonghong-song 

Thanks,

(`uname -a`: `Linux 4.16.18-151 #151 SMP Mon Apr 1 12:25:10 PDT 2019 x86_64 x86_64 x86_64 GNU/Linux`)