### PR TITLE
Fix segfault when lhist() isn't assigned to a map

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -216,6 +216,7 @@ void SemanticAnalyser::visit(Call &call)
     call.type = SizedType(Type::hist, 8);
   }
   else if (call.func == "lhist") {
+    check_assignment(call, true, false);
     if (check_nargs(call, 4)) {
       check_arg(call, Type::integer, 0, false);
       check_arg(call, Type::integer, 1, true);

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -249,12 +249,18 @@ TEST(semantic_analyser, call_hist)
 {
   test("kprobe:f { @x = hist(1); }", 0);
   test("kprobe:f { @x = hist(); }", 1);
-  test("kprobe:f { hist(); }", 1);
+  test("kprobe:f { hist(1); }", 1);
 }
 
 TEST(semantic_analyser, call_lhist)
 {
   test("kprobe:f { @ = lhist(5, 0, 10, 1); }", 0);
+  test("kprobe:f { @ = lhist(5, 0, 10); }", 1);
+  test("kprobe:f { @ = lhist(5, 0); }", 1);
+  test("kprobe:f { @ = lhist(5); }", 1);
+  test("kprobe:f { @ = lhist(); }", 1);
+  test("kprobe:f { @ = lhist(5, 0, 10, 1, 2); }", 1);
+  test("kprobe:f { lhist(-10, -10, 10, 1); }", 1);
   test("kprobe:f { @ = lhist(-10, -10, 10, 1); }", 10); // must be positive
 }
 


### PR DESCRIPTION
Fixes #760