### PR TITLE
add support for delimiters in join() statement

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,7 +280,7 @@ Functions:
 - `kaddr(char *name)` - Resolve kernel symbol name
 - `uaddr(char *name)` - Resolve user space symbol name
 - `reg(char *name)` - Returns the value stored in the named register
-- `join(char *arr[])` - Prints the string array
+- `join(char *arr[] [, char *delim])` - Prints the string array
 - `time(char *fmt)` - Print the current time
 - `system(char *fmt)` - Execute shell command
 - `exit()` - Quit bpftrace

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1368,7 +1368,7 @@ Tracing block I/O sizes > 0 bytes
 
 - `printf(char *fmt, ...)` - Print formatted
 - `time(char *fmt)` - Print formatted time
-- `join(char *arr[])` - Print the array
+- `join(char *arr[] [, char *delim])` - Print the array
 - `str(char *s [, int length])` - Returns the string pointed to by s
 - `ksym(void *p)` - Resolve kernel address
 - `usym(void *p)` - Resolve user space address
@@ -1428,9 +1428,11 @@ If a format string is not provided, it defaults to "%H:%M:%S\n".
 
 ## 4. `join()`: Join
 
-Syntax: `join(char *arr[])`
+Syntax: `join(char *arr[] [, char *delim])`
 
-This joins the array of strings with a space character, and prints it out. This current version does not return a string, so it cannot be used as an argument in printf(). Example:
+This joins the array of strings with a space character, and prints it out, separated by delimiters.
+The default delimiter, if none is provided, is the space character. This current version does not
+return a string, so it cannot be used as an argument in printf(). Example:
 
 ```
 # bpftrace -e 'tracepoint:syscalls:sys_enter_execve { join(args->argv); }'
@@ -1442,6 +1444,19 @@ preconv -e UTF-8
 preconv -e UTF-8
 preconv -e UTF-8
 preconv -e UTF-8
+tbl
+[...]
+```
+```
+# bpftrace -e 'tracepoint:syscalls:sys_enter_execve { join(args->argv, ","); }'
+Attaching 1 probe...
+ls,--color=auto
+man,ls
+preconv,-e,UTF-8
+preconv,-e,UTF-8
+preconv,-e,UTF-8
+preconv,-e,UTF-8
+preconv,-e,UTF-8
 tbl
 [...]
 ```

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -80,6 +80,7 @@ private:
   std::map<std::string, AllocaInst *> variables_;
   int printf_id_ = 0;
   int time_id_ = 0;
+  uint64_t join_id_ = 0;
   int system_id_ = 0;
 };
 

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -254,17 +254,18 @@ void perf_event_printer(void *cb_cookie, void *data, int size __attribute__((unu
   }
   else if (printf_id == asyncactionint(AsyncAction::join))
   {
-     const char *joinstr = " ";
-     for (int i = 0; i < bpftrace->join_argnum_; i++) {
-       auto *arg = arg_data+sizeof(uint64_t) + i * bpftrace->join_argsize_;
-       if (arg[0] == 0)
-         break;
-       if (i)
-         printf("%s", joinstr);
-       printf("%s", arg);
-     }
-     printf("\n");
-     return;
+    uint64_t join_id = (uint64_t)*(static_cast<uint64_t*>(data) + sizeof(uint64_t) / sizeof(uint64_t));
+    auto joinstr = bpftrace->join_args_[join_id].c_str();
+    for (int i = 0; i < bpftrace->join_argnum_; i++) {
+      auto *arg = arg_data + 2*sizeof(uint64_t) + i * bpftrace->join_argsize_;
+      if (arg[0] == 0)
+        break;
+      if (i)
+        printf("%s", joinstr);
+      printf("%s", arg);
+    }
+    printf("\n");
+    return;
   }
   else if ( printf_id >= asyncactionint(AsyncAction::syscall))
   {

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -85,6 +85,7 @@ public:
   std::map<std::string, std::string> macros_;
   std::vector<std::tuple<std::string, std::vector<Field>>> printf_args_;
   std::vector<std::tuple<std::string, std::vector<Field>>> system_args_;
+  std::vector<std::string> join_args_;
   std::vector<std::string> time_args_;
   std::unordered_map<StackType, std::unique_ptr<IMap>> stackid_maps_;
   std::unique_ptr<IMap> join_map_;

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -23,6 +23,11 @@ RUN bpftrace -e 'i:ms:1 { system("echo 'A'"); } kprobe:sys_execve { join(arg1); 
 EXPECT A
 TIMEOUT 5
 
+NAME join_delim
+RUN bpftrace -e 'i:ms:1 { system("echo 'A'"); } kprobe:sys_execve { join(arg1, ","); exit();}'
+EXPECT A
+TIMEOUT 5
+
 NAME str
 RUN bpftrace -e 'k:sys_execve { printf("P: %s\n", str(arg0)); exit();}'
 BEFORE sleep 0.1s && /bin/sh -c 'exit 0' &

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -507,6 +507,15 @@ TEST(semantic_analyser, join)
   test("kprobe:f { $x = join(arg0) }", 1);
 }
 
+TEST(semantic_analyser, join_delimiter)
+{
+  test("kprobe:f { join(arg0, \",\") }", 0);
+  test("kprobe:f { printf(\"%s\", join(arg0, \",\")) }", 10);
+  test("kprobe:f { $fmt = \"mystring\"; join($fmt, \",\") }", 10);
+  test("kprobe:f { @x = join(arg0, \",\") }", 1);
+  test("kprobe:f { $x = join(arg0, \",\") }", 1);
+}
+
 TEST(semantic_analyser, kprobe)
 {
   test("kprobe:f { 1 }", 0);


### PR DESCRIPTION
Fixes https://github.com/iovisor/bpftrace/issues/25.

Default is retained as space, single-length and multiple-length strings are acceptable.
```
[jkoch@jkoch-nflx build]$ sudo ./src/bpftrace -e 'kprobe:do_execve { join(arg1); join(arg1, "."); join(arg1, "___"); }'
Attaching 1 probe...
ls --color=auto
ls.--color=auto
ls___--color=auto
^C
```