### PR TITLE
improve LLVM IR typing and fix the OOM issue reported in #528

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ matrix:
     # String comparisons and args multiple tracepoints tests are the exception
     # - they are just broken in debug builds.
     - name: "Static LLVM 5 Debug"
-      env: LLVM_VERSION=5.0 BASE=alpine TYPE=Debug STATIC_LINKING=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*:codegen.string_equal_comparison:codegen.string_not_equal_comparison:codegen.args_multiple_tracepoints*"
+      env: LLVM_VERSION=5.0 BASE=alpine TYPE=Debug STATIC_LINKING=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*:codegen.string_equal_comparison:codegen.string_not_equal_comparison:codegen.args_multiple_tracepoints*:codegen.logical_and_or_different_type"
     - name: "Static LLVM 5 Release"
       env: LLVM_VERSION=5.0 BASE=alpine TYPE=Release STATIC_LINKING=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*:codegen.args_multiple_tracepoints*"
 

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -991,7 +991,12 @@ void CodegenLLVM::visit(FieldAccess &acc)
     // The struct we are reading from has not been pulled into BPF-memory,
     // so expr_ will contain an external pointer to the start of the struct
 
-    Value *src = b_.CreateAdd(expr_, b_.getInt64(field.offset));
+    // LLVM doesn't like Binops with different types, so we convert our pointer
+    // to integer and then back to pointer.
+    // Value *src = b_.CreateAdd(expr_, b_.getInt64(field.offset));
+    Value *src = b_.CreatePtrToInt(expr_, b_.getInt64Ty());
+    src = b_.CreateAdd(src, b_.getInt64(field.offset));
+    src = b_.CreateIntToPtr(src, b_.getInt8PtrTy());
 
     if (field.type.type == Type::cast && !field.type.is_pointer)
     {

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1684,7 +1684,8 @@ void CodegenLLVM::createFormatStringCall(Call &call, int &id, CallArgs &call_arg
     if (arg.type.IsArray())
       b_.CREATE_MEMCPY(offset, expr_, arg.type.size, 1);
     else
-      b_.CreateStore(expr_, offset);
+      // Promote to 64-bits to match `offset` type
+      b_.CreateStore(b_.CreateIntCast(expr_, b_.getInt64Ty(), false), offset);
 
     if (expr_deleter_)
       expr_deleter_();

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -162,7 +162,7 @@ CallInst *IRBuilderBPF::CreateGetJoinMap(Value *ctx __attribute__((unused)))
 
   FunctionType *lookup_func_type = FunctionType::get(
       getInt8PtrTy(),
-      {getInt8PtrTy(), getInt8PtrTy()},
+      {getInt8PtrTy(), key->getType()},
       false);
   PointerType *lookup_func_ptr_type = PointerType::get(lookup_func_type, 0);
   Constant *lookup_func = ConstantExpr::getCast(
@@ -181,7 +181,7 @@ Value *IRBuilderBPF::CreateMapLookupElem(Map &map, AllocaInst *key)
   // Return: Map value or NULL
   FunctionType *lookup_func_type = FunctionType::get(
       getInt8PtrTy(),
-      {getInt8PtrTy(), getInt8PtrTy()},
+      {getInt8PtrTy(), key->getType()},
       false);
   PointerType *lookup_func_ptr_type = PointerType::get(lookup_func_type, 0);
   Constant *lookup_func = ConstantExpr::getCast(
@@ -233,7 +233,7 @@ void IRBuilderBPF::CreateMapUpdateElem(Map &map, AllocaInst *key, Value *val)
   // Return: 0 on success or negative error
   FunctionType *update_func_type = FunctionType::get(
       getInt64Ty(),
-      {getInt8PtrTy(), getInt8PtrTy(), getInt8PtrTy(), getInt64Ty()},
+      {getInt8PtrTy(), key->getType(), val->getType(), getInt64Ty()},
       false);
   PointerType *update_func_ptr_type = PointerType::get(update_func_type, 0);
   Constant *update_func = ConstantExpr::getCast(
@@ -267,7 +267,7 @@ void IRBuilderBPF::CreateProbeRead(AllocaInst *dst, size_t size, Value *src)
   // Return: 0 on success or negative error
   FunctionType *proberead_func_type = FunctionType::get(
       getInt64Ty(),
-      {getInt8PtrTy(), getInt64Ty(), getInt8PtrTy()},
+      {dst->getType(), getInt64Ty(), src->getType()},
       false);
   PointerType *proberead_func_ptr_type = PointerType::get(proberead_func_type, 0);
   Constant *proberead_func = ConstantExpr::getCast(

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -69,16 +69,18 @@ AllocaInst *IRBuilderBPF::CreateAllocaBPFInit(const SizedType &stype, const std:
   else
     SetInsertPoint(&entry_block.front());
 
-  llvm::Type *ty = GetType(stype);
-  AllocaInst *alloca = CreateAllocaBPF(ty, nullptr, name);
+  AllocaInst *alloca;
 
-  if (!stype.IsArray())
+  if (!stype.IsArray() && !stype.is_pointer)
   {
+    llvm::Type *ty = GetType(stype);
+    alloca = CreateAllocaBPF(ty, nullptr, name);
     CreateStore(getInt64(0), alloca);
   }
   else
   {
-    CreateMemSet(alloca, getInt64(0), stype.size, 1);
+    alloca = CreateAllocaBPF(getIntPtrTy(module_.getDataLayout()), nullptr, name);
+    CreateMemSet(alloca, getInt8(0), stype.size, 1);
   }
 
   restoreIP(ip);

--- a/src/bpforc.h
+++ b/src/bpforc.h
@@ -61,7 +61,7 @@ public:
   void compileModule(std::unique_ptr<Module> M)
   {
     auto mod = addModule(move(M));
-    CompileLayer.emitAndFinalize(mod);
+    cantFail(CompileLayer.emitAndFinalize(mod));
   }
 
   ModuleHandle addModule(std::unique_ptr<Module> M) {

--- a/tests/codegen/args_multiple_tracepoints.cpp
+++ b/tests/codegen/args_multiple_tracepoints.cpp
@@ -79,13 +79,15 @@ entry:
   %2 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %2, i8 0, i64 64, i1 false)
-  %3 = add i8* %0, i64 16
-  %4 = bitcast i64* %_tracepoint_syscalls_sys_enter_open.filename to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_open.filename, i64 8, i8* %3)
-  %5 = load i64, i64* %_tracepoint_syscalls_sys_enter_open.filename, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %5)
+  %3 = ptrtoint i8* %0 to i64
+  %4 = add i64 %3, 16
+  %5 = inttoptr i64 %4 to i8*
+  %6 = bitcast i64* %_tracepoint_syscalls_sys_enter_open.filename to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_open.filename, i64 8, i8* %5)
+  %7 = load i64, i64* %_tracepoint_syscalls_sys_enter_open.filename, align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %7)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %1, i8* nonnull align 1 %2, i64 64, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [64 x i8]* nonnull %"@_key")
@@ -93,19 +95,19 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %6 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %6, 1
+  %8 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %8, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %7 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
+  %9 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [64 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   ret i64 0
 }
 
@@ -129,13 +131,15 @@ entry:
   %2 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %2, i8 0, i64 64, i1 false)
-  %3 = add i8* %0, i64 24
-  %4 = bitcast i64* %_tracepoint_syscalls_sys_enter_openat.filename to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_openat.filename, i64 8, i8* %3)
-  %5 = load i64, i64* %_tracepoint_syscalls_sys_enter_openat.filename, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %5)
+  %3 = ptrtoint i8* %0 to i64
+  %4 = add i64 %3, 24
+  %5 = inttoptr i64 %4 to i8*
+  %6 = bitcast i64* %_tracepoint_syscalls_sys_enter_openat.filename to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_openat.filename, i64 8, i8* %5)
+  %7 = load i64, i64* %_tracepoint_syscalls_sys_enter_openat.filename, align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %7)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %1, i8* nonnull align 1 %2, i64 64, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [64 x i8]* nonnull %"@_key")
@@ -143,19 +147,19 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %6 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %6, 1
+  %8 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %8, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %7 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
+  %9 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [64 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   ret i64 0
 }
 

--- a/tests/codegen/args_multiple_tracepoints.cpp
+++ b/tests/codegen/args_multiple_tracepoints.cpp
@@ -189,13 +189,13 @@ entry:
   %5 = inttoptr i64 %4 to i8*
   %6 = bitcast i64* %_tracepoint_syscalls_sys_enter_open.filename to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_open.filename, i64 8, i8* %5)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_open.filename, i64 8, i8* %5)
   %7 = load i64, i64* %_tracepoint_syscalls_sys_enter_open.filename, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %7)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %1, i8* nonnull %2, i64 64, i32 1, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, [64 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, [64 x i8]*)*)(i64 %pseudo, [64 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -210,7 +210,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo1, [64 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [64 x i8]*, i64*, i64)*)(i64 %pseudo1, [64 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   ret i64 0
@@ -241,13 +241,13 @@ entry:
   %5 = inttoptr i64 %4 to i8*
   %6 = bitcast i64* %_tracepoint_syscalls_sys_enter_openat.filename to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_openat.filename, i64 8, i8* %5)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_openat.filename, i64 8, i8* %5)
   %7 = load i64, i64* %_tracepoint_syscalls_sys_enter_openat.filename, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %7)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %1, i8* nonnull %2, i64 64, i32 1, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, [64 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, [64 x i8]*)*)(i64 %pseudo, [64 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -262,7 +262,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo1, [64 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [64 x i8]*, i64*, i64)*)(i64 %pseudo1, [64 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   ret i64 0

--- a/tests/codegen/args_multiple_tracepoints.cpp
+++ b/tests/codegen/args_multiple_tracepoints.cpp
@@ -184,13 +184,15 @@ entry:
   %2 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.memset.p0i8.i64(i8* nonnull %2, i8 0, i64 64, i32 1, i1 false)
-  %3 = add i8* %0, i64 16
-  %4 = bitcast i64* %_tracepoint_syscalls_sys_enter_open.filename to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_open.filename, i64 8, i8* %3)
-  %5 = load i64, i64* %_tracepoint_syscalls_sys_enter_open.filename, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %5)
+  %3 = ptrtoint i8* %0 to i64
+  %4 = add i64 %3, 16
+  %5 = inttoptr i64 %4 to i8*
+  %6 = bitcast i64* %_tracepoint_syscalls_sys_enter_open.filename to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_open.filename, i64 8, i8* %5)
+  %7 = load i64, i64* %_tracepoint_syscalls_sys_enter_open.filename, align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %7)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %1, i8* nonnull %2, i64 64, i32 1, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [64 x i8]* nonnull %"@_key")
@@ -198,19 +200,19 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %6 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %6, 1
+  %8 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %8, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %7 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
+  %9 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [64 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   ret i64 0
 }
 
@@ -234,13 +236,15 @@ entry:
   %2 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.memset.p0i8.i64(i8* nonnull %2, i8 0, i64 64, i32 1, i1 false)
-  %3 = add i8* %0, i64 24
-  %4 = bitcast i64* %_tracepoint_syscalls_sys_enter_openat.filename to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_openat.filename, i64 8, i8* %3)
-  %5 = load i64, i64* %_tracepoint_syscalls_sys_enter_openat.filename, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %5)
+  %3 = ptrtoint i8* %0 to i64
+  %4 = add i64 %3, 24
+  %5 = inttoptr i64 %4 to i8*
+  %6 = bitcast i64* %_tracepoint_syscalls_sys_enter_openat.filename to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_openat.filename, i64 8, i8* %5)
+  %7 = load i64, i64* %_tracepoint_syscalls_sys_enter_openat.filename, align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %7)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %1, i8* nonnull %2, i64 64, i32 1, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [64 x i8]* nonnull %"@_key")
@@ -248,19 +252,19 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %6 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %6, 1
+  %8 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %8, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %7 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
+  %9 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [64 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   ret i64 0
 }
 

--- a/tests/codegen/args_multiple_tracepoints.cpp
+++ b/tests/codegen/args_multiple_tracepoints.cpp
@@ -84,13 +84,13 @@ entry:
   %5 = inttoptr i64 %4 to i8*
   %6 = bitcast i64* %_tracepoint_syscalls_sys_enter_open.filename to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_open.filename, i64 8, i8* %5)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_open.filename, i64 8, i8* %5)
   %7 = load i64, i64* %_tracepoint_syscalls_sys_enter_open.filename, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %7)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %1, i8* nonnull align 1 %2, i64 64, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [64 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, [64 x i8]*)*)(i64 %pseudo, [64 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -105,7 +105,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [64 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [64 x i8]*, i64*, i64)*)(i64 %pseudo1, [64 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   ret i64 0
@@ -136,13 +136,13 @@ entry:
   %5 = inttoptr i64 %4 to i8*
   %6 = bitcast i64* %_tracepoint_syscalls_sys_enter_openat.filename to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_openat.filename, i64 8, i8* %5)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_openat.filename, i64 8, i8* %5)
   %7 = load i64, i64* %_tracepoint_syscalls_sys_enter_openat.filename, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %7)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %1, i8* nonnull align 1 %2, i64 64, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [64 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, [64 x i8]*)*)(i64 %pseudo, [64 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -157,7 +157,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [64 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [64 x i8]*, i64*, i64)*)(i64 %pseudo1, [64 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   ret i64 0
@@ -195,7 +195,7 @@ entry:
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %7)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %1, i8* nonnull %2, i64 64, i32 1, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [64 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, [64 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -210,7 +210,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [64 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo1, [64 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   ret i64 0
@@ -247,7 +247,7 @@ entry:
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %7)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %1, i8* nonnull %2, i64 64, i32 1, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [64 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, [64 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -262,7 +262,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [64 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo1, [64 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   ret i64 0

--- a/tests/codegen/args_multiple_tracepoints_wild.cpp
+++ b/tests/codegen/args_multiple_tracepoints_wild.cpp
@@ -230,12 +230,12 @@ entry:
   %4 = inttoptr i64 %3 to i8*
   %5 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvfrom.flags, i64 8, i8* %4)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvfrom.flags, i64 8, i8* %4)
   %6 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   store i64 %6, i8* %1, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -250,7 +250,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
@@ -271,12 +271,12 @@ entry:
   %4 = inttoptr i64 %3 to i8*
   %5 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvmmsg.flags to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmmsg.flags, i64 8, i8* %4)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmmsg.flags, i64 8, i8* %4)
   %6 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvmmsg.flags, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   store i64 %6, i8* %1, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -291,7 +291,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
@@ -309,12 +309,12 @@ entry:
   %4 = inttoptr i64 %3 to i8*
   %5 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvmsg.flags to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmsg.flags, i64 8, i8* %4)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmsg.flags, i64 8, i8* %4)
   %6 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvmsg.flags, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   store i64 %6, i8* %1, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -329,7 +329,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0

--- a/tests/codegen/args_multiple_tracepoints_wild.cpp
+++ b/tests/codegen/args_multiple_tracepoints_wild.cpp
@@ -98,32 +98,34 @@ entry:
   %"@_key" = alloca [8 x i8], align 8
   %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = add i8* %0, i64 40
-  %3 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvfrom.flags, i64 8, i8* %2)
-  %4 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  store i64 %4, i8* %1, align 8
+  %2 = ptrtoint i8* %0 to i64
+  %3 = add i64 %2, 40
+  %4 = inttoptr i64 %3 to i8*
+  %5 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvfrom.flags, i64 8, i8* %4)
+  %6 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags, align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  store i64 %6, i8* %1, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %5 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %5, 1
+  %7 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %7, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %6 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %8 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
 }
 
@@ -137,32 +139,34 @@ entry:
   %"@_key" = alloca [8 x i8], align 8
   %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = add i8* %0, i64 40
-  %3 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvmmsg.flags to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmmsg.flags, i64 8, i8* %2)
-  %4 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvmmsg.flags, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  store i64 %4, i8* %1, align 8
+  %2 = ptrtoint i8* %0 to i64
+  %3 = add i64 %2, 40
+  %4 = inttoptr i64 %3 to i8*
+  %5 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvmmsg.flags to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmmsg.flags, i64 8, i8* %4)
+  %6 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvmmsg.flags, align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  store i64 %6, i8* %1, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %5 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %5, 1
+  %7 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %7, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %6 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %8 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
 }
 
@@ -173,32 +177,34 @@ entry:
   %"@_key" = alloca [8 x i8], align 8
   %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = add i8* %0, i64 32
-  %3 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvmsg.flags to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmsg.flags, i64 8, i8* %2)
-  %4 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvmsg.flags, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  store i64 %4, i8* %1, align 8
+  %2 = ptrtoint i8* %0 to i64
+  %3 = add i64 %2, 32
+  %4 = inttoptr i64 %3 to i8*
+  %5 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvmsg.flags to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmsg.flags, i64 8, i8* %4)
+  %6 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvmsg.flags, align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  store i64 %6, i8* %1, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %5 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %5, 1
+  %7 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %7, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %6 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %8 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
 }
 

--- a/tests/codegen/args_multiple_tracepoints_wild.cpp
+++ b/tests/codegen/args_multiple_tracepoints_wild.cpp
@@ -103,12 +103,12 @@ entry:
   %4 = inttoptr i64 %3 to i8*
   %5 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvfrom.flags, i64 8, i8* %4)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvfrom.flags, i64 8, i8* %4)
   %6 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   store i64 %6, i8* %1, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -123,7 +123,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
@@ -144,12 +144,12 @@ entry:
   %4 = inttoptr i64 %3 to i8*
   %5 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvmmsg.flags to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmmsg.flags, i64 8, i8* %4)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmmsg.flags, i64 8, i8* %4)
   %6 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvmmsg.flags, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   store i64 %6, i8* %1, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -164,7 +164,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
@@ -182,12 +182,12 @@ entry:
   %4 = inttoptr i64 %3 to i8*
   %5 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvmsg.flags to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmsg.flags, i64 8, i8* %4)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmsg.flags, i64 8, i8* %4)
   %6 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvmsg.flags, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   store i64 %6, i8* %1, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -202,7 +202,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
@@ -235,7 +235,7 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   store i64 %6, i8* %1, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -250,7 +250,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
@@ -276,7 +276,7 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   store i64 %6, i8* %1, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -291,7 +291,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
@@ -314,7 +314,7 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   store i64 %6, i8* %1, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -329,7 +329,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0

--- a/tests/codegen/args_multiple_tracepoints_wild.cpp
+++ b/tests/codegen/args_multiple_tracepoints_wild.cpp
@@ -225,32 +225,34 @@ entry:
   %"@_key" = alloca [8 x i8], align 8
   %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = add i8* %0, i64 40
-  %3 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvfrom.flags, i64 8, i8* %2)
-  %4 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  store i64 %4, i8* %1, align 8
+  %2 = ptrtoint i8* %0 to i64
+  %3 = add i64 %2, 40
+  %4 = inttoptr i64 %3 to i8*
+  %5 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvfrom.flags, i64 8, i8* %4)
+  %6 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags, align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  store i64 %6, i8* %1, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %5 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %5, 1
+  %7 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %7, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %6 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %8 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
 }
 
@@ -264,32 +266,34 @@ entry:
   %"@_key" = alloca [8 x i8], align 8
   %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = add i8* %0, i64 40
