### PR TITLE
[WIP] Add list.cpp unit tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(bpftrace_test
   bpftrace.cpp
   clang_parser.cpp
   codegen.cpp
+  list.cpp
   main.cpp
   mocks.cpp
   parser.cpp
@@ -27,7 +28,7 @@ add_executable(bpftrace_test
   ${CMAKE_SOURCE_DIR}/src/tracepoint_format_parser.cpp
   ${CMAKE_SOURCE_DIR}/src/types.cpp
   ${CMAKE_SOURCE_DIR}/src/utils.cpp
-)
+  ${CMAKE_SOURCE_DIR}/src/list.cpp)
 
 if(HAVE_NAME_TO_HANDLE_AT)
   target_compile_definitions(bpftrace_test PRIVATE HAVE_NAME_TO_HANDLE_AT=1)

--- a/tests/list.cpp
+++ b/tests/list.cpp
@@ -13,10 +13,9 @@ namespace list {
 
 using ::testing::ContainerEq;
 using ::testing::StrictMock;
-using namespace std;
 
-void vector_from_output(std::stringstream &ss, std::regex ex, std::vector<string>& results, bool fail_on_mismatch) {
-  string tmp;
+void vector_from_output(std::stringstream &ss, std::regex ex, std::vector<std::string>& results, bool fail_on_mismatch) {
+  std::string tmp;
   while (getline(ss, tmp)) {
     if (!ss) {
       return;
@@ -26,13 +25,13 @@ void vector_from_output(std::stringstream &ss, std::regex ex, std::vector<string
         auto s = tmp.substr(pos + 1, (tmp.length() - pos - 2));
         results.push_back(s);
       } else if(fail_on_mismatch) {
-        FAIL() << "mismatch found: " << tmp << endl;
+        FAIL() << "mismatch found: " << tmp << std::endl;
       }
     }
   }
 }
 
-void compare_probe_list(std::vector<ProbeListItem> pList, std::vector<string> sList)
+void compare_probe_list(std::vector<ProbeListItem> pList, std::vector<std::string> sList)
 {
   EXPECT_EQ(pList.size(), sList.size());
   for (auto i=0; i<pList.size(); i++)
@@ -49,10 +48,10 @@ TEST(list, empty_arg_test)
   std::string output = testing::internal::GetCapturedStdout();
   std::stringstream sw_out(output);
   std::stringstream hw_out(output);
-  std::vector<string> sw_results;
-  std::vector<string> hw_results;
-  vector_from_output(sw_out, regex("software:.*"), sw_results, false);
-  vector_from_output(hw_out, regex("hardware:.*"), hw_results, false);
+  std::vector<std::string> sw_results;
+  std::vector<std::string> hw_results;
+  vector_from_output(sw_out, std::regex("software:.*"), sw_results, false);
+  vector_from_output(hw_out, std::regex("hardware:.*"), hw_results, false);
   compare_probe_list(SW_PROBE_LIST, sw_results);
   compare_probe_list(HW_PROBE_LIST, hw_results);
 }
@@ -63,8 +62,8 @@ TEST(list, software_test)
   list_probes(bpftrace, "software*");
   std::string output = testing::internal::GetCapturedStdout();
   std::stringstream ss(output);
-  std::vector<string> results;
-  vector_from_output(ss, regex("software:.*"),results, true);
+  std::vector<std::string> results;
+  vector_from_output(ss, std::regex("software:.*"),results, true);
   compare_probe_list(SW_PROBE_LIST, results);
 }
 TEST(list, hardware_test)
@@ -74,8 +73,8 @@ TEST(list, hardware_test)
   list_probes(bpftrace, "hardware*");
   std::string output = testing::internal::GetCapturedStdout();
   std::stringstream ss(output);
-  std::vector<string> results;
-  vector_from_output(ss, regex("hardware:.*"),results, true);
+  std::vector<std::string> results;
+  vector_from_output(ss, std::regex("hardware:.*"),results, true);
   compare_probe_list(HW_PROBE_LIST, results);
 }
 TEST(list, expect_empty)
@@ -88,7 +87,7 @@ TEST(list, expect_empty)
 }
 TEST(list, find_cpu)
 {
-  vector<ProbeListItem> expected_results;
+  std::vector<ProbeListItem> expected_results;
   ProbeListItem p1 = {"cpu-clock"};
   ProbeListItem p2 = {"cpu-migrations"};
   ProbeListItem p3 = {"cpu-cycles"};
@@ -100,8 +99,8 @@ TEST(list, find_cpu)
   list_probes(bpftrace, "*cpu*");
   std::string output = testing::internal::GetCapturedStdout();
   std::stringstream ss(output);
-  std::vector<string> results;
-  vector_from_output(ss, regex(".*cpu.*"), results, false);
+  std::vector<std::string> results;
+  vector_from_output(ss, std::regex(".*cpu.*"), results, false);
   compare_probe_list(expected_results, results);
 }
 }

