### PR TITLE
Add new environment variable BPFTRACE_LOG_SIZE

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -23,7 +23,6 @@
 
 namespace bpftrace {
 
-const int BPF_LOG_SIZE = 400 * 1024;
 /*
  * Kernel functions that are unsafe to trace are excluded in the Kernel with
  * `notrace`. However, the ones below are not excluded.
@@ -325,7 +324,7 @@ void AttachedProbe::load_prog()
   int prog_len = std::get<1>(func_);
   const char *license = "GPL";
   int log_level = 0;
-  char log_buf[BPF_LOG_SIZE];
+  char log_buf[probe_.log_size];
   char name[STRING_SIZE], *namep;
   unsigned log_buf_size = sizeof (log_buf);
 

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -381,8 +381,12 @@ void AttachedProbe::load_prog()
   }
 
   if (progfd_ < 0) {
-    if (bt_verbose)
+    if (bt_verbose) {
       std::cerr << std::endl << "Error log: " << std::endl << log_buf << std::endl;
+      if (errno == ENOSPC) {
+        std::cerr << "Error: No space left on device, try increasing BPFTRACE_LOG_SIZE environment variable" << std::endl;
+      }
+    }
     throw std::runtime_error("Error loading program: " + probe_.name + (bt_verbose ? "" : " (try -v)"));
   }
 

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -107,7 +107,7 @@ int BPFtrace::add_probe(ast::Probe &p)
       probe.path = "/proc/self/exe";
       probe.attach_point = "BEGIN_trigger";
       probe.type = probetype(attach_point->provider);
-      probe.log_size = this->log_size_;
+      probe.log_size = log_size_;
       probe.orig_name = p.name();
       probe.name = p.name();
       probe.loc = 0;
@@ -122,7 +122,7 @@ int BPFtrace::add_probe(ast::Probe &p)
       probe.path = "/proc/self/exe";
       probe.attach_point = "END_trigger";
       probe.type = probetype(attach_point->provider);
-      probe.log_size = this->log_size_;
+      probe.log_size = log_size_;
       probe.orig_name = p.name();
       probe.name = p.name();
       probe.loc = 0;
@@ -177,7 +177,7 @@ int BPFtrace::add_probe(ast::Probe &p)
       probe.path = attach_point->target;
       probe.attach_point = func_id;
       probe.type = probetype(attach_point->provider);
-      probe.log_size = this->log_size_;
+      probe.log_size = log_size_;
       probe.orig_name = p.name();
       probe.ns = attach_point->ns;
       probe.name = attach_point->name(func_id);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -107,6 +107,7 @@ int BPFtrace::add_probe(ast::Probe &p)
       probe.path = "/proc/self/exe";
       probe.attach_point = "BEGIN_trigger";
       probe.type = probetype(attach_point->provider);
+      probe.log_size = this->log_size_;
       probe.orig_name = p.name();
       probe.name = p.name();
       probe.loc = 0;
@@ -121,6 +122,7 @@ int BPFtrace::add_probe(ast::Probe &p)
       probe.path = "/proc/self/exe";
       probe.attach_point = "END_trigger";
       probe.type = probetype(attach_point->provider);
+      probe.log_size = this->log_size_;
       probe.orig_name = p.name();
       probe.name = p.name();
       probe.loc = 0;
@@ -175,6 +177,7 @@ int BPFtrace::add_probe(ast::Probe &p)
       probe.path = attach_point->target;
       probe.attach_point = func_id;
       probe.type = probetype(attach_point->provider);
+      probe.log_size = this->log_size_;
       probe.orig_name = p.name();
       probe.ns = attach_point->ns;
       probe.name = attach_point->name(func_id);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -119,6 +119,7 @@ public:
   uint64_t mapmax_ = 4096;
   size_t cat_bytes_max_ = 10240;
   uint64_t max_probes_ = 512;
+  uint64_t log_size_ = 409600;
   bool demangle_cpp_symbols = true;
   bool safe_mode = true;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -332,7 +332,7 @@ int main(int argc, char *argv[])
     return 1;
 
   if (!get_uint64_env_var("BPFTRACE_MAX_PROBES", bpftrace.max_probes_))
-		return 1;
+    return 1;
 	
   if (!get_uint64_env_var("BPFTRACE_LOG_SIZE", bpftrace.log_size_))
     return 1;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -47,6 +47,7 @@ void usage()
   std::cerr << "    BPFTRACE_MAP_KEYS_MAX     [default: 4096] max keys in a map" << std::endl;
   std::cerr << "    BPFTRACE_CAT_BYTES_MAX    [default: 10k] maximum bytes read by cat builtin" << std::endl;
   std::cerr << "    BPFTRACE_MAX_PROBES       [default: 512] max number of probes" << std::endl;
+  std::cerr << "    BPFTRACE_LOG_SIZE         [default: 409600] log size in bytes" << std::endl;
   std::cerr << std::endl;
   std::cerr << "EXAMPLES:" << std::endl;
   std::cerr << "bpftrace -l '*sleep*'" << std::endl;
@@ -330,7 +331,7 @@ int main(int argc, char *argv[])
   if (!get_uint64_env_var("BPFTRACE_MAP_KEYS_MAX", bpftrace.mapmax_))
     return 1;
 
-  if (!get_uint64_env_var("BPFTRACE_MAX_PROBES", bpftrace.max_probes_))
+  if (!get_uint64_env_var("BPFTRACE_LOG_SIZE", bpftrace.log_size_))
     return 1;
 
   if (const char* env_p = std::getenv("BPFTRACE_CAT_BYTES_MAX"))

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -331,6 +331,9 @@ int main(int argc, char *argv[])
   if (!get_uint64_env_var("BPFTRACE_MAP_KEYS_MAX", bpftrace.mapmax_))
     return 1;
 
+  if (!get_uint64_env_var("BPFTRACE_MAX_PROBES", bpftrace.max_probes_))
+		return 1;
+	
   if (!get_uint64_env_var("BPFTRACE_LOG_SIZE", bpftrace.log_size_))
     return 1;
 

--- a/src/types.h
+++ b/src/types.h
@@ -139,6 +139,7 @@ public:
   std::string name;             // full probe name
   std::string ns;               // for USDT probes, if provider namespace not from path
   uint64_t loc;                 // for USDT probes
+  uint64_t log_size;
   int index = 0;
   int freq;
 };

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -112,6 +112,17 @@ RUN bpftrace -e 'i:ms:1 { cat("/proc/loadavg"); exit(); }'
 EXPECT ^[0-9]$
 TIMEOUT 5
 
+NAME log size too small
+ENV BPFTRACE_LOG_SIZE=1
+RUN bpftrace -ve 'BEGIN { if (str($1) == str($2)) { printf("%s\n", str($1)); exit() } }' "hello" "hello"
+EXPECT ^Error loading program: BEGIN
+TIMEOUT 5
+
+NAME increase log size 
+RUN bpftrace -ve 'BEGIN { if (str($1) == str($2)) { printf("%s\n", str($1)); exit() } }' "hello" "hello"
+EXPECT ^Attaching 1 probe 
+TIMEOUT 5
+
 NAME cat "no such file"
 RUN bpftrace -e 'i:ms:1 { cat("/does/not/exist/file"); exit(); }'
 EXPECT ^Error opening file '/does/not/exist/file': No such file or directory$


### PR DESCRIPTION
Per Issue https://github.com/iovisor/bpftrace/issues/584, running with -v can cause programs to fail, due to `BPF_LOG_SIZE` not being large enough to store the program. As noted in the issue, log size should be settable from an environment variable and bpftrace should give a better error message when this occurs.

This PR introduces a new environment variable `BPFTRACE_LOG_SIZE` as a replacement of the `const int BPF_LOG_SIZE = 400 * 1024;` in `attached_probe.cpp`. Additionally we add logging as a hint to the user to increase `BPFTRACE_LOG_SIZE` when ENOSPC is received. Finally we've added runtime tests for verification.