-  %3 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvmmsg.flags to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmmsg.flags, i64 8, i8* %2)
-  %4 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvmmsg.flags, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  store i64 %4, i8* %1, align 8
+  %2 = ptrtoint i8* %0 to i64
+  %3 = add i64 %2, 40
+  %4 = inttoptr i64 %3 to i8*
+  %5 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvmmsg.flags to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmmsg.flags, i64 8, i8* %4)
+  %6 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvmmsg.flags, align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  store i64 %6, i8* %1, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %5 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %5, 1
+  %7 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %7, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %6 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %8 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
 }
 
@@ -300,32 +304,34 @@ entry:
   %"@_key" = alloca [8 x i8], align 8
   %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = add i8* %0, i64 32
-  %3 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvmsg.flags to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmsg.flags, i64 8, i8* %2)
-  %4 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvmsg.flags, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  store i64 %4, i8* %1, align 8
+  %2 = ptrtoint i8* %0 to i64
+  %3 = add i64 %2, 32
+  %4 = inttoptr i64 %3 to i8*
+  %5 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvmsg.flags to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmsg.flags, i64 8, i8* %4)
+  %6 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvmsg.flags, align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  store i64 %6, i8* %1, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %5 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %5, 1
+  %7 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %7, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %6 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %8 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
 }
 

--- a/tests/codegen/bitshift_left.cpp
+++ b/tests/codegen/bitshift_left.cpp
@@ -25,7 +25,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 1024, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/bitshift_right.cpp
+++ b/tests/codegen/bitshift_right.cpp
@@ -25,7 +25,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 2, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/bitwise_not.cpp
+++ b/tests/codegen/bitwise_not.cpp
@@ -25,7 +25,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 -11, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/builtin_arg.cpp
+++ b/tests/codegen/builtin_arg.cpp
@@ -29,7 +29,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %arg0, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %4 = getelementptr i8, i8* %0, i64 96
@@ -41,7 +41,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %arg2, i64* %"@y_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
+  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0

--- a/tests/codegen/builtin_comm.cpp
+++ b/tests/codegen/builtin_comm.cpp
@@ -27,7 +27,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [16 x i8]* nonnull %comm, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [16 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [16 x i8]* nonnull %comm, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0

--- a/tests/codegen/builtin_comm.cpp
+++ b/tests/codegen/builtin_comm.cpp
@@ -27,7 +27,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [16 x i8]* nonnull %comm, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [16 x i8]* nonnull %comm, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -61,7 +61,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [16 x i8]* nonnull %comm, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [16 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [16 x i8]* nonnull %comm, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0

--- a/tests/codegen/builtin_cpu.cpp
+++ b/tests/codegen/builtin_cpu.cpp
@@ -26,7 +26,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 %get_cpu_id, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/builtin_ctx.cpp
+++ b/tests/codegen/builtin_ctx.cpp
@@ -26,7 +26,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %2, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/builtin_curtask.cpp
+++ b/tests/codegen/builtin_curtask.cpp
@@ -26,7 +26,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 %get_cur_task, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/builtin_func.cpp
+++ b/tests/codegen/builtin_func.cpp
@@ -27,7 +27,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %func, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/builtin_func_wild.cpp
+++ b/tests/codegen/builtin_func_wild.cpp
@@ -37,7 +37,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %func, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/builtin_kstack.cpp
+++ b/tests/codegen/builtin_kstack.cpp
@@ -27,7 +27,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 %get_stackid, i64* %"@x_val", align 8
   %pseudo1 = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/builtin_nsecs.cpp
+++ b/tests/codegen/builtin_nsecs.cpp
@@ -26,7 +26,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 %get_ns, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/builtin_pid_tid.cpp
+++ b/tests/codegen/builtin_pid_tid.cpp
@@ -29,7 +29,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to i64 ()*)()
@@ -41,7 +41,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %4, i64* %"@y_val", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem3 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo2, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
+  %update_elem3 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo2, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0

--- a/tests/codegen/builtin_probe.cpp
+++ b/tests/codegen/builtin_probe.cpp
@@ -25,7 +25,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/builtin_probe_wild.cpp
+++ b/tests/codegen/builtin_probe_wild.cpp
@@ -35,7 +35,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/builtin_rand.cpp
+++ b/tests/codegen/builtin_rand.cpp
@@ -26,7 +26,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 %get_random, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/builtin_retval.cpp
+++ b/tests/codegen/builtin_retval.cpp
@@ -27,7 +27,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %retval, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/builtin_uid_gid.cpp
+++ b/tests/codegen/builtin_uid_gid.cpp
@@ -29,7 +29,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %get_uid_gid1 = call i64 inttoptr (i64 15 to i64 ()*)()
@@ -41,7 +41,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %4, i64* %"@y_val", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem3 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo2, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
+  %update_elem3 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo2, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0

--- a/tests/codegen/builtin_username.cpp
+++ b/tests/codegen/builtin_username.cpp
@@ -29,7 +29,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %get_uid_gid1 = call i64 inttoptr (i64 15 to i64 ()*)()
@@ -41,7 +41,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %4, i64* %"@y_val", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem3 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo2, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
+  %update_elem3 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo2, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0

--- a/tests/codegen/builtin_ustack.cpp
+++ b/tests/codegen/builtin_ustack.cpp
@@ -30,7 +30,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %2, i64* %"@x_val", align 8
   %pseudo1 = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/call_avg.cpp
+++ b/tests/codegen/call_avg.cpp
@@ -24,7 +24,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, i64* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, i64* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -39,14 +39,14 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %lookup_elem_val.0, i64* %"@x_num", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_num", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_num", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %4 = bitcast i64* %"@x_key2" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 1, i64* %"@x_key2", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem4 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo3, i64* nonnull %"@x_key2")
+  %lookup_elem4 = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo3, i64* nonnull %"@x_key2")
   %map_lookup_cond9 = icmp eq i8* %lookup_elem4, null
   br i1 %map_lookup_cond9, label %lookup_merge7, label %lookup_success5
 
@@ -63,7 +63,7 @@ lookup_merge7:                                    ; preds = %lookup_merge, %look
   %8 = add i64 %7, %lookup_elem_val8.0
   store i64 %8, i64* %"@x_val", align 8
   %pseudo10 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem11 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo10, i64* nonnull %"@x_key2", i64* nonnull %"@x_val", i64 0)
+  %update_elem11 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo10, i64* nonnull %"@x_key2", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0

--- a/tests/codegen/call_clear.cpp
+++ b/tests/codegen/call_clear.cpp
@@ -25,7 +25,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/call_count.cpp
+++ b/tests/codegen/call_count.cpp
@@ -22,7 +22,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, i64* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, i64* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -37,7 +37,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/call_delete.cpp
+++ b/tests/codegen/call_delete.cpp
@@ -26,7 +26,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = bitcast i64* %"@x_key1" to i8*

--- a/tests/codegen/call_hist.cpp
+++ b/tests/codegen/call_hist.cpp
@@ -55,7 +55,7 @@ log2.exit:                                        ; preds = %entry, %hist.is_not
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %26)
   store i64 %log22, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, i64* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, i64* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -70,7 +70,7 @@ lookup_merge:                                     ; preds = %log2.exit, %lookup_
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %28)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %26)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %28)
   ret i64 0

--- a/tests/codegen/call_kstack.cpp
+++ b/tests/codegen/call_kstack.cpp
@@ -27,7 +27,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 %get_stackid, i64* %"@x_val", align 8
   %pseudo1 = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
@@ -39,7 +39,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %get_stackid3, i64* %"@y_val", align 8
   %pseudo4 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem5 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo4, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
+  %update_elem5 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo4, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/call_lhist.cpp
+++ b/tests/codegen/call_lhist.cpp
@@ -28,7 +28,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %linear3, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, i64* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, i64* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -43,7 +43,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo2, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo2, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0

--- a/tests/codegen/call_max.cpp
+++ b/tests/codegen/call_max.cpp
@@ -22,7 +22,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, i64* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, i64* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -47,7 +47,7 @@ min.lt:                                           ; preds = %lookup_merge, %min.
 min.ge:                                           ; preds = %lookup_merge
   store i64 %4, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   br label %min.lt
 }
 

--- a/tests/codegen/call_min.cpp
+++ b/tests/codegen/call_min.cpp
@@ -22,7 +22,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, i64* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, i64* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -48,7 +48,7 @@ min.lt:                                           ; preds = %lookup_merge, %min.
 min.ge:                                           ; preds = %lookup_merge
   store i64 %5, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   br label %min.lt
 }
 

--- a/tests/codegen/call_ntop_char16.cpp
+++ b/tests/codegen/call_ntop_char16.cpp
@@ -66,7 +66,7 @@ entry:
   %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
   call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %3, i8 0, i64 16, i1 false)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* nonnull %2, i64 16, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* nonnull %2, i64 16, i8* null)
   %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/call_ntop_char16.cpp
+++ b/tests/codegen/call_ntop_char16.cpp
@@ -32,7 +32,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -66,12 +66,12 @@ entry:
   %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
   call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %3, i8 0, i64 16, i1 false)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* nonnull %2, i64 16, i8* null)
+  %probe_read = call i64 inttoptr (i64 4 to i64 ([16 x i8]*, i64, i8*)*)([16 x i8]* nonnull %2, i64 16, i8* null)
   %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, %inet_t*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -110,7 +110,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0

--- a/tests/codegen/call_ntop_char16.cpp
+++ b/tests/codegen/call_ntop_char16.cpp
@@ -27,7 +27,7 @@ entry:
   %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
   call void @llvm.memset.p0i8.i64(i8* %3, i8 0, i64 16, i32 8, i1 false)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* %2, i64 16, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* %2, i64 16, i8* null)
   %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
@@ -105,7 +105,7 @@ entry:
   %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
   call void @llvm.memset.p0i8.i64(i8* nonnull %3, i8 0, i64 16, i32 8, i1 false)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* nonnull %2, i64 16, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* nonnull %2, i64 16, i8* null)
   %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/call_ntop_char16.cpp
+++ b/tests/codegen/call_ntop_char16.cpp
@@ -27,12 +27,12 @@ entry:
   %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
   call void @llvm.memset.p0i8.i64(i8* %3, i8 0, i64 16, i32 8, i1 false)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* %2, i64 16, i8* null)
+  %probe_read = call i64 inttoptr (i64 4 to i64 ([16 x i8]*, i64, i8*)*)([16 x i8]* %2, i64 16, i8* null)
   %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, %inet_t*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0

--- a/tests/codegen/call_ntop_char16.cpp
+++ b/tests/codegen/call_ntop_char16.cpp
@@ -105,12 +105,12 @@ entry:
   %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
   call void @llvm.memset.p0i8.i64(i8* nonnull %3, i8 0, i64 16, i32 8, i1 false)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* nonnull %2, i64 16, i8* null)
+  %probe_read = call i64 inttoptr (i64 4 to i64 ([16 x i8]*, i64, i8*)*)([16 x i8]* nonnull %2, i64 16, i8* null)
   %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, %inet_t*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0

--- a/tests/codegen/call_ntop_char4.cpp
+++ b/tests/codegen/call_ntop_char4.cpp
@@ -27,12 +27,12 @@ entry:
   %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
   call void @llvm.memset.p0i8.i64(i8* %3, i8 0, i64 16, i32 8, i1 false)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* %2, i64 4, i8* null)
+  %probe_read = call i64 inttoptr (i64 4 to i64 ([16 x i8]*, i64, i8*)*)([16 x i8]* %2, i64 4, i8* null)
   %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, %inet_t*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0

--- a/tests/codegen/call_ntop_char4.cpp
+++ b/tests/codegen/call_ntop_char4.cpp
@@ -105,12 +105,12 @@ entry:
   %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
   call void @llvm.memset.p0i8.i64(i8* nonnull %3, i8 0, i64 16, i32 8, i1 false)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* nonnull %2, i64 4, i8* null)
+  %probe_read = call i64 inttoptr (i64 4 to i64 ([16 x i8]*, i64, i8*)*)([16 x i8]* nonnull %2, i64 4, i8* null)
   %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, %inet_t*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0

--- a/tests/codegen/call_ntop_char4.cpp
+++ b/tests/codegen/call_ntop_char4.cpp
@@ -66,7 +66,7 @@ entry:
   %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
   call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %3, i8 0, i64 16, i1 false)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* nonnull %2, i64 4, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* nonnull %2, i64 4, i8* null)
   %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/call_ntop_char4.cpp
+++ b/tests/codegen/call_ntop_char4.cpp
@@ -32,7 +32,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -66,12 +66,12 @@ entry:
   %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
   call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %3, i8 0, i64 16, i1 false)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* nonnull %2, i64 4, i8* null)
+  %probe_read = call i64 inttoptr (i64 4 to i64 ([16 x i8]*, i64, i8*)*)([16 x i8]* nonnull %2, i64 4, i8* null)
   %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, %inet_t*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -110,7 +110,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0

--- a/tests/codegen/call_ntop_char4.cpp
+++ b/tests/codegen/call_ntop_char4.cpp
@@ -27,7 +27,7 @@ entry:
   %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
   call void @llvm.memset.p0i8.i64(i8* %3, i8 0, i64 16, i32 8, i1 false)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* %2, i64 4, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* %2, i64 4, i8* null)
   %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
@@ -105,7 +105,7 @@ entry:
   %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
   call void @llvm.memset.p0i8.i64(i8* nonnull %3, i8 0, i64 16, i32 8, i1 false)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* nonnull %2, i64 4, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* nonnull %2, i64 4, i8* null)
   %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/call_ntop_key.cpp
+++ b/tests/codegen/call_ntop_key.cpp
@@ -29,7 +29,7 @@ entry:
   %inet.sroa.5.0..sroa_idx = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 12
   call void @llvm.memset.p0i8.i64(i8* %inet.sroa.5.0..sroa_idx, i8 0, i64 12, i32 4, i1 false)
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [24 x i8]* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, [24 x i8]* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -44,7 +44,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [24 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo1, [24 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0
@@ -80,7 +80,7 @@ entry:
   %inet.sroa.5.0..sroa_idx = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 12
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %inet.sroa.5.0..sroa_idx, i8 0, i64 12, i1 false)
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [24 x i8]* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, [24 x i8]*)*)(i64 %pseudo, [24 x i8]* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -95,7 +95,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [24 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [24 x i8]*, i64*, i64)*)(i64 %pseudo1, [24 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0
@@ -131,7 +131,7 @@ entry:
   %inet.sroa.5.0..sroa_idx = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 12
   call void @llvm.memset.p0i8.i64(i8* nonnull %inet.sroa.5.0..sroa_idx, i8 0, i64 12, i32 4, i1 false)
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [24 x i8]* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, [24 x i8]*)*)(i64 %pseudo, [24 x i8]* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -146,7 +146,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [24 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [24 x i8]*, i64*, i64)*)(i64 %pseudo1, [24 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/call_ntop_key.cpp
+++ b/tests/codegen/call_ntop_key.cpp
@@ -29,7 +29,7 @@ entry:
   %inet.sroa.5.0..sroa_idx = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 12
   call void @llvm.memset.p0i8.i64(i8* %inet.sroa.5.0..sroa_idx, i8 0, i64 12, i32 4, i1 false)
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, [24 x i8]* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, [24 x i8]*)*)(i64 %pseudo, [24 x i8]* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -44,7 +44,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo1, [24 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [24 x i8]*, i64*, i64)*)(i64 %pseudo1, [24 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/call_print.cpp
+++ b/tests/codegen/call_print.cpp
@@ -26,7 +26,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0
@@ -80,7 +80,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0
@@ -134,7 +134,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/call_printf.cpp
+++ b/tests/codegen/call_printf.cpp
@@ -27,14 +27,14 @@ entry:
   %2 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.memset.p0i8.i64(i8* nonnull %2, i8 0, i64 16, i32 8, i1 false)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %Foo.c)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %Foo.c, i64 1, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %Foo.c, i64 1, i8* null)
   %3 = load i8, i8* %Foo.c, align 1
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %Foo.c)
   %4 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
   store i8 %3, i64* %4, align 8
   %5 = bitcast i64* %Foo.l to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.l, i64 8, i64 8)
+  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.l, i64 8, i8* inttoptr (i64 8 to i8*))
   %6 = load i64, i64* %Foo.l, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   %7 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2

--- a/tests/codegen/call_printf.cpp
+++ b/tests/codegen/call_printf.cpp
@@ -74,14 +74,14 @@ entry:
   %2 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %2, i8 0, i64 16, i1 false)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %Foo.c)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %Foo.c, i64 1, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %Foo.c, i64 1, i8* null)
   %3 = load i8, i8* %Foo.c, align 1
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %Foo.c)
   %4 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
   store i8 %3, i64* %4, align 8
   %5 = bitcast i64* %Foo.l to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.l, i64 8, i64 8)
+  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.l, i64 8, i8* inttoptr (i64 8 to i8*))
   %6 = load i64, i64* %Foo.l, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   %7 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2

--- a/tests/codegen/call_printf.cpp
+++ b/tests/codegen/call_printf.cpp
@@ -34,7 +34,7 @@ entry:
   store i8 %3, i64* %4, align 8
   %5 = bitcast i64* %Foo.l to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.l, i64 8, i8* inttoptr (i64 8 to i8*))
+  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %Foo.l, i64 8, i8* inttoptr (i64 8 to i8*))
   %6 = load i64, i64* %Foo.l, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   %7 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2

--- a/tests/codegen/call_printf.cpp
+++ b/tests/codegen/call_printf.cpp
@@ -81,7 +81,7 @@ entry:
   store i8 %3, i64* %4, align 8
   %5 = bitcast i64* %Foo.l to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.l, i64 8, i8* inttoptr (i64 8 to i8*))
+  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %Foo.l, i64 8, i8* inttoptr (i64 8 to i8*))
   %6 = load i64, i64* %Foo.l, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   %7 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2

--- a/tests/codegen/call_printf.cpp
+++ b/tests/codegen/call_printf.cpp
@@ -24,30 +24,28 @@ entry:
   %printf_args = alloca %printf_t, align 8
   %1 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* nonnull %2, i8 0, i64 16, i32 8, i1 false)
+  %2 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
+  store i64 0, i64* %2, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %Foo.c)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %Foo.c, i64 1, i8* null)
   %3 = load i8, i8* %Foo.c, align 1
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %Foo.c)
   %4 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
-  store i8 %3, i64* %4, align 8
-  %5 = bitcast i64* %Foo.l to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %5 = zext i8 %3 to i64
+  store i64 %5, i64* %4, align 8
+  %6 = bitcast i64* %Foo.l to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   %probe_read1 = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %Foo.l, i64 8, i8* inttoptr (i64 8 to i8*))
-  %6 = load i64, i64* %Foo.l, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
-  %7 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2
-  store i64 %6, i64* %7, align 8
+  %7 = load i64, i64* %Foo.l, align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  %8 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2
+  store i64 %7, i64* %8, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 24)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/call_printf.cpp
+++ b/tests/codegen/call_printf.cpp
@@ -71,30 +71,28 @@ entry:
   %printf_args = alloca %printf_t, align 8
   %1 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %2, i8 0, i64 16, i1 false)
+  %2 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
+  store i64 0, i64* %2, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %Foo.c)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %Foo.c, i64 1, i8* null)
   %3 = load i8, i8* %Foo.c, align 1
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %Foo.c)
   %4 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
