### PR TITLE
Fix runtime test parser to not break with commented out tests

### DIFF
--- a/tests/parser.py
+++ b/tests/parser.py
@@ -41,19 +41,20 @@ class TestParser(object):
         test_lines = []
         test_suite = file_name.split('/')[-1]
         with open (file_name, 'r') as file:
-            for line in file.readlines():
+            lines = file.readlines()
+            line_num = 0
+            for line in lines:
+                line_num += 1
                 if line.startswith("#"):
                     continue
                 if line != '\n':
                     test_lines.append(line)
-                else:
-                    test_struct = TestParser.__read_test_struct(test_lines, test_suite)
-                    if fnmatch("%s.%s" % (test_suite, test_struct.name), test_filter):
-                        tests.append(test_struct)
-                    test_lines = []
-            test_struct = TestParser.__read_test_struct(test_lines, test_suite)
-            if fnmatch("%s.%s" % (test_suite, test_struct.name), test_filter):
-                tests.append(test_struct)
+                if line == '\n' or line_num == len(lines):
+                    if test_lines:
+                        test_struct = TestParser.__read_test_struct(test_lines, test_suite)
+                        if fnmatch("%s.%s" % (test_suite, test_struct.name), test_filter):
+                            tests.append(test_struct)
+                        test_lines = []
 
         return (test_suite, tests)
 


### PR DESCRIPTION
A totally commented out test case, like this one (from runtime/regression):

```
# https://github.com/iovisor/bpftrace/issues/759
# Update test once https://github.com/iovisor/bpftrace/pull/781 lands
# NAME ntop_map_printf
# RUN bpftrace -v -e 'union ip { char v4[4]; char v6[16]; } uprobe:./testprogs/ntop:test_ntop { @a = ntop(2, ((union ip*)arg0)->v4); printf("v4: %s; ", @a); @b = ntop(10, ((union ip*)arg1)->v6); exit() } END { printf("v6: %s", @b); clear(@a); clear(@b) }'
# AFTER ./testprogs/ntop
# EXPECT v4: 127.0.0.1; v6: ffee:ffee:ddcc:ddcc:bbaa:bbaa:c0a8:1
# TIMEOUT 1
```

Was breaking the runtime tests.