### PR TITLE
Remove unneeded `probe_read`s

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -171,11 +171,10 @@ void CodegenLLVM::visit(Builtin &builtin)
       offset = arch::arg_offset(arg_num);
     }
 
-    AllocaInst *dst = b_.CreateAllocaBPF(builtin.type, builtin.ident);
-    Value *src = b_.CreateGEP(ctx_, b_.getInt64(offset * sizeof(uintptr_t)));
-    b_.CreateProbeRead(dst, builtin.type.size, src);
-    expr_ = b_.CreateLoad(dst);
-    b_.CreateLifetimeEnd(dst);
+    expr_ = b_.CreateLoad(
+        b_.getInt64Ty(),
+        b_.CreateGEP(ctx_, b_.getInt64(offset * sizeof(uintptr_t))),
+        builtin.ident);
   }
   else if (builtin.ident == "probe")
   {
@@ -546,11 +545,10 @@ void CodegenLLVM::visit(Call &call)
       abort();
     }
 
-    AllocaInst *dst = b_.CreateAllocaBPF(call.type, call.func+"_"+reg_name);
-    Value *src = b_.CreateGEP(ctx_, b_.getInt64(offset * sizeof(uintptr_t)));
-    b_.CreateProbeRead(dst, 8, src);
-    expr_ = b_.CreateLoad(dst);
-    b_.CreateLifetimeEnd(dst);
+    expr_ = b_.CreateLoad(
+        b_.getInt64Ty(),
+        b_.CreateGEP(ctx_, b_.getInt64(offset * sizeof(uintptr_t))),
+        call.func+"_"+reg_name);
   }
   else if (call.func == "printf")
   {

--- a/tests/codegen/builtin_arg.cpp
+++ b/tests/codegen/builtin_arg.cpp
@@ -14,46 +14,36 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
+define i64 @"kprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@y_val" = alloca i64, align 8
   %"@y_key" = alloca i64, align 8
-  %arg2 = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %arg0 = alloca i64, align 8
-  %1 = bitcast i64* %arg0 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = getelementptr i8, i8* %0, i64 112
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %arg0, i64 8, i8* %2)
-  %3 = load i64, i64* %arg0, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  %4 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  %1 = getelementptr i8, i8* %0, i64 112
+  %arg0 = load i64, i8* %1, align 8
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
-  %5 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  store i64 %3, i64* %"@x_val", align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %3 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 %arg0, i64* %"@x_val", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
-  %6 = bitcast i64* %arg2 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
-  %7 = getelementptr i8, i8* %0, i64 96
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %arg2, i64 8, i8* %7)
-  %8 = load i64, i64* %arg2, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
-  %9 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  %4 = getelementptr i8, i8* %0, i64 96
+  %arg2 = load i64, i8* %4, align 8
+  %5 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@y_key", align 8
-  %10 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
-  store i64 %8, i64* %"@y_val", align 8
-  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem3 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo2, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
+  %6 = bitcast i64* %"@y_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  store i64 %arg2, i64* %"@y_val", align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
 }
 

--- a/tests/codegen/builtin_func.cpp
+++ b/tests/codegen/builtin_func.cpp
@@ -14,27 +14,22 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
+define i64 @"kprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %func = alloca i64, align 8
-  %1 = bitcast i64* %func to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = getelementptr i8, i8* %0, i64 128
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %func, i64 8, i8* %2)
-  %3 = load i64, i64* %func, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  %4 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  %1 = getelementptr i8, i8* %0, i64 128
+  %func = load i64, i8* %1, align 8
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
-  %5 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  store i64 %3, i64* %"@x_val", align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %3 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 %func, i64* %"@x_val", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0
 }
 

