### PR TITLE
Highlight bpftrace source files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.bt linguist-language=D
+*.bt linguist-vendored


### PR DESCRIPTION
Tell [github-linguist](https://github.com/github/linguist/) to recognize these files as JavaScript (this works well enough for comments and strings). The second line then tells github-linguist to ignore those files in statistics, to avoid having this repository recognized as a JavaScript repository.

You can see it working on my fork, [on some of the files](https://github.com/pchaigno/bpftrace/blob/linguist-highlight/tools/gethostlatency.bt). Other files should be highlighted in a couple minutes/hours.