### PR TITLE
Add documentation for BEGIN/END probes

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -40,6 +40,7 @@ This is a work in progress. If something is missing, check the bpftrace source t
     - [10. `interval`: Timed Output](#10-interval-timed-output)
     - [11. `software`: Pre-defined Software Events](#11-software-pre-defined-software-events)
     - [12. `hardware`: Pre-defined Hardware Events](#12-hardware-pre-defined-hardware-events)
+    - [13. `BEGIN`/`END`: Built-in events](#13-beginend-built-in-events)
 - [Variables](#variables)
     - [1. Builtins](#1-builtins)
     - [2. `@`, `$`: Basic Variables](#2---basic-variables)
@@ -1045,6 +1046,17 @@ bpftrace -e 'hardware:cache-misses:1000000 { @[pid] = count(); }'
 ```
 
 That would fire once for every 1000000 cache misses. This usually indicates the last level cache (LLC).
+
+## 13. `BEGIN`/`END`: Built-in events
+
+Syntax:
+
+```
+BEGIN
+END
+```
+
+These are special built-in events provided by the bpftrace runtime. `BEGIN` is triggered before all other probes are attached. `END` is triggered after all other probes are detached.
 
 # Variables
 


### PR DESCRIPTION
The two probes were missing reference documentation. They're used
throughout the rest of the docs so we might as well make the docs
comprehensive.