### PR TITLE
Add BPFTRACE_NO_USER_SYMBOLS env var

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1833,7 +1833,6 @@ std::string BPFtrace::resolve_usym(uintptr_t addr, int pid, bool show_offset, bo
   struct bcc_symbol_option symopts;
   void *psyms;
 
-  // TODO: deal with these:
   symopts = {.use_debug_file = true,
              .check_debug_file_crc = true,
              .use_symbol_type = BCC_SYM_ALL_TYPES};
@@ -1849,7 +1848,7 @@ std::string BPFtrace::resolve_usym(uintptr_t addr, int pid, bool show_offset, bo
     psyms = pid_sym_[pid];
   }
 
-  if (bcc_symcache_resolve(psyms, addr, &usym) == 0)
+  if (resolve_user_symbols && bcc_symcache_resolve(psyms, addr, &usym) == 0)
   {
     if (demangle_cpp_symbols)
       symbol << usym.demangle_name;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -120,6 +120,7 @@ public:
   uint64_t max_probes_ = 512;
   uint64_t log_size_ = 409600;
   bool demangle_cpp_symbols = true;
+  bool resolve_user_symbols = true;
   bool safe_mode = true;
 
   static void sort_by_key(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,6 +48,7 @@ void usage()
   std::cerr << "    BPFTRACE_CAT_BYTES_MAX    [default: 10k] maximum bytes read by cat builtin" << std::endl;
   std::cerr << "    BPFTRACE_MAX_PROBES       [default: 512] max number of probes" << std::endl;
   std::cerr << "    BPFTRACE_LOG_SIZE         [default: 409600] log size in bytes" << std::endl;
+  std::cerr << "    BPFTRACE_NO_USER_SYMBOLS  [default: 0] disable user symbol resolution" << std::endl;
   std::cerr << std::endl;
   std::cerr << "EXAMPLES:" << std::endl;
   std::cerr << "bpftrace -l '*sleep*'" << std::endl;
@@ -346,6 +347,20 @@ int main(int argc, char *argv[])
       return 1;
     }
     bpftrace.cat_bytes_max_ = proposed;
+  }
+
+  if (const char* env_p = std::getenv("BPFTRACE_NO_USER_SYMBOLS"))
+  {
+    std::string s(env_p);
+    if (s == "1")
+      bpftrace.resolve_user_symbols = false;
+    else if (s == "0")
+      bpftrace.resolve_user_symbols = true;
+    else
+    {
+      std::cerr << "Env var 'BPFTRACE_NO_USER_SYMBOLS' did not contain a valid value (0 or 1)." << std::endl;
+      return 1;
+    }
   }
 
   if (cmd_str)


### PR DESCRIPTION
This env var lets the user disable user symbol resolution. We need this
because of iovisor/bcc#2421 , where symbol resolution can take too much
memory. I'll work on getting the proper fix in bcc.

The reason this isn't exposed as another stack mode is because this is
more of a workaround and not something we should expect the language
to support for a long time.

This patch also deletes an ambiguous (and possibly outdated) comment.

Test plan:
```
$ sudo BPFTRACE_NO_USER_SYMBOLS=1 ./build/src/bpftrace -e 'kprobe:do_sys_open{ @[ustack] = count(); }'
Attaching 1 probe...
^C

@[
    0x7f4cd9d5b626
]: 1
@[
    0x49bb6a
    0x492f00
    0x4bbdf5
    0x4b9bcf
    0x4b9ab6
    0x6b093b
    0x120b93b
    0x13eeb3b
    0x13f0859
    0x1244dd8
    0x1245147
    0x13f6132
    0x124415d
    0x1257526
    0x73bbd4
    0x76bb5a
    0x1255ec0
    0x73e94b
    0x73ac36
    0x4698c1
]: 1
@[
    0x7f4cd9d5b626
]: 1
@[
<cut>
```

Then scroll up and down a bit and verify no symbols names are present.