### PR TITLE
Fix call.system runtime test

### DIFF
--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -41,7 +41,7 @@ TIMEOUT 5
 AFTER sleep 0.1
 
 NAME system
-RUN bpftrace --unsafe -v -e 'i:ms:1 { system("echo 'ok_system'"); exit();}'
+RUN bpftrace --unsafe -v -e 'i:ms:100 { system("echo 'ok_system'"); exit();}'
 EXPECT ok_system
 TIMEOUT 5
 


### PR DESCRIPTION
Recent changes to the exit() builtin have made the action
async. I haven't fully debugged the issue yet but I have
theories and repro cases that demonstrate that it's likely
heavy loads can delay the async exit.

For now, decrease the amount of load for this test.