### PR TITLE
Fix snap instructions

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,10 +41,10 @@ This can be verified by running the `check_kernel_features` script from the
 
 ## Ubuntu snap package
 
-On Ubuntu 16.04 and later, bpftrace is available as a snap package (https://snapcraft.io/bpftrace) and can be installed with snap.
+On Ubuntu 16.04 and later, bpftrace is available as a snap package (https://snapcraft.io/bpftrace) and can be installed with snap. The current snap provides extremely limited file permissions so the --devmode option should be specified on installation in order avoid file access issues.
 
 ```
-sudo snap install bpftrace
+sudo snap install --devmode bpftrace
 sudo snap connect bpftrace:system-trace
 ```
 


### PR DESCRIPTION
Add a note to use the --devmode option when installing the snap to avoid
file permission issues.

This is a work around for #642.