### PR TITLE
Use pid to avoid mixing triggers of multiple instances

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -434,10 +434,12 @@ void AttachedProbe::attach_kprobe()
 
 void AttachedProbe::attach_uprobe()
 {
-  int pid = -1;
-
-  int perf_event_fd = bpf_attach_uprobe(progfd_, attachtype(probe_.type),
-      eventname().c_str(), probe_.path.c_str(), offset(), pid);
+  int perf_event_fd = bpf_attach_uprobe(progfd_,
+                                        attachtype(probe_.type),
+                                        eventname().c_str(),
+                                        probe_.path.c_str(),
+                                        offset(),
+                                        probe_.pid);
 
   if (perf_event_fd < 0)
     throw std::runtime_error("Error attaching probe: " + probe_.name);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -8,11 +8,11 @@
 #include <time.h>
 #include <arpa/inet.h>
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <sys/prctl.h>
-#include <sys/wait.h>
 #include <fcntl.h>
+#include <sys/prctl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
 #include <unistd.h>
 
 #ifdef HAVE_BCC_ELF_FOREACH_SYM
@@ -101,31 +101,17 @@ int BPFtrace::add_probe(ast::Probe &p)
 {
   for (auto attach_point : *p.attach_points)
   {
-    if (attach_point->provider == "BEGIN")
+    if (attach_point->provider == "BEGIN" || attach_point->provider == "END")
     {
       Probe probe;
       probe.path = "/proc/self/exe";
-      probe.attach_point = "BEGIN_trigger";
+      probe.attach_point = attach_point->provider + "_trigger";
       probe.type = probetype(attach_point->provider);
       probe.log_size = log_size_;
       probe.orig_name = p.name();
       probe.name = p.name();
       probe.loc = 0;
-      probe.index = attach_point->index(probe.name) > 0 ?
-          attach_point->index(probe.name) : p.index();
-      special_probes_.push_back(probe);
-      continue;
-    }
-    else if (attach_point->provider == "END")
-    {
-      Probe probe;
-      probe.path = "/proc/self/exe";
-      probe.attach_point = "END_trigger";
-      probe.type = probetype(attach_point->provider);
-      probe.log_size = log_size_;
-      probe.orig_name = p.name();
-      probe.name = p.name();
-      probe.loc = 0;
+      probe.pid = getpid();
       probe.index = attach_point->index(probe.name) > 0 ?
           attach_point->index(probe.name) : p.index();
       special_probes_.push_back(probe);

--- a/src/types.h
+++ b/src/types.h
@@ -3,8 +3,9 @@
 #include <ostream>
 #include <sstream>
 #include <string>
-#include <vector>
+#include <sys/types.h>
 #include <unistd.h>
+#include <vector>
 
 namespace bpftrace {
 
@@ -142,6 +143,7 @@ public:
   uint64_t log_size;
   int index = 0;
   int freq;
+  pid_t pid = -1;
 };
 
 enum class AsyncAction


### PR DESCRIPTION
When running multiple bpftrace instances the BEGIN and END probes
trigger each other. The following should only fire once but fires
for each `bpftrace` instance that gets started.

```
$ bpftrace -e 'BEGIN{printf("BEGIN: %d\n", pid)}'
Attaching 2 probes...
BEGIN: 29211
BEGIN: 29213
BEGIN: 29215
```

By attaching to the pid that can be avoided.

Fixes #777