### PR TITLE
check explicitly for systemtap sys/sdt.h and ignore if not present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,6 +83,9 @@ if(${LLVM_VERSION_MAJOR} VERSION_LESS 5)
   message(SEND_ERROR "Specify an LLVM major version using LLVM_REQUESTED_VERSION=<major version>")
 endif()
 
+include(CheckIncludeFile)
+check_include_file("sys/sdt.h" HAVE_SYSTEMTAP_SYS_SDT_H)
+
 include_directories(SYSTEM ${LLVM_INCLUDE_DIRS})
 add_definitions(${LLVM_DEFINITIONS})
 

--- a/tests/testprogs/usdt_test.c
+++ b/tests/testprogs/usdt_test.c
@@ -1,4 +1,8 @@
+#ifdef HAVE_SYSTEMTAP_SYS_SDT_H
 #include <sys/sdt.h>
+#else
+#define DTRACE_PROBE2(a, b, c, d) (void)0
+#endif
 #include <sys/time.h>
 #include <unistd.h>
 #include <stdio.h>


### PR DESCRIPTION
This fixes #590 by turning the DTRACE_PROBE2 call in the test into a no-op. This means the `usdt_test.c` test case is only testing something on environments where `systemtap-sdt-dev` is installed. This seems like a reasonable situation to me but others may have better suggestions.

Tested on ubuntu 18.04 with _and_ without `systemtap-sdt-dev`, and on arch linux.