### PR TITLE
Add option to redirect trace output to file

### DIFF
--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <iostream>
 #include <map>
 #include <memory>
 #include <set>
@@ -65,10 +66,11 @@ private:
 class BPFtrace
 {
 public:
-  BPFtrace() : ncpus_(get_possible_cpus().size()) { }
+  BPFtrace(std::ostream& o = std::cout) : out_(o),ncpus_(get_possible_cpus().size()) { }
   virtual ~BPFtrace();
   virtual int add_probe(ast::Probe &p);
   int num_probes() const;
+  std::ostream& outputstream() const { return out_; }
   int run(std::unique_ptr<BpfOrc> bpforc);
   int print_maps();
   int print_map_ident(const std::string &ident, uint32_t top, uint32_t div);
@@ -137,6 +139,7 @@ protected:
   std::vector<Probe> special_probes_;
 
 private:
+  std::ostream &out_;
   std::vector<std::unique_ptr<AttachedProbe>> attached_probes_;
   std::vector<std::unique_ptr<AttachedProbe>> special_attached_probes_;
   void* ksyms_{nullptr};

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -390,7 +390,7 @@ std::string resolve_binary_path(const std::string& cmd)
   }
 }
 
-void cat_file(const char *filename, size_t max_bytes)
+void cat_file(const char *filename, size_t max_bytes, std::ostream &out)
 {
   std::ifstream file(filename);
   const size_t BUFSIZE = 4096;
@@ -408,7 +408,7 @@ void cat_file(const char *filename, size_t max_bytes)
   while (bytes_read < max_bytes) {
     size_t size = std::min(BUFSIZE, max_bytes - bytes_read);
     file.read(buf, size);
-    std::cout.write(buf, file.gcount());
+    out.write(buf, file.gcount());
     if (file.eof()) {
       return;
     }

--- a/src/utils.h
+++ b/src/utils.h
@@ -76,7 +76,7 @@ std::string is_deprecated(std::string &str);
 bool is_unsafe_func(const std::string &func_name);
 std::string exec_system(const char* cmd);
 std::string resolve_binary_path(const std::string& cmd);
-void cat_file(const char *filename, size_t);
+void cat_file(const char *filename, size_t, std::ostream&);
 
 // trim from end of string (right)
 inline std::string& rtrim(std::string& s)

--- a/tests/runtime/file-output
+++ b/tests/runtime/file-output
@@ -1,0 +1,19 @@
+NAME printf to file
+RUN bpftrace -v -e 'i:ms:10 { printf("%s %d\n", "SUCCESS", 1); exit() }' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
+EXPECT ^SUCCESS 1$
+TIMEOUT 5
+
+NAME cat to file
+RUN bpftrace -v -e 'i:ms:10 { cat("/proc/loadavg"); exit(); }' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
+EXPECT ^([0-9]+\.[0-9]+ )+.*$
+TIMEOUT 5
+
+NAME print map to file
+RUN bpftrace -v -e 'i:ms:10 { @=lhist(50, 0, 100, 10); exit();}' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
+EXPECT ^\[50, 60\).*\@+\|$
+TIMEOUT 5
+
+NAME system stdout to file
+RUN bpftrace -v --unsafe -e 'i:ms:10 { system("cat /proc/loadavg"); exit(); }' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
+EXPECT ^([0-9]+\.[0-9]+ )+.*$
+TIMEOUT 5


### PR DESCRIPTION
This adds the option to redirect all output generated by the "trace
program" to be output to a file as discussed in #605. All other output
generated by `bpftrace` will still be sent either `stdout` or `stderr`.

It's implementation is quite straight forward. The `BPFtrace` class
stores a reference to an `ostream` object which will be used for all
output, replacing `cout` everywhere.
The `printf` command now uses `snprintf` to print to a buffer which then
gets written to the output stream. As the size isn't known initially
`sprintf` is called twice, once to calculate the required buffer size
and once to fill the buffer. A simple micro benchmark that compares the
two by doing 1k rounds shows that the new `snprintf` loop less than 5x
slower when writing to `/dev/null`. However, when writing to `stdout` the
difference drops to about 1.5x, as `stdout` is "slow".

Instead of calling `system` the `system` builtin now uses `exec_system`
from as that captures `stdout`. `stderr` is not captured (yet).

Closes #605 