### PR TITLE
New join behavior

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -165,6 +165,26 @@ CallInst *IRBuilderBPF::CreateGetJoinMap(Value *ctx __attribute__((unused)))
   return call;
 }
 
+CallInst *IRBuilderBPF::CreateGetPrintfMap(StructType *printf_struct)
+{
+  Value *map_ptr = CreateBpfPseudoCall(bpftrace_.printf_map_->mapfd_);
+  AllocaInst *key = CreateAllocaBPF(getInt32Ty(), "key");
+  Value *keyv = getInt32(0);
+  CreateStore(keyv, key);
+
+  FunctionType *lookup_func_type = FunctionType::get(
+      PointerType::get(printf_struct, 0),
+      {getInt8PtrTy(), getInt8PtrTy()},
+      false);
+  PointerType *lookup_func_ptr_type = PointerType::get(lookup_func_type, 0);
+  Constant *lookup_func = ConstantExpr::getCast(
+      Instruction::IntToPtr,
+      getInt64(BPF_FUNC_map_lookup_elem),
+      lookup_func_ptr_type);
+  CallInst *call = CreateCall(lookup_func, {map_ptr, key}, "lookup_printf_map");
+  return call;
+}
+
 Value *IRBuilderBPF::CreateMapLookupElem(Map &map, AllocaInst *key)
 {
   Value *map_ptr = CreateBpfPseudoCall(map);
@@ -253,7 +273,7 @@ void IRBuilderBPF::CreateMapDeleteElem(Map &map, AllocaInst *key)
   CreateCall(delete_func, {map_ptr, key}, "delete_elem");
 }
 