-  store i8 %3, i64* %4, align 8
-  %5 = bitcast i64* %Foo.l to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %5 = zext i8 %3 to i64
+  store i64 %5, i64* %4, align 8
+  %6 = bitcast i64* %Foo.l to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   %probe_read1 = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %Foo.l, i64 8, i8* inttoptr (i64 8 to i8*))
-  %6 = load i64, i64* %Foo.l, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
-  %7 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2
-  store i64 %6, i64* %7, align 8
+  %7 = load i64, i64* %Foo.l, align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  %8 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2
+  store i64 %7, i64* %8, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 24)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/call_reg.cpp
+++ b/tests/codegen/call_reg.cpp
@@ -27,7 +27,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %reg_ip, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/call_stats.cpp
+++ b/tests/codegen/call_stats.cpp
@@ -24,7 +24,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, i64* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, i64* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -39,14 +39,14 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %lookup_elem_val.0, i64* %"@x_num", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_num", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_num", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %4 = bitcast i64* %"@x_key2" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 1, i64* %"@x_key2", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem4 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo3, i64* nonnull %"@x_key2")
+  %lookup_elem4 = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo3, i64* nonnull %"@x_key2")
   %map_lookup_cond9 = icmp eq i8* %lookup_elem4, null
   br i1 %map_lookup_cond9, label %lookup_merge7, label %lookup_success5
 
@@ -63,7 +63,7 @@ lookup_merge7:                                    ; preds = %lookup_merge, %look
   %8 = add i64 %7, %lookup_elem_val8.0
   store i64 %8, i64* %"@x_val", align 8
   %pseudo10 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem11 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo10, i64* nonnull %"@x_key2", i64* nonnull %"@x_val", i64 0)
+  %update_elem11 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo10, i64* nonnull %"@x_key2", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0

--- a/tests/codegen/call_str.cpp
+++ b/tests/codegen/call_str.cpp
@@ -29,7 +29,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -65,7 +65,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0

--- a/tests/codegen/call_str_2_expr.cpp
+++ b/tests/codegen/call_str_2_expr.cpp
@@ -34,7 +34,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
@@ -75,7 +75,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/call_str_2_lit.cpp
+++ b/tests/codegen/call_str_2_lit.cpp
@@ -29,7 +29,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -65,7 +65,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0

--- a/tests/codegen/call_sum.cpp
+++ b/tests/codegen/call_sum.cpp
@@ -22,7 +22,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, i64* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, i64* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -39,7 +39,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   %5 = add i64 %4, %lookup_elem_val.0
   store i64 %5, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/call_ustack.cpp
+++ b/tests/codegen/call_ustack.cpp
@@ -30,7 +30,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %2, i64* %"@x_val", align 8
   %pseudo1 = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
@@ -45,7 +45,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %6, i64* %"@y_val", align 8
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem6 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo5, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
+  %update_elem6 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo5, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0

--- a/tests/codegen/call_usym_key.cpp
+++ b/tests/codegen/call_usym_key.cpp
@@ -28,7 +28,7 @@ entry:
   %usym.sroa.4.0..sroa_cast = bitcast i8* %usym.sroa.4.0..sroa_idx to i64*
   store i64 %2, i64* %usym.sroa.4.0..sroa_cast, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, [16 x i8]*)*)(i64 %pseudo, [16 x i8]* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -43,7 +43,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [16 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [16 x i8]*, i64*, i64)*)(i64 %pseudo1, [16 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/call_zero.cpp
+++ b/tests/codegen/call_zero.cpp
@@ -25,7 +25,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/dereference.cpp
+++ b/tests/codegen/dereference.cpp
@@ -21,7 +21,7 @@ entry:
   %deref = alloca i64, align 8
   %1 = bitcast i64* %deref to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %deref, i64 8, i64 1234)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i64)*)(i64* nonnull %deref, i64 8, i64 1234)
   %2 = load i64, i64* %deref, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key" to i8*
@@ -31,7 +31,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %2, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/enum.cpp
+++ b/tests/codegen/enum.cpp
@@ -27,7 +27,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 42, i64* %"@a_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@a_key", i64* nonnull %"@a_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@a_key", i64* nonnull %"@a_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = bitcast i64* %"@b_key" to i8*
@@ -37,7 +37,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 43, i64* %"@b_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@b_key", i64* nonnull %"@b_val", i64 0)
+  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@b_key", i64* nonnull %"@b_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/int_propagation.cpp
+++ b/tests/codegen/int_propagation.cpp
@@ -28,14 +28,14 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 1234, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = bitcast i64* %"@x_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key1", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo2, i64* nonnull %"@x_key1")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo2, i64* nonnull %"@x_key1")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -53,7 +53,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %lookup_elem_val.0, i64* %"@y_val", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo3, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo3, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0

--- a/tests/codegen/logical_and.cpp
+++ b/tests/codegen/logical_and.cpp
@@ -41,7 +41,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %"&&_result.0", i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/logical_and_or_different_type.cpp
+++ b/tests/codegen/logical_and_or_different_type.cpp
@@ -24,59 +24,57 @@ entry:
   %Foo.m6 = alloca i32, align 4
   %Foo.m = alloca i32, align 4
   %printf_args = alloca %printf_t, align 8
-  %"$foo" = alloca i32, align 4
-  %1 = bitcast i32* %"$foo" to i8*
+  %"$foo" = alloca i64, align 8
+  %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %1, i64 0, i64 4, i1 false)
+  %2 = bitcast i64* %"$foo" to i32*
+  store i32 0, i32* %2, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = load i32, i32 addrspace(64)* null, align 536870912
-  store i32 %2, i32* %"$foo", align 4
-  %3 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %4 = bitcast i32* %Foo.m to i8*
-  %5 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
-  store i64 0, i64* %5, align 8
+  %3 = load i32, i32 addrspace(64)* null, align 536870912
+  store i32 %3, i32* %2, align 8
+  %4 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m, i64 4, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  %6 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
+  %5 = bitcast i32* %Foo.m to i8*
+  %6 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
   store i64 0, i64* %6, align 8
-  %7 = bitcast i32* %Foo.m6 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m, i64 4, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  %7 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
+  store i64 0, i64* %7, align 8
+  %8 = bitcast i32* %Foo.m6 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m6, i64 4, i8* nonnull %1)
-  %8 = load i32, i32* %Foo.m6, align 4
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
-  %rhs_true_cond = icmp ne i32 %8, 0
+  %9 = load i32, i32* %Foo.m6, align 4
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
+  %rhs_true_cond = icmp ne i32 %9, 0
   %"&&_result5.0" = zext i1 %rhs_true_cond to i64
-  %9 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2
-  store i64 %"&&_result5.0", i64* %9, align 8
-  %10 = bitcast i32* %Foo.m8 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
+  %10 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2
+  store i64 %"&&_result5.0", i64* %10, align 8
+  %11 = bitcast i32* %Foo.m8 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %11)
   %probe_read9 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m8, i64 4, i8* nonnull %1)
-  %11 = load i32, i32* %Foo.m8, align 4
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
-  %lhs_true_cond10 = icmp ne i32 %11, 0
+  %12 = load i32, i32* %Foo.m8, align 4
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %11)
+  %lhs_true_cond10 = icmp ne i32 %12, 0
   %"||_result.0" = zext i1 %lhs_true_cond10 to i64
-  %12 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 3
-  store i64 %"||_result.0", i64* %12, align 8
-  %13 = bitcast i32* %Foo.m16 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %13)
+  %13 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 3
+  store i64 %"||_result.0", i64* %13, align 8
+  %14 = bitcast i32* %Foo.m16 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %14)
   %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m16, i64 4, i8* nonnull %1)
-  %14 = load i32, i32* %Foo.m16, align 4
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %13)
-  %rhs_true_cond18 = icmp ne i32 %14, 0
+  %15 = load i32, i32* %Foo.m16, align 4
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %14)
+  %rhs_true_cond18 = icmp ne i32 %15, 0
   %"||_result15.0" = zext i1 %rhs_true_cond18 to i64
-  %15 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 4
-  store i64 %"||_result15.0", i64* %15, align 8
+  %16 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 4
+  store i64 %"||_result15.0", i64* %16, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 40)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
 }
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/logical_and_or_different_type.cpp
+++ b/tests/codegen/logical_and_or_different_type.cpp
@@ -38,13 +38,13 @@ entry:
   %6 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
   store i64 0, i64* %6, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m, i64 4, i8* nonnull %1)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i64, i8*)*)(i32* nonnull %Foo.m, i64 4, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   %7 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
   store i64 0, i64* %7, align 8
   %8 = bitcast i32* %Foo.m6 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
-  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m6, i64 4, i8* nonnull %1)
+  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i32*, i64, i8*)*)(i32* nonnull %Foo.m6, i64 4, i8* nonnull %1)
   %9 = load i32, i32* %Foo.m6, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   %rhs_true_cond = icmp ne i32 %9, 0
@@ -53,7 +53,7 @@ entry:
   store i64 %"&&_result5.0", i64* %10, align 8
   %11 = bitcast i32* %Foo.m8 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %11)
-  %probe_read9 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m8, i64 4, i8* nonnull %1)
+  %probe_read9 = call i64 inttoptr (i64 4 to i64 (i32*, i64, i8*)*)(i32* nonnull %Foo.m8, i64 4, i8* nonnull %1)
   %12 = load i32, i32* %Foo.m8, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %11)
   %lhs_true_cond10 = icmp ne i32 %12, 0
@@ -62,7 +62,7 @@ entry:
   store i64 %"||_result.0", i64* %13, align 8
   %14 = bitcast i32* %Foo.m16 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %14)
-  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m16, i64 4, i8* nonnull %1)
+  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i32*, i64, i8*)*)(i32* nonnull %Foo.m16, i64 4, i8* nonnull %1)
   %15 = load i32, i32* %Foo.m16, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %14)
   %rhs_true_cond18 = icmp ne i32 %15, 0

--- a/tests/codegen/logical_and_or_different_type.cpp
+++ b/tests/codegen/logical_and_or_different_type.cpp
@@ -112,13 +112,13 @@ entry:
   %6 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
   store i64 0, i64* %6, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m, i64 4, i8* nonnull %1)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i64, i8*)*)(i32* nonnull %Foo.m, i64 4, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   %7 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
   store i64 0, i64* %7, align 8
   %8 = bitcast i32* %Foo.m6 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
-  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m6, i64 4, i8* nonnull %1)
+  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i32*, i64, i8*)*)(i32* nonnull %Foo.m6, i64 4, i8* nonnull %1)
   %9 = load i32, i32* %Foo.m6, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   %rhs_true_cond = icmp ne i32 %9, 0
@@ -127,7 +127,7 @@ entry:
   store i64 %"&&_result5.0", i64* %10, align 8
   %11 = bitcast i32* %Foo.m8 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %11)
-  %probe_read9 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m8, i64 4, i8* nonnull %1)
+  %probe_read9 = call i64 inttoptr (i64 4 to i64 (i32*, i64, i8*)*)(i32* nonnull %Foo.m8, i64 4, i8* nonnull %1)
   %12 = load i32, i32* %Foo.m8, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %11)
   %lhs_true_cond10 = icmp ne i32 %12, 0
@@ -136,7 +136,7 @@ entry:
   store i64 %"||_result.0", i64* %13, align 8
   %14 = bitcast i32* %Foo.m16 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %14)
-  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m16, i64 4, i8* nonnull %1)
+  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i32*, i64, i8*)*)(i32* nonnull %Foo.m16, i64 4, i8* nonnull %1)
   %15 = load i32, i32* %Foo.m16, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %14)
   %rhs_true_cond18 = icmp ne i32 %15, 0

--- a/tests/codegen/logical_and_or_different_type.cpp
+++ b/tests/codegen/logical_and_or_different_type.cpp
@@ -25,7 +25,6 @@ entry:
   %Foo.m = alloca i32, align 4
   %printf_args = alloca %printf_t, align 8
   %"$foo" = alloca i32, align 4
-  %tmpcast = bitcast i32* %"$foo" to [4 x i8]*
   %1 = bitcast i32* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %1, i64 0, i64 4, i1 false)
@@ -38,13 +37,13 @@ entry:
   %5 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
   store i64 0, i64* %5, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m, i64 4, [4 x i8]* nonnull %tmpcast)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m, i64 4, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %6 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
   store i64 0, i64* %6, align 8
   %7 = bitcast i32* %Foo.m6 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m6, i64 4, [4 x i8]* nonnull %tmpcast)
+  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m6, i64 4, i8* nonnull %1)
   %8 = load i32, i32* %Foo.m6, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   %rhs_true_cond = icmp ne i32 %8, 0
@@ -53,7 +52,7 @@ entry:
   store i64 %"&&_result5.0", i64* %9, align 8
   %10 = bitcast i32* %Foo.m8 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
-  %probe_read9 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m8, i64 4, [4 x i8]* nonnull %tmpcast)
+  %probe_read9 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m8, i64 4, i8* nonnull %1)
   %11 = load i32, i32* %Foo.m8, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
   %lhs_true_cond10 = icmp ne i32 %11, 0
@@ -62,7 +61,7 @@ entry:
   store i64 %"||_result.0", i64* %12, align 8
   %13 = bitcast i32* %Foo.m16 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %13)
-  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m16, i64 4, [4 x i8]* nonnull %tmpcast)
+  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m16, i64 4, i8* nonnull %1)
   %14 = load i32, i32* %Foo.m16, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %13)
   %rhs_true_cond18 = icmp ne i32 %14, 0

--- a/tests/codegen/logical_and_or_different_type.cpp
+++ b/tests/codegen/logical_and_or_different_type.cpp
@@ -101,7 +101,6 @@ entry:
   %Foo.m = alloca i32, align 4
   %printf_args = alloca %printf_t, align 8
   %"$foo" = alloca i32, align 4
-  %tmpcast = bitcast i32* %"$foo" to [4 x i8]*
   %1 = bitcast i32* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i64 0, i64 4, i32 4, i1 false)
@@ -114,13 +113,13 @@ entry:
   %5 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
   store i64 0, i64* %5, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m, i64 4, [4 x i8]* nonnull %tmpcast)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m, i64 4, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %6 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
   store i64 0, i64* %6, align 8
   %7 = bitcast i32* %Foo.m6 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m6, i64 4, [4 x i8]* nonnull %tmpcast)
+  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m6, i64 4, i8* nonnull %1)
   %8 = load i32, i32* %Foo.m6, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   %rhs_true_cond = icmp ne i32 %8, 0
@@ -129,7 +128,7 @@ entry:
   store i64 %"&&_result5.0", i64* %9, align 8
   %10 = bitcast i32* %Foo.m8 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
-  %probe_read9 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m8, i64 4, [4 x i8]* nonnull %tmpcast)
+  %probe_read9 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m8, i64 4, i8* nonnull %1)
   %11 = load i32, i32* %Foo.m8, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
   %lhs_true_cond10 = icmp ne i32 %11, 0
@@ -138,7 +137,7 @@ entry:
   store i64 %"||_result.0", i64* %12, align 8
   %13 = bitcast i32* %Foo.m16 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %13)
-  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m16, i64 4, [4 x i8]* nonnull %tmpcast)
+  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m16, i64 4, i8* nonnull %1)
   %14 = load i32, i32* %Foo.m16, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %13)
   %rhs_true_cond18 = icmp ne i32 %14, 0

--- a/tests/codegen/logical_and_or_different_type.cpp
+++ b/tests/codegen/logical_and_or_different_type.cpp
@@ -98,59 +98,57 @@ entry:
   %Foo.m6 = alloca i32, align 4
   %Foo.m = alloca i32, align 4
   %printf_args = alloca %printf_t, align 8
-  %"$foo" = alloca i32, align 4
-  %1 = bitcast i32* %"$foo" to i8*
+  %"$foo" = alloca i64, align 8
+  %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull %1, i64 0, i64 4, i32 4, i1 false)
+  %2 = bitcast i64* %"$foo" to i32*
+  store i32 0, i32* %2, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = load i32, i32 addrspace(64)* null, align 536870912
-  store i32 %2, i32* %"$foo", align 4
-  %3 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %4 = bitcast i32* %Foo.m to i8*
-  %5 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
-  store i64 0, i64* %5, align 8
+  %3 = load i32, i32 addrspace(64)* null, align 536870912
+  store i32 %3, i32* %2, align 8
+  %4 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m, i64 4, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  %6 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
+  %5 = bitcast i32* %Foo.m to i8*
+  %6 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
   store i64 0, i64* %6, align 8
-  %7 = bitcast i32* %Foo.m6 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m, i64 4, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  %7 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
+  store i64 0, i64* %7, align 8
+  %8 = bitcast i32* %Foo.m6 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m6, i64 4, i8* nonnull %1)
-  %8 = load i32, i32* %Foo.m6, align 4
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
-  %rhs_true_cond = icmp ne i32 %8, 0
+  %9 = load i32, i32* %Foo.m6, align 4
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
+  %rhs_true_cond = icmp ne i32 %9, 0
   %"&&_result5.0" = zext i1 %rhs_true_cond to i64
-  %9 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2
-  store i64 %"&&_result5.0", i64* %9, align 8
-  %10 = bitcast i32* %Foo.m8 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
+  %10 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2
+  store i64 %"&&_result5.0", i64* %10, align 8
+  %11 = bitcast i32* %Foo.m8 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %11)
   %probe_read9 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m8, i64 4, i8* nonnull %1)
-  %11 = load i32, i32* %Foo.m8, align 4
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
-  %lhs_true_cond10 = icmp ne i32 %11, 0
+  %12 = load i32, i32* %Foo.m8, align 4
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %11)
+  %lhs_true_cond10 = icmp ne i32 %12, 0
   %"||_result.0" = zext i1 %lhs_true_cond10 to i64
-  %12 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 3
-  store i64 %"||_result.0", i64* %12, align 8
-  %13 = bitcast i32* %Foo.m16 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %13)
+  %13 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 3
+  store i64 %"||_result.0", i64* %13, align 8
+  %14 = bitcast i32* %Foo.m16 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %14)
   %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m16, i64 4, i8* nonnull %1)
-  %14 = load i32, i32* %Foo.m16, align 4
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %13)
-  %rhs_true_cond18 = icmp ne i32 %14, 0
+  %15 = load i32, i32* %Foo.m16, align 4
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %14)
+  %rhs_true_cond18 = icmp ne i32 %15, 0
   %"||_result15.0" = zext i1 %rhs_true_cond18 to i64
-  %15 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 4
-  store i64 %"||_result15.0", i64* %15, align 8
+  %16 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 4
+  store i64 %"||_result15.0", i64* %16, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 40)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
 }
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/logical_not.cpp
+++ b/tests/codegen/logical_not.cpp
@@ -26,7 +26,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = bitcast i64* %"@y_key" to i8*
@@ -36,7 +36,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 1, i64* %"@y_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
+  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/logical_or.cpp
+++ b/tests/codegen/logical_or.cpp
@@ -41,7 +41,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %"||_result.0", i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/macro_definition.cpp
+++ b/tests/codegen/macro_definition.cpp
@@ -25,7 +25,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 100, i64* %"@_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/map_assign_int.cpp
+++ b/tests/codegen/map_assign_int.cpp
@@ -25,7 +25,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/map_assign_string.cpp
+++ b/tests/codegen/map_assign_string.cpp
@@ -34,7 +34,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -75,7 +75,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -116,7 +116,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0

