### PR TITLE
Signed types

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -229,7 +229,8 @@ void CodegenLLVM::visit(Call &call)
     AllocaInst *newval = b_.CreateAllocaBPF(map.type, map.ident + "_val");
 
     call.vargs->front()->accept(*this);
-    expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), false); // promote int to 64-bit
+    // promote int to 64-bit
+    expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), call.vargs->front()->type.is_signed);
     b_.CreateStore(b_.CreateAdd(expr_, oldval), newval);
     b_.CreateMapUpdateElem(map, key, newval);
 
@@ -249,7 +250,8 @@ void CodegenLLVM::visit(Call &call)
     // elements will always store on the first occurrance. Revent this later when printing.
     Function *parent = b_.GetInsertBlock()->getParent();
     call.vargs->front()->accept(*this);
-    expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), false); // promote int to 64-bit
+    // promote int to 64-bit
+    expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), call.vargs->front()->type.is_signed);
     Value *inverted = b_.CreateSub(b_.getInt64(0xffffffff), expr_);
     BasicBlock *lt = BasicBlock::Create(module_->getContext(), "min.lt", parent);
     BasicBlock *ge = BasicBlock::Create(module_->getContext(), "min.ge", parent);
@@ -274,7 +276,8 @@ void CodegenLLVM::visit(Call &call)
 
     Function *parent = b_.GetInsertBlock()->getParent();
     call.vargs->front()->accept(*this);
-    expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), false); // promote int to 64-bit
+    // promote int to 64-bit
+    expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), call.vargs->front()->type.is_signed);
     BasicBlock *lt = BasicBlock::Create(module_->getContext(), "min.lt", parent);
     BasicBlock *ge = BasicBlock::Create(module_->getContext(), "min.ge", parent);
     b_.CreateCondBr(b_.CreateICmpSGE(expr_, oldval), ge, lt);
@@ -307,7 +310,8 @@ void CodegenLLVM::visit(Call &call)
     Value *total_old = b_.CreateMapLookupElem(map, total_key);
     AllocaInst *total_new = b_.CreateAllocaBPF(map.type, map.ident + "_val");
     call.vargs->front()->accept(*this);
-    expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), false); // promote int to 64-bit
+    // promote int to 64-bit
+    expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), call.vargs->front()->type.is_signed);
     b_.CreateStore(b_.CreateAdd(expr_, total_old), total_new);
     b_.CreateMapUpdateElem(map, total_key, total_new);
     b_.CreateLifetimeEnd(total_key);
@@ -319,7 +323,8 @@ void CodegenLLVM::visit(Call &call)
   {
     Map &map = *call.map;
     call.vargs->front()->accept(*this);
-    expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), false); // promote int to 64-bit
+    // promote int to 64-bit
+    expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), call.vargs->front()->type.is_signed);
     Function *log2_func = module_->getFunction("log2");
     Value *log2 = b_.CreateCall(log2_func, expr_, "log2");
     AllocaInst *key = getHistMapKey(map, log2);
@@ -356,7 +361,7 @@ void CodegenLLVM::visit(Call &call)
     step = expr_;
 
     // promote int to 64-bit
-    value = b_.CreateIntCast(value, b_.getInt64Ty(), false);
+    value = b_.CreateIntCast(value, b_.getInt64Ty(), call.vargs->front()->type.is_signed);
     min = b_.CreateIntCast(min, b_.getInt64Ty(), false);
     max = b_.CreateIntCast(max, b_.getInt64Ty(), false);
     step = b_.CreateIntCast(step, b_.getInt64Ty(), false);
@@ -761,38 +766,59 @@ void CodegenLLVM::visit(Binop &binop)
     binop.right->accept(*this);
     rhs = expr_;
 
+    bool lsign = binop.left->type.is_signed;
+    bool rsign = binop.right->type.is_signed;
+    bool do_signed = lsign && rsign;
     // promote int to 64-bit
