### PR TITLE
Add location info into AST

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -212,11 +212,11 @@ void SemanticAnalyser::visit(Builtin &builtin)
 
 void SemanticAnalyser::visit(Call &call)
 {
+  std::stringstream buf;
   // Check for unsafe-ness first. It is likely the most pertinent issue
   // (and should be at the top) for any function call.
   if (bpftrace_.safe_mode_ && is_unsafe_func(call.func)) {
-    err_ << call.func << "() is an unsafe function being used in safe mode"
-      << std::endl;
+    buf << call.func << "() is an unsafe function being used in safe mode";
   }
 
   if (call.vargs) {
@@ -249,19 +249,19 @@ void SemanticAnalyser::visit(Call &call)
       Integer &max = static_cast<Integer&>(max_arg);
       Integer &step = static_cast<Integer&>(step_arg);
       if (step.n <= 0)
-        err_ << "lhist() step must be >= 1 (" << step.n << " provided)" << std::endl;
+        buf << "lhist() step must be >= 1 (" << step.n << " provided)";
       else
       {
         int buckets = (max.n - min.n) / step.n;
         if (buckets > 1000)
-          err_ << "lhist() too many buckets, must be <= 1000 (would need " << buckets << ")" << std::endl;
+          buf << "lhist() too many buckets, must be <= 1000 (would need " << buckets << ")";
       }
       if (min.n < 0)
-        err_ << "lhist() min must be non-negative (provided min " << min.n << ")" << std::endl;
+        buf << "lhist() min must be non-negative (provided min " << min.n << ")";
       if (min.n > max.n)
-        err_ << "lhist() min must be less than max (provided min " << min.n << " and max " << max.n << ")" << std::endl;
+        buf << "lhist() min must be less than max (provided min " << min.n << " and max ";
       if ((max.n - min.n) < step.n)
-        err_ << "lhist() step is too large for the given range (provided step " << step.n << " for range " << (max.n - min.n) << ")" << std::endl;
+        buf << "lhist() step is too large for the given range (provided step " << step.n << " for range " << (max.n - min.n) << ")";
 
       // store args for later passing to bpftrace::Map
       auto search = map_args_.find(call.map->ident);
@@ -311,7 +311,7 @@ void SemanticAnalyser::visit(Call &call)
     if (check_nargs(call, 1)) {
       auto &arg = *call.vargs->at(0);
       if (!arg.is_map)
-        err_ << "delete() expects a map to be provided" << std::endl;
+        buf << "delete() expects a map to be provided";
     }
 
     call.type = SizedType(Type::none, 0);
@@ -333,7 +333,7 @@ void SemanticAnalyser::visit(Call &call)
       // allow symbol lookups on casts (eg, function pointers)
       auto &arg = *call.vargs->at(0);
       if (arg.type.type != Type::integer && arg.type.type != Type::cast)
-        err_ << call.func << "() expects an integer or pointer argument" << std::endl;
+        buf << call.func << "() expects an integer or pointer argument";
     }
 
     if (call.func == "ksym")
@@ -352,7 +352,7 @@ void SemanticAnalyser::visit(Call &call)
     }
 
     if (arg->type.type != Type::integer && arg->type.type != Type::array)
-      err_ << call.func << "() expects an integer or array argument, got " << arg->type.type << std::endl;
+      buf << call.func << "() expects an integer or array argument, got " << arg->type.type;
 
     // Kind of:
     //
@@ -366,7 +366,7 @@ void SemanticAnalyser::visit(Call &call)
     int buffer_size = 24;
     if (arg->type.type == Type::array) {
       if (arg->type.elem_type != Type::integer || arg->type.pointee_size != 1 || !(arg->type.size == 4 || arg->type.size == 16)) {
-        err_ << call.func << "() invalid array" << std::endl;
+        buf << call.func << "() invalid array";
       }
     }
     call.type = SizedType(Type::inet, buffer_size);
