### PR TITLE
semantic_analyzer: check if positional parameters was given

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -23,6 +23,10 @@ void SemanticAnalyser::visit(Integer &integer)
 void SemanticAnalyser::visit(PositionalParameter &param)
 {
   param.type = SizedType(Type::integer, 8);
+  if (static_cast<size_t>(param.n) > bpftrace_.num_params()) {
+    err_ << "missing positional parameter $" << param.n << std::endl;
+    return;
+  }
   std::string pstr = bpftrace_.get_param(param.n);
   if (is_final_pass()) {
     if (!bpftrace_.is_numeric(pstr) && !param.is_in_str) {

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -594,6 +594,11 @@ std::string BPFtrace::get_param(size_t i) const
   return params_.at(i-1);
 }
 
+size_t BPFtrace::num_params() const
+{
+  return params_.size();
+}
+
 void perf_event_lost(void *cb_cookie __attribute__((unused)), uint64_t lost)
 {
   auto bpftrace = static_cast<BPFtrace*>(cb_cookie);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -93,6 +93,7 @@ public:
   void add_param(const std::string &param);
   bool is_numeric(std::string str) const;
   std::string get_param(size_t index) const;
+  size_t num_params() const;
   void request_finalize();
   std::string cmd_;
   int pid_{0};


### PR DESCRIPTION
Fixes: https://github.com/iovisor/bpftrace/issues/717