### PR TITLE
Make test compilation optional in Docker builds

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -3,16 +3,17 @@
 set -e
 
 STATIC_LINKING=${STATIC_LINKING:-OFF}
+BUILD_TESTS=${BUILD_TESTS:-ON}
 RUN_TESTS=${RUN_TESTS:-1}
 
 # Build bpftrace
 mkdir -p "$1"
 cd "$1"
-cmake -DCMAKE_BUILD_TYPE="$2" -DSTATIC_LINKING:BOOL=$STATIC_LINKING ../
+cmake -DCMAKE_BUILD_TYPE="$2" -DBUILD_TESTING:BOOL=$BUILD_TESTS -DSTATIC_LINKING:BOOL=$STATIC_LINKING ../
 shift 2
 make "$@"
 
-if [ $RUN_TESTS = 1 ]; then
+if [ $BUILD_TESTS = 1 ] && [ $RUN_TESTS = 1 ]; then
   set +e
   mount -t debugfs debugfs /sys/kernel/debug/
   ./tests/bpftrace_test $TEST_ARGS;


### PR DESCRIPTION
This builds on #363. An example use case is https://github.com/iovisor/kubectl-trace/issues/43.