@@ -396,7 +396,7 @@ void SemanticAnalyser::visit(Call &call)
       for (auto &attach_point : *probe_->attach_points) {
         ProbeType type = probetype(attach_point->provider);
         if (type == ProbeType::tracepoint) {
-          err_ << "The reg function cannot be used with 'tracepoint' probes" << std::endl;
+          buf << "The reg function cannot be used with 'tracepoint' probes";
           continue;
         }
       }
@@ -406,8 +406,8 @@ void SemanticAnalyser::visit(Call &call)
         auto &reg_name = static_cast<String&>(arg).str;
         int offset = arch::offset(reg_name);;
         if (offset == -1) {
-          err_ << "'" << reg_name << "' is not a valid register on this architecture";
-          err_ << " (" << arch::name() << ")" << std::endl;
+          buf << "'" << reg_name << "' is not a valid register on this architecture";
+          buf << " (" << arch::name() << ")";
         }
       }
     }
@@ -450,7 +450,7 @@ void SemanticAnalyser::visit(Call &call)
             ty.size = 8;
           args.push_back({ .type =  ty, .offset = 0 });
         }
-        err_ << verify_format_string(fmt.str, args);
+        buf << verify_format_string(fmt.str, args);
 
         if (call.func == "printf")
           bpftrace_.printf_args_.emplace_back(fmt.str, args);
