### PR TITLE
Fix error handling of invalid 'args' utilization (#698)

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -157,9 +157,11 @@ void SemanticAnalyser::visit(Builtin &builtin)
     for (auto &attach_point : *probe_->attach_points)
     {
       ProbeType type = probetype(attach_point->provider);
-      if (type != ProbeType::tracepoint)
-        err_ << "The args builtin can only be used with tracepoint probes"
+      if (type != ProbeType::tracepoint) {
+        err_ << "The args builtin can only be used with tracepoint probes "
              << "(" << attach_point->provider << " used here)" << std::endl;
+        continue;
+      }
 
       /*
        * tracepoint wildcard expansion, part 2 of 3. This:

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -671,6 +671,22 @@ TEST(semantic_analyser, tracepoint)
   test("tracepoint { 1 }", 1);
 }
 
+TEST(semantic_analyser, args_builtin_wrong_use)
+{
+  test("BEGIN { args->foo }", 1);
+  test("END { args->foo }", 1);
+  test("kprobe:f { args->foo }", 1);
+  test("kretprobe:f { args->foo }", 1);
+  test("uprobe:f { args->foo }", 1);
+  test("uretprobe:f { args->foo }", 1);
+  test("profile:f { args->foo }", 1);
+  test("usdt:sh:probe { args->foo }", 1);
+  test("profile:ms:100 { args->foo }", 1);
+  test("hardware:cache-references:1000000 { args->foo }", 1);
+  test("software:faults:1000 { args->foo }", 1);
+  test("interval:s:1 { args->foo }", 1);
+}
+
 TEST(semantic_analyser, profile)
 {
   test("profile:hz:997 { 1 }", 0);


### PR DESCRIPTION
The utilization of the 'args' builtin is allowed only for tracepoints.