-    lhs = b_.CreateIntCast(lhs, b_.getInt64Ty(), false);
-    rhs = b_.CreateIntCast(rhs, b_.getInt64Ty(), false);
+    lhs = b_.CreateIntCast(lhs, b_.getInt64Ty(), lsign);
+    rhs = b_.CreateIntCast(rhs, b_.getInt64Ty(), rsign);
 
     switch (binop.op) {
       case bpftrace::Parser::token::EQ:    expr_ = b_.CreateICmpEQ (lhs, rhs); break;
       case bpftrace::Parser::token::NE:    expr_ = b_.CreateICmpNE (lhs, rhs); break;
-      case bpftrace::Parser::token::LE:    expr_ = b_.CreateICmpSLE(lhs, rhs); break;
-      case bpftrace::Parser::token::GE:    expr_ = b_.CreateICmpSGE(lhs, rhs); break;
-      case bpftrace::Parser::token::LT:    expr_ = b_.CreateICmpSLT(lhs, rhs); break;
-      case bpftrace::Parser::token::GT:    expr_ = b_.CreateICmpSGT(lhs, rhs); break;
+      case bpftrace::Parser::token::LE: {
+        expr_ = do_signed ? b_.CreateICmpSLE(lhs, rhs) : b_.CreateICmpULE(lhs, rhs);
+        break;
+      }
+      case bpftrace::Parser::token::GE: {
+        expr_ = do_signed ? b_.CreateICmpSGE(lhs, rhs) : b_.CreateICmpUGE(lhs, rhs);
+        break;
+      }
+      case bpftrace::Parser::token::LT: {
+        expr_ = do_signed ? b_.CreateICmpSLT(lhs, rhs) : b_.CreateICmpULT(lhs, rhs);
+        break;
+      }
+      case bpftrace::Parser::token::GT: {
+        expr_ = do_signed ? b_.CreateICmpSGT(lhs, rhs) : b_.CreateICmpUGT(lhs, rhs);
+        break;
+      }
       case bpftrace::Parser::token::LEFT:  expr_ = b_.CreateShl    (lhs, rhs); break;
       case bpftrace::Parser::token::RIGHT: expr_ = b_.CreateLShr   (lhs, rhs); break;
       case bpftrace::Parser::token::PLUS:  expr_ = b_.CreateAdd    (lhs, rhs); break;
       case bpftrace::Parser::token::MINUS: expr_ = b_.CreateSub    (lhs, rhs); break;
       case bpftrace::Parser::token::MUL:   expr_ = b_.CreateMul    (lhs, rhs); break;
-      case bpftrace::Parser::token::DIV:   expr_ = b_.CreateUDiv   (lhs, rhs); break;
-      case bpftrace::Parser::token::MOD:   expr_ = b_.CreateURem   (lhs, rhs); break;
+      case bpftrace::Parser::token::DIV: {
+        expr_ = do_signed ? b_.CreateSDiv(lhs, rhs) : b_.CreateUDiv(lhs, rhs);
+        break;
+      }
+      case bpftrace::Parser::token::MOD: {
+        expr_ = do_signed ? b_.CreateSRem(lhs, rhs) : b_.CreateURem(lhs, rhs);
+        break;
+      }
       case bpftrace::Parser::token::BAND:  expr_ = b_.CreateAnd    (lhs, rhs); break;
       case bpftrace::Parser::token::BOR:   expr_ = b_.CreateOr     (lhs, rhs); break;
       case bpftrace::Parser::token::BXOR:  expr_ = b_.CreateXor    (lhs, rhs); break;
       case bpftrace::Parser::token::LAND:
-        std::cerr << "\"" << opstr(binop) << "\" was handled earlier" << std::endl;
-        abort();
       case bpftrace::Parser::token::LOR:
         std::cerr << "\"" << opstr(binop) << "\" was handled earlier" << std::endl;
         abort();
       default:
-        std::cerr << "missing codegen (LLVM) to string operator \"" << opstr(binop) << "\"" << std::endl;
+        std::cerr << "missing codegen (LLVM) to string operator \""
+                  << opstr(binop) << "\"" << std::endl;
         abort();
     }
   }
+  // Using signed extension will result in -1 which will likely confuse users
   expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), false);
 }
 
@@ -1039,7 +1065,8 @@ void CodegenLLVM::visit(ArrayAccess &arr)
   array = expr_;
 
   arr.indexpr->accept(*this);
-  index = b_.CreateIntCast(expr_, b_.getInt64Ty(), false); // promote int to 64-bit
+  // promote int to 64-bit
+  index = b_.CreateIntCast(expr_, b_.getInt64Ty(), arr.expr->type.is_signed);
   offset = b_.CreateMul(index, b_.getInt64(type.pointee_size));
 
   AllocaInst *dst = b_.CreateAllocaBPF(SizedType(Type::integer, type.pointee_size), "array_access");
@@ -1095,7 +1122,7 @@ void CodegenLLVM::visit(AssignMapStatement &assignment)
     if (map.type.type == Type::integer)
     {
       // Integers are always stored as 64-bit in map values
-      expr = b_.CreateIntCast(expr, b_.getInt64Ty(), false);
+      expr = b_.CreateIntCast(expr, b_.getInt64Ty(), map.type.is_signed);
     }
     val = b_.CreateAllocaBPF(map.type, map.ident + "_val");
     b_.CreateStore(expr, val);
@@ -1369,7 +1396,7 @@ AllocaInst *CodegenLLVM::getMapKey(Map &map)
         b_.CREATE_MEMCPY(offset_val, expr_, expr->type.size, 1);
       else
         // promote map key to 64-bit:
-        b_.CreateStore(b_.CreateIntCast(expr_, b_.getInt64Ty(), false), offset_val);
+        b_.CreateStore(b_.CreateIntCast(expr_, b_.getInt64Ty(), expr->type.is_signed), offset_val);
       offset += expr->type.size;
     }
   }
@@ -1746,6 +1773,5 @@ std::unique_ptr<BpfOrc> CodegenLLVM::compile(DebugLevel debug, std::ostream &out
 
   return bpforc;
 }
-
 } // namespace ast
 } // namespace bpftrace

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -797,10 +797,7 @@ void CodegenLLVM::visit(Binop &binop)
       case bpftrace::Parser::token::PLUS:  expr_ = b_.CreateAdd    (lhs, rhs); break;
       case bpftrace::Parser::token::MINUS: expr_ = b_.CreateSub    (lhs, rhs); break;
       case bpftrace::Parser::token::MUL:   expr_ = b_.CreateMul    (lhs, rhs); break;
