### PR TITLE
Do not emit GEP instruction when pushing string literals to stack

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -34,7 +34,7 @@ void CodegenLLVM::visit(PositionalParameter &param)
     Constant *const_str = ConstantDataArray::getString(module_->getContext(), pstr, true);
     AllocaInst *buf = b_.CreateAllocaBPF(ArrayType::get(b_.getInt8Ty(), pstr.length() + 1), "str");
     b_.CreateMemSet(buf, b_.getInt8(0), pstr.length() + 1, 1);
-    b_.CreateStore(b_.CreateGEP(const_str, b_.getInt64(0)), buf);
+    b_.CreateStore(const_str, buf);
     expr_ = buf;
   }
 }
@@ -44,7 +44,7 @@ void CodegenLLVM::visit(String &string)
   string.str.resize(string.type.size-1);
   Constant *const_str = ConstantDataArray::getString(module_->getContext(), string.str, true);
   AllocaInst *buf = b_.CreateAllocaBPF(string.type, "str");
-  b_.CreateStore(b_.CreateGEP(const_str, b_.getInt64(0)), buf);
+  b_.CreateStore(const_str, buf);
   expr_ = buf;
 }
 
@@ -663,7 +663,7 @@ void CodegenLLVM::visit(Call &call)
     Constant *const_str = ConstantDataArray::getString(module_->getContext(), map.ident, true);
     AllocaInst *str_buf = b_.CreateAllocaBPF(ArrayType::get(b_.getInt8Ty(), map.ident.length() + 1), "str");
     b_.CreateMemSet(str_buf, b_.getInt8(0), map.ident.length() + 1, 1);
-    b_.CreateStore(b_.CreateGEP(const_str, b_.getInt64(0)), str_buf);
+    b_.CreateStore(const_str, str_buf);
     ArrayType *perfdata_type = ArrayType::get(b_.getInt8Ty(), sizeof(uint64_t) + 2 * sizeof(uint64_t) + map.ident.length() + 1);
     AllocaInst *perfdata = b_.CreateAllocaBPF(perfdata_type, "perfdata");
 
@@ -707,7 +707,7 @@ void CodegenLLVM::visit(Call &call)
     Constant *const_str = ConstantDataArray::getString(module_->getContext(), map.ident, true);
     AllocaInst *str_buf = b_.CreateAllocaBPF(ArrayType::get(b_.getInt8Ty(), map.ident.length() + 1), "str");
     b_.CreateMemSet(str_buf, b_.getInt8(0), map.ident.length() + 1, 1);
-    b_.CreateStore(b_.CreateGEP(const_str, b_.getInt64(0)), str_buf);
+    b_.CreateStore(const_str, str_buf);
     ArrayType *perfdata_type = ArrayType::get(b_.getInt8Ty(), sizeof(uint64_t) + map.ident.length() + 1);
     AllocaInst *perfdata = b_.CreateAllocaBPF(perfdata_type, "perfdata");
     if (call.func == "clear")

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -560,7 +560,8 @@ void CodegenLLVM::visit(Call &call)
     AllocaInst *printf_args = b_.CreateAllocaBPF(printf_struct, "printf_args");
     b_.CreateMemSet(printf_args, b_.getInt8(0), struct_size, 1);
 
-    b_.CreateStore(b_.getInt64(printf_id_), printf_args);
+    Value *printf_id_offset = b_.CreateGEP(printf_args, {b_.getInt32(0), b_.getInt32(0)});
+    b_.CreateStore(b_.getInt64(printf_id_), printf_id_offset);
     for (size_t i=1; i<call.vargs->size(); i++)
     {
       Expression &arg = *call.vargs->at(i);

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -621,7 +621,13 @@ void IRBuilderBPF::CreatePerfEventOutput(Value *ctx, Value *data, size_t size)
   // int bpf_perf_event_output(ctx, map, flags, data, size)
   FunctionType *perfoutput_func_type = FunctionType::get(
       getInt64Ty(),
-      {getInt8PtrTy(), getInt8PtrTy(), getInt64Ty(), getInt8PtrTy(), getInt64Ty()},
+      {
+        getInt8PtrTy(),
+        getInt64Ty(),
+        getInt64Ty(),
+        cast<PointerType>(data->getType()),
+        getInt64Ty()
+      },
       false);
   PointerType *perfoutput_func_ptr_type = PointerType::get(perfoutput_func_type, 0);
   Constant *perfoutput_func = ConstantExpr::getCast(

--- a/tests/codegen/call_cat.cpp
+++ b/tests/codegen/call_cat.cpp
@@ -24,7 +24,7 @@ entry:
   store i64 0, i8* %2, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [16 x i8]* nonnull %perfdata, i64 16)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, [16 x i8]*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [16 x i8]* nonnull %perfdata, i64 16)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }

