### PR TITLE
Implement strncmp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ matrix:
     # String comparisons and args multiple tracepoints tests are the exception
     # - they are just broken in debug builds.
     - name: "Static LLVM 5 Debug"
-      env: LLVM_VERSION=5.0 BASE=alpine TYPE=Debug STATIC_LINKING=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*:codegen.string_equal_comparison:codegen.string_not_equal_comparison:codegen.args_multiple_tracepoints*:codegen.logical_and_or_different_type"
+      env: LLVM_VERSION=5.0 BASE=alpine TYPE=Debug STATIC_LINKING=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*:codegen.string_equal_comparison:codegen.string_not_equal_comparison:codegen.strncmp_test:codegen.args_multiple_tracepoints*:codegen.logical_and_or_different_type"
     - name: "Static LLVM 5 Release"
       env: LLVM_VERSION=5.0 BASE=alpine TYPE=Release STATIC_LINKING=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*:codegen.args_multiple_tracepoints*:codegen.logical_and_or_different_type"
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -2139,12 +2139,12 @@ The signal can also be specified using a name, similar to the `kill(1)` command:
 
 Syntax: `strncmp(char *s1, char *s2, int length)`
 
-Return true if the first `length` characters in `s1` and `s2` are equal, and false otherwise.
+Return zero if the first `length` characters in `s1` and `s2` are equal, and non-zero otherwise.
 
 Examples:
 
 ```
-bpftrace -e 't:syscalls:sys_enter_* /strncmp("mpv", comm, 3)/ { @[comm, probe] = count() }'
+bpftrace -e 't:syscalls:sys_enter_* /strncmp("mpv", comm, 3) == 0/ { @[comm, probe] = count() }'
 Attaching 320 probes...
 [...]
 @[mpv/vo, tracepoint:syscalls:sys_enter_rt_sigaction]: 238

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -73,6 +73,7 @@ This is a work in progress. If something is missing, check the bpftrace source t
     - [16. `ustack()`: Stack Traces, User](#16-ustack-stack-traces-user)
     - [17. `cat()`: Print file content](#17-cat-print-file-content)
     - [18. `signal()`: Send a signal to the current task](#18-signal-send-a-signal-to-current-task)
+    - [19. `strncmp()`: Compare first n characters of two strings](#19-strncmp-compare-first-n-characters-of-two-strings)
 - [Map Functions](#map-functions)
     - [1. Builtins](#1-builtins-2)
     - [2. `count()`: Count](#2-count-count)
@@ -2132,6 +2133,35 @@ The signal can also be specified using a name, similar to the `kill(1)` command:
 ```
 # bpftrace -e 'k:f { signal("KILL"); }'
 # bpftrace -e 'k:f { signal("SIGINT"); }'
