### PR TITLE
ntop: fix alignment issues

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -346,13 +346,11 @@ void SemanticAnalyser::visit(Call &call)
     //     char[16] inet6;
     //   }
     // }
-    int buffer_size = 8;
+    int buffer_size = 24;
     if (arg->type.type == Type::array) {
       if (arg->type.elem_type != Type::integer || arg->type.pointee_size != 1 || !(arg->type.size == 4 || arg->type.size == 16)) {
         err_ << call.func << "() invalid array" << std::endl;
       }
-      if (arg->type.size == 16)
-        buffer_size = 20;
     }
     call.type = SizedType(Type::inet, buffer_size);
     call.type.is_internal = true;

--- a/tests/codegen/call_ntop_char16.cpp
+++ b/tests/codegen/call_ntop_char16.cpp
@@ -8,7 +8,6 @@ TEST(codegen, call_ntop_char16)
 {
   test("struct inet { unsigned char addr[16] } kprobe:f { @x = ntop(((inet*)0)->addr); }",
 
-#if LLVM_VERSION_MAJOR > 5
 R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
@@ -18,17 +17,17 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
-  %inet = alloca [20 x i8], align 4
-  %1 = getelementptr inbounds [20 x i8], [20 x i8]* %inet, i64 0, i64 0
+  %inet = alloca [24 x i8], align 4
+  %1 = getelementptr inbounds [24 x i8], [24 x i8]* %inet, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i32 10, [20 x i8]* %inet, align 4
-  %2 = getelementptr inbounds [20 x i8], [20 x i8]* %inet, i64 0, i64 4
+  store i32 10, [24 x i8]* %inet, align 4
+  %2 = getelementptr inbounds [24 x i8], [24 x i8]* %inet, i64 0, i64 4
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %2, i64 16, i64 0)
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [20 x i8]* nonnull %inet, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [24 x i8]* nonnull %inet, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -40,39 +39,6 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
-#else
-R"EXPECTED(; Function Attrs: nounwind
-declare i64 @llvm.bpf.pseudo(i64, i64) #0
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
-
-define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
-entry:
-  %"@x_key" = alloca i64, align 8
-  %inet = alloca [20 x i8], align 4
-  %1 = getelementptr inbounds [20 x i8], [20 x i8]* %inet, i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i32 10, [20 x i8]* %inet, align 4
-  %2 = getelementptr inbounds [20 x i8], [20 x i8]* %inet, i64 0, i64 4
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* %2, i64 16, i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  store i64 0, i64* %"@x_key", align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [20 x i8]* nonnull %inet, i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  ret i64 0
-}
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
-
-attributes #0 = { nounwind }
-attributes #1 = { argmemonly nounwind }
-)EXPECTED");
-#endif
 }
 
 } // namespace codegen

--- a/tests/codegen/call_ntop_char4.cpp
+++ b/tests/codegen/call_ntop_char4.cpp
@@ -8,7 +8,6 @@ TEST(codegen, call_ntop_char4)
 {
   test("struct inet { unsigned char addr[4] } kprobe:f { @x = ntop(((inet*)0)->addr); }",
 
-#if LLVM_VERSION_MAJOR > 5
   R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
@@ -18,17 +17,17 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
-  %inet = alloca [8 x i8], align 4
-  %1 = getelementptr inbounds [8 x i8], [8 x i8]* %inet, i64 0, i64 0
+  %inet = alloca [24 x i8], align 4
+  %1 = getelementptr inbounds [24 x i8], [24 x i8]* %inet, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i32 2, [8 x i8]* %inet, align 4
-  %2 = getelementptr inbounds [8 x i8], [8 x i8]* %inet, i64 0, i64 4
+  store i32 2, [24 x i8]* %inet, align 4
+  %2 = getelementptr inbounds [24 x i8], [24 x i8]* %inet, i64 0, i64 4
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %2, i64 4, i64 0)
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [8 x i8]* nonnull %inet, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [24 x i8]* nonnull %inet, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -40,39 +39,6 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
-#else
-  R"EXPECTED(; Function Attrs: nounwind
-declare i64 @llvm.bpf.pseudo(i64, i64) #0
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
-
-define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
-entry:
-  %"@x_key" = alloca i64, align 8
-  %inet = alloca [8 x i8], align 4
-  %1 = getelementptr inbounds [8 x i8], [8 x i8]* %inet, i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i32 2, [8 x i8]* %inet, align 4
-  %2 = getelementptr inbounds [8 x i8], [8 x i8]* %inet, i64 0, i64 4
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* %2, i64 4, i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  store i64 0, i64* %"@x_key", align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [8 x i8]* nonnull %inet, i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  ret i64 0
-}
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
-
-attributes #0 = { nounwind }
-attributes #1 = { argmemonly nounwind }
-)EXPECTED");
-#endif
 }
 
 } // namespace codegen

--- a/tests/codegen/call_ntop_key.cpp
+++ b/tests/codegen/call_ntop_key.cpp
@@ -17,13 +17,16 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
-  %"@x_key" = alloca i64, align 8
-  %tmpcast = bitcast i64* %"@x_key" to [8 x i8]*
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_key" = alloca [24 x i8], align 4
+  %1 = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 -4294967294, i64* %"@x_key", align 8
+  %inet.sroa.0.0..sroa_cast = bitcast [24 x i8]* %"@x_key" to i32*
+  store i32 2, i32* %inet.sroa.0.0..sroa_cast, align 4
+  %inet.sroa.3.0..sroa_idx = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 4
+  %inet.sroa.3.0..sroa_cast = bitcast i8* %inet.sroa.3.0..sroa_idx to i32*
+  store i32 -1, i32* %inet.sroa.3.0..sroa_cast, align 4
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %tmpcast)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [24 x i8]* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -38,7 +41,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %tmpcast, i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [24 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0


### PR DESCRIPTION
ntop would behave unpredictably when used with if/else statements for
differently-sized ntop buffers (8/20, depending on inet AF type).
Upcasting to 20 fixes the issue for some tools, but caused other tools
to stop translating the address correctly. This second issue was caused
by LLVM adding pad between elements of the printf buffer, which caused
our printf implementation to read from incorrect memory addresses. To
prevent LLVM from adding paddings, we can change the size of ntop to a
stack-aligned size. 24 is the lowest stack-aligned size we can use for
ntop, so the new buffer size now is always 24.

Fixes: https://github.com/iovisor/bpftrace/issues/809