### PR TITLE
Collapse bcc symbol resolvers by process executable

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -87,10 +87,10 @@ BPFtrace::~BPFtrace()
     waitpid(pid, &status, 0);
   }
 
-  for (const auto& pair : pid_sym_)
+  for (const auto& pair : exe_sym_)
   {
-    if (pair.second)
-      bcc_free_symcache(pair.second, pair.first);
+    if (pair.second.second)
+      bcc_free_symcache(pair.second.second, pair.second.first);
   }
 
   if (ksyms_)
@@ -1844,15 +1844,16 @@ std::string BPFtrace::resolve_usym(uintptr_t addr, int pid, bool show_offset, bo
 
   if (resolve_user_symbols_)
   {
-    if (pid_sym_.find(pid) == pid_sym_.end())
+    std::string pid_exe = get_pid_exe(pid);
+    if (exe_sym_.find(pid_exe) == exe_sym_.end())
     {
       // not cached, create new ProcSyms cache
       psyms = bcc_symcache_new(pid, &symopts);
-      pid_sym_[pid] = psyms;
+      exe_sym_[pid_exe] = std::make_pair(pid, psyms);
     }
     else
     {
-      psyms = pid_sym_[pid];
+      psyms = exe_sym_[pid_exe].second;
     }
   }
 

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -6,6 +6,7 @@
 #include <set>
 #include <vector>
 #include <unordered_map>
+#include <utility>
 
 #include "ast.h"
 #include "attached_probe.h"
@@ -148,7 +149,7 @@ private:
   std::vector<std::unique_ptr<AttachedProbe>> attached_probes_;
   std::vector<std::unique_ptr<AttachedProbe>> special_attached_probes_;
   void* ksyms_{nullptr};
-  std::map<int, void *> pid_sym_;
+  std::map<std::string, std::pair<int, void *>> exe_sym_; // exe -> (pid, cache)
   int ncpus_;
   int online_cpus_;
   std::vector<int> child_pids_;


### PR DESCRIPTION
Before, we were creating a new resolver for each pid, even if multiple
pids shared the same underlying executable binary. This led to huge
amounts of duplication against processes that fork a lot.