### PR TITLE
Spawn the child only when the tracing is ready

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -532,6 +532,8 @@ std::unique_ptr<AttachedProbe> BPFtrace::attach_probe(Probe &probe, const BpfOrc
 
 int BPFtrace::run(std::unique_ptr<BpfOrc> bpforc)
 {
+  int go_pipe;
+
   auto r_special_probes = special_probes_.rbegin();
   for (; r_special_probes != special_probes_.rend(); ++r_special_probes)
   {
@@ -550,7 +552,7 @@ int BPFtrace::run(std::unique_ptr<BpfOrc> bpforc)
   {
     auto args = split_string(cmd_, ' ');
     args[0] = resolve_binary_path(args[0]);  // does path lookup on executable
-    int pid = spawn_child(args);
+    int pid = spawn_child(args, &go_pipe);
     if (pid < 0)
     {
       std::cerr << "Failed to spawn child=" << cmd_ << std::endl;
@@ -573,6 +575,21 @@ int BPFtrace::run(std::unique_ptr<BpfOrc> bpforc)
     if (attached_probe == nullptr)
       return -1;
     attached_probes_.push_back(std::move(attached_probe));
+  }
+
+  // Kick the child to execute the command.
+  if (cmd_.size())
+  {
+    char bf;
+
+    int ret = write(go_pipe, &bf, 1);
+    if (ret < 0)
+    {
+      perror("unable to write to 'go' pipe");
+      return ret;
+    }
+
+    close(go_pipe);
   }
 
   if (bt_verbose)
@@ -1234,10 +1251,11 @@ int BPFtrace::print_lhist(const std::vector<uint64_t> &values, int min, int max,
   return 0;
 }
 
-int BPFtrace::spawn_child(const std::vector<std::string>& args)
+int BPFtrace::spawn_child(const std::vector<std::string>& args, int *go_fd)
 {
   static const int maxargs = 256;
   char* argv[maxargs];
+  int go_pipe[2];
 
   // Convert vector of strings into raw array of C-strings for execve(2)
   int idx = 0;
@@ -1255,6 +1273,12 @@ int BPFtrace::spawn_child(const std::vector<std::string>& args)
   }
   argv[idx] = nullptr;  // must be null terminated
 
+  if (pipe(go_pipe) < 0)
+  {
+    perror("failed to create 'go' pipe");
+    return -1;
+  }
+
   // Fork and exec
   int ret = fork();
   if (ret == 0)
@@ -1265,6 +1289,21 @@ int BPFtrace::spawn_child(const std::vector<std::string>& args)
     if (prctl(PR_SET_PDEATHSIG, SIGTERM))
       perror("prctl(PR_SET_PDEATHSIG)");
 
+    // Closing the parent's end and wait until the
+    // parent tells us to go. Set the child's end
+    // to be closed on exec.
+    close(go_pipe[1]);
+    fcntl(go_pipe[0], F_SETFD, FD_CLOEXEC);
+
+    char bf;
+
+    ret = read(go_pipe[0], &bf, 1);
+    if (ret != 1)
+    {
+      perror("failed to read 'go' pipe");
+      return -1;
+    }
+
     if (execve(argv[0], argv, environ))
     {
       perror("execve");
@@ -1273,6 +1312,7 @@ int BPFtrace::spawn_child(const std::vector<std::string>& args)
   }
   else if (ret > 0)
   {
+    *go_fd = go_pipe[1];
     return ret;
   }
   else

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -137,7 +137,7 @@ private:
   static std::string lhist_index_label(int number);
   static std::vector<std::string> split_string(std::string &str, char split_by);
   std::vector<uint8_t> find_empty_key(IMap &map, size_t size) const;
-  static int spawn_child(const std::vector<std::string>& args);
+  static int spawn_child(const std::vector<std::string>& args, int *go_fd);
   static bool is_pid_alive(int pid);
 };
 


### PR DESCRIPTION
When we have fast program to trace it can finish before
we setup the probes and we get no hits, like:

  # cat ex.c
  int krava(int a)
  {
    return 0;
  }
  int main(int argc, char **argv)
  {
    return krava(1);
  }

  # bpftrace -e 'uprobe:/home/jolsa/bpftrace/bugs/469/ex:krava { printf("%d\n", arg0); }' -c ./ex
  Attaching 1 probe...

Using pipe to synchronize child with the parent and
executing it only when the probe are attached.

  # bpftrace -e 'uprobe:/home/jolsa/bpftrace/bugs/469/ex:krava { printf("%d\n", arg0); }' -c ./ex
  Attaching 1 probe...
  1