### PR TITLE
Fix logic of finalization through exit() call (#228)

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -786,7 +786,9 @@ void BPFtrace::poll_perf_events(int epollfd, bool drain)
     // Return if either
     //   * epoll_wait has encountered an error (eg signal delivery)
     //   * There's no events left and we've been instructed to drain
-    if (ready < 0 || (ready == 0 && (drain || finalize_)))
+    //   * finalize_ flag has been set through exit() call and this isn't
+    //     a drain call
+    if (ready < 0 || (ready == 0 && drain) || (finalize_ && !drain))
     {
       return;
     }

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -138,3 +138,8 @@ NAME BEGIN
 RUN bpftrace -v -e 'BEGIN { printf("Hello\n"); exit();}'
 EXPECT Hello
 TIMEOUT 2
+
+NAME END_processing_after_exit
+RUN bpftrace -v -e "interval:s:1 { exit(); } END { printf("end"); }"
+EXPECT end
+TIMEOUT 2


### PR DESCRIPTION
The fix for "exit() function bypasses END probe processing" #228 (#661)
introduced a bug which can cause bpftrace to never stop with a script
like this:

bpftrace -e 'i:ms:1 { cat("/proc/uptime"); exit();}'

This commit fixes the finalization logic:
- When finalize_ is set the function should return independently of the
ready value, the remaining data will be read via the drain=true call.