### PR TITLE
Fix k[ret]probe_order runtime tests

### DIFF
--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -17,7 +17,7 @@ NAME kprobe_order
 RUN bpftrace -v runtime/scripts/kprobe_order.bt
 EXPECT first second
 TIMEOUT 5
-AFTER /bin/bash -c : ; /bin/bash -c :
+AFTER /bin/bash -c "sleep 1e-6"; /bin/bash -c "sleep 1e-6"
 
 NAME kretprobe
 RUN bpftrace -v -e 'kretprobe:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
@@ -38,7 +38,7 @@ NAME kretprobe_order
 RUN bpftrace -v runtime/scripts/kretprobe_order.bt
 EXPECT first second
 TIMEOUT 5
-AFTER /bin/bash -c : ; /bin/bash -c :
+AFTER /bin/bash -c "sleep 1e-6"; /bin/bash -c "sleep 1e-6"
 
 NAME uprobe
 RUN bpftrace -v -e 'uprobe:/bin/bash:echo_builtin { printf("arg0: %d\n", arg0); exit();}'

--- a/tests/runtime/scripts/kprobe_order.bt
+++ b/tests/runtime/scripts/kprobe_order.bt
@@ -1,4 +1,4 @@
-kprobe:sys_execve
+kprobe:hrtimer_nanosleep
 {
   @probe1_ready = 1;
   if (@go == 1) {
@@ -6,7 +6,7 @@ kprobe:sys_execve
   }
 }
 
-kprobe:sys_execve
+kprobe:hrtimer_nanosleep
 {
   @probe2_ready = 1;
   if (@go == 1) {
@@ -15,7 +15,7 @@ kprobe:sys_execve
   }
 }
 
-kprobe:sys_execve
+kprobe:hrtimer_nanosleep
 {
   // Make sure all probes are attached before letting them print anything
   // so that the output we get is all from the same event.

--- a/tests/runtime/scripts/kretprobe_order.bt
+++ b/tests/runtime/scripts/kretprobe_order.bt
@@ -1,4 +1,4 @@
-kretprobe:sys_execve
+kretprobe:hrtimer_nanosleep
 {
   @probe1_ready = 1;
   if (@go == 1) {
@@ -6,7 +6,7 @@ kretprobe:sys_execve
   }
 }
 
-kretprobe:sys_execve
+kretprobe:hrtimer_nanosleep
 {
   @probe2_ready = 1;
   if (@go == 1) {
@@ -15,7 +15,7 @@ kretprobe:sys_execve
   }
 }
 
-kretprobe:sys_execve
+kretprobe:hrtimer_nanosleep
 {
   // Make sure all probes are attached before letting them print anything
   // so that the output we get is all from the same event.


### PR DESCRIPTION
On my system, I was getting

    Attaching kprobe:sys_execve
    cannot attach kprobe, probe entry may not exist
    Error attaching probe: 'kprobe:sys_execve'

It looks like commit e145242ea0df6b7d2 in the kernel changed
how syscall stubs are named. That was about a year ago so it
makes sense that now we're seeing some of that newer code being
run around the world.

This patch moves the kprobe rutime tests to use a more stable
kernel interface.