### PR TITLE
[parser] fix semicolon after if statements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,7 @@ include_directories(SYSTEM ${LIBELF_INCLUDE_DIRS})
 
 find_package(BISON REQUIRED)
 find_package(FLEX REQUIRED)
-bison_target(bison_parser src/parser.yy ${CMAKE_BINARY_DIR}/parser.tab.cc)
+bison_target(bison_parser src/parser.yy ${CMAKE_BINARY_DIR}/parser.tab.cc VERBOSE)
 flex_target(flex_lexer src/lexer.l ${CMAKE_BINARY_DIR}/lex.yy.cc)
 add_flex_bison_dependency(flex_lexer bison_parser)
 add_library(parser ${BISON_bison_parser_OUTPUTS} ${FLEX_flex_lexer_OUTPUTS})

--- a/tests/codegen/if_else_variable.cpp
+++ b/tests/codegen/if_else_variable.cpp
@@ -6,7 +6,7 @@ namespace codegen {
 
 TEST(codegen, if_else_variable)
 {
-  test("kprobe:f { if (pid > 10000) { $s = 10 } else { $s = 20 }; printf(\"s = %d\", $s) }",
+  test("kprobe:f { if (pid > 10000) { $s = 10 } else { $s = 20 } printf(\"s = %d\", $s) }",
 
 R"EXPECTED(%printf_t = type { i64, i64 }
 

--- a/tests/codegen/if_variable.cpp
+++ b/tests/codegen/if_variable.cpp
@@ -6,7 +6,7 @@ namespace codegen {
 
 TEST(codegen, if_variable)
 {
-  test("kprobe:f { if (pid > 10000) { $s = 10 }; printf(\"s = %d\", $s); }",
+  test("kprobe:f { if (pid > 10000) { $s = 10 } printf(\"s = %d\", $s); }",
 
 #if LLVM_VERSION_MAJOR < 6
 R"EXPECTED(%printf_t = type { i64, i64 }

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -381,6 +381,32 @@ TEST(Parser, if_block)
        "     builtin: pid\n");
 }
 
+TEST(Parser, if_stmt_if)
+{
+  test("kprobe:sys_open { if (pid > 10000) { printf(\"%d is high\\n\", pid); } @pid = pid; if (pid < 1000) { printf(\"%d is low\\n\", pid); } }",
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  if\n"
+       "   >\n"
+       "    builtin: pid\n"
+       "    int: 10000\n"
+       "   then\n"
+       "    call: printf\n"
+       "     string: %d is high\\n\n"
+       "     builtin: pid\n"
+       "  =\n"
+       "   map: @pid\n"
+       "   builtin: pid\n"
+       "  if\n"
+       "   <\n"
+       "    builtin: pid\n"
+       "    int: 1000\n"
+       "   then\n"
+       "    call: printf\n"
+       "     string: %d is low\\n\n"
+       "     builtin: pid\n");
+}
+
 TEST(Parser, if_block_variable)
 {
   test("kprobe:sys_open { if (pid > 10000) { $s = 10; } }",
@@ -398,7 +424,7 @@ TEST(Parser, if_block_variable)
 
 TEST(Parser, if_else)
 {
-  test("kprobe:sys_open { if (pid > 10000) { $s = \"a\"; } else { $s= \"b\"; }; printf(\"%d is high\\n\", pid, $s); }",
+  test("kprobe:sys_open { if (pid > 10000) { $s = \"a\"; } else { $s= \"b\"; } printf(\"%d is high\\n\", pid, $s); }",
        "Program\n"
        " kprobe:sys_open\n"
        "  if\n"


### PR DESCRIPTION
If we have two if statements, before the first if statmenet there's no
other statement and between the two stamenets there's another statement,
our parser will complain there's no semicolon after our first if
statement. This commit tries to fix it.

Fixes: https://github.com/iovisor/bpftrace/issues/544