### PR TITLE
improve probes lookup by dropping use of regex

### DIFF
--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -136,7 +136,6 @@ private:
   static uint64_t read_address_from_output(std::string output);
   static std::string hist_index_label(int power);
   static std::string lhist_index_label(int number);
-  static std::vector<std::string> split_string(std::string &str, char split_by);
   std::vector<uint8_t> find_empty_key(IMap &map, size_t size) const;
   static int spawn_child(const std::vector<std::string>& args);
   static bool is_pid_alive(int pid);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -4,6 +4,7 @@
 #include <map>
 #include <string>
 #include <tuple>
+#include <sstream>
 #include <fstream>
 #include <memory>
 
@@ -74,6 +75,38 @@ bool has_wildcard(const std::string &str)
   return str.find("*") != std::string::npos ||
          (str.find("[") != std::string::npos &&
           str.find("]") != std::string::npos);
+}
+
+std::vector<std::string> split_string(const std::string &str, char delimiter) {
+  std::vector<std::string> elems;
+  std::stringstream ss(str);
+  std::string value;
+  while(std::getline(ss, value, delimiter)) {
+    elems.push_back(value);
+  }
+  return elems;
+}
+
+bool wildcard_match(const std::string &str, std::vector<std::string> &tokens, bool start_wildcard, bool end_wildcard) {
+  size_t next = 0;
+
+  if (!start_wildcard)
+    if (str.find(tokens[0], next) != next)
+      return false;
+
+  for (std::string token : tokens) {
+    size_t found = str.find(token, next);
+    if (found == std::string::npos)
+      return false;
+
+    next = found + token.length();
+  }
+
+  if (!end_wildcard)
+    if (str.length() != next)
+      return false;
+
+  return true;
 }
 
 std::vector<int> get_online_cpus()

--- a/src/utils.h
+++ b/src/utils.h
@@ -30,6 +30,8 @@ static std::vector<DeprecatedName> DEPRECATED_LIST =
 
 
 bool has_wildcard(const std::string &str);
+std::vector<std::string> split_string(const std::string &str, char delimiter);
+bool wildcard_match(const std::string &str, std::vector<std::string> &tokens, bool start_wildcard, bool end_wildcard);
 std::vector<int> get_online_cpus();
 std::vector<int> get_possible_cpus();
 std::vector<std::string> get_kernel_cflags(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(bpftrace_test
   probe.cpp
   semantic_analyser.cpp
   tracepoint_format_parser.cpp
+  utils.cpp
 
   ${CMAKE_SOURCE_DIR}/src/attached_probe.cpp
   ${CMAKE_SOURCE_DIR}/src/bpftrace.cpp

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -1,0 +1,77 @@
+#include "gtest/gtest.h"
+#include "utils.h"
+
+namespace bpftrace {
+namespace test {
+namespace utils {
+
+TEST(utils, split_string)
+{
+  std::vector<std::string> tokens_empty = {};
+  std::vector<std::string> tokens_one_empty = {""};
+  std::vector<std::string> tokens_two_empty = {"", ""};
+  std::vector<std::string> tokens_f = {"", "f"};
+  std::vector<std::string> tokens_foo_bar = {"foo", "bar"};
+  std::vector<std::string> tokens_empty_foo_bar = {"", "foo", "bar"};
+  std::vector<std::string> tokens_empty_foo_empty_bar = {"", "foo", "", "bar"};
+  std::vector<std::string> tokens_empty_foo_bar_biz = {"", "foo", "bar", "biz"};
+
+  EXPECT_EQ(split_string("", '-'), tokens_empty);
+  EXPECT_EQ(split_string("-", '-'), tokens_one_empty);
+  EXPECT_EQ(split_string("--", '-'), tokens_two_empty);
+  EXPECT_EQ(split_string("-f-", '-'), tokens_f);
+  EXPECT_EQ(split_string("-foo-bar-", '-'), tokens_empty_foo_bar);
+  EXPECT_EQ(split_string("-foo--bar-", '-'), tokens_empty_foo_empty_bar);
+  EXPECT_EQ(split_string("-foo-bar-biz-", '-'), tokens_empty_foo_bar_biz);
+  EXPECT_EQ(split_string("-foo-bar", '-'), tokens_empty_foo_bar);
+  EXPECT_EQ(split_string("foo-bar-", '-'), tokens_foo_bar);
+  EXPECT_EQ(split_string("foo-bar", '-'), tokens_foo_bar);
+}
+
+TEST(utils, wildcard_match)
+{
+  std::vector<std::string> tokens_not = {"not"};
+  std::vector<std::string> tokens_bar = {"bar"};
+  std::vector<std::string> tokens_bar_not = {"bar", "not"};
+  std::vector<std::string> tokens_foo = {"foo"};
+  std::vector<std::string> tokens_biz = {"biz"};
+  std::vector<std::string> tokens_foo_biz = {"foo", "biz"};
+
+
+  // start: true, end: true
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_not, true, true), false);
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_bar, true, true), true);
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_bar_not, true, true), false);
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_foo, true, true), true);
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_biz, true, true), true);
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_foo_biz, true, true), true);
+
+  // start: false, end: true
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_not, false, true), false);
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_bar, false, true), false);
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_bar_not, false, true), false);
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_foo, false, true), true);
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_biz, false, true), false);
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_foo_biz, false, true), true);
+
+  // start: true, end: false
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_not, true, false), false);
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_bar, true, false), false);
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_bar_not, true, false), false);
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_foo, true, false), false);
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_biz, true, false), true);
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_foo_biz, true, false), true);
+
+  // start: false, end: false
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_not, false, false), false);
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_bar, false, false), false);
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_bar_not, false, false), false);
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_foo, false, false), false);
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_biz, false, false), false);
+  EXPECT_EQ(wildcard_match("foobarbiz", tokens_foo_biz, false, false), true);
+}
+
+} // namespace ast
+} // namespace test
+} // namespace bpftrace
+


### PR DESCRIPTION
This PR alone won't solve the performance issues, but combined with #410 I was able to reduce startup time when looking up a large library from almost 20s to about 300ms.

Also, let's keep #526 open since there are other performance improvements we can do (for example, only expand wildcards if there's a wildcard in our probe name).