### PR TITLE
WIP unify CI and ./build.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,25 +13,24 @@ matrix:
     # of passing occasionally.
     # String comparisons are the exception - they are just broken in debug builds.
     - name: "Static LLVM 5 Debug"
-      env: LLVM_VERSION=5.0 BASE=alpine TYPE=Debug STATIC_LINKING=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*:codegen.string_equal_comparison:codegen.string_not_equal_comparison"
+      env: LLVM_VERSION=5.0 DOCKER_BASE=alpine BUILD_TYPE=debug STATIC_LINKING=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*:codegen.string_equal_comparison:codegen.string_not_equal_comparison"
     - name: "Static LLVM 5 Release"
-      env: LLVM_VERSION=5.0 BASE=alpine TYPE=Release STATIC_LINKING=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*"
+      env: LLVM_VERSION=5.0 DOCKER_BASE=alpine BUILD_TYPE=release STATIC_LINKING=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*"
 
     - name: "LLVM 6 Debug"
-      env: LLVM_VERSION=6.0 BASE=bionic TYPE=Debug
+      env: LLVM_VERSION=6.0 DOCKER_BASE=bionic BUILD_TYPE=debug
     - name: "LLVM 6 Release"
-      env: LLVM_VERSION=6.0 BASE=bionic TYPE=Release
+      env: LLVM_VERSION=6.0 DOCKER_BASE=bionic BUILD_TYPE=release
 
     - name: "LLVM 7 Debug"
-      env: LLVM_VERSION=7 BASE=bionic TYPE=Debug
+      env: LLVM_VERSION=7 DOCKER_BASE=bionic BUILD_TYPE=debug
     - name: "LLVM 7 Release"
-      env: LLVM_VERSION=7 BASE=bionic TYPE=Release
+      env: LLVM_VERSION=7 DOCKER_BASE=bionic BUILD_TYPE=release
 
     - name: "LLVM 8 Debug"
-      env: LLVM_VERSION=8 BASE=bionic TYPE=Debug
+      env: LLVM_VERSION=8 DOCKER_BASE=bionic BUILD_TYPE=debug
     - name: "LLVM 8 Release"
-      env: LLVM_VERSION=8 BASE=bionic TYPE=Release
+      env: LLVM_VERSION=8 DOCKER_BASE=bionic BUILD_TYPE=release
 
 script:
-  - docker build --build-arg LLVM_VERSION=$LLVM_VERSION -t bpftrace-builder-$BASE-llvm-$LLVM_VERSION -f docker/Dockerfile.$BASE docker/
-  - sudo docker run --privileged --rm -it -v $(pwd):$(pwd) -v /sys/kernel/debug:/sys/kernel/debug:rw -e STATIC_LINKING=$STATIC_LINKING -e TEST_ARGS=$TEST_ARGS bpftrace-builder-$BASE-llvm-$LLVM_VERSION $(pwd)/build-$TYPE-$BASE $TYPE -j`getconf _NPROCESSORS_ONLN`
+  - sudo RUN_TESTS=1 ./build.sh

--- a/build-common.sh
+++ b/build-common.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+set -x
+set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+DOCKER_FLAGS="--rm -it  -u $(id -u):$(id -g) -e REPOSITORY=$DIR"
+DOCKER_VOLUMES="-v $DIR:$DIR"
+
+DOCKER_BASE="${DOCKER_BASE:-alpine}"
+IMAGE_NAME="bpftrace-builder-$DOCKER_BASE"
+
+if [ "$LLVM_VERSION" != "" ]; then
+  BUILD_FLAGS="$BUILD_FLAGS --build-arg LLVM_VERSION=$LLVM_VERSION"
+  IMAGE_NAME="${IMAGE_NAME}-llvm-$LLVM_VERSION"
+fi;
+
+if [ ! -z "$STATIC_LINKING" ]; then
+ DOCKER_FLAGS="$DOCKER_FLAGS  -e STATIC_LINKING=$STATIC_LINKING"
+elif [ "$DOCKER_BASE" == "alpine" ]; then
+ DOCKER_FLAGS="$DOCKER_FLAGS  -e STATIC_LINKING=ON"
+fi
+
+if [ ! -z "$RUN_TESTS" ] || [ ! -z "$RUN_ALL_TESTS" ]; then
+  DOCKER_FLAGS="$DOCKER_FLAGS --privileged -e RUN_TESTS=$RUN_TESTS"
+  DOCKER_VOLUMES="$DOCKER_VOLUMES -v /sys/kernel/debug:/sys/kernel/debug:rw"
+fi
+
+if [ ! -z "$TEST_ARGS" ]; then
+  DOCKER_FLAGS="$DOCKER_FLAGS -e TEST_ARGS=$TEST_ARGS"
+fi
+
+if [ ! -z "$RUN_ALL_TESTS" ]; then
+  DOCKER_FLAGS="$DOCKER_FLAGS -e RUN_ALL_TESTS=$RUN_ALL_TESTS"
+  DOCKER_VOLUMES="$DOCKER_VOLUMES -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro "
+fi
+
+docker run $DOCKER_FLAGS $DOCKER_VOLUMES $IMAGE_NAME "$@"

