### PR TITLE
Fix anonymous struct parsing

### DIFF
--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -88,7 +88,7 @@ RUN bpftrace -e "$(echo "#include <lol/no.h>"; echo "BEGIN { exit(); }")" 2>&1
 EXPECT file not found
 TIMEOUT 1
 
-NAME defines beginning with underscore are allowed
+NAME defines work
 RUN bpftrace -e "$(echo '#define _UNDERSCORE 314'; echo 'BEGIN { printf("%d\n", _UNDERSCORE); exit(); }')"
 EXPECT 314
 TIMEOUT 1


### PR DESCRIPTION
Found some bugs while trying to improve the unit tests.

Anonymous structs were having their sizes set incorrectly.

Bring union casting syntax in line with struct's syntax, although
we'll probably want to change this syntax in the future.

This change also simplifies the logic for handling indirect/anonymous
structs and makes our internal naming more in line with Clang's.