--- a/tests/codegen/map_increment_decrement.cpp
+++ b/tests/codegen/map_increment_decrement.cpp
@@ -33,14 +33,14 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 10, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = bitcast i64* %"@x_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key1", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo2, i64* nonnull %"@x_key1")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo2, i64* nonnull %"@x_key1")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -55,14 +55,14 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %lookup_elem_val.0, i64* %"@x_newval", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo3, i64* nonnull %"@x_key1", i64* nonnull %"@x_newval", i64 0)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo3, i64* nonnull %"@x_key1", i64* nonnull %"@x_newval", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   %6 = bitcast i64* %"@x_key5" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@x_key5", align 8
   %pseudo6 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem7 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo6, i64* nonnull %"@x_key5")
+  %lookup_elem7 = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo6, i64* nonnull %"@x_key5")
   %map_lookup_cond12 = icmp eq i8* %lookup_elem7, null
   br i1 %map_lookup_cond12, label %lookup_merge10, label %lookup_success8
 
@@ -77,14 +77,14 @@ lookup_merge10:                                   ; preds = %lookup_merge, %look
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %lookup_elem_val11.0, i64* %"@x_newval13", align 8
   %pseudo14 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem15 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo14, i64* nonnull %"@x_key5", i64* nonnull %"@x_newval13", i64 0)
+  %update_elem15 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo14, i64* nonnull %"@x_key5", i64* nonnull %"@x_newval13", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   %9 = bitcast i64* %"@x_key16" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 0, i64* %"@x_key16", align 8
   %pseudo17 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem18 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo17, i64* nonnull %"@x_key16")
+  %lookup_elem18 = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo17, i64* nonnull %"@x_key16")
   %map_lookup_cond23 = icmp eq i8* %lookup_elem18, null
   br i1 %map_lookup_cond23, label %lookup_merge21, label %lookup_success19
 
@@ -99,14 +99,14 @@ lookup_merge21:                                   ; preds = %lookup_merge10, %lo
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %11)
   store i64 %lookup_elem_val22.0, i64* %"@x_newval24", align 8
   %pseudo25 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem26 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo25, i64* nonnull %"@x_key16", i64* nonnull %"@x_newval24", i64 0)
+  %update_elem26 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo25, i64* nonnull %"@x_key16", i64* nonnull %"@x_newval24", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %11)
   %12 = bitcast i64* %"@x_key27" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %12)
   store i64 0, i64* %"@x_key27", align 8
   %pseudo28 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem29 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo28, i64* nonnull %"@x_key27")
+  %lookup_elem29 = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo28, i64* nonnull %"@x_key27")
   %map_lookup_cond34 = icmp eq i8* %lookup_elem29, null
   br i1 %map_lookup_cond34, label %lookup_merge32, label %lookup_success30
 
@@ -121,7 +121,7 @@ lookup_merge32:                                   ; preds = %lookup_merge21, %lo
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %14)
   store i64 %lookup_elem_val33.0, i64* %"@x_newval35", align 8
   %pseudo36 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem37 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo36, i64* nonnull %"@x_key27", i64* nonnull %"@x_newval35", i64 0)
+  %update_elem37 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo36, i64* nonnull %"@x_key27", i64* nonnull %"@x_newval35", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %12)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %14)
   ret i64 0

--- a/tests/codegen/map_key_int.cpp
+++ b/tests/codegen/map_key_int.cpp
@@ -29,7 +29,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 44, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, [24 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [24 x i8]*, i64*, i64)*)(i64 %pseudo, [24 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/map_key_probe.cpp
+++ b/tests/codegen/map_key_probe.cpp
@@ -23,7 +23,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 0, i8* %1, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -42,7 +42,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo2, [8 x i8]* nonnull %"@x_key1", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [8 x i8]*, i64*, i64)*)(i64 %pseudo2, [8 x i8]* nonnull %"@x_key1", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
@@ -60,7 +60,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 1, i8* %1, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -79,7 +79,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo2, [8 x i8]* nonnull %"@x_key1", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [8 x i8]*, i64*, i64)*)(i64 %pseudo2, [8 x i8]* nonnull %"@x_key1", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/map_key_string.cpp
+++ b/tests/codegen/map_key_string.cpp
@@ -110,7 +110,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 44, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, [128 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [128 x i8]*, i64*, i64)*)(i64 %pseudo, [128 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/map_key_string.cpp
+++ b/tests/codegen/map_key_string.cpp
@@ -71,7 +71,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 44, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, [128 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [128 x i8]*, i64*, i64)*)(i64 %pseudo, [128 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/map_key_string.cpp
+++ b/tests/codegen/map_key_string.cpp
@@ -32,7 +32,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 44, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, [128 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [128 x i8]*, i64*, i64)*)(i64 %pseudo, [128 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0
@@ -71,7 +71,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 44, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, [128 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, [128 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0
@@ -110,7 +110,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 44, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, [128 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, [128 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/optional_positional_parameter.cpp
+++ b/tests/codegen/optional_positional_parameter.cpp
@@ -79,7 +79,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0

--- a/tests/codegen/optional_positional_parameter.cpp
+++ b/tests/codegen/optional_positional_parameter.cpp
@@ -29,7 +29,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
@@ -43,7 +43,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@y_key", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem3 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo2, i64* nonnull %"@y_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem3 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo2, i64* nonnull %"@y_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0
@@ -79,7 +79,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
@@ -93,7 +93,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@y_key", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem3 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo2, i64* nonnull %"@y_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem3 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo2, i64* nonnull %"@y_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/pred_binop.cpp
+++ b/tests/codegen/pred_binop.cpp
@@ -34,7 +34,7 @@ pred_true:                                        ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/string_equal_comparison.cpp
+++ b/tests/codegen/string_equal_comparison.cpp
@@ -31,7 +31,7 @@ entry:
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i8 0, i64 16, i1 false)
   %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char, i64 1, [16 x i8]* nonnull %comm)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, [16 x i8]*)*)(i8* nonnull %strcmp.char, i64 1, [16 x i8]* nonnull %comm)
   %2 = load i8, i8* %strcmp.char, align 1
   %strcmp.cmp = icmp eq i8 %2, 115
   br i1 %strcmp.cmp, label %strcmp.loop, label %pred_false
@@ -48,14 +48,14 @@ pred_true:                                        ; preds = %strcmp.loop9
   %get_comm18 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm17, i64 16)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %3, i8* nonnull align 1 %4, i64 16, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, [16 x i8]*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 strcmp.loop:                                      ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char2)
   %5 = add [16 x i8]* %comm, i64 1
-  %probe_read3 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char2, i64 1, [16 x i8]* %5)
+  %probe_read3 = call i64 inttoptr (i64 4 to i64 (i8*, i64, [16 x i8]*)*)(i8* nonnull %strcmp.char2, i64 1, [16 x i8]* %5)
   %6 = load i8, i8* %strcmp.char2, align 1
   %strcmp.cmp4 = icmp eq i8 %6, 115
   br i1 %strcmp.cmp4, label %strcmp.loop1, label %pred_false
@@ -63,7 +63,7 @@ strcmp.loop:                                      ; preds = %entry
 strcmp.loop1:                                     ; preds = %strcmp.loop
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char6)
   %7 = add [16 x i8]* %comm, i64 2
-  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char6, i64 1, [16 x i8]* %7)
+  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, [16 x i8]*)*)(i8* nonnull %strcmp.char6, i64 1, [16 x i8]* %7)
   %8 = load i8, i8* %strcmp.char6, align 1
   %strcmp.cmp8 = icmp eq i8 %8, 104
   br i1 %strcmp.cmp8, label %strcmp.loop5, label %pred_false
@@ -71,7 +71,7 @@ strcmp.loop1:                                     ; preds = %strcmp.loop
 strcmp.loop5:                                     ; preds = %strcmp.loop1
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char10)
   %9 = add [16 x i8]* %comm, i64 3
-  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char10, i64 1, [16 x i8]* %9)
+  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i8*, i64, [16 x i8]*)*)(i8* nonnull %strcmp.char10, i64 1, [16 x i8]* %9)
   %10 = load i8, i8* %strcmp.char10, align 1
   %strcmp.cmp12 = icmp eq i8 %10, 100
   br i1 %strcmp.cmp12, label %strcmp.loop9, label %pred_false
@@ -79,7 +79,7 @@ strcmp.loop5:                                     ; preds = %strcmp.loop1
 strcmp.loop9:                                     ; preds = %strcmp.loop5
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char14)
   %11 = add [16 x i8]* %comm, i64 4
-  %probe_read15 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char14, i64 1, [16 x i8]* %11)
+  %probe_read15 = call i64 inttoptr (i64 4 to i64 (i8*, i64, [16 x i8]*)*)(i8* nonnull %strcmp.char14, i64 1, [16 x i8]* %11)
   %12 = load i8, i8* %strcmp.char14, align 1
   %strcmp.cmp16 = icmp eq i8 %12, 0
   br i1 %strcmp.cmp16, label %pred_true, label %pred_false
@@ -95,7 +95,7 @@ lookup_merge:                                     ; preds = %pred_true, %lookup_
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %14)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo19 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo19, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [16 x i8]*, i64*, i64)*)(i64 %pseudo19, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %14)
   ret i64 0
@@ -136,7 +136,7 @@ entry:
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 16, i32 1, i1 false)
   %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char, i64 1, [16 x i8]* nonnull %comm)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i8* nonnull %strcmp.char, i64 1, [16 x i8]* nonnull %comm)
   %2 = load i8, i8* %strcmp.char, align 1
   %strcmp.cmp = icmp eq i8 %2, 115
   br i1 %strcmp.cmp, label %strcmp.loop, label %pred_false
@@ -153,14 +153,14 @@ pred_true:                                        ; preds = %strcmp.loop9
   %get_comm18 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm17, i64 16)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %3, i8* nonnull %4, i64 16, i32 1, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 strcmp.loop:                                      ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char2)
   %5 = add [16 x i8]* %comm, i64 1
-  %probe_read3 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char2, i64 1, [16 x i8]* %5)
+  %probe_read3 = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i8* nonnull %strcmp.char2, i64 1, [16 x i8]* %5)
   %6 = load i8, i8* %strcmp.char2, align 1
   %strcmp.cmp4 = icmp eq i8 %6, 115
   br i1 %strcmp.cmp4, label %strcmp.loop1, label %pred_false
@@ -168,7 +168,7 @@ strcmp.loop:                                      ; preds = %entry
 strcmp.loop1:                                     ; preds = %strcmp.loop
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char6)
   %7 = add [16 x i8]* %comm, i64 2
-  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char6, i64 1, [16 x i8]* %7)
+  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i8* nonnull %strcmp.char6, i64 1, [16 x i8]* %7)
   %8 = load i8, i8* %strcmp.char6, align 1
   %strcmp.cmp8 = icmp eq i8 %8, 104
   br i1 %strcmp.cmp8, label %strcmp.loop5, label %pred_false
@@ -176,7 +176,7 @@ strcmp.loop1:                                     ; preds = %strcmp.loop
 strcmp.loop5:                                     ; preds = %strcmp.loop1
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char10)
   %9 = add [16 x i8]* %comm, i64 3
-  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char10, i64 1, [16 x i8]* %9)
+  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i8* nonnull %strcmp.char10, i64 1, [16 x i8]* %9)
   %10 = load i8, i8* %strcmp.char10, align 1
   %strcmp.cmp12 = icmp eq i8 %10, 100
   br i1 %strcmp.cmp12, label %strcmp.loop9, label %pred_false
@@ -184,7 +184,7 @@ strcmp.loop5:                                     ; preds = %strcmp.loop1
 strcmp.loop9:                                     ; preds = %strcmp.loop5
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char14)
   %11 = add [16 x i8]* %comm, i64 4
-  %probe_read15 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char14, i64 1, [16 x i8]* %11)
+  %probe_read15 = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i8* nonnull %strcmp.char14, i64 1, [16 x i8]* %11)
   %12 = load i8, i8* %strcmp.char14, align 1
   %strcmp.cmp16 = icmp eq i8 %12, 0
   br i1 %strcmp.cmp16, label %pred_true, label %pred_false
@@ -200,7 +200,7 @@ lookup_merge:                                     ; preds = %pred_true, %lookup_
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %14)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo19 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo19, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo19, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %14)
   ret i64 0

--- a/tests/codegen/string_equal_comparison.cpp
+++ b/tests/codegen/string_equal_comparison.cpp
@@ -136,7 +136,7 @@ entry:
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 16, i32 1, i1 false)
   %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i8* nonnull %strcmp.char, i64 1, [16 x i8]* nonnull %comm)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, [16 x i8]*)*)(i8* nonnull %strcmp.char, i64 1, [16 x i8]* nonnull %comm)
   %2 = load i8, i8* %strcmp.char, align 1
   %strcmp.cmp = icmp eq i8 %2, 115
   br i1 %strcmp.cmp, label %strcmp.loop, label %pred_false
@@ -153,14 +153,14 @@ pred_true:                                        ; preds = %strcmp.loop9
   %get_comm18 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm17, i64 16)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %3, i8* nonnull %4, i64 16, i32 1, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, [16 x i8]*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 strcmp.loop:                                      ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char2)
   %5 = add [16 x i8]* %comm, i64 1
-  %probe_read3 = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i8* nonnull %strcmp.char2, i64 1, [16 x i8]* %5)
+  %probe_read3 = call i64 inttoptr (i64 4 to i64 (i8*, i64, [16 x i8]*)*)(i8* nonnull %strcmp.char2, i64 1, [16 x i8]* %5)
   %6 = load i8, i8* %strcmp.char2, align 1
   %strcmp.cmp4 = icmp eq i8 %6, 115
   br i1 %strcmp.cmp4, label %strcmp.loop1, label %pred_false
@@ -168,7 +168,7 @@ strcmp.loop:                                      ; preds = %entry
 strcmp.loop1:                                     ; preds = %strcmp.loop
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char6)
   %7 = add [16 x i8]* %comm, i64 2
-  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i8* nonnull %strcmp.char6, i64 1, [16 x i8]* %7)
+  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, [16 x i8]*)*)(i8* nonnull %strcmp.char6, i64 1, [16 x i8]* %7)
   %8 = load i8, i8* %strcmp.char6, align 1
   %strcmp.cmp8 = icmp eq i8 %8, 104
   br i1 %strcmp.cmp8, label %strcmp.loop5, label %pred_false
@@ -176,7 +176,7 @@ strcmp.loop1:                                     ; preds = %strcmp.loop
 strcmp.loop5:                                     ; preds = %strcmp.loop1
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char10)
   %9 = add [16 x i8]* %comm, i64 3
-  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i8* nonnull %strcmp.char10, i64 1, [16 x i8]* %9)
+  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i8*, i64, [16 x i8]*)*)(i8* nonnull %strcmp.char10, i64 1, [16 x i8]* %9)
   %10 = load i8, i8* %strcmp.char10, align 1
   %strcmp.cmp12 = icmp eq i8 %10, 100
   br i1 %strcmp.cmp12, label %strcmp.loop9, label %pred_false
@@ -184,7 +184,7 @@ strcmp.loop5:                                     ; preds = %strcmp.loop1
 strcmp.loop9:                                     ; preds = %strcmp.loop5
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char14)
   %11 = add [16 x i8]* %comm, i64 4
-  %probe_read15 = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i8* nonnull %strcmp.char14, i64 1, [16 x i8]* %11)
+  %probe_read15 = call i64 inttoptr (i64 4 to i64 (i8*, i64, [16 x i8]*)*)(i8* nonnull %strcmp.char14, i64 1, [16 x i8]* %11)
   %12 = load i8, i8* %strcmp.char14, align 1
   %strcmp.cmp16 = icmp eq i8 %12, 0
   br i1 %strcmp.cmp16, label %pred_true, label %pred_false
@@ -200,7 +200,7 @@ lookup_merge:                                     ; preds = %pred_true, %lookup_
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %14)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo19 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo19, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [16 x i8]*, i64*, i64)*)(i64 %pseudo19, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %14)
   ret i64 0

--- a/tests/codegen/string_not_equal_comparison.cpp
+++ b/tests/codegen/string_not_equal_comparison.cpp
@@ -136,7 +136,7 @@ entry:
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 16, i32 1, i1 false)
   %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i8* nonnull %strcmp.char, i64 1, [16 x i8]* nonnull %comm)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, [16 x i8]*)*)(i8* nonnull %strcmp.char, i64 1, [16 x i8]* nonnull %comm)
   %2 = load i8, i8* %strcmp.char, align 1
   %strcmp.cmp = icmp eq i8 %2, 115
   br i1 %strcmp.cmp, label %strcmp.loop, label %pred_true
@@ -153,14 +153,14 @@ pred_true:                                        ; preds = %strcmp.loop9, %strc
   %get_comm18 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm17, i64 16)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %3, i8* nonnull %4, i64 16, i32 1, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, [16 x i8]*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 strcmp.loop:                                      ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char2)
   %5 = add [16 x i8]* %comm, i64 1
-  %probe_read3 = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i8* nonnull %strcmp.char2, i64 1, [16 x i8]* %5)
+  %probe_read3 = call i64 inttoptr (i64 4 to i64 (i8*, i64, [16 x i8]*)*)(i8* nonnull %strcmp.char2, i64 1, [16 x i8]* %5)
   %6 = load i8, i8* %strcmp.char2, align 1
   %strcmp.cmp4 = icmp eq i8 %6, 115
   br i1 %strcmp.cmp4, label %strcmp.loop1, label %pred_true
@@ -168,7 +168,7 @@ strcmp.loop:                                      ; preds = %entry
 strcmp.loop1:                                     ; preds = %strcmp.loop
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char6)
   %7 = add [16 x i8]* %comm, i64 2
-  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i8* nonnull %strcmp.char6, i64 1, [16 x i8]* %7)
+  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, [16 x i8]*)*)(i8* nonnull %strcmp.char6, i64 1, [16 x i8]* %7)
   %8 = load i8, i8* %strcmp.char6, align 1
   %strcmp.cmp8 = icmp eq i8 %8, 104
   br i1 %strcmp.cmp8, label %strcmp.loop5, label %pred_true
@@ -176,7 +176,7 @@ strcmp.loop1:                                     ; preds = %strcmp.loop
 strcmp.loop5:                                     ; preds = %strcmp.loop1
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char10)
   %9 = add [16 x i8]* %comm, i64 3
-  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i8* nonnull %strcmp.char10, i64 1, [16 x i8]* %9)
+  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i8*, i64, [16 x i8]*)*)(i8* nonnull %strcmp.char10, i64 1, [16 x i8]* %9)
   %10 = load i8, i8* %strcmp.char10, align 1
   %strcmp.cmp12 = icmp eq i8 %10, 100
   br i1 %strcmp.cmp12, label %strcmp.loop9, label %pred_true
@@ -184,7 +184,7 @@ strcmp.loop5:                                     ; preds = %strcmp.loop1
 strcmp.loop9:                                     ; preds = %strcmp.loop5
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char14)
   %11 = add [16 x i8]* %comm, i64 4
