### PR TITLE
semantic_analyzer: don't crash if args is used outside of tracepoints

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -157,9 +157,11 @@ void SemanticAnalyser::visit(Builtin &builtin)
     for (auto &attach_point : *probe_->attach_points)
     {
       ProbeType type = probetype(attach_point->provider);
-      if (type != ProbeType::tracepoint)
+      if (type != ProbeType::tracepoint) {
         err_ << "The args builtin can only be used with tracepoint probes"
              << "(" << attach_point->provider << " used here)" << std::endl;
+        continue;
+      }
 
       /*
        * tracepoint wildcard expansion, part 2 of 3. This:

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -86,6 +86,7 @@ TEST(semantic_analyser, builtin_variables)
   test("kprobe:f { func }", 0);
   test("kprobe:f { probe }", 0);
   test("tracepoint:a:b { args }", 0);
+  test("kprobe:f { args }", 1);
   test("kprobe:f { fake }", 1);
 }
 


### PR DESCRIPTION
Fixes: https://github.com/iovisor/bpftrace/issues/572