### PR TITLE
Fail in case there's unresolved type in definitions (second try)

### DIFF
--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -411,13 +411,6 @@ bool ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<s
             struct_name = ptypestr;
           remove_struct_union_prefix(struct_name);
 
-          // TODO(mmarchini): re-enable this check once we figure out how to
-          // handle flexible array members.
-          // if (clang_Type_getSizeOf(type) < 0) {
-            // std::cerr << "Can't get size of '" << ptypestr << "::" << ident << "', please provide proper definiton." << std::endl;
-            // return CXChildVisit_Break;
-          // }
-
           structs[struct_name].fields[ident].offset = offset;
           structs[struct_name].fields[ident].type = get_sized_type(type);
           structs[struct_name].size = ptypesize;

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -374,13 +374,11 @@ TEST(clang_parser, macro_preprocessor)
   EXPECT_EQ(macros["_UNDERSCORE"], "314");
 }
 
-// TODO(mmarchini): re-enable this test once we figure out how to handle
-// flexible array members.
-// TEST(clang_parser, parse_fail)
-// {
-  // BPFtrace bpftrace;
-  // parse("struct a { int a; struct b b; };", bpftrace, 1);
-// }
+TEST(clang_parser, parse_fail)
+{
+  BPFtrace bpftrace;
+  parse("struct a { int a; struct b b; };", bpftrace, false);
+}
 
 } // namespace clang_parser
 } // namespace test


### PR DESCRIPTION
The issue we tried to fix in:
  ecb7a1bf422f Fail in case there's unresolved type in definitions

and got reverted:
  22397560daaf clang_parser: disable incomplete member check for now

got actualy fixed by:
  364849d70279 clang_parser: return with error code if clang_parser finds an error

The bpftrace now properly fails on following script, with:

```
  # cat test.bt
  struct a {
    int a;
    int b;
    struct c c;
  };
  # bpftrace test.bt
  definitions.h:4:12: error: field has incomplete type 'struct c'
  definitions.h:4:10: note: forward declaration of 'struct c'
```
The automated tests also properly fails, enabling it back.

Fixes: #469