-      case bpftrace::Parser::token::DIV: {
-        expr_ = do_signed ? b_.CreateSDiv(lhs, rhs) : b_.CreateUDiv(lhs, rhs);
-        break;
-      }
+      case bpftrace::Parser::token::DIV:   expr_ = b_.CreateUDiv   (lhs, rhs); break;
       case bpftrace::Parser::token::MOD: {
         expr_ = do_signed ? b_.CreateSRem(lhs, rhs) : b_.CreateURem(lhs, rhs);
         break;

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -301,20 +301,14 @@ void SemanticAnalyser::visit(Call &call)
     call.type = SizedType(Type::max, 8, sign);
   }
   else if (call.func == "avg") {
-    bool sign = false;
     check_assignment(call, true, false);
-    if (check_nargs(call, 1)) {
-      sign = call.vargs->at(0)->type.is_signed;
-    }
-    call.type = SizedType(Type::avg, 8, sign);
+    check_nargs(call, 1);
+    call.type = SizedType(Type::avg, 8, true);
   }
   else if (call.func == "stats") {
-    bool sign = false;
     check_assignment(call, true, false);
-    if (check_nargs(call, 1)) {
-      sign = call.vargs->at(0)->type.is_signed;
-    }
-    call.type = SizedType(Type::stats, 8, sign);
+    check_nargs(call, 1);
+    call.type = SizedType(Type::stats, 8, true);
   }
   else if (call.func == "delete") {
     check_assignment(call, false, false);

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -19,12 +19,12 @@ namespace ast {
 
 void SemanticAnalyser::visit(Integer &integer)
 {
-  integer.type = SizedType(Type::integer, 8);
+  integer.type = SizedType(Type::integer, 8, true);
 }
 
 void SemanticAnalyser::visit(PositionalParameter &param)
 {
-  param.type = SizedType(Type::integer, 8);
+  param.type = SizedType(Type::integer, 8, true);
   switch (param.ptype) {
     case PositionalParameterType::positional:
       if (param.n <= 0) {
@@ -102,7 +102,7 @@ void SemanticAnalyser::visit(Builtin &builtin)
       builtin.ident == "curtask" ||
       builtin.ident == "rand" ||
       builtin.ident == "ctx") {
-    builtin.type = SizedType(Type::integer, 8);
+    builtin.type = SizedType(Type::integer, 8, false);
     if (builtin.ident == "cgroup") {
       #ifndef HAVE_GET_CURRENT_CGROUP_ID
         err_ << "BPF_FUNC_get_current_cgroup_id is not available for your kernel version" << std::endl;
@@ -277,34 +277,44 @@ void SemanticAnalyser::visit(Call &call)
     call.type = SizedType(Type::count, 8);
   }
   else if (call.func == "sum") {
+    bool sign = false;
     check_assignment(call, true, false);
-    check_nargs(call, 1);
-
-    call.type = SizedType(Type::sum, 8);
+    if (check_nargs(call, 1)) {
+      sign = call.vargs->at(0)->type.is_signed;
+    }
+    call.type = SizedType(Type::sum, 8, sign);
   }
   else if (call.func == "min") {
+    bool sign = false;
     check_assignment(call, true, false);
-    check_nargs(call, 1);
-
-    call.type = SizedType(Type::min, 8);
+    if (check_nargs(call, 1)) {
+      sign = call.vargs->at(0)->type.is_signed;
+    }
+    call.type = SizedType(Type::min, 8, sign);
   }
   else if (call.func == "max") {
+    bool sign = false;
     check_assignment(call, true, false);
-    check_nargs(call, 1);
-
-    call.type = SizedType(Type::max, 8);
+    if (check_nargs(call, 1)) {
+      sign = call.vargs->at(0)->type.is_signed;
+    }
+    call.type = SizedType(Type::max, 8, sign);
   }
   else if (call.func == "avg") {
+    bool sign = false;
     check_assignment(call, true, false);
-    check_nargs(call, 1);
-
-    call.type = SizedType(Type::avg, 8);
+    if (check_nargs(call, 1)) {
+      sign = call.vargs->at(0)->type.is_signed;
+    }
+    call.type = SizedType(Type::avg, 8, sign);
   }
   else if (call.func == "stats") {
+    bool sign = false;
     check_assignment(call, true, false);
-    check_nargs(call, 1);
-
-    call.type = SizedType(Type::stats, 8);
+    if (check_nargs(call, 1)) {
+      sign = call.vargs->at(0)->type.is_signed;
+    }
+    call.type = SizedType(Type::stats, 8, sign);
   }
   else if (call.func == "delete") {
     check_assignment(call, false, false);
@@ -598,7 +608,13 @@ void SemanticAnalyser::visit(Map &map)
         // promote map key to 64-bit:
         if (!expr->type.IsArray())
           expr->type.size = 8;
-        key.args_.push_back(expr->type);
+
+        // Skip is_signed when comparing keys to not break existing scripts
+        // which use maps as a lookup table
+        // TODO (fbs): This needs a better solution
+        SizedType keytype = expr->type;
+        keytype.is_signed = false;
+        key.args_.push_back(keytype);
       }
     }
 
@@ -674,6 +690,8 @@ void SemanticAnalyser::visit(Binop &binop)
   binop.right->accept(*this);
   Type &lhs = binop.left->type.type;
   Type &rhs = binop.right->type.type;
+  bool lsign = binop.left->type.is_signed;
+  bool rsign = binop.right->type.is_signed;
 
   std::stringstream buf;
   if (is_final_pass()) {
@@ -686,7 +704,58 @@ void SemanticAnalyser::visit(Binop &binop)
       buf << "with '" << rhs << "'";
       bpftrace_.error(err_, binop.loc, buf.str());
     }
+    // Follow what C does
+    else if (lhs == Type::integer && rhs == Type::integer) {
+      auto &left = binop.left;
+      auto &right = binop.right;
+      if (lsign != rsign) {
+        // In case of:
+        //
+        // unsigned int a;
+        // if (a > 10) ...;
+        //
+        // No warning should be emitted as we know that 10 can be
+        // represented as unsigned int
+        if (lsign && !rsign && left->is_literal &&
+            (static_cast<ast::Integer*>(binop.left))->n >= 0) {
+          left->type.is_signed = lsign = false;
 
+        }
+        // The reverse (10 < a) should also hold
+        else if (!lsign && rsign && right->is_literal &&
+            (static_cast<ast::Integer*>(binop.right))->n >= 0) {
+          right->type.is_signed = rsign = false;
+        }
+        else {
+          switch (binop.op) {
+          case bpftrace::Parser::token::EQ:
+          case bpftrace::Parser::token::NE:
+          case bpftrace::Parser::token::LE:
+          case bpftrace::Parser::token::GE:
+          case bpftrace::Parser::token::LT:
+          case bpftrace::Parser::token::GT:
+            buf << "comparison of integers of different signs: '"
+                << binop.left->type << "' and '"
+                << binop.right->type << "'"
+                << " can lead to undefined behavior";
+            bpftrace_.warning(out_, binop.loc, buf.str());
+            break;
+          case bpftrace::Parser::token::PLUS:
+          case bpftrace::Parser::token::MINUS:
+          case bpftrace::Parser::token::MUL:
+          case bpftrace::Parser::token::DIV:
+          case bpftrace::Parser::token::MOD:
+            buf << "arithmetic on integers of different signs: '"
+                << left->type << "' and '" << right->type << "'"
+                << " can lead to undefined behavior";
+            bpftrace_.warning(out_, binop.loc, buf.str());
+            break;
+          default:
+            break;
+          }
+        }
+      }
+    }
     else if (lhs != Type::integer
              && binop.op != Parser::token::EQ
              && binop.op != Parser::token::NE) {
@@ -697,7 +766,17 @@ void SemanticAnalyser::visit(Binop &binop)
     }
   }
 
-  binop.type = SizedType(Type::integer, 8);
+  bool is_signed = lsign && rsign;
+  switch (binop.op) {
+    case bpftrace::Parser::token::LEFT:
+    case bpftrace::Parser::token::RIGHT:
+      is_signed = lsign;
+      break;
+    default:
+      break;
+  }
+
+  binop.type = SizedType(Type::integer, 8, is_signed);
 }
 
 void SemanticAnalyser::visit(Unop &unop)
@@ -712,7 +791,7 @@ void SemanticAnalyser::visit(Unop &unop)
     }
     if (unop.expr->is_map) {
       Map &map = static_cast<Map&>(*unop.expr);
-      assign_map_type(map, SizedType(Type::integer, 8));
+      assign_map_type(map, SizedType(Type::integer, 8, true));
     }
   }
 