-void IRBuilderBPF::CreateProbeRead(AllocaInst *dst, size_t size, Value *src)
+void IRBuilderBPF::CreateProbeRead(Value *dst, size_t size, Value *src)
 {
   // int bpf_probe_read(void *dst, int size, void *src)
   // Return: 0 on success or negative error

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -40,7 +40,7 @@ public:
   Value      *CreateMapLookupElem(Map &map, AllocaInst *key);
   void        CreateMapUpdateElem(Map &map, AllocaInst *key, Value *val);
   void        CreateMapDeleteElem(Map &map, AllocaInst *key);
-  void        CreateProbeRead(Value *dst, size_t size, Value *src);
+  CallInst   *CreateProbeRead(Value *dst, size_t size, Value *src);
   CallInst   *CreateProbeReadStr(AllocaInst *dst, llvm::Value *size, Value *src);
   CallInst   *CreateProbeReadStr(AllocaInst *dst, size_t size, Value *src);
   CallInst   *CreateProbeReadStr(Value *dst, size_t size, Value *src);

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -40,7 +40,7 @@ public:
   Value      *CreateMapLookupElem(Map &map, AllocaInst *key);
   void        CreateMapUpdateElem(Map &map, AllocaInst *key, Value *val);
   void        CreateMapDeleteElem(Map &map, AllocaInst *key);
-  void        CreateProbeRead(AllocaInst *dst, size_t size, Value *src);
+  void        CreateProbeRead(Value *dst, size_t size, Value *src);
   CallInst   *CreateProbeReadStr(AllocaInst *dst, llvm::Value *size, Value *src);
   CallInst   *CreateProbeReadStr(AllocaInst *dst, size_t size, Value *src);
   CallInst   *CreateProbeReadStr(Value *dst, size_t size, Value *src);
@@ -56,6 +56,7 @@ public:
   CallInst   *CreateGetRandom();
   CallInst   *CreateGetStackId(Value *ctx, bool ustack, StackType stack_type);
   CallInst   *CreateGetJoinMap(Value *ctx);
+  CallInst   *CreateGetPrintfMap(StructType *printf_struct);
   void        CreateGetCurrentComm(AllocaInst *buf, size_t size);
   void        CreatePerfEventOutput(Value *ctx, Value *data, size_t size);
 

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -359,10 +359,10 @@ void SemanticAnalyser::visit(Call &call)
     call.type.is_internal = true;
   }
   else if (call.func == "join") {
-    check_assignment(call, false, false);
+    // check_assignment(call, false, false);
     check_varargs(call, 1, 2);
     check_arg(call, Type::integer, 0);
-    call.type = SizedType(Type::none, 0);
+    call.type = SizedType(Type::join, 8 + bpftrace_.join_argnum_ * bpftrace_.join_argsize_);
     needs_join_map_ = true;
 
     if (is_final_pass()) {
@@ -1190,7 +1190,7 @@ int SemanticAnalyser::create_maps(bool debug)
     {
       // join uses map storage as we'd like to process data larger than can fit on the BPF stack.
       std::string map_ident = "join";
-      SizedType type = SizedType(Type::join, 8 + 8 + bpftrace_.join_argnum_ * bpftrace_.join_argsize_);
+      SizedType type = SizedType(Type::join, 8 + bpftrace_.join_argnum_ * bpftrace_.join_argsize_);
       MapKey key;
       bpftrace_.join_map_ = std::make_unique<bpftrace::FakeMap>(map_ident, type, key);
     }
@@ -1202,7 +1202,7 @@ int SemanticAnalyser::create_maps(bool debug)
     {
       // join uses map storage as we'd like to process data larger than can fit on the BPF stack.
       std::string map_ident = "join";
-      SizedType type = SizedType(Type::join, 8 + 8 + bpftrace_.join_argnum_ * bpftrace_.join_argsize_);
+      SizedType type = SizedType(Type::join, 8 + bpftrace_.join_argnum_ * bpftrace_.join_argsize_);
       MapKey key;
       bpftrace_.join_map_ = std::make_unique<bpftrace::Map>(map_ident, type, key, 1);
     }

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -414,6 +414,7 @@ void SemanticAnalyser::visit(Call &call)
     call.type = SizedType(Type::integer, 8);
   }
   else if (call.func == "printf" || call.func == "system") {
+    needs_printf_map_ = true;
     check_assignment(call, false, false);
     if (check_varargs(call, 1, 7)) {
       check_arg(call, Type::string, 0, true);
@@ -421,13 +422,16 @@ void SemanticAnalyser::visit(Call &call)
         auto &fmt_arg = *call.vargs->at(0);
         String &fmt = static_cast<String&>(fmt_arg);
         std::vector<Field> args;
+        size_t args_size = 0;
         for (auto iter = call.vargs->begin()+1; iter != call.vargs->end(); iter++) {
           auto ty = (*iter)->type;
           // Promote to 64-bit if it's not an array type
           if (!ty.IsArray())
             ty.size = 8;
           args.push_back({ .type =  ty, .offset = 0 });
+          args_size += ty.size;
         }
+        max_printf_args_size_ = std::max(max_printf_args_size_, args_size);
         err_ << verify_format_string(fmt.str, args);
 
         if (call.func == "printf")
@@ -1203,6 +1207,19 @@ int SemanticAnalyser::create_maps(bool debug)
       bpftrace_.join_map_ = std::make_unique<bpftrace::Map>(map_ident, type, key, 1);
     }
     bpftrace_.perf_event_map_ = std::make_unique<bpftrace::Map>(BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+  }
+
+  if (needs_printf_map_)
+  {
+    std::string map_ident = "printf";
+
+    SizedType type = SizedType(Type::printf, sizeof(size_t) + max_printf_args_size_);
+    MapKey key;
+    if (debug)
+      bpftrace_.printf_map_ = std::make_unique<bpftrace::FakeMap>(map_ident, type, key);
+    else
+      bpftrace_.printf_map_ = std::make_unique<bpftrace::Map>(map_ident, type, key, 1);
+    bpftrace_.print_map_zero_ = calloc(1, max_printf_args_size_ + sizeof(size_t));
   }
 
   return 0;

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -73,8 +73,10 @@ private:
   std::map<std::string, ExpressionList> map_args_;
   std::unordered_set<StackType> needs_stackid_maps_;
   bool needs_join_map_ = false;
+  bool needs_printf_map_ = false;
   bool has_begin_probe_ = false;
   bool has_end_probe_ = false;
+  size_t max_printf_args_size_ = 0;
 };
 
 } // namespace ast

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -110,6 +110,8 @@ public:
   std::vector<std::string> cat_args_;
   std::unordered_map<StackType, std::unique_ptr<IMap>> stackid_maps_;
   std::unique_ptr<IMap> join_map_;
