### PR TITLE
Fix attaching to USDT probes with semaphore and USDT runtime tests

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -481,7 +481,6 @@ void AttachedProbe::attach_usdt(int pid)
   probe_.path = std::get<USDT_PATH_INDEX>(u);
 
   err = bcc_usdt_get_location(ctx, probe_.ns.c_str(), probe_.attach_point.c_str(), 0, &loc);
-  bcc_usdt_close(ctx);
   if (err)
     throw std::runtime_error("Error finding location for probe: " + probe_.name);
   probe_.loc = loc.address;

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -125,3 +125,10 @@ EXPECT usdt_test:tracetest:testprobe
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
+
+NAME "usdt probes - attach to probe with semaphore"
+RUN bpftrace -e 'usdt::tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }' -p $(pidof usdt_semaphore_test)
+EXPECT tracetest_testprobe_semaphore: 1
+TIMEOUT 5
+BEFORE ./testprogs/usdt_semaphore_test
+REQUIRES ./testprogs/usdt_semaphore_test should_not_skip

--- a/tests/testprogs/usdt_semaphore_test.c
+++ b/tests/testprogs/usdt_semaphore_test.c
@@ -1,0 +1,38 @@
+#define _SDT_HAS_SEMAPHORES 1
+
+#ifdef HAVE_SYSTEMTAP_SYS_SDT_H
+#include <sys/sdt.h>
+#else
+#define DTRACE_PROBE2(a, b, c, d) (void)0
+#endif
+#include <sys/time.h>
+#include <unistd.h>
+#include <stdio.h>
+
+__extension__ unsigned short tracetest_testprobe_semaphore __attribute__ ((unused)) __attribute__ ((section (".probes"))) __attribute__ ((visibility ("hidden")));
+
+static long
+myclock() {
+  char buffer[100];
+  struct timeval tv;
+  gettimeofday(&tv, NULL);
+  sprintf(buffer, "tracetest_testprobe_semaphore: %d\n", tracetest_testprobe_semaphore);
+  DTRACE_PROBE2(tracetest,  testprobe,  tv.tv_sec, buffer);
+  return tv.tv_sec;
+}
+
+int
+main(int argc, char **argv) {
+  if (argc > 1)
+  // If we don't have Systemtap headers, we should skip USDT tests. Returning 1 can be used as validation in the REQUIRE
+#ifndef HAVE_SYSTEMTAP_SYS_SDT_H
+    return 1;
+#else
+    return 0;
+#endif
+
+  while (1) {
+    myclock();
+  }
+  return 0;
+}


### PR DESCRIPTION
This should fix #612 which @anelson correctly identified the issue in his detailed bug report.

I erroneously added code to close the USDT context in an inappropriate spot, which broke the semaphore handling functionality.

I've added a runtime test that will prevent this issue in the future, as well as fixed an issue with runtime tests for USDT that was introduced in #610 where the macro wasn't actually defined, which caused runtime tests to fail even on platforms with `sys/sdt.h` (cc @jasonk000)

@ajor can you take a look please?