### PR TITLE
codegen: ensure logical OR and AND works with non-64-bit integers

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1518,7 +1518,7 @@ Value *CodegenLLVM::createLogicalAnd(Binop &binop)
   Value *lhs;
   binop.left->accept(*this);
   lhs = expr_;
-  b_.CreateCondBr(b_.CreateICmpNE(lhs, b_.getInt64(0), "lhs_true_cond"),
+  b_.CreateCondBr(b_.CreateICmpNE(lhs, b_.GetIntSameSize(0, lhs), "lhs_true_cond"),
                   lhs_true_block,
                   false_block);
 
@@ -1526,7 +1526,7 @@ Value *CodegenLLVM::createLogicalAnd(Binop &binop)
   Value *rhs;
   binop.right->accept(*this);
   rhs = expr_;
-  b_.CreateCondBr(b_.CreateICmpNE(rhs, b_.getInt64(0), "rhs_true_cond"),
+  b_.CreateCondBr(b_.CreateICmpNE(rhs, b_.GetIntSameSize(0, rhs), "rhs_true_cond"),
                   true_block,
                   false_block);
 
@@ -1557,7 +1557,7 @@ Value *CodegenLLVM::createLogicalOr(Binop &binop)
   Value *lhs;
   binop.left->accept(*this);
   lhs = expr_;
-  b_.CreateCondBr(b_.CreateICmpNE(lhs, b_.getInt64(0), "lhs_true_cond"),
+  b_.CreateCondBr(b_.CreateICmpNE(lhs, b_.GetIntSameSize(0, lhs), "lhs_true_cond"),
                   true_block,
                   lhs_false_block);
 
@@ -1565,7 +1565,7 @@ Value *CodegenLLVM::createLogicalOr(Binop &binop)
   Value *rhs;
   binop.right->accept(*this);
   rhs = expr_;
-  b_.CreateCondBr(b_.CreateICmpNE(rhs, b_.getInt64(0), "rhs_true_cond"),
+  b_.CreateCondBr(b_.CreateICmpNE(rhs, b_.GetIntSameSize(0, rhs), "rhs_true_cond"),
                   true_block,
                   false_block);
 

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -99,6 +99,12 @@ AllocaInst *IRBuilderBPF::CreateAllocaBPF(int bytes, const std::string &name)
   return CreateAllocaBPF(ty, name);
 }
 
+llvm::ConstantInt *IRBuilderBPF::GetIntSameSize(uint64_t C, llvm::Value *expr)
+{
+  unsigned size = expr->getType()->getIntegerBitWidth();
+  return getIntN(size, C);
+}
+
 llvm::Type *IRBuilderBPF::GetType(const SizedType &stype)
 {
   llvm::Type *ty;

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -35,6 +35,7 @@ public:
   AllocaInst *CreateAllocaBPF(const SizedType &stype, llvm::Value *arraysize, const std::string &name="");
   AllocaInst *CreateAllocaBPF(int bytes, const std::string &name="");
   llvm::Type *GetType(const SizedType &stype);
+  llvm::ConstantInt *GetIntSameSize(uint64_t C, llvm::Value *expr);
   CallInst   *CreateBpfPseudoCall(int mapfd);
   CallInst   *CreateBpfPseudoCall(Map &map);
   Value      *CreateMapLookupElem(Map &map, AllocaInst *key);

--- a/tests/codegen/logical_and_or_different_type.cpp
+++ b/tests/codegen/logical_and_or_different_type.cpp
@@ -1,0 +1,171 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, logical_and_or_different_type)
+{
+  test("struct Foo { int m; } BEGIN { $foo = (struct Foo)0; printf(\"%d %d %d %d\", $foo.m && 0, 1 && $foo.m, $foo.m || 0, 0 || $foo.m); }",
+
+#if LLVM_VERSION_MAJOR > 6
+R"EXPECTED(%printf_t = type { i64, i64, i64, i64, i64 }
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @BEGIN(i8*) local_unnamed_addr section "s_BEGIN_1" {
+entry:
+  %Foo.m16 = alloca i32, align 4
+  %Foo.m8 = alloca i32, align 4
+  %Foo.m6 = alloca i32, align 4
+  %Foo.m = alloca i32, align 4
+  %printf_args = alloca %printf_t, align 8
+  %"$foo" = alloca i32, align 4
+  %tmpcast = bitcast i32* %"$foo" to [4 x i8]*
+  %1 = bitcast i32* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %1, i64 0, i64 4, i1 false)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  %2 = load i32, i32 addrspace(64)* null, align 536870912
+  store i32 %2, i32* %"$foo", align 4
+  %3 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %4 = bitcast i32* %Foo.m to i8*
+  %5 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
+  store i64 0, i64* %5, align 8
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m, i64 4, [4 x i8]* nonnull %tmpcast)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  %6 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
+  store i64 0, i64* %6, align 8
+  %7 = bitcast i32* %Foo.m6 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
+  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m6, i64 4, [4 x i8]* nonnull %tmpcast)
+  %8 = load i32, i32* %Foo.m6, align 4
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  %rhs_true_cond = icmp ne i32 %8, 0
+  %"&&_result5.0" = zext i1 %rhs_true_cond to i64
+  %9 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2
+  store i64 %"&&_result5.0", i64* %9, align 8
+  %10 = bitcast i32* %Foo.m8 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
+  %probe_read9 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m8, i64 4, [4 x i8]* nonnull %tmpcast)
+  %11 = load i32, i32* %Foo.m8, align 4
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
+  %lhs_true_cond10 = icmp ne i32 %11, 0
+  %"||_result.0" = zext i1 %lhs_true_cond10 to i64
+  %12 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 3
+  store i64 %"||_result.0", i64* %12, align 8
+  %13 = bitcast i32* %Foo.m16 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %13)
+  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m16, i64 4, [4 x i8]* nonnull %tmpcast)
+  %14 = load i32, i32* %Foo.m16, align 4
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %13)
+  %rhs_true_cond18 = icmp ne i32 %14, 0
+  %"||_result15.0" = zext i1 %rhs_true_cond18 to i64
+  %15 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 4
+  store i64 %"||_result15.0", i64* %15, align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 40)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+#else
+R"EXPECTED(%printf_t = type { i64, i64, i64, i64, i64 }
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @BEGIN(i8*) local_unnamed_addr section "s_BEGIN_1" {
+entry:
+  %Foo.m16 = alloca i32, align 4
+  %Foo.m8 = alloca i32, align 4
+  %Foo.m6 = alloca i32, align 4
+  %Foo.m = alloca i32, align 4
+  %printf_args = alloca %printf_t, align 8
+  %"$foo" = alloca i32, align 4
+  %tmpcast = bitcast i32* %"$foo" to [4 x i8]*
+  %1 = bitcast i32* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.memset.p0i8.i64(i8* nonnull %1, i64 0, i64 4, i32 4, i1 false)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  %2 = load i32, i32 addrspace(64)* null, align 536870912
+  store i32 %2, i32* %"$foo", align 4
+  %3 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %4 = bitcast i32* %Foo.m to i8*
+  %5 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
+  store i64 0, i64* %5, align 8
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m, i64 4, [4 x i8]* nonnull %tmpcast)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  %6 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
+  store i64 0, i64* %6, align 8
+  %7 = bitcast i32* %Foo.m6 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
+  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m6, i64 4, [4 x i8]* nonnull %tmpcast)
+  %8 = load i32, i32* %Foo.m6, align 4
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  %rhs_true_cond = icmp ne i32 %8, 0
+  %"&&_result5.0" = zext i1 %rhs_true_cond to i64
+  %9 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2
+  store i64 %"&&_result5.0", i64* %9, align 8
+  %10 = bitcast i32* %Foo.m8 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
+  %probe_read9 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m8, i64 4, [4 x i8]* nonnull %tmpcast)
+  %11 = load i32, i32* %Foo.m8, align 4
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
+  %lhs_true_cond10 = icmp ne i32 %11, 0
+  %"||_result.0" = zext i1 %lhs_true_cond10 to i64
+  %12 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 3
+  store i64 %"||_result.0", i64* %12, align 8
+  %13 = bitcast i32* %Foo.m16 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %13)
+  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m16, i64 4, [4 x i8]* nonnull %tmpcast)
+  %14 = load i32, i32* %Foo.m16, align 4
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %13)
+  %rhs_true_cond18 = icmp ne i32 %14, 0
+  %"||_result15.0" = zext i1 %rhs_true_cond18 to i64
+  %15 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 4
+  store i64 %"||_result15.0", i64* %15, align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 40)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+#endif
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace
+

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -4,6 +4,12 @@ RUN bpftrace -e 'struct Foo { int m; struct { int x; int y; } bar; int n; } BEGI
 EXPECT done
 TIMEOUT 1
 
+NAME logical_and_or_different_sizes
+RUN bpftrace -v -e 'struct Foo { int m; } uprobe:./testprogs/simple_struct:func { $foo = (struct Foo*)arg0; printf("%d %d %d %d %d\n", $foo->m, $foo->m && 0, 1 && $foo->m, $foo->m || 0, 0 || $foo->m); exit(); }'
+AFTER ./testprogs/simple_struct
+EXPECT 2 0 1 1 1
+TIMEOUT 5
+
 # https://github.com/iovisor/bpftrace/issues/759
 # Update test once https://github.com/iovisor/bpftrace/pull/781 lands
 # NAME ntop_map_printf

--- a/tests/testprogs/simple_struct.c
+++ b/tests/testprogs/simple_struct.c
@@ -1,0 +1,17 @@
+struct Foo
+{
+  int m;
+};
+
+int func(struct Foo *foo)
+{
+  return foo->m;
+}
+
+int main()
+{
+  struct Foo foo;
+  foo.m = 2;
+  func(&foo);
+  return 0;
+}


### PR DESCRIPTION
Ref: https://github.com/iovisor/bpftrace/issues/634