--- a/tests/codegen/call_clear.cpp
+++ b/tests/codegen/call_clear.cpp
@@ -48,7 +48,7 @@ entry:
   store i8 0, i8* %str.sroa.5.0..sroa_idx, align 2
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [11 x i8]* nonnull %perfdata, i64 11)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, [11 x i8]*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [11 x i8]* nonnull %perfdata, i64 11)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }

--- a/tests/codegen/call_exit.cpp
+++ b/tests/codegen/call_exit.cpp
@@ -22,7 +22,7 @@ entry:
   store i64 20000, [8 x i8]* %perfdata, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [8 x i8]* nonnull %perfdata, i64 8)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, [8 x i8]*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [8 x i8]* nonnull %perfdata, i64 8)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }

--- a/tests/codegen/call_print.cpp
+++ b/tests/codegen/call_print.cpp
@@ -51,7 +51,7 @@ entry:
   store i8 0, i8* %str.sroa.5.0..sroa_idx, align 2
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [27 x i8]* nonnull %perfdata, i64 27)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, [27 x i8]*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [27 x i8]* nonnull %perfdata, i64 27)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }
@@ -105,7 +105,7 @@ entry:
   store i8 0, i8* %str.sroa.5.0..sroa_idx, align 2
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [27 x i8]* nonnull %perfdata, i64 27)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, [27 x i8]*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [27 x i8]* nonnull %perfdata, i64 27)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }
@@ -159,7 +159,7 @@ entry:
   store i8 0, i8* %str.sroa.5.0..sroa_idx, align 2
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [27 x i8]* nonnull %perfdata, i64 27)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, [27 x i8]*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [27 x i8]* nonnull %perfdata, i64 27)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }

--- a/tests/codegen/call_printf.cpp
+++ b/tests/codegen/call_printf.cpp
@@ -41,7 +41,7 @@ entry:
   store i64 %6, i64* %7, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 24)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 24)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }
@@ -88,7 +88,7 @@ entry:
   store i64 %6, i64* %7, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 24)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 24)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }

--- a/tests/codegen/call_system.cpp
+++ b/tests/codegen/call_system.cpp
@@ -26,7 +26,7 @@ entry:
   store i64 100, i64* %2, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %system_t* nonnull %system_args, i64 16)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %system_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %system_t* nonnull %system_args, i64 16)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }

--- a/tests/codegen/call_time.cpp
+++ b/tests/codegen/call_time.cpp
@@ -24,7 +24,7 @@ entry:
   store i64 0, i8* %2, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [16 x i8]* nonnull %perfdata, i64 16)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, [16 x i8]*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [16 x i8]* nonnull %perfdata, i64 16)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }

--- a/tests/codegen/call_zero.cpp
+++ b/tests/codegen/call_zero.cpp
@@ -48,7 +48,7 @@ entry:
   store i8 0, i8* %str.sroa.5.0..sroa_idx, align 2
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [11 x i8]* nonnull %perfdata, i64 11)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, [11 x i8]*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [11 x i8]* nonnull %perfdata, i64 11)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }

--- a/tests/codegen/if_else_printf.cpp
+++ b/tests/codegen/if_else_printf.cpp
@@ -28,7 +28,8 @@ entry:
 if_stmt:                                          ; preds = %entry
   %2 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  store i64 0, %printf_t* %printf_args, align 8
+  %3 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
+  store i64 0, i64* %3, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 8)
@@ -36,13 +37,14 @@ if_stmt:                                          ; preds = %entry
   br label %done
 
 else_stmt:                                        ; preds = %entry
