### PR TITLE
RFC: allocate printf arguments in a map instead of the stack

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1645,11 +1645,26 @@ void CodegenLLVM::createFormatStringCall(Call &call, int &id, CallArgs &call_arg
     arg.offset = struct_layout->getElementOffset(i+1); // +1 for the id field
   }
 
-  AllocaInst *fmt_args = b_.CreateAllocaBPF(fmt_struct, call_name + "_args");
-  b_.CreateMemSet(fmt_args, b_.getInt8(0), struct_size, 1);
+  int asyncId = id + asyncactionint(async_action);
+  Value *fmt_args = b_.CreateGetFmtStrMap(fmt_struct, asyncId);
+
+  Function *parent = b_.GetInsertBlock()->getParent();
+  BasicBlock *zero = BasicBlock::Create(module_->getContext(), "fmtstrzero", parent);
+  BasicBlock *notzero = BasicBlock::Create(module_->getContext(), "fmtstrnotzero", parent);
+
+  auto fmt_struct_ptr_ty = PointerType::get(fmt_struct, 0);
+  auto null_ptr = ConstantExpr::getCast(Instruction::IntToPtr, b_.getInt64(0), fmt_struct_ptr_ty);
+  b_.CreateCondBr(b_.CreateICmpNE(fmt_args, null_ptr, "fmtstrcond"), notzero, zero);
+
+  b_.SetInsertPoint(notzero);
+
+  auto zeroed_area_ptr = b_.getInt64(reinterpret_cast<uintptr_t>(bpftrace_.fmtstr_map_zero_));
+
+  b_.CreateProbeRead(fmt_args, struct_size,
+                     ConstantExpr::getCast(Instruction::IntToPtr, zeroed_area_ptr, fmt_struct_ptr_ty));
 
   Value *id_offset = b_.CreateGEP(fmt_args, {b_.getInt32(0), b_.getInt32(0)});
-  b_.CreateStore(b_.getInt64(id + asyncactionint(async_action)), id_offset);
+  b_.CreateStore(b_.getInt64(asyncId), id_offset);
   for (size_t i=1; i<call.vargs->size(); i++)
   {
     Expression &arg = *call.vargs->at(i);
@@ -1668,6 +1683,11 @@ void CodegenLLVM::createFormatStringCall(Call &call, int &id, CallArgs &call_arg
   id++;
   b_.CreatePerfEventOutput(ctx_, fmt_args, struct_size);
   b_.CreateLifetimeEnd(fmt_args);
+
+  b_.CreateBr(zero);
+
+  // done
+  b_.SetInsertPoint(zero);
   expr_ = nullptr;
 }
 

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -40,7 +40,7 @@ public:
   Value      *CreateMapLookupElem(Map &map, AllocaInst *key);
   void        CreateMapUpdateElem(Map &map, AllocaInst *key, Value *val);
   void        CreateMapDeleteElem(Map &map, AllocaInst *key);
-  void        CreateProbeRead(AllocaInst *dst, size_t size, Value *src);
+  void        CreateProbeRead(Value *dst, size_t size, Value *src);
   CallInst   *CreateProbeReadStr(AllocaInst *dst, llvm::Value *size, Value *src);
   CallInst   *CreateProbeReadStr(AllocaInst *dst, size_t size, Value *src);
   CallInst   *CreateProbeReadStr(Value *dst, size_t size, Value *src);
@@ -56,6 +56,7 @@ public:
   CallInst   *CreateGetRandom();
   CallInst   *CreateGetStackId(Value *ctx, bool ustack, StackType stack_type);
   CallInst   *CreateGetJoinMap(Value *ctx);
+  CallInst   *CreateGetFmtStrMap(StructType *printf_struct, int asyncId);
   void        CreateGetCurrentComm(AllocaInst *buf, size_t size);
   void        CreatePerfEventOutput(Value *ctx, Value *data, size_t size);
 

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -74,8 +74,10 @@ private:
   std::map<std::string, ExpressionList> map_args_;
   std::unordered_set<StackType> needs_stackid_maps_;
   bool needs_join_map_ = false;
+  bool needs_fmtstr_map_ = false;
   bool has_begin_probe_ = false;
   bool has_end_probe_ = false;
+  size_t max_fmtstr_args_size_ = 0;
 };
 
 } // namespace ast

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -121,6 +121,8 @@ public:
   std::vector<std::tuple<std::string, std::vector<Field>>> cat_args_;
   std::unordered_map<StackType, std::unique_ptr<IMap>> stackid_maps_;
   std::unique_ptr<IMap> join_map_;
