### PR TITLE
Fix map key validation for print(), clear() and zero()

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -587,19 +587,21 @@ void SemanticAnalyser::visit(Map &map)
       }
     }
 
-    auto search = map_key_.find(map.ident);
-    if (search != map_key_.end()) {
-      if (!map.skip_key_validation && search->second != key) {
-        err_ << "Argument mismatch for " << map.ident << ": ";
-        err_ << "trying to access with arguments: ";
-        err_ << key.argument_type_list();
-        err_ << "\n\twhen map expects arguments: ";
-        err_ << search->second.argument_type_list();
-        err_ << "\n" << std::endl;
+    if (!map.skip_key_validation) {
+      auto search = map_key_.find(map.ident);
+      if (search != map_key_.end()) {
+        if (search->second != key) {
+          err_ << "Argument mismatch for " << map.ident << ": ";
+          err_ << "trying to access with arguments: ";
+          err_ << key.argument_type_list();
+          err_ << "\n\twhen map expects arguments: ";
+          err_ << search->second.argument_type_list();
+          err_ << "\n" << std::endl;
+        }
       }
-    }
-    else {
-      map_key_.insert({map.ident, key});
+      else {
+        map_key_.insert({map.ident, key});
+      }
     }
   }
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -324,6 +324,7 @@ TEST(semantic_analyser, call_print)
   test("kprobe:f { @x = count(); print(@x, 5, 10, 1); }", 1);
   test("kprobe:f { @x = count(); @x = print(); }", 1);
 
+  test("kprobe:f { print(@x); @x[1,2] = count(); }", 0);
   test("kprobe:f { @x[1,2] = count(); print(@x); }", 0);
   test("kprobe:f { @x[1,2] = count(); print(@x[3,4]); }", 1);
 }
@@ -334,6 +335,7 @@ TEST(semantic_analyser, call_clear)
   test("kprobe:f { @x = count(); clear(@x, 1); }", 1);
   test("kprobe:f { @x = count(); @x = clear(); }", 1);
 
+  test("kprobe:f { clear(@x); @x[1,2] = count(); }", 0);
   test("kprobe:f { @x[1,2] = count(); clear(@x); }", 0);
   test("kprobe:f { @x[1,2] = count(); clear(@x[3,4]); }", 1);
 }
@@ -344,6 +346,7 @@ TEST(semantic_analyser, call_zero)
   test("kprobe:f { @x = count(); zero(@x, 1); }", 1);
   test("kprobe:f { @x = count(); @x = zero(); }", 1);
 
+  test("kprobe:f { zero(@x); @x[1,2] = count(); }", 0);
   test("kprobe:f { @x[1,2] = count(); zero(@x); }", 0);
   test("kprobe:f { @x[1,2] = count(); zero(@x[3,4]); }", 1);
 }


### PR DESCRIPTION
See new tests for cases which were broken