--- a/build-debug.sh
+++ b/build-debug.sh
@@ -1,3 +1,8 @@
 #!/bin/bash
+set -x
 set -e
-docker run --rm -it -u $(id -u):$(id -g) -v $(pwd):$(pwd) -e STATIC_LINKING=ON -e RUN_TESTS=0 bpftrace-builder-alpine "$(pwd)/build-debug" Debug "$@"
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export BUILD_DIR="${BUILD_DIR:-"${DIR}/build-debug"}"
+
+./build-common.sh $BUILD_DIR Debug $@

--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -1,5 +1,23 @@
 #!/bin/bash
+
+set -x
 set -e
-pushd docker
-docker build -t bpftrace-builder-alpine -f Dockerfile.alpine .
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DOCKER_BASE="${DOCKER_BASE:-alpine}"
+
+BUILD_FLAGS=""
+IMAGE_NAME="bpftrace-builder-$DOCKER_BASE"
+
+if [ "$LLVM_VERSION" != "" ]; then
+  BUILD_FLAGS="$BUILD_FLAGS --build-arg LLVM_VERSION=$LLVM_VERSION"
+  IMAGE_NAME="${IMAGE_NAME}-llvm-$LLVM_VERSION"
+fi;
+
+if [ $DOCKER_FORCE_REBUILD = 1 ]; then
+  BUILD_FLAGS="$BUILD_FLAGS --no-cache"
+fi
+
+pushd $DIR/docker
+docker build $BUILD_FLAGS -t $IMAGE_NAME -f Dockerfile.$DOCKER_BASE .
 popd

--- a/build-release.sh
+++ b/build-release.sh
@@ -1,3 +1,9 @@
 #!/bin/bash
+
+set -x
 set -e
-docker run --rm -it -u $(id -u):$(id -g) -v $(pwd):$(pwd) -e STATIC_LINKING=ON -e RUN_TESTS=0 bpftrace-builder-alpine "$(pwd)/build-release" Release "$@"
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export BUILD_DIR="${BUILD_DIR:-"${DIR}/build-release"}"
+
+./build-common.sh $BUILD_DIR Release $@

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,12 @@
 #!/bin/bash
+set -x
 set -e
+
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+pushd $DIR
+BUILD_TYPE="${BUILD_TYPE:-release}"
+
 ./build-docker-image.sh
-./build-release.sh "$@"
+./build-${BUILD_TYPE}.sh "$@"
+popd

--- a/docker/Dockerfile.cosmic
+++ b/docker/Dockerfile.cosmic
@@ -1,18 +1,18 @@
-FROM ubuntu:bionic
+FROM ubuntu:cosmic
 
 ARG LLVM_VERSION
 ENV LLVM_VERSION=$LLVM_VERSION
 
 RUN apt-get update && apt-get install -y curl gnupg &&\
     llvmRepository="\n\
-deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main\n\
-deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic main\n\
-deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-${LLVM_VERSION} main\n\
-deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-${LLVM_VERSION} main\n" &&\
+deb http://apt.llvm.org/cosmic/ llvm-toolchain-cosmic main\n\
+deb-src http://apt.llvm.org/cosmic/ llvm-toolchain-cosmic main\n\
+deb http://apt.llvm.org/cosmic/ llvm-toolchain-cosmic-${LLVM_VERSION} main\n\
+deb-src http://apt.llvm.org/cosmic/ llvm-toolchain-cosmic-${LLVM_VERSION} main\n" &&\
     echo $llvmRepository >> /etc/apt/sources.list && \
     curl -L https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4052245BD4284CDD && \
