### PR TITLE
Fix runtime tests

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -102,8 +102,8 @@ class Utils(object):
             output = ""
 
             while p.poll() is None:
-                nextline = p.stdout.readline()
-                output += nextline.decode()
+                nextline = p.stdout.readline().decode()
+                output += nextline
                 if nextline == "Running...\n":
                     signal.alarm(test.timeout or DEFAULT_TIMEOUT)
                     if not after and test.after:


### PR DESCRIPTION
The byte stream needs to be decoded before it can be compared to the
string `running...`.

@javierhonduco  seems like this broke with the merge of #651, but tests pass? Might be python 3 version related. I'm testing with Python 3.6.8 on ubuntu 18.04