--- a/tests/codegen/builtin_func_wild.cpp
+++ b/tests/codegen/builtin_func_wild.cpp
@@ -9,14 +9,14 @@ using ::testing::Return;
 TEST(codegen, builtin_func_wild)
 {
   std::set<std::string> wildcard_matches = {
-    "sys_enter_nanosleep"
+    "do_execve"
   };
   MockBPFtrace bpftrace;
   ON_CALL(bpftrace, find_wildcard_matches(_, _, _))
     .WillByDefault(Return(wildcard_matches));
 
   test(bpftrace,
-      "tracepoint:syscalls:sys_enter_nanoslee* { @x = func }",
+      "kprobe:do_execve* { @x = func }",
 
 R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
@@ -24,27 +24,22 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"tracepoint:syscalls:sys_enter_nanoslee*"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_nanoslee*_1" {
+define i64 @"kprobe:do_execve*"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:do_execve*_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %func = alloca i64, align 8
-  %1 = bitcast i64* %func to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = getelementptr i8, i8* %0, i64 128
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %func, i64 8, i8* %2)
-  %3 = load i64, i64* %func, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  %4 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  %1 = getelementptr i8, i8* %0, i64 128
+  %func = load i64, i8* %1, align 8
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
-  %5 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  store i64 %3, i64* %"@x_val", align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %3 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 %func, i64* %"@x_val", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0
 }
 

--- a/tests/codegen/builtin_retval.cpp
+++ b/tests/codegen/builtin_retval.cpp
@@ -14,27 +14,22 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kretprobe:f"(i8*) local_unnamed_addr section "s_kretprobe:f_1" {
+define i64 @"kretprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kretprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %retval = alloca i64, align 8
-  %1 = bitcast i64* %retval to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = getelementptr i8, i8* %0, i64 80
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %retval, i64 8, i8* %2)
-  %3 = load i64, i64* %retval, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  %4 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  %1 = getelementptr i8, i8* %0, i64 80
+  %retval = load i64, i8* %1, align 8
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
-  %5 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  store i64 %3, i64* %"@x_val", align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %3 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 %retval, i64* %"@x_val", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0
 }
 

--- a/tests/codegen/call_reg.cpp
+++ b/tests/codegen/call_reg.cpp
@@ -14,27 +14,22 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
+define i64 @"kprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %reg_ip = alloca i64, align 8
-  %1 = bitcast i64* %reg_ip to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = getelementptr i8, i8* %0, i64 128
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %reg_ip, i64 8, i8* %2)
-  %3 = load i64, i64* %reg_ip, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  %4 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  %1 = getelementptr i8, i8* %0, i64 128
+  %reg_ip = load i64, i8* %1, align 8
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
-  %5 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  store i64 %3, i64* %"@x_val", align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %3 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 %reg_ip, i64* %"@x_val", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0
 }
 

--- a/tests/codegen/call_str.cpp
+++ b/tests/codegen/call_str.cpp
@@ -15,27 +15,22 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
+define i64 @"kprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
-  %arg0 = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %1 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 64, i32 1, i1 false)
-  %2 = bitcast i64* %arg0 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %3 = getelementptr i8, i8* %0, i64 112
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %arg0, i64 8, i8* %3)
-  %4 = load i64, i64* %arg0, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %4)
-  %5 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %2 = getelementptr i8, i8* %0, i64 112
+  %arg0 = load i64, i8* %2, align 8
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %arg0)
+  %3 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }
@@ -56,27 +51,22 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
+define i64 @"kprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
-  %arg0 = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %1 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i8 0, i64 64, i1 false)
-  %2 = bitcast i64* %arg0 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %3 = getelementptr i8, i8* %0, i64 112
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %arg0, i64 8, i8* %3)
-  %4 = load i64, i64* %arg0, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %4)
-  %5 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %2 = getelementptr i8, i8* %0, i64 112
+  %arg0 = load i64, i8* %2, align 8
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %arg0)
+  %3 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }

--- a/tests/codegen/call_str_2_expr.cpp
+++ b/tests/codegen/call_str_2_expr.cpp
@@ -15,38 +15,28 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
+define i64 @"kprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
-  %arg0 = alloca i64, align 8
   %str = alloca [64 x i8], align 1
