### PR TITLE
Suppress deprecated builtins warnings during unit tests

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -149,6 +149,13 @@ void USDTHelper::read_probes_for_path(const std::string &path)
   provider_cache_loaded = true;
 }
 
+void suppress_deprecation_warnings()
+{
+  for (auto& item : DEPRECATED_LIST) {
+    item.show_warning = false;
+  }
+}
+
 bool get_uint64_env_var(const std::string &str, uint64_t &dest)
 {
   if (const char* env_p = std::getenv(str.c_str()))

--- a/src/utils.h
+++ b/src/utils.h
@@ -55,6 +55,10 @@ static std::vector<DeprecatedName> DEPRECATED_LIST =
   { "sym", "ksym"},
 };
 
+// HACK to prevent warnings from being printed out while unit tests
+// run.
+void suppress_deprecation_warnings();
+
 static std::vector<std::string> UNSAFE_BUILTIN_FUNCS =
 {
   "system",

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -5,6 +5,7 @@
 #include "driver.h"
 #include "mocks.h"
 #include "semantic_analyser.h"
+#include "utils.h"
 
 namespace bpftrace {
 namespace test {
@@ -19,6 +20,7 @@ void test(
     int expected_result=0,
     bool safe_mode = true)
 {
+  suppress_deprecation_warnings();
   bpftrace.safe_mode = safe_mode;
   ASSERT_EQ(driver.parse_str(input), 0);
 


### PR DESCRIPTION
This PR addresses #457 and #455.

Although the unit tests properly stubbed out the output object (responsible for writing to stderr),
the function [`is_deprecated`](https://github.com/iovisor/bpftrace/blob/master/src/utils.cpp#L366-L371) still prints out the warnings to stderr.

I think the ideal fix here would be to move the `is_deprecated` check into the semantic analyser and have it rewrite the AST with the new names. Right now `is_deprecated` is called as the AST gets built, so it is hard alter the behaviour.

This PR works, but it is kind of hacky.

I'm looking for feedback on which approach to take.

---

## Testing

No warning messages are output during the unit tests run.

### codegen.builtin_stack

```
$ sudo ./tests/bpftrace_test --gtest_filter=codegen.builtin_stack
Note: Google Test filter = codegen.builtin_stack
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from codegen
[ RUN      ] codegen.builtin_stack
[       OK ] codegen.builtin_stack (4 ms)
[----------] 1 test from codegen (4 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (4 ms total)
[  PASSED  ] 1 test.
```

### semantic_analyser.builtin_functions

```
$ sudo ./tests/bpftrace_test --gtest_filter=semantic_analyser.builtin_functions
Note: Google Test filter = semantic_analyser.builtin_functions
[==========] Running 1 test from 1 test case.
[----------] Global test environment set-up.
[----------] 1 test from semantic_analyser
[ RUN      ] semantic_analyser.builtin_functions
[       OK ] semantic_analyser.builtin_functions (3 ms)
[----------] 1 test from semantic_analyser (3 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test case ran. (3 ms total)
[  PASSED  ] 1 test.
``` 