### PR TITLE
utils: unpack kheaders.tar.xz if necessary

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -305,6 +305,77 @@ bool is_dir(const std::string& path)
   return S_ISDIR(buf.st_mode);
 }
 
+namespace {
+  class KernelHeaderTmpDir {
+    KernelHeaderTmpDir()
+    {
+      if (::mkdtemp(&path[0]) == nullptr) {
+        throw std::runtime_error("creating temporary path for kheaders.tar.xz failed");
+      }
+    }
+
+    void move_to(const std::string& new_path)
+    {
+      int err = ::rename(path.c_str(), new_path.c_str());
+      if (err == 0) {
+        path = "";
+      }
+    }
+
+    std::string path{"/tmp/bpftrace-XXXXXX"};
+
+    friend std::string unpack_kheaders_tar_xz(const struct utsname&);
+
+  public:
+    ~KernelHeaderTmpDir()
+    {
+      if (path.size() > 0) {
+        // move_to either did not succeed or did not run, so clean up after ourselves
+        exec_system(("rm -rf " + path).c_str());
+      }
+    }
+  };
+
+  std::string unpack_kheaders_tar_xz(const struct utsname& utsname)
+  {
+    std::string shared_path("/tmp/kheaders-");
+    shared_path += utsname.release;
+
+    struct stat stat_buf;
+
+    if (::stat(shared_path.c_str(), &stat_buf) == 0) {
+      // already unpacked
+      return shared_path;
+    }
+
+    if (::stat("/sys/kernel/kheaders.tar.xz", &stat_buf) != 0) {
+      FILE* modprobe = popen("modprobe kheaders", "w");
+      if (modprobe == nullptr || pclose(modprobe) != 0) {
+        return "";
+      }
+
+      if (::stat("/sys/kernel/kheaders.tar.xz", &stat_buf) != 0) {
+        return "";
+      }
+    }
+
+    KernelHeaderTmpDir tmpdir;
+
+    FILE* tar = popen(("tar xf /sys/kernel/kheaders.tar.xz -C " + tmpdir.path).c_str(), "w");
+    if (!tar) {
+      return "";
+    }
+
+    int rc = pclose(tar);
+    if (rc == 0) {
+      tmpdir.move_to(shared_path);
+      return shared_path;
+    }
+
+    return "";
+  }
+} // namespace
+
 // get_kernel_dirs returns {ksrc, kobj} - directories for pristine and
 // generated kernel sources.
 //
@@ -343,6 +414,10 @@ std::tuple<std::string, std::string> get_kernel_dirs(const struct utsname& utsna
     kobj = "";
   }
   if (ksrc == "" && kobj == "") {
+    const auto kheaders_tar_xz_path = unpack_kheaders_tar_xz(utsname);
+    if (kheaders_tar_xz_path.size() > 0) {
+      return std::make_tuple(kheaders_tar_xz_path, kheaders_tar_xz_path);
+    }
     return std::make_tuple("", "");
   }
   if (ksrc == "") {


### PR DESCRIPTION
When CONFIG_IKHEADERS is enabled, a tarball containing the kernel
headers is available in /sys/kernel, allowing the kernel type
definitions to be used even if the headers have not been separately
distributed to /lib on the target.

This is akin to [how bcc handles it][1], but with the new path in /sys
after [2].  Notably, use the same path in /tmp, so that the tarball will
be unpacked only once between the two tools.

[1]: https://github.com/iovisor/bcc/commit/ae92f3ddb6aa5b81c750abf3540b99f24d219e67
[2]: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=f7b101d33046a837c2aa4526cef28a3c785d7af2