-  %probe_read15 = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i8* nonnull %strcmp.char14, i64 1, [16 x i8]* %11)
+  %probe_read15 = call i64 inttoptr (i64 4 to i64 (i8*, i64, [16 x i8]*)*)(i8* nonnull %strcmp.char14, i64 1, [16 x i8]* %11)
   %12 = load i8, i8* %strcmp.char14, align 1
   %strcmp.cmp16 = icmp eq i8 %12, 0
   br i1 %strcmp.cmp16, label %pred_false, label %pred_true
@@ -200,7 +200,7 @@ lookup_merge:                                     ; preds = %pred_true, %lookup_
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %14)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo19 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo19, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [16 x i8]*, i64*, i64)*)(i64 %pseudo19, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %14)
   ret i64 0

--- a/tests/codegen/string_not_equal_comparison.cpp
+++ b/tests/codegen/string_not_equal_comparison.cpp
@@ -31,7 +31,7 @@ entry:
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i8 0, i64 16, i1 false)
   %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char, i64 1, [16 x i8]* nonnull %comm)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, [16 x i8]*)*)(i8* nonnull %strcmp.char, i64 1, [16 x i8]* nonnull %comm)
   %2 = load i8, i8* %strcmp.char, align 1
   %strcmp.cmp = icmp eq i8 %2, 115
   br i1 %strcmp.cmp, label %strcmp.loop, label %pred_true
@@ -48,14 +48,14 @@ pred_true:                                        ; preds = %strcmp.loop9, %strc
   %get_comm18 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm17, i64 16)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %3, i8* nonnull align 1 %4, i64 16, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, [16 x i8]*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 strcmp.loop:                                      ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char2)
   %5 = add [16 x i8]* %comm, i64 1
-  %probe_read3 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char2, i64 1, [16 x i8]* %5)
+  %probe_read3 = call i64 inttoptr (i64 4 to i64 (i8*, i64, [16 x i8]*)*)(i8* nonnull %strcmp.char2, i64 1, [16 x i8]* %5)
   %6 = load i8, i8* %strcmp.char2, align 1
   %strcmp.cmp4 = icmp eq i8 %6, 115
   br i1 %strcmp.cmp4, label %strcmp.loop1, label %pred_true
@@ -63,7 +63,7 @@ strcmp.loop:                                      ; preds = %entry
 strcmp.loop1:                                     ; preds = %strcmp.loop
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char6)
   %7 = add [16 x i8]* %comm, i64 2
-  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char6, i64 1, [16 x i8]* %7)
+  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, [16 x i8]*)*)(i8* nonnull %strcmp.char6, i64 1, [16 x i8]* %7)
   %8 = load i8, i8* %strcmp.char6, align 1
   %strcmp.cmp8 = icmp eq i8 %8, 104
   br i1 %strcmp.cmp8, label %strcmp.loop5, label %pred_true
@@ -71,7 +71,7 @@ strcmp.loop1:                                     ; preds = %strcmp.loop
 strcmp.loop5:                                     ; preds = %strcmp.loop1
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char10)
   %9 = add [16 x i8]* %comm, i64 3
-  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char10, i64 1, [16 x i8]* %9)
+  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i8*, i64, [16 x i8]*)*)(i8* nonnull %strcmp.char10, i64 1, [16 x i8]* %9)
   %10 = load i8, i8* %strcmp.char10, align 1
   %strcmp.cmp12 = icmp eq i8 %10, 100
   br i1 %strcmp.cmp12, label %strcmp.loop9, label %pred_true
@@ -79,7 +79,7 @@ strcmp.loop5:                                     ; preds = %strcmp.loop1
 strcmp.loop9:                                     ; preds = %strcmp.loop5
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char14)
   %11 = add [16 x i8]* %comm, i64 4
-  %probe_read15 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char14, i64 1, [16 x i8]* %11)
+  %probe_read15 = call i64 inttoptr (i64 4 to i64 (i8*, i64, [16 x i8]*)*)(i8* nonnull %strcmp.char14, i64 1, [16 x i8]* %11)
   %12 = load i8, i8* %strcmp.char14, align 1
   %strcmp.cmp16 = icmp eq i8 %12, 0
   br i1 %strcmp.cmp16, label %pred_false, label %pred_true
@@ -95,7 +95,7 @@ lookup_merge:                                     ; preds = %pred_true, %lookup_
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %14)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo19 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo19, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, [16 x i8]*, i64*, i64)*)(i64 %pseudo19, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %14)
   ret i64 0
@@ -136,7 +136,7 @@ entry:
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 16, i32 1, i1 false)
   %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char, i64 1, [16 x i8]* nonnull %comm)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i8* nonnull %strcmp.char, i64 1, [16 x i8]* nonnull %comm)
   %2 = load i8, i8* %strcmp.char, align 1
   %strcmp.cmp = icmp eq i8 %2, 115
   br i1 %strcmp.cmp, label %strcmp.loop, label %pred_true
@@ -153,14 +153,14 @@ pred_true:                                        ; preds = %strcmp.loop9, %strc
   %get_comm18 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm17, i64 16)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %3, i8* nonnull %4, i64 16, i32 1, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 strcmp.loop:                                      ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char2)
   %5 = add [16 x i8]* %comm, i64 1
-  %probe_read3 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char2, i64 1, [16 x i8]* %5)
+  %probe_read3 = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i8* nonnull %strcmp.char2, i64 1, [16 x i8]* %5)
   %6 = load i8, i8* %strcmp.char2, align 1
   %strcmp.cmp4 = icmp eq i8 %6, 115
   br i1 %strcmp.cmp4, label %strcmp.loop1, label %pred_true
@@ -168,7 +168,7 @@ strcmp.loop:                                      ; preds = %entry
 strcmp.loop1:                                     ; preds = %strcmp.loop
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char6)
   %7 = add [16 x i8]* %comm, i64 2
-  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char6, i64 1, [16 x i8]* %7)
+  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i8* nonnull %strcmp.char6, i64 1, [16 x i8]* %7)
   %8 = load i8, i8* %strcmp.char6, align 1
   %strcmp.cmp8 = icmp eq i8 %8, 104
   br i1 %strcmp.cmp8, label %strcmp.loop5, label %pred_true
@@ -176,7 +176,7 @@ strcmp.loop1:                                     ; preds = %strcmp.loop
 strcmp.loop5:                                     ; preds = %strcmp.loop1
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char10)
   %9 = add [16 x i8]* %comm, i64 3
-  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char10, i64 1, [16 x i8]* %9)
+  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i8* nonnull %strcmp.char10, i64 1, [16 x i8]* %9)
   %10 = load i8, i8* %strcmp.char10, align 1
   %strcmp.cmp12 = icmp eq i8 %10, 100
   br i1 %strcmp.cmp12, label %strcmp.loop9, label %pred_true
@@ -184,7 +184,7 @@ strcmp.loop5:                                     ; preds = %strcmp.loop1
 strcmp.loop9:                                     ; preds = %strcmp.loop5
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char14)
   %11 = add [16 x i8]* %comm, i64 4
-  %probe_read15 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char14, i64 1, [16 x i8]* %11)
+  %probe_read15 = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i8* nonnull %strcmp.char14, i64 1, [16 x i8]* %11)
   %12 = load i8, i8* %strcmp.char14, align 1
   %strcmp.cmp16 = icmp eq i8 %12, 0
   br i1 %strcmp.cmp16, label %pred_false, label %pred_true
@@ -200,7 +200,7 @@ lookup_merge:                                     ; preds = %pred_true, %lookup_
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %14)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo19 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo19, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo19, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %14)
   ret i64 0

--- a/tests/codegen/string_propagation.cpp
+++ b/tests/codegen/string_propagation.cpp
@@ -37,14 +37,14 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key1", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo2, i64* nonnull %"@x_key1")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo2, i64* nonnull %"@x_key1")
   %4 = getelementptr inbounds [64 x i8], [64 x i8]* %lookup_elem_val, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
@@ -64,7 +64,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@y_key", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo3, i64* nonnull %"@y_key", [64 x i8]* nonnull %lookup_elem_val, i64 0)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo3, i64* nonnull %"@y_key", [64 x i8]* nonnull %lookup_elem_val, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
@@ -111,14 +111,14 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key1", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo2, i64* nonnull %"@x_key1")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo2, i64* nonnull %"@x_key1")
   %4 = getelementptr inbounds [64 x i8], [64 x i8]* %lookup_elem_val, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
@@ -138,7 +138,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@y_key", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo3, i64* nonnull %"@y_key", [64 x i8]* nonnull %lookup_elem_val, i64 0)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo3, i64* nonnull %"@y_key", [64 x i8]* nonnull %lookup_elem_val, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
@@ -185,14 +185,14 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key1", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo2, i64* nonnull %"@x_key1")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo2, i64* nonnull %"@x_key1")
   %4 = getelementptr inbounds [64 x i8], [64 x i8]* %lookup_elem_val, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
@@ -212,7 +212,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@y_key", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo3, i64* nonnull %"@y_key", [64 x i8]* nonnull %lookup_elem_val, i64 0)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo3, i64* nonnull %"@y_key", [64 x i8]* nonnull %lookup_elem_val, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/struct_char.cpp
+++ b/tests/codegen/struct_char.cpp
@@ -73,7 +73,7 @@ entry:
   %2 = load i8, i8 addrspace(64)* null, align 536870912
   store i8 %2, i8* %1, align 1
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %Foo.x)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %Foo.x, i64 1, [1 x i8]* nonnull %"$foo")
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %Foo.x, i64 1, i8* nonnull %1)
   %3 = load i8, i8* %Foo.x, align 1
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %Foo.x)
   %4 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/struct_char.cpp
+++ b/tests/codegen/struct_char.cpp
@@ -27,7 +27,7 @@ entry:
   %2 = load i8, i8 addrspace(64)* null, align 536870912
   store i8 %2, i8* %1, align 1
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %Foo.x)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %Foo.x, i64 1, [1 x i8]* nonnull %"$foo")
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %Foo.x, i64 1, i8* nonnull %1)
   %3 = load i8, i8* %Foo.x, align 1
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %Foo.x)
   %4 = bitcast i64* %"@x_key" to i8*
@@ -121,7 +121,7 @@ entry:
   %"@x_key" = alloca i64, align 8
   %Foo.x = alloca i8, align 1
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %Foo.x)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %Foo.x, i64 1, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %Foo.x, i64 1, i8* null)
   %1 = load i8, i8* %Foo.x, align 1
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %Foo.x)
   %2 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/struct_char.cpp
+++ b/tests/codegen/struct_char.cpp
@@ -38,7 +38,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %5, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
@@ -81,7 +81,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %5, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
@@ -126,7 +126,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %3, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/struct_char.cpp
+++ b/tests/codegen/struct_char.cpp
@@ -19,13 +19,13 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %Foo.x = alloca i8, align 1
-  %"$foo" = alloca [1 x i8], align 1
-  %1 = getelementptr inbounds [1 x i8], [1 x i8]* %"$foo", i64 0, i64 0
+  %"$foo" = alloca i64, align 8
+  %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i64 0, i64 1, i1 false)
+  store i8 0, i8* %1, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i8, i8 addrspace(64)* null, align 536870912
-  store i8 %2, i8* %1, align 1
+  store i8 %2, i8* %1, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %Foo.x)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %Foo.x, i64 1, i8* nonnull %1)
   %3 = load i8, i8* %Foo.x, align 1
@@ -43,9 +43,6 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
 }
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/struct_char.cpp
+++ b/tests/codegen/struct_char.cpp
@@ -62,13 +62,13 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %Foo.x = alloca i8, align 1
-  %"$foo" = alloca [1 x i8], align 1
-  %1 = getelementptr inbounds [1 x i8], [1 x i8]* %"$foo", i64 0, i64 0
+  %"$foo" = alloca i64, align 8
+  %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull %1, i64 0, i64 1, i32 1, i1 false)
+  store i8 0, i8* %1, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i8, i8 addrspace(64)* null, align 536870912
-  store i8 %2, i8* %1, align 1
+  store i8 %2, i8* %1, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %Foo.x)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %Foo.x, i64 1, i8* nonnull %1)
   %3 = load i8, i8* %Foo.x, align 1
@@ -86,9 +86,6 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
 }
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/struct_integer_ptr.cpp
+++ b/tests/codegen/struct_integer_ptr.cpp
@@ -22,7 +22,7 @@ entry:
   %"$foo" = alloca i64, align 8
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %1, i64 0, i64 8, i1 false)
+  store i64 0, i64* %"$foo", align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i64, i64 addrspace(64)* null, align 536870912
   store i64 %2, i64* %"$foo", align 8
@@ -49,9 +49,6 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   ret i64 0
 }
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/struct_integer_ptr.cpp
+++ b/tests/codegen/struct_integer_ptr.cpp
@@ -28,12 +28,12 @@ entry:
   store i64 %2, i64* %"$foo", align 8
   %3 = bitcast i64* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, i8* nonnull %1)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, i8* nonnull %1)
   %4 = load i64, i64* %Foo.x, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i32* %deref to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %deref, i64 4, i64 %4)
+  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i32*, i64, i64)*)(i32* nonnull %deref, i64 4, i64 %4)
   %6 = load i32, i32* %deref, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   %7 = bitcast i64* %"@x_key" to i8*
@@ -44,7 +44,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 %8, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   ret i64 0
@@ -83,7 +83,7 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i32* %deref to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %deref, i64 4, i64 %4)
+  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i32* nonnull %deref, i64 4, i64 %4)
   %6 = load i32, i32* %deref, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   %7 = bitcast i64* %"@x_key" to i8*
@@ -94,7 +94,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 %8, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   ret i64 0
@@ -130,12 +130,12 @@ entry:
   %Foo.x = alloca i64, align 8
   %1 = bitcast i64* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, i8* null)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, i8* null)
   %2 = load i64, i64* %Foo.x, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i32* %deref to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %deref, i64 4, i64 %2)
+  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i32*, i64, i64)*)(i32* nonnull %deref, i64 4, i64 %2)
   %4 = load i32, i32* %deref, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*
@@ -146,7 +146,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %6, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0

--- a/tests/codegen/struct_integer_ptr.cpp
+++ b/tests/codegen/struct_integer_ptr.cpp
@@ -72,7 +72,7 @@ entry:
   %"$foo" = alloca i64, align 8
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull %1, i64 0, i64 8, i32 8, i1 false)
+  store i64 0, i64* %"$foo", align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i64, i64 addrspace(64)* null, align 536870912
   store i64 %2, i64* %"$foo", align 8
@@ -99,9 +99,6 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   ret i64 0
 }
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/struct_integer_ptr.cpp
+++ b/tests/codegen/struct_integer_ptr.cpp
@@ -73,7 +73,6 @@ entry:
   %deref = alloca i32, align 4
   %Foo.x = alloca i64, align 8
   %"$foo" = alloca i64, align 8
-  %tmpcast = bitcast i64* %"$foo" to [8 x i8]*
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i64 0, i64 8, i32 8, i1 false)
@@ -82,7 +81,7 @@ entry:
   store i64 %2, i64* %"$foo", align 8
   %3 = bitcast i64* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, [8 x i8]* nonnull %tmpcast)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, i8* nonnull %1)
   %4 = load i64, i64* %Foo.x, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i32* %deref to i8*

--- a/tests/codegen/struct_integer_ptr.cpp
+++ b/tests/codegen/struct_integer_ptr.cpp
@@ -20,7 +20,6 @@ entry:
   %deref = alloca i32, align 4
   %Foo.x = alloca i64, align 8
   %"$foo" = alloca i64, align 8
-  %tmpcast = bitcast i64* %"$foo" to [8 x i8]*
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %1, i64 0, i64 8, i1 false)
@@ -29,7 +28,7 @@ entry:
   store i64 %2, i64* %"$foo", align 8
   %3 = bitcast i64* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, [8 x i8]* nonnull %tmpcast)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, i8* nonnull %1)
   %4 = load i64, i64* %Foo.x, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i32* %deref to i8*
@@ -138,7 +137,7 @@ entry:
   %Foo.x = alloca i64, align 8
   %1 = bitcast i64* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, i8* null)
   %2 = load i64, i64* %Foo.x, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i32* %deref to i8*

--- a/tests/codegen/struct_integer_ptr.cpp
+++ b/tests/codegen/struct_integer_ptr.cpp
@@ -78,12 +78,12 @@ entry:
   store i64 %2, i64* %"$foo", align 8
   %3 = bitcast i64* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, i8* nonnull %1)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, i8* nonnull %1)
   %4 = load i64, i64* %Foo.x, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i32* %deref to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i32* nonnull %deref, i64 4, i64 %4)
+  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i32*, i64, i64)*)(i32* nonnull %deref, i64 4, i64 %4)
   %6 = load i32, i32* %deref, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   %7 = bitcast i64* %"@x_key" to i8*
@@ -94,7 +94,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 %8, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   ret i64 0

--- a/tests/codegen/struct_integers.cpp
+++ b/tests/codegen/struct_integers.cpp
@@ -18,34 +18,32 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %Foo.x = alloca i32, align 4
-  %"$foo" = alloca i32, align 4
-  %1 = bitcast i32* %"$foo" to i8*
+  %"$foo" = alloca i64, align 8
+  %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %1, i64 0, i64 4, i1 false)
+  %2 = bitcast i64* %"$foo" to i32*
+  store i32 0, i32* %2, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = load i32, i32 addrspace(64)* null, align 536870912
-  store i32 %2, i32* %"$foo", align 4
-  %3 = bitcast i32* %Foo.x to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %3 = load i32, i32 addrspace(64)* null, align 536870912
+  store i32 %3, i32* %2, align 8
+  %4 = bitcast i32* %Foo.x to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.x, i64 4, i8* nonnull %1)
-  %4 = load i32, i32* %Foo.x, align 4
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  %5 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %5 = load i32, i32* %Foo.x, align 4
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  %6 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@x_key", align 8
-  %6 = zext i32 %4 to i64
-  %7 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  store i64 %6, i64* %"@x_val", align 8
+  %7 = zext i32 %5 to i64
+  %8 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
+  store i64 %7, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
 }
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/struct_integers.cpp
+++ b/tests/codegen/struct_integers.cpp
@@ -19,7 +19,6 @@ entry:
   %"@x_key" = alloca i64, align 8
   %Foo.x = alloca i32, align 4
   %"$foo" = alloca i32, align 4
-  %tmpcast = bitcast i32* %"$foo" to [4 x i8]*
   %1 = bitcast i32* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %1, i64 0, i64 4, i1 false)
@@ -28,7 +27,7 @@ entry:
   store i32 %2, i32* %"$foo", align 4
   %3 = bitcast i32* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.x, i64 4, [4 x i8]* nonnull %tmpcast)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.x, i64 4, i8* nonnull %1)
   %4 = load i32, i32* %Foo.x, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*
@@ -126,7 +125,7 @@ entry:
   %Foo.x = alloca i32, align 4
   %1 = bitcast i32* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.x, i64 4, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.x, i64 4, i8* null)
   %2 = load i32, i32* %Foo.x, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/struct_integers.cpp
+++ b/tests/codegen/struct_integers.cpp
@@ -66,7 +66,6 @@ entry:
   %"@x_key" = alloca i64, align 8
   %Foo.x = alloca i32, align 4
   %"$foo" = alloca i32, align 4
