### PR TITLE
[tests] fix and enhance runtime tests

### DIFF
--- a/tests/runtime-tests.sh
+++ b/tests/runtime-tests.sh
@@ -7,4 +7,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 BPFTRACE_RUNTIME_TEST_EXECUTABLE=${BPFTRACE_RUNTIME_TEST_EXECUTABLE:-$DIR/../src/};
 export BPFTRACE_RUNTIME_TEST_EXECUTABLE;
 
-python main.py;
+python main.py $@

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -55,12 +55,12 @@ EXPECT SUCCESS ustack
 TIMEOUT 5
 
 NAME arg
-RUN bpftrace -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", arg0); exit(); }'
+RUN bpftrace -e 'k:vfs_read { printf("SUCCESS '$test' %d\n", arg0); exit(); }'
 EXPECT SUCCESS arg -?[0-9][0-9]*
 TIMEOUT 5
 
 NAME retval
-RUN bpftrace -e 'k:vfs_read { printf("SUCCESS '$test' %d\n", retval); exit(); }'
+RUN bpftrace -e 'kretprobe:vfs_read { printf("SUCCESS '$test' %d\n", retval); exit(); }'
 EXPECT SUCCESS retval .*
 TIMEOUT 5
 
@@ -93,3 +93,4 @@ NAME cgroup
 RUN bpftrace -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", cgroup); exit(); }'
 EXPECT SUCCESS cgroup -?[0-9][0-9]*
 TIMEOUT 5
+MIN_KERNEL 4.18

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -1,35 +1,35 @@
 NAME if_gt
-RUN bpftrace -e 'i:ms:1 {$a = 10; if ($a > 2) { $a = 20 }; printf("a=%d\n", $a); exit();}'
+RUN bpftrace -e 'i:ms:1 {$a = 10; if ($a > 2) { $a = 20 } printf("a=%d\n", $a); exit();}'
 EXPECT a=20
 TIMEOUT 5
 
 NAME if_lt
-RUN bpftrace -e 'i:ms:1 {$a = 10; if ($a < 2) { $a = 20 }; printf("a=%d\n", $a); exit();}'
+RUN bpftrace -e 'i:ms:1 {$a = 10; if ($a < 2) { $a = 20 } printf("a=%d\n", $a); exit();}'
 EXPECT a=10
 TIMEOUT 5
 
 NAME ifelse_go_else
-RUN bpftrace -e 'i:ms:1 {$a = ""; if (10 < 2) { $a = "hi" } else {$a = "hello"}; printf("a=%s\n", $a); exit();}'
+RUN bpftrace -e 'i:ms:1 {$a = ""; if (10 < 2) { $a = "hi" } else {$a = "hello"} printf("a=%s\n", $a); exit();}'
 EXPECT a=hello
 TIMEOUT 5
 
 NAME ifelse_go_if
-RUN bpftrace -e 'i:ms:1 {$a = ""; if (10 > 2) { $a = "hi" } else {$a = "hello"}; printf("a=%s\n", $a); exit();}'
+RUN bpftrace -e 'i:ms:1 {$a = ""; if (10 > 2) { $a = "hi" } else {$a = "hello"} printf("a=%s\n", $a); exit();}'
 EXPECT a=hi
 TIMEOUT 5
 
 NAME unroll
-RUN bpftrace -e 'i:ms:1 {$a = 1; unroll (10) { $a = $a + 1; }; printf("a=%d\n", $a); exit();}'
+RUN bpftrace -e 'i:ms:1 {$a = 1; unroll (10) { $a = $a + 1; } printf("a=%d\n", $a); exit();}'
 EXPECT a=11
 TIMEOUT 5
 
 NAME unroll_max_value
-RUN bpftrace -e 'i:ms:1 {$a = 1; unroll (30) { $a = $a + 2; }; printf("a=%d\n", $a); exit();}'
+RUN bpftrace -e 'i:ms:1 {$a = 1; unroll (30) { $a = $a + 2; } printf("a=%d\n", $a); exit();}'
 EXPECT unroll maximum value is 20
 TIMEOUT 5
 
 NAME unroll_min_value
-RUN bpftrace -e 'i:ms:1 {$a = 1; unroll (0) { $a = $a + 2; }; printf("a=%d\n", $a); exit();}'
+RUN bpftrace -e 'i:ms:1 {$a = 1; unroll (0) { $a = $a + 2; } printf("a=%d\n", $a); exit();}'
 EXPECT unroll minimum value is 1
 TIMEOUT 5
 
