### PR TITLE
add basic support to enums (treat them as constants)

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -47,8 +47,15 @@ void CodegenLLVM::visit(String &string)
 
 void CodegenLLVM::visit(Identifier &identifier)
 {
-  std::cerr << "unknown identifier \"" << identifier.ident << "\"" << std::endl;
-  abort();
+  if (bpftrace_.enums_.count(identifier.ident) != 0)
+  {
+    expr_ = b_.getInt64(bpftrace_.enums_[identifier.ident]);
+  }
+  else
+  {
+    std::cerr << "unknown identifier \"" << identifier.ident << "\"" << std::endl;
+    abort();
+  }
 }
 
 void CodegenLLVM::visit(Builtin &builtin)

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -61,8 +61,13 @@ void SemanticAnalyser::visit(StackMode &mode)
 
 void SemanticAnalyser::visit(Identifier &identifier)
 {
-  identifier.type = SizedType(Type::none, 0);
-  err_ << "Unknown identifier: '" << identifier.ident << "'" << std::endl;
+  if (bpftrace_.enums_.count(identifier.ident) != 0) {
+    identifier.type = SizedType(Type::integer, 8);
+  }
+  else {
+    identifier.type = SizedType(Type::none, 0);
+    err_ << "Unknown identifier: '" << identifier.ident << "'" << std::endl;
+  }
 }
 
 void SemanticAnalyser::visit(Builtin &builtin)

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -83,6 +83,7 @@ public:
   std::map<std::string, std::unique_ptr<IMap>> maps_;
   std::map<std::string, Struct> structs_;
   std::map<std::string, std::string> macros_;
+  std::map<std::string, uint64_t> enums_;
   std::vector<std::tuple<std::string, std::vector<Field>>> printf_args_;
   std::vector<std::tuple<std::string, std::vector<Field>>> system_args_;
   std::vector<std::string> time_args_;

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -315,6 +315,13 @@ void ClangParser::parse(ast::Program *program, BPFtrace &bpftrace)
             return CXChildVisit_Recurse;
           }
 
+          if (clang_getCursorKind(parent) == CXCursor_EnumDecl)
+          {
+            auto &enums = static_cast<BPFtrace*>(client_data)->enums_;
+            enums[get_clang_string(clang_getCursorSpelling(c))] = clang_getEnumConstantDeclValue(c);
+            return CXChildVisit_Recurse;
+          }
+
           if (clang_getCursorKind(parent) != CXCursor_StructDecl &&
               clang_getCursorKind(parent) != CXCursor_UnionDecl)
             return CXChildVisit_Recurse;

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -27,6 +27,7 @@ space  {hspace}|{vspace}
 path   :(\\.|[_\-\./a-zA-Z0-9])*:
 %x STR
 %x STRUCT
+%x ENUM
 %x BRACE
 %x COMMENT
 
@@ -116,7 +117,8 @@ bpftrace|perf {
 }
 
 struct|union            yy_push_state(STRUCT, yyscanner); buffer.clear(); struct_type = yytext;
-<STRUCT,BRACE>{
+enum                    yy_push_state(ENUM, yyscanner); buffer.clear();
+<STRUCT,BRACE,ENUM>{
   "*"|")"               { if (YY_START == STRUCT) {
                             yy_pop_state(yyscanner);
                             unput(yytext[0]);
@@ -130,6 +132,10 @@ struct|union            yy_push_state(STRUCT, yyscanner); buffer.clear(); struct
                           if (YY_START == STRUCT) {
                             yy_pop_state(yyscanner);
                             return Parser::make_STRUCT(struct_type + buffer, loc);
+                          }
+                          if (YY_START == ENUM) {
+                            yy_pop_state(yyscanner);
+                            return Parser::make_ENUM("enum " + buffer, loc);
                           }
                         }
   .                     buffer += yytext[0];

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -80,6 +80,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %token <std::string> PATH "path"
 %token <std::string> CPREPROC "preprocessor directive"
 %token <std::string> STRUCT "struct"
+%token <std::string> ENUM "enum"
 %token <std::string> STRING "string"
 %token <std::string> MAP "map"
 %token <std::string> VAR "variable"
@@ -131,6 +132,7 @@ program : c_definitions probes { driver.root_ = new ast::Program($1, $2); }
 
 c_definitions : CPREPROC c_definitions { $$ = $1 + "\n" + $2; }
               | STRUCT c_definitions   { $$ = $1 + ";\n" + $2; }
+              | ENUM c_definitions     { $$ = $1 + ";\n" + $2; }
               |                        { $$ = std::string(); }
               ;
 

--- a/tests/codegen.cpp
+++ b/tests/codegen.cpp
@@ -48,6 +48,7 @@
 #include "codegen/call_zero.cpp"
 #include "codegen/dereference.cpp"
 #include "codegen/empty_function.cpp"
+#include "codegen/enum.cpp"
 #include "codegen/if_else_printf.cpp"
 #include "codegen/if_else_variable.cpp"
 #include "codegen/if_nested_printf.cpp"

--- a/tests/codegen/enum.cpp
+++ b/tests/codegen/enum.cpp
@@ -1,0 +1,58 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, enum_declaration)
+{
+  test("enum { a = 42, b } k:f { @a = a; @b = b }",
+
+R"EXPECTED(; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
+entry:
+  %"@b_val" = alloca i64, align 8
+  %"@b_key" = alloca i64, align 8
+  %"@a_val" = alloca i64, align 8
+  %"@a_key" = alloca i64, align 8
+  %1 = bitcast i64* %"@a_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  store i64 0, i64* %"@a_key", align 8
+  %2 = bitcast i64* %"@a_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  store i64 42, i64* %"@a_val", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@a_key", i64* nonnull %"@a_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  %3 = bitcast i64* %"@b_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 0, i64* %"@b_key", align 8
+  %4 = bitcast i64* %"@b_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 43, i64* %"@b_val", align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@b_key", i64* nonnull %"@b_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace
+
+

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -707,6 +707,12 @@ TEST(semantic_analyser, macros)
 {
   test("#define A 1\nkprobe:f { printf(\"%d\", A); }", 0);
   test("#define A A\nkprobe:f { printf(\"%d\", A); }", 1);
+  test("enum { A = 1 }\n#define A A\nkprobe:f { printf(\"%d\", A); }", 0);
+}
+
+TEST(semantic_analyser, enums)
+{
+  test("enum { a = 1, b } kprobe:f { printf(\"%d\", a); }", 0);
 }
 
 } // namespace semantic_analyser


### PR DESCRIPTION
This adds basic support for C-style enumerators. By basic support I mean we are treating them as constants (almost `#define`s) instead of new types. Maybe in the future we want to add more sophisticated support for them (allowing cast to an enum type, checking if an assignment is within the enum range, etc.). Maybe we will want to keep it simple. But for now this should solve the most common use cases, especially when dealing with enumerators from Kernel headers.

Usage example:

```c
enum { 
  a=1, 
  b 
} 

i:s;1 { 
  printf("%d %d\n", a, b); 
}
```