### PR TITLE
Clean up includes in clang_parser

### DIFF
--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -1,11 +1,9 @@
-#include <clang-c/Index.h>
 #include <iostream>
 #include <string.h>
 
 #include "llvm/Config/llvm-config.h"
 
 #include "ast.h"
-#include "bpftrace.h"
 #include "clang_parser.h"
 #include "types.h"
 #include "utils.h"

--- a/src/clang_parser.h
+++ b/src/clang_parser.h
@@ -1,15 +1,11 @@
 #pragma once
 
 #include <clang-c/Index.h>
-
-#include "struct.h"
 #include "bpftrace.h"
 
 namespace bpftrace {
 
 namespace ast { class Program; }
-
-using StructMap = std::map<std::string, Struct>;
 
 class ClangParser
 {

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -2,10 +2,13 @@
 #include "clang_parser.h"
 #include "driver.h"
 #include "bpftrace.h"
+#include "struct.h"
 
 namespace bpftrace {
 namespace test {
 namespace clang_parser {
+
+using StructMap = std::map<std::string, Struct>;
 
 static void parse(const std::string &input, BPFtrace &bpftrace, bool result = true)
 {


### PR DESCRIPTION
* Dedup includes that are done in both clang_parser.h and
clang_parser.cpp
* Move includes only used for tests into test file

An added benefit is that it should improve compile times.