### PR TITLE
Allow non-zero lhist min value

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1679,12 +1679,12 @@ void CodegenLLVM::createLinearFunction()
   b_.CreateCondBr(cmp1, gt_max, le_max);
 
   b_.SetInsertPoint(gt_max);
-  Value *div = b_.CreateSDiv(b_.CreateSub(b_.CreateLoad(max_alloc), b_.CreateLoad(min_alloc)), b_.CreateLoad(step_alloc));
+  Value *div = b_.CreateUDiv(b_.CreateSub(b_.CreateLoad(max_alloc), b_.CreateLoad(min_alloc)), b_.CreateLoad(step_alloc));
   b_.CreateStore(b_.CreateAdd(div, b_.getInt64(1)), result_alloc);
   b_.CreateRet(b_.CreateLoad(result_alloc));
 
   b_.SetInsertPoint(le_max);
-  Value *div3 = b_.CreateSDiv(b_.CreateSub(b_.CreateLoad(value_alloc), b_.CreateLoad(min_alloc)), b_.CreateLoad(step_alloc));
+  Value *div3 = b_.CreateUDiv(b_.CreateSub(b_.CreateLoad(value_alloc), b_.CreateLoad(min_alloc)), b_.CreateLoad(step_alloc));
   b_.CreateStore(b_.CreateAdd(div3, b_.getInt64(1)), result_alloc);
   b_.CreateRet(b_.CreateLoad(result_alloc));
 }


### PR DESCRIPTION
Signed division isn't allowed when using bpf as a target[1]. When `min = 0`
the llvm can apparently figure out that signed division isn't required
and it rewrites it to unsigned. However when `min > 0` the  llvm seems
to account for `value - min < 0` and uses signed division.
As `value < min` has already been checked earlier we can be sure that
`value - min >= 0` and always use unsigned division.

This closes #529

[1]: https://github.com/llvm-mirror/llvm/commit/2462cfbd350cbabad4c33c8aeb7601a7219be2fd