+  std::unique_ptr<IMap> fmtstr_map_;
+  void *fmtstr_map_zero_ = nullptr;
   std::unique_ptr<IMap> perf_event_map_;
   std::vector<std::string> probe_ids_;
   unsigned int join_argnum_;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -44,7 +44,7 @@ Map::Map(const std::string &name, const SizedType &type, const MapKey &key, int 
   {
       map_type = BPF_MAP_TYPE_PERCPU_HASH;
   }
-  else if (type.type == Type::join)
+  else if (type.type == Type::join || type.type == Type::fmtstr)
   {
     map_type = BPF_MAP_TYPE_PERCPU_ARRAY;
     max_entries = 1;

--- a/src/types.h
+++ b/src/types.h
@@ -33,6 +33,7 @@ enum class Type
   usym,
   cast,
   join,
+  fmtstr,
   probe,
   username,
   inet,

--- a/tests/codegen/call_cat.cpp
+++ b/tests/codegen/call_cat.cpp
@@ -18,16 +18,28 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
-  %cat_args = alloca %cat_t, align 8
-  %1 = bitcast %cat_t* %cat_args to i8*
+  %key = alloca i32, align 4
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %1 = bitcast i32* %key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = getelementptr inbounds %cat_t, %cat_t* %cat_args, i64 0, i32 0
-  store i64 20000, i64* %2, align 8
-  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %cat_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %cat_t* nonnull %cat_args, i64 8)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  store i32 0, i32* %key, align 4
+  %lookup_fmtstr_map = call %cat_t* inttoptr (i64 1 to %cat_t* (i8*, i8*)*)(i64 %pseudo, i32* nonnull %key)
+  %fmtstrcond = icmp eq %cat_t* %lookup_fmtstr_map, null
+  br i1 %fmtstrcond, label %fmtstrzero, label %fmtstrnotzero
+
+fmtstrzero:                                       ; preds = %entry, %fmtstrnotzero
   ret i64 0
+
+fmtstrnotzero:                                    ; preds = %entry
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(%cat_t* nonnull %lookup_fmtstr_map, i64 8, %cat_t* null)
+  %2 = getelementptr %cat_t, %cat_t* %lookup_fmtstr_map, i64 0, i32 0
+  store i64 20000, i64* %2, align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %cat_t*, i64)*)(i8* %0, i64 %pseudo1, i64 %get_cpu_id, %cat_t* nonnull %lookup_fmtstr_map, i64 8)
+  %3 = bitcast %cat_t* %lookup_fmtstr_map to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
+  br label %fmtstrzero
 }
 
 ; Function Attrs: argmemonly nounwind

--- a/tests/codegen/call_printf.cpp
+++ b/tests/codegen/call_printf.cpp
@@ -8,7 +8,6 @@ TEST(codegen, call_printf)
 {
   test("struct Foo { char c; long l; } kprobe:f { $foo = (Foo*)0; printf(\"%c %lu\\n\", $foo->c, $foo->l) }",
 
-#if LLVM_VERSION_MAJOR < 7
 R"EXPECTED(%printf_t = type { i64, i64, i64 }
 
 ; Function Attrs: nounwind
@@ -21,33 +20,42 @@ define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %Foo.l = alloca i64, align 8
   %Foo.c = alloca i8, align 1
-  %printf_args = alloca %printf_t, align 8
-  %1 = bitcast %printf_t* %printf_args to i8*
+  %key = alloca i32, align 4
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %1 = bitcast i32* %key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* nonnull %2, i8 0, i64 16, i32 8, i1 false)
+  store i32 0, i32* %key, align 4
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i8*, i8*)*)(i64 %pseudo, i32* nonnull %key)
+  %fmtstrcond = icmp eq %printf_t* %lookup_fmtstr_map, null
+  br i1 %fmtstrcond, label %fmtstrzero, label %fmtstrnotzero
+
+fmtstrzero:                                       ; preds = %entry, %fmtstrnotzero
+  ret i64 0
+
+fmtstrnotzero:                                    ; preds = %entry
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(%printf_t* nonnull %lookup_fmtstr_map, i64 24, %printf_t* null)
+  %2 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i64 0, i32 0
+  store i64 0, i64* %2, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %Foo.c)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %Foo.c, i64 1, i64 0)
+  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %Foo.c, i64 1, i64 0)
   %3 = load i8, i8* %Foo.c, align 1
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %Foo.c)
-  %4 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
-  store i8 %3, i64* %4, align 8
+  %4 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i64 0, i32 1
+  store i8 %3, i64* %4, align 1
   %5 = bitcast i64* %Foo.l to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.l, i64 8, i64 8)
+  %probe_read2 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.l, i64 8, i64 8)
   %6 = load i64, i64* %Foo.l, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
