### PR TITLE
Add vargs support for cat() builtin

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -2044,6 +2044,21 @@ Attaching 1 probe...
 ^C
 ```
 
+The `cat()` builtin also supports a format string as argument:
+
+```
+./bpftrace -e 'tracepoint:syscalls:sys_enter_sendmsg { printf("%s => ", comm); cat("/proc/%d/cmdline", pid); printf("\n") }'
+Attaching 1 probe...
+Gecko_IOThread => /usr/lib64/firefox/firefox
+Gecko_IOThread => /usr/lib64/firefox/firefox
+Gecko_IOThread => /usr/lib64/firefox/firefox
+Gecko_IOThread => /usr/lib64/firefox/firefox
+Gecko_IOThread => /usr/lib64/firefox/firefox
+Gecko_IOThread => /usr/lib64/firefox/firefox
+Gecko_IOThread => /usr/lib64/firefox/firefox
+^C
+```
+
 # Map Functions
 
 Maps are special BPF data types that can be used to store counts, statistics, and histograms. They are also used for some variable types as discussed in the previous section, whenever `@` is used: [globals](#21-global), [per thread variables](#22-per-thread), and [associative arrays](#3--associative-arrays).

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -17,6 +17,8 @@ namespace ast {
 
 using namespace llvm;
 
+using CallArgs = std::vector<std::tuple<std::string, std::vector<Field>>>;
+
 class CodegenLLVM : public Visitor {
 public:
   explicit CodegenLLVM(Node *root, BPFtrace &bpftrace) :
@@ -60,6 +62,8 @@ public:
 
   void createLog2Function();
   void createLinearFunction();
+  void createFormatStringCall(Call &call, int &id, CallArgs &call_args,
+                              const std::string &call_name, AsyncAction async_action);
   std::unique_ptr<BpfOrc> compile(DebugLevel debug=DebugLevel::kNone, std::ostream &out=std::cout);
 
 private:

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -435,7 +435,7 @@ void SemanticAnalyser::visit(Call &call)
     }
     call.type = SizedType(Type::integer, 8);
   }
-  else if (call.func == "printf" || call.func == "system") {
+  else if (call.func == "printf" || call.func == "system" || call.func == "cat") {
     check_assignment(call, false, false);
     if (check_varargs(call, 1, 7)) {
       check_arg(call, Type::string, 0, true);
@@ -454,8 +454,10 @@ void SemanticAnalyser::visit(Call &call)
 
         if (call.func == "printf")
           bpftrace_.printf_args_.emplace_back(fmt.str, args);
-        else
+        else if (call.func == "system")
           bpftrace_.system_args_.emplace_back(fmt.str, args);
+        else
+          bpftrace_.cat_args_.emplace_back(fmt.str, args);
       }
     }
 
@@ -530,17 +532,6 @@ void SemanticAnalyser::visit(Call &call)
         } else {
           std::string fmt_default = "%H:%M:%S\n";
           bpftrace_.time_args_.push_back(fmt_default.c_str());
-        }
-      }
-    }
-  }
-  else if (call.func == "cat") {
-    check_assignment(call, false, false);
-    if (check_nargs(call, 1)) {
-      if (check_arg(call, Type::string, 0, true)) {
-        if (is_final_pass()) {
-          auto &arg = *call.vargs->at(0);
-          bpftrace_.cat_args_.push_back(static_cast<String&>(arg).str);
         }
       }
     }

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -118,7 +118,7 @@ public:
   std::vector<std::tuple<std::string, std::vector<Field>>> system_args_;
   std::vector<std::string> join_args_;
   std::vector<std::string> time_args_;
-  std::vector<std::string> cat_args_;
+  std::vector<std::tuple<std::string, std::vector<Field>>> cat_args_;
   std::unordered_map<StackType, std::unique_ptr<IMap>> stackid_maps_;
   std::unique_ptr<IMap> join_map_;
   std::unique_ptr<IMap> perf_event_map_;

--- a/src/types.h
+++ b/src/types.h
@@ -151,17 +151,19 @@ public:
   std::string mode;             // for watchpoint probes, watch mode (rwx)
 };
 
+const int RESERVED_IDS_PER_ASYNCACTION = 10000;
+
 enum class AsyncAction
 {
-  // printf reserves 0-9999 for printf_ids
+  printf  = 0,     // printf reserves 0-9999 for printf_ids
   syscall = 10000, // system reserves 10000-19999 for printf_ids
-  exit = 20000,
+  cat     = 20000, // cat reserves 20000-29999 for printf_ids
+  exit    = 30000,
   print,
   clear,
   zero,
   time,
   join,
-  cat
 };
 
 uint64_t asyncactionint(AsyncAction a);

--- a/tests/codegen/call_cat.cpp
+++ b/tests/codegen/call_cat.cpp
@@ -8,7 +8,9 @@ TEST(codegen, call_cat)
 {
   test("kprobe:f { cat(\"/proc/loadavg\"); }",
 
-R"EXPECTED(; Function Attrs: nounwind
+R"EXPECTED(%cat_t = type { i64 }
+
+; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -16,15 +18,14 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
-  %perfdata = alloca [16 x i8], align 8
-  %1 = getelementptr inbounds [16 x i8], [16 x i8]* %perfdata, i64 0, i64 0
+  %cat_args = alloca %cat_t, align 8
+  %1 = bitcast %cat_t* %cat_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 20006, [16 x i8]* %perfdata, align 8
-  %2 = getelementptr inbounds [16 x i8], [16 x i8]* %perfdata, i64 0, i64 8
-  store i64 0, i8* %2, align 8
+  %2 = getelementptr inbounds %cat_t, %cat_t* %cat_args, i64 0, i32 0
+  store i64 20000, i64* %2, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, [16 x i8]*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [16 x i8]* nonnull %perfdata, i64 16)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %cat_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %cat_t* nonnull %cat_args, i64 8)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }

--- a/tests/codegen/call_clear.cpp
+++ b/tests/codegen/call_clear.cpp
@@ -39,7 +39,7 @@ entry:
   %perfdata = alloca [11 x i8], align 8
   %1 = getelementptr inbounds [11 x i8], [11 x i8]* %perfdata, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 20002, [11 x i8]* %perfdata, align 8
+  store i64 30002, [11 x i8]* %perfdata, align 8
   %str.sroa.0.0..sroa_idx = getelementptr inbounds [11 x i8], [11 x i8]* %perfdata, i64 0, i64 8
   store i8 64, i8* %str.sroa.0.0..sroa_idx, align 8
   %str.sroa.4.0..sroa_idx = getelementptr inbounds [11 x i8], [11 x i8]* %perfdata, i64 0, i64 9

--- a/tests/codegen/call_exit.cpp
+++ b/tests/codegen/call_exit.cpp
@@ -19,7 +19,7 @@ entry:
   %perfdata = alloca [8 x i8], align 8
   %1 = getelementptr inbounds [8 x i8], [8 x i8]* %perfdata, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 20000, [8 x i8]* %perfdata, align 8
+  store i64 30000, [8 x i8]* %perfdata, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, [8 x i8]*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [8 x i8]* nonnull %perfdata, i64 8)

--- a/tests/codegen/call_print.cpp
+++ b/tests/codegen/call_print.cpp
@@ -40,7 +40,7 @@ entry:
   %perfdata = alloca [27 x i8], align 8
   %1 = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 20001, [27 x i8]* %perfdata, align 8
+  store i64 30001, [27 x i8]* %perfdata, align 8
   %2 = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 8
   %str.sroa.0.0..sroa_idx = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 24
   call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %2, i8 0, i64 16, i1 false)
@@ -94,7 +94,7 @@ entry:
   %perfdata = alloca [27 x i8], align 8
   %1 = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 20001, [27 x i8]* %perfdata, align 8
+  store i64 30001, [27 x i8]* %perfdata, align 8
   %2 = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 8
   %str.sroa.0.0..sroa_idx = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 24
   call void @llvm.memset.p0i8.i64(i8* nonnull %2, i8 0, i64 16, i32 8, i1 false)
@@ -148,7 +148,7 @@ entry:
   %perfdata = alloca [27 x i8], align 8
   %1 = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 20001, [27 x i8]* %perfdata, align 8
+  store i64 30001, [27 x i8]* %perfdata, align 8
   %2 = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 8
   %str.sroa.0.0..sroa_idx = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 24
   call void @llvm.memset.p0i8.i64(i8* %2, i8 0, i64 16, i32 8, i1 false)

--- a/tests/codegen/call_system.cpp
+++ b/tests/codegen/call_system.cpp
@@ -21,9 +21,10 @@ entry:
   %system_args = alloca %system_t, align 8
   %1 = bitcast %system_t* %system_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 10000, %system_t* %system_args, align 8
-  %2 = getelementptr inbounds %system_t, %system_t* %system_args, i64 0, i32 1
-  store i64 100, i64* %2, align 8
+  %2 = getelementptr inbounds %system_t, %system_t* %system_args, i64 0, i32 0
+  store i64 10000, i64* %2, align 8
+  %3 = getelementptr inbounds %system_t, %system_t* %system_args, i64 0, i32 1
+  store i64 100, i64* %3, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %system_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %system_t* nonnull %system_args, i64 16)

--- a/tests/codegen/call_time.cpp
+++ b/tests/codegen/call_time.cpp
@@ -19,7 +19,7 @@ entry:
   %perfdata = alloca [16 x i8], align 8
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %perfdata, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 20004, [16 x i8]* %perfdata, align 8
+  store i64 30004, [16 x i8]* %perfdata, align 8
   %2 = getelementptr inbounds [16 x i8], [16 x i8]* %perfdata, i64 0, i64 8
   store i64 0, i8* %2, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)

--- a/tests/codegen/call_zero.cpp
+++ b/tests/codegen/call_zero.cpp
@@ -39,7 +39,7 @@ entry:
   %perfdata = alloca [11 x i8], align 8
   %1 = getelementptr inbounds [11 x i8], [11 x i8]* %perfdata, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 20003, [11 x i8]* %perfdata, align 8
+  store i64 30003, [11 x i8]* %perfdata, align 8
   %str.sroa.0.0..sroa_idx = getelementptr inbounds [11 x i8], [11 x i8]* %perfdata, i64 0, i64 8
   store i8 64, i8* %str.sroa.0.0..sroa_idx, align 8
   %str.sroa.4.0..sroa_idx = getelementptr inbounds [11 x i8], [11 x i8]* %perfdata, i64 0, i64 9

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -481,6 +481,7 @@ TEST(semantic_analyser, call_probe)
 TEST(semantic_analyser, call_cat)
 {
   test("kprobe:f { cat(\"/proc/loadavg\"); }", 0);
+  test("kprobe:f { cat(\"/proc/%d/cmdline\", 1); }", 0);
   test("kprobe:f { cat(); }", 1);
   test("kprobe:f { cat(123); }", 1);
   test("kprobe:f { @x = cat(\"/proc/loadavg\"); }", 1);


### PR DESCRIPTION
This commit adds support to use variables as cat() parameters using a
format string in the same way system() already does:

./bpftrace -e 't:syscalls:sys_enter_nanosleep { cat("/proc/%d/cmdline",
pid); }'