@@ -743,11 +822,14 @@ void SemanticAnalyser::visit(Unop &unop)
       }
     }
     else if (type.type == Type::integer) {
-      unop.type = SizedType(Type::integer, type.size);
+      unop.type = SizedType(Type::integer, type.size, type.is_signed);
     }
   }
+  else if (unop.op == Parser::token::LNOT) {
+    unop.type = SizedType(Type::integer, type.size, false);
+  }
   else {
-    unop.type = SizedType(Type::integer, 8);
+    unop.type = SizedType(Type::integer, 8, type.is_signed);
   }
 }
 
@@ -768,7 +850,7 @@ void SemanticAnalyser::visit(Ternary &ternary)
   if (lhs == Type::string)
     ternary.type = SizedType(lhs, STRING_SIZE);
   else if (lhs == Type::integer)
-    ternary.type = SizedType(lhs, 8);
+    ternary.type = SizedType(lhs, 8, ternary.left->type.is_signed);
   else {
     err_ << "Ternary return type unsupported " << lhs << std::endl;
   }

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -17,7 +17,8 @@ public:
   explicit SemanticAnalyser(Node *root, BPFtrace &bpftrace, std::ostream &out = std::cerr)
     : root_(root),
       bpftrace_(bpftrace),
-      out_(out) { }
+      out_(out)
+      { }
 
   void visit(Integer &integer) override;
   void visit(PositionalParameter &param) override;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1806,7 +1806,15 @@ const std::string BPFtrace::get_source_line(unsigned int n)
   return buf;
 }
 