-  %7 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2
+  %7 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i64 0, i32 2
   store i64 %6, i64* %7, align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 24)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  ret i64 0
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo3, i64 %get_cpu_id, %printf_t* nonnull %lookup_fmtstr_map, i64 24)
+  %8 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  br label %fmtstrzero
 }
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
@@ -55,54 +63,6 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
-#else
-R"EXPECTED(%printf_t = type { i64, i64, i64 }
-
-; Function Attrs: nounwind
-declare i64 @llvm.bpf.pseudo(i64, i64) #0
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
-
-define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
-entry:
-  %Foo.l = alloca i64, align 8
-  %Foo.c = alloca i8, align 1
-  %printf_args = alloca %printf_t, align 8
-  %1 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %2, i8 0, i64 16, i1 false)
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %Foo.c)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %Foo.c, i64 1, i64 0)
-  %3 = load i8, i8* %Foo.c, align 1
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %Foo.c)
-  %4 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
-  store i8 %3, i64* %4, align 8
-  %5 = bitcast i64* %Foo.l to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.l, i64 8, i64 8)
-  %6 = load i64, i64* %Foo.l, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
-  %7 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2
-  store i64 %6, i64* %7, align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 24)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  ret i64 0
-}
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
-
-attributes #0 = { nounwind }
-attributes #1 = { argmemonly nounwind }
-)EXPECTED");
-#endif
 }
 
 } // namespace codegen

--- a/tests/codegen/call_system.cpp
+++ b/tests/codegen/call_system.cpp
@@ -18,18 +18,30 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
-  %system_args = alloca %system_t, align 8
-  %1 = bitcast %system_t* %system_args to i8*
+  %key = alloca i32, align 4
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %1 = bitcast i32* %key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = getelementptr inbounds %system_t, %system_t* %system_args, i64 0, i32 0
-  store i64 10000, i64* %2, align 8
-  %3 = getelementptr inbounds %system_t, %system_t* %system_args, i64 0, i32 1
-  store i64 100, i64* %3, align 8
-  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %system_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %system_t* nonnull %system_args, i64 16)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  store i32 0, i32* %key, align 4
+  %lookup_fmtstr_map = call %system_t* inttoptr (i64 1 to %system_t* (i8*, i8*)*)(i64 %pseudo, i32* nonnull %key)
+  %fmtstrcond = icmp eq %system_t* %lookup_fmtstr_map, null
+  br i1 %fmtstrcond, label %fmtstrzero, label %fmtstrnotzero
+
+fmtstrzero:                                       ; preds = %entry, %fmtstrnotzero
   ret i64 0
+
+fmtstrnotzero:                                    ; preds = %entry
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(%system_t* nonnull %lookup_fmtstr_map, i64 16, %system_t* null)
+  %2 = getelementptr %system_t, %system_t* %lookup_fmtstr_map, i64 0, i32 0
+  store i64 10000, i64* %2, align 8
+  %3 = getelementptr %system_t, %system_t* %lookup_fmtstr_map, i64 0, i32 1
+  store i64 100, i64* %3, align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %system_t*, i64)*)(i8* %0, i64 %pseudo1, i64 %get_cpu_id, %system_t* nonnull %lookup_fmtstr_map, i64 16)
+  %4 = bitcast %system_t* %lookup_fmtstr_map to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  br label %fmtstrzero
 }
 
 ; Function Attrs: argmemonly nounwind

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -66,6 +66,9 @@ static void test(
 
   std::string full_expected_output = header + expected_output;
   EXPECT_EQ(full_expected_output, out.str());
+  if(::testing::Test::HasFailure()) {
+    std::cerr << "Program: '" << input <<"'" <<  std::endl;
+  }
 }
 
 static void test(

--- a/tests/codegen/if_else_printf.cpp
+++ b/tests/codegen/if_else_printf.cpp
@@ -8,8 +8,8 @@ TEST(codegen, if_else_printf)
 {
   test("kprobe:f { if (pid > 10) { printf(\"hi\\n\"); } else {printf(\"hello\\n\")} }",
 
-R"EXPECTED(%printf_t.0 = type { i64 }
-%printf_t = type { i64 }
+R"EXPECTED(%printf_t = type { i64 }
+%printf_t.0 = type { i64 }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
@@ -19,36 +19,53 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
-  %printf_args1 = alloca %printf_t.0, align 8
-  %printf_args = alloca %printf_t, align 8
+  %key3 = alloca i32, align 4
+  %key = alloca i32, align 4
   %get_pid_tgid = tail call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = icmp ugt i64 %get_pid_tgid, 47244640255
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   br i1 %1, label %if_stmt, label %else_stmt
 
 if_stmt:                                          ; preds = %entry
-  %2 = bitcast %printf_t* %printf_args to i8*
+  %2 = bitcast i32* %key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %3 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
-  store i64 0, i64* %3, align 8
-  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 8)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
-  br label %done
+  store i32 0, i32* %key, align 4
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i8*, i8*)*)(i64 %pseudo, i32* nonnull %key)
+  %fmtstrcond = icmp eq %printf_t* %lookup_fmtstr_map, null
+  br i1 %fmtstrcond, label %done, label %fmtstrnotzero
 
 else_stmt:                                        ; preds = %entry
