### PR TITLE
Fix failing test

### DIFF
--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -46,8 +46,8 @@ EXPECT ok_system
 TIMEOUT 5
 
 NAME count
-RUN bpftrace -v -e 'i:ms:100 { @[sym(reg("ip"))] = count(); exit();}'
-EXPECT @\[[0-9]*\]\:\s[0-9]*
+RUN bpftrace -v -e 'i:ms:100 { @ = count(); exit();}'
+EXPECT @:\s[0-9]+
 TIMEOUT 5
 
 NAME sum


### PR DESCRIPTION
The merge of #739 broke this test*. As this is a `count` test, not a
`sym` test (which is also deprecated) the sym can be dropped and the
test simplified.

* It now correctly reads the IP which makes `sym` translate the address,
translating `0` return 0.