### PR TITLE
print: skip keys which were removed during iteration

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1032,7 +1032,13 @@ int BPFtrace::print_map(IMap &map, uint32_t top, uint32_t div)
       value_size *= ncpus_;
     auto value = std::vector<uint8_t>(value_size);
     int err = bpf_lookup_elem(map.mapfd_, key.data(), value.data());
-    if (err)
+    if (err == -1)
+    {
+      // key was removed by the eBPF program during bpf_get_next_key() and bpf_lookup_elem(),
+      // let's skip this key
+      continue;
+    }
+    else if (err)
     {
       std::cerr << "Error looking up elem: " << err << std::endl;
       return -1;
@@ -1108,7 +1114,13 @@ int BPFtrace::print_map_hist(IMap &map, uint32_t top, uint32_t div)
     int value_size = map.type_.size * ncpus_;
     auto value = std::vector<uint8_t>(value_size);
     int err = bpf_lookup_elem(map.mapfd_, key.data(), value.data());
-    if (err)
+    if (err == -1)
+    {
+      // key was removed by the eBPF program during bpf_get_next_key() and bpf_lookup_elem(),
+      // let's skip this key
+      continue;
+    }
+    else if (err)
     {
       std::cerr << "Error looking up elem: " << err << std::endl;
       return -1;
@@ -1180,7 +1192,13 @@ int BPFtrace::print_map_stats(IMap &map)
     int value_size = map.type_.size * ncpus_;
     auto value = std::vector<uint8_t>(value_size);
     int err = bpf_lookup_elem(map.mapfd_, key.data(), value.data());
-    if (err)
+    if (err == -1)
+    {
+      // key was removed by the eBPF program during bpf_get_next_key() and bpf_lookup_elem(),
+      // let's skip this key
+      continue;
+    }
+    else if (err)
     {
       std::cerr << "Error looking up elem: " << err << std::endl;
       return -1;


### PR DESCRIPTION
I'm consuming bpftrace maps with another program by printing them to stdout every 1s (`interval:s:1`). I just ran into the following issue:
In `int BPFtrace::print_map(IMap &map, uint32_t top, uint32_t div)` there is an iteration over all keys with `bpf_get_next_key`, and a few lines below they key is accessed with `bpf_lookup_elem`. In case the key is removed during `bpf_get_next_key` and `bpf_lookup_elem` by the eBPF program, bpftrace aborts with
```
Error looking up elem: -1
terminate called after throwing an instance of 'std::runtime_error'
  what():  Could not print map with ident "@qtime", err=-1
```

I'd suggest to ignore key not found errors here, and just continue the iteration.
Thoughts?

Looking at the man page of `bpf_lookup_elem`, it can return only 0 for success or -1 for key not found. I left the error handling code intact, in case the API returns another error code for a new type of error at some point.