### PR TITLE
Add support for go symbol names to uaddr

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -418,7 +418,7 @@ void SemanticAnalyser::visit(Call &call)
    {
     if (check_nargs(call, 1)) {
       if (check_arg(call, Type::string, 0, true)) {
-        check_alpha_numeric(call, 0);
+        check_symbol(call, 0);
       }
     }
     call.type = SizedType(Type::integer, 8);
@@ -1314,17 +1314,18 @@ bool SemanticAnalyser::check_arg(const Call &call, Type type, int arg_num, bool 
   return true;
 }
 
-bool SemanticAnalyser::check_alpha_numeric(const Call &call, int arg_num __attribute__((unused)))
+bool SemanticAnalyser::check_symbol(const Call &call, int arg_num __attribute__((unused)))
 {
   if (!call.vargs)
     return false;
 
   auto &arg = static_cast<String&>(*call.vargs->at(0)).str;
 
-  bool is_alpha = std::regex_match(arg, std::regex("^[a-zA-Z0-9_-]+$"));
-  if (!is_alpha)
+  std::string re = "^[a-zA-Z0-9./_-]+$";
+  bool is_valid = std::regex_match(arg, std::regex(re));
+  if (!is_valid)
   {
-    err_ << call.func << "() expects an alpha numeric string as input";
+    err_ << call.func << "() expects a string that is a valid symbol (" << re << ") as input";
     err_ << " (\"" << arg << "\" provided)" << std::endl;
     return false;
   }

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -61,7 +61,7 @@ private:
   bool check_nargs(const Call &call, size_t expected_nargs);
   bool check_varargs(const Call &call, size_t min_nargs, size_t max_nargs);
   bool check_arg(const Call &call, Type type, int arg_num, bool want_literal=false);
-  bool check_alpha_numeric(const Call &call, int arg_num);
+  bool check_symbol(const Call &call, int arg_num);
 
   void check_stack_call(Call &call, Type type);
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -114,6 +114,8 @@ TEST(semantic_analyser, builtin_functions)
   test("kprobe:f { sym(0xffff) }", 0);
   test("kprobe:f { ksym(0xffff) }", 0);
   test("kprobe:f { usym(0xffff) }", 0);
+  test("kprobe:f { kaddr(\"sym\") }", 0);
+  test("kprobe:f { uaddr(\"sym\") }", 0);
   test("kprobe:f { ntop(0xffff) }", 0);
   test("kprobe:f { ntop(2, 0xffff) }", 0);
   test("kprobe:f { reg(\"ip\") }", 0);
@@ -437,6 +439,16 @@ TEST(semantic_analyser, call_kaddr)
   test("kprobe:f { @x = kaddr(\"avenrun\"); }", 0);
   test("kprobe:f { kaddr(); }", 1);
   test("kprobe:f { kaddr(123); }", 1);
+}
+
+TEST(semantic_analyser, call_uaddr)
+{
+  test("kprobe:f { uaddr(\"counter\"); }", 0);
+  test("kprobe:f { uaddr(\"github.com/golang/glog.severityName\"); }", 0);
+  test("kprobe:f { @x = uaddr(\"counter\"); }", 0);
+  test("kprobe:f { uaddr(); }", 1);
+  test("kprobe:f { uaddr(123); }", 1);
+  test("kprobe:f { uaddr(\"?\"); }", 1);
 }
 
 TEST(semantic_analyser, call_reg)


### PR DESCRIPTION
This is needed to support Go symbol names in `uaddr`.

Technically, Go's symbol names can also contain unicode code points. If you'd like to support all Go symbols then I would recommend just removing the regex check from `check_symbol`.