@@ -44,16 +44,16 @@ EXPECT @x: 0
 TIMEOUT 5
 
 NAME struct positional string compare - equal returns true
-RUN bpftrace -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));}; exit();}' "hello" "hello"
+RUN bpftrace -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} exit();}' "hello" "hello"
 EXPECT I got hello
 TIMEOUT 5
 
 NAME struct positional string compare - equal returns false
-RUN bpftrace -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");}; exit();}' "hi" "hello"
+RUN bpftrace -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hi" "hello"
 EXPECT not equal
 TIMEOUT 5
 
 NAME struct positional string compare - not equal
-RUN bpftrace -e 'BEGIN { if (str($1) != str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");}; exit();}' "hello" "hello"
+RUN bpftrace -e 'BEGIN { if (str($1) != str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hello" "hello"
 EXPECT not equal
 TIMEOUT 5

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,20 +1,47 @@
 import subprocess
 import signal
-import sys
-from os import environ
+from os import environ, uname
+from distutils.version import LooseVersion
 import re
 
 BPF_PATH = environ["BPFTRACE_RUNTIME_TEST_EXECUTABLE"]
 
 
 OK_COLOR = '\033[92m'
+WARN_COLOR = '\033[94m'
 ERROR_COLOR = '\033[91m'
 NO_COLOR = '\033[0m'
+
+# TODO(mmarchini) only add colors if terminal supports it
+def colorify(s, color):
+    return "%s%s%s" % (color, s, NO_COLOR)
+
+def ok(s):
+    return colorify(s, OK_COLOR)
+
+def warn(s):
+    return colorify(s, WARN_COLOR)
+
+def fail(s):
+    return colorify(s, ERROR_COLOR)
 
 class TimeoutError(Exception):
     pass
 
 class Utils(object):
+    PASS = 0
+    FAIL = 1
+    SKIP = 2
+    TIMEOUT = 3
+
+    @staticmethod
+    def failed(status):
+        return status in [Utils.FAIL, Utils.TIMEOUT]
+
+    @staticmethod
+    def skipped(status):
+        return status == Utils.SKIP
+
     @staticmethod
     def prepare_bpf_call(test):
         return ('test={}; '.format(test.name) +
@@ -26,10 +53,16 @@ class Utils(object):
 
     @staticmethod
     def run_test(test):
+        current_kernel = LooseVersion(uname()[2])
+        if test.kernel and LooseVersion(test.kernel) > current_kernel:
+            print(warn("[   SKIP   ] ") + "%s.%s" % (test.file_name, test.name))
+            return Utils.SKIP
+
         signal.signal(signal.SIGALRM, Utils.__handler)
         signal.alarm(test.timeout)
 
         try:
+            print(ok("[ RUN      ] ") + "%s.%s" % (test.file_name, test.name))
             bpf_call = Utils.prepare_bpf_call(test)
             p = subprocess.Popen(
                 [bpf_call], shell=True, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
@@ -47,13 +80,17 @@ class Utils(object):
             result = re.search(test.expect, output)
 
         except (TimeoutError):
-            print(test.name + ERROR_COLOR + ' ' + ' TIMEOUT ' + NO_COLOR)
-            return False
+            print(fail("[  TIMEOUT ] ") + "%s.%s" % (test.file_name, test.name))
+            print('\tCommand: %s' % bpf_call)
+            print('\tTimeout: %s' % test.timeout)
+            return Utils.TIMEOUT
 
         if result:
-            print(test.name + OK_COLOR + ' OK' + NO_COLOR)
-            return True
+            print(ok("[       OK ] ") + "%s.%s" % (test.file_name, test.name))
+            return Utils.PASS
         else:
-            print(test.name + ERROR_COLOR + ' ERROR' + NO_COLOR +
-                '\n\tExpected: ' + test.expect + '\n\tFound: ' + output)
-            return False
+            print(fail("[  FAILED  ] ") + "%s.%s" % (test.file_name, test.name))
+            print('\tCommand: ' + bpf_call)
+            print('\tExpected: ' + test.expect)
+            print('\tFound: ' + output)
+            return Utils.FAIL


### PR DESCRIPTION
Several runtime tests were broken because of recent changes. This commit
fixes those tests, and improves our runtime tests suite with the
following changes:

  - Change output format to resemble googletest format
  - Add a flag `--filter`, which allows to glob filter which tests
    should run
  - Output which tests failed at the end
  - Output the command executed on failed tests
  - Add a new filed to our tests: MIN_KERNEL, which will test if the
    current kernel can run a certain test. Skip tests which doesn't
    match Kernel requirements, and print those tests at the end.