### PR TITLE
Add /usr/include to header search path

### DIFF
--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -210,7 +210,9 @@ void ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<s
 
   std::vector<const char *> args =
   {
+    "-I", "/usr/local/include",
     "-I", "/bpftrace/include",
+    "-I", "/usr/include",
   };
   for (auto &flag : extra_flags)
   {

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -72,3 +72,13 @@ NAME pid fails validation with non-numeric argument
 RUN bpftrace -p not_a_pid
 EXPECT ERROR: pid 'not_a_pid' is not a valid number.
 TIMEOUT 1
+
+NAME libraries under /usr/include are in the search path
+RUN bpftrace -e "$(echo "#include <sys/types.h>"; echo "BEGIN { exit(); }")" 2>&1
+EXPECT ^((?!file not found).)*$
+TIMEOUT 1
+
+NAME non existent library include fails
+RUN bpftrace -e "$(echo "#include <lol/no.h>"; echo "BEGIN { exit(); }")" 2>&1
+EXPECT file not found
+TIMEOUT 1


### PR DESCRIPTION
Add /usr/include to header search path, I think most users would expect bpftrace to know where to find header files automatically. We can add more paths if needed, but on the systems I've checked all the headers live here

## Test Plan:
Added two runtime tests:
```
[...]
[ RUN      ] basic.libraries under /usr/include are in the search path
[       OK ] basic.libraries under /usr/include are in the search path
[ RUN      ] basic.non existent library include fails
[       OK ] basic.non existent library include fails
[----------] 17 tests from basic
[...]
```

Fixes: #648, related: #645