### PR TITLE
Add sargX alias to support Go function arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,6 +267,7 @@ Variables:
 - `stack` - Kernel stack trace
 - `ustack` - User stack trace
 - `arg0`, `arg1`, ... etc. - Arguments to the function being traced
+- `sarg0`, `sarg1`, ... etc. - Arguments to the function being traced (for programs that store arguments on the stack)
 - `retval` - Return value from function being traced
 - `func` - Name of the function currently being traced
 - `probe` - Full name of the probe

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1187,7 +1187,8 @@ bpftrace -e 'watchpoint::0x10000000:8:rw { printf("hit!\n"); }' -c ~/binary
 - `comm` - Process name
 - `kstack` - Kernel stack trace
 - `ustack` - User stack trace
-- `arg0`, `arg1`, ..., `argN`. - Arguments to the traced function
+- `arg0`, `arg1`, ..., `argN`. - Arguments to the traced function; assumed to be 64 bits wide
+- `sarg0`, `sarg1`, ..., `sargN`. - Arguments to the traced function (for programs that store arguments on the stack); assumed to be 64 bits wide
 - `retval` - Return value from traced function
 - `func` - Name of the traced function
 - `probe` - Full name of the probe

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -47,7 +47,7 @@ path   :(\\.|[_\-\./a-zA-Z0-9#\*])*:
   <<EOF>>               yy_pop_state(yyscanner); driver.error(loc, "end of file during comment");
 }
 
-pid|tid|cgroup|uid|gid|nsecs|cpu|comm|kstack|stack|ustack|arg[0-9]|retval|func|probe|curtask|rand|ctx|username|args|elapsed {
+pid|tid|cgroup|uid|gid|nsecs|cpu|comm|kstack|stack|ustack|arg[0-9]|sarg[0-9]|retval|func|probe|curtask|rand|ctx|username|args|elapsed {
                           return Parser::make_BUILTIN(yytext, loc); }
 bpftrace|perf {
                           return Parser::make_STACK_MODE(yytext, loc); }

--- a/tests/codegen/builtin_sarg.cpp
+++ b/tests/codegen/builtin_sarg.cpp
@@ -1,0 +1,73 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, builtin_sarg)
+{
+  test("kprobe:f { @x = sarg0; @y = sarg2 }",
+
+R"EXPECTED(; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:f_1" {
+entry:
+  %"@y_val" = alloca i64, align 8
+  %"@y_key" = alloca i64, align 8
+  %sarg2 = alloca i64, align 8
+  %"@x_val" = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  %sarg0 = alloca i64, align 8
+  %1 = getelementptr i8, i8* %0, i64 152
+  %reg_sp = load i64, i8* %1, align 8
+  %2 = bitcast i64* %sarg0 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  %3 = add i64 %reg_sp, 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %sarg0, i64 8, i64 %3)
+  %4 = load i64, i64* %sarg0, align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  %5 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  store i64 0, i64* %"@x_key", align 8
+  %6 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  store i64 %4, i64* %"@x_val", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  %reg_sp1 = load i64, i8* %1, align 8
+  %7 = bitcast i64* %sarg2 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
+  %8 = add i64 %reg_sp1, 24
+  %probe_read2 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %sarg2, i64 8, i64 %8)
+  %9 = load i64, i64* %sarg2, align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  %10 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
+  store i64 0, i64* %"@y_key", align 8
+  %11 = bitcast i64* %"@y_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %11)
+  store i64 %9, i64* %"@y_val", align 8
+  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo3, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %11)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -41,6 +41,7 @@ TEST(Parser, builtin_variables)
   test("kprobe:f { kstack }", "Program\n kprobe:f\n  builtin: kstack\n");
   test("kprobe:f { ustack }", "Program\n kprobe:f\n  builtin: ustack\n");
   test("kprobe:f { arg0 }", "Program\n kprobe:f\n  builtin: arg0\n");
+  test("kprobe:f { sarg0 }", "Program\n kprobe:f\n  builtin: sarg0\n");
   test("kprobe:f { retval }", "Program\n kprobe:f\n  builtin: retval\n");
   test("kprobe:f { func }", "Program\n kprobe:f\n  builtin: func\n");
   test("kprobe:f { probe }", "Program\n kprobe:f\n  builtin: probe\n");

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -58,6 +58,12 @@ RUN bpftrace -v -e 'k:vfs_read { printf("SUCCESS '$test' %d\n", arg0); exit(); }
 EXPECT SUCCESS arg -?[0-9][0-9]*
 TIMEOUT 5
 
+NAME sarg
+RUN bpftrace -v -e 'uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS '$test' %d %d\n", sarg0, sarg1); exit(); }'
+EXPECT SUCCESS sarg 32 64
+TIMEOUT 5
+AFTER ./testprogs/stack_args
+
 NAME retval
 RUN bpftrace -v -e 'kretprobe:vfs_read { printf("SUCCESS '$test' %d\n", retval); exit(); }'
 EXPECT SUCCESS retval .*

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -118,6 +118,7 @@ TEST(semantic_analyser, builtin_variables)
   test("kprobe:f { kstack }", 0);
   test("kprobe:f { ustack }", 0);
   test("kprobe:f { arg0 }", 0);
+  test("kprobe:f { sarg0 }", 0);
   test("kretprobe:f { retval }", 0);
   test("kprobe:f { func }", 0);
   test("kprobe:f { probe }", 0);

--- a/tests/testprogs/stack_args.c
+++ b/tests/testprogs/stack_args.c
@@ -1,0 +1,10 @@
+#define ARG(x) int (x) __attribute((unused))
+
+// Declare enough args that some are placed on the stack
+void too_many_args(ARG(a), ARG(b), ARG(c), ARG(d), ARG(e), ARG(f), ARG(g), ARG(h)) {}
+
+int main(void)
+{
+  too_many_args(0, 1, 2, 4, 8, 16, 32, 64);
+  return 0;
+}


### PR DESCRIPTION
~I played with two different implementations and finally settled on this lexer spec approach. Adding something to the parser was another possibility, but it was fairly ugly and referenced a lot more types.~

~If this lexer rule sees an `sarg[0-9]` token, it swallows the token and then uses lex's `unput` to feed the stack expression back into the input stream (in reverse order). It's then lexed and parsed as normal.~

Resolves #740.