### PR TITLE
Fix possible crash if an invalid char is used in search (#664)

### DIFF
--- a/src/list.cpp
+++ b/src/list.cpp
@@ -103,6 +103,7 @@ void list_probes(const std::string &search_input, int pid)
 {
   std::string search = search_input;
   std::string probe_name;
+  std::regex re;
 
   std::smatch probe_match;
   std::regex probe_regex(":.*");
@@ -127,7 +128,12 @@ void list_probes(const std::string &search_input, int pid)
       s += c;
   }
   s += '$';
-  std::regex re(s, std::regex::icase | std::regex::grep | std::regex::nosubs | std::regex::optimize);
+  try {
+    re = std::regex(s, std::regex::icase | std::regex::grep | std::regex::nosubs | std::regex::optimize);
+  } catch(std::regex_error& e) {
+    std::cerr << "ERROR: invalid character in search expression." << std::endl;
+    return;
+  }
 
   // software
   list_probes_from_list(SW_PROBE_LIST, "software", search, re);

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -58,6 +58,11 @@ RUN bpftrace -l "hardware:*"
 EXPECT hardware
 TIMEOUT 1
 
+NAME errors on invalid character in search expression
+RUN bpftrace -l '\n'
+EXPECT ERROR: invalid character in search expression
+TIMEOUT 1
+
 NAME pid fails validation with leading non-number
 RUN bpftrace -p a1111
 EXPECT ERROR: pid 'a1111' is not a valid number.


### PR DESCRIPTION
Avoid this kind of crash if by mistake a string with an invalid
character is used with '-l':

bpftrace -l 'BEGIN { printf("hello world\n"); }'
terminate called after throwing an instance of 'std::regex_error'
  what():  Unexpected escape character.