### PR TITLE
Default -d and -dd output to stdout

### DIFF
--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -60,7 +60,7 @@ public:
 
   void createLog2Function();
   void createLinearFunction();
-  std::unique_ptr<BpfOrc> compile(DebugLevel debug=DebugLevel::kNone, std::ostream &out=std::cerr);
+  std::unique_ptr<BpfOrc> compile(DebugLevel debug=DebugLevel::kNone, std::ostream &out=std::cout);
 
 private:
   Node *root_;


### PR DESCRIPTION
Previously, AST/Structs were printed to stdout and the IR was printed to stderr. Now, the IR is printed to stdout as well.

Errors are still printed to stderr, as getting them alone may be useful in building syntax checkers.

Since 'out' is only used for printing the debug info in this function, this seems safe to change to me.

Test Commands:
```
[jay@eve build]$ sudo ./src/bpftrace -d /tmp/python.bt >/dev/null
[jay@eve build]$ sudo ./src/bpftrace -dd /tmp/python.bt >/dev/null
[jay@eve build]$ sudo ./src/bpftrace -d /tmp/broken.bt >/dev/null
5.10-14: syntax error, unexpected identifier, expecting }
[jay@eve build]$ sudo ./src/bpftrace -dd /tmp/broken.bt >/dev/null
5.10-14: syntax error, unexpected identifier, expecting }
```


Longer term, it would be nice to have `-d` not require root. Since it dosen't insert probes, I think it should be possible, right? Doing this would allow for a trivial flycheck/flymake plugin to syntax-check bpftrace files.