+  std::unique_ptr<IMap> printf_map_;
+  void *print_map_zero_;
   std::unique_ptr<IMap> perf_event_map_;
   std::vector<std::string> probe_ids_;
   unsigned int join_argnum_;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -43,7 +43,7 @@ Map::Map(const std::string &name, const SizedType &type, const MapKey &key, int 
   {
       map_type = BPF_MAP_TYPE_PERCPU_HASH;
   }
-  else if (type.type == Type::join)
+  else if (type.type == Type::join || type.type == Type::printf)
   {
     map_type = BPF_MAP_TYPE_PERCPU_ARRAY;
     max_entries = 1;

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -35,7 +35,7 @@ std::string verify_format_string(const std::string &fmt, std::vector<Field> args
     Type arg_type = args.at(i).type.type;
     if (arg_type == Type::ksym || arg_type == Type::usym || arg_type == Type::probe ||
         arg_type == Type::username || arg_type == Type::kstack || arg_type == Type::ustack ||
-        arg_type == Type::inet)
+        arg_type == Type::inet || arg_type == Type::join)
       arg_type = Type::string; // Symbols should be printed as strings
     if (arg_type == Type::cast && args.at(i).type.is_pointer)
       arg_type = Type::integer; // Casts (pointers) can be printed as integers

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -27,7 +27,7 @@ bool SizedType::operator==(const SizedType &t) const
 bool SizedType::IsArray() const
 {
   return type == Type::array || type == Type::string ||
-         type == Type::usym  || type == Type::inet ||
+         type == Type::usym  || type == Type::inet || type == Type::join ||
          (type == Type::cast && !is_pointer);
 }
 
@@ -59,6 +59,7 @@ std::string typestr(Type t)
     case Type::cast:     return "cast";     break;
     case Type::probe:    return "probe";    break;
     case Type::array:    return "array";    break;
+    case Type::join:     return "join";    break;
     default:
       std::cerr << "call or probe type not found" << std::endl;
       abort();

--- a/src/types.h
+++ b/src/types.h
@@ -32,6 +32,7 @@ enum class Type
   usym,
   cast,
   join,
+  printf,
   probe,
   username,
   inet,

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -96,13 +96,13 @@ NAME kstack
 RUN bpftrace -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n%s\n", kstack(), kstack(1)); exit(); }'
 EXPECT SUCCESS kstack
 TIMEOUT 5
-AFTER cat /dev/null
+AFTER sleep 0.1
 
 NAME ustack
 RUN bpftrace -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n%s\n", ustack(), ustack(1)); exit(); }'
 EXPECT SUCCESS ustack
 TIMEOUT 5
-AFTER cat /dev/null
+AFTER sleep 0.1
 
 NAME cat
 RUN bpftrace -v -e 'i:ms:1 { cat("/proc/uptime"); exit();}'

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -39,22 +39,22 @@ EXPECT comm: bpftrace
 TIMEOUT 5
 
 NAME struct keyword optional when casting
-RUN bpftrace -v -e 'struct Bar { int x; } struct Foo { struct Bar *bar; } i:ms:1 { $foo = (struct Foo *)0; @x = $foo->bar->x; exit()}'
+RUN bpftrace -e 'struct Bar { int x; } struct Foo { struct Bar *bar; } i:ms:1 { $foo = (struct Foo *)0; @x = $foo->bar->x; exit()}'
 EXPECT @x: 0
 TIMEOUT 5
 
 NAME struct positional string compare - equal returns true
-RUN bpftrace -v -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} exit();}' "hello" "hello"
+RUN bpftrace -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} exit();}' "hello" "hello"
 EXPECT I got hello
 TIMEOUT 5
 
 NAME struct positional string compare - equal returns false
-RUN bpftrace -v -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hi" "hello"
+RUN bpftrace -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hi" "hello"
 EXPECT not equal
 TIMEOUT 5
 
 NAME struct positional string compare - not equal
-RUN bpftrace -v -e 'BEGIN { if (str($1) != str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hello" "hello"
+RUN bpftrace -e 'BEGIN { if (str($1) != str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hello" "hello"
 EXPECT not equal
 TIMEOUT 5
 


### PR DESCRIPTION
Built on top of #750.

This is still a work-in-progress. Tests were not updated and not all cases are working, but I decided to open the PR already because there are some issues we need to consider before moving forward.

Below are some considerations for each scenario I tested. tl;dr I'm not sure it's a good idea to change how join works, due to it's nature.

## Pass `join` to `printf`


This is the most trivial use case for the new behavior, and it's working:

