### PR TITLE
improve startup speed for expanded probes w/o *

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -145,6 +145,8 @@ int BPFtrace::add_probe(ast::Probe &p)
 
 std::set<std::string> BPFtrace::find_wildcard_matches(const std::string &prefix, const std::string &func, std::istream &symbol_name_stream)
 {
+  if (!has_wildcard(func))
+    return std::set<std::string>({func});
   // Turn glob into a regex
   auto regex_str = "(" + std::regex_replace(func, std::regex("\\*"), "[^\\s]*") + ")";
   if (prefix != "")
@@ -170,6 +172,8 @@ std::set<std::string> BPFtrace::find_wildcard_matches(const std::string &prefix,
 
 std::set<std::string> BPFtrace::find_wildcard_matches(const std::string &prefix, const std::string &func, const std::string &file_name)
 {
+  if (!has_wildcard(func))
+    return std::set<std::string>({func});
   std::ifstream file(file_name);
   if (file.fail())
   {


### PR DESCRIPTION
Improved speed by not performing wildcard match on probes without a
wildcard. Speedup of complex scripts (especially those using tracepoints
with arguments) will be much faster now. As an example from our toos:

Before:

```
# time bpftrace -d statsnoop.bt
...
bpftrace -d statsnoop.bt  1.67s user 0.06s system 99% cpu 1.748 total
```

After:

```
# time bpftrace -d statsnoop.bt
...
bpftrace -d statsnoop.bt  0.06s user 0.02s system 80% cpu 0.098 total
```

Ref: https://github.com/iovisor/bpftrace/issues/526