-  %4 = bitcast %printf_t.0* %printf_args1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %5 = getelementptr inbounds %printf_t.0, %printf_t.0* %printf_args1, i64 0, i32 0
-  store i64 1, i64* %5, align 8
-  %pseudo2 = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id3 = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output4 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.0*, i64)*)(i8* %0, i64 %pseudo2, i64 %get_cpu_id3, %printf_t.0* nonnull %printf_args1, i64 8)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  %3 = bitcast i32* %key3 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i32 0, i32* %key3, align 4
+  %lookup_fmtstr_map4 = call %printf_t.0* inttoptr (i64 1 to %printf_t.0* (i8*, i8*)*)(i64 %pseudo, i32* nonnull %key3)
+  %fmtstrcond7 = icmp eq %printf_t.0* %lookup_fmtstr_map4, null
+  br i1 %fmtstrcond7, label %done, label %fmtstrnotzero6
+
+fmtstrnotzero:                                    ; preds = %if_stmt
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(%printf_t* nonnull %lookup_fmtstr_map, i64 8, %printf_t* null)
+  %4 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i64 0, i32 0
+  store i64 0, i64* %4, align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo1, i64 %get_cpu_id, %printf_t* nonnull %lookup_fmtstr_map, i64 8)
+  %5 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
   br label %done
 
-done:                                             ; preds = %else_stmt, %if_stmt
+done:                                             ; preds = %fmtstrnotzero6, %else_stmt, %fmtstrnotzero, %if_stmt
   ret i64 0
+
+fmtstrnotzero6:                                   ; preds = %else_stmt
+  %probe_read8 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(%printf_t.0* nonnull %lookup_fmtstr_map4, i64 8, %printf_t.0* null)
+  %6 = getelementptr %printf_t.0, %printf_t.0* %lookup_fmtstr_map4, i64 0, i32 0
+  store i64 1, i64* %6, align 8
+  %pseudo9 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %get_cpu_id10 = call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output11 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.0*, i64)*)(i8* %0, i64 %pseudo9, i64 %get_cpu_id10, %printf_t.0* nonnull %lookup_fmtstr_map4, i64 8)
+  %7 = bitcast %printf_t.0* %lookup_fmtstr_map4 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  br label %done
 }
 
 ; Function Attrs: argmemonly nounwind

--- a/tests/codegen/if_else_variable.cpp
+++ b/tests/codegen/if_else_variable.cpp
@@ -18,21 +18,33 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
-  %printf_args = alloca %printf_t, align 8
+  %key = alloca i32, align 4
   %get_pid_tgid = tail call i64 inttoptr (i64 14 to i64 ()*)()
-  %1 = icmp ugt i64 %get_pid_tgid, 42953967927295
-  %. = select i1 %1, i64 10, i64 20
-  %2 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %3 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
-  %4 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
-  store i64 0, i64* %4, align 8
-  store i64 %., i64* %3, align 8
-  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 16)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %1 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  store i32 0, i32* %key, align 4
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i8*, i8*)*)(i64 %pseudo, i32* nonnull %key)
+  %fmtstrcond = icmp eq %printf_t* %lookup_fmtstr_map, null
+  br i1 %fmtstrcond, label %fmtstrzero, label %fmtstrnotzero
+
+fmtstrzero:                                       ; preds = %entry, %fmtstrnotzero
   ret i64 0
+
+fmtstrnotzero:                                    ; preds = %entry
+  %2 = icmp ugt i64 %get_pid_tgid, 42953967927295
+  %. = select i1 %2, i64 10, i64 20
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(%printf_t* nonnull %lookup_fmtstr_map, i64 16, %printf_t* null)
+  %3 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i64 0, i32 0
+  store i64 0, i64* %3, align 8
+  %4 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i64 0, i32 1
+  store i64 %., i64* %4, align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo1, i64 %get_cpu_id, %printf_t* nonnull %lookup_fmtstr_map, i64 16)
+  %5 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  br label %fmtstrzero
 }
 
 ; Function Attrs: argmemonly nounwind

--- a/tests/codegen/if_nested_printf.cpp
+++ b/tests/codegen/if_nested_printf.cpp
@@ -18,7 +18,7 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
-  %printf_args = alloca %printf_t, align 8
+  %key = alloca i32, align 4
   %get_pid_tgid = tail call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = icmp ugt i64 %get_pid_tgid, 42953967927295
   br i1 %1, label %if_stmt, label %else_stmt
@@ -29,18 +29,27 @@ if_stmt:                                          ; preds = %entry
   %true_cond4 = icmp eq i64 %.lobit, 0
   br i1 %true_cond4, label %if_stmt1, label %else_stmt
 
-else_stmt:                                        ; preds = %if_stmt, %if_stmt1, %entry
+else_stmt:                                        ; preds = %fmtstrnotzero, %if_stmt1, %if_stmt, %entry
   ret i64 0
 
 if_stmt1:                                         ; preds = %if_stmt
