### PR TITLE
tests: Use Python 3 for integration tests + test fix

### DIFF
--- a/tests/main.py
+++ b/tests/main.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 import time
 from datetime import timedelta

--- a/tests/parser.py
+++ b/tests/parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 
 from fnmatch import fnmatch
 from collections import namedtuple

--- a/tests/runtime-tests.sh
+++ b/tests/runtime-tests.sh
@@ -7,4 +7,4 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 BPFTRACE_RUNTIME_TEST_EXECUTABLE=${BPFTRACE_RUNTIME_TEST_EXECUTABLE:-$DIR/../src/};
 export BPFTRACE_RUNTIME_TEST_EXECUTABLE;
 
-python main.py $@
+python3 main.py $@

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -15,7 +15,7 @@ TIMEOUT 1
 
 NAME errors on non existent file
 RUN bpftrace non_existent_file.bt
-EXPECT Error: Could not open file 'non_existent_file.bt'
+EXPECT Error opening file 'non_existent_file.bt': No such file or directory
 TIMEOUT 1
 
 NAME it lists kprobes

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -103,14 +103,14 @@ class Utils(object):
 
             while p.poll() is None:
                 nextline = p.stdout.readline()
-                output += nextline
+                output += nextline.decode()
                 if nextline == "Running...\n":
                     signal.alarm(test.timeout or DEFAULT_TIMEOUT)
                     if not after and test.after:
                         after = subprocess.Popen(test.after, shell=True)
                     break
 
-            output += p.communicate()[0]
+            output += p.communicate()[0].decode()
 
             signal.alarm(0)
             result = re.search(test.expect, output)
@@ -120,7 +120,7 @@ class Utils(object):
             # bpftrace process might still be alive
             if p.poll() is None:
                 p.kill()
-            output += p.communicate()[0]
+            output += p.communicate()[0].decode()
             result = re.search(test.expect, output)
             if not result:
                 print(fail("[  TIMEOUT ] ") + "%s.%s" % (test.suite, test.name))

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 import subprocess
 import signal
 from os import environ, uname, devnull


### PR DESCRIPTION
Some Linux distributions `python`  alias points to Python 3 and [Python 2 is going to be deprecated soon](https://pythonclock.org/).

Let's switch to Python 3 for the integration tests :). This PR also fixes some small encoding issue + an unrelated broken test