### PR TITLE
Fix typo in type mismatch error message

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -661,7 +661,7 @@ void SemanticAnalyser::visit(Binop &binop)
       // allow integer to cast pointer comparisons (eg, ptr != 0):
       !(lhs == Type::cast && rhs == Type::integer) &&
       !(lhs == Type::integer && rhs == Type::cast)) {
-      err_ << "TYpe mismatch for '" << opstr(binop) << "': ";
+      err_ << "Type mismatch for '" << opstr(binop) << "': ";
       err_ << "comparing '" << lhs << "' ";
       err_ << "with '" << rhs << "'" << std::endl;
     }


### PR DESCRIPTION
Output of test command:
```
[jay@laythe build]$ sudo ./src/bpftrace -e 'BEGIN { @kerbin = nsecs - @laythe[1]; }'                                                                                                                                                                 [jay/typeerror-typo] [9472]  9:29AM
Undefined map: @laythe
Type mismatch for '-': comparing 'integer' with 'none'
```
