### PR TITLE
Spawn the child only when the tracing is ready

### DIFF
--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -137,7 +137,7 @@ private:
   static std::string lhist_index_label(int number);
   static std::vector<std::string> split_string(std::string &str, char split_by);
   std::vector<uint8_t> find_empty_key(IMap &map, size_t size) const;
-  static int spawn_child(const std::vector<std::string>& args);
+  static int spawn_child(const std::vector<std::string>& args, int *notify_trace_start_pipe_fd);
   static bool is_pid_alive(int pid);
 };
 


### PR DESCRIPTION
When we have fast program to trace it can finish before
we setup the probes and we get no hits, like:

```
  # cat ex.c
  int krava(int a)
  {
    return 0;
  }
  int main(int argc, char **argv)
  {
    return krava(1);
  }

  # bpftrace -e 'uprobe:/home/jolsa/bpftrace/bugs/469/ex:krava { printf("%d\n", arg0); }' -c ./ex
  Attaching 1 probe...
```

Using pipe to synchronize child with the parent and
executing it only when the probe are attached.

```
  # bpftrace -e 'uprobe:/home/jolsa/bpftrace/bugs/469/ex:krava { printf("%d\n", arg0); }' -c ./ex
  Attaching 1 probe...
  1
```