-  %3 = bitcast %printf_t.0* %printf_args1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  store i64 1, %printf_t.0* %printf_args1, align 8
+  %4 = bitcast %printf_t.0* %printf_args1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  %5 = getelementptr inbounds %printf_t.0, %printf_t.0* %printf_args1, i64 0, i32 0
+  store i64 1, i64* %5, align 8
   %pseudo2 = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id3 = tail call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output4 = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo2, i64 %get_cpu_id3, %printf_t.0* nonnull %printf_args1, i64 8)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   br label %done
 
 done:                                             ; preds = %else_stmt, %if_stmt

--- a/tests/codegen/if_else_printf.cpp
+++ b/tests/codegen/if_else_printf.cpp
@@ -32,7 +32,7 @@ if_stmt:                                          ; preds = %entry
   store i64 0, i64* %3, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 8)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 8)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   br label %done
 
@@ -43,7 +43,7 @@ else_stmt:                                        ; preds = %entry
   store i64 1, i64* %5, align 8
   %pseudo2 = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id3 = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output4 = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo2, i64 %get_cpu_id3, %printf_t.0* nonnull %printf_args1, i64 8)
+  %perf_event_output4 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.0*, i64)*)(i8* %0, i64 %pseudo2, i64 %get_cpu_id3, %printf_t.0* nonnull %printf_args1, i64 8)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   br label %done
 

--- a/tests/codegen/if_else_variable.cpp
+++ b/tests/codegen/if_else_variable.cpp
@@ -30,7 +30,7 @@ entry:
   store i64 %., i64* %3, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 16)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 16)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0
 }

--- a/tests/codegen/if_nested_printf.cpp
+++ b/tests/codegen/if_nested_printf.cpp
@@ -39,7 +39,7 @@ if_stmt1:                                         ; preds = %if_stmt
   store i64 0, i64* %3, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 8)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 8)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   br label %else_stmt
 }

--- a/tests/codegen/if_nested_printf.cpp
+++ b/tests/codegen/if_nested_printf.cpp
@@ -35,7 +35,8 @@ else_stmt:                                        ; preds = %if_stmt, %if_stmt1,
 if_stmt1:                                         ; preds = %if_stmt
   %2 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  store i64 0, %printf_t* %printf_args, align 8
+  %3 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
+  store i64 0, i64* %3, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 8)

--- a/tests/codegen/if_printf.cpp
+++ b/tests/codegen/if_printf.cpp
@@ -34,7 +34,7 @@ if_stmt:                                          ; preds = %entry
   store i64 %4, i64* %5, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 16)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 16)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   br label %else_stmt
 

--- a/tests/codegen/if_variable.cpp
+++ b/tests/codegen/if_variable.cpp
@@ -31,7 +31,7 @@ entry:
   store i64 %., i64* %3, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 16)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 16)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0
 }
@@ -65,7 +65,7 @@ entry:
   store i64 %spec.select, i64* %3, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 16)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 16)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0
 }

--- a/tests/codegen/struct_semicolon.cpp
+++ b/tests/codegen/struct_semicolon.cpp
@@ -30,7 +30,7 @@ entry:
   store i64 %4, i64* %5, align 8
   %pseudo1 = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo1, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 16)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo1, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 16)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }

--- a/tests/codegen/variable_increment_decrement.cpp
+++ b/tests/codegen/variable_increment_decrement.cpp
@@ -37,31 +37,34 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %4 = bitcast %printf_t.0* %printf_args1 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  store i64 1, %printf_t.0* %printf_args1, align 8
-  %5 = getelementptr inbounds %printf_t.0, %printf_t.0* %printf_args1, i64 0, i32 1
-  store i64 12, i64* %5, align 8
+  %5 = getelementptr inbounds %printf_t.0, %printf_t.0* %printf_args1, i64 0, i32 0
+  store i64 1, i64* %5, align 8
+  %6 = getelementptr inbounds %printf_t.0, %printf_t.0* %printf_args1, i64 0, i32 1
+  store i64 12, i64* %6, align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id3 = call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output4 = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo2, i64 %get_cpu_id3, %printf_t.0* nonnull %printf_args1, i64 16)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  %6 = bitcast %printf_t.1* %printf_args5 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
-  store i64 2, %printf_t.1* %printf_args5, align 8
-  %7 = getelementptr inbounds %printf_t.1, %printf_t.1* %printf_args5, i64 0, i32 1
-  store i64 12, i64* %7, align 8
+  %7 = bitcast %printf_t.1* %printf_args5 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
+  %8 = getelementptr inbounds %printf_t.1, %printf_t.1* %printf_args5, i64 0, i32 0
+  store i64 2, i64* %8, align 8
+  %9 = getelementptr inbounds %printf_t.1, %printf_t.1* %printf_args5, i64 0, i32 1
+  store i64 12, i64* %9, align 8
   %pseudo6 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id7 = call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output8 = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo6, i64 %get_cpu_id7, %printf_t.1* nonnull %printf_args5, i64 16)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
