### PR TITLE
RFC: -l for uprobes

### DIFF
--- a/src/list.h
+++ b/src/list.h
@@ -2,6 +2,8 @@
 
 #include <linux/perf_event.h>
 
+#include "bpftrace.h"
+
 namespace bpftrace {
 
 struct ProbeListItem
@@ -39,6 +41,6 @@ const std::vector<ProbeListItem> HW_PROBE_LIST = {
   { "ref-cycles",          "",         PERF_COUNT_HW_REF_CPU_CYCLES,          1000000 }
 };
 
-void list_probes(const std::string &search = "", int pid = 0);
+void list_probes(const BPFtrace &bpftrace, const std::string &search = "");
 
 } // namespace bpftrace

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -237,9 +237,9 @@ int main(int argc, char *argv[])
       return 1;
 
     if (optind == argc-1)
-      list_probes(argv[optind], bpftrace.pid_);
+      list_probes(bpftrace, argv[optind]);
     else if (optind == argc)
-      list_probes("", bpftrace.pid_);
+      list_probes(bpftrace, "");
     else
     {
       usage();

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -8,6 +8,7 @@
 #include <sstream>
 #include <fstream>
 #include <memory>
+#include <unistd.h>
 #include <sys/stat.h>
 
 #include "utils.h"
@@ -160,6 +161,23 @@ bool get_uint64_env_var(const std::string &str, uint64_t &dest)
     }
   }
   return true;
+}
+
+std::string get_pid_exe(pid_t pid)
+{
+  char proc_path[512];
+  char exe_path[4096];
+  int res;
+
+  sprintf(proc_path, "/proc/%d/exe", pid);
+  res = readlink(proc_path, exe_path, sizeof(exe_path));
+  if (res == -1)
+    return "";
+  if (res >= static_cast<int>(sizeof(exe_path))) {
+    throw std::runtime_error("executable path exceeded maximum supported size of 4096 characters");
+  }
+  exe_path[res] = '\0';
+  return std::string(exe_path);
 }
 
 bool has_wildcard(const std::string &str)

--- a/src/utils.h
+++ b/src/utils.h
@@ -60,8 +60,8 @@ static std::vector<std::string> UNSAFE_BUILTIN_FUNCS =
   "system",
 };
 
-
 bool get_uint64_env_var(const ::std::string &str, uint64_t &dest);
+std::string get_pid_exe(pid_t pid);
 bool has_wildcard(const std::string &str);
 std::vector<std::string> split_string(const std::string &str, char delimiter);
 bool wildcard_match(const std::string &str, std::vector<std::string> &tokens, bool start_wildcard, bool end_wildcard);

--- a/tests/runtime/uprobe
+++ b/tests/runtime/uprobe
@@ -1,0 +1,26 @@
+NAME "uprobes - list probes by file"
+RUN bpftrace -l 'uprobe:./testprogs/uprobe_test'
+EXPECT uprobe:./testprogs/uprobe_test:function1
+TIMEOUT 5
+
+NAME "uprobes - list probes by file with wildcarded filter"
+RUN bpftrace -l 'uprobe:./testprogs/uprobe_test:func*'
+EXPECT uprobe:./testprogs/uprobe_test:function1
+TIMEOUT 5
+
+NAME "uprobes - list probes by file with specific filter"
+RUN bpftrace -l 'uprobe:./testprogs/uprobe_test:function1'
+EXPECT uprobe:./testprogs/uprobe_test:function1
+TIMEOUT 5
+
+NAME "uprobes - list probes by pid"
+RUN bpftrace -l -p $(pidof uprobe_test)
+EXPECT uprobe:.*/testprogs/uprobe_test:function1
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+
+NAME "uprobes - list probes by pid, uprobes only"
+RUN bpftrace -l 'uprobe:*' -p $(pidof uprobe_test)
+EXPECT uprobe:.*/testprogs/uprobe_test:function1
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test

--- a/tests/testprogs/uprobe_test.c
+++ b/tests/testprogs/uprobe_test.c
@@ -1,0 +1,11 @@
+#include <unistd.h>
+
+int function1()
+{
+  return 0;
+}
+
+int main(int argc, char **argv) {
+  usleep(1000000);
+  return function1();
+}


### PR DESCRIPTION
Fixes https://github.com/iovisor/bpftrace/issues/673

Same syntax and semantics as listing for USDT:

### List by absolute binary path

```
# bpftrace -l 'uprobe:/lib/x86_64-linux-gnu/libc.so.6'
uprobe:/lib/x86_64-linux-gnu/libc.so.6:free_derivation
uprobe:/lib/x86_64-linux-gnu/libc.so.6:derivation_compare
uprobe:/lib/x86_64-linux-gnu/libc.so.6:__gconv_release_step.part.1
uprobe:/lib/x86_64-linux-gnu/libc.so.6:free_modules_db
...
```

### List by absolute binary path, with filter

```
# bpftrace -l 'uprobe:/lib/x86_64-linux-gnu/libc.so.6:usle*'
uprobe:/lib/x86_64-linux-gnu/libc.so.6:usleep
uprobe:/lib/x86_64-linux-gnu/libc.so.6:usleep
```

### List by binary path, with PATH lookup:

```
# sudo ./src/bpftrace -l 'uprobe:slack'
uprobe:slack:_cgo_f7895c2c5a3a_Cfunc_freeaddrinfo
uprobe:slack:crosscall2
uprobe:slack:_fini
uprobe:slack:_cgo_d76b870879f1_Cfunc_free
uprobe:slack:x_cgo_mmap
uprobe:slack:_cgo_release_context
uprobe:slack:__libc_csu_init
uprobe:slack:_cgo_90cee26748d5_Cfunc_mygetpwnam_r
...
```

### List by pid

```
# bpftrace -l -p PID
...
uprobe:/snap/slack/13/usr/lib/slack/slack:_ZN2gl10Uniform1ivEiiPKi
uprobe:/snap/slack/13/usr/lib/slack/slack:_ZThn32_N4atom3api3App7OnLoginE13scoped_refptrINS_12LoginHandlerEERKN4base15DictionaryValueE
uprobe:/snap/slack/13/usr/lib/slack/slack:_ZN4mate9ConverterIN3gfx5PointEvE4ToV8EPN2v87IsolateERKS2_
...
```

### List by pid, filter `uprobe` only

```
# bpftrace -l 'uprobe:*' -p PID
uprobe:/snap/slack/13/usr/lib/slack/slack:_ZN2gl10Uniform1ivEiiPKi
uprobe:/snap/slack/13/usr/lib/slack/slack:_ZThn32_N4atom3api3App7OnLoginE13scoped_refptrINS_12LoginHandlerEERKN4base15DictionaryValueE
uprobe:/snap/slack/13/usr/lib/slack/slack:_ZN4mate9ConverterIN3gfx5PointEvE4ToV8EPN2v87IsolateERKS2_
...
```

I might have missed some use cases. Will add some tests before merging if there's no objections on the behavior here.