### PR TITLE
 add macro definition support

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -21,6 +21,10 @@ void Builtin::accept(Visitor &v) {
   v.visit(*this);
 }
 
+void Identifier::accept(Visitor &v) {
+  v.visit(*this);
+}
+
 void PositionalParameter::accept(Visitor &v) {
   v.visit(*this);
 }

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -63,6 +63,14 @@ public:
   void accept(Visitor &v) override;
 };
 
+class Identifier : public Expression {
+public:
+  explicit Identifier(std::string ident) : ident(ident) {}
+  std::string ident;
+
+  void accept(Visitor &v) override;
+};
+
 class Builtin : public Expression {
 public:
   explicit Builtin(std::string ident) : ident(is_deprecated(ident)) {}
@@ -288,6 +296,7 @@ public:
   virtual void visit(PositionalParameter &integer) = 0;
   virtual void visit(String &string) = 0;
   virtual void visit(Builtin &builtin) = 0;
+  virtual void visit(Identifier &identifier) = 0;
   virtual void visit(StackMode &mode) = 0;
   virtual void visit(Call &call) = 0;
   virtual void visit(Map &map) = 0;

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -45,6 +45,12 @@ void CodegenLLVM::visit(String &string)
   expr_ = buf;
 }
 
+void CodegenLLVM::visit(Identifier &identifier)
+{
+  std::cerr << "unknown identifier \"" << identifier.ident << "\"" << std::endl;
+  abort();
+}
+
 void CodegenLLVM::visit(Builtin &builtin)
 {
   if (builtin.ident == "nsecs")

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -30,6 +30,7 @@ public:
   void visit(Integer &integer) override;
   void visit(PositionalParameter &param) override;
   void visit(String &string) override;
+  void visit(Identifier &identifier) override;
   void visit(Builtin &builtin) override;
   void visit(StackMode &) override { };
   void visit(Call &call) override;

--- a/src/ast/printer.cpp
+++ b/src/ast/printer.cpp
@@ -43,6 +43,12 @@ void Printer::visit(Builtin &builtin)
   out_ << indent << "builtin: " << builtin.ident << std::endl;
 }
 
+void Printer::visit(Identifier &identifier)
+{
+  std::string indent(depth_, ' ');
+  out_ << indent << "identifier: " << identifier.ident << std::endl;
+}
+
 void Printer::visit(Call &call)
 {
   std::string indent(depth_, ' ');

--- a/src/ast/printer.h
+++ b/src/ast/printer.h
@@ -14,6 +14,7 @@ public:
   void visit(PositionalParameter &param) override;
   void visit(String &string) override;
   void visit(StackMode &mode) override;
+  void visit(Identifier &identifier) override;
   void visit(Builtin &builtin) override;
   void visit(Call &call) override;
   void visit(Map &map) override;

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -59,6 +59,12 @@ void SemanticAnalyser::visit(StackMode &mode)
   }
 }
 
