### PR TITLE
Limit bytes read by cat builtin

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -352,7 +352,7 @@ void perf_event_printer(void *cb_cookie, void *data, int size __attribute__((unu
   {
     uint64_t cat_id = (uint64_t)*(static_cast<uint64_t*>(data) + sizeof(uint64_t) / sizeof(uint64_t));
     auto filename = bpftrace->cat_args_[cat_id].c_str();
-    cat_file(filename);
+    cat_file(filename, bpftrace->cat_bytes_max_);
     return;
   }
   else if (printf_id == asyncactionint(AsyncAction::join))

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -112,6 +112,7 @@ public:
 
   uint64_t strlen_ = 64;
   uint64_t mapmax_ = 4096;
+  size_t cat_bytes_max_ = 10240;
   bool demangle_cpp_symbols = true;
   bool safe_mode = true;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,7 +40,9 @@ void usage()
   std::cerr << "ENVIRONMENT:" << std::endl;
   std::cerr << "    BPFTRACE_STRLEN           [default: 64] bytes on BPF stack per str()" << std::endl;
   std::cerr << "    BPFTRACE_NO_CPP_DEMANGLE  [default: 0] disable C++ symbol demangling" << std::endl;
-  std::cerr << "    BPFTRACE_MAP_KEYS_MAX     [default: 4096] max keys in a map" << std::endl << std::endl;
+  std::cerr << "    BPFTRACE_MAP_KEYS_MAX     [default: 4096] max keys in a map" << std::endl;
+  std::cerr << "    BPFTRACE_CAT_BYTES_MAX    [default: 10k] maximum bytes read by cat builtin" << std::endl;
+  std::cerr << std::endl;
   std::cerr << "EXAMPLES:" << std::endl;
   std::cerr << "bpftrace -l '*sleep*'" << std::endl;
   std::cerr << "    list probes containing \"sleep\"" << std::endl;
@@ -314,6 +316,17 @@ int main(int argc, char *argv[])
     }
     // no maximum is enforced. Imagine a map recording a timestamp by struct page *: this could exceed 10M entries.
     bpftrace.mapmax_ = proposed;
+  }
+
+  if (const char* env_p = std::getenv("BPFTRACE_CAT_BYTES_MAX"))
+  {
+    uint64_t proposed;
+    std::istringstream stringstream(env_p);
+    if (!(stringstream >> proposed)) {
+      std::cerr << "Env var 'BPFTRACE_CAT_BYTES_MAX' did not contain a valid uint64_t, or was zero-valued." << std::endl;
+      return 1;
+    }
+    bpftrace.cat_bytes_max_ = proposed;
   }
 
   if (cmd_str)

--- a/src/utils.h
+++ b/src/utils.h
@@ -76,7 +76,7 @@ std::string is_deprecated(std::string &str);
 bool is_unsafe_func(const std::string &func_name);
 std::string exec_system(const char* cmd);
 std::string resolve_binary_path(const std::string& cmd);
-void cat_file(const char *filename);
+void cat_file(const char *filename, size_t);
 
 // trim from end of string (right)
 inline std::string& rtrim(std::string& s)

--- a/tests/parser.py
+++ b/tests/parser.py
@@ -15,7 +15,7 @@ class UnknownFieldError(Exception):
     pass
 
 
-TestStruct = namedtuple('TestStruct', 'name run expect timeout before after suite kernel requirement')
+TestStruct = namedtuple('TestStruct', 'name run expect timeout before after suite kernel requirement env')
 
 
 class TestParser(object):
@@ -64,6 +64,7 @@ class TestParser(object):
         after = ''
         kernel = ''
         requirement = ''
+        env = {}
 
         for item in test:
             item_split = item.split()
@@ -86,6 +87,10 @@ class TestParser(object):
                 kernel = line
             elif item_name == 'REQUIRES':
                 requirement = line
+            elif item_name == 'ENV':
+                for e in line.split():
+                    k, v = e.split('=')
+                    env[k]=v
             else:
                 raise UnknownFieldError('Field %s is unknown. Suite: %s' % (item_name, test_suite))
 
@@ -98,4 +103,4 @@ class TestParser(object):
         elif timeout == '':
             raise RequiredFieldError('Test TIMEOUT is required. Suite: ' + test_suite)
 
-        return TestStruct(name, run, expect, timeout, before, after, test_suite, kernel, requirement)
+        return TestStruct(name, run, expect, timeout, before, after, test_suite, kernel, requirement, env)

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -94,3 +94,19 @@ RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", cgroup); exit(); }'
 EXPECT SUCCESS cgroup -?[0-9][0-9]*
 TIMEOUT 5
 MIN_KERNEL 4.18
+
+NAME cat
+RUN bpftrace -e 'i:ms:1 { cat("/proc/loadavg"); exit(); }'
+EXPECT ^([0-9]+\.[0-9]+ ?)+.*$
+TIMEOUT 5
+
+NAME cat limited output
+ENV BPFTRACE_CAT_BYTES_MAX=1
+RUN bpftrace -e 'i:ms:1 { cat("/proc/loadavg"); exit(); }'
+EXPECT ^[0-9]$
+TIMEOUT 5
+
+NAME cat "no such file"
+RUN bpftrace -e 'i:ms:1 { cat("/does/not/exist/file"); exit(); }'
+EXPECT ^Error opening file '/does/not/exist/file': No such file or directory$
+TIMEOUT 5

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -115,7 +115,7 @@ class Utils(object):
             output += p.communicate()[0].decode()
 
             signal.alarm(0)
-            result = re.search(test.expect, output)
+            result = re.search(test.expect, output, re.M)
 
         except (TimeoutError):
             # Give it a last chance, the test might have worked but the

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -88,12 +88,14 @@ class Utils(object):
                 before = subprocess.Popen(test.before, shell=True)
 
             bpf_call = Utils.prepare_bpf_call(test)
+            env = {'test': test.name}
+            env.update(test.env)
             p = subprocess.Popen(
                 bpf_call,
                 shell=True,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT,
-                env={"test": test.name},
+                env=env,
                 bufsize=1
             )
 


### PR DESCRIPTION
This MR combines a few things:

- Add environment var support to the runtime tests. This is makes it possible to test things that can only be set with envvars.
- Use `multiline` regex in the runtime tests. This will make the `^` and `$` behave as expected in the `EXPECT` block.
- Limit the amount of bytes the `cat` builtin reads (and outputs) to prevent killing the system by `cat`ing a 1GB file. It also adds a runtime test for `cat`, which requires test suite changes ^

If separate merge requests are preferred I'll happily split them.

This fixes #624