-  %8 = bitcast %printf_t.2* %printf_args9 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
-  store i64 3, %printf_t.2* %printf_args9, align 8
-  %9 = getelementptr inbounds %printf_t.2, %printf_t.2* %printf_args9, i64 0, i32 1
-  store i64 10, i64* %9, align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  %10 = bitcast %printf_t.2* %printf_args9 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
+  %11 = getelementptr inbounds %printf_t.2, %printf_t.2* %printf_args9, i64 0, i32 0
+  store i64 3, i64* %11, align 8
+  %12 = getelementptr inbounds %printf_t.2, %printf_t.2* %printf_args9, i64 0, i32 1
+  store i64 10, i64* %12, align 8
   %pseudo10 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id11 = call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output12 = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo10, i64 %get_cpu_id11, %printf_t.2* nonnull %printf_args9, i64 16)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
   ret i64 0
 }
 

--- a/tests/codegen/variable_increment_decrement.cpp
+++ b/tests/codegen/variable_increment_decrement.cpp
@@ -33,7 +33,7 @@ entry:
   store i64 10, i64* %2, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 16)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 16)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %4 = bitcast %printf_t.0* %printf_args1 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
@@ -43,7 +43,7 @@ entry:
   store i64 12, i64* %6, align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id3 = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output4 = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo2, i64 %get_cpu_id3, %printf_t.0* nonnull %printf_args1, i64 16)
+  %perf_event_output4 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.0*, i64)*)(i8* %0, i64 %pseudo2, i64 %get_cpu_id3, %printf_t.0* nonnull %printf_args1, i64 16)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %7 = bitcast %printf_t.1* %printf_args5 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
@@ -53,7 +53,7 @@ entry:
   store i64 12, i64* %9, align 8
   %pseudo6 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id7 = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output8 = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo6, i64 %get_cpu_id7, %printf_t.1* nonnull %printf_args5, i64 16)
+  %perf_event_output8 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.1*, i64)*)(i8* %0, i64 %pseudo6, i64 %get_cpu_id7, %printf_t.1* nonnull %printf_args5, i64 16)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   %10 = bitcast %printf_t.2* %printf_args9 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
@@ -63,7 +63,7 @@ entry:
   store i64 10, i64* %12, align 8
   %pseudo10 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id11 = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output12 = call i64 inttoptr (i64 25 to i64 (i8*, i8*, i64, i8*, i64)*)(i8* %0, i64 %pseudo10, i64 %get_cpu_id11, %printf_t.2* nonnull %printf_args9, i64 16)
+  %perf_event_output12 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.2*, i64)*)(i8* %0, i64 %pseudo10, i64 %get_cpu_id11, %printf_t.2* nonnull %printf_args9, i64 16)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
   ret i64 0
 }


### PR DESCRIPTION
I am able to crash bpftrace on one of asserts in llvm/Support/Casting.h when
building with LLVM8 and asserts enabled. Minimal repro I found is:
```
bpftrace -e 'BEGIN { printf("%s", "a"); }'
```
The crash occurs while creating GEP instruction when generating code pushing "a"
string literal to stack (see
https://github.com/iovisor/bpftrace/blob/master/src/ast/codegen_llvm.cpp#L46).
GEP expects its argument to be a `Value` of type `PointerType`, whereas type of
`Constant` pointed to by `const_str` is `ArrayType`. Proposed fix is to skip GEP
in this case, store opcode can handle arrays.

The issue might be hard to spot because with asserts disabled code seem to
work fine (fields of PointerType and ArrayType fortunately overlap in a way
that makes sense, `PointeeTy` in `PointerType` overlaps with `ContainedType`
added in `ArrayType`'s superclass).

Test plan:
Build bpftrace with LLVM8 and asserts enabled and make sure that I can't repro
the crash anymore. In additoin pick  run:
- biolatency.bt
- biosnoop.bt
- runqlat.bt
- tcpconnect.bt