@@ -471,13 +471,13 @@ void SemanticAnalyser::visit(Call &call)
     if (check_varargs(call, 1, 3)) {
       auto &arg = *call.vargs->at(0);
       if (!arg.is_map)
-        err_ << "print() expects a map to be provided" << std::endl;
+        buf << "print() expects a map to be provided";
       else {
         Map &map = static_cast<Map&>(arg);
         map.skip_key_validation = true;
         if (map.vargs != nullptr) {
-          err_ << "The map passed to " << call.func << "() should not be "
-                  "indexed by a key" << std::endl;
+          buf << "The map passed to " << call.func << "() should not be "
+              << "indexed by a key";
         }
       }
       if (is_final_pass()) {
@@ -493,13 +493,13 @@ void SemanticAnalyser::visit(Call &call)
     if (check_nargs(call, 1)) {
       auto &arg = *call.vargs->at(0);
       if (!arg.is_map)
-        err_ << "clear() expects a map to be provided" << std::endl;
+        buf << "clear() expects a map to be provided";
       else {
         Map &map = static_cast<Map&>(arg);
         map.skip_key_validation = true;
         if (map.vargs != nullptr) {
-          err_ << "The map passed to " << call.func << "() should not be "
-                  "indexed by a key" << std::endl;
+          buf << "The map passed to " << call.func << "() should not be "
+              << "indexed by a key";
         }
       }
     }
@@ -509,13 +509,13 @@ void SemanticAnalyser::visit(Call &call)
     if (check_nargs(call, 1)) {
       auto &arg = *call.vargs->at(0);
       if (!arg.is_map)
-        err_ << "zero() expects a map to be provided" << std::endl;
+        buf << "zero() expects a map to be provided";
       else {
         Map &map = static_cast<Map&>(arg);
         map.skip_key_validation = true;
         if (map.vargs != nullptr) {
-          err_ << "The map passed to " << call.func << "() should not be "
-                  "indexed by a key" << std::endl;
+          buf << "The map passed to " << call.func << "() should not be "
+              << "indexed by a key";
         }
       }
     }
@@ -543,9 +543,13 @@ void SemanticAnalyser::visit(Call &call)
     check_stack_call(call, Type::ustack);
   }
   else {
-    err_ << "Unknown function: '" << call.func << "'" << std::endl;
+    buf << "Unknown function: '" << call.func << "'";
     call.type = SizedType(Type::none, 0);
   }
+
+  std::string err = buf.str();
+  if (err.size() > 0)
+    bpftrace_.error(err_, call.loc, err);
 }
 
 void SemanticAnalyser::check_stack_call(Call &call, Type type) {
@@ -684,7 +688,7 @@ void SemanticAnalyser::visit(Binop &binop)
       buf << "Type mismatch for '" << opstr(binop) << "': ";
       buf << "comparing '" << lhs << "' ";
       buf << "with '" << rhs << "'";
-      bpftrace_.error(err_, binop.loc, buf.str());
+      bpftrace_.error(err_, binop.left->loc + binop.right->loc, buf.str());
     }
 
     else if (lhs != Type::integer
@@ -1261,11 +1265,13 @@ bool SemanticAnalyser::is_final_pass() const
 
 bool SemanticAnalyser::check_assignment(const Call &call, bool want_map, bool want_var)
 {
+  std::stringstream buf;
   if (want_map && want_var)
   {
     if (!call.map && !call.var)
     {
-      err_ << call.func << "() should be assigned to a map or a variable" << std::endl;
+      buf << call.func << "() should be assigned to a map or a variable";
+      bpftrace_.error(err_, call.loc, buf.str());
       return false;
     }
   }
@@ -1273,7 +1279,8 @@ bool SemanticAnalyser::check_assignment(const Call &call, bool want_map, bool wa
   {
     if (!call.map)
     {
-      err_ << call.func << "() should be assigned to a map" << std::endl;
+      buf << call.func << "() should be assigned to a map";
+      bpftrace_.error(err_, call.loc, buf.str());
       return false;
     }
   }
@@ -1281,7 +1288,8 @@ bool SemanticAnalyser::check_assignment(const Call &call, bool want_map, bool wa
   {
     if (!call.var)
     {
-      err_ << call.func << "() should be assigned to a variable" << std::endl;
+      buf << call.func << "() should be assigned to a variable";
+      bpftrace_.error(err_, call.loc, buf.str());
       return false;
     }
   }
@@ -1289,7 +1297,8 @@ bool SemanticAnalyser::check_assignment(const Call &call, bool want_map, bool wa
   {
     if (call.map || call.var)
     {
-      err_ << call.func << "() should not be used in an assignment" << std::endl;
+      buf << call.func << "() should not be used in an assignment";
+      bpftrace_.error(err_, call.loc, buf.str());
       return false;
     }
   }
@@ -1298,14 +1307,22 @@ bool SemanticAnalyser::check_assignment(const Call &call, bool want_map, bool wa
 
 bool SemanticAnalyser::check_nargs(const Call &call, size_t expected_nargs)
 {
+  std::stringstream buf;
   std::vector<Expression*>::size_type nargs = 0;
   if (call.vargs)
     nargs = call.vargs->size();
 
   if (nargs != expected_nargs)
   {
-    err_ << call.func << "() should take " << expected_nargs << " arguments ("; // TODO plural
-    err_ << nargs << " provided)" << std::endl;
+    if (expected_nargs == 0)
+      buf << call.func << "() requires no arguments";
+    else if (expected_nargs == 1)
+      buf << call.func << "() requires one argument";
+    else
+      buf << call.func << "() requires " << expected_nargs << " arguments";
+
+    buf << " (" << nargs << " provided)";
+    bpftrace_.error(err_, call.loc, buf.str());
     return false;
   }
   return true;
@@ -1314,21 +1331,34 @@ bool SemanticAnalyser::check_nargs(const Call &call, size_t expected_nargs)
 bool SemanticAnalyser::check_varargs(const Call &call, size_t min_nargs, size_t max_nargs)
 {
   std::vector<Expression*>::size_type nargs = 0;
+  std::stringstream buf;
   if (call.vargs)
     nargs = call.vargs->size();
 
   if (nargs < min_nargs)
   {
-    err_ << call.func << "() requires at least " << min_nargs << " argument ("; // TODO plural
-    err_ << nargs << " provided)" << std::endl;
+    if (min_nargs == 1)
+      buf << call.func << "() requires at least one argument";
+    else
+      buf << call.func << "() requires at least " << min_nargs << " arguments";
+    buf << " (" << nargs << " provided)";
+    bpftrace_.error(err_, call.loc, buf.str());
     return false;
   }
   else if (nargs > max_nargs)
   {
-    err_ << call.func << "() can only take up to " << max_nargs << " arguments (";
-    err_ << nargs << " provided)" << std::endl;
+    if (max_nargs == 0)
+      buf << call.func << "() requires no arguments";
+    else if (max_nargs == 1)
+      buf << call.func << "() takes up to one argument";
+    else
+      buf << call.func << "() takes up to " << max_nargs << " arguments";
+
+    buf << " (" << nargs << " provided)";
+    bpftrace_.error(err_, call.loc, buf.str());
     return false;
   }
+
   return true;
 }
 
@@ -1337,16 +1367,19 @@ bool SemanticAnalyser::check_arg(const Call &call, Type type, int arg_num, bool 
   if (!call.vargs)
     return false;
 
+  std::stringstream buf;
   auto &arg = *call.vargs->at(arg_num);
   if (want_literal && (!arg.is_literal || arg.type.type != type))
   {
-    err_ << call.func << "() expects a " << type << " literal";
-    err_ << " (" << arg.type.type << " provided)" << std::endl;
+    buf << call.func << "() expects a " << type << " literal";
+    buf << " (" << arg.type.type << " provided)" << std::endl;
+    bpftrace_.error(err_, call.loc, buf.str());
     return false;
   }
   else if (is_final_pass() && arg.type.type != type) {
-    err_ << call.func << "() only supports " << type << " arguments";
-    err_ << " (" << arg.type.type << " provided)" << std::endl;
+    buf << call.func << "() only supports " << type << " arguments";
+    buf << " (" << arg.type.type << " provided)" << std::endl;
+    bpftrace_.error(err_, call.loc, buf.str());
     return false;
   }
   return true;
@@ -1363,8 +1396,10 @@ bool SemanticAnalyser::check_symbol(const Call &call, int arg_num __attribute__(
   bool is_valid = std::regex_match(arg, std::regex(re));
   if (!is_valid)
   {
-    err_ << call.func << "() expects a string that is a valid symbol (" << re << ") as input";
-    err_ << " (\"" << arg << "\" provided)" << std::endl;
+    std::stringstream buf;
+    buf << call.func << "() expects a string that is a valid symbol (" << re << ") as input";
+    buf << " (\"" << arg << "\" provided)";
+    bpftrace_.error(err_, call.loc, buf.str());
     return false;
   }
 

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -162,16 +162,16 @@ attach_points : attach_points "," attach_point { $$ = $1; $1->push_back($3); }
               | attach_point                   { $$ = new ast::AttachPointList; $$->push_back($1); }
               ;
 
-attach_point : ident               { $$ = new ast::AttachPoint($1); }
-             | ident ":" wildcard  { $$ = new ast::AttachPoint($1, $3); }
-             | ident PATH STRING   { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, false); }
-             | ident PATH wildcard { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, true); }
-             | ident PATH INT      { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3); }
-             | ident PATH INT CINT ident  { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, $4, $5); }
-             | ident PATH STRING ":" STRING  { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, $5, false); }
-             | ident PATH STRING ":" wildcard  { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, $5, true); }
-             | ident PATH wildcard ":" STRING  { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, $5, true); }
-             | ident PATH wildcard ":" wildcard  { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, $5, true); }
+attach_point : ident               { $$ = new ast::AttachPoint($1, @$); }
+             | ident ":" wildcard  { $$ = new ast::AttachPoint($1, $3, @$); }
+             | ident PATH STRING   { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, false, @$); }
+             | ident PATH wildcard { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, true, @$); }
+             | ident PATH INT      { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, @$); }
+             | ident PATH INT CINT ident  { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, $4, $5, @$); }
+             | ident PATH STRING ":" STRING  { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, $5, false, @$); }
+             | ident PATH STRING ":" wildcard  { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, $5, true, @$); }
+             | ident PATH wildcard ":" STRING  { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, $5, true, @$); }
+             | ident PATH wildcard ":" wildcard  { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, $5, true, @$); }
              ;
 
 wildcard : wildcard ident    { $$ = $1 + $2; }
