### PR TITLE
Fix g++ issue with building bpftrace

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1615,9 +1615,9 @@ std::string BPFtrace::resolve_usym(uintptr_t addr, int pid, bool show_offset, bo
   struct bcc_symbol_option symopts;
   void *psyms = nullptr;
 
-  symopts = {.use_debug_file = true,
-             .check_debug_file_crc = true,
-             .use_symbol_type = BCC_SYM_ALL_TYPES};
+  symopts.use_debug_file = true;
+  symopts.check_debug_file_crc = true;
+  symopts.use_symbol_type = BCC_SYM_ALL_TYPES;
 
   if (resolve_user_symbols_)
   {


### PR DESCRIPTION
I keep getting this error when building bpftrace:
bpftrace.cpp:1620:33: sorry, unimplemented: non-trivial designated initializers not supported

It has something to do with the construct not implemented in my g++
compiler. The compiler version is 7. Let us just use simple
initialization code for the struct to make it work for everyone.

Related stackoverflow discussion:
https://stackoverflow.com/questions/31215971/non-trivial-designated-initializers-not-supported/45387695

Signed-off-by: Joel Fernandes (Google) <joel@joelfernandes.org>