### PR TITLE
undef struct

### DIFF
--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -13,8 +13,8 @@
 
 namespace bpftrace {
 
-std::unordered_map<std::string, CXCursor> indirect_structs;
-std::unordered_set<std::string> unvisited_indirect_structs;
+static std::unordered_map<std::string, CXCursor> indirect_structs;
+static std::unordered_set<std::string> unvisited_indirect_structs;
 
 static std::string get_clang_string(CXString string)
 {

--- a/src/clang_parser.h
+++ b/src/clang_parser.h
@@ -12,7 +12,7 @@ using StructMap = std::map<std::string, Struct>;
 class ClangParser
 {
 public:
-  void parse(ast::Program *program, BPFtrace &bpftrace, std::vector<std::string> extra_flags = {});
+  int parse(ast::Program *program, BPFtrace &bpftrace, std::vector<std::string> extra_flags = {});
 };
 
 } // namespace bpftrace

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -355,7 +355,10 @@ int main(int argc, char *argv[])
     if (ksrc != "")
       extra_flags = get_kernel_cflags(utsname.machine, ksrc, kobj);
   }
-  clang.parse(driver.root_, bpftrace, extra_flags);
+
+  err = clang.parse(driver.root_, bpftrace, extra_flags);
+  if (err)
+    return 1;
 
   if (script.empty())
   {

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -7,14 +7,14 @@ namespace bpftrace {
 namespace test {
 namespace clang_parser {
 
-void parse(const std::string &input, BPFtrace &bpftrace)
+static void parse(const std::string &input, BPFtrace &bpftrace, int result = 0)
 {
   auto extended_input = input + "kprobe:sys_read { 1 }";
   Driver driver(bpftrace);
   ASSERT_EQ(driver.parse_str(extended_input), 0);
 
   ClangParser clang;
-  clang.parse(driver.root_, bpftrace);
+  ASSERT_EQ(clang.parse(driver.root_, bpftrace), result);
 }
 
 TEST(clang_parser, integers)
@@ -282,6 +282,12 @@ TEST(clang_parser, macro_preprocessor)
 
   ASSERT_EQ(macros.count("FOO"), 1U);
   ASSERT_EQ(macros["FOO"], "size_t");
+}
+
+TEST(clang_parser, parse_fail)
+{
+  BPFtrace bpftrace;
+  parse("struct a { int a; struct b b; };", bpftrace, 1);
 }
 
 } // namespace clang_parser


### PR DESCRIPTION
Fail in case there's unresolved type in definitions

When we have undefined struct, we won't fail and continue
with wrong struct definitions, like:

```
  # cat test.bt
  struct a { 
    int a;
    int b;
    struct c c;
  };  
  ... 
  # bpftrace test.bt
  definitions.h:4:14: error: field has incomplete type 'struct c'
  definitions.h:4:12: note: forward declaration of 'struct c'
  Attaching 1 probe...

```
The fields in 'struct a' will have zero offset and provide wrong data.

Making bpftrace to fail in this case with:

```
  # bpftrace test.bt
  definitions.h:4:14: error: field has incomplete type 'struct c'
  definitions.h:4:12: note: forward declaration of 'struct c'
  Can't get size of 'struct a::c', please provide proper definiton.
```

v3 changes:
  - use the default argument in test

v2 changes:
  - check for ClangParser::parse result in existing tests
  - added test for ClangParser::parse failure

Fixes: #469