@@ -181,15 +181,15 @@ wildcard : wildcard ident    { $$ = $1 + $2; }
          |                   { $$ = ""; }
          ;
 
-pred : DIV expr ENDPRED { $$ = new ast::Predicate($2); }
+pred : DIV expr ENDPRED { $$ = new ast::Predicate($2, @$); }
      |                  { $$ = nullptr; }
      ;
 
-ternary : expr QUES expr COLON expr { $$ = new ast::Ternary($1, $3, $5); }
+ternary : expr QUES expr COLON expr { $$ = new ast::Ternary($1, $3, $5, @$); }
      ;
 
-param : PARAM      { $$ = new ast::PositionalParameter(PositionalParameterType::positional, std::stoll($1.substr(1, $1.size()-1))); }
-      | PARAMCOUNT { $$ = new ast::PositionalParameter(PositionalParameterType::count, 0); }
+param : PARAM      { $$ = new ast::PositionalParameter(PositionalParameterType::positional, std::stoll($1.substr(1, $1.size()-1)), @$); }
+      | PARAMCOUNT { $$ = new ast::PositionalParameter(PositionalParameterType::count, 0, @$); }
       ;
 
 block : "{" stmts "}"     { $$ = $2; }
@@ -211,93 +211,93 @@ block_stmt : IF "(" expr ")" block  { $$ = new ast::If($3, $5); }
 
 stmt : expr                { $$ = new ast::ExprStatement($1); }
      | compound_assignment { $$ = $1; }
