### PR TITLE
Fix sigint handling under heavy load

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -336,6 +336,12 @@ void perf_event_printer(void *cb_cookie, void *data, int size __attribute__((unu
   if (bpftrace->finalize_)
     return;
 
+  if (bpftrace->exitsig_recv)
+  {
+    bpftrace->request_finalize();
+    return;
+  }
+
   // async actions
   if (printf_id == asyncactionint(AsyncAction::exit))
   {
@@ -751,9 +757,10 @@ int BPFtrace::run(std::unique_ptr<BpfOrc> bpforc)
 
   poll_perf_events(epollfd);
   attached_probes_.clear();
-  // finalize_ should be false from now on otherwise perf_event_printer() can
-  // ignore the END_trigger() events.
+  // finalize_ and exitsig_recv should be false from now on otherwise
+  // perf_event_printer() can ignore the END_trigger() events.
   finalize_ = false;
+  exitsig_recv = false;
 
   END_trigger();
   poll_perf_events(epollfd, true);

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -92,3 +92,9 @@ NAME avg can be cleared
 RUN bpftrace -e 'BEGIN{ @[1] = avg(1); clear(@); exit() }'
 EXPECT .*
 TIMEOUT 1
+
+NAME sigint under heavy load
+RUN ./bpftrace --unsafe -v -e 'tracepoint:sched:sched_switch { system("echo foo"); } END { printf("end"); }'
+EXPECT end
+TIMEOUT 5
+AFTER  sleep 2; killall -s INT bpftrace


### PR DESCRIPTION
As noted by @ajor (https://github.com/iovisor/bpftrace/issues/705#issuecomment-498878027) in some situations of heavy load Control+C (sigint) may not work, this commit fix this problem.