### PR TITLE
Fix UnboundLocalError on skipped test

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -72,6 +72,9 @@ class Utils(object):
         signal.signal(signal.SIGALRM, Utils.__handler)
 
         try:
+            before = None
+            after = None
+
             print(ok("[ RUN      ] ") + "%s.%s" % (test.suite, test.name))
             if test.requirement:
                 with open(devnull, 'w') as dn:
@@ -79,7 +82,6 @@ class Utils(object):
                         print(warn("[   SKIP   ] ") + "%s.%s" % (test.suite, test.name))
                         return Utils.SKIP_REQUIREMENT_UNSATISFIED
 
-            before = None
             if test.before:
                 before = subprocess.Popen(test.before, shell=True)
 
@@ -94,8 +96,6 @@ class Utils(object):
             )
 
             signal.alarm(ATTACH_TIMEOUT)
-
-            after = None
 
             output = ""
 


### PR DESCRIPTION
If a runtime test is skipped, the script running the tests fails with an `UnboundLocalError`:
```
~/bpftrace/build$ sudo make runtime-tests
...
[ RUN      ] probe.software
[       OK ] probe.software
[ RUN      ] probe.hardware
[   SKIP   ] probe.hardware
Traceback (most recent call last):
  File "main.py", line 66, in <module>
    main(args.tests_filter)
  File "main.py", line 31, in main
    status = Utils.run_test(test)
  File "/home/ubuntu/bpftrace/build/tests/utils.py", line 130, in run_test
    if before and before.poll() is None:
UnboundLocalError: local variable 'before' referenced before assignment
tests/CMakeFiles/runtime-tests.dir/build.make:57: recipe for target 'tests/CMakeFiles/runtime-tests' failed
make[3]: *** [tests/CMakeFiles/runtime-tests] Error 1
CMakeFiles/Makefile2:1503: recipe for target 'tests/CMakeFiles/runtime-tests.dir/all' failed
make[2]: *** [tests/CMakeFiles/runtime-tests.dir/all] Error 2
CMakeFiles/Makefile2:1510: recipe for target 'tests/CMakeFiles/runtime-tests.dir/rule' failed
make[1]: *** [tests/CMakeFiles/runtime-tests.dir/rule] Error 2
Makefile:708: recipe for target 'runtime-tests' failed
make: *** [runtime-tests] Error 2
```
This can be fixed by lifting the declaration of the `before` and `after` variables to the top of the `try` block so they are always defined when the `finally` block runs. With this fix, the test run continues on after a skipped test:
```
~/bpftrace/build$ sudo make runtime-tests
...
[ RUN      ] probe.software
[       OK ] probe.software
[ RUN      ] probe.hardware
[   SKIP   ] probe.hardware
[ RUN      ] probe.BEGIN
[       OK ] probe.BEGIN
...
```