### PR TITLE
Refactor find_wildcard_matches() to allow for proper testing

### DIFF
--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -48,6 +48,20 @@ inline DebugLevel operator++(DebugLevel& level, int)
   return level;
 }
 
+class WildcardException : public std::exception
+{
+public:
+  WildcardException(const std::string &msg) : msg_(msg) {}
+
+  const char *what() const noexcept override
+  {
+    return msg_.c_str();
+  }
+
+private:
+  std::string msg_;
+};
+
 class BPFtrace
 {
 public:
@@ -70,7 +84,7 @@ public:
   std::string resolve_uid(uintptr_t addr) const;
   uint64_t resolve_kname(const std::string &name) const;
   uint64_t resolve_uname(const std::string &name, const std::string &path) const;
-  std::string extract_func_symbols_from_path(const std::string &path) const;
+  virtual std::string extract_func_symbols_from_path(const std::string &path) const;
   std::string resolve_probe(uint64_t probe_id) const;
   uint64_t resolve_cgroupid(const std::string &path) const;
   std::vector<std::unique_ptr<IPrintable>> get_arg_values(const std::vector<Field> &args, uint8_t* arg_data);
@@ -101,11 +115,20 @@ public:
   bool demangle_cpp_symbols = true;
   bool safe_mode = true;
 
-  static void sort_by_key(std::vector<SizedType> key_args,
-      std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> &values_by_key);
-  virtual std::set<std::string> find_usdt_wildcard_matches(const std::string &prefix, const std::string &func, std::istream &symbol_name_stream);
-  virtual std::set<std::string> find_wildcard_matches(const std::string &prefix, const std::string &func, std::istream &symbol_name_stream);
-  virtual std::set<std::string> find_wildcard_matches(const std::string &prefix, const std::string &attach_point, const std::string &file_name);
+  static void sort_by_key(
+      std::vector<SizedType> key_args,
+      std::vector<std::pair<std::vector<uint8_t>,
+      std::vector<uint8_t>>> &values_by_key);
+  std::set<std::string> find_wildcard_matches(
+      const ast::AttachPoint &attach_point) const;
+  std::set<std::string> find_wildcard_matches(
+      const std::string &prefix,
+      const std::string &func,
+      std::istream &symbol_stream) const;
+  virtual std::unique_ptr<std::istream> get_symbols_from_file(const std::string &path) const;
+  virtual std::unique_ptr<std::istream> get_symbols_from_usdt(
+      int pid,
+      const std::string &target) const;
 
 protected:
   std::vector<Probe> probes_;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -50,7 +50,11 @@ static void usdt_probe_each(struct bcc_usdt *usdt_probe)
   usdt_provider_cache[usdt_probe->provider].push_back(std::make_tuple(usdt_probe->bin_path, usdt_probe->provider, usdt_probe->name));
 }
 
-usdt_probe_entry USDTHelper::find(int pid, std::string target, std::string provider, std::string name)
+usdt_probe_entry USDTHelper::find(
+    int pid,
+    const std::string &target,
+    const std::string &provider,
+    const std::string &name)
 {
 
   if (pid > 0)
@@ -68,7 +72,7 @@ usdt_probe_entry USDTHelper::find(int pid, std::string target, std::string provi
   }
 }
 
-usdt_probe_list USDTHelper::probes_for_provider(std::string provider)
+usdt_probe_list USDTHelper::probes_for_provider(const std::string &provider)
 {
   usdt_probe_list probes;
 
@@ -93,7 +97,7 @@ usdt_probe_list USDTHelper::probes_for_pid(int pid)
   return probes;
 }
 
-usdt_probe_list USDTHelper::probes_for_path(std::string path)
+usdt_probe_list USDTHelper::probes_for_path(const std::string &path)
 {
   read_probes_for_path(path);
 
@@ -103,27 +107,6 @@ usdt_probe_list USDTHelper::probes_for_path(std::string path)
     probes.insert( probes.end(), usdt_probes.second.begin(), usdt_probes.second.end() );
   }
   return probes;