--- a/tests/list.cpp
+++ b/tests/list.cpp
@@ -1,0 +1,109 @@
+#include <sys/stat.h>
+#include <iostream>
+#include <regex>
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "bpftrace.h"
+#include "mocks.h"
+#include "list.h"
+
+namespace bpftrace {
+namespace test {
+namespace list {
+
+using ::testing::ContainerEq;
+using ::testing::StrictMock;
+using namespace std;
+
+void vector_from_output(std::stringstream &ss, std::regex ex, std::vector<string>& results, bool fail_on_mismatch) {
+  string tmp;
+  while (getline(ss, tmp)) {
+    if (!ss) {
+      return;
+    } else {
+      if (std::regex_match(tmp, ex)) {
+        auto pos = tmp.find(':');
+        auto s = tmp.substr(pos + 1, (tmp.length() - pos - 2));
+        results.push_back(s);
+      } else if(fail_on_mismatch) {
+        FAIL() << "mismatch found: " << tmp << endl;
+      }
+    }
+  }
+}
+
+void compare_probe_list(std::vector<ProbeListItem> pList, std::vector<string> sList)
+{
+  EXPECT_EQ(pList.size(), sList.size());
+  for (auto i=0; i<pList.size(); i++)
+  {
+    EXPECT_EQ(pList[i].path, sList[i]);
+  }
+}
+
+TEST(list, empty_arg_test)
+{
+  BPFtrace bpftrace;
+  testing::internal::CaptureStdout();
+  list_probes(bpftrace, "");
+  std::string output = testing::internal::GetCapturedStdout();
+  std::stringstream sw_out(output);
+  std::stringstream hw_out(output);
+  std::vector<string> sw_results;
+  std::vector<string> hw_results;
+  vector_from_output(sw_out, regex("software:.*"), sw_results, false);
+  vector_from_output(hw_out, regex("hardware:.*"), hw_results, false);
+  compare_probe_list(SW_PROBE_LIST, sw_results);
+  compare_probe_list(HW_PROBE_LIST, hw_results);
+}
+TEST(list, software_test)
+{
+  BPFtrace bpftrace;
+  testing::internal::CaptureStdout();
+  list_probes(bpftrace, "software*");
+  std::string output = testing::internal::GetCapturedStdout();
+  std::stringstream ss(output);
+  std::vector<string> results;
+  vector_from_output(ss, regex("software:.*"),results, true);
+  compare_probe_list(SW_PROBE_LIST, results);
+}
+TEST(list, hardware_test)
+{
+  BPFtrace bpftrace;
+  testing::internal::CaptureStdout();
+  list_probes(bpftrace, "hardware*");
+  std::string output = testing::internal::GetCapturedStdout();
+  std::stringstream ss(output);
+  std::vector<string> results;
+  vector_from_output(ss, regex("hardware:.*"),results, true);
+  compare_probe_list(HW_PROBE_LIST, results);
+}
+TEST(list, expect_empty)
+{
+  BPFtrace bpftrace;
+  testing::internal::CaptureStdout();
+  list_probes(bpftrace, "xxxx");
+  std::string output = testing::internal::GetCapturedStdout();
+  EXPECT_EQ(0, output.length());
+}
+TEST(list, find_cpu)
+{
+  vector<ProbeListItem> expected_results;
+  ProbeListItem p1 = {"cpu-clock"};
+  ProbeListItem p2 = {"cpu-migrations"};
+  ProbeListItem p3 = {"cpu-cycles"};
+  expected_results.push_back(p1);
+  expected_results.push_back(p2);
+  expected_results.push_back(p3);
+  BPFtrace bpftrace;
+  testing::internal::CaptureStdout();
+  list_probes(bpftrace, "*cpu*");
+  std::string output = testing::internal::GetCapturedStdout();
+  std::stringstream ss(output);
+  std::vector<string> results;
+  vector_from_output(ss, regex(".*cpu.*"), results, false);
+  compare_probe_list(expected_results, results);
+}
+}
+}
+}


### PR DESCRIPTION
N.B. This is a WIP, as I am a new contributor, any additional detail on the related issue would be helpful.

Per Issue https://github.com/iovisor/bpftrace/issues/603 @ajor has stated that unit tests are needed for list.cpp. The API for list.h consists of a single function 

`void list_probes(const BPFtrace &bpftrace, const std::string &search = "");`. 

The `list_probes` function returns `void` and outputs to stdout, so these unit tests rely on `  testing::internal::CaptureStdout();` Additionally, it should be noted there were no `FRIEND_TEST` declarations in any of the unit tests, so rather than attempting to test private functions, we've only tested the public API in this PR.

This PR provides a few tests for the two statically defined `std::vector<ProbeListItems>` in lists.h named SW_PROBE_LIST and HW_PROBE_LIST. Additionally we check for expected empty results when querying for an expected empty set `(xxxx)`. Finally we include a test for any probes with `*cpu*` which span both the SW/HW probe vectors. I suspect we'll want extend testing to include more list calls including things like `kprobe:*` and `tracepoints:*` but it isn't entirely clear to me whether that is desirable at the unit tests level vs. runtime.

Finally, it should be noted that there are runtime tests for listing probes in https://github.com/iovisor/bpftrace/blob/master/tests/runtime/basic#L21-L64, however @ajor has specifically called out the need for unit tests.
