### PR TITLE
docker: add Fedora 30

### DIFF
--- a/docker/Dockerfile.fedora30
+++ b/docker/Dockerfile.fedora30
@@ -1,0 +1,17 @@
+FROM fedora:30
+RUN dnf install -y \
+    bison \
+    clang-devel \
+    cmake \
+    elfutils-libelf-devel \
+    flex \
+    gcc-c++ \
+    git \
+    llvm-devel \
+    make \
+    zlib-devel \
+    bcc-devel \
+    systemtap-sdt-devel
+
+COPY build.sh /build.sh
+ENTRYPOINT ["/bin/sh", "/build.sh"]


### PR DESCRIPTION
Fedora 30 carries the necessary build dependencies.
Tested on both x86_64 and aarch64.

Signed-off-by: Zi Shen Lim <zlim.lnx@gmail.com>