-  %tmpcast = bitcast i32* %"$foo" to [4 x i8]*
   %1 = bitcast i32* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i64 0, i64 4, i32 4, i1 false)
@@ -75,7 +74,7 @@ entry:
   store i32 %2, i32* %"$foo", align 4
   %3 = bitcast i32* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.x, i64 4, [4 x i8]* nonnull %tmpcast)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.x, i64 4, i8* nonnull %1)
   %4 = load i32, i32* %Foo.x, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/struct_integers.cpp
+++ b/tests/codegen/struct_integers.cpp
@@ -73,7 +73,7 @@ entry:
   store i32 %3, i32* %2, align 8
   %4 = bitcast i32* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.x, i64 4, i8* nonnull %1)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i64, i8*)*)(i32* nonnull %Foo.x, i64 4, i8* nonnull %1)
   %5 = load i32, i32* %Foo.x, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %6 = bitcast i64* %"@x_key" to i8*
@@ -84,7 +84,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %7, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0

--- a/tests/codegen/struct_integers.cpp
+++ b/tests/codegen/struct_integers.cpp
@@ -28,7 +28,7 @@ entry:
   store i32 %3, i32* %2, align 8
   %4 = bitcast i32* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.x, i64 4, i8* nonnull %1)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i64, i8*)*)(i32* nonnull %Foo.x, i64 4, i8* nonnull %1)
   %5 = load i32, i32* %Foo.x, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %6 = bitcast i64* %"@x_key" to i8*
@@ -39,7 +39,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %7, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
@@ -120,7 +120,7 @@ entry:
   %Foo.x = alloca i32, align 4
   %1 = bitcast i32* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.x, i64 4, i8* null)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i64, i8*)*)(i32* nonnull %Foo.x, i64 4, i8* null)
   %2 = load i32, i32* %Foo.x, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key" to i8*
@@ -131,7 +131,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %4, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0

--- a/tests/codegen/struct_integers.cpp
+++ b/tests/codegen/struct_integers.cpp
@@ -63,34 +63,32 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %Foo.x = alloca i32, align 4
-  %"$foo" = alloca i32, align 4
-  %1 = bitcast i32* %"$foo" to i8*
+  %"$foo" = alloca i64, align 8
+  %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull %1, i64 0, i64 4, i32 4, i1 false)
+  %2 = bitcast i64* %"$foo" to i32*
+  store i32 0, i32* %2, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = load i32, i32 addrspace(64)* null, align 536870912
-  store i32 %2, i32* %"$foo", align 4
-  %3 = bitcast i32* %Foo.x to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %3 = load i32, i32 addrspace(64)* null, align 536870912
+  store i32 %3, i32* %2, align 8
+  %4 = bitcast i32* %Foo.x to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.x, i64 4, i8* nonnull %1)
-  %4 = load i32, i32* %Foo.x, align 4
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  %5 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %5 = load i32, i32* %Foo.x, align 4
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  %6 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@x_key", align 8
-  %6 = zext i32 %4 to i64
-  %7 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  store i64 %6, i64* %"@x_val", align 8
+  %7 = zext i32 %5 to i64
+  %8 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
+  store i64 %7, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
 }
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/struct_long.cpp
+++ b/tests/codegen/struct_long.cpp
@@ -65,7 +65,6 @@ entry:
   %"@x_key" = alloca i64, align 8
   %Foo.x = alloca i64, align 8
   %"$foo" = alloca i64, align 8
-  %tmpcast = bitcast i64* %"$foo" to [8 x i8]*
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i64 0, i64 8, i32 8, i1 false)
@@ -74,7 +73,7 @@ entry:
   store i64 %2, i64* %"$foo", align 8
   %3 = bitcast i64* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, [8 x i8]* nonnull %tmpcast)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, i8* nonnull %1)
   %4 = load i64, i64* %Foo.x, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/struct_long.cpp
+++ b/tests/codegen/struct_long.cpp
@@ -64,7 +64,7 @@ entry:
   %"$foo" = alloca i64, align 8
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull %1, i64 0, i64 8, i32 8, i1 false)
+  store i64 0, i64* %"$foo", align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i64, i64 addrspace(64)* null, align 536870912
   store i64 %2, i64* %"$foo", align 8
@@ -85,9 +85,6 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
 }
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/struct_long.cpp
+++ b/tests/codegen/struct_long.cpp
@@ -70,7 +70,7 @@ entry:
   store i64 %2, i64* %"$foo", align 8
   %3 = bitcast i64* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, i8* nonnull %1)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, i8* nonnull %1)
   %4 = load i64, i64* %Foo.x, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/struct_long.cpp
+++ b/tests/codegen/struct_long.cpp
@@ -21,7 +21,7 @@ entry:
   %"$foo" = alloca i64, align 8
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %1, i64 0, i64 8, i1 false)
+  store i64 0, i64* %"$foo", align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i64, i64 addrspace(64)* null, align 536870912
   store i64 %2, i64* %"$foo", align 8
@@ -42,9 +42,6 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
 }
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/struct_long.cpp
+++ b/tests/codegen/struct_long.cpp
@@ -27,7 +27,7 @@ entry:
   store i64 %2, i64* %"$foo", align 8
   %3 = bitcast i64* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, i8* nonnull %1)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, i8* nonnull %1)
   %4 = load i64, i64* %Foo.x, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*
@@ -37,7 +37,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %4, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
@@ -80,7 +80,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %4, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
@@ -115,7 +115,7 @@ entry:
   %Foo.x = alloca i64, align 8
   %1 = bitcast i64* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, i8* null)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, i8* null)
   %2 = load i64, i64* %Foo.x, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key" to i8*
@@ -125,7 +125,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %2, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/struct_long.cpp
+++ b/tests/codegen/struct_long.cpp
@@ -19,7 +19,6 @@ entry:
   %"@x_key" = alloca i64, align 8
   %Foo.x = alloca i64, align 8
   %"$foo" = alloca i64, align 8
-  %tmpcast = bitcast i64* %"$foo" to [8 x i8]*
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %1, i64 0, i64 8, i1 false)
@@ -28,7 +27,7 @@ entry:
   store i64 %2, i64* %"$foo", align 8
   %3 = bitcast i64* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, [8 x i8]* nonnull %tmpcast)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, i8* nonnull %1)
   %4 = load i64, i64* %Foo.x, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*
@@ -123,7 +122,7 @@ entry:
   %Foo.x = alloca i64, align 8
   %1 = bitcast i64* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, i8* null)
   %2 = load i64, i64* %Foo.x, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/struct_nested_struct_anon.cpp
+++ b/tests/codegen/struct_nested_struct_anon.cpp
@@ -74,7 +74,7 @@ entry:
   store i32 %3, i32* %2, align 8
   %4 = bitcast i32* %"Foo::(anonymous at definitions.h:1:14).x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"Foo::(anonymous at definitions.h:1:14).x", i64 4, i8* nonnull %1)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i64, i8*)*)(i32* nonnull %"Foo::(anonymous at definitions.h:1:14).x", i64 4, i8* nonnull %1)
   %5 = load i32, i32* %"Foo::(anonymous at definitions.h:1:14).x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %6 = bitcast i64* %"@x_key" to i8*
@@ -85,7 +85,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %7, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0

--- a/tests/codegen/struct_nested_struct_anon.cpp
+++ b/tests/codegen/struct_nested_struct_anon.cpp
@@ -29,7 +29,7 @@ entry:
   store i32 %3, i32* %2, align 8
   %4 = bitcast i32* %"Foo::(anonymous at definitions.h:1:14).x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"Foo::(anonymous at definitions.h:1:14).x", i64 4, i8* nonnull %1)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i64, i8*)*)(i32* nonnull %"Foo::(anonymous at definitions.h:1:14).x", i64 4, i8* nonnull %1)
   %5 = load i32, i32* %"Foo::(anonymous at definitions.h:1:14).x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %6 = bitcast i64* %"@x_key" to i8*
@@ -40,7 +40,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %7, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
@@ -120,7 +120,7 @@ entry:
   %"Foo::(anonymous at definitions.h:1:14).x" = alloca i32, align 4
   %1 = bitcast i32* %"Foo::(anonymous at definitions.h:1:14).x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"Foo::(anonymous at definitions.h:1:14).x", i64 4, i8* null)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i64, i8*)*)(i32* nonnull %"Foo::(anonymous at definitions.h:1:14).x", i64 4, i8* null)
   %2 = load i32, i32* %"Foo::(anonymous at definitions.h:1:14).x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key" to i8*
@@ -131,7 +131,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %4, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0

--- a/tests/codegen/struct_nested_struct_anon.cpp
+++ b/tests/codegen/struct_nested_struct_anon.cpp
@@ -19,34 +19,32 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %"Foo::(anonymous at definitions.h:1:14).x" = alloca i32, align 4
-  %"$foo" = alloca i32, align 4
-  %1 = bitcast i32* %"$foo" to i8*
+  %"$foo" = alloca i64, align 8
+  %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %1, i64 0, i64 4, i1 false)
+  %2 = bitcast i64* %"$foo" to i32*
+  store i32 0, i32* %2, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = load i32, i32 addrspace(64)* null, align 536870912
-  store i32 %2, i32* %"$foo", align 4
-  %3 = bitcast i32* %"Foo::(anonymous at definitions.h:1:14).x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %3 = load i32, i32 addrspace(64)* null, align 536870912
+  store i32 %3, i32* %2, align 8
+  %4 = bitcast i32* %"Foo::(anonymous at definitions.h:1:14).x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"Foo::(anonymous at definitions.h:1:14).x", i64 4, i8* nonnull %1)
-  %4 = load i32, i32* %"Foo::(anonymous at definitions.h:1:14).x", align 4
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  %5 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %5 = load i32, i32* %"Foo::(anonymous at definitions.h:1:14).x", align 4
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  %6 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@x_key", align 8
-  %6 = zext i32 %4 to i64
-  %7 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  store i64 %6, i64* %"@x_val", align 8
+  %7 = zext i32 %5 to i64
+  %8 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
+  store i64 %7, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
 }
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/struct_nested_struct_anon.cpp
+++ b/tests/codegen/struct_nested_struct_anon.cpp
@@ -64,34 +64,32 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %"Foo::(anonymous at definitions.h:1:14).x" = alloca i32, align 4
-  %"$foo" = alloca i32, align 4
-  %1 = bitcast i32* %"$foo" to i8*
+  %"$foo" = alloca i64, align 8
+  %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull %1, i64 0, i64 4, i32 4, i1 false)
+  %2 = bitcast i64* %"$foo" to i32*
+  store i32 0, i32* %2, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = load i32, i32 addrspace(64)* null, align 536870912
-  store i32 %2, i32* %"$foo", align 4
-  %3 = bitcast i32* %"Foo::(anonymous at definitions.h:1:14).x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %3 = load i32, i32 addrspace(64)* null, align 536870912
+  store i32 %3, i32* %2, align 8
+  %4 = bitcast i32* %"Foo::(anonymous at definitions.h:1:14).x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"Foo::(anonymous at definitions.h:1:14).x", i64 4, i8* nonnull %1)
-  %4 = load i32, i32* %"Foo::(anonymous at definitions.h:1:14).x", align 4
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  %5 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %5 = load i32, i32* %"Foo::(anonymous at definitions.h:1:14).x", align 4
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  %6 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@x_key", align 8
-  %6 = zext i32 %4 to i64
-  %7 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  store i64 %6, i64* %"@x_val", align 8
+  %7 = zext i32 %5 to i64
+  %8 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
+  store i64 %7, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
 }
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/struct_nested_struct_anon.cpp
+++ b/tests/codegen/struct_nested_struct_anon.cpp
@@ -67,7 +67,6 @@ entry:
   %"@x_key" = alloca i64, align 8
   %"Foo::(anonymous at definitions.h:1:14).x" = alloca i32, align 4
   %"$foo" = alloca i32, align 4
-  %tmpcast = bitcast i32* %"$foo" to [4 x i8]*
   %1 = bitcast i32* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i64 0, i64 4, i32 4, i1 false)
@@ -76,7 +75,7 @@ entry:
   store i32 %2, i32* %"$foo", align 4
   %3 = bitcast i32* %"Foo::(anonymous at definitions.h:1:14).x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"Foo::(anonymous at definitions.h:1:14).x", i64 4, [4 x i8]* nonnull %tmpcast)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"Foo::(anonymous at definitions.h:1:14).x", i64 4, i8* nonnull %1)
   %4 = load i32, i32* %"Foo::(anonymous at definitions.h:1:14).x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/struct_nested_struct_anon.cpp
+++ b/tests/codegen/struct_nested_struct_anon.cpp
@@ -20,7 +20,6 @@ entry:
   %"@x_key" = alloca i64, align 8
   %"Foo::(anonymous at definitions.h:1:14).x" = alloca i32, align 4
   %"$foo" = alloca i32, align 4
-  %tmpcast = bitcast i32* %"$foo" to [4 x i8]*
   %1 = bitcast i32* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %1, i64 0, i64 4, i1 false)
@@ -29,7 +28,7 @@ entry:
   store i32 %2, i32* %"$foo", align 4
   %3 = bitcast i32* %"Foo::(anonymous at definitions.h:1:14).x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"Foo::(anonymous at definitions.h:1:14).x", i64 4, [4 x i8]* nonnull %tmpcast)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"Foo::(anonymous at definitions.h:1:14).x", i64 4, i8* nonnull %1)
   %4 = load i32, i32* %"Foo::(anonymous at definitions.h:1:14).x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*
@@ -126,7 +125,7 @@ entry:
   %"Foo::(anonymous at definitions.h:1:14).x" = alloca i32, align 4
   %1 = bitcast i32* %"Foo::(anonymous at definitions.h:1:14).x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"Foo::(anonymous at definitions.h:1:14).x", i64 4, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"Foo::(anonymous at definitions.h:1:14).x", i64 4, i8* null)
   %2 = load i32, i32* %"Foo::(anonymous at definitions.h:1:14).x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/struct_nested_struct_named.cpp
+++ b/tests/codegen/struct_nested_struct_named.cpp
@@ -28,7 +28,7 @@ entry:
   store i32 %3, i32* %2, align 8
   %4 = bitcast i32* %Bar.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i8* nonnull %1)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i8* nonnull %1)
   %5 = load i32, i32* %Bar.x, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %6 = bitcast i64* %"@x_key" to i8*
@@ -39,7 +39,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %7, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
@@ -119,7 +119,7 @@ entry:
   %Bar.x = alloca i32, align 4
   %1 = bitcast i32* %Bar.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i8* null)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i8* null)
   %2 = load i32, i32* %Bar.x, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key" to i8*
@@ -130,7 +130,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %4, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0

--- a/tests/codegen/struct_nested_struct_named.cpp
+++ b/tests/codegen/struct_nested_struct_named.cpp
@@ -66,7 +66,6 @@ entry:
   %"@x_key" = alloca i64, align 8
   %Bar.x = alloca i32, align 4
   %"$foo" = alloca i32, align 4
-  %tmpcast = bitcast i32* %"$foo" to [4 x i8]*
   %1 = bitcast i32* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i64 0, i64 4, i32 4, i1 false)
@@ -75,7 +74,7 @@ entry:
   store i32 %2, i32* %"$foo", align 4
   %3 = bitcast i32* %Bar.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, [4 x i8]* nonnull %tmpcast)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i8* nonnull %1)
   %4 = load i32, i32* %Bar.x, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/struct_nested_struct_named.cpp
+++ b/tests/codegen/struct_nested_struct_named.cpp
@@ -73,7 +73,7 @@ entry:
   store i32 %3, i32* %2, align 8
   %4 = bitcast i32* %Bar.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i8* nonnull %1)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i8* nonnull %1)
   %5 = load i32, i32* %Bar.x, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %6 = bitcast i64* %"@x_key" to i8*
@@ -84,7 +84,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %7, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0

--- a/tests/codegen/struct_nested_struct_named.cpp
+++ b/tests/codegen/struct_nested_struct_named.cpp
@@ -18,34 +18,32 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %Bar.x = alloca i32, align 4
-  %"$foo" = alloca i32, align 4
-  %1 = bitcast i32* %"$foo" to i8*
+  %"$foo" = alloca i64, align 8
+  %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %1, i64 0, i64 4, i1 false)
+  %2 = bitcast i64* %"$foo" to i32*
+  store i32 0, i32* %2, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = load i32, i32 addrspace(64)* null, align 536870912
-  store i32 %2, i32* %"$foo", align 4
-  %3 = bitcast i32* %Bar.x to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %3 = load i32, i32 addrspace(64)* null, align 536870912
+  store i32 %3, i32* %2, align 8
+  %4 = bitcast i32* %Bar.x to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i8* nonnull %1)
-  %4 = load i32, i32* %Bar.x, align 4
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  %5 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %5 = load i32, i32* %Bar.x, align 4
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  %6 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@x_key", align 8
-  %6 = zext i32 %4 to i64
-  %7 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  store i64 %6, i64* %"@x_val", align 8
+  %7 = zext i32 %5 to i64
+  %8 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
+  store i64 %7, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
 }
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/struct_nested_struct_named.cpp
+++ b/tests/codegen/struct_nested_struct_named.cpp
@@ -19,7 +19,6 @@ entry:
   %"@x_key" = alloca i64, align 8
   %Bar.x = alloca i32, align 4
   %"$foo" = alloca i32, align 4
-  %tmpcast = bitcast i32* %"$foo" to [4 x i8]*
   %1 = bitcast i32* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %1, i64 0, i64 4, i1 false)
@@ -28,7 +27,7 @@ entry:
   store i32 %2, i32* %"$foo", align 4
   %3 = bitcast i32* %Bar.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, [4 x i8]* nonnull %tmpcast)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i8* nonnull %1)
   %4 = load i32, i32* %Bar.x, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*
@@ -125,7 +124,7 @@ entry:
   %Bar.x = alloca i32, align 4
   %1 = bitcast i32* %Bar.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i8* null)
   %2 = load i32, i32* %Bar.x, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/struct_nested_struct_named.cpp
+++ b/tests/codegen/struct_nested_struct_named.cpp
@@ -63,34 +63,32 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %Bar.x = alloca i32, align 4
-  %"$foo" = alloca i32, align 4
-  %1 = bitcast i32* %"$foo" to i8*
+  %"$foo" = alloca i64, align 8
+  %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull %1, i64 0, i64 4, i32 4, i1 false)
+  %2 = bitcast i64* %"$foo" to i32*
+  store i32 0, i32* %2, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = load i32, i32 addrspace(64)* null, align 536870912
-  store i32 %2, i32* %"$foo", align 4
-  %3 = bitcast i32* %Bar.x to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %3 = load i32, i32 addrspace(64)* null, align 536870912
+  store i32 %3, i32* %2, align 8
+  %4 = bitcast i32* %Bar.x to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i8* nonnull %1)
-  %4 = load i32, i32* %Bar.x, align 4
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  %5 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %5 = load i32, i32* %Bar.x, align 4
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  %6 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@x_key", align 8
-  %6 = zext i32 %4 to i64
-  %7 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  store i64 %6, i64* %"@x_val", align 8
+  %7 = zext i32 %5 to i64
+  %8 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
+  store i64 %7, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
 }
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/struct_nested_struct_ptr_named.cpp
+++ b/tests/codegen/struct_nested_struct_ptr_named.cpp
@@ -79,13 +79,13 @@ entry:
   store i64 %2, i64* %"$foo", align 8
   %3 = bitcast i64* %Foo.bar to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.bar, i64 8, i8* nonnull %1)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %Foo.bar, i64 8, i8* nonnull %1)
   %4 = bitcast i64* %Foo.bar to i8**
   %5 = load i8*, i8** %4, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %6 = bitcast i32* %Bar.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i8* %5)
