### PR TITLE
Avoid crash if incorrect command line option is used

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -198,12 +198,12 @@ int main(int argc, char *argv[])
   if (script.empty())
   {
     // Script file
-    file_name = std::string(argv[optind]);
-    if (file_name.empty())
+    if (argv[optind] == nullptr)
     {
       std::cerr << "USAGE: filename or -e 'program' required." << std::endl;
       return 1;
     }
+    file_name = std::string(argv[optind]);
     err = driver.parse_file(file_name);
     optind++;
   }


### PR DESCRIPTION
Fix this:

./bpftrace -v
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_M_construct null not valid
Aborted (core dumped)