### PR TITLE
ntop: fix alignment issues

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -363,13 +363,11 @@ void SemanticAnalyser::visit(Call &call)
     //     char[16] inet6;
     //   }
     // }
-    int buffer_size = 8;
+    int buffer_size = 24;
     if (arg->type.type == Type::array) {
       if (arg->type.elem_type != Type::integer || arg->type.pointee_size != 1 || !(arg->type.size == 4 || arg->type.size == 16)) {
         err_ << call.func << "() invalid array" << std::endl;
       }
-      if (arg->type.size == 16)
-        buffer_size = 20;
     }
     call.type = SizedType(Type::inet, buffer_size);
     call.type.is_internal = true;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -513,8 +513,8 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(const std::vec
         arg_values.push_back(
           std::make_unique<PrintableString>(
             resolve_inet(
-              *reinterpret_cast<int32_t*>(arg_data+arg.offset),
-              reinterpret_cast<uint8_t*>(arg_data+arg.offset + 4))));
+              *reinterpret_cast<int64_t*>(arg_data+arg.offset),
+              reinterpret_cast<uint8_t*>(arg_data+arg.offset + 8))));
         break;
       case Type::username:
         arg_values.push_back(
@@ -990,7 +990,7 @@ std::string BPFtrace::map_value_to_str(IMap &map, std::vector<uint8_t> value, ui
   else if (map.type_.type == Type::usym)
     return resolve_usym(*(uintptr_t*)value.data(), *(uint64_t*)(value.data() + 8));
   else if (map.type_.type == Type::inet)
-    return resolve_inet(*(int32_t*)value.data(), (uint8_t*)(value.data() + 4));
+    return resolve_inet(*(int32_t*)value.data(), (uint8_t*)(value.data() + 8));
   else if (map.type_.type == Type::username)
     return resolve_uid(*(uint64_t*)(value.data()));
   else if (map.type_.type == Type::string)

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -83,7 +83,7 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
     case Type::usym:
       return bpftrace.resolve_usym(*(const uint64_t*)data, *(const uint64_t*)(arg_data + 8));
     case Type::inet:
-      return bpftrace.resolve_inet(*(const int32_t*)data, (const uint8_t*)(arg_data + 4));
+      return bpftrace.resolve_inet(*(const int64_t*)data, (const uint8_t*)(arg_data + 8));
     case Type::username:
       return bpftrace.resolve_uid(*(const uint64_t*)data);
     case Type::probe:

--- a/tests/codegen/call_ntop_char16.cpp
+++ b/tests/codegen/call_ntop_char16.cpp
@@ -8,8 +8,10 @@ TEST(codegen, call_ntop_char16)
 {
   test("struct inet { unsigned char addr[16] } kprobe:f { @x = ntop(((inet*)0)->addr); }",
 
-#if LLVM_VERSION_MAJOR > 5
-R"EXPECTED(; Function Attrs: nounwind
+#if LLVM_VERSION_MAJOR < 6
+R"EXPECTED(%inet_t = type { i64, [16 x i8] }
+
+; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -18,21 +20,65 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
-  %inet = alloca [20 x i8], align 4
-  %1 = getelementptr inbounds [20 x i8], [20 x i8]* %inet, i64 0, i64 0
+  %inet = alloca %inet_t, align 8
+  %1 = bitcast %inet_t* %inet to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i32 10, [20 x i8]* %inet, align 4
-  %2 = getelementptr inbounds [20 x i8], [20 x i8]* %inet, i64 0, i64 4
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %2, i64 16, i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 10, %inet_t* %inet, align 8
+  %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
+  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
+  call void @llvm.memset.p0i8.i64(i8* %3, i8 0, i64 16, i32 8, i1 false)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* %2, i64 16, i64 0)
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [20 x i8]* nonnull %inet, i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+#elif LLVM_VERSION_MAJOR > 6
+R"EXPECTED(%inet_t = type { i64, [16 x i8] }
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
+entry:
+  %"@x_key" = alloca i64, align 8
+  %inet = alloca %inet_t, align 8
+  %1 = bitcast %inet_t* %inet to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  store i64 10, %inet_t* %inet, align 8
+  %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
+  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %3, i8 0, i64 16, i1 false)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* nonnull %2, i64 16, i64 0)
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 0, i64* %"@x_key", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
@@ -41,7 +87,9 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #else
-R"EXPECTED(; Function Attrs: nounwind
+R"EXPECTED(%inet_t = type { i64, [16 x i8] }
+
+; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -50,21 +98,26 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
-  %inet = alloca [20 x i8], align 4
-  %1 = getelementptr inbounds [20 x i8], [20 x i8]* %inet, i64 0, i64 0
+  %inet = alloca %inet_t, align 8
+  %1 = bitcast %inet_t* %inet to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i32 10, [20 x i8]* %inet, align 4
-  %2 = getelementptr inbounds [20 x i8], [20 x i8]* %inet, i64 0, i64 4
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* %2, i64 16, i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 10, %inet_t* %inet, align 8
+  %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
+  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
+  call void @llvm.memset.p0i8.i64(i8* nonnull %3, i8 0, i64 16, i32 8, i1 false)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* nonnull %2, i64 16, i64 0)
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [20 x i8]* nonnull %inet, i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/call_ntop_char4.cpp
+++ b/tests/codegen/call_ntop_char4.cpp
@@ -8,8 +8,10 @@ TEST(codegen, call_ntop_char4)
 {
   test("struct inet { unsigned char addr[4] } kprobe:f { @x = ntop(((inet*)0)->addr); }",
 
-#if LLVM_VERSION_MAJOR > 5
-  R"EXPECTED(; Function Attrs: nounwind
+#if LLVM_VERSION_MAJOR < 6
+R"EXPECTED(%inet_t = type { i64, [16 x i8] }
+
+; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -18,21 +20,65 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
-  %inet = alloca [8 x i8], align 4
-  %1 = getelementptr inbounds [8 x i8], [8 x i8]* %inet, i64 0, i64 0
+  %inet = alloca %inet_t, align 8
+  %1 = bitcast %inet_t* %inet to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i32 2, [8 x i8]* %inet, align 4
-  %2 = getelementptr inbounds [8 x i8], [8 x i8]* %inet, i64 0, i64 4
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %2, i64 4, i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 2, %inet_t* %inet, align 8
+  %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
+  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
+  call void @llvm.memset.p0i8.i64(i8* %3, i8 0, i64 16, i32 8, i1 false)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* %2, i64 4, i64 0)
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [8 x i8]* nonnull %inet, i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+#elif LLVM_VERSION_MAJOR > 6
+R"EXPECTED(%inet_t = type { i64, [16 x i8] }
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
+entry:
+  %"@x_key" = alloca i64, align 8
+  %inet = alloca %inet_t, align 8
+  %1 = bitcast %inet_t* %inet to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  store i64 2, %inet_t* %inet, align 8
+  %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
+  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %3, i8 0, i64 16, i1 false)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* nonnull %2, i64 4, i64 0)
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 0, i64* %"@x_key", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
@@ -41,7 +87,9 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #else
-  R"EXPECTED(; Function Attrs: nounwind
+R"EXPECTED(%inet_t = type { i64, [16 x i8] }
+
+; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -50,21 +98,26 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
-  %inet = alloca [8 x i8], align 4
-  %1 = getelementptr inbounds [8 x i8], [8 x i8]* %inet, i64 0, i64 0
+  %inet = alloca %inet_t, align 8
+  %1 = bitcast %inet_t* %inet to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i32 2, [8 x i8]* %inet, align 4
-  %2 = getelementptr inbounds [8 x i8], [8 x i8]* %inet, i64 0, i64 4
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* %2, i64 4, i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 2, %inet_t* %inet, align 8
+  %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
+  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
+  call void @llvm.memset.p0i8.i64(i8* nonnull %3, i8 0, i64 16, i32 8, i1 false)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* nonnull %2, i64 4, i64 0)
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [8 x i8]* nonnull %inet, i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/call_ntop_key.cpp
+++ b/tests/codegen/call_ntop_key.cpp
@@ -8,6 +8,7 @@ TEST(codegen, call_ntop_key)
 {
   test("kprobe:f { @x[ntop(2, 0xFFFFFFFF)] = count()}",
 
+#if LLVM_VERSION_MAJOR < 6
 R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
@@ -17,13 +18,18 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
-  %"@x_key" = alloca i64, align 8
-  %tmpcast = bitcast i64* %"@x_key" to [8 x i8]*
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_key" = alloca [24 x i8], align 8
+  %1 = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 -4294967294, i64* %"@x_key", align 8
+  %inet.sroa.0.0..sroa_cast = bitcast [24 x i8]* %"@x_key" to i64*
+  store i64 2, i64* %inet.sroa.0.0..sroa_cast, align 8
+  %inet.sroa.3.0..sroa_idx = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 8
+  %inet.sroa.3.0..sroa_cast = bitcast i8* %inet.sroa.3.0..sroa_idx to i32*
+  store i32 -1, i32* %inet.sroa.3.0..sroa_cast, align 8
+  %inet.sroa.5.0..sroa_idx = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 12
+  call void @llvm.memset.p0i8.i64(i8* %inet.sroa.5.0..sroa_idx, i8 0, i64 12, i32 4, i1 false)
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %tmpcast)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [24 x i8]* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -38,11 +44,14 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %tmpcast, i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [24 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0
 }
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
@@ -50,6 +59,109 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
+#elif LLVM_VERSION_MAJOR > 6
+R"EXPECTED(; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
+entry:
+  %"@x_val" = alloca i64, align 8
+  %"@x_key" = alloca [24 x i8], align 8
+  %1 = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  %inet.sroa.0.0..sroa_cast = bitcast [24 x i8]* %"@x_key" to i64*
+  store i64 2, i64* %inet.sroa.0.0..sroa_cast, align 8
+  %inet.sroa.3.0..sroa_idx = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 8
+  %inet.sroa.3.0..sroa_cast = bitcast i8* %inet.sroa.3.0..sroa_idx to i32*
+  store i32 -1, i32* %inet.sroa.3.0..sroa_cast, align 8
+  %inet.sroa.5.0..sroa_idx = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 12
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %inet.sroa.5.0..sroa_idx, i8 0, i64 12, i1 false)
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [24 x i8]* nonnull %"@x_key")
+  %map_lookup_cond = icmp eq i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
+
+lookup_success:                                   ; preds = %entry
+  %2 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %2, 1
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %entry, %lookup_success
+  %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
+  %3 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [24 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+#else
+R"EXPECTED(; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
+entry:
+  %"@x_val" = alloca i64, align 8
+  %"@x_key" = alloca [24 x i8], align 8
+  %1 = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  %inet.sroa.0.0..sroa_cast = bitcast [24 x i8]* %"@x_key" to i64*
+  store i64 2, i64* %inet.sroa.0.0..sroa_cast, align 8
+  %inet.sroa.3.0..sroa_idx = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 8
+  %inet.sroa.3.0..sroa_cast = bitcast i8* %inet.sroa.3.0..sroa_idx to i32*
+  store i32 -1, i32* %inet.sroa.3.0..sroa_cast, align 8
+  %inet.sroa.5.0..sroa_idx = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 12
+  call void @llvm.memset.p0i8.i64(i8* nonnull %inet.sroa.5.0..sroa_idx, i8 0, i64 12, i32 4, i1 false)
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [24 x i8]* nonnull %"@x_key")
+  %map_lookup_cond = icmp eq i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
+
+lookup_success:                                   ; preds = %entry
+  %2 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %2, 1
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %entry, %lookup_success
+  %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
+  %3 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [24 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+#endif
 }
 
 } // namespace codegen


### PR DESCRIPTION
ntop would behave unpredictably when used with if/else statements for
differently-sized ntop buffers (8/20, depending on inet AF type).
Upcasting to 20 fixes the issue for some tools, but caused other tools
to stop translating the address correctly. This second issue was caused
by LLVM adding pad between elements of the printf buffer, which caused
our printf implementation to read from incorrect memory addresses. To
prevent LLVM from adding paddings, we can change the size of ntop to a
stack-aligned size. 24 is the lowest stack-aligned size, so we use 24.

Fixes: https://github.com/iovisor/bpftrace/issues/809