+  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i32*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i8* %5)
   %7 = load i32, i32* %Bar.x, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   %8 = bitcast i64* %"@x_key" to i8*
@@ -96,7 +96,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
   store i64 %9, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
   ret i64 0

--- a/tests/codegen/struct_nested_struct_ptr_named.cpp
+++ b/tests/codegen/struct_nested_struct_ptr_named.cpp
@@ -20,7 +20,6 @@ entry:
   %Bar.x = alloca i32, align 4
   %Foo.bar = alloca i64, align 8
   %"$foo" = alloca i64, align 8
-  %tmpcast = bitcast i64* %"$foo" to [8 x i8]*
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %1, i64 0, i64 8, i1 false)
@@ -29,25 +28,26 @@ entry:
   store i64 %2, i64* %"$foo", align 8
   %3 = bitcast i64* %Foo.bar to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.bar, i64 8, [8 x i8]* nonnull %tmpcast)
-  %4 = load i64, i64* %Foo.bar, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.bar, i64 8, i8* nonnull %1)
+  %4 = bitcast i64* %Foo.bar to i8**
+  %5 = load i8*, i8** %4, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  %5 = bitcast i32* %Bar.x to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i64 %4)
-  %6 = load i32, i32* %Bar.x, align 4
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
-  %7 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
+  %6 = bitcast i32* %Bar.x to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i8* %5)
+  %7 = load i32, i32* %Bar.x, align 4
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 0, i64* %"@x_key", align 8
-  %8 = zext i32 %6 to i64
-  %9 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
-  store i64 %8, i64* %"@x_val", align 8
+  %9 = zext i32 %7 to i64
+  %10 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
+  store i64 %9, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
   ret i64 0
 }
 
@@ -138,25 +138,26 @@ entry:
   %Foo.bar = alloca i64, align 8
   %1 = bitcast i64* %Foo.bar to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.bar, i64 8, i64 0)
-  %2 = load i64, i64* %Foo.bar, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.bar, i64 8, i8* null)
+  %2 = bitcast i64* %Foo.bar to i8**
+  %3 = load i8*, i8** %2, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  %3 = bitcast i32* %Bar.x to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i64 %2)
-  %4 = load i32, i32* %Bar.x, align 4
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  %5 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %4 = bitcast i32* %Bar.x to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i8* %3)
+  %5 = load i32, i32* %Bar.x, align 4
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  %6 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@x_key", align 8
-  %6 = zext i32 %4 to i64
-  %7 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  store i64 %6, i64* %"@x_val", align 8
+  %7 = zext i32 %5 to i64
+  %8 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
+  store i64 %7, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
 }
 

--- a/tests/codegen/struct_nested_struct_ptr_named.cpp
+++ b/tests/codegen/struct_nested_struct_ptr_named.cpp
@@ -73,7 +73,7 @@ entry:
   %"$foo" = alloca i64, align 8
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull %1, i64 0, i64 8, i32 8, i1 false)
+  store i64 0, i64* %"$foo", align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i64, i64 addrspace(64)* null, align 536870912
   store i64 %2, i64* %"$foo", align 8
@@ -101,9 +101,6 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
   ret i64 0
 }
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/struct_nested_struct_ptr_named.cpp
+++ b/tests/codegen/struct_nested_struct_ptr_named.cpp
@@ -28,13 +28,13 @@ entry:
   store i64 %2, i64* %"$foo", align 8
   %3 = bitcast i64* %Foo.bar to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.bar, i64 8, i8* nonnull %1)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %Foo.bar, i64 8, i8* nonnull %1)
   %4 = bitcast i64* %Foo.bar to i8**
   %5 = load i8*, i8** %4, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %6 = bitcast i32* %Bar.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i8* %5)
+  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i32*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i8* %5)
   %7 = load i32, i32* %Bar.x, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   %8 = bitcast i64* %"@x_key" to i8*
@@ -45,7 +45,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
   store i64 %9, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
   ret i64 0
@@ -132,13 +132,13 @@ entry:
   %Foo.bar = alloca i64, align 8
   %1 = bitcast i64* %Foo.bar to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.bar, i64 8, i8* null)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %Foo.bar, i64 8, i8* null)
   %2 = bitcast i64* %Foo.bar to i8**
   %3 = load i8*, i8** %2, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %4 = bitcast i32* %Bar.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i8* %3)
+  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i32*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i8* %3)
   %5 = load i32, i32* %Bar.x, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %6 = bitcast i64* %"@x_key" to i8*
@@ -149,7 +149,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %7, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0

--- a/tests/codegen/struct_nested_struct_ptr_named.cpp
+++ b/tests/codegen/struct_nested_struct_ptr_named.cpp
@@ -22,7 +22,7 @@ entry:
   %"$foo" = alloca i64, align 8
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %1, i64 0, i64 8, i1 false)
+  store i64 0, i64* %"$foo", align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i64, i64 addrspace(64)* null, align 536870912
   store i64 %2, i64* %"$foo", align 8
@@ -50,9 +50,6 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
   ret i64 0
 }
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/struct_nested_struct_ptr_named.cpp
+++ b/tests/codegen/struct_nested_struct_ptr_named.cpp
@@ -74,7 +74,6 @@ entry:
   %Bar.x = alloca i32, align 4
   %Foo.bar = alloca i64, align 8
   %"$foo" = alloca i64, align 8
-  %tmpcast = bitcast i64* %"$foo" to [8 x i8]*
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i64 0, i64 8, i32 8, i1 false)
@@ -83,25 +82,26 @@ entry:
   store i64 %2, i64* %"$foo", align 8
   %3 = bitcast i64* %Foo.bar to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.bar, i64 8, [8 x i8]* nonnull %tmpcast)
-  %4 = load i64, i64* %Foo.bar, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.bar, i64 8, i8* nonnull %1)
+  %4 = bitcast i64* %Foo.bar to i8**
+  %5 = load i8*, i8** %4, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  %5 = bitcast i32* %Bar.x to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i64 %4)
-  %6 = load i32, i32* %Bar.x, align 4
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
-  %7 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
+  %6 = bitcast i32* %Bar.x to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i8* %5)
+  %7 = load i32, i32* %Bar.x, align 4
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 0, i64* %"@x_key", align 8
-  %8 = zext i32 %6 to i64
-  %9 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
-  store i64 %8, i64* %"@x_val", align 8
+  %9 = zext i32 %7 to i64
+  %10 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
+  store i64 %9, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
   ret i64 0
 }
 

--- a/tests/codegen/struct_save.cpp
+++ b/tests/codegen/struct_save.cpp
@@ -21,9 +21,9 @@ entry:
   store i64 0, i64* %"@foo_key", align 8
   %2 = getelementptr inbounds [12 x i8], [12 x i8]* %"@foo_val", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([12 x i8]* nonnull %"@foo_val", i64 12, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 ([12 x i8]*, i64, i64)*)([12 x i8]* nonnull %"@foo_val", i64 12, i64 0)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@foo_key", [12 x i8]* nonnull %"@foo_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [12 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@foo_key", [12 x i8]* nonnull %"@foo_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/struct_save_nested.cpp
+++ b/tests/codegen/struct_save_nested.cpp
@@ -28,16 +28,16 @@ entry:
   store i64 0, i64* %"@foo_key", align 8
   %2 = getelementptr inbounds [16 x i8], [16 x i8]* %"@foo_val", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* nonnull %"@foo_val", i64 16, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 ([16 x i8]*, i64, i64)*)([16 x i8]* nonnull %"@foo_val", i64 16, i64 0)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@foo_key", [16 x i8]* nonnull %"@foo_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [16 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@foo_key", [16 x i8]* nonnull %"@foo_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = bitcast i64* %"@foo_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@foo_key1", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo2, i64* nonnull %"@foo_key1")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo2, i64* nonnull %"@foo_key1")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -57,14 +57,14 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@bar_key", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo3, i64* nonnull %"@bar_key", [8 x i8]* nonnull %tmpcast, i64 0)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [8 x i8]*, i64)*)(i64 %pseudo3, i64* nonnull %"@bar_key", [8 x i8]* nonnull %tmpcast, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %6 = bitcast i64* %"@foo_key5" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@foo_key5", align 8
   %pseudo6 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %lookup_elem7 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo6, i64* nonnull %"@foo_key5")
+  %lookup_elem7 = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo6, i64* nonnull %"@foo_key5")
   %map_lookup_cond12 = icmp eq i8* %lookup_elem7, null
   br i1 %map_lookup_cond12, label %lookup_merge10, label %lookup_success8
 
@@ -85,7 +85,7 @@ lookup_merge10:                                   ; preds = %lookup_merge, %look
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %lookup_elem_val11.sroa.3.0, i64* %"@x_val", align 8
   %pseudo14 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
-  %update_elem15 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo14, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem15 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo14, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0

--- a/tests/codegen/struct_save_string.cpp
+++ b/tests/codegen/struct_save_string.cpp
@@ -91,9 +91,9 @@ entry:
   store i64 0, i64* %"@foo_key", align 8
   %2 = getelementptr inbounds [32 x i8], [32 x i8]* %"@foo_val", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)([32 x i8]* nonnull %"@foo_val", i64 32, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 ([32 x i8]*, i64, i64)*)([32 x i8]* nonnull %"@foo_val", i64 32, i64 0)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@foo_key", [32 x i8]* nonnull %"@foo_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [32 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@foo_key", [32 x i8]* nonnull %"@foo_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = bitcast i64* %"@foo_key1" to i8*
@@ -120,7 +120,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@str_key", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo3, i64* nonnull %"@str_key", i8* nonnull %4, i64 0)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i8*, i64)*)(i64 %pseudo3, i64* nonnull %"@str_key", i8* nonnull %4, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/struct_save_string.cpp
+++ b/tests/codegen/struct_save_string.cpp
@@ -25,16 +25,16 @@ entry:
   store i64 0, i64* %"@foo_key", align 8
   %2 = getelementptr inbounds [32 x i8], [32 x i8]* %"@foo_val", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([32 x i8]* nonnull %"@foo_val", i64 32, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 ([32 x i8]*, i64, i64)*)([32 x i8]* nonnull %"@foo_val", i64 32, i64 0)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@foo_key", [32 x i8]* nonnull %"@foo_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [32 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@foo_key", [32 x i8]* nonnull %"@foo_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = bitcast i64* %"@foo_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@foo_key1", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo2, i64* nonnull %"@foo_key1")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo2, i64* nonnull %"@foo_key1")
   %4 = getelementptr inbounds [32 x i8], [32 x i8]* %lookup_elem_val, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
@@ -54,7 +54,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@str_key", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo3, i64* nonnull %"@str_key", i8* nonnull %4, i64 0)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i8*, i64)*)(i64 %pseudo3, i64* nonnull %"@str_key", i8* nonnull %4, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
@@ -91,16 +91,16 @@ entry:
   store i64 0, i64* %"@foo_key", align 8
   %2 = getelementptr inbounds [32 x i8], [32 x i8]* %"@foo_val", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([32 x i8]* nonnull %"@foo_val", i64 32, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)([32 x i8]* nonnull %"@foo_val", i64 32, i64 0)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@foo_key", [32 x i8]* nonnull %"@foo_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@foo_key", [32 x i8]* nonnull %"@foo_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = bitcast i64* %"@foo_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@foo_key1", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo2, i64* nonnull %"@foo_key1")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo2, i64* nonnull %"@foo_key1")
   %4 = getelementptr inbounds [32 x i8], [32 x i8]* %lookup_elem_val, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
@@ -120,7 +120,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@str_key", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo3, i64* nonnull %"@str_key", i8* nonnull %4, i64 0)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo3, i64* nonnull %"@str_key", i8* nonnull %4, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/struct_short.cpp
+++ b/tests/codegen/struct_short.cpp
@@ -66,7 +66,6 @@ entry:
   %"@x_key" = alloca i64, align 8
   %Foo.x = alloca i16, align 2
   %"$foo" = alloca i16, align 2
-  %tmpcast = bitcast i16* %"$foo" to [2 x i8]*
   %1 = bitcast i16* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i64 0, i64 2, i32 2, i1 false)
@@ -75,7 +74,7 @@ entry:
   store i16 %2, i16* %"$foo", align 2
   %3 = bitcast i16* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i16* nonnull %Foo.x, i64 2, [2 x i8]* nonnull %tmpcast)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i16* nonnull %Foo.x, i64 2, i8* nonnull %1)
   %4 = load i16, i16* %Foo.x, align 2
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/struct_short.cpp
+++ b/tests/codegen/struct_short.cpp
@@ -18,34 +18,32 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %Foo.x = alloca i16, align 2
-  %"$foo" = alloca i16, align 2
-  %1 = bitcast i16* %"$foo" to i8*
+  %"$foo" = alloca i64, align 8
+  %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 2 %1, i64 0, i64 2, i1 false)
+  %2 = bitcast i64* %"$foo" to i16*
+  store i16 0, i16* %2, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = load i16, i16 addrspace(64)* null, align 536870912
-  store i16 %2, i16* %"$foo", align 2
-  %3 = bitcast i16* %Foo.x to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %3 = load i16, i16 addrspace(64)* null, align 536870912
+  store i16 %3, i16* %2, align 8
+  %4 = bitcast i16* %Foo.x to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i16* nonnull %Foo.x, i64 2, i8* nonnull %1)
-  %4 = load i16, i16* %Foo.x, align 2
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  %5 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %5 = load i16, i16* %Foo.x, align 2
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  %6 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@x_key", align 8
-  %6 = zext i16 %4 to i64
-  %7 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  store i64 %6, i64* %"@x_val", align 8
+  %7 = zext i16 %5 to i64
+  %8 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
+  store i64 %7, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
 }
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/struct_short.cpp
+++ b/tests/codegen/struct_short.cpp
@@ -63,34 +63,32 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %Foo.x = alloca i16, align 2
-  %"$foo" = alloca i16, align 2
-  %1 = bitcast i16* %"$foo" to i8*
+  %"$foo" = alloca i64, align 8
+  %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull %1, i64 0, i64 2, i32 2, i1 false)
+  %2 = bitcast i64* %"$foo" to i16*
+  store i16 0, i16* %2, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = load i16, i16 addrspace(64)* null, align 536870912
-  store i16 %2, i16* %"$foo", align 2
-  %3 = bitcast i16* %Foo.x to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %3 = load i16, i16 addrspace(64)* null, align 536870912
+  store i16 %3, i16* %2, align 8
+  %4 = bitcast i16* %Foo.x to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i16* nonnull %Foo.x, i64 2, i8* nonnull %1)
-  %4 = load i16, i16* %Foo.x, align 2
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  %5 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %5 = load i16, i16* %Foo.x, align 2
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  %6 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@x_key", align 8
-  %6 = zext i16 %4 to i64
-  %7 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  store i64 %6, i64* %"@x_val", align 8
+  %7 = zext i16 %5 to i64
+  %8 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
+  store i64 %7, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
 }
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/struct_short.cpp
+++ b/tests/codegen/struct_short.cpp
@@ -28,7 +28,7 @@ entry:
   store i16 %3, i16* %2, align 8
   %4 = bitcast i16* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i16* nonnull %Foo.x, i64 2, i8* nonnull %1)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i16*, i64, i8*)*)(i16* nonnull %Foo.x, i64 2, i8* nonnull %1)
   %5 = load i16, i16* %Foo.x, align 2
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %6 = bitcast i64* %"@x_key" to i8*
@@ -39,7 +39,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %7, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
@@ -119,7 +119,7 @@ entry:
   %Foo.x = alloca i16, align 2
   %1 = bitcast i16* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i16* nonnull %Foo.x, i64 2, i8* null)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i16*, i64, i8*)*)(i16* nonnull %Foo.x, i64 2, i8* null)
   %2 = load i16, i16* %Foo.x, align 2
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key" to i8*
@@ -130,7 +130,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %4, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0

--- a/tests/codegen/struct_short.cpp
+++ b/tests/codegen/struct_short.cpp
@@ -73,7 +73,7 @@ entry:
   store i16 %3, i16* %2, align 8
   %4 = bitcast i16* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i16* nonnull %Foo.x, i64 2, i8* nonnull %1)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i16*, i64, i8*)*)(i16* nonnull %Foo.x, i64 2, i8* nonnull %1)
   %5 = load i16, i16* %Foo.x, align 2
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %6 = bitcast i64* %"@x_key" to i8*
@@ -84,7 +84,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %7, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0

--- a/tests/codegen/struct_short.cpp
+++ b/tests/codegen/struct_short.cpp
@@ -19,7 +19,6 @@ entry:
   %"@x_key" = alloca i64, align 8
   %Foo.x = alloca i16, align 2
   %"$foo" = alloca i16, align 2
-  %tmpcast = bitcast i16* %"$foo" to [2 x i8]*
   %1 = bitcast i16* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 2 %1, i64 0, i64 2, i1 false)
@@ -28,7 +27,7 @@ entry:
   store i16 %2, i16* %"$foo", align 2
   %3 = bitcast i16* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i16* nonnull %Foo.x, i64 2, [2 x i8]* nonnull %tmpcast)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i16* nonnull %Foo.x, i64 2, i8* nonnull %1)
   %4 = load i16, i16* %Foo.x, align 2
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*
@@ -125,7 +124,7 @@ entry:
   %Foo.x = alloca i16, align 2
   %1 = bitcast i16* %Foo.x to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i16* nonnull %Foo.x, i64 2, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i16* nonnull %Foo.x, i64 2, i8* null)
   %2 = load i16, i16* %Foo.x, align 2
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/struct_string_array.cpp
+++ b/tests/codegen/struct_string_array.cpp
@@ -67,12 +67,12 @@ entry:
   call void @llvm.memcpy.p0i8.p64i8.i64(i8* nonnull %1, i8 addrspace(64)* null, i64 32, i32 8, i1 false)
   %2 = getelementptr inbounds [32 x i8], [32 x i8]* %Foo.str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([32 x i8]* nonnull %Foo.str, i64 32, i8* nonnull %1)
+  %probe_read = call i64 inttoptr (i64 4 to i64 ([32 x i8]*, i64, i8*)*)([32 x i8]* nonnull %Foo.str, i64 32, i8* nonnull %1)
   %3 = bitcast i64* %"@mystr_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@mystr_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [32 x i8]* nonnull %Foo.str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [32 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [32 x i8]* nonnull %Foo.str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/struct_string_array.cpp
+++ b/tests/codegen/struct_string_array.cpp
@@ -25,12 +25,12 @@ entry:
   call void @llvm.memcpy.p0i8.p64i8.i64(i8* nonnull align 8 %1, i8 addrspace(64)* align 536870912 null, i64 32, i1 false)
   %2 = getelementptr inbounds [32 x i8], [32 x i8]* %Foo.str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([32 x i8]* nonnull %Foo.str, i64 32, i8* nonnull %1)