+void SemanticAnalyser::visit(Identifier &identifier)
+{
+  identifier.type = SizedType(Type::none, 0);
+  err_ << "Unknown identifier: '" << identifier.ident << "'" << std::endl;
+}
+
 void SemanticAnalyser::visit(Builtin &builtin)
 {
   if (builtin.ident == "nsecs" ||

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -23,6 +23,7 @@ public:
   void visit(PositionalParameter &param) override;
   void visit(String &string) override;
   void visit(StackMode &mode) override;
+  void visit(Identifier &identifier) override;
   void visit(Builtin &builtin) override;
   void visit(Call &call) override;
   void visit(Map &map) override;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -82,6 +82,7 @@ public:
 
   std::map<std::string, std::unique_ptr<IMap>> maps_;
   std::map<std::string, Struct> structs_;
+  std::map<std::string, std::string> macros_;
   std::vector<std::tuple<std::string, std::vector<Field>>> printf_args_;
   std::vector<std::tuple<std::string, std::vector<Field>>> system_args_;
   std::vector<std::string> time_args_;

--- a/src/clang_parser.h
+++ b/src/clang_parser.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "struct.h"
+#include "bpftrace.h"
 
 namespace bpftrace {
 
@@ -11,7 +12,7 @@ using StructMap = std::map<std::string, Struct>;
 class ClangParser
 {
 public:
-  void parse(ast::Program *program, StructMap &structs);
+  void parse(ast::Program *program, BPFtrace &bpftrace);
 };
 
 } // namespace bpftrace

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -10,7 +10,7 @@ extern int yylex_destroy (yyscan_t yyscanner);
 
 namespace bpftrace {
 
-Driver::Driver()
+Driver::Driver(BPFtrace &bpftrace) : bpftrace_(bpftrace)
 {
   yylex_init(&scanner_);
   parser_ = std::make_unique<Parser>(*this, scanner_);

--- a/src/driver.h
+++ b/src/driver.h
@@ -3,6 +3,7 @@
 #include <memory>
 
 #include "ast.h"
+#include "bpftrace.h"
 #include "parser.tab.hh"
 
 typedef void* yyscan_t;
@@ -14,7 +15,7 @@ namespace bpftrace {
 class Driver
 {
 public:
-  Driver();
+  explicit Driver(BPFtrace &bpftrace);
   ~Driver();
 
   int parse_stdin();
@@ -25,6 +26,7 @@ public:
 
   ast::Program *root_;
 
+  BPFtrace &bpftrace_;
 private:
   std::unique_ptr<Parser> parser_;
   yyscan_t scanner_;

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -136,7 +136,16 @@ struct|union            yy_push_state(STRUCT, yyscanner); buffer.clear(); struct
   \n                    buffer += '\n'; loc.lines(1); loc.step();
 }
 
-{ident}                 { return Parser::make_IDENT(yytext, loc); }
+{ident}                 {
+                          if (driver.bpftrace_.macros_.count(yytext) != 0) {
+                            const char *s = driver.bpftrace_.macros_[yytext].c_str();
+                            int z;
+                            for (z=strlen(s) - 1; z >= 0; z--)
+                              unput(s[z]);
+                          } else {
+                            return Parser::make_IDENT(yytext, loc);
+                          }
+                        }
 .                       { driver.error(loc, std::string("invalid character '") +
                                             std::string(yytext) + std::string("'")); }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -283,7 +283,7 @@ int main(int argc, char *argv[])
   }
 
   ClangParser clang;
-  clang.parse(driver.root_, bpftrace.structs_);
+  clang.parse(driver.root_, bpftrace);
 
   ast::SemanticAnalyser semantics(driver.root_, bpftrace);
   err = semantics.analyse();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,7 +83,6 @@ bool is_numeric(char* string)
 int main(int argc, char *argv[])
 {
   int err;
-  Driver driver;
   char *pid_str = nullptr;
   char *cmd_str = nullptr;
   bool listing = false;
@@ -94,7 +93,7 @@ int main(int argc, char *argv[])
     return 0;
   }
 
-  std::string script, search;
+  std::string script, search, file_name;
   int c;
   while ((c = getopt(argc, argv, "dB:e:hlp:vc:")) != -1)
   {
@@ -163,6 +162,7 @@ int main(int argc, char *argv[])
   }
 
   BPFtrace bpftrace;
+  Driver driver(bpftrace);
 
   // PID is currently only used for USDT probes that need enabling. Future work:
   // - make PID a filter for all probe types: pass to perf_event_open(), etc.
@@ -198,8 +198,8 @@ int main(int argc, char *argv[])
   if (script.empty())
   {
     // Script file
-    char *file_name = argv[optind];
-    if (!file_name)
+    file_name = std::string(argv[optind]);
+    if (file_name.empty())
     {
       std::cerr << "USAGE: filename or -e 'program' required." << std::endl;
       return 1;
@@ -284,6 +284,18 @@ int main(int argc, char *argv[])
 
   ClangParser clang;
   clang.parse(driver.root_, bpftrace);
+
+  if (script.empty())
+  {
+    err = driver.parse_file(file_name);
+  }
+  else
+  {
+    err = driver.parse_str(script);
+  }
+
+  if (err)
+    return err;
 
   ast::SemanticAnalyser semantics(driver.root_, bpftrace);
   err = semantics.analyse();

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -203,6 +203,7 @@ stmt : expr         { $$ = new ast::ExprStatement($1); }
 expr : INT             { $$ = new ast::Integer($1); }
      | STRING          { $$ = new ast::String($1); }
      | BUILTIN         { $$ = new ast::Builtin($1); }
+     | IDENT           { $$ = new ast::Identifier($1); }
      | STACK_MODE      { $$ = new ast::StackMode($1); }
      | ternary         { $$ = $1; }
      | param           { $$ = $1; }

--- a/src/tracepoint_format_parser.h
+++ b/src/tracepoint_format_parser.h
@@ -17,6 +17,7 @@ public:
   void visit(__attribute__((unused)) PositionalParameter &integer) override { };  // Leaf
   void visit(__attribute__((unused)) String &string) override { };  // Leaf
   void visit(__attribute__((unused)) StackMode &mode) override { };  // Leaf
+  void visit(__attribute__((unused)) Identifier &identifier) override { };  // Leaf
   void visit(Builtin &builtin) override {  // Leaf
     if (builtin.ident == "args")
       probe_->need_tp_args_structs = true;

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -10,7 +10,7 @@ namespace clang_parser {
 void parse(const std::string &input, BPFtrace &bpftrace)
 {
   auto extended_input = input + "kprobe:sys_read { 1 }";
-  Driver driver;
+  Driver driver(bpftrace);
   ASSERT_EQ(driver.parse_str(extended_input), 0);
 
   ClangParser clang;

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -1,25 +1,28 @@
 #include "gtest/gtest.h"
 #include "clang_parser.h"
 #include "driver.h"
+#include "bpftrace.h"
 
 namespace bpftrace {
 namespace test {
 namespace clang_parser {
 
-void parse(const std::string &input, StructMap &structs)
+void parse(const std::string &input, BPFtrace &bpftrace)
 {
   auto extended_input = input + "kprobe:sys_read { 1 }";
   Driver driver;
   ASSERT_EQ(driver.parse_str(extended_input), 0);
 
   ClangParser clang;
-  clang.parse(driver.root_, structs);
+  clang.parse(driver.root_, bpftrace);
 }
 
 TEST(clang_parser, integers)
 {
-  StructMap structs;
-  parse("struct Foo { int x; int y, z; }", structs);
+  BPFtrace bpftrace;
+  parse("struct Foo { int x; int y, z; }", bpftrace);
+
+  StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs.size(), 1U);
   ASSERT_EQ(structs.count("Foo"), 1U);
@@ -45,8 +48,10 @@ TEST(clang_parser, integers)
 
 TEST(clang_parser, c_union)
 {
-  StructMap structs;
-  parse("union Foo { char c; short s; int i; long l; }", structs);
+  BPFtrace bpftrace;
+  parse("union Foo { char c; short s; int i; long l; }", bpftrace);
+
+  StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs.size(), 1U);
   ASSERT_EQ(structs.count("Foo"), 1U);
@@ -77,8 +82,10 @@ TEST(clang_parser, c_union)
 
 TEST(clang_parser, integer_ptr)
 {
-  StructMap structs;
-  parse("struct Foo { int *x; }", structs);
+  BPFtrace bpftrace;
+  parse("struct Foo { int *x; }", bpftrace);
+
+  StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs.size(), 1U);
   ASSERT_EQ(structs.count("Foo"), 1U);
@@ -96,8 +103,10 @@ TEST(clang_parser, integer_ptr)
 
 TEST(clang_parser, string_ptr)
 {
-  StructMap structs;
-  parse("struct Foo { char *str; }", structs);
+  BPFtrace bpftrace;
+  parse("struct Foo { char *str; }", bpftrace);
+
+  StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs.size(), 1U);
   ASSERT_EQ(structs.count("Foo"), 1U);
@@ -115,8 +124,10 @@ TEST(clang_parser, string_ptr)
 
 TEST(clang_parser, string_array)
 {
-  StructMap structs;
-  parse("struct Foo { char str[32]; }", structs);
+  BPFtrace bpftrace;
+  parse("struct Foo { char str[32]; }", bpftrace);
+
+  StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs.size(), 1U);
   ASSERT_EQ(structs.count("Foo"), 1U);
@@ -132,8 +143,10 @@ TEST(clang_parser, string_array)
 
 TEST(clang_parser, nested_struct_named)
 {
-  StructMap structs;
-  parse("struct Bar { int x; } struct Foo { struct Bar bar; }", structs);
+  BPFtrace bpftrace;
+  parse("struct Bar { int x; } struct Foo { struct Bar bar; }", bpftrace);
+
+  StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs.size(), 2U);
   ASSERT_EQ(structs.count("Foo"), 1U);
@@ -151,8 +164,10 @@ TEST(clang_parser, nested_struct_named)
 
 TEST(clang_parser, nested_struct_ptr_named)
 {
-  StructMap structs;
-  parse("struct Bar { int x; } struct Foo { struct Bar *bar; }", structs);
+  BPFtrace bpftrace;
+  parse("struct Bar { int x; } struct Foo { struct Bar *bar; }", bpftrace);
+
+  StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs.size(), 2U);
   ASSERT_EQ(structs.count("Foo"), 1U);
@@ -172,8 +187,10 @@ TEST(clang_parser, nested_struct_ptr_named)
 
 TEST(clang_parser, nested_struct_anon)
 {
-  StructMap structs;
-  parse("struct Foo { struct { int x; } bar; }", structs);
+  BPFtrace bpftrace;
+  parse("struct Foo { struct { int x; } bar; }", bpftrace);
+
+  StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs.size(), 2U);
   ASSERT_EQ(structs.count("Foo"), 1U);
@@ -190,8 +207,10 @@ TEST(clang_parser, nested_struct_anon)
 
 TEST(clang_parser, nested_struct_indirect_fields)
 {
-  StructMap structs;
-  parse("struct Foo { struct { int x; int y;}; int a; struct { int z; }; }", structs);
+  BPFtrace bpftrace;
+  parse("struct Foo { struct { int x; int y;}; int a; struct { int z; }; }", bpftrace);
+
+  StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs["Foo"].fields.size(), 4U);
   EXPECT_EQ(structs["Foo"].fields["x"].offset, 0);
@@ -206,8 +225,10 @@ TEST(clang_parser, nested_struct_indirect_fields)
 
 TEST(clang_parser, nested_struct_anon_union_struct)
 {
-  StructMap structs;
-  parse("struct Foo { union { long long _xy; struct { int x; int y;}; }; int a; struct { int z; }; }", structs);
+  BPFtrace bpftrace;
+  parse("struct Foo { union { long long _xy; struct { int x; int y;}; }; int a; struct { int z; }; }", bpftrace);
+
+  StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs["Foo"].fields.size(), 5U);
   EXPECT_EQ(structs["Foo"].fields["_xy"].offset, 0);
@@ -225,8 +246,10 @@ TEST(clang_parser, nested_struct_anon_union_struct)
 TEST(clang_parser, builtin_headers)
 {
   // size_t is definied in stddef.h
-  StructMap structs;
-  parse("#include <stddef.h>\nstruct Foo { size_t x, y, z; }", structs);
+  BPFtrace bpftrace;
+  parse("#include <stddef.h>\nstruct Foo { size_t x, y, z; }", bpftrace);
+
+  StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs.count("Foo"), 1U);
 

--- a/tests/codegen/call_kstack.cpp
+++ b/tests/codegen/call_kstack.cpp
@@ -62,7 +62,7 @@ attributes #1 = { argmemonly nounwind }
 TEST(codegen, call_kstack_mapids)
 {
   BPFtrace bpftrace;
-  Driver driver;
+  Driver driver(bpftrace);
   FakeMap::next_mapfd_ = 1;
 
   ASSERT_EQ(driver.parse_str("kprobe:f { @x = kstack(5); @y = kstack(6); @z = kstack(6) }"), 0);
@@ -90,7 +90,7 @@ TEST(codegen, call_kstack_mapids)
 TEST(codegen, call_kstack_modes_mapids)
 {
   BPFtrace bpftrace;
-  Driver driver;
+  Driver driver(bpftrace);
   FakeMap::next_mapfd_ = 1;
 
   ASSERT_EQ(driver.parse_str("kprobe:f { @x = kstack(perf); @y = kstack(bpftrace); @z = kstack() }"), 0);

--- a/tests/codegen/call_kstack.cpp
+++ b/tests/codegen/call_kstack.cpp
@@ -68,7 +68,7 @@ TEST(codegen, call_kstack_mapids)
   ASSERT_EQ(driver.parse_str("kprobe:f { @x = kstack(5); @y = kstack(6); @z = kstack(6) }"), 0);
 
   ClangParser clang;
-  clang.parse(driver.root_, bpftrace.structs_);
+  clang.parse(driver.root_, bpftrace);
 
   ast::SemanticAnalyser semantics(driver.root_, bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
@@ -96,7 +96,7 @@ TEST(codegen, call_kstack_modes_mapids)
   ASSERT_EQ(driver.parse_str("kprobe:f { @x = kstack(perf); @y = kstack(bpftrace); @z = kstack() }"), 0);
 
   ClangParser clang;
-  clang.parse(driver.root_, bpftrace.structs_);
+  clang.parse(driver.root_, bpftrace);
 
   ast::SemanticAnalyser semantics(driver.root_, bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);

--- a/tests/codegen/call_ustack.cpp
+++ b/tests/codegen/call_ustack.cpp
@@ -68,7 +68,7 @@ attributes #1 = { argmemonly nounwind }
 TEST(codegen, call_ustack_mapids)
 {
   BPFtrace bpftrace;
-  Driver driver;
+  Driver driver(bpftrace);
   FakeMap::next_mapfd_ = 1;
 
   ASSERT_EQ(driver.parse_str("kprobe:f { @x = ustack(5); @y = ustack(6); @z = ustack(6) }"), 0);
@@ -96,7 +96,7 @@ TEST(codegen, call_ustack_mapids)
 TEST(codegen, call_ustack_modes_mapids)
 {
   BPFtrace bpftrace;
-  Driver driver;
+  Driver driver(bpftrace);
   FakeMap::next_mapfd_ = 1;
 
   ASSERT_EQ(driver.parse_str("kprobe:f { @x = ustack(perf); @y = ustack(bpftrace); @z = ustack() }"), 0);

--- a/tests/codegen/call_ustack.cpp
+++ b/tests/codegen/call_ustack.cpp
@@ -74,7 +74,7 @@ TEST(codegen, call_ustack_mapids)
   ASSERT_EQ(driver.parse_str("kprobe:f { @x = ustack(5); @y = ustack(6); @z = ustack(6) }"), 0);
 
   ClangParser clang;
-  clang.parse(driver.root_, bpftrace.structs_);
+  clang.parse(driver.root_, bpftrace);
 
   ast::SemanticAnalyser semantics(driver.root_, bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
@@ -102,7 +102,7 @@ TEST(codegen, call_ustack_modes_mapids)
   ASSERT_EQ(driver.parse_str("kprobe:f { @x = ustack(perf); @y = ustack(bpftrace); @z = ustack() }"), 0);
 
   ClangParser clang;
-  clang.parse(driver.root_, bpftrace.structs_);
+  clang.parse(driver.root_, bpftrace);
 
   ast::SemanticAnalyser semantics(driver.root_, bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -30,7 +30,7 @@ static void test(const std::string &input, const std::string expected_output)
   ASSERT_EQ(driver.parse_str(input), 0);
 
   ClangParser clang;
-  clang.parse(driver.root_, bpftrace.structs_);
+  clang.parse(driver.root_, bpftrace);
 
   ast::SemanticAnalyser semantics(driver.root_, bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -24,7 +24,7 @@ target triple = "bpf-pc-linux"
 static void test(const std::string &input, const std::string expected_output)
 {
   BPFtrace bpftrace;
-  Driver driver;
+  Driver driver(bpftrace);
   FakeMap::next_mapfd_ = 1;
 
   ASSERT_EQ(driver.parse_str(input), 0);

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -22,7 +22,7 @@ public:
 TEST(codegen, populate_sections)
 {
   BPFtrace bpftrace;
-  Driver driver;
+  Driver driver(bpftrace);
 
   ASSERT_EQ(driver.parse_str("kprobe:foo { 1 } kprobe:bar { 1 }"), 0);
   ast::SemanticAnalyser semantics(driver.root_, bpftrace);
@@ -40,7 +40,7 @@ TEST(codegen, populate_sections)
 TEST(codegen, printf_offsets)
 {
   BPFtrace bpftrace;
-  Driver driver;
+  Driver driver(bpftrace);
 
   // TODO (mmarchini): also test printf with a string argument
   ASSERT_EQ(driver.parse_str("struct Foo { char c; int i; } kprobe:f { $foo = (Foo*)0; printf(\"%c %u\\n\", $foo->c, $foo->i) }"), 0);
@@ -77,7 +77,7 @@ TEST(codegen, probe_count)
   MockBPFtrace bpftrace;
   EXPECT_CALL(bpftrace, add_probe(_)).Times(2);
 
-  Driver driver;
+  Driver driver(bpftrace);
 
   ASSERT_EQ(driver.parse_str("kprobe:f { 1; } kprobe:d { 1; }"), 0);
   ast::SemanticAnalyser semantics(driver.root_, bpftrace);

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -45,7 +45,7 @@ TEST(codegen, printf_offsets)
   // TODO (mmarchini): also test printf with a string argument
   ASSERT_EQ(driver.parse_str("struct Foo { char c; int i; } kprobe:f { $foo = (Foo*)0; printf(\"%c %u\\n\", $foo->c, $foo->i) }"), 0);
   ClangParser clang;
-  clang.parse(driver.root_, bpftrace.structs_);
+  clang.parse(driver.root_, bpftrace);
   ast::SemanticAnalyser semantics(driver.root_, bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -12,7 +12,8 @@ using Printer = ast::Printer;
 
 void test(const std::string &input, const std::string &output)
 {
-  Driver driver;
+  BPFtrace bpftrace;
+  Driver driver(bpftrace);
   ASSERT_EQ(driver.parse_str(input), 0);
 
   std::ostringstream out;
@@ -875,7 +876,8 @@ TEST(Parser, cstruct_nested)
 TEST(Parser, unterminated_string)
 {
   // Make sure parser doesn't get stuck in an infinite loop
-  Driver driver;
+  BPFtrace bpftrace;
+  Driver driver(bpftrace);
   EXPECT_EQ(driver.parse_str("kprobe:f { \"asdf }"), 1);
 }
 

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -22,7 +22,7 @@ using bpftrace::ast::Probe;
 void gen_bytecode(const std::string &input, std::stringstream &out)
 {
 	BPFtrace bpftrace;
-	Driver driver;
+	Driver driver(bpftrace);
 	FakeMap::next_mapfd_ = 1;
 
 	ASSERT_EQ(driver.parse_str(input), 0);

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -28,7 +28,7 @@ void gen_bytecode(const std::string &input, std::stringstream &out)
 	ASSERT_EQ(driver.parse_str(input), 0);
 
 	ClangParser clang;
-	clang.parse(driver.root_, bpftrace.structs_);
+	clang.parse(driver.root_, bpftrace);
 
 	ast::SemanticAnalyser semantics(driver.root_, bpftrace);
 	ASSERT_EQ(semantics.analyse(), 0);

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -27,7 +27,7 @@ void test(BPFtrace &bpftrace, Driver &driver, const std::string &input, int expe
 
 void test(BPFtrace &bpftrace, const std::string &input, int expected_result=0)
 {
-  Driver driver;
+  Driver driver(bpftrace);
   test(bpftrace, driver, input, expected_result);
 }
 
@@ -40,7 +40,7 @@ void test(Driver &driver, const std::string &input, int expected_result=0)
 void test(const std::string &input, int expected_result=0)
 {
   BPFtrace bpftrace;
-  Driver driver;
+  Driver driver(bpftrace);
   test(bpftrace, driver, input, expected_result);
 }
 
@@ -347,7 +347,8 @@ TEST(semantic_analyser, variables_are_local)
 
 TEST(semantic_analyser, variable_type)
 {
-  Driver driver;
+  BPFtrace bpftrace;
+  Driver driver(bpftrace);
   test(driver, "kprobe:f { $x = 1 }", 0);
   SizedType st(Type::integer, 8);
   auto assignment = static_cast<ast::AssignVarStatement*>(driver.root_->probes->at(0)->stmts->at(0));
@@ -363,7 +364,8 @@ TEST(semantic_analyser, unroll)
 
 TEST(semantic_analyser, map_integer_sizes)
 {
-  Driver driver;
+  BPFtrace bpftrace;
+  Driver driver(bpftrace);
   std::string structs = "struct type1 { int x; }";
   test(driver, structs + "kprobe:f { $x = ((type1)0).x; @x = $x; }", 0);
 
@@ -665,7 +667,8 @@ TEST(semantic_analyser, field_access_sub_struct)
 
 TEST(semantic_analyser, field_access_is_internal)
 {
-  Driver driver;
+  BPFtrace bpftrace;
+  Driver driver(bpftrace);
   std::string structs = "struct type1 { int x; }";
 
   test(driver, structs + "kprobe:f { $x = ((type1)0).x }", 0);

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -16,7 +16,7 @@ void test(BPFtrace &bpftrace, Driver &driver, const std::string &input, int expe
   ASSERT_EQ(driver.parse_str(input), 0);
 
   ClangParser clang;
-  clang.parse(driver.root_, bpftrace.structs_);
+  clang.parse(driver.root_, bpftrace);
 
   std::stringstream out;
   ast::SemanticAnalyser semantics(driver.root_, bpftrace, out);


### PR DESCRIPTION
Add macro definition support as a bpftrace "preprocessor"-like feature.
This is implemented by running our Bison parser stage to collect
preprocessor stuff, structs, enums, etc., then we run our clang parser
stage, and then we run our parser stage again, replacing all occurrences
of macros with their literal values. This will work for multi-level
macro definitions, because Bison will keep parsing and replacing until
there's no macro left in its cursor. Macro expressions (`#define
MACRO()`) are not supported, but we can consider adding support for
those in the future. The downside (maybe it is not a downside) is that
macros defining things that bpftrace can't parse will throw.

Fixes: #153