### PR TITLE
 [clang_parser] fix struct definition from headers

### DIFF
--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -46,6 +46,10 @@ static std::string get_parent_struct_name(CXCursor c)
 {
   CXCursor parent = get_indirect_field_parent_struct(c);
 
+  if (clang_getCursorKind(parent) != CXCursor_StructDecl &&
+      clang_getCursorKind(parent) != CXCursor_UnionDecl)
+    return "";
+
   return get_clang_string(clang_getCursorSpelling(parent));
 }
 


### PR DESCRIPTION
Regression caused by 80ce138. With the changes on how
we identify the parent struct, we ended up with our parent cursor in the
header file sometimes instead of a valid cursor. This PR checks if the
parent cursor is a struct, otherwise returns an empty string and let the
caller handle the situation (which is similar to the previous behavior).