### PR TITLE
clang_parser: workaround for asm goto in Kernel 5+ headers

### DIFF
--- a/resources/asm_goto_workaround.h
+++ b/resources/asm_goto_workaround.h
@@ -1,0 +1,19 @@
+// linux/types.h is included by default, which will bring
+// in asm_volatile_goto definition if permitted based on
+// compiler setup and kernel configs.
+//
+// clang does not support "asm volatile goto" yet.
+// So redefine asm_volatile_goto to some invalid asm code.
+// We won't execute this code anyway, so we just need to make sure clang is
+// able to parse our headers.
+//
+// From: https://github.com/iovisor/bcc/pull/2133/files
+
+#ifndef __ASM_GOTO_WORKAROUND_H
+#define __ASM_GOTO_WORKAROUND_H
+#include <linux/types.h>
+#ifdef asm_volatile_goto
+#undef asm_volatile_goto
+#define asm_volatile_goto(x...) asm volatile("invalid use of asm_volatile_goto")
+#endif
+#endif

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -321,6 +321,11 @@ bool ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<s
       .Contents = stdint_h,
       .Length = stdint_h_len,
     },
+    {
+      .Filename = "/bpftrace/include/" ASM_GOTO_WORKAROUND_H,
+      .Contents = asm_goto_workaround_h,
+      .Length = asm_goto_workaround_h_len,
+    },
   };
 
   std::vector<const char *> args =

--- a/src/clang_parser.h
+++ b/src/clang_parser.h
@@ -3,6 +3,8 @@
 #include <clang-c/Index.h>
 #include "bpftrace.h"
 
+#define ASM_GOTO_WORKAROUND_H "asm_goto_workaround.h"
+
 namespace bpftrace {
 
 namespace ast { class Program; }

--- a/src/headers.h
+++ b/src/headers.h
@@ -15,5 +15,7 @@ extern const char stddef_h[];
 extern const unsigned stddef_h_len;
 extern const char stdint_h[];
 extern const unsigned stdint_h_len;
+extern const char asm_goto_workaround_h[];
+extern const unsigned asm_goto_workaround_h_len;
 
 } // namespace bpftrace

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -370,6 +370,8 @@ int main(int argc, char *argv[])
     if (ksrc != "")
       extra_flags = get_kernel_cflags(utsname.machine, ksrc, kobj);
   }
+  extra_flags.push_back("-include");
+  extra_flags.push_back(ASM_GOTO_WORKAROUND_H);
 
   for (auto dir : include_dirs)
   {


### PR DESCRIPTION
Fixes: https://github.com/iovisor/bpftrace/issues/611