-void BPFtrace::error(std::ostream &out, const location &l, const std::string &m)
+void BPFtrace::warning(std::ostream &out, const location &l, const std::string &m) {
+  log_with_location("WARNING", out, l, m);
+    }
+
+void BPFtrace::error(std::ostream &out, const location &l, const std::string &m) {
+  log_with_location("ERROR", out, l, m);
+}
+
+void BPFtrace::log_with_location(std::string level, std::ostream &out, const location &l, const std::string &m)
 {
   if (filename_ != "") {
     out << filename_ << ":";
@@ -1814,13 +1822,13 @@ void BPFtrace::error(std::ostream &out, const location &l, const std::string &m)
 
   // print only the message if location info wasn't set
   if (l.begin.line == 0) {
-    out << "ERROR: " << m << std::endl;
+    out << level << ": " << m << std::endl;
     return;
   }
 
   if (l.begin.line > l.end.line) {
     out << "BUG: begin > end: " << l.begin << ":" << l.end << std::endl;
-    out << "ERROR: " << m << std::endl;
+    out << level << ": " << m << std::endl;
     return;
   }
 
@@ -1846,7 +1854,7 @@ void BPFtrace::error(std::ostream &out, const location &l, const std::string &m)
             ~~~~~~~~~~
   */
   out << l.begin.line << ":" << l.begin.column << "-" << l.end.column;
-  out << ": ERROR: " << m << std::endl;
+  out << ": " << level << ": " << m << std::endl;
   std::string srcline = get_source_line(l.begin.line - 1);
 
   if (srcline == "")

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1217,7 +1217,7 @@ int BPFtrace::print_map_stats(IMap &map)
   }
   auto key(old_key);
 
-  std::map<std::vector<uint8_t>, std::vector<uint64_t>> values_by_key;
+  std::map<std::vector<uint8_t>, std::vector<int64_t>> values_by_key;
 
   while (bpf_get_next_key(map.mapfd_, old_key.data(), key.data()) == 0)
   {
@@ -1245,22 +1245,21 @@ int BPFtrace::print_map_stats(IMap &map)
     if (values_by_key.find(key_prefix) == values_by_key.end())
     {
       // New key - create a list of buckets for it
-      values_by_key[key_prefix] = std::vector<uint64_t>(2);
+      values_by_key[key_prefix] = std::vector<int64_t>(2);
     }
-    // TODO: check
-    values_by_key[key_prefix].at(bucket) = reduce_value<uint64_t>(value, ncpus_);
+    values_by_key[key_prefix].at(bucket) = reduce_value<int64_t>(value, ncpus_);
 
     old_key = key;
   }
 
   // Sort based on sum of counts in all buckets
-  std::vector<std::pair<std::vector<uint8_t>, uint64_t>> total_counts_by_key;
+  std::vector<std::pair<std::vector<uint8_t>, int64_t>> total_counts_by_key;
   for (auto &map_elem : values_by_key)
   {
     assert(map_elem.second.size() == 2);
-    uint64_t count = map_elem.second.at(0);
-    uint64_t total = map_elem.second.at(1);
-    uint64_t value = 0;
+    int64_t count = map_elem.second.at(0);
+    int64_t total = map_elem.second.at(1);
+    int64_t value = 0;
 
     if (count != 0)
       value = total / count;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -103,6 +103,8 @@ public:
   size_t num_params() const;
   void request_finalize();
   void error(std::ostream &out, const location &l, const std::string &m);
+  void warning(std::ostream &out, const location &l, const std::string &m);
+  void log_with_location(std::string, std::ostream &, const location &, const std::string &);
 
   std::string cmd_;
   int pid_{0};

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -184,7 +184,7 @@ private:
   int print_map_stats(IMap &map);
   int print_hist(const std::vector<uint64_t> &values, uint32_t div) const;
   int print_lhist(const std::vector<uint64_t> &values, int min, int max, int step) const;
-  static uint64_t reduce_value(const std::vector<uint8_t> &value, int ncpus);
+  template <typename T> static T reduce_value(const std::vector<uint8_t> &value, int ncpus);
   static int64_t min_value(const std::vector<uint8_t> &value, int ncpus);
   static uint64_t max_value(const std::vector<uint8_t> &value, int ncpus);
   static uint64_t read_address_from_output(std::string output);

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -182,21 +182,22 @@ static SizedType get_sized_type(CXType clang_type)
   switch (clang_type.kind)
   {
     case CXType_Bool:
-    case CXType_Char_S:
     case CXType_Char_U:
-    case CXType_SChar:
     case CXType_UChar:
-    case CXType_Short:
     case CXType_UShort:
-    case CXType_Int:
     case CXType_UInt:
-    case CXType_Long:
     case CXType_ULong:
-    case CXType_LongLong:
     case CXType_ULongLong:
       return SizedType(Type::integer, size);
     case CXType_Record:
       return SizedType(Type::cast, size, typestr);
+    case CXType_Char_S:
+    case CXType_SChar:
+    case CXType_Short:
+    case CXType_Long:
+    case CXType_LongLong:
+    case CXType_Int:
+      return SizedType(Type::integer, size, true);
     case CXType_Pointer:
     {
       auto pointee_type = clang_getPointeeType(clang_type);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -362,7 +362,7 @@ int main(int argc, char *argv[])
 
   if (!get_uint64_env_var("BPFTRACE_MAX_PROBES", bpftrace.max_probes_))
     return 1;
-	
+
   if (!get_uint64_env_var("BPFTRACE_LOG_SIZE", bpftrace.log_size_))
     return 1;
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -260,8 +260,8 @@ void TextOutput::map_hist(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t 
 }
 
 void TextOutput::map_stats(BPFtrace &bpftrace, IMap &map,
-                           const std::map<std::vector<uint8_t>, std::vector<uint64_t>> &values_by_key,
-                           const std::vector<std::pair<std::vector<uint8_t>, uint64_t>> &total_counts_by_key) const
+                           const std::map<std::vector<uint8_t>, std::vector<int64_t>> &values_by_key,
+                           const std::vector<std::pair<std::vector<uint8_t>, int64_t>> &total_counts_by_key) const
 {
   for (auto &key_count : total_counts_by_key)
   {
@@ -269,9 +269,9 @@ void TextOutput::map_stats(BPFtrace &bpftrace, IMap &map,
     auto &value = values_by_key.at(key);
     out_ << map.name_ << map.key_.argument_value_list_str(bpftrace, key) << ": ";
 
-    uint64_t count = value.at(0);
-    uint64_t total = value.at(1);
-    uint64_t average = 0;
+    int64_t count = (int64_t)value.at(0);
+    int64_t total = value.at(1);
+    int64_t average = 0;
 
     if (count != 0)
       average = total / count;
@@ -506,8 +506,8 @@ void JsonOutput::map_hist(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t 
 }
 
 void JsonOutput::map_stats(BPFtrace &bpftrace, IMap &map,
-                           const std::map<std::vector<uint8_t>, std::vector<uint64_t>> &values_by_key,
-                           const std::vector<std::pair<std::vector<uint8_t>, uint64_t>> &total_counts_by_key) const
+                           const std::map<std::vector<uint8_t>, std::vector<int64_t>> &values_by_key,
+                           const std::vector<std::pair<std::vector<uint8_t>, int64_t>> &total_counts_by_key) const
 {
   if (total_counts_by_key.empty())
     return;
@@ -531,8 +531,8 @@ void JsonOutput::map_stats(BPFtrace &bpftrace, IMap &map,
     }
 
     uint64_t count = value.at(0);
-    uint64_t total = value.at(1);
-    uint64_t average = 0;
+    int64_t total = value.at(1);
+    int64_t average = 0;
 
     if (count != 0)
       average = total / count;

--- a/src/output.h
+++ b/src/output.h
@@ -42,8 +42,8 @@ public:
                         const std::map<std::vector<uint8_t>, std::vector<uint64_t>> &values_by_key,
                         const std::vector<std::pair<std::vector<uint8_t>, uint64_t>> &total_counts_by_key) const = 0;
   virtual void map_stats(BPFtrace &bpftrace, IMap &map,
-                         const std::map<std::vector<uint8_t>, std::vector<uint64_t>> &values_by_key,
-                         const std::vector<std::pair<std::vector<uint8_t>, uint64_t>> &total_counts_by_key) const = 0;
+                         const std::map<std::vector<uint8_t>, std::vector<int64_t>> &values_by_key,
+                         const std::vector<std::pair<std::vector<uint8_t>, int64_t>> &total_counts_by_key) const = 0;
 
   virtual void message(MessageType type, const std::string& msg, bool nl = true) const = 0;
   virtual void lost_events(uint64_t lost) const = 0;
@@ -66,8 +66,8 @@ public:
                 const std::map<std::vector<uint8_t>, std::vector<uint64_t>> &values_by_key,
                 const std::vector<std::pair<std::vector<uint8_t>, uint64_t>> &total_counts_by_key) const override;
   void map_stats(BPFtrace &bpftrace, IMap &map,
-                 const std::map<std::vector<uint8_t>, std::vector<uint64_t>> &values_by_key,
-                 const std::vector<std::pair<std::vector<uint8_t>, uint64_t>> &total_counts_by_key) const override;
+                 const std::map<std::vector<uint8_t>, std::vector<int64_t>> &values_by_key,
+                 const std::vector<std::pair<std::vector<uint8_t>, int64_t>> &total_counts_by_key) const override;
 
   void message(MessageType type, const std::string& msg, bool nl = true) const override;
   void lost_events(uint64_t lost) const override;
@@ -90,8 +90,8 @@ public:
                 const std::map<std::vector<uint8_t>, std::vector<uint64_t>> &values_by_key,
                 const std::vector<std::pair<std::vector<uint8_t>, uint64_t>> &total_counts_by_key) const override;
   void map_stats(BPFtrace &bpftrace, IMap &map,
-                 const std::map<std::vector<uint8_t>, std::vector<uint64_t>> &values_by_key,
-                 const std::vector<std::pair<std::vector<uint8_t>, uint64_t>> &total_counts_by_key) const override;
+                 const std::map<std::vector<uint8_t>, std::vector<int64_t>> &values_by_key,
+                 const std::vector<std::pair<std::vector<uint8_t>, int64_t>> &total_counts_by_key) const override;
 
   void message(MessageType type, const std::string& msg, bool nl = true) const override;
   void message(MessageType type, const std::string& field, uint64_t value) const;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -17,18 +17,24 @@ std::ostream &operator<<(std::ostream &os, const SizedType &type)
   {
     os << type.cast_type;
   }