+  %probe_read = call i64 inttoptr (i64 4 to i64 ([32 x i8]*, i64, i8*)*)([32 x i8]* nonnull %Foo.str, i64 32, i8* nonnull %1)
   %3 = bitcast i64* %"@mystr_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@mystr_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [32 x i8]* nonnull %Foo.str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [32 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [32 x i8]* nonnull %Foo.str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0
@@ -72,7 +72,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@mystr_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [32 x i8]* nonnull %Foo.str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [32 x i8]* nonnull %Foo.str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0
@@ -112,12 +112,12 @@ entry:
   %Foo.str = alloca [32 x i8], align 1
   %1 = getelementptr inbounds [32 x i8], [32 x i8]* %Foo.str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([32 x i8]* nonnull %Foo.str, i64 32, i8* null)
+  %probe_read = call i64 inttoptr (i64 4 to i64 ([32 x i8]*, i64, i8*)*)([32 x i8]* nonnull %Foo.str, i64 32, i8* null)
   %2 = bitcast i64* %"@mystr_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@mystr_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [32 x i8]* nonnull %Foo.str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [32 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [32 x i8]* nonnull %Foo.str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0

--- a/tests/codegen/struct_string_array.cpp
+++ b/tests/codegen/struct_string_array.cpp
@@ -59,12 +59,12 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@mystr_key" = alloca i64, align 8
   %Foo.str = alloca [32 x i8], align 1
-  %"$foo" = alloca [32 x i8], align 1
-  %1 = getelementptr inbounds [32 x i8], [32 x i8]* %"$foo", i64 0, i64 0
+  %"$foo" = alloca i64, align 8
+  %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull %1, i64 0, i64 32, i32 1, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 32, i32 8, i1 false)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memcpy.p0i8.p64i8.i64(i8* nonnull %1, i8 addrspace(64)* null, i64 32, i32 1, i1 false)
+  call void @llvm.memcpy.p0i8.p64i8.i64(i8* nonnull %1, i8 addrspace(64)* null, i64 32, i32 8, i1 false)
   %2 = getelementptr inbounds [32 x i8], [32 x i8]* %Foo.str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([32 x i8]* nonnull %Foo.str, i64 32, i8* nonnull %1)

--- a/tests/codegen/struct_string_array.cpp
+++ b/tests/codegen/struct_string_array.cpp
@@ -25,7 +25,7 @@ entry:
   call void @llvm.memcpy.p0i8.p64i8.i64(i8* nonnull align 1 %1, i8 addrspace(64)* align 536870912 null, i64 32, i1 false)
   %2 = getelementptr inbounds [32 x i8], [32 x i8]* %Foo.str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([32 x i8]* nonnull %Foo.str, i64 32, [32 x i8]* nonnull %"$foo")
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([32 x i8]* nonnull %Foo.str, i64 32, i8* nonnull %1)
   %3 = bitcast i64* %"@mystr_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@mystr_key", align 8
@@ -112,7 +112,7 @@ entry:
   %Foo.str = alloca [32 x i8], align 1
   %1 = getelementptr inbounds [32 x i8], [32 x i8]* %Foo.str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([32 x i8]* nonnull %Foo.str, i64 32, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([32 x i8]* nonnull %Foo.str, i64 32, i8* null)
   %2 = bitcast i64* %"@mystr_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@mystr_key", align 8

--- a/tests/codegen/struct_string_array.cpp
+++ b/tests/codegen/struct_string_array.cpp
@@ -17,12 +17,12 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@mystr_key" = alloca i64, align 8
   %Foo.str = alloca [32 x i8], align 1
-  %"$foo" = alloca [32 x i8], align 1
-  %1 = getelementptr inbounds [32 x i8], [32 x i8]* %"$foo", i64 0, i64 0
+  %"$foo" = alloca i64, align 8
+  %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i64 0, i64 32, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %1, i8 0, i64 32, i1 false)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memcpy.p0i8.p64i8.i64(i8* nonnull align 1 %1, i8 addrspace(64)* align 536870912 null, i64 32, i1 false)
+  call void @llvm.memcpy.p0i8.p64i8.i64(i8* nonnull align 8 %1, i8 addrspace(64)* align 536870912 null, i64 32, i1 false)
   %2 = getelementptr inbounds [32 x i8], [32 x i8]* %Foo.str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([32 x i8]* nonnull %Foo.str, i64 32, i8* nonnull %1)

--- a/tests/codegen/struct_string_array.cpp
+++ b/tests/codegen/struct_string_array.cpp
@@ -67,7 +67,7 @@ entry:
   call void @llvm.memcpy.p0i8.p64i8.i64(i8* nonnull %1, i8 addrspace(64)* null, i64 32, i32 1, i1 false)
   %2 = getelementptr inbounds [32 x i8], [32 x i8]* %Foo.str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([32 x i8]* nonnull %Foo.str, i64 32, [32 x i8]* nonnull %"$foo")
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([32 x i8]* nonnull %Foo.str, i64 32, i8* nonnull %1)
   %3 = bitcast i64* %"@mystr_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@mystr_key", align 8

--- a/tests/codegen/struct_string_ptr.cpp
+++ b/tests/codegen/struct_string_ptr.cpp
@@ -66,7 +66,6 @@ entry:
   %Foo.str = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %"$foo" = alloca i64, align 8
-  %tmpcast = bitcast i64* %"$foo" to [8 x i8]*
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i64 0, i64 8, i32 8, i1 false)
@@ -78,7 +77,7 @@ entry:
   call void @llvm.memset.p0i8.i64(i8* nonnull %3, i8 0, i64 64, i32 1, i1 false)
   %4 = bitcast i64* %Foo.str to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.str, i64 8, [8 x i8]* nonnull %tmpcast)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.str, i64 8, i8* nonnull %1)
   %5 = load i64, i64* %Foo.str, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %5)
@@ -168,7 +167,7 @@ entry:
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 64, i32 1, i1 false)
   %2 = bitcast i64* %Foo.str to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.str, i64 8, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.str, i64 8, i8* null)
   %3 = load i64, i64* %Foo.str, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %3)

--- a/tests/codegen/struct_string_ptr.cpp
+++ b/tests/codegen/struct_string_ptr.cpp
@@ -19,7 +19,6 @@ entry:
   %Foo.str = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %"$foo" = alloca i64, align 8
-  %tmpcast = bitcast i64* %"$foo" to [8 x i8]*
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %1, i64 0, i64 8, i1 false)
@@ -31,7 +30,7 @@ entry:
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %3, i8 0, i64 64, i1 false)
   %4 = bitcast i64* %Foo.str to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.str, i64 8, [8 x i8]* nonnull %tmpcast)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.str, i64 8, i8* nonnull %1)
   %5 = load i64, i64* %Foo.str, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %5)
@@ -129,7 +128,7 @@ entry:
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i8 0, i64 64, i1 false)
   %2 = bitcast i64* %Foo.str to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.str, i64 8, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.str, i64 8, i8* null)
   %3 = load i64, i64* %Foo.str, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %3)

--- a/tests/codegen/struct_string_ptr.cpp
+++ b/tests/codegen/struct_string_ptr.cpp
@@ -77,7 +77,7 @@ entry:
   call void @llvm.memset.p0i8.i64(i8* nonnull %3, i8 0, i64 64, i32 1, i1 false)
   %4 = bitcast i64* %Foo.str to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.str, i64 8, i8* nonnull %1)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %Foo.str, i64 8, i8* nonnull %1)
   %5 = load i64, i64* %Foo.str, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %5)
@@ -167,7 +167,7 @@ entry:
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 64, i32 1, i1 false)
   %2 = bitcast i64* %Foo.str to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.str, i64 8, i8* null)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %Foo.str, i64 8, i8* null)
   %3 = load i64, i64* %Foo.str, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %3)

--- a/tests/codegen/struct_string_ptr.cpp
+++ b/tests/codegen/struct_string_ptr.cpp
@@ -68,7 +68,7 @@ entry:
   %"$foo" = alloca i64, align 8
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull %1, i64 0, i64 8, i32 8, i1 false)
+  store i64 0, i64* %"$foo", align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i64, i64 addrspace(64)* null, align 536870912
   store i64 %2, i64* %"$foo", align 8

--- a/tests/codegen/struct_string_ptr.cpp
+++ b/tests/codegen/struct_string_ptr.cpp
@@ -21,7 +21,7 @@ entry:
   %"$foo" = alloca i64, align 8
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %1, i64 0, i64 8, i1 false)
+  store i64 0, i64* %"$foo", align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i64, i64 addrspace(64)* null, align 536870912
   store i64 %2, i64* %"$foo", align 8

--- a/tests/codegen/struct_string_ptr.cpp
+++ b/tests/codegen/struct_string_ptr.cpp
@@ -30,7 +30,7 @@ entry:
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %3, i8 0, i64 64, i1 false)
   %4 = bitcast i64* %Foo.str to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.str, i64 8, i8* nonnull %1)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %Foo.str, i64 8, i8* nonnull %1)
   %5 = load i64, i64* %Foo.str, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %5)
@@ -38,7 +38,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@mystr_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0
@@ -85,7 +85,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@mystr_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0
@@ -127,7 +127,7 @@ entry:
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i8 0, i64 64, i1 false)
   %2 = bitcast i64* %Foo.str to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.str, i64 8, i8* null)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i64, i8*)*)(i64* nonnull %Foo.str, i64 8, i8* null)
   %3 = load i64, i64* %Foo.str, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %3)
@@ -135,7 +135,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@mystr_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -175,7 +175,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@mystr_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0

--- a/tests/codegen/ternary_int.cpp
+++ b/tests/codegen/ternary_int.cpp
@@ -28,7 +28,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %., i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/ternary_str.cpp
+++ b/tests/codegen/ternary_str.cpp
@@ -48,7 +48,7 @@ done:                                             ; preds = %right, %left
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %buf, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %buf, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -103,7 +103,7 @@ done:                                             ; preds = %right, %left
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %buf, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %buf, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -144,7 +144,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %buf, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %buf, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0

--- a/tests/codegen/unroll.cpp
+++ b/tests/codegen/unroll.cpp
@@ -40,14 +40,14 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@i_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@i_key", i64* nonnull %"@i_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@i_key", i64* nonnull %"@i_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = bitcast i64* %"@i_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@i_key1", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo2, i64* nonnull %"@i_key1")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo2, i64* nonnull %"@i_key1")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -66,14 +66,14 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %lookup_elem_val.0, i64* %"@i_val4", align 8
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem6 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo5, i64* nonnull %"@i_key3", i64* nonnull %"@i_val4", i64 0)
+  %update_elem6 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo5, i64* nonnull %"@i_key3", i64* nonnull %"@i_val4", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   %7 = bitcast i64* %"@i_key7" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 0, i64* %"@i_key7", align 8
   %pseudo8 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem9 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo8, i64* nonnull %"@i_key7")
+  %lookup_elem9 = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo8, i64* nonnull %"@i_key7")
   %map_lookup_cond14 = icmp eq i8* %lookup_elem9, null
   br i1 %map_lookup_cond14, label %lookup_merge12, label %lookup_success10
 
@@ -92,14 +92,14 @@ lookup_merge12:                                   ; preds = %lookup_merge, %look
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
   store i64 %lookup_elem_val13.0, i64* %"@i_val16", align 8
   %pseudo17 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem18 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo17, i64* nonnull %"@i_key15", i64* nonnull %"@i_val16", i64 0)
+  %update_elem18 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo17, i64* nonnull %"@i_key15", i64* nonnull %"@i_val16", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
   %11 = bitcast i64* %"@i_key19" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %11)
   store i64 0, i64* %"@i_key19", align 8
   %pseudo20 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem21 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo20, i64* nonnull %"@i_key19")
+  %lookup_elem21 = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo20, i64* nonnull %"@i_key19")
   %map_lookup_cond26 = icmp eq i8* %lookup_elem21, null
   br i1 %map_lookup_cond26, label %lookup_merge24, label %lookup_success22
 
@@ -118,14 +118,14 @@ lookup_merge24:                                   ; preds = %lookup_merge12, %lo
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %14)
   store i64 %lookup_elem_val25.0, i64* %"@i_val28", align 8
   %pseudo29 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem30 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo29, i64* nonnull %"@i_key27", i64* nonnull %"@i_val28", i64 0)
+  %update_elem30 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo29, i64* nonnull %"@i_key27", i64* nonnull %"@i_val28", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %13)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %14)
   %15 = bitcast i64* %"@i_key31" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %15)
   store i64 0, i64* %"@i_key31", align 8
   %pseudo32 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem33 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo32, i64* nonnull %"@i_key31")
+  %lookup_elem33 = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo32, i64* nonnull %"@i_key31")
   %map_lookup_cond38 = icmp eq i8* %lookup_elem33, null
   br i1 %map_lookup_cond38, label %lookup_merge36, label %lookup_success34
 
@@ -144,14 +144,14 @@ lookup_merge36:                                   ; preds = %lookup_merge24, %lo
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %18)
   store i64 %lookup_elem_val37.0, i64* %"@i_val40", align 8
   %pseudo41 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem42 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo41, i64* nonnull %"@i_key39", i64* nonnull %"@i_val40", i64 0)
+  %update_elem42 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo41, i64* nonnull %"@i_key39", i64* nonnull %"@i_val40", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %17)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %18)
   %19 = bitcast i64* %"@i_key43" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %19)
   store i64 0, i64* %"@i_key43", align 8
   %pseudo44 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem45 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo44, i64* nonnull %"@i_key43")
+  %lookup_elem45 = call i8* inttoptr (i64 1 to i8* (i8*, i64*)*)(i64 %pseudo44, i64* nonnull %"@i_key43")
   %map_lookup_cond50 = icmp eq i8* %lookup_elem45, null
   br i1 %map_lookup_cond50, label %lookup_merge48, label %lookup_success46
 
@@ -170,7 +170,7 @@ lookup_merge48:                                   ; preds = %lookup_merge36, %lo
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %22)
   store i64 %lookup_elem_val49.0, i64* %"@i_val52", align 8
   %pseudo53 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem54 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo53, i64* nonnull %"@i_key51", i64* nonnull %"@i_val52", i64 0)
+  %update_elem54 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo53, i64* nonnull %"@i_key51", i64* nonnull %"@i_val52", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %21)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %22)
   ret i64 0

--- a/tests/codegen/variable.cpp
+++ b/tests/codegen/variable.cpp
@@ -83,13 +83,13 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"$var", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"$var", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %4 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@y_key", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@y_key", i64* nonnull %"$var", i64 0)
+  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@y_key", i64* nonnull %"$var", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
 }

--- a/tests/codegen/variable.cpp
+++ b/tests/codegen/variable.cpp
@@ -19,28 +19,28 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@y_key" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %"$var" = alloca [16 x i8], align 1
-  %1 = getelementptr inbounds [16 x i8], [16 x i8]* %"$var", i64 0, i64 0
+  %"$var" = alloca i64, align 8
+  %1 = bitcast i64* %"$var" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i64 0, i64 16, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %1, i8 0, i64 16, i1 false)
   %comm = alloca [16 x i8], align 1
   %2 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %2, i8 0, i64 16, i1 false)
   %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %1, i8* nonnull align 1 %2, i64 16, i1 false)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 8 %1, i8* nonnull align 1 %2, i64 16, i1 false)
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [16 x i8]* nonnull %"$var", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"$var", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %4 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@y_key", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@y_key", [16 x i8]* nonnull %"$var", i64 0)
+  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@y_key", i64* nonnull %"$var", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
 }

--- a/tests/codegen/variable.cpp
+++ b/tests/codegen/variable.cpp
@@ -68,10 +68,10 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@y_key" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %"$var" = alloca [16 x i8], align 1
-  %1 = getelementptr inbounds [16 x i8], [16 x i8]* %"$var", i64 0, i64 0
+  %"$var" = alloca i64, align 8
+  %1 = bitcast i64* %"$var" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.memset.p0i8.i64(i8* nonnull %1, i64 0, i64 16, i32 1, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 16, i32 8, i1 false)
   %comm = alloca [16 x i8], align 1
   %2 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
@@ -83,13 +83,13 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [16 x i8]* nonnull %"$var", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"$var", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %4 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@y_key", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@y_key", [16 x i8]* nonnull %"$var", i64 0)
+  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@y_key", i64* nonnull %"$var", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
 }

--- a/tests/codegen/variable.cpp
+++ b/tests/codegen/variable.cpp
@@ -34,13 +34,13 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"$var", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"$var", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %4 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@y_key", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@y_key", i64* nonnull %"$var", i64 0)
+  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i8*, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@y_key", i64* nonnull %"$var", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
 }

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -10,6 +10,24 @@ AFTER ./testprogs/simple_struct
 EXPECT 2 0 1 1 1
 TIMEOUT 5
 
+# https://github.com/iovisor/bpftrace/pull/711#issuecomment-505097671
+NAME invalid_var_scope
+RUN bpftrace -e 'BEGIN { @x = 0; if (@x == 1) { $var = 1234 } printf("result: %d\n", $var); exit() }'
+EXPECT ^result: 0$
+TIMEOUT 1
+
+# https://github.com/iovisor/bpftrace/issues/528
+NAME llvm_oom_1
+RUN bpftrace -de 'struct Foo { u8 field[4] } BEGIN { $a = (struct Foo)0; $ip = $a.field; printf("%d\n", $ip[1])  }'
+EXPECT { argmemonly nounwind }
+TIMEOUT 1
+
+# https://github.com/iovisor/bpftrace/issues/528
+NAME llvm_oom_2
+RUN bpftrace --include "linux/sched.h" -de 'struct struct_b { int data; }; struct struct_a { int member_a; struct struct_b member_b; }; BEGIN { $task = (struct task_struct *)curtask; @u = $task->last_wakee; $s = (struct struct_a *)@u; printf("%d\n", $s->member_b.data); }'
+EXPECT { argmemonly nounwind }
+TIMEOUT 1
+
 # https://github.com/iovisor/bpftrace/issues/759
 # Update test once https://github.com/iovisor/bpftrace/pull/781 lands
 # NAME ntop_map_printf


### PR DESCRIPTION
(#667 needs to land first. Changes in this PR are on [this commit](https://github.com/iovisor/bpftrace/commit/bc3d16ea6b5bc155118180b1ebfe0c74366c70db))

I was trying to find a way to fix #528, which has been very challenging since the OOM crash happens after IR generation (i.e., during optimization or BPF generation, when we're entirely in LLVM context), and it occurred to me that the issue could be happening because of somethings we're doing wrong in our IR generation. LLVM has **a lot** of aserts to ensure correctness of the IR generation in their debug build (unfortunately most of those checks are not performed in their release build), so I
did a Debug build of LLVM (6) and used it to find typing issues in our IR generation. I started with the code from #667, since @michalgr already fixed several assert errors. I found a few more while trying to run the examples from #528, and after fixing those the OOM issue seems to be fixed (for the scenarios we found at least).

While working on this, I also found a couple of things we can improve in our IR generation:

- Don't promote every integer to 64-bits by making sure we properly check and propagate their types.
- For known structs and arrays, use StructLayout + GEP instead of pointer arithmetic