### PR TITLE
[tests] more runtime tests enhancements

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -23,7 +23,7 @@
 
 namespace bpftrace {
 
-const int BPF_LOG_SIZE = 100 * 1024;
+const int BPF_LOG_SIZE = 100 * 4096;
 /*
  * Kernel functions that are unsafe to trace are excluded in the Kernel with
  * `notrace`. However, the ones below are not excluded.

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -23,7 +23,7 @@
 
 namespace bpftrace {
 
-const int BPF_LOG_SIZE = 100 * 4096;
+const int BPF_LOG_SIZE = 400 * 1024;
 /*
  * Kernel functions that are unsafe to trace are excluded in the Kernel with
  * `notrace`. However, the ones below are not excluded.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,7 +100,7 @@ file(GLOB testprogs testprogs/*)
 foreach(testprog ${testprogs})
   get_filename_component(bin_name ${testprog} NAME_WE)
   add_executable (${bin_name} ${testprog})
-  set_target_properties( ${bin_name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testprogs/ )
+  set_target_properties( ${bin_name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testprogs/ COMPILE_FLAGS "-g -O0")
 endforeach()
 
 configure_file(tools-parsing-test.sh tools-parsing-test.sh COPYONLY)

--- a/tests/runtime/array
+++ b/tests/runtime/array
@@ -1,17 +1,17 @@
 NAME array element access - assign to map
-RUN bpftrace -e 'struct MyStruct { int y[4]; } uprobe:./testprogs/array_access:test_struct { $s = (struct MyStruct *) arg0; @x = $s->y[0]; exit(); }'
+RUN bpftrace -v -e 'struct MyStruct { int y[4]; } uprobe:./testprogs/array_access:test_struct { $s = (struct MyStruct *) arg0; @x = $s->y[0]; exit(); }'
 EXPECT @x: 1
 TIMEOUT 5
-BEFORE (sleep 1 && ./testprogs/array_access) &
+AFTER ./testprogs/array_access
 
 NAME array element access - assign to var
-RUN bpftrace -e 'struct MyStruct { int y[4]; } uprobe:./testprogs/array_access:test_struct { $s = (struct MyStruct *) arg0; $x = $s->y[0]; printf("%d\n", $x); exit(); }'
-EXPECT 1
+RUN bpftrace -v -e 'struct MyStruct { int y[4]; } uprobe:./testprogs/array_access:test_struct { $s = (struct MyStruct *) arg0; $x = $s->y[0]; printf("Result: %d\n", $x); exit(); }'
+EXPECT Result: 1
 TIMEOUT 5
-BEFORE (sleep 1 && ./testprogs/array_access) &
+AFTER ./testprogs/array_access
 
 NAME array element access - out of bounds
-RUN bpftrace -e 'struct MyStruct { int y[4]; } uprobe:./testprogs/array_access:test_struct { $s = (struct MyStruct *) arg0; $x = $s->y[5]; printf("%d\n", $x); exit(); }'
+RUN bpftrace -v -e 'struct MyStruct { int y[4]; } uprobe:./testprogs/array_access:test_struct { $s = (struct MyStruct *) arg0; $x = $s->y[5]; printf("%d\n", $x); exit(); }'
 EXPECT the index 5 is out of bounds for array of size 4
 TIMEOUT 5
-BEFORE (sleep 1 && ./testprogs/array_access) &
+AFTER ./testprogs/array_access

--- a/tests/runtime/banned_probes
+++ b/tests/runtime/banned_probes
@@ -1,19 +1,19 @@
 NAME kretprobe:_raw_spin_lock is banned
-RUN bpftrace -e 'kretprobe:_raw_spin_lock { exit(); }'
+RUN bpftrace -v -e 'kretprobe:_raw_spin_lock { exit(); }'
 EXPECT error: kretprobe:_raw_spin_lock can't be used as it might lock up your system.
 TIMEOUT 1
 
 NAME kretprobe:queued_spin_lock_slowpath is banned
-RUN bpftrace -e 'kretprobe:queued_spin_lock_slowpath { exit(); }'
+RUN bpftrace -v -e 'kretprobe:queued_spin_lock_slowpath { exit(); }'
 EXPECT error: kretprobe:queued_spin_lock_slowpath can't be used as it might lock up your system.
 TIMEOUT 1
 
 NAME kretprobe:_raw_spin_unlock_irqrestore is banned
-RUN bpftrace -e 'kretprobe:_raw_spin_unlock_irqrestore { exit(); }'
+RUN bpftrace -v -e 'kretprobe:_raw_spin_unlock_irqrestore { exit(); }'
 EXPECT error: kretprobe:_raw_spin_unlock_irqrestore can't be used as it might lock up your system.
 TIMEOUT 1
 
 NAME kretprobe:_raw_spin_lock_irqsave is banned
-RUN bpftrace -e 'kretprobe:_raw_spin_lock_irqsave { exit(); }'
+RUN bpftrace -v -e 'kretprobe:_raw_spin_lock_irqsave { exit(); }'
 EXPECT error: kretprobe:_raw_spin_lock_irqsave can't be used as it might lock up your system.
 TIMEOUT 1

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -1,96 +1,96 @@
 NAME pid
-RUN bpftrace -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT SUCCESS pid [0-9][0-9]*
 TIMEOUT 5
 
 NAME tid
-RUN bpftrace -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", tid); exit(); }'
+RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", tid); exit(); }'
 EXPECT SUCCESS tid [0-9][0-9]*
 TIMEOUT 5
 
 NAME uid
-RUN bpftrace -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", uid); exit(); }'
+RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", uid); exit(); }'
 EXPECT SUCCESS uid [0-9][0-9]*
 TIMEOUT 5
 
 NAME gid
-RUN bpftrace -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", gid); exit(); }'
+RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", gid); exit(); }'
 EXPECT SUCCESS gid [0-9][0-9]*
 TIMEOUT 5
 
 NAME nsecs
-RUN bpftrace -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", nsecs); exit(); }'
+RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", nsecs); exit(); }'
 EXPECT SUCCESS nsecs -?[0-9][0-9]*
 TIMEOUT 5
 
 NAME elapsed
-RUN bpftrace -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", elapsed); exit(); }'
+RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", elapsed); exit(); }'
 EXPECT SUCCESS elapsed -?[0-9][0-9]*
 TIMEOUT 5
 
 NAME cpu
-RUN bpftrace -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", cpu); exit(); }'
+RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", cpu); exit(); }'
 EXPECT SUCCESS cpu -?[0-9][0-9]*
 TIMEOUT 5
 
 NAME comm
-RUN bpftrace -e 'k:vfs_read { printf("SUCCESS '$test' %s\n", comm); exit(); }'
+RUN bpftrace -v -e 'k:vfs_read { printf("SUCCESS '$test' %s\n", comm); exit(); }'
 EXPECT SUCCESS comm .*
 TIMEOUT 5
-AFTER | egrep 'SUCCESS comm .*'
 
 NAME stack
-RUN bpftrace -e 'k:vfs_read{ printf("SUCCESS '$test' %s\n", stack); exit(); }'
+RUN bpftrace -v -e 'k:vfs_read{ printf("SUCCESS '$test' %s\n", stack); exit(); }'
 EXPECT SUCCESS stack
 TIMEOUT 5
 
 NAME kstack
-RUN bpftrace -e 'k:vfs_read{ printf("SUCCESS '$test' %s\n", kstack); exit(); }'
+RUN bpftrace -v -e 'k:vfs_read{ printf("SUCCESS '$test' %s\n", kstack); exit(); }'
 EXPECT SUCCESS kstack
 TIMEOUT 5
 
 NAME ustack
-RUN bpftrace -e 'k:vfs_read { printf("SUCCESS '$test' %s\n", ustack); exit(); }'
+RUN bpftrace -v -e 'k:vfs_read { printf("SUCCESS '$test' %s\n", ustack); exit(); }'
 EXPECT SUCCESS ustack
 TIMEOUT 5
 
 NAME arg
-RUN bpftrace -e 'k:vfs_read { printf("SUCCESS '$test' %d\n", arg0); exit(); }'
+RUN bpftrace -v -e 'k:vfs_read { printf("SUCCESS '$test' %d\n", arg0); exit(); }'
 EXPECT SUCCESS arg -?[0-9][0-9]*
 TIMEOUT 5
 
 NAME retval
-RUN bpftrace -e 'kretprobe:vfs_read { printf("SUCCESS '$test' %d\n", retval); exit(); }'
+RUN bpftrace -v -e 'kretprobe:vfs_read { printf("SUCCESS '$test' %d\n", retval); exit(); }'
 EXPECT SUCCESS retval .*
 TIMEOUT 5
 
 NAME func
-RUN bpftrace -e 'k:vfs_read { printf("SUCCESS '$test' %s\n", func); exit(); }'
+RUN bpftrace -v -e 'k:vfs_read { printf("SUCCESS '$test' %s\n", func); exit(); }'
 EXPECT SUCCESS func .*
 TIMEOUT 5
 
 NAME username
-RUN bpftrace -e 'i:ms:1 { printf("SUCCESS '$test' %s\n", username); exit(); }'
+RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %s\n", username); exit(); }'
 EXPECT SUCCESS username .*
 TIMEOUT 5
 
 NAME probe
-RUN bpftrace -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n", probe); exit(); }'
+RUN bpftrace -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n", probe); exit(); }'
 EXPECT SUCCESS probe kprobe:do_nanosleep
 TIMEOUT 5
-BEFORE sleep 0.1 && sleep 0.1 &
+AFTER sleep 0.1
+
 NAME curtask
-RUN bpftrace -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", curtask); exit(); }'
+RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", curtask); exit(); }'
 EXPECT SUCCESS curtask -?[0-9][0-9]*
 TIMEOUT 5
 
 NAME rand
-RUN bpftrace -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", rand); exit(); }'
+RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", rand); exit(); }'
 EXPECT SUCCESS rand -?[0-9][0-9]*
 TIMEOUT 5
 
 NAME cgroup
-RUN bpftrace -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", cgroup); exit(); }'
+RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", cgroup); exit(); }'
 EXPECT SUCCESS cgroup -?[0-9][0-9]*
 TIMEOUT 5
 MIN_KERNEL 4.18

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -1,110 +1,110 @@
 NAME printf
-RUN bpftrace -e 'i:ms:1 { printf("hi!\n"); exit();}'
+RUN bpftrace -v -e 'i:ms:1 { printf("hi!\n"); exit();}'
 EXPECT hi!
 TIMEOUT 5
 
 NAME printf_argument
-RUN bpftrace -e 'i:ms:1 { printf("value: %d100\n", 100); exit();}'
+RUN bpftrace -v -e 'i:ms:1 { printf("value: %d100\n", 100); exit();}'
 EXPECT value: 100
 TIMEOUT 5
 
 NAME time
-RUN bpftrace -e 'i:ms:1 { time("%H:%M:%S\n"); exit();}'
+RUN bpftrace -v -e 'i:ms:1 { time("%H:%M:%S\n"); exit();}'
 EXPECT [0-9]*:[0-9]*:[0-9]*
 TIMEOUT 5
 
 NAME time_short
-RUN bpftrace -e 'i:ms:1 { time("%H-%M:%S\n"); exit();}'
+RUN bpftrace -v -e 'i:ms:1 { time("%H-%M:%S\n"); exit();}'
 EXPECT [0-9]*-[0-9]*
 TIMEOUT 5
 
 NAME join
-RUN bpftrace -e 'i:ms:1 { system("echo 'A'"); } kprobe:sys_execve { join(arg1); exit();}'
+RUN bpftrace -v -e 'i:ms:1 { system("echo 'A'"); } kprobe:sys_execve { join(arg1); exit();}'
 EXPECT A
 TIMEOUT 5
 
 NAME join_delim
-RUN bpftrace -e 'i:ms:1 { system("echo 'A'"); } kprobe:sys_execve { join(arg1, ","); exit();}'
+RUN bpftrace -v -e 'i:ms:1 { system("echo 'A'"); } kprobe:sys_execve { join(arg1, ","); exit();}'
 EXPECT A
 TIMEOUT 5
 
 NAME str
-RUN bpftrace -e 'k:sys_execve { printf("P: %s\n", str(arg0)); exit();}'
-BEFORE sleep 0.1s && /bin/sh -c 'exit 0' &
+RUN bpftrace -v -e 'k:sys_execve { printf("P: %s\n", str(arg0)); exit();}'
+AFTER ls
 EXPECT P: /*.
 TIMEOUT 5
 
 NAME ksym
-RUN bpftrace -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("ip"))); exit();}'
+RUN bpftrace -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("ip"))); exit();}'
 EXPECT do_nanosleep
 TIMEOUT 5
-BEFORE sleep 0.1 && sleep 0.1 &
+AFTER sleep 0.1
 
 NAME system
-RUN bpftrace -e 'i:ms:1 { system("echo 'ok_system'"); exit();}'
+RUN bpftrace -v -e 'i:ms:1 { system("echo 'ok_system'"); exit();}'
 EXPECT ok_system
 TIMEOUT 5
 
 NAME count
-RUN bpftrace -e 'i:ms:100 { @[sym(reg("ip"))] = count(); exit();}'
+RUN bpftrace -v -e 'i:ms:100 { @[sym(reg("ip"))] = count(); exit();}'
 EXPECT @\[[0-9]*\]\:\s[0-9]*
 TIMEOUT 5
 
 NAME sum
-RUN bpftrace -e 'kprobe:vfs_read { @bytes[comm] = sum(arg2); exit();}'
+RUN bpftrace -v -e 'kprobe:vfs_read { @bytes[comm] = sum(arg2); exit();}'
 EXPECT @.*\[.*\]\:\s[0-9]*
 TIMEOUT 5
-BEFORE sleep 0.1 && sleep 0.1 &
+AFTER cat /dev/null
 
 NAME avg
-RUN bpftrace -e 'kprobe:vfs_read { @bytes[comm] = avg(arg2); exit();}'
+RUN bpftrace -v -e 'kprobe:vfs_read { @bytes[comm] = avg(arg2); exit();}'
 EXPECT @.*\[.*\]\:\s[0-9]*
 TIMEOUT 5
-BEFORE sleep 0.1 && sleep 0.1 &
+AFTER cat /dev/null
 
 NAME min
-RUN bpftrace -e 'kprobe:vfs_read { @bytes[comm] = min(arg2); exit();}'
+RUN bpftrace -v -e 'kprobe:vfs_read { @bytes[comm] = min(arg2); exit();}'
 EXPECT @.*\[.*\]\:\s[0-9]*
 TIMEOUT 5
-BEFORE sleep 0.1 && sleep 0.1 &
+AFTER cat /dev/null
 
 NAME max
-RUN bpftrace -e 'kprobe:vfs_read { @bytes[comm] = max(arg2); exit();}'
+RUN bpftrace -v -e 'kprobe:vfs_read { @bytes[comm] = max(arg2); exit();}'
 EXPECT @.*\[.*\]\:\s[0-9]*
-BEFORE sleep 0.1 && sleep 0.1 &
+AFTER cat /dev/null
 TIMEOUT 5
 
 NAME stats
-RUN bpftrace -e 'kprobe:vfs_read { @bytes[comm] = stats(arg2); exit();}'
+RUN bpftrace -v -e 'kprobe:vfs_read { @bytes[comm] = stats(arg2); exit();}'
 EXPECT @.*\[.*\]\:\scount\s[0-9]*\,\saverage\s[0-9]*\,\stotal\s[0-9]*
 TIMEOUT 5
-BEFORE sleep 0.1 && sleep 0.1 &
+AFTER cat /dev/null
 
 NAME hist
-RUN bpftrace -e 'kretprobe:vfs_read { @bytes = hist(retval); exit();}'
-EXPECT @bytes:\s\n\n\(?\[?.*
-BEFORE sleep 0.1 && sleep 0.1 &
+RUN bpftrace -v -e 'kretprobe:vfs_read { @bytes = hist(retval); exit();}'
+EXPECT @bytes: *\n[\[(].*
+AFTER cat /dev/null
 TIMEOUT 5
 
 NAME lhist
-RUN bpftrace -e 'kretprobe:vfs_read { @bytes = lhist(retval, 0, 10000, 1000); exit()}'
-EXPECT @bytes:\s\n\n\(?\[?.*
+RUN bpftrace -v -e 'kretprobe:vfs_read { @bytes = lhist(retval, 0, 10000, 1000); exit()}'
+EXPECT @bytes: *\n[\[(].*
 TIMEOUT 5
-BEFORE sleep 0.1 && sleep 0.1 &
+AFTER cat /dev/null
 
 NAME kstack
-RUN bpftrace -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n%s\n", kstack(), kstack(1)); exit(); }'
+RUN bpftrace -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n%s\n", kstack(), kstack(1)); exit(); }'
 EXPECT SUCCESS kstack
 TIMEOUT 5
-BEFORE sleep 0.1 && sleep 0.1 &
+AFTER cat /dev/null
 
 NAME ustack
-RUN bpftrace -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n%s\n", ustack(), ustack(1)); exit(); }'
+RUN bpftrace -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n%s\n", ustack(), ustack(1)); exit(); }'
 EXPECT SUCCESS ustack
 TIMEOUT 5
-BEFORE sleep 0.1 && sleep 0.1 &
+AFTER cat /dev/null
 
 NAME cat
-RUN bpftrace -e 'i:ms:1 { cat("/proc/uptime"); exit();}'
+RUN bpftrace -v -e 'i:ms:1 { cat("/proc/uptime"); exit();}'
 EXPECT [0-9]*.[0-9]* [0-9]*.[0-9]*
 TIMEOUT 5

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -1,59 +1,59 @@
 NAME if_gt
-RUN bpftrace -e 'i:ms:1 {$a = 10; if ($a > 2) { $a = 20 } printf("a=%d\n", $a); exit();}'
+RUN bpftrace -v -e 'i:ms:1 {$a = 10; if ($a > 2) { $a = 20 } printf("a=%d\n", $a); exit();}'
 EXPECT a=20
 TIMEOUT 5
 
 NAME if_lt
-RUN bpftrace -e 'i:ms:1 {$a = 10; if ($a < 2) { $a = 20 } printf("a=%d\n", $a); exit();}'
+RUN bpftrace -v -e 'i:ms:1 {$a = 10; if ($a < 2) { $a = 20 } printf("a=%d\n", $a); exit();}'
 EXPECT a=10
 TIMEOUT 5
 
 NAME ifelse_go_else
-RUN bpftrace -e 'i:ms:1 {$a = ""; if (10 < 2) { $a = "hi" } else {$a = "hello"} printf("a=%s\n", $a); exit();}'
+RUN bpftrace -v -e 'i:ms:1 {$a = ""; if (10 < 2) { $a = "hi" } else {$a = "hello"} printf("a=%s\n", $a); exit();}'
 EXPECT a=hello
 TIMEOUT 5
 
 NAME ifelse_go_if
-RUN bpftrace -e 'i:ms:1 {$a = ""; if (10 > 2) { $a = "hi" } else {$a = "hello"} printf("a=%s\n", $a); exit();}'
+RUN bpftrace -v -e 'i:ms:1 {$a = ""; if (10 > 2) { $a = "hi" } else {$a = "hello"} printf("a=%s\n", $a); exit();}'
 EXPECT a=hi
 TIMEOUT 5
 
 NAME unroll
-RUN bpftrace -e 'i:ms:1 {$a = 1; unroll (10) { $a = $a + 1; } printf("a=%d\n", $a); exit();}'
+RUN bpftrace -v -e 'i:ms:1 {$a = 1; unroll (10) { $a = $a + 1; } printf("a=%d\n", $a); exit();}'
 EXPECT a=11
 TIMEOUT 5
 
 NAME unroll_max_value
-RUN bpftrace -e 'i:ms:1 {$a = 1; unroll (30) { $a = $a + 2; } printf("a=%d\n", $a); exit();}'
+RUN bpftrace -v -e 'i:ms:1 {$a = 1; unroll (30) { $a = $a + 2; } printf("a=%d\n", $a); exit();}'
 EXPECT unroll maximum value is 20
 TIMEOUT 5
 
 NAME unroll_min_value
-RUN bpftrace -e 'i:ms:1 {$a = 1; unroll (0) { $a = $a + 2; } printf("a=%d\n", $a); exit();}'
+RUN bpftrace -v -e 'i:ms:1 {$a = 1; unroll (0) { $a = $a + 2; } printf("a=%d\n", $a); exit();}'
 EXPECT unroll minimum value is 1
 TIMEOUT 5
 
 NAME if_compare_and_print_string
-RUN bpftrace -e 'BEGIN { if (comm == "bpftrace") { printf("comm: %s\n", comm);} exit();}'
+RUN bpftrace -v -e 'BEGIN { if (comm == "bpftrace") { printf("comm: %s\n", comm);} exit();}'
 EXPECT comm: bpftrace
 TIMEOUT 5
 
 NAME struct keyword optional when casting
-RUN bpftrace -e 'struct Bar { int x; } struct Foo { struct Bar *bar; } i:ms:1 { $foo = (struct Foo *)0; @x = $foo->bar->x; exit()}'
+RUN bpftrace -v -e 'struct Bar { int x; } struct Foo { struct Bar *bar; } i:ms:1 { $foo = (struct Foo *)0; @x = $foo->bar->x; exit()}'
 EXPECT @x: 0
 TIMEOUT 5
 
 NAME struct positional string compare - equal returns true
-RUN bpftrace -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} exit();}' "hello" "hello"
+RUN bpftrace -v -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} exit();}' "hello" "hello"
 EXPECT I got hello
 TIMEOUT 5
 
 NAME struct positional string compare - equal returns false
-RUN bpftrace -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hi" "hello"
+RUN bpftrace -v -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hi" "hello"
 EXPECT not equal
 TIMEOUT 5
 
 NAME struct positional string compare - not equal
-RUN bpftrace -e 'BEGIN { if (str($1) != str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hello" "hello"
+RUN bpftrace -v -e 'BEGIN { if (str($1) != str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hello" "hello"
 EXPECT not equal
 TIMEOUT 5

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -1,91 +1,89 @@
 NAME kprobe
-RUN bpftrace -e 'kprobe:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN bpftrace -v -e 'kprobe:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT SUCCESS kprobe [0-9][0-9]*
 TIMEOUT 5
 
 NAME kprobe_short_name
-RUN bpftrace -e 'k:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN bpftrace -v -e 'k:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT SUCCESS kprobe_short_name [0-9][0-9]*
 TIMEOUT 5
 
 NAME kprobe_target
-RUN bpftrace -e 'kprobe:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN bpftrace -v -e 'kprobe:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT kprobes should not have a target
 TIMEOUT 5
 
 NAME kretprobe
-RUN bpftrace -e 'kretprobe:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN bpftrace -v -e 'kretprobe:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT SUCCESS kretprobe [0-9][0-9]*
 TIMEOUT 5
 
 NAME kretprobe_short_name
-RUN bpftrace -e 'kr:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN bpftrace -v -e 'kr:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT SUCCESS kretprobe_short_name [0-9][0-9]*
 TIMEOUT 5
 
 NAME kretprobe_target
-RUN bpftrace -e 'kretprobe:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN bpftrace -v -e 'kretprobe:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT kprobes should not have a target
 TIMEOUT 5
 
 NAME uprobe
-RUN bpftrace -e 'uprobe:/bin/bash:echo_builtin { printf("arg0: %d", arg0); exit();}'
+RUN bpftrace -v -e 'uprobe:/bin/bash:echo_builtin { printf("arg0: %d\n", arg0); exit();}'
 EXPECT arg0: [0-9]*
 TIMEOUT 5
-BEFORE (sleep 0.1; /bin/bash -c echo) &
+AFTER /bin/bash -c "echo lala"
 
 NAME uretprobe
-RUN bpftrace -e 'uretprobe:/bin/bash:echo_builtin { printf("readline: %d\n", retval); exit();}'
+RUN bpftrace -v -e 'uretprobe:/bin/bash:echo_builtin { printf("readline: %d\n", retval); exit();}'
 EXPECT readline: [0-9]*
 TIMEOUT 5
-BEFORE (sleep 0.1; /bin/bash -c echo) &
+AFTER /bin/bash -c "echo lala"
 
 NAME tracepoint
-RUN bpftrace -e 'tracepoint:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", gid); exit(); }'
+RUN bpftrace -v -e 'tracepoint:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", gid); exit(); }'
 EXPECT SUCCESS tracepoint [0-9][0-9]*
-BEFORE sleep 0.1 &
+AFTER sleep 0.1
 TIMEOUT 5
 
 NAME tracepoint_short_name
-RUN bpftrace -e 't:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", gid); exit(); }'
+RUN bpftrace -v -e 't:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", gid); exit(); }'
 EXPECT SUCCESS tracepoint_short_name [0-9][0-9]*
-BEFORE sleep 0.1 &
+AFTER sleep 0.1
 TIMEOUT 5
 
 NAME profile
-RUN bpftrace -e 'profile:hz:599 { @[tid] = count(); exit();}'
+RUN bpftrace -v -e 'profile:hz:599 { @[tid] = count(); exit();}'
 EXPECT \@\[[0-9]*\]\:\s[0-9]
 TIMEOUT 5
 
 NAME profile_short_name
-RUN bpftrace -e 'p:hz:599 { @[tid] = count(); exit();}'
+RUN bpftrace -v -e 'p:hz:599 { @[tid] = count(); exit();}'
 EXPECT \@\[[0-9]*\]\:\s[0-9]
 TIMEOUT 5
 
 NAME interval
-RUN bpftrace -e 't:raw_syscalls:sys_enter { @syscalls = count(); } interval:ms:1{ print(@syscalls); clear(@syscalls); exit();}'
+RUN bpftrace -v -e 't:raw_syscalls:sys_enter { @syscalls = count(); } interval:ms:1{ print(@syscalls); clear(@syscalls); exit();}'
 EXPECT @syscalls\:\s[0-9]*
 TIMEOUT 5
 
 NAME interval_short_name
-RUN bpftrace -e 't:raw_syscalls:sys_enter { @syscalls = count(); } i:ms:1{ print(@syscalls); clear(@syscalls); exit();}'
+RUN bpftrace -v -e 't:raw_syscalls:sys_enter { @syscalls = count(); } i:ms:1{ print(@syscalls); clear(@syscalls); exit();}'
 EXPECT @syscalls\:\s[0-9]*
 TIMEOUT 5
 
 NAME software
-RUN bpftrace -e 'software:faults:1 { @[comm] = count(); exit();}'
-BEFORE sleep 2 && sleep 0.1 &
+RUN bpftrace -v -e 'software:faults:1 { @[comm] = count(); exit();}'
 EXPECT @\[.*\]\:\s[0-9]*
 TIMEOUT 5
 
 NAME hardware
 REQUIRES ls /sys/devices/cpu/events/cache-misses
-RUN bpftrace -e 'hardware:cache-misses:10 { @[pid] = count(); exit(); }'
-BEFORE sleep 2 && sleep 0.1 &
+RUN bpftrace -v -e 'hardware:cache-misses:10 { @[pid] = count(); exit(); }'
 EXPECT @\[.*\]\:\s[0-9]*
 TIMEOUT 5
 
 NAME BEGIN
-RUN bpftrace -e 'BEGIN { printf("Hello\n"); exit();}'
+RUN bpftrace -v -e 'BEGIN { printf("Hello\n"); exit();}'
 EXPECT Hello
 TIMEOUT 2

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -1,43 +1,43 @@
 NAME global_int
-RUN bpftrace -e 'i:ms:1 {@a = 10; printf("%d\n", @a); exit();}'
+RUN bpftrace -v -e 'i:ms:1 {@a = 10; printf("%d\n", @a); exit();}'
 EXPECT \@a: 10
 TIMEOUT 5
 
 NAME global_string
-RUN bpftrace -e 'i:ms:1 {@a = "hi"; printf("%s\\n", @a); exit();}'
+RUN bpftrace -v -e 'i:ms:1 {@a = "hi"; printf("%s\\n", @a); exit();}'
 EXPECT @a: hi
 TIMEOUT 5
 
 NAME local_int
-RUN bpftrace -e 'i:ms:1  {$a = 10; printf("a=%d\n", $a); exit();}'
+RUN bpftrace -v -e 'i:ms:1  {$a = 10; printf("a=%d\n", $a); exit();}'
 EXPECT a=10
 TIMEOUT 5
 
 NAME local_string
-RUN bpftrace -e 'i:ms:1  {$a = "hi"; printf("a=%s\n", $a); exit();}'
+RUN bpftrace -v -e 'i:ms:1  {$a = "hi"; printf("a=%s\n", $a); exit();}'
 EXPECT a=hi
 TIMEOUT 5
 
 NAME global_associative_arrays
-RUN bpftrace -e 'k:vfs_read { @start[tid] = nsecs; } kretprobe:vfs_read /@start[tid] != 0/ { printf("slept for %d ms\n", (nsecs - @start[tid]) / 1000000); delete(@start[tid]); exit();}'
+RUN bpftrace -v -e 'k:vfs_read { @start[tid] = nsecs; } kretprobe:vfs_read /@start[tid] != 0/ { printf("slept for %d ms\n", (nsecs - @start[tid]) / 1000000); delete(@start[tid]); exit();}'
 EXPECT slept for [0-9]+ ms
 TIMEOUT 5
-BEFORE (sleep 1; sleep 1) &
+AFTER cat /dev/null
 
 NAME scratch
-RUN bpftrace -e 'k:vfs_read { @start[tid] = nsecs; } kretprobe:vfs_read /@start[tid] != 0/ { $delta = nsecs - @start[tid]; printf("slept for %d ms\n", $delta / 1000000); delete(@start[tid]); exit(); }'
+RUN bpftrace -v -e 'k:vfs_read { @start[tid] = nsecs; } kretprobe:vfs_read /@start[tid] != 0/ { $delta = nsecs - @start[tid]; printf("slept for %d ms\n", $delta / 1000000); delete(@start[tid]); exit(); }'
 EXPECT slept for [0-9]* ms
 TIMEOUT 5
-BEFORE sleep 1 && sleep 1 &
+AFTER cat /dev/null
 
 NAME 32-bit tracepoint arg
-RUN bpftrace -e 'tracepoint:block:block_rq_issue { @start[args->dev, args->sector] = nsecs; } tracepoint:block:block_rq_complete { @usecs = hist(nsecs - @start[args->dev, args->sector]); exit(); }'
+RUN bpftrace -v -e 'tracepoint:block:block_rq_issue { @start[args->dev, args->sector] = nsecs; } tracepoint:block:block_rq_complete { @usecs = hist(nsecs - @start[args->dev, args->sector]); exit(); }'
 EXPECT @
 TIMEOUT 5
-BEFORE (sleep 1; sync) &
+AFTER cat /dev/null
 
 NAME tracepoint arg casts in predicates
-RUN bpftrace -e 'tracepoint:syscalls:sys_enter_wait4 /args->ru/ { @ru[tid] = args->ru; } tracepoint:syscalls:sys_exit_wait4 /@ru[tid]/ { @++; exit(); }'
+RUN bpftrace -v -e 'tracepoint:syscalls:sys_enter_wait4 /args->ru/ { @ru[tid] = args->ru; } tracepoint:syscalls:sys_exit_wait4 /@ru[tid]/ { @++; exit(); }'
 EXPECT @
 TIMEOUT 5
-BEFORE (sleep 1; sleep 0.1) &
+AFTER sleep 1 || wait $!


### PR DESCRIPTION
  - Build `testprog` binaries with debug symbols for Release builds
  - Use Python Popen to call BEFORE and AFTER
    - Wait until BPF program attached to call AFTER (we need to run
      programs with -v for that, otherwise we don't know when the BPF
      program is attached)
  - Revamp TIMEOUT
    - Have a default timeout for attaching to a program (5 seconds) and
      a default timeout for the program to exit (also 5 seconds). The second
      timeout can be overriden in a test by test basis
    - If the test times out, check the output first to see if our test
      condition passed. Only fails if it doesn't.
    - Kill the test if it's still running after timeout, so the process
      doesn't keep running forever.
  - Changed a few tests to make them more reliable