### PR TITLE
Use signalfd to catch SIGINT, retry epoll on EINTR

### DIFF
--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -154,8 +154,8 @@ private:
   int next_probe_id_ = 0;
 
   std::unique_ptr<AttachedProbe> attach_probe(Probe &probe, const BpfOrc &bpforc);
-  int setup_perf_events();
-  void poll_perf_events(int epollfd, bool drain=false);
+  std::tuple<int, int> setup_perf_events();
+  void poll_perf_events(int epollfd, int signalfd, bool drain=false);
   int clear_map(IMap &map);
   int zero_map(IMap &map);
   int print_map(IMap &map, uint32_t top, uint32_t div);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -419,11 +419,6 @@ int main(int argc, char *argv[])
   if (bt_debug != DebugLevel::kNone)
     return 0;
 
-  // Empty signal handler for cleanly terminating the program
-  struct sigaction act = {};
-  act.sa_handler = [](int) { };
-  sigaction(SIGINT, &act, NULL);
-
   uint64_t num_probes = bpftrace.num_probes();
   if (num_probes == 0)
   {


### PR DESCRIPTION
This prevents an early return from poll_perf_events when other signals
(e.g. SIGCONT from terminal job control or attaching gdb to bpftrace)
are delivered.