+```
+
+## 19. `strncmp()`: Compare first n characters of two strings
+
+Syntax: `strncmp(char *s1, char *s2, int length)`
+
+Return true if the first `length` characters in `s1` and `s2` are equal, and false otherwise.
+
+Examples:
+
+```
+bpftrace -e 't:syscalls:sys_enter_* /strncmp("mpv", comm, 3)/ { @[comm, probe] = count() }'
+Attaching 320 probes...
+[...]
+@[mpv/vo, tracepoint:syscalls:sys_enter_rt_sigaction]: 238
+@[mpv:gdrv0, tracepoint:syscalls:sys_enter_futex]: 680
+@[mpv/ao, tracepoint:syscalls:sys_enter_write]: 1022
+@[mpv, tracepoint:syscalls:sys_enter_ioctl]: 2677
+@[mpv:cs0, tracepoint:syscalls:sys_enter_ioctl]: 2889
+@[mpv/vo, tracepoint:syscalls:sys_enter_read]: 2993
+@[mpv/demux, tracepoint:syscalls:sys_enter_futex]: 4745
+@[mpv, tracepoint:syscalls:sys_enter_write]: 6936
+@[mpv/vo, tracepoint:syscalls:sys_enter_futex]: 7662
+@[mpv:cs0, tracepoint:syscalls:sys_enter_futex]: 8127
+@[mpv/lua script , tracepoint:syscalls:sys_enter_futex]: 10150
+@[mpv/vo, tracepoint:syscalls:sys_enter_poll]: 10241
+@[mpv/vo, tracepoint:syscalls:sys_enter_recvmsg]: 15018
+@[mpv, tracepoint:syscalls:sys_enter_getpid]: 31178
+@[mpv, tracepoint:syscalls:sys_enter_futex]: 403868
 ```
 
 # Map Functions

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -378,7 +378,7 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_poin
 
 Value *IRBuilderBPF::CreateStrcmp(Value* val, std::string str, bool inverse) {
   auto cmpAmount = strlen(str.c_str()) + 1;
-  return CreateStrncmp(val, str, cmpAmount, inverse);
+  return CreateStrncmp(val, str, cmpAmount, !inverse);
 }
 
 Value *IRBuilderBPF::CreateStrncmp(Value* val, std::string str, uint64_t n, bool inverse) {
@@ -386,7 +386,7 @@ Value *IRBuilderBPF::CreateStrncmp(Value* val, std::string str, uint64_t n, bool
   BasicBlock *str_ne = BasicBlock::Create(module_.getContext(), "strcmp.false", parent);
   AllocaInst *store = CreateAllocaBPF(getInt8Ty(), "strcmp.result");
 
-  CreateStore(getInt1(inverse), store);
+  CreateStore(getInt1(!inverse), store);
 
   const char *c_str = str.c_str();
   for (size_t i = 0; i < n; i++)
@@ -405,7 +405,7 @@ Value *IRBuilderBPF::CreateStrncmp(Value* val, std::string str, uint64_t n, bool
     CreateCondBr(cmp, str_ne, char_eq);
     SetInsertPoint(char_eq);
   }
-  CreateStore(getInt1(!inverse), store);
+  CreateStore(getInt1(inverse), store);
   CreateBr(str_ne);
 
   SetInsertPoint(str_ne);
@@ -416,7 +416,7 @@ Value *IRBuilderBPF::CreateStrncmp(Value* val, std::string str, uint64_t n, bool
 }
 
 Value *IRBuilderBPF::CreateStrcmp(Value* val1, Value* val2, bool inverse) {
-  return CreateStrncmp(val1, val2, bpftrace_.strlen_, inverse);
+  return CreateStrncmp(val1, val2, bpftrace_.strlen_, !inverse);
 }
 
 Value *IRBuilderBPF::CreateStrncmp(Value* val1, Value* val2, uint64_t n, bool inverse) {
@@ -446,7 +446,7 @@ Value *IRBuilderBPF::CreateStrncmp(Value* val1, Value* val2, uint64_t n, bool in
   AllocaInst *store = CreateAllocaBPF(getInt8Ty(), "strcmp.result");
   BasicBlock *done = BasicBlock::Create(module_.getContext(), "strcmp.done", parent);
 
-  CreateStore(getInt1(inverse), store);
+  CreateStore(getInt1(!inverse), store);
 
   Value *null_byte = getInt8(0);
 
@@ -478,7 +478,7 @@ Value *IRBuilderBPF::CreateStrncmp(Value* val1, Value* val2, uint64_t n, bool in
 
   CreateBr(done);
   SetInsertPoint(done);
-  CreateStore(getInt1(!inverse), store);
+  CreateStore(getInt1(inverse), store);
 
   CreateBr(str_ne);
   SetInsertPoint(str_ne);

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -48,6 +48,8 @@ public:
   Value      *CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_point, int arg_name, Builtin &builtin, int pid);
   Value      *CreateStrcmp(Value* val, std::string str, bool inverse=false);
   Value      *CreateStrcmp(Value* val1, Value* val2, bool inverse=false);
+  Value      *CreateStrncmp(Value* val, std::string str, uint64_t n, bool inverse=false);
+  Value      *CreateStrncmp(Value* val1, Value* val2, uint64_t n, bool inverse=false);
   CallInst   *CreateGetNs();
   CallInst   *CreateGetPidTgid();
   CallInst   *CreateGetCurrentCgroupId();

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -645,6 +645,18 @@ void SemanticAnalyser::visit(Call &call)
     buf << "BPF_FUNC_send_signal not available for your kernel version";
 #endif
   }
+  else if (call.func == "strncmp") {
+    if (check_nargs(call, 3)) {
+      check_arg(call, Type::string, 0);
+      check_arg(call, Type::string, 1);
+      if (check_arg(call, Type::integer, 2, true)){
+        Integer &size = static_cast<Integer&>(*call.vargs->at(2));
+        if (size.n < 0)
+          err_ << "Builtin strncmp requires a non-negative size" << std::endl;
+      }
+    }
+    call.type = SizedType(Type::integer, 8);
+  }
   else {
     buf << "Unknown function: '" << call.func << "'";
     call.type = SizedType(Type::none, 0);

--- a/tests/codegen/strncmp.cpp
+++ b/tests/codegen/strncmp.cpp
@@ -31,12 +31,12 @@ entry:
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char, i64 1, [16 x i8]* nonnull %comm)
   %2 = load i8, i8* %strcmp.char, align 1
   %strcmp.cmp = icmp eq i8 %2, 115
-  br i1 %strcmp.cmp, label %strcmp.loop, label %pred_false
+  br i1 %strcmp.cmp, label %strcmp.loop, label %pred_true
 
-pred_false:                                       ; preds = %strcmp.loop, %entry
+pred_false:                                       ; preds = %strcmp.loop
   ret i64 0
 
-pred_true:                                        ; preds = %strcmp.loop
+pred_true:                                        ; preds = %strcmp.loop, %entry
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   %4 = getelementptr inbounds [16 x i8], [16 x i8]* %comm5, i64 0, i64 0
@@ -55,7 +55,7 @@ strcmp.loop:                                      ; preds = %entry
   %probe_read3 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char2, i64 1, [16 x i8]* %5)
   %6 = load i8, i8* %strcmp.char2, align 1
   %strcmp.cmp4 = icmp eq i8 %6, 115
-  br i1 %strcmp.cmp4, label %pred_true, label %pred_false
+  br i1 %strcmp.cmp4, label %pred_false, label %pred_true
 
 lookup_success:                                   ; preds = %pred_true
   %7 = load i64, i8* %lookup_elem, align 8
@@ -109,12 +109,12 @@ entry:
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char, i64 1, [16 x i8]* nonnull %comm)
   %2 = load i8, i8* %strcmp.char, align 1
   %strcmp.cmp = icmp eq i8 %2, 115
-  br i1 %strcmp.cmp, label %strcmp.loop, label %pred_false
+  br i1 %strcmp.cmp, label %strcmp.loop, label %pred_true
 
-pred_false:                                       ; preds = %strcmp.loop, %entry
+pred_false:                                       ; preds = %strcmp.loop
   ret i64 0
 
-pred_true:                                        ; preds = %strcmp.loop
+pred_true:                                        ; preds = %strcmp.loop, %entry
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   %4 = getelementptr inbounds [16 x i8], [16 x i8]* %comm5, i64 0, i64 0
@@ -133,7 +133,7 @@ strcmp.loop:                                      ; preds = %entry
   %probe_read3 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char2, i64 1, [16 x i8]* %5)
   %6 = load i8, i8* %strcmp.char2, align 1
   %strcmp.cmp4 = icmp eq i8 %6, 115
-  br i1 %strcmp.cmp4, label %pred_true, label %pred_false
+  br i1 %strcmp.cmp4, label %pred_false, label %pred_true
 
 lookup_success:                                   ; preds = %pred_true
   %7 = load i64, i8* %lookup_elem, align 8

--- a/tests/codegen/strncmp.cpp
+++ b/tests/codegen/strncmp.cpp
@@ -1,0 +1,172 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, strncmp_test)
+{
+  test("kretprobe:vfs_read /strncmp(comm, \"sshd\", 2)/ { @[comm] = count(); }",
+
+#if LLVM_VERSION_MAJOR > 6
+R"EXPECTED(; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kretprobe:vfs_read"(i8* nocapture readnone) local_unnamed_addr section "s_kretprobe:vfs_read_1" {
+entry:
+  %"@_val" = alloca i64, align 8
+  %comm5 = alloca [16 x i8], align 1
+  %"@_key" = alloca [16 x i8], align 1
+  %strcmp.char2 = alloca i8, align 1
+  %strcmp.char = alloca i8, align 1
+  %comm = alloca [16 x i8], align 1
+  %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i8 0, i64 16, i1 false)
+  %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char, i64 1, [16 x i8]* nonnull %comm)
+  %2 = load i8, i8* %strcmp.char, align 1
+  %strcmp.cmp = icmp eq i8 %2, 115
+  br i1 %strcmp.cmp, label %strcmp.loop, label %pred_false
+
+pred_false:                                       ; preds = %strcmp.loop, %entry
+  ret i64 0
+
+pred_true:                                        ; preds = %strcmp.loop
+  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %"@_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %comm5, i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %4, i8 0, i64 16, i1 false)
+  %get_comm6 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm5, i64 16)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %3, i8* nonnull align 1 %4, i64 16, i1 false)
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
+  %map_lookup_cond = icmp eq i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
+
+strcmp.loop:                                      ; preds = %entry
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char2)
+  %5 = add [16 x i8]* %comm, i64 1
+  %probe_read3 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char2, i64 1, [16 x i8]* %5)
+  %6 = load i8, i8* %strcmp.char2, align 1
+  %strcmp.cmp4 = icmp eq i8 %6, 115
+  br i1 %strcmp.cmp4, label %pred_true, label %pred_false
+
+lookup_success:                                   ; preds = %pred_true
+  %7 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %7, 1
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %pred_true, %lookup_success
+  %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %pred_true ]
+  %8 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
+  store i64 %lookup_elem_val.0, i64* %"@_val", align 8
+  %pseudo7 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo7, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+#else
+R"EXPECTED(; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kretprobe:vfs_read"(i8* nocapture readnone) local_unnamed_addr section "s_kretprobe:vfs_read_1" {
+entry:
+  %"@_val" = alloca i64, align 8
+  %comm5 = alloca [16 x i8], align 1
+  %"@_key" = alloca [16 x i8], align 1
+  %strcmp.char2 = alloca i8, align 1
+  %strcmp.char = alloca i8, align 1
+  %comm = alloca [16 x i8], align 1
+  %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 16, i32 1, i1 false)
+  %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char, i64 1, [16 x i8]* nonnull %comm)
+  %2 = load i8, i8* %strcmp.char, align 1
+  %strcmp.cmp = icmp eq i8 %2, 115
+  br i1 %strcmp.cmp, label %strcmp.loop, label %pred_false
+
+pred_false:                                       ; preds = %strcmp.loop, %entry
+  ret i64 0
+
+pred_true:                                        ; preds = %strcmp.loop
+  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %"@_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %comm5, i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  call void @llvm.memset.p0i8.i64(i8* nonnull %4, i8 0, i64 16, i32 1, i1 false)
+  %get_comm6 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm5, i64 16)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %3, i8* nonnull %4, i64 16, i32 1, i1 false)
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
+  %map_lookup_cond = icmp eq i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
+
+strcmp.loop:                                      ; preds = %entry
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char2)
+  %5 = add [16 x i8]* %comm, i64 1
+  %probe_read3 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char2, i64 1, [16 x i8]* %5)
+  %6 = load i8, i8* %strcmp.char2, align 1
+  %strcmp.cmp4 = icmp eq i8 %6, 115
+  br i1 %strcmp.cmp4, label %pred_true, label %pred_false
+
+lookup_success:                                   ; preds = %pred_true
+  %7 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %7, 1
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %pred_true, %lookup_success
+  %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %pred_true ]
+  %8 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
+  store i64 %lookup_elem_val.0, i64* %"@_val", align 8
+  %pseudo7 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo7, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i32, i1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+#endif
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -64,12 +64,12 @@ EXPECT @\[cat\]: 1
 TIMEOUT 5
 
 NAME struct partial string compare - pass
-RUN bpftrace -v -e 'BEGIN { if (strncmp(str($1), str($2), 4)) { printf("I got %s\n", str($1));} exit();}' "hhvm" "hhvm-proc"
+RUN bpftrace -v -e 'BEGIN { if (strncmp(str($1), str($2), 4) == 0) { printf("I got %s\n", str($1));} exit();}' "hhvm" "hhvm-proc"
 EXPECT I got hhvm
 TIMEOUT 5
 
 NAME struct partial string compare - pass reverse
-RUN bpftrace -v -e 'BEGIN { if (strncmp(str($1), str($2), 4)) { printf("I got %s\n", str($1));} exit();}' "hhvm-proc" "hhvm"
+RUN bpftrace -v -e 'BEGIN { if (strncmp(str($1), str($2), 4) == 0) { printf("I got %s\n", str($1));} exit();}' "hhvm-proc" "hhvm"
 EXPECT I got hhvm-proc
 TIMEOUT 5
 

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -58,6 +58,21 @@ RUN bpftrace -v -e 'BEGIN { if (str($1) != str($2)) { printf("I got %s\n", str($
 EXPECT not equal
 TIMEOUT 5
 
+NAME string compare map lookup
+RUN bpftrace -v -e 't:syscalls:sys_enter_openat /comm == "cat"/ { @[comm] = 1; }' -c "cat /dev/null"
+EXPECT @\[cat\]: 1
+TIMEOUT 5
+
+NAME struct partial string compare - pass
+RUN bpftrace -v -e 'BEGIN { if (strncmp(str($1), str($2), 4)) { printf("I got %s\n", str($1));} exit();}' "hhvm" "hhvm-proc"
+EXPECT I got hhvm
+TIMEOUT 5
+
+NAME struct partial string compare - pass reverse
+RUN bpftrace -v -e 'BEGIN { if (strncmp(str($1), str($2), 4)) { printf("I got %s\n", str($1));} exit();}' "hhvm-proc" "hhvm"
+EXPECT I got hhvm-proc
+TIMEOUT 5
+
 NAME optional_positional_int
 RUN bpftrace -e 'BEGIN { printf("-%d-\n", $1); exit() }'
 EXPECT -0-

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1270,6 +1270,18 @@ TEST(semantic_analyser, signal)
   test("k:f { signal(\"SIGABC\"); }", 1, false);
   test("k:f { signal(\"ABC\"); }", 1, false);
 }
+TEST(semantic_analyser, strncmp)
+{
+  // Test strncmp builtin
+  test("i:s:1 { $a = \"bar\"; strncmp(\"foo\", $a, 1) }", 0);
+  test("i:s:1 { strncmp(\"foo\", \"bar\", 1) }", 0);
+
+  test("i:s:1 { strncmp(1) }", 1);
+  test("i:s:1 { strncmp(1,1,1) }", 10);
+  test("i:s:1 { strncmp(\"a\",1,1) }", 10);
+  test("i:s:1 { strncmp(\"a\",\"a\",-1) }", 1);
+  test("i:s:1 { strncmp(\"a\",\"a\",\"foo\") }", 1);
+}
 } // namespace semantic_analyser
 } // namespace test
 } // namespace bpftrace


### PR DESCRIPTION
I'll be honest and say I mostly have no idea what I'm doing here, so I'd appreciate it if I could get some extra review and guidance for this. This is my first time working with any serious compiler stuff, and my first real exposure to LLVM. I know you're probably busy for the 0.9.1 release, so feel free to put this on the backburner until you have more time.

For some reason:

```
BEGIN { if (strncmp("hhvm", str($1), 4)) { printf("hello!"); } }
```
results in 
```
bpftrace: /usr/include/llvm/IR/Instructions.h:1117: void llvm::ICmpInst::AssertOK(): Assertion `getOperand(0)->getType() == getOperand(1)->getType() && "Both operands to ICmp instruction are not of the same type!"' failed.
```
but, `if(1)` or `if(strncmp("hhvm", str($1), -1) != 0)` work fine. I think I'm missing something in the semantic analyzer but I'm not sure. It might need some changes to the `if` logic, but I'm not sure what/where those would be.

Fixes #459