```
# bpftrace -e 'tracepoint:syscalls:sys_enter_execve { printf("%s\n", join(args->argv)) }'
Attaching 1 probe...
ls --color=tty
ps1_exec_async
tmux-set-left-statusbar
git config --get oh-my-zsh.hide-status
...
```

## Assign `join` to map

```
# bpftrace -ve 'tracepoint:syscalls:sys_enter_execve { @ = join(args->argv) }'
Attaching 1 probe...

Error log: 
0: (bf) r3 = r1
1: (07) r3 += 24
2: (bf) r1 = r10
3: (07) r1 += -8
4: (b7) r2 = 8
5: (85) call bpf_probe_read#4
6: (79) r7 = *(u64 *)(r10 -8)
7: (18) r1 = 0xffff890e70ae5800
9: (b7) r8 = 0
10: (63) *(u32 *)(r10 -12) = r8
11: (bf) r2 = r10
12: (07) r2 += -12
13: (85) call bpf_map_lookup_elem#1
14: (bf) r6 = r0
15: (55) if r6 != 0x0 goto pc+2
 R0=inv0 R6=inv0 R7=inv(id=0) R8=inv0 R10=fp0
16: (b7) r0 = 0
17: (95) exit

from 15 to 18: R0=map_value(id=0,off=0,ks=4,vs=16392,imm=0) R6=map_value(id=0,off=0,ks=4,vs=16392,imm=0) R7=inv(id=0) R8=inv0 R10=fp0
18: (7b) *(u64 *)(r6 +0) = r8
 R0=map_value(id=0,off=0,ks=4,vs=16392,imm=0) R6=map_value(id=0,off=0,ks=4,vs=16392,imm=0) R7=inv(id=0) R8=inv0 R10=fp0
19: (bf) r1 = r10
20: (07) r1 += -8
21: (b7) r2 = 8
22: (bf) r3 = r7
23: (85) call bpf_probe_read#4
24: (65) if r0 s> 0xffffffff goto pc+11
 R0=inv(id=0,umin_value=9223372036854775808,var_off=(0x8000000000000000; 0x7fffffffffffffff)) R6=map_value(id=0,off=0,ks=4,vs=16392,imm=0) R7=inv(id=0) R8=inv0 R10=fp0
25: (b7) r1 = 0
26: (7b) *(u64 *)(r10 -8) = r1
27: (18) r1 = 0xffff890e70ae4d00
29: (bf) r2 = r10
30: (07) r2 += -8
31: (bf) r3 = r6
32: (b7) r4 = 0
33: (85) call bpf_map_update_elem#2
R3 type=map_value expected=fp

Error loading program: tracepoint:syscalls:sys_enter_execve
```

This doesn't work because `BPF_map_update_elem` doesn't accept a map address as it's third (`void *value`) argument, but storing the `join` in the stack is not feasible since it will blow the stack immediately (join size is  `8 + 16 * 1024`). We `could` keep each join call in a separate map and store this joinmap key on our map when assigning (similar to how getstackid works), but I'm still thinking if this is a good idea.

## Use `join` as map key

```
# bpftrace -ve 'tracepoint:syscalls:sys_enter_execve { @[join(args->argv)] = 0; }'
Error creating map: '@'
error: <unknown>:0:0: in function tracepoint:syscalls:sys_enter_execve i64 (i8*): Looks like the BPF stack limit of 512 bytes is exceeded. Please move large on stack variables into BPF per-cpu array map.

```

Besides having the same problem as described above (map_lookup_elem doesn't accept a map as it's key), there are memset and memcpy instructions in the code path of getMapKey, which means we'll either blow the stack, or get a `invalid call to builtin method` if LLVM doesn't unroll these calls.

## Assign `join` to variable, use on printf

```
# bpftrace -ve 'tracepoint:syscalls:sys_enter_execve { $a = join(args->argv); printf("%s\n", $a)}'
error: <unknown>:0:0: in function tracepoint:syscalls:sys_enter_execve i64 (i8*): A call to built-in function 'memset' is not supported.
```

Since variables are stored on the stack, and the size of join is huge, it will blow the stack, or we'll get the error above if LLVM doesn't unroll memset/memcpy.

-----

`join` is an memory expensive operation, which causes most of the problems described above. We could make some improvements (do the join in BPF scope, save it as string, limit it's size like we do with str, etc.), but the way join works today is probably better than what we could achieve by making join usable as a map key/printf arg/map value. Not sure what others think, but maybe we should keep join as it is.