### PR TITLE
increase map limit and add an env var

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -15,8 +15,7 @@ This is a work in progress. If something is missing, check the bpftrace source t
     - [5. `-d`: Debug Output](#5--d-debug-output)
     - [6. `-v`: Verbose Output](#6--v-verbose-output)
     - [7. Other Options](#7-other-options)
-    - [8. Env: `BPFTRACE_STRLEN`](#8-env-bpftrace_strlen)
-    - [9. Env: `BPFTRACE_NO_CPP_DEMANGLE`](#9-env-bpftrace_no_cpp_demangle)
+    - [8. Environment Variables](#8-environment-variables)
 - [Language](#language)
     - [1. `{...}`: Action Blocks](#1--action-blocks)
     - [2. `/.../`: Filtering](#2--filtering)
@@ -127,6 +126,7 @@ OPTIONS:
 ENVIRONMENT:
     BPFTRACE_STRLEN           [default: 64] bytes on BPF stack per str()
     BPFTRACE_NO_CPP_DEMANGLE  [default: 0] disable C++ symbol demangling
+    BPFTRACE_MAP_KEYS_MAX     [default: 4096] max keys in a map
 
 EXAMPLES:
 bpftrace -l '*sleep*'
@@ -361,7 +361,9 @@ The `--version` option prints the bpftrace version:
 bpftrace v0.8-90-g585e-dirty
 ```
 
-## 8. Env: `BPFTRACE_STRLEN`
+## 8. Environment Variables
+
+### 8.1 `BPFTRACE_STRLEN`
 
 Default: 64
 
@@ -373,13 +375,19 @@ Beware that the BPF stack is small (512 bytes), and that you pay the toll again 
 
 Support for even larger strings is [being discussed](https://github.com/iovisor/bpftrace/issues/305).
 
-## 9. Env: `BPFTRACE_NO_CPP_DEMANGLE`
+### 8.2 `BPFTRACE_NO_CPP_DEMANGLE`
 
 Default: 0
 
 C++ symbol demangling in userspace stack traces is enabled by default.
 
 This feature can be turned off by setting the value of this environment variable to `1`.
+
+### 8.3 `BPFTRACE_MAP_KEYS_MAX`
+
+Default: 4096
+
+This is the maximum number of keys that can be stored in a map. Increasing the value will consume more memory and increase startup times. There are some cases where you will want to: for example, sampling stack traces, recording timestamps for each page, etc.
 
 # Language
 

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1136,10 +1136,10 @@ int SemanticAnalyser::create_maps(bool debug)
         Integer &min = static_cast<Integer&>(min_arg);
         Integer &max = static_cast<Integer&>(max_arg);
         Integer &step = static_cast<Integer&>(step_arg);
-        bpftrace_.maps_[map_name] = std::make_unique<bpftrace::Map>(map_name, type, key, min.n, max.n, step.n);
+        bpftrace_.maps_[map_name] = std::make_unique<bpftrace::Map>(map_name, type, key, min.n, max.n, step.n, bpftrace_.mapmax_);
       }
       else
-        bpftrace_.maps_[map_name] = std::make_unique<bpftrace::Map>(map_name, type, key);
+        bpftrace_.maps_[map_name] = std::make_unique<bpftrace::Map>(map_name, type, key, bpftrace_.mapmax_);
     }
   }
 
@@ -1172,7 +1172,7 @@ int SemanticAnalyser::create_maps(bool debug)
       std::string map_ident = "join";
       SizedType type = SizedType(Type::join, 8 + 8 + bpftrace_.join_argnum_ * bpftrace_.join_argsize_);
       MapKey key;
-      bpftrace_.join_map_ = std::make_unique<bpftrace::Map>(map_ident, type, key);
+      bpftrace_.join_map_ = std::make_unique<bpftrace::Map>(map_ident, type, key, 1);
     }
     bpftrace_.perf_event_map_ = std::make_unique<bpftrace::Map>(BPF_MAP_TYPE_PERF_EVENT_ARRAY);
   }

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -97,6 +97,7 @@ public:
   unsigned int join_argsize_;
 
   uint64_t strlen_ = 64;
+  uint64_t mapmax_ = 4096;
   bool demangle_cpp_symbols = true;
 
   static void sort_by_key(std::vector<SizedType> key_args,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -37,7 +37,8 @@ void usage()
   std::cerr << "    --version      bpftrace version" << std::endl << std::endl;
   std::cerr << "ENVIRONMENT:" << std::endl;
   std::cerr << "    BPFTRACE_STRLEN           [default: 64] bytes on BPF stack per str()" << std::endl;
-  std::cerr << "    BPFTRACE_NO_CPP_DEMANGLE  [default: 0] disable C++ symbol demangling" << std::endl << std::endl;
+  std::cerr << "    BPFTRACE_NO_CPP_DEMANGLE  [default: 0] disable C++ symbol demangling" << std::endl;
+  std::cerr << "    BPFTRACE_MAP_KEYS_MAX     [default: 4096] max keys in a map" << std::endl << std::endl;
   std::cerr << "EXAMPLES:" << std::endl;
   std::cerr << "bpftrace -l '*sleep*'" << std::endl;
   std::cerr << "    list probes containing \"sleep\"" << std::endl;
@@ -268,6 +269,18 @@ int main(int argc, char *argv[])
       std::cerr << "Env var 'BPFTRACE_NO_CPP_DEMANGLE' did not contain a valid value (0 or 1)." << std::endl;
       return 1;
     }
+  }
+
+  if (const char* env_p = std::getenv("BPFTRACE_MAP_KEYS_MAX"))
+  {
+    uint64_t proposed;
+    std::istringstream stringstream(env_p);
+    if (!(stringstream >> proposed)) {
+      std::cerr << "Env var 'BPFTRACE_MAP_KEYS_MAX' did not contain a valid uint64_t, or was zero-valued." << std::endl;
+      return 1;
+    }
+    // no maximum is enforced. Imagine a map recording a timestamp by struct page *: this could exceed 10M entries.
+    bpftrace.mapmax_ = proposed;
   }
 
   if (cmd_str)

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4,6 +4,7 @@
 
 #include "libbpf.h"
 #include "utils.h"
+#include "bpftrace.h"
 
 #include "map.h"
 
@@ -17,7 +18,7 @@ int Map::create_map(enum bpf_map_type map_type, const char *name, int key_size, 
 #endif
 }
 
-Map::Map(const std::string &name, const SizedType &type, const MapKey &key, int min, int max, int step)
+Map::Map(const std::string &name, const SizedType &type, const MapKey &key, int min, int max, int step, int max_entries)
 {
   name_ = name;
   type_ = type;
@@ -34,7 +35,6 @@ Map::Map(const std::string &name, const SizedType &type, const MapKey &key, int 
   if (key_size == 0)
     key_size = 8;
 
-  int max_entries = 128;
   enum bpf_map_type map_type;
   if ((type.type == Type::hist || type.type == Type::lhist || type.type == Type::count ||
       type.type == Type::sum || type.type == Type::min || type.type == Type::max ||

--- a/src/map.h
+++ b/src/map.h
@@ -6,9 +6,9 @@ namespace bpftrace {
 
 class Map : public IMap {
 public:
-  Map(const std::string &name, const SizedType &type, const MapKey &key)
-    : Map(name, type, key, 0, 0, 0) {};
-  Map(const std::string &name, const SizedType &type, const MapKey &key, int min, int max, int step);
+  Map(const std::string &name, const SizedType &type, const MapKey &key, int max_entries)
+    : Map(name, type, key, 0, 0, 0, max_entries) {};
+  Map(const std::string &name, const SizedType &type, const MapKey &key, int min, int max, int step, int max_entries);
   Map(const SizedType &type);
   Map(enum bpf_map_type map_type);
   virtual ~Map() override;


### PR DESCRIPTION
fixes #594 

Testing it works, and its impact on runtime:

```
# BPFTRACE_MAP_KEYS_MAX=128 time ../build/src/bpftrace -e 'profile:hz:999 { @[cpu, nsecs] = count(); } interval:s:1 { exit() }' | wc -l
0.03user 0.02system 0:01.12elapsed 5%CPU (0avgtext+0avgdata 53100maxresident)k
0inputs+0outputs (0major+3103minor)pagefaults 0swaps
131

# time ../build/src/bpftrace -e 'profile:hz:999 { @[cpu, nsecs] = count(); } interval:s:1 { exit() }' | wc -l
4099

real	0m1.156s
user	0m0.084s
sys	0m0.061s

# BPFTRACE_MAP_KEYS_MAX=1000000 time ../build/src/bpftrace -e 'profile:hz:999 { @[cpu, nsecs] = count(); } interval:s:1 { exit() }' | wc -l
0.07user 0.81system 0:01.94elapsed 45%CPU (0avgtext+0avgdata 53188maxresident)k
0inputs+0outputs (0major+3291minor)pagefaults 0swaps
7121
```

I've set it to 4096 to start with, but I think we could set it to 10,000 if need be without a noticeable difference.

Setting it to 1,000,000 does make a noticeable difference, not just in the startup times, but also memory consumed (unseen in the above output is an extra 150 Mbytes that the kernel consumes for the 1M setting).