-     | map "=" expr        { $$ = new ast::AssignMapStatement($1, $3); }
-     | var "=" expr        { $$ = new ast::AssignVarStatement($1, $3); }
+     | map "=" expr        { $$ = new ast::AssignMapStatement($1, $3, @2); }
+     | var "=" expr        { $$ = new ast::AssignVarStatement($1, $3, @2); }
      ;
 
-compound_assignment : map LEFTASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::LEFT,  $3, @$)); }
-                    | var LEFTASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::LEFT,  $3, @$)); }
-                    | map RIGHTASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::RIGHT,   $3, @$)); }
-                    | var RIGHTASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::RIGHT,   $3, @$)); }
-                    | map PLUSASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::PLUS,  $3, @$)); }
-                    | var PLUSASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::PLUS,  $3, @$)); }
-                    | map MINUSASSIGN expr { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MINUS, $3, @$)); }
-                    | var MINUSASSIGN expr { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MINUS, $3, @$)); }
-                    | map MULASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MUL,   $3, @$)); }
-                    | var MULASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MUL,   $3, @$)); }
-                    | map DIVASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::DIV,   $3, @$)); }
-                    | var DIVASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::DIV,   $3, @$)); }
-                    | map MODASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MOD,   $3, @$)); }
-                    | var MODASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MOD,   $3, @$)); }
-                    | map BANDASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BAND,  $3, @$)); }
-                    | var BANDASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BAND,  $3, @$)); }
-                    | map BORASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BOR,   $3, @$)); }
-                    | var BORASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BOR,   $3, @$)); }
-                    | map BXORASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BXOR,  $3, @$)); }
-                    | var BXORASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BXOR,  $3, @$)); }
+compound_assignment : map LEFTASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::LEFT,  $3, @2)); }
+                    | var LEFTASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::LEFT,  $3, @2)); }
+                    | map RIGHTASSIGN expr { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::RIGHT, $3, @2)); }
+                    | var RIGHTASSIGN expr { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::RIGHT, $3, @2)); }
+                    | map PLUSASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::PLUS,  $3, @2)); }
+                    | var PLUSASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::PLUS,  $3, @2)); }
+                    | map MINUSASSIGN expr { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MINUS, $3, @2)); }
+                    | var MINUSASSIGN expr { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MINUS, $3, @2)); }
+                    | map MULASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MUL,   $3, @2)); }
+                    | var MULASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MUL,   $3, @2)); }
+                    | map DIVASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::DIV,   $3, @2)); }
+                    | var DIVASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::DIV,   $3, @2)); }
+                    | map MODASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MOD,   $3, @2)); }
+                    | var MODASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MOD,   $3, @2)); }
+                    | map BANDASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BAND,  $3, @2)); }
+                    | var BANDASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BAND,  $3, @2)); }
+                    | map BORASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BOR,   $3, @2)); }
+                    | var BORASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BOR,   $3, @2)); }
+                    | map BXORASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BXOR,  $3, @2)); }
+                    | var BXORASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BXOR,  $3, @2)); }
                     ;
 
