### PR TITLE
Use getopt_long instead of getopt

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -6,6 +6,7 @@
 #include <cstring>
 #include <unistd.h>
 #include <string.h>
+#include <getopt.h>
 
 #include "bpforc.h"
 #include "bpftrace.h"
@@ -29,12 +30,12 @@ void usage()
   std::cerr << "    -d             debug info dry run" << std::endl;
   std::cerr << "    -dd            verbose debug info dry run" << std::endl;
   std::cerr << "    -e 'program'   execute this program" << std::endl;
-  std::cerr << "    -h             show this help message" << std::endl;
+  std::cerr << "    -h, --help     show this help message" << std::endl;
   std::cerr << "    -l [search]    list probes" << std::endl;
   std::cerr << "    -p PID         enable USDT probes on PID" << std::endl;
   std::cerr << "    -c 'CMD'       run CMD and enable USDT probes on resulting process" << std::endl;
   std::cerr << "    -v             verbose messages" << std::endl;
-  std::cerr << "    --version      bpftrace version" << std::endl << std::endl;
+  std::cerr << "    -V, --version  bpftrace version" << std::endl << std::endl;
   std::cerr << "ENVIRONMENT:" << std::endl;
   std::cerr << "    BPFTRACE_STRLEN           [default: 64] bytes on BPF stack per str()" << std::endl;
   std::cerr << "    BPFTRACE_NO_CPP_DEMANGLE  [default: 0] disable C++ symbol demangling" << std::endl;
@@ -88,16 +89,17 @@ int main(int argc, char *argv[])
   char *pid_str = nullptr;
   char *cmd_str = nullptr;
   bool listing = false;
-
-  if (argc > 1 && strcmp(argv[1], "--version") == 0)
-  {
-    std::cout << "bpftrace " << BPFTRACE_VERSION<< "\n" << std::endl;
-    return 0;
-  }
-
   std::string script, search, file_name;
   int c;
-  while ((c = getopt(argc, argv, "dB:e:hlp:vc:")) != -1)
+
+  const char* const short_options = "dB:e:hlp:vc:V";
+  option long_options[] = {
+    option{"help", no_argument, nullptr, 'h'},
+    option{"version", no_argument, nullptr, 'V'},
+    option{nullptr, 0, nullptr, 0},  // Must be last
+  };
+  while ((c = getopt_long(
+              argc, argv, short_options, long_options, nullptr)) != -1)
   {
     switch (c)
     {
@@ -137,6 +139,9 @@ int main(int argc, char *argv[])
         break;
       case 'h':
         usage();
+        return 0;
+      case 'V':
+        std::cout << "bpftrace " << BPFTRACE_VERSION << std::endl;
         return 0;
       default:
         usage();


### PR DESCRIPTION
Long options can be friendlier for new users. Especially when used in
examples, it can be confusing to have to open a man page to figure out
what a switch does.

Test Plan:
```
$ ./build/src/bpftrace --version
bpftrace v0.9-149-g8316-dirty
$ ./build/src/bpftrace -V
bpftrace v0.9-149-g8316-dirty
$ ./build/src/bpftrace -h
USAGE:
    bpftrace [options] filename
    bpftrace [options] -e 'program'

OPTIONS:
    -B MODE        output buffering mode ('line', 'full', or 'none')
    -d             debug info dry run
    -dd            verbose debug info dry run
    -e 'program'   execute this program
    -h, --help     show this help message
    -l [search]    list probes
    -p PID         enable USDT probes on PID
    -c 'CMD'       run CMD and enable USDT probes on resulting process
    -v             verbose messages
    -V, --version  bpftrace version

ENVIRONMENT:
    BPFTRACE_STRLEN           [default: 64] bytes on BPF stack per str()
    BPFTRACE_NO_CPP_DEMANGLE  [default: 0] disable C++ symbol demangling
    BPFTRACE_MAP_KEYS_MAX     [default: 4096] max keys in a map

EXAMPLES:
bpftrace -l '*sleep*'
    list probes containing "sleep"
bpftrace -e 'kprobe:do_nanosleep { printf("PID %d sleeping...\n", pid); }'
    trace processes calling sleep
bpftrace -e 'tracepoint:raw_syscalls:sys_enter { @[comm] = count(); }'
    count syscalls by process name
$ ./build/src/bpftrace --help
USAGE:
    bpftrace [options] filename
    bpftrace [options] -e 'program'

OPTIONS:
    -B MODE        output buffering mode ('line', 'full', or 'none')
    -d             debug info dry run
    -dd            verbose debug info dry run
    -e 'program'   execute this program
    -h, --help     show this help message
    -l [search]    list probes
    -p PID         enable USDT probes on PID
    -c 'CMD'       run CMD and enable USDT probes on resulting process
    -v             verbose messages
    -V, --version  bpftrace version

ENVIRONMENT:
    BPFTRACE_STRLEN           [default: 64] bytes on BPF stack per str()
    BPFTRACE_NO_CPP_DEMANGLE  [default: 0] disable C++ symbol demangling
    BPFTRACE_MAP_KEYS_MAX     [default: 4096] max keys in a map

EXAMPLES:
bpftrace -l '*sleep*'
    list probes containing "sleep"
bpftrace -e 'kprobe:do_nanosleep { printf("PID %d sleeping...\n", pid); }'
    trace processes calling sleep
bpftrace -e 'tracepoint:raw_syscalls:sys_enter { @[comm] = count(); }'
    count syscalls by process name
$ sudo ./build/src/bpftrace -e 'interval:s:1 { printf("ls\n"); }'
Attaching 1 probe...
ls
ls
^C

```