### PR TITLE
Document multiple attach points for probes

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -666,7 +666,7 @@ Attaching 1 probe...
 - `software` - kernel software events
 - `hardware` - processor-level events
 
-Some probe types allow wildcards to match multiple probes, eg, `kprobe:vfs_*`.
+Some probe types allow wildcards to match multiple probes, eg, `kprobe:vfs_*`. You may also specify multiple attach points for an action block using a comma separated list.
 
 ## 1. `kprobe`/`kretprobe`: Dynamic Tracing, Kernel-Level
 


### PR DESCRIPTION
There isn't mention of comma separated lists of attach points. It's a
pretty handy feature so we should document it.