### PR TITLE
Allow `probe` builtin for `BEGIN` and `END` probes

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1301,7 +1301,12 @@ void CodegenLLVM::visit(Probe &probe)
     for (auto attach_point : *probe.attach_points) {
       current_attach_point_ = attach_point;
 
-      auto matches = bpftrace_.find_wildcard_matches(*attach_point);
+      std::set<std::string> matches;
+      if (attach_point->provider == "BEGIN" || attach_point->provider == "END") {
+        matches.insert(attach_point->provider);
+      } else {
+        matches = bpftrace_.find_wildcard_matches(*attach_point);
+      }
 
       tracepoint_struct_ = "";
       for (auto &match_ : matches) {
@@ -1329,6 +1334,8 @@ void CodegenLLVM::visit(Probe &probe)
 
           // Set the probe identifier so that we can read arguments later
           attach_point->usdt = USDTHelper::find(bpftrace_.pid_, attach_point->target, ns, func_id);
+        } else if (attach_point->provider == "BEGIN" || attach_point->provider == "END") {
+          probefull_ = attach_point->provider;
         } else {
           probefull_ = attach_point->name(full_func_id);
         }

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -79,6 +79,12 @@ EXPECT SUCCESS probe kprobe:do_nanosleep
 TIMEOUT 5
 AFTER sleep 0.1
 
+NAME begin probe
+RUN bpftrace -v -e 'BEGIN { printf("%s", probe);exit(); } END{printf("-%s\n", probe); }'
+EXPECT ^BEGIN-END$
+TIMEOUT 5
+AFTER sleep 0.1
+
 NAME curtask
 RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", curtask); exit(); }'
 EXPECT SUCCESS curtask -?[0-9][0-9]*


### PR DESCRIPTION
The `BEGIN` and `END` probes need a bit of special treatment as wildcard
expansions isn't possible for them.

This fixes #672