### PR TITLE
Add unsafe-mode and make default execution mode safe-mode

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1625,7 +1625,7 @@ Syntax: `system(fmt)`
 This runs the provided command at the shell. For example:
 
 ```
-# bpftrace -e 'kprobe:do_nanosleep { system("ps -p %d\n", pid); }'
+# bpftrace --unsafe -e 'kprobe:do_nanosleep { system("ps -p %d\n", pid); }'
 Attaching 1 probe...
   PID TTY          TIME CMD
  1339 ?        00:00:15 iscsid
@@ -1639,6 +1639,8 @@ Attaching 1 probe...
 ```
 
 This can be useful to execute commands or a shell script when an instrumented event happens.
+
+Note this is an unsafe function. To use it, bpftrace must be run with `--unsafe`.
 
 ## 12. `exit()`: Exit
 

--- a/man/man8/bpftrace.8
+++ b/man/man8/bpftrace.8
@@ -68,6 +68,11 @@ Helper to run CMD. Equivalent to manually running CMD and then giving passing th
 you've traced at least the duration CMD's execution.
 .
 .TP
+\fB\--unsafe\fR
+Enable unsafe builtin functions. By default, bpftrace runs in safe mode. Safe mode ensure programs cannot modify system state.
+Unsafe builtin functions are marked as such in \fBBUILTINS (functions)\fR.
+.
+.TP
 \fB\-v\fR
 Verbose messages.
 .
@@ -384,7 +389,7 @@ Print file content
 Convert IP address data to text
 .
 .TP
