### PR TITLE
Fix some bugs with positional parameters

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -41,8 +41,9 @@ public:
 
 class PositionalParameter : public Expression {
 public:
-  explicit PositionalParameter(long n) : n(n) { is_literal = true; }
+  explicit PositionalParameter(long n) : n(n) {}
   long n;
+  bool is_in_str = false;
 
   void accept(Visitor &v) override;
 };

--- a/src/ast/printer.cpp
+++ b/src/ast/printer.cpp
@@ -15,7 +15,7 @@ void Printer::visit(Integer &integer)
 void Printer::visit(PositionalParameter &param)
 {
   std::string indent(depth_, ' ');
-  out_ << indent << "builtin: $" << param.n << std::endl;
+  out_ << indent << "param: $" << param.n << std::endl;
 }
 
 void Printer::visit(String &string)

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -67,7 +67,6 @@ private:
   void check_stack_call(Call &call, Type type);
 
   Probe *probe_;
-  Call *call_;
   std::map<std::string, SizedType> variable_val_;
   std::map<std::string, SizedType> map_val_;
   std::map<std::string, MapKey> map_key_;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -588,9 +588,7 @@ void BPFtrace::add_param(const std::string &param)
 
 std::string BPFtrace::get_param(size_t i) const
 {
-  if (i > 0 && i < params_.size() + 1)
-      return params_[i - 1];
-  return "0";
+  return params_.at(i-1);
 }
 
 void perf_event_lost(void *cb_cookie __attribute__((unused)), uint64_t lost)

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -45,7 +45,11 @@ TEST(Parser, builtin_variables)
   test("kprobe:f { func }", "Program\n kprobe:f\n  builtin: func\n");
   test("kprobe:f { probe }", "Program\n kprobe:f\n  builtin: probe\n");
   test("kprobe:f { args }", "Program\n kprobe:f\n  builtin: args\n");
-  test("kprobe:f { $1 }", "Program\n kprobe:f\n  builtin: $1\n");
+}
+
+TEST(Parser, positional_param)
+{
+  test("kprobe:f { $1 }", "Program\n kprobe:f\n  param: $1\n");
 }
 
 TEST(Parser, comment)

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -85,7 +85,6 @@ TEST(semantic_analyser, builtin_variables)
   test("kretprobe:f { retval }", 0);
   test("kprobe:f { func }", 0);
   test("kprobe:f { probe }", 0);
-  test("kprobe:f { $1 }", 0);
   test("tracepoint:a:b { args }", 0);
   test("kprobe:f { fake }", 1);
 }
@@ -774,9 +773,15 @@ TEST(semantic_analyser, probe_short_name)
 
 TEST(semantic_analyser, positional_parameters)
 {
-  // $1 won't be defined, will be tested more in runtime.
-  test("kprobe:f { printf(\"%d\", $1); }", 0);
-  test("kprobe:f { printf(\"%s\", str($1)); }", 0);
+  BPFtrace bpftrace;
+  bpftrace.add_param("123");
+  bpftrace.add_param("hello");
+
+  test(bpftrace, "kprobe:f { printf(\"%d\", $1); }", 0);
+  test(bpftrace, "kprobe:f { printf(\"%s\", str($1)); }", 10);
+
+  test(bpftrace, "kprobe:f { printf(\"%s\", str($2)); }", 0);
+  test(bpftrace, "kprobe:f { printf(\"%d\", $2); }", 10);
 }
 
 TEST(semantic_analyser, macros)


### PR DESCRIPTION
This invalid script used to compile:
    bpftrace -e 'BEGIN { str(0); @x = $1 }' a
Now bpftrace correctly recognises that $1 is not inside the str() call

This script did not function correctly since "234" was
treated as a numeric value despite being inside str():
    bpftrace -e 'BEGIN { @x = str($1) }' 234
I've just disabled using numeric values in str() because the
codegen is not set up for it, although this is something that
should be valid.

Positional parameters are no longer marked as literals because we're
not set up for this and it resulted some dodgy memory accesses. We
probably do want them to be capable of being used as literals, but
more work is required to support that.