+  else if (type.type == Type::integer)
+  {
+    os << (type.is_signed ? "" : "unsigned ") << "int" << 8*type.size;
+  }
   else
   {
     os << type.type;
   }
+
   if (type.is_pointer)
     os << "*";
+
   return os;
 }
 
 bool SizedType::operator==(const SizedType &t) const
 {
-  return type == t.type && size == t.size;
+  return type == t.type && size == t.size && is_signed == t.is_signed;
 }
 
 bool SizedType::IsArray() const

--- a/src/types.h
+++ b/src/types.h
@@ -62,8 +62,11 @@ class SizedType
 {
 public:
   SizedType() : type(Type::none), size(0) { }
+ SizedType(Type type, size_t size_, bool is_signed, const std::string &cast_type = "")
+    : type(type), size(size_), is_signed(is_signed), cast_type(cast_type) { }
   SizedType(Type type, size_t size_, const std::string &cast_type = "")
     : type(type), size(size_), cast_type(cast_type) { }
+
   SizedType(Type type, StackType stack_type_)
     : SizedType(type, 8) {
     stack_type = stack_type_;
@@ -72,6 +75,7 @@ public:
   Type elem_type; // Array element type if accessing elements of an array
   size_t size;
   StackType stack_type;
+  bool is_signed = false;
   std::string cast_type;
   bool is_internal = false;
   bool is_pointer = false;

--- a/tests/codegen/comparison_extend.cpp
+++ b/tests/codegen/comparison_extend.cpp
@@ -1,0 +1,50 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, comparison_extend)
+{
+  // Make sure i1 is zero extended
+  test("kprobe:f { @ = 1 < arg0 }",
+
+R"EXPECTED(; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:f_1" {
+entry:
+  %"@_val" = alloca i64, align 8
+  %"@_key" = alloca i64, align 8
+  %1 = getelementptr i8, i8* %0, i64 112
+  %arg0 = load i64, i8* %1, align 8
+  %2 = icmp ugt i64 %arg0, 1
+  %3 = zext i1 %2 to i64
+  %4 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 0, i64* %"@_key", align 8
+  %5 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  store i64 %3, i64* %"@_val", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/struct_char.cpp
+++ b/tests/codegen/struct_char.cpp
@@ -33,7 +33,7 @@ entry:
   %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
-  %5 = zext i8 %3 to i64
+  %5 = sext i8 %3 to i64
   %6 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %5, i64* %"@x_val", align 8
@@ -79,7 +79,7 @@ entry:
   %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
-  %5 = zext i8 %3 to i64
+  %5 = sext i8 %3 to i64
   %6 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %5, i64* %"@x_val", align 8
@@ -127,7 +127,7 @@ entry:
   %2 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
-  %3 = zext i8 %1 to i64
+  %3 = sext i8 %1 to i64
   %4 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %3, i64* %"@x_val", align 8

--- a/tests/codegen/struct_integers.cpp
+++ b/tests/codegen/struct_integers.cpp
@@ -34,7 +34,7 @@ entry:
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@x_key", align 8
-  %6 = zext i32 %4 to i64
+  %6 = sext i32 %4 to i64
   %7 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %6, i64* %"@x_val", align 8
@@ -82,7 +82,7 @@ entry:
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@x_key", align 8
-  %6 = zext i32 %4 to i64
+  %6 = sext i32 %4 to i64
   %7 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %6, i64* %"@x_val", align 8
@@ -132,7 +132,7 @@ entry:
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
-  %4 = zext i32 %2 to i64
+  %4 = sext i32 %2 to i64
   %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %4, i64* %"@x_val", align 8

--- a/tests/codegen/struct_nested_struct_anon.cpp
+++ b/tests/codegen/struct_nested_struct_anon.cpp
@@ -35,7 +35,7 @@ entry:
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@x_key", align 8
-  %6 = zext i32 %4 to i64
+  %6 = sext i32 %4 to i64
   %7 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %6, i64* %"@x_val", align 8
@@ -83,7 +83,7 @@ entry:
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@x_key", align 8
-  %6 = zext i32 %4 to i64
+  %6 = sext i32 %4 to i64
   %7 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %6, i64* %"@x_val", align 8
@@ -132,7 +132,7 @@ entry:
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
-  %4 = zext i32 %2 to i64
+  %4 = sext i32 %2 to i64
   %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %4, i64* %"@x_val", align 8

--- a/tests/codegen/struct_nested_struct_named.cpp
+++ b/tests/codegen/struct_nested_struct_named.cpp
@@ -34,7 +34,7 @@ entry:
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@x_key", align 8
-  %6 = zext i32 %4 to i64
+  %6 = sext i32 %4 to i64
   %7 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %6, i64* %"@x_val", align 8
@@ -82,7 +82,7 @@ entry:
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@x_key", align 8
-  %6 = zext i32 %4 to i64
+  %6 = sext i32 %4 to i64
   %7 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %6, i64* %"@x_val", align 8
@@ -131,7 +131,7 @@ entry:
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
-  %4 = zext i32 %2 to i64
+  %4 = sext i32 %2 to i64
   %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %4, i64* %"@x_val", align 8

--- a/tests/codegen/struct_nested_struct_ptr_named.cpp
+++ b/tests/codegen/struct_nested_struct_ptr_named.cpp
@@ -40,7 +40,7 @@ entry:
   %7 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 0, i64* %"@x_key", align 8
-  %8 = zext i32 %6 to i64
+  %8 = sext i32 %6 to i64
   %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 %8, i64* %"@x_val", align 8
@@ -94,7 +94,7 @@ entry:
   %7 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 0, i64* %"@x_key", align 8
-  %8 = zext i32 %6 to i64
+  %8 = sext i32 %6 to i64
   %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 %8, i64* %"@x_val", align 8
@@ -149,7 +149,7 @@ entry:
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@x_key", align 8
-  %6 = zext i32 %4 to i64
+  %6 = sext i32 %4 to i64
   %7 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %6, i64* %"@x_val", align 8

--- a/tests/codegen/struct_save_nested.cpp
+++ b/tests/codegen/struct_save_nested.cpp
@@ -72,7 +72,8 @@ lookup_success8:                                  ; preds = %lookup_merge
   %lookup_elem_val11.sroa.3.0.lookup_elem7.sroa_idx = getelementptr inbounds i8, i8* %lookup_elem7, i64 4
   %lookup_elem_val11.sroa.3.0.lookup_elem7.sroa_cast = bitcast i8* %lookup_elem_val11.sroa.3.0.lookup_elem7.sroa_idx to i64*
   %lookup_elem_val11.sroa.3.0.copyload = load i64, i64* %lookup_elem_val11.sroa.3.0.lookup_elem7.sroa_cast, align 1
-  %phitmp17 = and i64 %lookup_elem_val11.sroa.3.0.copyload, 4294967295
+  %sext = shl i64 %lookup_elem_val11.sroa.3.0.copyload, 32
+  %phitmp17 = ashr exact i64 %sext, 32
   br label %lookup_merge10
 
 lookup_merge10:                                   ; preds = %lookup_merge, %lookup_success8

--- a/tests/codegen/struct_short.cpp
+++ b/tests/codegen/struct_short.cpp
@@ -34,7 +34,7 @@ entry:
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@x_key", align 8
-  %6 = zext i16 %4 to i64
+  %6 = sext i16 %4 to i64
   %7 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %6, i64* %"@x_val", align 8
@@ -82,7 +82,7 @@ entry:
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@x_key", align 8
-  %6 = zext i16 %4 to i64
+  %6 = sext i16 %4 to i64
   %7 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %6, i64* %"@x_val", align 8
@@ -131,7 +131,7 @@ entry:
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
-  %4 = zext i16 %2 to i64
+  %4 = sext i16 %2 to i64
   %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %4, i64* %"@x_val", align 8

--- a/tests/runtime/signed_ints
+++ b/tests/runtime/signed_ints
@@ -1,0 +1,29 @@
+NAME stats with negative values
+RUN bpftrace -e 'BEGIN { @=stats(-10); @=stats(-5); @=stats(5); exit() }'
+EXPECT ^@:\scount\s3,\saverage\s-3+,\stotal\s-10$
+TIMEOUT 5
+
+NAME avg with negative values
+RUN bpftrace -e 'BEGIN { @=avg(-30); @=avg(-10); exit(); }'
+EXPECT ^@:\s-20$
+TIMEOUT 5
+
+NAME negative map value
+RUN bpftrace -e 'BEGIN { @ = -11; exit(); }'
+EXPECT @: -11$
+TIMEOUT 1
+
+NAME sum negative maps
+RUN bpftrace -e 'BEGIN { @ = -11; @+=@; exit() }'
+EXPECT @: -22$
+TIMEOUT 1
+
+NAME Comparison should print as 0 or 1
+RUN bpftrace -e 'struct x { uint64_t x; }; BEGIN { $a = ((x)0).x; printf("%d %d\n", $a > -1, $a < 1); exit(); }'
+EXPECT ^0 1$
+TIMEOUT 1
+
+NAME sum with negative value
+RUN bpftrace -e 'BEGIN { @=sum(10); @=sum(-20); exit(); }'
+EXPECT ^@: -10$
+TIMEOUT 1


### PR DESCRIPTION
While working on #554 / #772 I realised that most of the work I was doing was adding signed integer support to the language so that the casts and printing make sense. My cast implementation is only a few lines of code. As int casts and signed ints are related but different things I decided to split this parts into a new MR.

Opening this now to get some feedback on the approach. So far it seems to work quite well with only minor modifications to  clang struct tests.

Example:

```
$ sudo bpftrace -e 'kr:sock_recvmsg { @=sum(-11); }'

@: -22

$ sudo bpftrace -e  'BEGIN { @[10]=-10; @[0]=10; @[5]=0; @[-10]=100; exit() }'

@[10]: -10
@[5]: 0
@[0]: 10
@[-10]: 100
```

----

Add signed types

bpftrace currently has a somewhat confusing mix of signed and unsinged
integers throughout the codebase. As an example, we can assign a
negative as map value but the printer will see it as unsigned[1].

This change introduces signed integer types by adding a new `is_signed`
attribute to the `SizedType` which is implemented throughout the
codebase with the exception of the trace point parser, which will be
done in a future version.

With this change all integer literals are signed by default as negative
numbers are already supported. If there is a need for 64 bits unsigned
ints it should be easy to add.

This does not try to be smart about signed and unsigned binops, instead
if prints a warning if the types do not match on both sides. I did not
want to introduce additional complexity without having a good reason to
do so.

[1]
```
sudo bpftrace_stable -e  'BEGIN { @[10]=-10; @[0]=10; @[5]=0; @[-10]=100; exit() }'

Program
 BEGIN
  =
   map: @
    int: 10
   int: -10
[..]
    call: exit

@[5]: 0
@[0]: 10
@[-10]: 100
@[10]: 18446744073709551606
```
