### PR TITLE
Fail in case there's unresolved type in definitions

### DIFF
--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -13,8 +13,8 @@
 
 namespace bpftrace {
 
-std::unordered_map<std::string, CXCursor> indirect_structs;
-std::unordered_set<std::string> unvisited_indirect_structs;
+static std::unordered_map<std::string, CXCursor> indirect_structs;
+static std::unordered_set<std::string> unvisited_indirect_structs;
 
 static std::string get_clang_string(CXString string)
 {

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -163,11 +163,11 @@ static SizedType get_sized_type(CXType clang_type)
   }
 }
 
-void ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<std::string> extra_flags)
+int ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<std::string> extra_flags)
 {
   auto input = program->c_definitions;
   if (input.size() == 0)
-    return; // We occasionally get crashes in libclang otherwise
+    return 0; // We occasionally get crashes in libclang otherwise
 
   CXUnsavedFile unsaved_files[] =
   {
@@ -238,9 +238,10 @@ void ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<s
   CXCursor cursor = clang_getTranslationUnitCursor(translation_unit);
 
   bool iterate = true;
+  int err;
 
   do {
-    clang_visitChildren(
+    err = clang_visitChildren(
         cursor,
         [](CXCursor c, CXCursor parent, CXClientData client_data)
         {
@@ -298,6 +299,11 @@ void ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<s
               struct_name = ptypestr;
             remove_struct_prefix(struct_name);
 
+            if (clang_Type_getSizeOf(type) < 0) {
+              std::cerr << "Can't get size of '" << ptypestr << "::" << ident << "', please provide proper definiton." << std::endl;
+              return CXChildVisit_Break;
+            }
+
             structs[struct_name].fields[ident].offset = offset;
             structs[struct_name].fields[ident].type = get_sized_type(type);
             structs[struct_name].size = ptypesize;
@@ -306,6 +312,12 @@ void ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<s
           return CXChildVisit_Recurse;
         },
         &bpftrace);
+
+    // clang_visitChildren returns a non-zero value if the traversal
+    // was terminated by the visitor returning CXChildVisit_Break.
+    if (err)
+      break;
+
     if (unvisited_indirect_structs.size()) {
       cursor = indirect_structs[*unvisited_indirect_structs.begin()];
       unvisited_indirect_structs.erase(unvisited_indirect_structs.begin());
@@ -319,6 +331,7 @@ void ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<s
 
   clang_disposeTranslationUnit(translation_unit);
   clang_disposeIndex(index);
+  return err;
 }
 
 } // namespace bpftrace

--- a/src/clang_parser.h
+++ b/src/clang_parser.h
@@ -12,7 +12,7 @@ using StructMap = std::map<std::string, Struct>;
 class ClangParser
 {
 public:
-  void parse(ast::Program *program, BPFtrace &bpftrace, std::vector<std::string> extra_flags = {});
+  int parse(ast::Program *program, BPFtrace &bpftrace, std::vector<std::string> extra_flags = {});
 };
 
 } // namespace bpftrace

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -309,7 +309,10 @@ int main(int argc, char *argv[])
     if (ksrc != "")
       extra_flags = get_kernel_cflags(utsname.machine, ksrc, kobj);
   }
-  clang.parse(driver.root_, bpftrace, extra_flags);
+
+  err = clang.parse(driver.root_, bpftrace, extra_flags);
+  if (err)
+    return 1;
 
   if (script.empty())
   {


### PR DESCRIPTION
Fail in case there's unresolved type in definitions

When we have undefined struct, we won't fail and continue
with wrong struct definitions, like:

```
  # cat test.bt
  struct a { 
    int a;
    int b;
    struct c c;
  };  
  ... 
  # bpftrace test.bt
  definitions.h:4:14: error: field has incomplete type 'struct c'
  definitions.h:4:12: note: forward declaration of 'struct c'
  Attaching 1 probe...

```
The fields in 'struct a' will have zero offset and provide wrong data.

Making bpftrace to fail in this case with:

```
  # bpftrace test.bt
  definitions.h:4:14: error: field has incomplete type 'struct c'
  definitions.h:4:12: note: forward declaration of 'struct c'
  Can't get size of 'struct a::c', please provide proper definiton.
```

Fixes: #469