-  %2 = bitcast %printf_t* %printf_args to i8*
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %2 = bitcast i32* %key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %3 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
+  store i32 0, i32* %key, align 4
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i8*, i8*)*)(i64 %pseudo, i32* nonnull %key)
+  %fmtstrcond = icmp eq %printf_t* %lookup_fmtstr_map, null
+  br i1 %fmtstrcond, label %else_stmt, label %fmtstrnotzero
+
+fmtstrnotzero:                                    ; preds = %if_stmt1
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(%printf_t* nonnull %lookup_fmtstr_map, i64 8, %printf_t* null)
+  %3 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i64 0, i32 0
   store i64 0, i64* %3, align 8
-  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 8)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo5, i64 %get_cpu_id, %printf_t* nonnull %lookup_fmtstr_map, i64 8)
+  %4 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   br label %else_stmt
 }
 

--- a/tests/codegen/if_printf.cpp
+++ b/tests/codegen/if_printf.cpp
@@ -18,28 +18,37 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
-  %printf_args = alloca %printf_t, align 8
+  %key = alloca i32, align 4
   %get_pid_tgid = tail call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = icmp ugt i64 %get_pid_tgid, 42953967927295
   br i1 %1, label %if_stmt, label %else_stmt
 
 if_stmt:                                          ; preds = %entry
-  %2 = bitcast %printf_t* %printf_args to i8*
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %2 = bitcast i32* %key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %3 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
-  store i64 0, i64* %3, align 8
-  %get_pid_tgid1 = tail call i64 inttoptr (i64 14 to i64 ()*)()
-  %4 = lshr i64 %get_pid_tgid1, 32
-  %5 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
-  store i64 %4, i64* %5, align 8
-  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 16)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
-  br label %else_stmt
+  store i32 0, i32* %key, align 4
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i8*, i8*)*)(i64 %pseudo, i32* nonnull %key)
+  %fmtstrcond = icmp eq %printf_t* %lookup_fmtstr_map, null
+  br i1 %fmtstrcond, label %else_stmt, label %fmtstrnotzero
 
-else_stmt:                                        ; preds = %if_stmt, %entry
+else_stmt:                                        ; preds = %fmtstrnotzero, %if_stmt, %entry
   ret i64 0
+
+fmtstrnotzero:                                    ; preds = %if_stmt
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(%printf_t* nonnull %lookup_fmtstr_map, i64 16, %printf_t* null)
+  %3 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i64 0, i32 0
+  store i64 0, i64* %3, align 8
+  %get_pid_tgid1 = call i64 inttoptr (i64 14 to i64 ()*)()
+  %4 = lshr i64 %get_pid_tgid1, 32
+  %5 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i64 0, i32 1
+  store i64 %4, i64* %5, align 8
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo2, i64 %get_cpu_id, %printf_t* nonnull %lookup_fmtstr_map, i64 16)
+  %6 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  br label %else_stmt
 }
 
 ; Function Attrs: argmemonly nounwind

--- a/tests/codegen/if_variable.cpp
+++ b/tests/codegen/if_variable.cpp
@@ -19,21 +19,33 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
-  %printf_args = alloca %printf_t, align 8
+  %key = alloca i32, align 4
   %get_pid_tgid = tail call i64 inttoptr (i64 14 to i64 ()*)()
-  %1 = icmp ugt i64 %get_pid_tgid, 42953967927295
-  %. = select i1 %1, i64 10, i64 0
-  %2 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %3 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
-  %4 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
-  store i64 0, i64* %4, align 8
-  store i64 %., i64* %3, align 8
-  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 16)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %1 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  store i32 0, i32* %key, align 4
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i8*, i8*)*)(i64 %pseudo, i32* nonnull %key)
+  %fmtstrcond = icmp eq %printf_t* %lookup_fmtstr_map, null
+  br i1 %fmtstrcond, label %fmtstrzero, label %fmtstrnotzero
+
+fmtstrzero:                                       ; preds = %entry, %fmtstrnotzero
   ret i64 0
+
+fmtstrnotzero:                                    ; preds = %entry
+  %2 = icmp ugt i64 %get_pid_tgid, 42953967927295
+  %. = select i1 %2, i64 10, i64 0
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(%printf_t* nonnull %lookup_fmtstr_map, i64 16, %printf_t* null)
+  %3 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i64 0, i32 0
+  store i64 0, i64* %3, align 8
+  %4 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i64 0, i32 1
+  store i64 %., i64* %4, align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo1, i64 %get_cpu_id, %printf_t* nonnull %lookup_fmtstr_map, i64 16)
+  %5 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  br label %fmtstrzero
 }
 
 ; Function Attrs: argmemonly nounwind
@@ -53,21 +65,33 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
-  %printf_args = alloca %printf_t, align 8
+  %key = alloca i32, align 4
   %get_pid_tgid = tail call i64 inttoptr (i64 14 to i64 ()*)()
