### PR TITLE
Fix clearing action for some aggregations

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -890,7 +890,8 @@ int BPFtrace::clear_map(IMap &map)
   std::vector<uint8_t> old_key;
   try
   {
-    if (map.type_.type == Type::hist)
+    if (map.type_.type == Type::hist || map.type_.type == Type::lhist ||
+        map.type_.type == Type::stats || map.type_.type == Type::avg)
       // hist maps have 8 extra bytes for the bucket number
       old_key = find_empty_key(map, map.key_.size() + 8);
     else

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -57,3 +57,23 @@ NAME struct positional string compare - not equal
 RUN bpftrace -v -e 'BEGIN { if (str($1) != str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hello" "hello"
 EXPECT not equal
 TIMEOUT 5
+
+NAME lhist can be cleared
+RUN bpftrace -e 'BEGIN{ @[1] = lhist(3,0,10,1); clear(@); exit() }'
+EXPECT .*
+TIMEOUT 1
+
+NAME hist can be cleared
+RUN bpftrace -e 'BEGIN{ @[1] = hist(1); clear(@); exit() }'
+EXPECT .*
+TIMEOUT 1
+
+NAME stats can be cleared
+RUN bpftrace -e 'BEGIN{ @[1] = stats(1); clear(@); exit() }'
+EXPECT .*
+TIMEOUT 1
+
+NAME avg can be cleared
+RUN bpftrace -e 'BEGIN{ @[1] = avg(1); clear(@); exit() }'
+EXPECT .*
+TIMEOUT 1


### PR DESCRIPTION
Fixes #660, as the comment below in the zero'ing function says:

> // hist maps have 8 extra bytes for the bucket number

## Test Plan
```
$ sudo src/bpftrace -e 'BEGIN{@[1] = stats(1); clear(@); exit()}'
Attaching 1 probe...




```

```
[ RUN      ] other.lhist can be cleared
[       OK ] other.lhist can be cleared
[ RUN      ] other.hist can be cleared
[       OK ] other.hist can be cleared
[ RUN      ] other.stats can be cleared
[       OK ] other.stats can be cleared
[ RUN      ] other.avg can be cleared
[       OK ] other.avg can be cleared
```

Note: could not run all the runtime as in my machine many tests are not working :(