### PR TITLE
Add basic editorconfig for defining style

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,14 @@
+[*]
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_size = 4
+
+[tools/*.bt]
+indent_style = tab
+indent_size = unset


### PR DESCRIPTION
Editorconfig is a program which configures editors on a per-project basis through editor hooks, defined through project override files. Defining a file makes it much easier to contribute if your preferred settings aren't matching the current files.

Existing code seems to use 2 spaces for most files, but 4 spaces for python. 

The existing `bt` files seem to be mixed, with some using tabs and some using 2 spaces. I decided to set the `bt` files in the `tools` directory to indent with tabs to minimize changes.