-  %arg1 = alloca i64, align 8
-  %1 = bitcast i64* %arg1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = getelementptr i8, i8* %0, i64 104
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %arg1, i64 8, i8* %2)
-  %3 = load i64, i64* %arg1, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  %4 = add i64 %3, 1
-  %5 = icmp ult i64 %4, 64
-  %str.min.select = select i1 %5, i64 %4, i64 64
-  %6 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
+  %1 = getelementptr i8, i8* %0, i64 104
+  %arg1 = load i64, i8* %1, align 8
+  %2 = add i64 %arg1, 1
+  %3 = icmp ult i64 %2, 64
+  %str.min.select = select i1 %3, i64 %2, i64 64
+  %4 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  call void @llvm.memset.p0i8.i64(i8* nonnull %4, i8 0, i64 64, i32 1, i1 false)
+  %5 = getelementptr i8, i8* %0, i64 112
+  %arg0 = load i64, i8* %5, align 8
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 %str.min.select, i64 %arg0)
+  %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
-  call void @llvm.memset.p0i8.i64(i8* nonnull %6, i8 0, i64 64, i32 1, i1 false)
-  %7 = bitcast i64* %arg0 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  %8 = getelementptr i8, i8* %0, i64 112
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %arg0, i64 8, i8* %8)
-  %9 = load i64, i64* %arg0, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 %str.min.select, i64 %9)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
 }
 
@@ -66,38 +56,28 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
+define i64 @"kprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
-  %arg0 = alloca i64, align 8
   %str = alloca [64 x i8], align 1
-  %arg1 = alloca i64, align 8
-  %1 = bitcast i64* %arg1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = getelementptr i8, i8* %0, i64 104
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %arg1, i64 8, i8* %2)
-  %3 = load i64, i64* %arg1, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  %4 = add i64 %3, 1
-  %5 = icmp ult i64 %4, 64
-  %str.min.select = select i1 %5, i64 %4, i64 64
-  %6 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
+  %1 = getelementptr i8, i8* %0, i64 104
+  %arg1 = load i64, i8* %1, align 8
+  %2 = add i64 %arg1, 1
+  %3 = icmp ult i64 %2, 64
+  %str.min.select = select i1 %3, i64 %2, i64 64
+  %4 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %4, i8 0, i64 64, i1 false)
+  %5 = getelementptr i8, i8* %0, i64 112
+  %arg0 = load i64, i8* %5, align 8
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 %str.min.select, i64 %arg0)
+  %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %6, i8 0, i64 64, i1 false)
-  %7 = bitcast i64* %arg0 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  %8 = getelementptr i8, i8* %0, i64 112
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %arg0, i64 8, i8* %8)
-  %9 = load i64, i64* %arg0, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 %str.min.select, i64 %9)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
 }
 

--- a/tests/codegen/call_str_2_lit.cpp
+++ b/tests/codegen/call_str_2_lit.cpp
@@ -15,27 +15,22 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
+define i64 @"kprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
-  %arg0 = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %1 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 64, i32 1, i1 false)
-  %2 = bitcast i64* %arg0 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %3 = getelementptr i8, i8* %0, i64 112
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %arg0, i64 8, i8* %3)
-  %4 = load i64, i64* %arg0, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 7, i64 %4)
-  %5 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %2 = getelementptr i8, i8* %0, i64 112
+  %arg0 = load i64, i8* %2, align 8
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 7, i64 %arg0)
+  %3 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }
@@ -56,27 +51,22 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
+define i64 @"kprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
-  %arg0 = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %1 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i8 0, i64 64, i1 false)
-  %2 = bitcast i64* %arg0 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %3 = getelementptr i8, i8* %0, i64 112
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %arg0, i64 8, i8* %3)
-  %4 = load i64, i64* %arg0, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 7, i64 %4)
-  %5 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %2 = getelementptr i8, i8* %0, i64 112
+  %arg0 = load i64, i8* %2, align 8
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 7, i64 %arg0)
+  %3 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }


### PR DESCRIPTION
Looking through codegen I noticed that the argX,retval,func calls do an
alloca and `probe_read` to read `ctx`. Which shouldn't be neeeded.

Looking at the bpf code emitted by BCCs opensnoop (using bpftool),

This bit of code:

