### PR TITLE
Add memory watchpoint probe prototype

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -43,6 +43,7 @@ This is a work in progress. If something is missing, check the bpftrace source t
     - [11. `software`: Pre-defined Software Events](#11-software-pre-defined-software-events)
     - [12. `hardware`: Pre-defined Hardware Events](#12-hardware-pre-defined-hardware-events)
     - [13. `BEGIN`/`END`: Built-in events](#13-beginend-built-in-events)
+    - [14. `watchpoint`: Memory watchpoints](#14-watchpoint-memory-watchpoints)
 - [Variables](#variables)
     - [1. Builtins](#1-builtins)
     - [2. `@`, `$`: Basic Variables](#2---basic-variables)
@@ -1109,6 +1110,24 @@ END
 ```
 
 These are special built-in events provided by the bpftrace runtime. `BEGIN` is triggered before all other probes are attached. `END` is triggered after all other probes are detached.
+
+## 14. `watchpoint`: Memory watchpoints
+
+**WARNING**: this feature is experimental and may be subject to interface changes.
+
+Syntax:
+
+```
+watchpoint::hex_address:length:mode
+```
+
+These are memory watchpoints provided by the kernel. Whenever a memory address is written to (`w`), read from (`r`), or executed (`x`), the kernel can generate an event. Note that a pid (`-p`) or a command (`-c`) must be provided to bpftrace. Also note you may not monitor for execution while monitoring read or write.
+
+Examples:
+
+```
+bpftrace -e 'watchpoint::0x10000000:8:rw { printf("hit!\n"); }' -c ~/binary
+```
 
 # Variables
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -254,6 +254,11 @@ public:
               const std::string &target,
               int freq)
     : provider(probetypeName(provider)), target(target), freq(freq), need_expansion(true) { }
+  AttachPoint(const std::string &provider,
+              const std::string &target,
+              uint64_t addr,
+              uint64_t len)
+    : provider(probetypeName(provider)), target(target), addr(addr), len(len) { }
 
   std::string provider;
   std::string target;
@@ -261,6 +266,8 @@ public:
   std::string func;
   usdt_probe_entry usdt; // resolved USDT entry, used to support arguments with wildcard matches
   int freq = 0;
+  uint64_t addr = 0;
+  uint64_t len = 0;
   bool need_expansion = false;
 
   void accept(Visitor &v) override;

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -257,8 +257,9 @@ public:
   AttachPoint(const std::string &provider,
               const std::string &target,
               uint64_t addr,
-              uint64_t len)
-    : provider(probetypeName(provider)), target(target), addr(addr), len(len) { }
+              uint64_t len,
+              const std::string &mode)
+    : provider(probetypeName(provider)), target(target), addr(addr), len(len), mode(mode) { }
 
   std::string provider;
   std::string target;
@@ -268,6 +269,7 @@ public:
   int freq = 0;
   uint64_t addr = 0;
   uint64_t len = 0;
+  std::string mode;
   bool need_expansion = false;
 
   void accept(Visitor &v) override;

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1055,6 +1055,12 @@ void SemanticAnalyser::visit(AttachPoint &ap)
     else if (ap.freq < 0)
       err_ << "software count should be a positive integer" << std::endl;
   }
+  else if (ap.provider == "watchpoint") {
+    if (!ap.addr)
+      err_ << "watchpoint must be attached to a non-zero address" << std::endl;
+    if (ap.len != 1 && ap.len != 2 && ap.len != 4 && ap.len != 8)
+      err_ << "watchpoint length must be one of (1,2,4,8)" << std::endl;
+  }
   else if (ap.provider == "hardware") {
     if (ap.target == "")
       err_ << "hardware probe must have a hardware event name" << std::endl;

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -7,6 +7,7 @@
 #include "utils.h"
 #include "arch/arch.h"
 #include "list.h"
+#include <algorithm>
 #include <cstring>
 #include <sys/stat.h>
 #include <regex>
@@ -1060,6 +1061,17 @@ void SemanticAnalyser::visit(AttachPoint &ap)
       err_ << "watchpoint must be attached to a non-zero address" << std::endl;
     if (ap.len != 1 && ap.len != 2 && ap.len != 4 && ap.len != 8)
       err_ << "watchpoint length must be one of (1,2,4,8)" << std::endl;
+    std::sort(ap.mode.begin(), ap.mode.end());
+    for (const char c : ap.mode) {
+      if (c != 'r' && c != 'w' && c != 'x')
+        err_ << "watchpoint mode must be combination of (r,w,x)" << std::endl;
+    }
+    for (size_t i = 0; i < ap.mode.size() - 1; ++i) {
+      if (ap.mode[i] == ap.mode[i+1])
+        err_ << "watchpoint modes may not be duplicated" << std::endl;
+    }
+    if (ap.mode == "rx" || ap.mode == "wx" || ap.mode == "rwx")
+      err_ << "watchpoint modes (rx, wx, rwx) not allowed" << std::endl;
   }
   else if (ap.provider == "hardware") {
     if (ap.target == "")

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -32,7 +32,7 @@ private:
   void attach_interval();
   void attach_software();
   void attach_hardware();
-  void attach_watchpoint(int pid);
+  void attach_watchpoint(int pid, const std::string& mode);
 
   Probe &probe_;
   std::tuple<uint8_t *, uintptr_t> func_;

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -32,6 +32,7 @@ private:
   void attach_interval();
   void attach_software();
   void attach_hardware();
+  void attach_watchpoint(int pid);
 
   Probe &probe_;
   std::tuple<uint8_t *, uintptr_t> func_;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -170,6 +170,8 @@ int BPFtrace::add_probe(ast::Probe &p)
       probe.loc = 0;
       probe.index = attach_point->index(full_func_id) > 0 ?
           attach_point->index(full_func_id) : p.index();
+      probe.addr = attach_point->addr;
+      probe.len = attach_point->len;
       probes_.push_back(probe);
     }
   }
@@ -618,7 +620,7 @@ std::unique_ptr<AttachedProbe> BPFtrace::attach_probe(Probe &probe, const BpfOrc
   }
   try
   {
-    if (probe.type == ProbeType::usdt)
+    if (probe.type == ProbeType::usdt || probe.type == ProbeType::watchpoint)
       return std::make_unique<AttachedProbe>(probe, func->second, pid_);
     else
       return std::make_unique<AttachedProbe>(probe, func->second);
@@ -644,6 +646,7 @@ bool attach_reverse(const Probe &p)
     case ProbeType::tracepoint:
     case ProbeType::profile:
     case ProbeType::interval:
+    case ProbeType::watchpoint:
     case ProbeType::hardware:
       return false;
     default:

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -172,6 +172,7 @@ int BPFtrace::add_probe(ast::Probe &p)
           attach_point->index(full_func_id) : p.index();
       probe.addr = attach_point->addr;
       probe.len = attach_point->len;
+      probe.mode = attach_point->mode;
       probes_.push_back(probe);
     }
   }

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -21,6 +21,7 @@ ident  [_a-zA-Z][_a-zA-Z0-9]*
 map    @{ident}|@
 var    ${ident}
 int    [0-9]+|0[xX][0-9a-fA-F]+
+cint   :{int}:
 hspace [ \t]
 vspace [\n\r]
 space  {hspace}|{vspace}
@@ -54,10 +55,11 @@ pid|tid|cgroup|uid|gid|nsecs|cpu|comm|kstack|stack|ustack|arg[0-9]|retval|func|p
                           return Parser::make_BUILTIN(yytext, loc); }
 bpftrace|perf {
                           return Parser::make_STACK_MODE(yytext, loc); }
+{int}                   { return Parser::make_INT(strtoll(yytext, NULL, 0), loc); }
+{cint}                  { return Parser::make_CINT(strtoll(yytext+1, NULL, 0), loc); }
 {path}                  { return Parser::make_PATH(yytext, loc); }
 {map}                   { return Parser::make_MAP(yytext, loc); }
 {var}                   { return Parser::make_VAR(yytext, loc); }
-{int}                   { return Parser::make_INT(strtoll(yytext, NULL, 0), loc); }
 ":"                     { return Parser::make_COLON(loc); }
 ";"                     { return Parser::make_SEMI(loc); }
 "{"                     { return Parser::make_LBRACE(loc); }

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -166,6 +166,7 @@ attach_point : ident               { $$ = new ast::AttachPoint($1); }
              | ident PATH STRING   { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, false); }
              | ident PATH wildcard { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, true); }
              | ident PATH INT      { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3); }
+             | ident PATH INT ":" INT        { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, $5); }
              | ident PATH STRING ":" STRING  { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, $5, false); }
              | ident PATH STRING ":" wildcard  { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, $5, true); }
              | ident PATH wildcard ":" STRING  { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, $5, true); }

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -98,6 +98,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %token <std::string> VAR "variable"
 %token <std::string> PARAM "positional parameter"
 %token <long> INT "integer"
+%token <long> CINT "colon surrounded integer"
 %token <std::string> STACK_MODE "stack_mode"
 %nonassoc <std::string> IF "if"
 %nonassoc <std::string> ELSE "else"
@@ -166,7 +167,7 @@ attach_point : ident               { $$ = new ast::AttachPoint($1); }
              | ident PATH STRING   { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, false); }
              | ident PATH wildcard { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, true); }
              | ident PATH INT      { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3); }
-             | ident PATH INT ":" INT        { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, $5); }
+             | ident PATH INT CINT ident  { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, $4, $5); }
              | ident PATH STRING ":" STRING  { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, $5, false); }
              | ident PATH STRING ":" wildcard  { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, $5, true); }
              | ident PATH wildcard ":" STRING  { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, $5, true); }

--- a/src/types.h
+++ b/src/types.h
@@ -99,6 +99,7 @@ enum class ProbeType
   interval,
   software,
   hardware,
+  watchpoint,
 };
 
 struct ProbeItem
@@ -121,7 +122,8 @@ const std::vector<ProbeItem> PROBE_LIST =
   { "profile", "p", ProbeType::profile },
   { "interval", "i", ProbeType::interval },
   { "software", "s", ProbeType::software },
-  { "hardware", "h", ProbeType::hardware }
+  { "hardware", "h", ProbeType::hardware },
+  { "watchpoint", "w", ProbeType::watchpoint },
 };
 
 std::string typestr(Type t);
@@ -144,6 +146,8 @@ public:
   int index = 0;
   int freq;
   pid_t pid = -1;
+  uint64_t addr = 0;            // for watchpoint probes, start of region
+  uint64_t len = 0;             // for watchpoint probes, size of region
 };
 
 enum class AsyncAction

--- a/src/types.h
+++ b/src/types.h
@@ -148,6 +148,7 @@ public:
   pid_t pid = -1;
   uint64_t addr = 0;            // for watchpoint probes, start of region
   uint64_t len = 0;             // for watchpoint probes, size of region
+  std::string mode;             // for watchpoint probes, watch mode (rwx)
 };
 
 enum class AsyncAction

--- a/tests/runtime/watchpoint
+++ b/tests/runtime/watchpoint
@@ -1,0 +1,4 @@
+NAME watchpoint - absolute address
+RUN bpftrace -v -e 'watchpoint::0x10000000:8:w { printf("hit!\n"); }' -c ./testprogs/watchpoint
+EXPECT hit!
+TIMEOUT 5

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -789,6 +789,19 @@ TEST(semantic_analyser, tracepoint)
   test("tracepoint { 1 }", 1);
 }
 
+TEST(semantic_analyser, watchpoint)
+{
+  test("watchpoint::0x1234:8:rw { 1 }", 0);
+  test("watchpoint:/dev/null:0x1234:8:rw { 1 }", 0);
+  test("watchpoint::0x1234:9:rw { 1 }", 1);
+  test("watchpoint::0x1234:8:rwx { 1 }", 1);
+  test("watchpoint::0x1234:8:rx { 1 }", 1);
+  test("watchpoint::0x1234:8:b { 1 }", 1);
+  test("watchpoint::0x1234:8:rww { 1 }", 1);
+  test("watchpoint::0x0:8:rww { 1 }", 1);
+}
+
+
 TEST(semantic_analyser, args_builtin_wrong_use)
 {
   test("BEGIN { args->foo }", 1);

--- a/tests/testprogs/watchpoint.c
+++ b/tests/testprogs/watchpoint.c
@@ -12,10 +12,10 @@ int main() {
       -1,
       0);
 
-  if (addr < 0) {
+  if ((long)addr < 0) {
     perror("mmap");
     return 1;
   }
 
-  *((uint8_t*)addr) = 2;
+  *((volatile uint8_t*)addr) = 2;
 }

--- a/tests/testprogs/watchpoint.c
+++ b/tests/testprogs/watchpoint.c
@@ -1,0 +1,21 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <sys/mman.h>
+#include <unistd.h>
+
+int main() {
+  volatile void* addr = mmap(
+      (void*)0x10000000,
+      2 << 20,
+      PROT_READ | PROT_WRITE,
+      MAP_PRIVATE | MAP_ANONYMOUS,
+      -1,
+      0);
+
+  if (addr < 0) {
+    perror("mmap");
+    return 1;
+  }
+
+  *((uint8_t*)addr) = 2;
+}


### PR DESCRIPTION
This patch adds a new probe type, `watchpoint`. This is like a debugger
memory watchpoint except when an area of memory is read/written,
we can run an arbitrary bpftrace action block.

This is a proof of concept patch. It's missing the following features:

* symbol resolution -- obviously users don't usually used fixed virtual
  addresses. We'll want to let users pass a symbol name, parse
  DWARF/ELF, and de-ASLR the addrs
* kernel support -- right now this prototype only supports userspace
  processes

Test plan:
```
$ cat main.cpp
int main() {
  using namespace std::chrono_literals;

  void* addr = ::mmap(
      reinterpret_cast<void*>(0x10000000),
      2 << 20,
      PROT_READ | PROT_WRITE,
      MAP_PRIVATE | MAP_ANONYMOUS,
      -1,
      0);

  if (addr < 0) {
    ::perror("mmap");
    return 1;
  }

  printf("Mapped %d bytes at %d (%p)\n", 2 << 20, addr, addr);

  uint8_t count = 0;
  while (count < 20) {
    *reinterpret_cast<uint8_t*>(addr) = count++;
    std::this_thread::sleep_for(1s);
  }

  printf("Exiting...\n");
}

$ g++ -std=c++17 mmap_touch.cpp

$ sudo ./build/src/bpftrace -e 'watchpoint::0x10000000:8:rw { printf("hit!\n"); }' -c ~/scratch/bpftrace/mmap_addr/a.out
Attaching 1 probe...
Mapped 2097152 bytes at 268435456 (0x10000000)
hit!
hit!
^C

```