-int : MINUS INT    { $$ = new ast::Integer(-1 * $2); }
-    | INT          { $$ = new ast::Integer($1); }
+int : MINUS INT    { $$ = new ast::Integer(-1 * $2, @$); }
+    | INT          { $$ = new ast::Integer($1, @$); }
     ;
 
 expr : int             { $$ = $1; }
-     | STRING          { $$ = new ast::String($1); }
-     | BUILTIN         { $$ = new ast::Builtin($1); }
-     | IDENT           { $$ = new ast::Identifier($1); }
-     | STACK_MODE      { $$ = new ast::StackMode($1); }
+     | STRING          { $$ = new ast::String($1, @$); }
+     | BUILTIN         { $$ = new ast::Builtin($1, @$); }
+     | IDENT           { $$ = new ast::Identifier($1, @$); }
+     | STACK_MODE      { $$ = new ast::StackMode($1, @$); }
      | ternary         { $$ = $1; }
      | param           { $$ = $1; }
      | map             { $$ = $1; }
      | var             { $$ = $1; }
      | call            { $$ = $1; }
      | "(" expr ")"    { $$ = $2; }
-     | expr EQ expr    { $$ = new ast::Binop($1, token::EQ, $3, @$); }
-     | expr NE expr    { $$ = new ast::Binop($1, token::NE, $3, @$); }
-     | expr LE expr    { $$ = new ast::Binop($1, token::LE, $3, @$); }
-     | expr GE expr    { $$ = new ast::Binop($1, token::GE, $3, @$); }
-     | expr LT expr    { $$ = new ast::Binop($1, token::LT, $3, @$); }
-     | expr GT expr    { $$ = new ast::Binop($1, token::GT, $3, @$); }
-     | expr LAND expr  { $$ = new ast::Binop($1, token::LAND,  $3, @$); }
-     | expr LOR expr   { $$ = new ast::Binop($1, token::LOR,   $3, @$); }
-     | expr LEFT expr  { $$ = new ast::Binop($1, token::LEFT,  $3, @$); }
-     | expr RIGHT expr { $$ = new ast::Binop($1, token::RIGHT, $3, @$); }
-     | expr PLUS expr  { $$ = new ast::Binop($1, token::PLUS,  $3, @$); }
-     | expr MINUS expr { $$ = new ast::Binop($1, token::MINUS, $3, @$); }
-     | expr MUL expr   { $$ = new ast::Binop($1, token::MUL,   $3, @$); }
-     | expr DIV expr   { $$ = new ast::Binop($1, token::DIV,   $3, @$); }
-     | expr MOD expr   { $$ = new ast::Binop($1, token::MOD,   $3, @$); }
-     | expr BAND expr  { $$ = new ast::Binop($1, token::BAND,  $3, @$); }
-     | expr BOR expr   { $$ = new ast::Binop($1, token::BOR,   $3, @$); }
-     | expr BXOR expr  { $$ = new ast::Binop($1, token::BXOR,  $3, @$); }
-     | LNOT expr       { $$ = new ast::Unop(token::LNOT, $2); }
-     | BNOT expr       { $$ = new ast::Unop(token::BNOT, $2); }
-     | MINUS expr      { $$ = new ast::Unop(token::MINUS, $2); }
-     | expr PLUSPLUS   { $$ = new ast::Unop(token::PLUSPLUS, $1, true); }
-     | expr MINUSMINUS { $$ = new ast::Unop(token::MINUSMINUS, $1, true); }
-     | PLUSPLUS expr   { $$ = new ast::Unop(token::PLUSPLUS, $2); }
-     | MINUSMINUS expr { $$ = new ast::Unop(token::MINUSMINUS, $2); }
-     | MUL  expr %prec DEREF { $$ = new ast::Unop(token::MUL,  $2); }
-     | expr DOT ident  { $$ = new ast::FieldAccess($1, $3); }
-     | expr PTR ident  { $$ = new ast::FieldAccess(new ast::Unop(token::MUL, $1), $3); }
-     | expr "[" expr "]" { $$ = new ast::ArrayAccess($1, $3); }
-     | "(" IDENT ")" expr %prec CAST  { $$ = new ast::Cast($2, false, $4); }
-     | "(" IDENT MUL ")" expr %prec CAST  { $$ = new ast::Cast($2, true, $5); }
+     | expr EQ expr    { $$ = new ast::Binop($1, token::EQ, $3, @2); }
+     | expr NE expr    { $$ = new ast::Binop($1, token::NE, $3, @2); }
+     | expr LE expr    { $$ = new ast::Binop($1, token::LE, $3, @2); }
+     | expr GE expr    { $$ = new ast::Binop($1, token::GE, $3, @2); }
+     | expr LT expr    { $$ = new ast::Binop($1, token::LT, $3, @2); }
+     | expr GT expr    { $$ = new ast::Binop($1, token::GT, $3, @2); }
+     | expr LAND expr  { $$ = new ast::Binop($1, token::LAND,  $3, @2); }
+     | expr LOR expr   { $$ = new ast::Binop($1, token::LOR,   $3, @2); }
+     | expr LEFT expr  { $$ = new ast::Binop($1, token::LEFT,  $3, @2); }
+     | expr RIGHT expr { $$ = new ast::Binop($1, token::RIGHT, $3, @2); }
+     | expr PLUS expr  { $$ = new ast::Binop($1, token::PLUS,  $3, @2); }
+     | expr MINUS expr { $$ = new ast::Binop($1, token::MINUS, $3, @2); }
+     | expr MUL expr   { $$ = new ast::Binop($1, token::MUL,   $3, @2); }
+     | expr DIV expr   { $$ = new ast::Binop($1, token::DIV,   $3, @2); }
+     | expr MOD expr   { $$ = new ast::Binop($1, token::MOD,   $3, @2); }
+     | expr BAND expr  { $$ = new ast::Binop($1, token::BAND,  $3, @2); }
+     | expr BOR expr   { $$ = new ast::Binop($1, token::BOR,   $3, @2); }
+     | expr BXOR expr  { $$ = new ast::Binop($1, token::BXOR,  $3, @2); }
+     | LNOT expr       { $$ = new ast::Unop(token::LNOT, $2, @1); }
+     | BNOT expr       { $$ = new ast::Unop(token::BNOT, $2, @1); }
+     | MINUS expr      { $$ = new ast::Unop(token::MINUS, $2, @1); }
+     | expr PLUSPLUS   { $$ = new ast::Unop(token::PLUSPLUS, $1, true, @2); }
+     | expr MINUSMINUS { $$ = new ast::Unop(token::MINUSMINUS, $1, true, @2); }
+     | PLUSPLUS expr   { $$ = new ast::Unop(token::PLUSPLUS, $2, @1); }
+     | MINUSMINUS expr { $$ = new ast::Unop(token::MINUSMINUS, $2, @1); }
+     | MUL  expr %prec DEREF { $$ = new ast::Unop(token::MUL,  $2, @1); }
+     | expr DOT ident  { $$ = new ast::FieldAccess($1, $3, @2); }
+     | expr PTR ident  { $$ = new ast::FieldAccess(new ast::Unop(token::MUL, $1, @2), $3, @$); }
+     | expr "[" expr "]" { $$ = new ast::ArrayAccess($1, $3, @2 + @4); }
+     | "(" IDENT ")" expr %prec CAST  { $$ = new ast::Cast($2, false, $4, @1 + @3); }
+     | "(" IDENT MUL ")" expr %prec CAST  { $$ = new ast::Cast($2, true, $5, @1 + @4); }
      ;
 
 ident : IDENT   { $$ = $1; }
       | BUILTIN { $$ = $1; }
       ;
 