-    echo "deb https://repo.iovisor.org/apt/bionic bionic main" | tee /etc/apt/sources.list.d/iovisor.list
+    echo "deb https://repo.iovisor.org/apt/cosmic cosmic main" | tee /etc/apt/sources.list.d/iovisor.list
 
 RUN apt-get update && apt-get install -y \
       bison \

--- a/docker/Dockerfile.disco
+++ b/docker/Dockerfile.disco
@@ -1,18 +1,18 @@
-FROM ubuntu:bionic
+FROM ubuntu:disco
 
 ARG LLVM_VERSION
 ENV LLVM_VERSION=$LLVM_VERSION
 
 RUN apt-get update && apt-get install -y curl gnupg &&\
     llvmRepository="\n\
-deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main\n\
-deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic main\n\
-deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-${LLVM_VERSION} main\n\
-deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic-${LLVM_VERSION} main\n" &&\
+deb http://apt.llvm.org/disco/ llvm-toolchain-disco main\n\
+deb-src http://apt.llvm.org/disco/ llvm-toolchain-disco main\n\
+deb http://apt.llvm.org/disco/ llvm-toolchain-disco-${LLVM_VERSION} main\n\
+deb-src http://apt.llvm.org/disco/ llvm-toolchain-disco-${LLVM_VERSION} main\n" &&\
     echo $llvmRepository >> /etc/apt/sources.list && \
     curl -L https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4052245BD4284CDD && \
-    echo "deb https://repo.iovisor.org/apt/bionic bionic main" | tee /etc/apt/sources.list.d/iovisor.list
+    echo "deb https://repo.iovisor.org/apt/disco disco main" | tee /etc/apt/sources.list.d/iovisor.list
 
 RUN apt-get update && apt-get install -y \
       bison \

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,21 +1,24 @@
 #!/bin/bash
 
+set -x
 set -e
 
 STATIC_LINKING=${STATIC_LINKING:-OFF}
 RUN_TESTS=${RUN_TESTS:-1}
+REPOSITORY=${REPOSITORY:-../}
 
 # Build bpftrace
 mkdir -p "$1"
 cd "$1"
-cmake -DCMAKE_BUILD_TYPE="$2" -DSTATIC_LINKING:BOOL=$STATIC_LINKING ../
+cmake -DCMAKE_BUILD_TYPE="$2" -DSTATIC_LINKING:BOOL=$STATIC_LINKING $REPOSITORY
 shift 2
 make "$@"
 
-if [ $RUN_TESTS = 1 ]; then
+if [ "$RUN_TESTS" = "1" ] || [ "$RUN_ALL_TESTS" = "1" ]; then
   set +e
-  mount -t debugfs debugfs /sys/kernel/debug/
-  ./tests/bpftrace_test $TEST_ARGS;
-  # TODO(mmarchini) re-enable once we figured out how to run it properly on CI
-  # make runtime-tests;
+  if [ "$RUN_ALL_TESTS" = "1" ]; then
+    ctest -V
+  else
+    ./tests/bpftrace_test $TEST_ARGS;
+  fi
 fi


### PR DESCRIPTION
It's still a work in progress, I'm opening the PR early to see if travis works with this approach.

The general idea is to unify `build.sh` and `.travis.yml` so we don't duplicate `docker build` and `docker run` arguments. Also this introduces RUN_ALL_TESTS, so folks can run runtime-tests and tools-parsing-tests easier, and introduces Dockerfiles for 18.10 and 19.04 (untested, will do it while Travis runs).

Once everything is working on my machine and on Travis, I'll move files around to keep things more organized (having everything on `./` is not a good idea, we probably only want to keep ./build.sh there).