-  %1 = icmp ugt i64 %get_pid_tgid, 42953967927295
-  %spec.select = select i1 %1, i64 10, i64 0
-  %2 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %3 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
-  %4 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
-  store i64 0, i64* %4, align 8
-  store i64 %spec.select, i64* %3, align 8
-  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 16)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %1 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  store i32 0, i32* %key, align 4
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i8*, i8*)*)(i64 %pseudo, i32* nonnull %key)
+  %fmtstrcond = icmp eq %printf_t* %lookup_fmtstr_map, null
+  br i1 %fmtstrcond, label %fmtstrzero, label %fmtstrnotzero
+
+fmtstrzero:                                       ; preds = %entry, %fmtstrnotzero
   ret i64 0
+
+fmtstrnotzero:                                    ; preds = %entry
+  %2 = icmp ugt i64 %get_pid_tgid, 42953967927295
+  %spec.select = select i1 %2, i64 10, i64 0
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(%printf_t* nonnull %lookup_fmtstr_map, i64 16, %printf_t* null)
+  %3 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i64 0, i32 0
+  store i64 0, i64* %3, align 8
+  %4 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i64 0, i32 1
+  store i64 %spec.select, i64* %4, align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo1, i64 %get_cpu_id, %printf_t* nonnull %lookup_fmtstr_map, i64 16)
+  %5 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  br label %fmtstrzero
 }
 
 ; Function Attrs: argmemonly nounwind

--- a/tests/codegen/struct_semicolon.cpp
+++ b/tests/codegen/struct_semicolon.cpp
@@ -16,23 +16,35 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
-  %printf_args = alloca %printf_t, align 8
-  %1 = bitcast %printf_t* %printf_args to i8*
+  %key = alloca i32, align 4
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %1 = bitcast i32* %key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
+  store i32 0, i32* %key, align 4
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i8*, i8*)*)(i64 %pseudo, i32* nonnull %key)
+  %fmtstrcond = icmp eq %printf_t* %lookup_fmtstr_map, null
+  br i1 %fmtstrcond, label %fmtstrzero, label %fmtstrnotzero
+
+fmtstrzero:                                       ; preds = %entry, %fmtstrnotzero
+  ret i64 0
+
+fmtstrnotzero:                                    ; preds = %entry
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(%printf_t* nonnull %lookup_fmtstr_map, i64 16, %printf_t* null)
+  %2 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i64 0, i32 0
   store i64 0, i64* %2, align 8
-  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_stackid = tail call i64 inttoptr (i64 27 to i64 (i8*, i8*, i64)*)(i8* %0, i64 %pseudo, i64 256)
-  %get_pid_tgid = tail call i64 inttoptr (i64 14 to i64 ()*)()
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, i8*, i64)*)(i8* %0, i64 %pseudo1, i64 256)
+  %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %3 = shl i64 %get_pid_tgid, 32
   %4 = or i64 %3, %get_stackid
-  %5 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
+  %5 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i64 0, i32 1
   store i64 %4, i64* %5, align 8
-  %pseudo1 = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo1, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 16)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  ret i64 0
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo2, i64 %get_cpu_id, %printf_t* nonnull %lookup_fmtstr_map, i64 16)
+  %6 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  br label %fmtstrzero
 }
 
 ; Function Attrs: argmemonly nounwind