```
    data.uid = bpf_get_current_uid_gid();
    data.flags = valp->flags; // EXTENDED_STRUCT_MEMBER
    data.ret = PT_REGS_RC(ctx);
```

Compiles into:

```
  67: (85) call bpf_get_current_uid_gid#68096
  68: (63) *(u32 *)(r10 -288) = r0
  69: (79) r1 = *(u64 *)(r6 +80) # <<---  RC = offset 80
  70: (63) *(u32 *)(r10 -284) = r1
```

So no `probe_read` is automatically inserted by `BCC` either.

The attached patch seems to work fine, all runtime tests pass.

For a simple example like `-e 'kr:sock_sendmsg { @t[retval]++;  }'` the
amount of code is reduced by quite a bit:

Master:

```
3601: kprobe  name sock_sendvmsg  tag 5a611cfc6c681762  gpl
  loaded_at 2019-06-08T17:48:18+0000  uid 0
  xlated 304B  jited 211B  memlock 4096B  map_ids 3332
```

Patched:

```
3602: kprobe  name sock_sendmsg  tag e286460edf83a14c  gpl
  loaded_at 2019-06-08T17:48:21+0000  uid 0
  xlated 216B  jited 166B  memlock 4096B  map_ids 3334
```

```
$ bpftool  prog  dump xlated id 3601
   0: (bf) r6 = r1
   1: (07) r6 += 80
   2: (bf) r1 = r10
   3: (07) r1 += -8
   4: (b7) r2 = 8
   5: (bf) r3 = r6
   6: (85) call bpf_probe_read#-47296
   7: (79) r1 = *(u64 *)(r10 -8)
   8: (7b) *(u64 *)(r10 -8) = r1
   9: (18) r1 = map[id:3332]
  11: (bf) r2 = r10
  12: (07) r2 += -8
  13: (85) call __htab_map_lookup_elem#72336
  14: (15) if r0 == 0x0 goto pc+1
  15: (07) r0 += 56
  16: (b7) r7 = 1
  17: (15) if r0 == 0x0 goto pc+2
  18: (79) r7 = *(u64 *)(r0 +0)
  19: (07) r7 += 1
  20: (bf) r1 = r10
  21: (07) r1 += -8
  22: (b7) r2 = 8
  23: (bf) r3 = r6
  24: (85) call bpf_probe_read#-47296
  25: (79) r1 = *(u64 *)(r10 -8)
  26: (7b) *(u64 *)(r10 -16) = r1
  27: (7b) *(u64 *)(r10 -8) = r7
  28: (18) r1 = map[id:3332]
  30: (bf) r2 = r10
  31: (07) r2 += -16
  32: (bf) r3 = r10
  33: (07) r3 += -8
  34: (b7) r4 = 0
  35: (85) call htab_map_update_elem#75504
  36: (b7) r0 = 0
  37: (95) exit
```
```
$ bpftool  prog  dump xlated id 3602
   0: (bf) r6 = r1
   1: (79) r1 = *(u64 *)(r6 +80)
   2: (7b) *(u64 *)(r10 -8) = r1
   3: (18) r1 = map[id:3334]
   5: (bf) r2 = r10
   6: (07) r2 += -8
   7: (85) call __htab_map_lookup_elem#72336
   8: (15) if r0 == 0x0 goto pc+1
   9: (07) r0 += 56
  10: (b7) r1 = 1
  11: (15) if r0 == 0x0 goto pc+2
  12: (79) r1 = *(u64 *)(r0 +0)
  13: (07) r1 += 1
  14: (79) r2 = *(u64 *)(r6 +80)
  15: (7b) *(u64 *)(r10 -16) = r2
  16: (7b) *(u64 *)(r10 -8) = r1
  17: (18) r1 = map[id:3334]
  19: (bf) r2 = r10
  20: (07) r2 += -16
  21: (bf) r3 = r10
  22: (07) r3 += -8
  23: (b7) r4 = 0
  24: (85) call htab_map_update_elem#75504
  25: (b7) r0 = 0
  26: (95) exit
```

Or am I missing something here? :)

Didn't look into codegen tests yet as there are a few big MRs for those open (and im not 100% sure this is correct yet).