### PR TITLE
Script to check kernel requirements

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -34,6 +34,9 @@ CONFIG_HAVE_EBPF_JIT=y
 CONFIG_BPF_EVENTS=y
 ```
 
+This can be verified by running the `check_kernel_features` script from the
+`scripts` directory.
+
 # Package install
 
 ## Ubuntu snap package

--- a/scripts/check_kernel_features.sh
+++ b/scripts/check_kernel_features.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+
+# Report missing kernel features
+#
+# Usage: ./check_kernel_features.sh
+
+set -e
+set -u
+
+err=0
+config=''
+
+# Find kernel config
+for c in "/boot/config-$(uname -r)" "/boot/config" "/proc/config.gz"; do
+    if [ -f "$c" ]; then
+        config="$c"
+        break
+    fi
+done
+
+if [ -z "$config" ]; then
+    echo "Could not find kernel config" >&2
+    exit 1
+fi
+
+# Check feature
+check_opt() {
+    if ! zgrep -qE "^${1}[[:space:]]*=[[:space:]]*[y|Y]" "$config"; then
+        err=1
+        echo "Required option ${1} not set" >&2
+    fi
+}
+
+check_opt 'CONFIG_BPF'
+check_opt 'CONFIG_BPF_EVENTS'
+check_opt 'CONFIG_BPF_JIT'
+check_opt 'CONFIG_BPF_SYSCALL'
+check_opt 'CONFIG_FTRACE_SYSCALLS'
+check_opt 'CONFIG_HAVE_EBPF_JIT'
+
+# Status report
+if [ $err -eq 0 ]; then
+    echo "All required features present!"
+else
+    echo "Missing required features"
+fi
+
+exit $err


### PR DESCRIPTION
This adds a simple script that checks whether the kernel was
compiled with all options that bpftrace needs. All missing features will
be reported to the user.

As light weight distros used for CI usually leave out `bash` this script
is written to work with `sh`.

Closes #622