-}
-
-std::istringstream USDTHelper::probe_stream(int pid, std::string target)
-{
-  std::string probes;
-  usdt_probe_list usdt_probes;
-
-  if (pid > 0)
-    usdt_probes = probes_for_pid(pid);
-  else
-    usdt_probes = probes_for_path(target);
-
-  for (auto const& usdt_probe : usdt_probes)
-  {
-    std::string path     = std::get<USDT_PATH_INDEX>(usdt_probe);
-    std::string provider = std::get<USDT_PROVIDER_INDEX>(usdt_probe);
-    std::string fname    = std::get<USDT_FNAME_INDEX>(usdt_probe);
-    probes += provider + ":" + fname + "\n";
-  }
-
-  return std::istringstream(probes);
 }
 
 void USDTHelper::read_probes_for_pid(int pid)
@@ -149,7 +132,7 @@ void USDTHelper::read_probes_for_pid(int pid)
   }
 }
 
-void USDTHelper::read_probes_for_path(std::string path)
+void USDTHelper::read_probes_for_path(const std::string &path)
 {
   if(provider_cache_loaded)
     return;

--- a/src/utils.h
+++ b/src/utils.h
@@ -17,14 +17,16 @@ typedef std::vector<usdt_probe_entry> usdt_probe_list;
 class USDTHelper
 {
 public:
-  static usdt_probe_entry find(int pid, std::string target, std::string provider, std::string name);
-  static usdt_probe_list probes_for_provider(std::string provider);
+  static usdt_probe_entry find(
+      int pid,
+      const std::string &target,
+      const std::string &provider,
+      const std::string &name);
+  static usdt_probe_list probes_for_provider(const std::string &provider);
   static usdt_probe_list probes_for_pid(int pid);
-  static usdt_probe_list probes_for_path(std::string path);
-  static std::istringstream probe_stream(int pid, std::string target);
-private:
+  static usdt_probe_list probes_for_path(const std::string &path);
   static void read_probes_for_pid(int pid);
-  static void read_probes_for_path(std::string path);
+  static void read_probes_for_path(const std::string &path);
 };
 
 // Hack used to suppress build warning related to #474

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,6 +8,7 @@ add_executable(bpftrace_test
   clang_parser.cpp
   codegen.cpp
   main.cpp
+  mocks.cpp
   parser.cpp
   probe.cpp
   semantic_analyser.cpp

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -1,0 +1,72 @@
+#include "mocks.h"
+
+namespace bpftrace {
+namespace test {
+
+using ::testing::_;
+using ::testing::NiceMock;
+using ::testing::Return;
+using ::testing::StrictMock;
+
+void setup_mock_bpftrace(MockBPFtrace &bpftrace)
+{
+  ON_CALL(bpftrace,
+          get_symbols_from_file("/sys/kernel/debug/tracing/available_filter_functions"))
+      .WillByDefault([](const std::string &)
+      {
+        std::string ksyms = "SyS_read\n"
+                            "sys_read\n"
+                            "sys_write\n"
+                            "my_one\n"
+                            "my_two\n";
+        auto myval = std::unique_ptr<std::istream>(new std::istringstream(ksyms));
+        printf("doing ok\n");
+        return myval;
+      });
+
+  ON_CALL(bpftrace,
+          get_symbols_from_file("/sys/kernel/debug/tracing/available_events"))
+      .WillByDefault([](const std::string &)
+      {
+        std::string tracepoints = "sched:sched_one\n"
+                                  "sched:sched_two\n"
+                                  "sched:foo\n"
+                                  "notsched:bar\n";
+        return std::unique_ptr<std::istream>(new std::istringstream(tracepoints));
+      });
+
+  std::string usyms = "first_open\n"
+                      "second_open\n"
+                      "open_as_well\n"
+                      "something_else\n";
+  ON_CALL(bpftrace, extract_func_symbols_from_path(_))
+      .WillByDefault(Return(usyms));
+
+  ON_CALL(bpftrace, get_symbols_from_usdt(_, _))
+      .WillByDefault([](int, const std::string &)
+      {
+        std::string usdt_syms = "prov1:tp1\n"
+                                "prov1:tp2\n"
+                                "prov2:tp\n"
+                                "prov2:notatp\n"
+                                "nahprov:tp\n";
+        return std::unique_ptr<std::istream>(new std::istringstream(usdt_syms));
+      });
+}
+
+std::unique_ptr<MockBPFtrace> get_mock_bpftrace()
+{
+  auto bpftrace = std::make_unique<NiceMock<MockBPFtrace>>();
+  setup_mock_bpftrace(*bpftrace);
+  return bpftrace;
+}
+
+std::unique_ptr<MockBPFtrace> get_strict_mock_bpftrace()
+{
+  auto bpftrace = std::make_unique<StrictMock<MockBPFtrace>>();
+  setup_mock_bpftrace(*bpftrace);
+  return bpftrace;
+}
+
+} // namespace test
+} // namespace bpftrace

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -1,0 +1,29 @@
+#include "gmock/gmock.h"
+#include "bpftrace.h"
+
+namespace bpftrace {
+namespace test {
+
+class MockBPFtrace : public BPFtrace {
+public:
+  MOCK_CONST_METHOD1(get_symbols_from_file,
+      std::unique_ptr<std::istream>(const std::string &path));
+  MOCK_CONST_METHOD2(get_symbols_from_usdt,
+      std::unique_ptr<std::istream>(int pid, const std::string &target));
+  MOCK_CONST_METHOD1(extract_func_symbols_from_path,
+      std::string(const std::string &path));
+  std::vector<Probe> get_probes()
+  {
+    return probes_;
+  }
+  std::vector<Probe> get_special_probes()
+  {
+    return special_probes_;
+  }
+};
+
+std::unique_ptr<MockBPFtrace> get_mock_bpftrace();
+std::unique_ptr<MockBPFtrace> get_strict_mock_bpftrace();
+
+} // namespace test
+} // namespace bpftrace

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -6,14 +6,12 @@
 #include "codegen_llvm.h"
 #include "driver.h"
 #include "fake_map.h"
+#include "mocks.h"
 #include "semantic_analyser.h"
 
-namespace bpftrace
-{
-namespace test
-{
-namespace probe
-{
+namespace bpftrace {
+namespace test {
+namespace probe {
 
 using bpftrace::ast::AttachPoint;
 using bpftrace::ast::AttachPointList;
@@ -21,20 +19,20 @@ using bpftrace::ast::Probe;
 
 void gen_bytecode(const std::string &input, std::stringstream &out)
 {
-  BPFtrace bpftrace;
-  Driver driver(bpftrace);
+  auto bpftrace = get_mock_bpftrace();
+  Driver driver(*bpftrace);
   FakeMap::next_mapfd_ = 1;
 
   ASSERT_EQ(driver.parse_str(input), 0);
 
   ClangParser clang;
-  clang.parse(driver.root_, bpftrace);
+  clang.parse(driver.root_, *bpftrace);
 
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace);
+  ast::SemanticAnalyser semantics(driver.root_, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 
-  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  ast::CodegenLLVM codegen(driver.root_, *bpftrace);
   codegen.compile(DebugLevel::kDebug, out);
 }
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -3,6 +3,7 @@
 #include "bpftrace.h"
 #include "clang_parser.h"
 #include "driver.h"
+#include "mocks.h"
 #include "semantic_analyser.h"
 
 namespace bpftrace {
@@ -46,17 +47,17 @@ void test(Driver &driver,
     int expected_result=0,
     bool safe_mode = true)
 {
-  BPFtrace bpftrace;
-  test(bpftrace, driver, input, expected_result, safe_mode);
+  auto bpftrace = get_mock_bpftrace();
+  test(*bpftrace, driver, input, expected_result, safe_mode);
 }
 
 void test(const std::string &input,
     int expected_result=0,
     bool safe_mode = true)
 {
-  BPFtrace bpftrace;
-  Driver driver(bpftrace);
-  test(bpftrace, driver, input, expected_result, safe_mode);
+  auto bpftrace = get_mock_bpftrace();
+  Driver driver(*bpftrace);
+  test(*bpftrace, driver, input, expected_result, safe_mode);
 }
 
 TEST(semantic_analyser, builtin_variables)


### PR DESCRIPTION
Some tests weren't running correctly (add_probes_character_class)
and some were system-dependent (e.g. add_probes_uprobe_wildcard).