--- a/tests/codegen/variable_increment_decrement.cpp
+++ b/tests/codegen/variable_increment_decrement.cpp
@@ -8,10 +8,10 @@ TEST(codegen, variable_increment_decrement)
 {
   test("BEGIN { $x = 10; printf(\"%d\", $x++); printf(\"%d\", ++$x); printf(\"%d\", $x--); printf(\"%d\", --$x); }",
 
-R"EXPECTED(%printf_t.2 = type { i64, i64 }
-%printf_t.1 = type { i64, i64 }
+R"EXPECTED(%printf_t = type { i64, i64 }
 %printf_t.0 = type { i64, i64 }
-%printf_t = type { i64, i64 }
+%printf_t.1 = type { i64, i64 }
+%printf_t.2 = type { i64, i64 }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
@@ -21,51 +21,105 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 define i64 @BEGIN(i8*) local_unnamed_addr section "s_BEGIN_1" {
 entry:
-  %printf_args9 = alloca %printf_t.2, align 8
-  %printf_args5 = alloca %printf_t.1, align 8
-  %printf_args1 = alloca %printf_t.0, align 8
-  %printf_args = alloca %printf_t, align 8
-  %1 = bitcast %printf_t* %printf_args to i8*
+  %key23 = alloca i32, align 4
+  %key13 = alloca i32, align 4
+  %key3 = alloca i32, align 4
+  %key = alloca i32, align 4
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %1 = bitcast i32* %key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
-  %3 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
+  store i32 0, i32* %key, align 4
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i8*, i8*)*)(i64 %pseudo, i32* nonnull %key)
+  %fmtstrcond = icmp eq %printf_t* %lookup_fmtstr_map, null
+  br i1 %fmtstrcond, label %fmtstrzero, label %fmtstrnotzero
+
+fmtstrzero:                                       ; preds = %entry, %fmtstrnotzero
+  %"$x.0" = phi i64 [ 11, %fmtstrnotzero ], [ 10, %entry ]
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %2 = bitcast i32* %key3 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  store i32 0, i32* %key3, align 4
+  %lookup_fmtstr_map4 = call %printf_t.0* inttoptr (i64 1 to %printf_t.0* (i8*, i8*)*)(i64 %pseudo2, i32* nonnull %key3)
+  %fmtstrcond7 = icmp eq %printf_t.0* %lookup_fmtstr_map4, null
+  br i1 %fmtstrcond7, label %fmtstrzero5, label %fmtstrnotzero6
+
+fmtstrnotzero:                                    ; preds = %entry
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(%printf_t* nonnull %lookup_fmtstr_map, i64 16, %printf_t* null)
+  %3 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i64 0, i32 0
   store i64 0, i64* %3, align 8
-  store i64 10, i64* %2, align 8
-  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 16)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  %4 = bitcast %printf_t.0* %printf_args1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %5 = getelementptr inbounds %printf_t.0, %printf_t.0* %printf_args1, i64 0, i32 0
-  store i64 1, i64* %5, align 8
-  %6 = getelementptr inbounds %printf_t.0, %printf_t.0* %printf_args1, i64 0, i32 1
-  store i64 12, i64* %6, align 8
-  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id3 = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output4 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.0*, i64)*)(i8* %0, i64 %pseudo2, i64 %get_cpu_id3, %printf_t.0* nonnull %printf_args1, i64 16)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  %7 = bitcast %printf_t.1* %printf_args5 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  %8 = getelementptr inbounds %printf_t.1, %printf_t.1* %printf_args5, i64 0, i32 0
-  store i64 2, i64* %8, align 8
-  %9 = getelementptr inbounds %printf_t.1, %printf_t.1* %printf_args5, i64 0, i32 1
-  store i64 12, i64* %9, align 8
-  %pseudo6 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id7 = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output8 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.1*, i64)*)(i8* %0, i64 %pseudo6, i64 %get_cpu_id7, %printf_t.1* nonnull %printf_args5, i64 16)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
-  %10 = bitcast %printf_t.2* %printf_args9 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
-  %11 = getelementptr inbounds %printf_t.2, %printf_t.2* %printf_args9, i64 0, i32 0
-  store i64 3, i64* %11, align 8
-  %12 = getelementptr inbounds %printf_t.2, %printf_t.2* %printf_args9, i64 0, i32 1
-  store i64 10, i64* %12, align 8
-  %pseudo10 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id11 = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output12 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.2*, i64)*)(i8* %0, i64 %pseudo10, i64 %get_cpu_id11, %printf_t.2* nonnull %printf_args9, i64 16)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
+  %4 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i64 0, i32 1
+  store i64 10, i64* %4, align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo1, i64 %get_cpu_id, %printf_t* nonnull %lookup_fmtstr_map, i64 16)
+  %5 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  br label %fmtstrzero
+
+fmtstrzero5:                                      ; preds = %fmtstrzero, %fmtstrnotzero6
+  %"$x.1" = phi i64 [ %8, %fmtstrnotzero6 ], [ %"$x.0", %fmtstrzero ]
+  %pseudo12 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %6 = bitcast i32* %key13 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  store i32 0, i32* %key13, align 4
+  %lookup_fmtstr_map14 = call %printf_t.1* inttoptr (i64 1 to %printf_t.1* (i8*, i8*)*)(i64 %pseudo12, i32* nonnull %key13)
+  %fmtstrcond17 = icmp eq %printf_t.1* %lookup_fmtstr_map14, null
+  br i1 %fmtstrcond17, label %fmtstrzero15, label %fmtstrnotzero16
+
+fmtstrnotzero6:                                   ; preds = %fmtstrzero
+  %probe_read8 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(%printf_t.0* nonnull %lookup_fmtstr_map4, i64 16, %printf_t.0* null)
+  %7 = getelementptr %printf_t.0, %printf_t.0* %lookup_fmtstr_map4, i64 0, i32 0
+  store i64 1, i64* %7, align 8
+  %8 = add nuw nsw i64 %"$x.0", 1
+  %9 = getelementptr %printf_t.0, %printf_t.0* %lookup_fmtstr_map4, i64 0, i32 1
+  store i64 %8, i64* %9, align 8
+  %pseudo9 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %get_cpu_id10 = call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output11 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.0*, i64)*)(i8* %0, i64 %pseudo9, i64 %get_cpu_id10, %printf_t.0* nonnull %lookup_fmtstr_map4, i64 16)
+  %10 = bitcast %printf_t.0* %lookup_fmtstr_map4 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  br label %fmtstrzero5
+
+fmtstrzero15:                                     ; preds = %fmtstrzero5, %fmtstrnotzero16
+  %"$x.2" = phi i64 [ %13, %fmtstrnotzero16 ], [ %"$x.1", %fmtstrzero5 ]
+  %pseudo22 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %11 = bitcast i32* %key23 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %11)
+  store i32 0, i32* %key23, align 4
+  %lookup_fmtstr_map24 = call %printf_t.2* inttoptr (i64 1 to %printf_t.2* (i8*, i8*)*)(i64 %pseudo22, i32* nonnull %key23)
+  %fmtstrcond27 = icmp eq %printf_t.2* %lookup_fmtstr_map24, null
+  br i1 %fmtstrcond27, label %fmtstrzero25, label %fmtstrnotzero26
+
+fmtstrnotzero16:                                  ; preds = %fmtstrzero5
+  %probe_read18 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(%printf_t.1* nonnull %lookup_fmtstr_map14, i64 16, %printf_t.1* null)
+  %12 = getelementptr %printf_t.1, %printf_t.1* %lookup_fmtstr_map14, i64 0, i32 0
+  store i64 2, i64* %12, align 8
+  %13 = add nsw i64 %"$x.1", -1
+  %14 = getelementptr %printf_t.1, %printf_t.1* %lookup_fmtstr_map14, i64 0, i32 1
+  store i64 %"$x.1", i64* %14, align 8
+  %pseudo19 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %get_cpu_id20 = call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output21 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.1*, i64)*)(i8* %0, i64 %pseudo19, i64 %get_cpu_id20, %printf_t.1* nonnull %lookup_fmtstr_map14, i64 16)
+  %15 = bitcast %printf_t.1* %lookup_fmtstr_map14 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  br label %fmtstrzero15
+
+fmtstrzero25:                                     ; preds = %fmtstrzero15, %fmtstrnotzero26
   ret i64 0
