### PR TITLE
[lexer] fix expansion of recursive macros

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -140,8 +140,17 @@ struct|union            yy_push_state(STRUCT, yyscanner); buffer.clear(); struct
                           if (driver.bpftrace_.macros_.count(yytext) != 0) {
                             const char *s = driver.bpftrace_.macros_[yytext].c_str();
                             int z;
-                            for (z=strlen(s) - 1; z >= 0; z--)
-                              unput(s[z]);
+                            // NOTE(mmarchini) workaround for simple recursive
+                            // macros. More complex recursive macros (for
+                            // example, with operators) will go into an
+                            // infinite loop. Yes, we should fix that in the
+                            // future.
+                            if (strcmp(s, yytext) == 0) {
+                              return Parser::make_IDENT(yytext, loc);
+                            } else {
+                              for (z=strlen(s) - 1; z >= 0; z--)
+                                unput(s[z]);
+                            }
                           } else {
                             return Parser::make_IDENT(yytext, loc);
                           }

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -18,6 +18,7 @@ void test(BPFtrace &bpftrace, Driver &driver, const std::string &input, int expe
   ClangParser clang;
   clang.parse(driver.root_, bpftrace);
 
+  ASSERT_EQ(driver.parse_str(input), 0);
   std::stringstream out;
   ast::SemanticAnalyser semantics(driver.root_, bpftrace, out);
   std::stringstream msg;
@@ -700,6 +701,12 @@ TEST(semantic_analyser, positional_parameters)
   // $1 won't be defined, will be tested more in runtime.
   test("kprobe:f { printf(\"%d\", $1); }", 0);
   test("kprobe:f { printf(\"%s\", str($1)); }", 0);
+}
+
+TEST(semantic_analyser, macros)
+{
+  test("#define A 1\nkprobe:f { printf(\"%d\", A); }", 0);
+  test("#define A A\nkprobe:f { printf(\"%d\", A); }", 1);
 }
 
 } // namespace semantic_analyser


### PR DESCRIPTION
There are some occurrences of "recursive macros" in the Kernel (for example: https://github.com/torvalds/linux/blob/master/include/uapi/linux/in.h#L26-L81), and the way our "preprocessor" is implemented can lead to an infinite loop. This PR fixes the simplest case `#define NAME NAME`. We should still fix more complex cases like `#define NAME    NAME + 1` later.