### PR TITLE
[ast] introduce Identifier type to AST

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -21,6 +21,10 @@ void Builtin::accept(Visitor &v) {
   v.visit(*this);
 }
 
+void Identifier::accept(Visitor &v) {
+  v.visit(*this);
+}
+
 void PositionalParameter::accept(Visitor &v) {
   v.visit(*this);
 }

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -63,6 +63,14 @@ public:
   void accept(Visitor &v) override;
 };
 
+class Identifier : public Expression {
+public:
+  explicit Identifier(std::string ident) : ident(ident) {}
+  std::string ident;
+
+  void accept(Visitor &v) override;
+};
+
 class Builtin : public Expression {
 public:
   explicit Builtin(std::string ident) : ident(is_deprecated(ident)) {}
@@ -288,6 +296,7 @@ public:
   virtual void visit(PositionalParameter &integer) = 0;
   virtual void visit(String &string) = 0;
   virtual void visit(Builtin &builtin) = 0;
+  virtual void visit(Identifier &identifier) = 0;
   virtual void visit(StackMode &mode) = 0;
   virtual void visit(Call &call) = 0;
   virtual void visit(Map &map) = 0;

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -45,6 +45,12 @@ void CodegenLLVM::visit(String &string)
   expr_ = buf;
 }
 
+void CodegenLLVM::visit(Identifier &identifier)
+{
+  std::cerr << "unknown identifier \"" << identifier.ident << "\"" << std::endl;
+  abort();
+}
+
 void CodegenLLVM::visit(Builtin &builtin)
 {
   if (builtin.ident == "nsecs")

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -30,6 +30,7 @@ public:
   void visit(Integer &integer) override;
   void visit(PositionalParameter &param) override;
   void visit(String &string) override;
+  void visit(Identifier &identifier) override;
   void visit(Builtin &builtin) override;
   void visit(StackMode &) override { };
   void visit(Call &call) override;

--- a/src/ast/printer.cpp
+++ b/src/ast/printer.cpp
@@ -43,6 +43,12 @@ void Printer::visit(Builtin &builtin)
   out_ << indent << "builtin: " << builtin.ident << std::endl;
 }
 
+void Printer::visit(Identifier &identifier)
+{
+  std::string indent(depth_, ' ');
+  out_ << indent << "identifier: " << identifier.ident << std::endl;
+}
+
 void Printer::visit(Call &call)
 {
   std::string indent(depth_, ' ');

--- a/src/ast/printer.h
+++ b/src/ast/printer.h
@@ -14,6 +14,7 @@ public:
   void visit(PositionalParameter &param) override;
   void visit(String &string) override;
   void visit(StackMode &mode) override;
+  void visit(Identifier &identifier) override;
   void visit(Builtin &builtin) override;
   void visit(Call &call) override;
   void visit(Map &map) override;

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -59,6 +59,12 @@ void SemanticAnalyser::visit(StackMode &mode)
   }
 }
 
+void SemanticAnalyser::visit(Identifier &identifier)
+{
+  identifier.type = SizedType(Type::none, 0);
+  err_ << "Unknown identifier: '" << identifier.ident << "'" << std::endl;
+}
+
 void SemanticAnalyser::visit(Builtin &builtin)
 {
   if (builtin.ident == "nsecs" ||

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -23,6 +23,7 @@ public:
   void visit(PositionalParameter &param) override;
   void visit(String &string) override;
   void visit(StackMode &mode) override;
+  void visit(Identifier &identifier) override;
   void visit(Builtin &builtin) override;
   void visit(Call &call) override;
   void visit(Map &map) override;

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -203,6 +203,7 @@ stmt : expr         { $$ = new ast::ExprStatement($1); }
 expr : INT             { $$ = new ast::Integer($1); }
      | STRING          { $$ = new ast::String($1); }
      | BUILTIN         { $$ = new ast::Builtin($1); }
+     | IDENT           { $$ = new ast::Identifier($1); }
      | STACK_MODE      { $$ = new ast::StackMode($1); }
      | ternary         { $$ = $1; }
      | param           { $$ = $1; }

--- a/src/tracepoint_format_parser.h
+++ b/src/tracepoint_format_parser.h
@@ -17,6 +17,7 @@ public:
   void visit(__attribute__((unused)) PositionalParameter &integer) override { };  // Leaf
   void visit(__attribute__((unused)) String &string) override { };  // Leaf
   void visit(__attribute__((unused)) StackMode &mode) override { };  // Leaf
+  void visit(__attribute__((unused)) Identifier &identifier) override { };  // Leaf
   void visit(Builtin &builtin) override {  // Leaf
     if (builtin.ident == "args")
       probe_->need_tp_args_structs = true;


### PR DESCRIPTION
Identifiers are the building block for enums and defines. With
Identifiers, we also have better error message for undefined names.
Instead of:

```
16.26: syntax error, unexpected ), expecting (
```

We get:

```
Unknown identifier: 'TASK_NEW'
```