### PR TITLE
preprocessor: Allow defines to begin with an underscore

### DIFF
--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -76,8 +76,6 @@ static bool translateMacro(CXCursor cursor, std::string &name, std::string &valu
     {
       value.clear();
       name = clang_getCString(tokenText);
-      if (name[0] == '_')
-        break;
     }
     else
     {

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -82,3 +82,8 @@ NAME non existent library include fails
 RUN bpftrace -e "$(echo "#include <lol/no.h>"; echo "BEGIN { exit(); }")" 2>&1
 EXPECT file not found
 TIMEOUT 1
+
+NAME defines beginning with underscore are allowed
+RUN bpftrace -e "$(echo '#define _UNDERSCORE 314'; echo 'BEGIN { printf("%d\n", _UNDERSCORE); exit(); }')"
+EXPECT 314
+TIMEOUT 1


### PR DESCRIPTION
@tyroguru and I were trying to include some header file starting with an `_` but we couldn't get it to work. We eventually noticed we were filtering out includes prefixed with such symbol

## Test Plan:
Added a new runtime test:

```shell
[ RUN      ] basic.defines beginning with underscore are allowed
[       OK ] basic.defines beginning with underscore are allowed
```

cc @mmarchini who implemented this feature in #540