+
+fmtstrnotzero26:                                  ; preds = %fmtstrzero15
+  %probe_read28 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(%printf_t.2* nonnull %lookup_fmtstr_map24, i64 16, %printf_t.2* null)
+  %16 = getelementptr %printf_t.2, %printf_t.2* %lookup_fmtstr_map24, i64 0, i32 0
+  store i64 3, i64* %16, align 8
+  %17 = add nsw i64 %"$x.2", -1
+  %18 = getelementptr %printf_t.2, %printf_t.2* %lookup_fmtstr_map24, i64 0, i32 1
+  store i64 %17, i64* %18, align 8
+  %pseudo29 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %get_cpu_id30 = call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output31 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.2*, i64)*)(i8* %0, i64 %pseudo29, i64 %get_cpu_id30, %printf_t.2* nonnull %lookup_fmtstr_map24, i64 16)
+  %19 = bitcast %printf_t.2* %lookup_fmtstr_map24 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  br label %fmtstrzero25
 }
 
 ; Function Attrs: argmemonly nounwind

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -96,13 +96,13 @@ NAME kstack
 RUN bpftrace -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n%s\n", kstack(), kstack(1)); exit(); }'
 EXPECT SUCCESS kstack
 TIMEOUT 5
-AFTER cat /dev/null
+AFTER sleep 0.1
 
 NAME ustack
 RUN bpftrace -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n%s\n", ustack(), ustack(1)); exit(); }'
 EXPECT SUCCESS ustack
 TIMEOUT 5
-AFTER cat /dev/null
+AFTER sleep 0.1
 
 NAME cat
 RUN bpftrace -v -e 'i:ms:1 { cat("/proc/uptime"); exit();}'

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -39,22 +39,22 @@ EXPECT comm: bpftrace
 TIMEOUT 5
 
 NAME struct keyword optional when casting
-RUN bpftrace -v -e 'struct Bar { int x; } struct Foo { struct Bar *bar; } i:ms:1 { $foo = (struct Foo *)0; @x = $foo->bar->x; exit()}'
+RUN bpftrace -e 'struct Bar { int x; } struct Foo { struct Bar *bar; } i:ms:1 { $foo = (struct Foo *)0; @x = $foo->bar->x; exit()}'
 EXPECT @x: 0
 TIMEOUT 5
 
 NAME struct positional string compare - equal returns true
-RUN bpftrace -v -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} exit();}' "hello" "hello"
+RUN bpftrace -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} exit();}' "hello" "hello"
 EXPECT I got hello
 TIMEOUT 5
 
 NAME struct positional string compare - equal returns false
-RUN bpftrace -v -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hi" "hello"
+RUN bpftrace -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hi" "hello"
 EXPECT not equal
 TIMEOUT 5
 
 NAME struct positional string compare - not equal
-RUN bpftrace -v -e 'BEGIN { if (str($1) != str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hello" "hello"
+RUN bpftrace -e 'BEGIN { if (str($1) != str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hello" "hello"
 EXPECT not equal
 TIMEOUT 5
 


### PR DESCRIPTION
While working on #26 I hit the 512 stack limit, since printf arguments are stored in the stack and join will have a fixed size of `8 + 8 + (16 * 1024)`. To avoid bloating the stack, we can move printf arguments to a map (like we do for the list of strings that `join`  take).

`runtime-tests` passed (with the adjusts I made here) and tools parsing+codegen is working as well. Only a few codegen unit tests broke with this chages.

This is also one small step towards large string support.