### PR TITLE
 tests: fix and improve runtime tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -103,10 +103,13 @@ add_test(NAME runtime_test COMMAND ./runtime-tests.sh)
 
 # Compile all testprograms, one per .c file for runtime testing
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testprogs/)
-file(GLOB testprogs testprogs/*)
+file(GLOB testprogs testprogs/*.c)
 foreach(testprog ${testprogs})
   get_filename_component(bin_name ${testprog} NAME_WE)
   add_executable (${bin_name} ${testprog})
+  if(HAVE_SYSTEMTAP_SYS_SDT_H)
+    target_compile_definitions(${bin_name} PRIVATE HAVE_SYSTEMTAP_SYS_SDT_H)
+  endif(HAVE_SYSTEMTAP_SYS_SDT_H)
   set_target_properties( ${bin_name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testprogs/ COMPILE_FLAGS "-g -O0")
 endforeach()
 

--- a/tests/parser.py
+++ b/tests/parser.py
@@ -41,6 +41,8 @@ class TestParser(object):
         test_suite = file_name.split('/')[-1]
         with open (file_name, 'r') as file:
             for line in file.readlines():
+                if line.startswith("#"):
+                    continue
                 if line != '\n':
                     test_lines.append(line)
                 else:

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -89,6 +89,6 @@ EXPECT file not found
 TIMEOUT 1
 
 NAME defines work
-RUN bpftrace -e "$(echo '#define _UNDERSCORE 314'; echo 'BEGIN { printf("%d\n", _UNDERSCORE); exit(); }')"
+RUN bpftrace -e "$(echo '#define _UNDERSCORE 314'; echo 'BEGIN { printf("%d\\n", _UNDERSCORE); exit(); }')"
 EXPECT 314
 TIMEOUT 1

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -2,91 +2,126 @@ NAME "usdt probes - list probes by file"
 RUN bpftrace -l 'usdt:./testprogs/usdt_test'
 EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe
 TIMEOUT 5
+REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - list probes by pid"
 RUN bpftrace -l 'usdt:*' -p $(pidof usdt_test)
 EXPECT usdt_test:tracetest:testprobe
 TIMEOUT 5
-BEFORE (./testprogs/usdt_test &);
+BEFORE ./testprogs/usdt_test
+REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - filter probes by file on provider"
 RUN bpftrace -l 'usdt:./testprogs/usdt_test:tracetest2:*'
 EXPECT usdt:./testprogs/usdt_test:tracetest2:testprobe2
 TIMEOUT 5
+REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - filter probes by pid on provider"
 RUN bpftrace -l 'usdt:*:tracetest2:*' -p $(pidof usdt_test)
 EXPECT usdt_test:tracetest2:testprobe2
 TIMEOUT 5
-BEFORE (./testprogs/usdt_test &);
+BEFORE ./testprogs/usdt_test
+REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - filter probes by file and wildcard probe name"
 RUN bpftrace -l 'usdt:./testprogs/usdt_test:tracetest:test*'
 EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe2
 TIMEOUT 5
+REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - filter probes by pid and wildcard probe name"
 RUN bpftrace -l 'usdt:*:tracetest:test*' -p $(pidof usdt_test)
 EXPECT usdt_test:tracetest:testprobe2
 TIMEOUT 5
-BEFORE (./testprogs/usdt_test &);
+BEFORE ./testprogs/usdt_test
+REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - attach to fully specified probe by file"
 RUN bpftrace -e 'usdt:./testprogs/usdt_test:tracetest:testprobe { printf("here\n" ); exit(); }'
 EXPECT here
 TIMEOUT 5
-BEFORE (./testprogs/usdt_test &);
+BEFORE ./testprogs/usdt_test
+REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - attach to fully specified probe by pid"
 RUN bpftrace -e 'usdt::tracetest:testprobe { printf("here\n" ); exit(); }' -p $(pidof usdt_test)
 EXPECT here
 TIMEOUT 5
-BEFORE (./testprogs/usdt_test &);
+BEFORE ./testprogs/usdt_test
+REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - all probes by wildcard and file"
 RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("here\n" ); exit(); }'
 EXPECT Attaching 3 probes...
 TIMEOUT 5
-BEFORE (./testprogs/usdt_test &);
+BEFORE ./testprogs/usdt_test
+REQUIRES ./testprogs/usdt_test should_not_skip
 
+# TODO(mmarchini): re-enable this test
+# This test has two problems: it relies on the latest version of bcc and it
+# assumes USDTs are coming only from the binary. On Ubuntu, glibc is built with
+# USDT support, which means it will attach to 43 probes instead of 3. Before
+# re-enabling this test, we should:
+#  - Skip if bcc doesn't support multiple probes with the same name
+#  - Fix https://github.com/iovisor/bpftrace/issues/565#issuecomment-496731112
+#    and https://github.com/iovisor/bpftrace/issues/688
 NAME "usdt probes - all probes by wildcard and pid"
 RUN bpftrace -e 'usdt:* { printf("here\n" ); exit(); }' -p $(pidof usdt_test)
 EXPECT Attaching 3 probes...
 TIMEOUT 5
-BEFORE (./testprogs/usdt_test &);
+BEFORE ./testprogs/usdt_test
+REQUIRES bash -c "exit 1"
+# REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - attach to probe on multiple providers by wildcard and file"
 RUN bpftrace -e 'usdt:./testprogs/usdt_test::*probe2 { printf("here\n" ); exit(); }'
 EXPECT Attaching 2 probes...
 TIMEOUT 5
-BEFORE (./testprogs/usdt_test &);
+BEFORE ./testprogs/usdt_test
+REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - attach to probe on multiple providers by wildcard and pid"
 RUN bpftrace -e 'usdt:::*probe2 { printf("here\n" ); exit(); }' -p $(pidof usdt_test)
 EXPECT Attaching 2 probes...
 TIMEOUT 5
-BEFORE (./testprogs/usdt_test &);
+BEFORE ./testprogs/usdt_test
+REQUIRES ./testprogs/usdt_test should_not_skip
 
+# TODO(mmarchini): re-enable this test
+# This test relies on the latest version of bcc. Before re-enabling this test,
+# we should:
+#  - Skip if bcc doesn't support multiple probes with the same name
 NAME "usdt probes - attach to probe with args by file"
 RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("%s\n", str(arg1) ); exit(); }'
 EXPECT Hello world
 TIMEOUT 5
-BEFORE (./testprogs/usdt_test &);
+BEFORE ./testprogs/usdt_test
+REQUIRES bash -c "exit 1"
+# REQUIRES ./testprogs/usdt_test should_not_skip
 
+# TODO(mmarchini): re-enable this test
+# This test relies on the latest version of bcc. Before re-enabling this test,
+# we should:
+#  - Skip if bcc doesn't support multiple probes with the same name
 NAME "usdt probes - attach to probe with args by pid"
 RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("%s\n", str(arg1) ); exit(); }' -p $(pidof usdt_test)
 EXPECT Hello world
 TIMEOUT 5
-BEFORE (./testprogs/usdt_test &);
+BEFORE ./testprogs/usdt_test
+REQUIRES bash -c "exit 1"
+# REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - attach to probe with probe builtin and args by file"
 RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }'
 EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe
 TIMEOUT 5
-BEFORE (./testprogs/usdt_test &);
+BEFORE ./testprogs/usdt_test
+REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - attach to probe with probe builtin and args by pid"
 RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }' -p $(pidof usdt_test)
 EXPECT usdt_test:tracetest:testprobe
 TIMEOUT 5
-BEFORE (./testprogs/usdt_test &);
+BEFORE ./testprogs/usdt_test
+REQUIRES ./testprogs/usdt_test should_not_skip

--- a/tests/testprogs/uprobe_test.c
+++ b/tests/testprogs/uprobe_test.c
@@ -6,6 +6,8 @@ int function1()
 }
 
 int main(int argc, char **argv) {
-  usleep(1000000);
-  return function1();
+  while (1) {
+    function1();
+  }
+  return 0;
 }

--- a/tests/testprogs/usdt_test.c
+++ b/tests/testprogs/usdt_test.c
@@ -19,7 +19,16 @@ myclock() {
 
 int
 main(int argc, char **argv) {
-  usleep(500000);
-    myclock();
+  if (argc > 1)
+  // If we don't have Systemtap headers, we should skip USDT tests. Returning 1 can be used as validation in the REQUIRE
+#ifndef HAVE_SYSTEMTAP_SYS_SDT_H
+    return 1;
+#else
     return 0;
+#endif
+
+  while (1) {
+    myclock();
+  }
+  return 0;
 }

--- a/tests/tools-parsing-test.sh
+++ b/tests/tools-parsing-test.sh
@@ -10,11 +10,11 @@ EXIT_STATUS=0;
 
 # TODO(mmarchini) get path from cmake
 for f in $(ls ../../tools/*.bt); do
-  if $BPFTRACE_EXECUTABLE -d $f 2>/dev/null >/dev/null; then
+  if $BPFTRACE_EXECUTABLE --unsafe -d $f 2>/dev/null >/dev/null; then
     echo "$f    passed"
   else
     echo "$f    failed";
-    $BPFTRACE_EXECUTABLE -d $f;
+    $BPFTRACE_EXECUTABLE --unsafe -d $f;
     EXIT_STATUS=1;
   fi
 done


### PR DESCRIPTION
  - Properly pass HAVE_SYSTEMTAP_SYS_SDT_H to testprogs
  - Allow comments in the test definition
  - Skip USDT tests if sys/sdt.h is not present
  - Skip a couple of USDT tests that are bcc-version dependant
  - Don't sleep on usdt and uprobe test programs, so we don't have to
    wait unnecessarily and also avoid possible racing condition issues
  - Fix decoding issue on our test runner
  - Use process groups to send kill signals (just sending a kill won't
    work, since our Popen subprocesses are using shell=True)

Should merge #678 first.