### PR TITLE
Parse negative integer literals correctly

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -2305,7 +2305,7 @@ Syntax:
 @histogram_name[optional_key] = lhist(value, min, max, step)
 ```
 
-This is implemented using a BPF map.
+This is implemented using a BPF map. `min` must be non-negative.
 
 Examples:
 

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -221,10 +221,10 @@ void SemanticAnalyser::visit(Call &call)
   }
   else if (call.func == "lhist") {
     if (check_nargs(call, 4)) {
-      check_arg(call, Type::integer, 0);
-      check_arg(call, Type::integer, 1);
-      check_arg(call, Type::integer, 2);
-      check_arg(call, Type::integer, 3);
+      check_arg(call, Type::integer, 0, false);
+      check_arg(call, Type::integer, 1, true);
+      check_arg(call, Type::integer, 2, true);
+      check_arg(call, Type::integer, 3, true);
     }
 
     if (is_final_pass()) {
@@ -242,6 +242,8 @@ void SemanticAnalyser::visit(Call &call)
         if (buckets > 1000)
           err_ << "lhist() too many buckets, must be <= 1000 (would need " << buckets << ")" << std::endl;
       }
+      if (min.n < 0)
+        err_ << "lhist() min must be non-negative (provided min " << min.n << ")" << std::endl;
       if (min.n > max.n)
         err_ << "lhist() min must be less than max (provided min " << min.n << " and max " << max.n << ")" << std::endl;
       if ((max.n - min.n) < step.n)

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -119,6 +119,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %type <ast::PositionalParameter *> param
 %type <std::string> wildcard
 %type <std::string> ident
+%type <ast::Integer *> int
 
 %right ASSIGN
 %left QUES COLON
@@ -235,7 +236,11 @@ compound_assignment : map LEFTASSIGN expr  { $$ = new ast::AssignMapStatement($1
                     | var BXORASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BXOR,  $3)); }
                     ;
 
-expr : INT             { $$ = new ast::Integer($1); }
+int : MINUS INT    { $$ = new ast::Integer(-1 * $2); }
+    | INT          { $$ = new ast::Integer($1); }
+    ;
+
+expr : int             { $$ = $1; }
      | STRING          { $$ = new ast::String($1); }
      | BUILTIN         { $$ = new ast::Builtin($1); }
      | IDENT           { $$ = new ast::Identifier($1); }

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -145,8 +145,7 @@ TEST(Parser, variable_assign)
       " kprobe:sys_open\n"
       "  =\n"
       "   variable: $x\n"
-      "   -\n"
-      "    int: 1\n");
+      "   int: -1\n");
 }
 
 TEST(semantic_analyser, compound_variable_assignments)

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -94,6 +94,7 @@ TEST(semantic_analyser, builtin_functions)
   // Just check that each function exists.
   // Each function should also get its own test case for more thorough testing
   test("kprobe:f { @x = hist(123) }", 0);
+  test("kprobe:f { @x = lhist(123, 0, 123, 1) }", 0);
   test("kprobe:f { @x = count() }", 0);
   test("kprobe:f { @x = sum(pid) }", 0);
   test("kprobe:f { @x = min(pid) }", 0);
@@ -249,6 +250,12 @@ TEST(semantic_analyser, call_hist)
   test("kprobe:f { @x = hist(1); }", 0);
   test("kprobe:f { @x = hist(); }", 1);
   test("kprobe:f { hist(); }", 1);
+}
+
+TEST(semantic_analyser, call_lhist)
+{
+  test("kprobe:f { @ = lhist(5, 0, 10, 1); }", 0);
+  test("kprobe:f { @ = lhist(-10, -10, 10, 1); }", 10); // must be positive
 }
 
 TEST(semantic_analyser, call_count)


### PR DESCRIPTION
The parser was parsing "-10" an a unary op on an integer. This
led to reading invalid memory because the semantic analyser
did a static_cast upcast to `Integer` from `Expression`
(which was actually an `Unop`).

This patch requires the constant lhist arguments to be positive
integer literals. This patch also modifies the parser so it correctly
parses negative inteters as literals (vs `Unop`s).

Test Plan:
Before:
```
$ sudo ./build/src/bpftrace -e 'i:ms:1 { @=lhist(-10, -10, 10, 1); }'
lhist() min must be less than max (provided min 13989904 and max 10)
lhist() step is too large for the given range (provided step 1 for range
-13989894)
```

After:
```
$ sudo ./build/src/bpftrace -e 'i:ms:1 { @=lhist(-10, -10, 10, 1); }'
lhist() min must be non-negative (provided min -10)
```

This closes #618.