-call : ident "(" ")"       { $$ = new ast::Call($1); }
-     | ident "(" vargs ")" { $$ = new ast::Call($1, $3); }
+call : ident "(" ")"       { $$ = new ast::Call($1, @$); }
+     | ident "(" vargs ")" { $$ = new ast::Call($1, $3, @$); }
      ;
 
-map : MAP               { $$ = new ast::Map($1); }
-    | MAP "[" vargs "]" { $$ = new ast::Map($1, $3); }
+map : MAP               { $$ = new ast::Map($1, @$); }
+    | MAP "[" vargs "]" { $$ = new ast::Map($1, $3, @$); }
     ;
 
-var : VAR { $$ = new ast::Variable($1); }
+var : VAR { $$ = new ast::Variable($1, @$); }
     ;
 
 vargs : vargs "," expr { $$ = $1; $1->push_back($3); }


### PR DESCRIPTION
This adds location support into all relevant parts of the AST. Which hopefully makes it easier to start using this feature throughout the code base, as you won't have to update the AST and parser anymore. 
There might be a few bugs in it, passing either too much or too little location info, but those should be easy to fix if they pop up. They're hard to spot now as not everything is using the location info yet but I think most of them are correct.

I've also updated the error prints of calls, builtins, strings and identifiers, which now look like:

```
stdin:1:31-37: ERROR: The retval builtin can only be used with 'kretprobe' and 'uretprobe' probes (try to use args->ret instead)
t:syscalls:sys_enter_openat { retval ; arg0 ; call(); lhist(1); join(1,2,3,4,5); uaddr("a.z"); @a = hist(); a }
                              ~~~~~~
stdin:1:40-44: ERROR: The arg0 builtin can only be used with 'kprobes', 'uprobes' and 'usdt' probes
t:syscalls:sys_enter_openat { retval ; arg0 ; call(); lhist(1); join(1,2,3,4,5); uaddr("a.z"); @a = hist(); a }
                                       ~~~~
stdin:1:47-53: ERROR: Unknown function: 'call'
t:syscalls:sys_enter_openat { retval ; arg0 ; call(); lhist(1); join(1,2,3,4,5); uaddr("a.z"); @a = hist(); a }
                                              ~~~~~~
stdin:1:55-63: ERROR: lhist() should be assigned to a map
t:syscalls:sys_enter_openat { retval ; arg0 ; call(); lhist(1); join(1,2,3,4,5); uaddr("a.z"); @a = hist(); a }
                                                      ~~~~~~~~
stdin:1:55-63: ERROR: lhist() requires 4 arguments (1 provided)
t:syscalls:sys_enter_openat { retval ; arg0 ; call(); lhist(1); join(1,2,3,4,5); uaddr("a.z"); @a = hist(); a }
                                                      ~~~~~~~~
stdin:1:65-80: ERROR: join() takes up to 2 arguments (5 provided)
t:syscalls:sys_enter_openat { retval ; arg0 ; call(); lhist(1); join(1,2,3,4,5); uaddr("a.z"); @a = hist(); a }
                                                                ~~~~~~~~~~~~~~~
stdin:1:101-107: ERROR: hist() requires one argument (0 provided)
t:syscalls:sys_enter_openat { retval ; arg0 ; call(); lhist(1); join(1,2,3,4,5); uaddr("a.z"); @a = hist(); a }
                                                                                                    ~~~~~~
stdin:1:109-110: ERROR: Unknown identifier: 'a'
t:syscalls:sys_enter_openat { retval ; arg0 ; call(); lhist(1); join(1,2,3,4,5); uaddr("a.z"); @a = hist(); a }
                                                                                                            ~
```