-\fBsystem(char *fmt)\fR
+\fBsystem(char *fmt)\fR (unsafe)
 Execute shell command
 .
 .TP

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -190,6 +190,13 @@ void SemanticAnalyser::visit(Builtin &builtin)
 
 void SemanticAnalyser::visit(Call &call)
 {
+  // Check for unsafe-ness first. It is likely the most pertinent issue
+  // (and should be at the top) for any function call.
+  if (bpftrace_.safe_mode && is_unsafe_func(call.func)) {
+    err_ << call.func << "() is an unsafe function being used in safe mode"
+      << std::endl;
+  }
+
   // needed for positional parameters context:
   call_ = &call;
 

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -350,6 +350,12 @@ void perf_event_printer(void *cb_cookie, void *data, int size __attribute__((unu
   }
   else if ( printf_id >= asyncactionint(AsyncAction::syscall))
   {
+    if (bpftrace->safe_mode)
+    {
+      std::cerr << "syscall() not allowed in safe mode" << std::endl;
+      abort();
+    }
+
     auto id = printf_id - asyncactionint(AsyncAction::syscall);
     auto fmt = std::get<0>(bpftrace->system_args_[id]).c_str();
     auto args = std::get<1>(bpftrace->system_args_[id]);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -99,6 +99,7 @@ public:
   uint64_t strlen_ = 64;
   uint64_t mapmax_ = 4096;
   bool demangle_cpp_symbols = true;
+  bool safe_mode = true;
 
   static void sort_by_key(std::vector<SizedType> key_args,
       std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> &values_by_key);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -34,6 +34,7 @@ void usage()
   std::cerr << "    -l [search]    list probes" << std::endl;
   std::cerr << "    -p PID         enable USDT probes on PID" << std::endl;
   std::cerr << "    -c 'CMD'       run CMD and enable USDT probes on resulting process" << std::endl;
+  std::cerr << "    --unsafe       allow unsafe builtin functions" << std::endl;
   std::cerr << "    -v             verbose messages" << std::endl;
   std::cerr << "    -V, --version  bpftrace version" << std::endl << std::endl;
   std::cerr << "ENVIRONMENT:" << std::endl;
@@ -89,6 +90,7 @@ int main(int argc, char *argv[])
   char *pid_str = nullptr;
   char *cmd_str = nullptr;
   bool listing = false;
+  bool safe_mode = true;
   std::string script, search, file_name;
   int c;
 
@@ -96,6 +98,7 @@ int main(int argc, char *argv[])
   option long_options[] = {
     option{"help", no_argument, nullptr, 'h'},
     option{"version", no_argument, nullptr, 'V'},
+    option{"unsafe", no_argument, nullptr, 'u'},
     option{nullptr, 0, nullptr, 0},  // Must be last
   };
   while ((c = getopt_long(
@@ -137,6 +140,9 @@ int main(int argc, char *argv[])
       case 'c':
         cmd_str = optarg;
         break;
+      case 'u':
+        safe_mode = false;
+        break;
       case 'h':
         usage();
         return 0;
@@ -170,6 +176,8 @@ int main(int argc, char *argv[])
 
   BPFtrace bpftrace;
   Driver driver(bpftrace);
+
+  bpftrace.safe_mode = safe_mode;
 
   // PID is currently only used for USDT probes that need enabling. Future work:
   // - make PID a filter for all probe types: pass to perf_event_open(), etc.

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -362,6 +362,16 @@ std::string is_deprecated(std::string &str)
   return str;
 }
 
+bool is_unsafe_func(const std::string &func_name)
+{
+  return std::any_of(
+      UNSAFE_BUILTIN_FUNCS.begin(),
+      UNSAFE_BUILTIN_FUNCS.end(),
+      [&](const auto& cand) {
+        return func_name == cand;
+      });
+}
+
 std::string exec_system(const char* cmd)
 {
   std::array<char, 128> buffer;

--- a/src/utils.h
+++ b/src/utils.h
@@ -53,6 +53,11 @@ static std::vector<DeprecatedName> DEPRECATED_LIST =
   { "sym", "ksym"},
 };
 
+static std::vector<std::string> UNSAFE_BUILTIN_FUNCS =
+{
+  "system",
+};
+
 
 bool has_wildcard(const std::string &str);
 std::vector<std::string> split_string(const std::string &str, char delimiter);
@@ -66,6 +71,7 @@ std::vector<std::string> get_kernel_cflags(
     const std::string& ksrc,
     const std::string& kobj);
 std::string is_deprecated(std::string &str);
+bool is_unsafe_func(const std::string &func_name);
 std::string exec_system(const char* cmd);
 std::string resolve_binary_path(const std::string& cmd);
 void cat_file(const char *filename);

--- a/tests/codegen/call_system.cpp
+++ b/tests/codegen/call_system.cpp
@@ -36,7 +36,7 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
-)EXPECTED");
+)EXPECTED", false);
 }
 
 } // namespace codegen

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -21,9 +21,13 @@ target triple = "bpf-pc-linux"
 
 )HEAD";
 
-static void test(const std::string &input, const std::string expected_output)
+static void test(
+    const std::string &input,
+    const std::string expected_output,
+    bool safe_mode = true)
 {
   BPFtrace bpftrace;
+  bpftrace.safe_mode = safe_mode;
   Driver driver(bpftrace);
   FakeMap::next_mapfd_ = 1;
 


### PR DESCRIPTION
bpftrace as an tracing language should try to remain as safe as
possible. That is to say, anything that can cause side effects on a
system should be used with care. Similar to the concept of unsafe code
in rust, we introduce an unsafe (`-u`) mode to bpftrace.

Currently, `system()` is the only builtin function marked as unsafe.
If/when more unsafe builtins get added, we can adjust the list
accordingly.

This patch also moves bpftrace to safe by default. Note: this is an API
breaking change.

Test Plan:
```
$ sudo ./build/src/bpftrace -e 'interval:s:5 { system("ls"); }'
system() is an unsafe function being used in safe mode

$ sudo ./build/src/bpftrace -ue 'interval:s:5 { system("ls"); }'
Attaching 1 probe...
build  build-debug  build-debug.sh  build-docker-image.sh  build-release
build-release.sh  build.sh  CHANGELOG.md  cmake  CMakeLists.txt
CONTRIBUTING-TOOLS.md  docker  docs  images  INSTALL.md  LICENSE  man
README.md  resources  scripts  src  tests  tools
^C

$ sudo ./build/src/bpftrace -e 'interval:s:5 { printf("ls\n"); }'
Attaching 1 probe...
ls
^C

```

This closes #613 