### PR TITLE
Do not generate extra load for ++/-- for maps/variables

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -796,9 +796,22 @@ void CodegenLLVM::visit(Binop &binop)
   expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), false);
 }
 
+static bool unop_skip_accept(Unop &unop)
+{
+  if (unop.expr->type.type == Type::integer)
+  {
+    if (unop.op == bpftrace::Parser::token::PLUSPLUS ||
+        unop.op == bpftrace::Parser::token::MINUSMINUS)
+      return unop.expr->is_map || unop.expr->is_variable;
+  }
+
+  return false;
+}
+
 void CodegenLLVM::visit(Unop &unop)
 {
-  unop.expr->accept(*this);
+  if (!unop_skip_accept(unop))
+    unop.expr->accept(*this);
 
   SizedType &type = unop.expr->type;
   if (type.type == Type::integer)

--- a/tests/codegen/map_increment_decrement.cpp
+++ b/tests/codegen/map_increment_decrement.cpp
@@ -16,17 +16,13 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 define i64 @BEGIN(i8* nocapture readnone) local_unnamed_addr section "s_BEGIN_1" {
 entry:
-  %"@x_newval67" = alloca i64, align 8
-  %"@x_key59" = alloca i64, align 8
-  %"@x_key51" = alloca i64, align 8
-  %"@x_newval48" = alloca i64, align 8
-  %"@x_key40" = alloca i64, align 8
-  %"@x_key32" = alloca i64, align 8
-  %"@x_newval29" = alloca i64, align 8
-  %"@x_key21" = alloca i64, align 8
-  %"@x_key13" = alloca i64, align 8
+  %"@x_newval35" = alloca i64, align 8
+  %"@x_key27" = alloca i64, align 8
+  %"@x_newval24" = alloca i64, align 8
+  %"@x_key16" = alloca i64, align 8
+  %"@x_newval13" = alloca i64, align 8
+  %"@x_key5" = alloca i64, align 8
   %"@x_newval" = alloca i64, align 8
-  %"@x_key3" = alloca i64, align 8
   %"@x_key1" = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
@@ -45,113 +41,89 @@ entry:
   store i64 0, i64* %"@x_key1", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo2, i64* nonnull %"@x_key1")
+  %map_lookup_cond = icmp eq i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
+
+lookup_success:                                   ; preds = %entry
+  %4 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %4, 1
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %entry, %lookup_success
+  %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
+  %5 = bitcast i64* %"@x_newval" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  store i64 %lookup_elem_val.0, i64* %"@x_newval", align 8
+  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo3, i64* nonnull %"@x_key1", i64* nonnull %"@x_newval", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  %4 = bitcast i64* %"@x_key3" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  store i64 0, i64* %"@x_key3", align 8
-  %pseudo4 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem5 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo4, i64* nonnull %"@x_key3")
-  %map_lookup_cond10 = icmp eq i8* %lookup_elem5, null
-  br i1 %map_lookup_cond10, label %lookup_merge8, label %lookup_success6
-
-lookup_success6:                                  ; preds = %entry
-  %5 = load i64, i8* %lookup_elem5, align 8
-  %phitmp = add i64 %5, 1
-  br label %lookup_merge8
-
-lookup_merge8:                                    ; preds = %entry, %lookup_success6
-  %lookup_elem_val9.0 = phi i64 [ %phitmp, %lookup_success6 ], [ 1, %entry ]
-  %6 = bitcast i64* %"@x_newval" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  %6 = bitcast i64* %"@x_key5" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
-  store i64 %lookup_elem_val9.0, i64* %"@x_newval", align 8
-  %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem12 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo11, i64* nonnull %"@x_key3", i64* nonnull %"@x_newval", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
-  %7 = bitcast i64* %"@x_key13" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  store i64 0, i64* %"@x_key13", align 8
-  %pseudo14 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem15 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo14, i64* nonnull %"@x_key13")
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
-  %8 = bitcast i64* %"@x_key21" to i8*
+  store i64 0, i64* %"@x_key5", align 8
+  %pseudo6 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem7 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo6, i64* nonnull %"@x_key5")
+  %map_lookup_cond12 = icmp eq i8* %lookup_elem7, null
+  br i1 %map_lookup_cond12, label %lookup_merge10, label %lookup_success8
+
+lookup_success8:                                  ; preds = %lookup_merge
+  %7 = load i64, i8* %lookup_elem7, align 8
+  %phitmp38 = add i64 %7, 1
+  br label %lookup_merge10
+
+lookup_merge10:                                   ; preds = %lookup_merge, %lookup_success8
+  %lookup_elem_val11.0 = phi i64 [ %phitmp38, %lookup_success8 ], [ 1, %lookup_merge ]
+  %8 = bitcast i64* %"@x_newval13" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
-  store i64 0, i64* %"@x_key21", align 8
-  %pseudo22 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem23 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo22, i64* nonnull %"@x_key21")
-  %map_lookup_cond28 = icmp eq i8* %lookup_elem23, null
-  br i1 %map_lookup_cond28, label %lookup_merge26, label %lookup_success24
-
-lookup_success24:                                 ; preds = %lookup_merge8
-  %9 = load i64, i8* %lookup_elem23, align 8
-  %phitmp70 = add i64 %9, 1
-  br label %lookup_merge26
-
-lookup_merge26:                                   ; preds = %lookup_merge8, %lookup_success24
-  %lookup_elem_val27.0 = phi i64 [ %phitmp70, %lookup_success24 ], [ 1, %lookup_merge8 ]
-  %10 = bitcast i64* %"@x_newval29" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
-  store i64 %lookup_elem_val27.0, i64* %"@x_newval29", align 8
-  %pseudo30 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem31 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo30, i64* nonnull %"@x_key21", i64* nonnull %"@x_newval29", i64 0)
+  store i64 %lookup_elem_val11.0, i64* %"@x_newval13", align 8
+  %pseudo14 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem15 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo14, i64* nonnull %"@x_key5", i64* nonnull %"@x_newval13", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
-  %11 = bitcast i64* %"@x_key32" to i8*
+  %9 = bitcast i64* %"@x_key16" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
+  store i64 0, i64* %"@x_key16", align 8
+  %pseudo17 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem18 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo17, i64* nonnull %"@x_key16")
+  %map_lookup_cond23 = icmp eq i8* %lookup_elem18, null
+  br i1 %map_lookup_cond23, label %lookup_merge21, label %lookup_success19
+
+lookup_success19:                                 ; preds = %lookup_merge10
+  %10 = load i64, i8* %lookup_elem18, align 8
+  %phitmp39 = add i64 %10, -1
+  br label %lookup_merge21
+
+lookup_merge21:                                   ; preds = %lookup_merge10, %lookup_success19
+  %lookup_elem_val22.0 = phi i64 [ %phitmp39, %lookup_success19 ], [ -1, %lookup_merge10 ]
+  %11 = bitcast i64* %"@x_newval24" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %11)
-  store i64 0, i64* %"@x_key32", align 8
-  %pseudo33 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem34 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo33, i64* nonnull %"@x_key32")
+  store i64 %lookup_elem_val22.0, i64* %"@x_newval24", align 8
+  %pseudo25 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem26 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo25, i64* nonnull %"@x_key16", i64* nonnull %"@x_newval24", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %11)
-  %12 = bitcast i64* %"@x_key40" to i8*
+  %12 = bitcast i64* %"@x_key27" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %12)
-  store i64 0, i64* %"@x_key40", align 8
-  %pseudo41 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem42 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo41, i64* nonnull %"@x_key40")
-  %map_lookup_cond47 = icmp eq i8* %lookup_elem42, null
-  br i1 %map_lookup_cond47, label %lookup_merge45, label %lookup_success43
+  store i64 0, i64* %"@x_key27", align 8
+  %pseudo28 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem29 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo28, i64* nonnull %"@x_key27")
+  %map_lookup_cond34 = icmp eq i8* %lookup_elem29, null
+  br i1 %map_lookup_cond34, label %lookup_merge32, label %lookup_success30
 
-lookup_success43:                                 ; preds = %lookup_merge26
-  %13 = load i64, i8* %lookup_elem42, align 8
-  %phitmp71 = add i64 %13, -1
-  br label %lookup_merge45
+lookup_success30:                                 ; preds = %lookup_merge21
+  %13 = load i64, i8* %lookup_elem29, align 8
+  %phitmp40 = add i64 %13, -1
+  br label %lookup_merge32
 
-lookup_merge45:                                   ; preds = %lookup_merge26, %lookup_success43
-  %lookup_elem_val46.0 = phi i64 [ %phitmp71, %lookup_success43 ], [ -1, %lookup_merge26 ]
-  %14 = bitcast i64* %"@x_newval48" to i8*
+lookup_merge32:                                   ; preds = %lookup_merge21, %lookup_success30
+  %lookup_elem_val33.0 = phi i64 [ %phitmp40, %lookup_success30 ], [ -1, %lookup_merge21 ]
+  %14 = bitcast i64* %"@x_newval35" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %14)
-  store i64 %lookup_elem_val46.0, i64* %"@x_newval48", align 8
-  %pseudo49 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem50 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo49, i64* nonnull %"@x_key40", i64* nonnull %"@x_newval48", i64 0)
+  store i64 %lookup_elem_val33.0, i64* %"@x_newval35", align 8
+  %pseudo36 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem37 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo36, i64* nonnull %"@x_key27", i64* nonnull %"@x_newval35", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %12)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %14)
-  %15 = bitcast i64* %"@x_key51" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %15)
-  store i64 0, i64* %"@x_key51", align 8
-  %pseudo52 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem53 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo52, i64* nonnull %"@x_key51")
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %15)
-  %16 = bitcast i64* %"@x_key59" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %16)
-  store i64 0, i64* %"@x_key59", align 8
-  %pseudo60 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem61 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo60, i64* nonnull %"@x_key59")
-  %map_lookup_cond66 = icmp eq i8* %lookup_elem61, null
-  br i1 %map_lookup_cond66, label %lookup_merge64, label %lookup_success62
-
-lookup_success62:                                 ; preds = %lookup_merge45
-  %17 = load i64, i8* %lookup_elem61, align 8
-  %phitmp72 = add i64 %17, -1
-  br label %lookup_merge64
-
-lookup_merge64:                                   ; preds = %lookup_merge45, %lookup_success62
-  %lookup_elem_val65.0 = phi i64 [ %phitmp72, %lookup_success62 ], [ -1, %lookup_merge45 ]
-  %18 = bitcast i64* %"@x_newval67" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %18)
-  store i64 %lookup_elem_val65.0, i64* %"@x_newval67", align 8
-  %pseudo68 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem69 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo68, i64* nonnull %"@x_key59", i64* nonnull %"@x_newval67", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %16)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %18)
   ret i64 0
 }
 


### PR DESCRIPTION
I noticed that for ++/-- operators we generated extra
lookups and loads for maps and variables specifically.

Like for example for following program:

```
  tracepoint:syscalls:sys_enter_write
  {
    @write++;
  }
```

We should generate single map lookup followed by value
increase and map update, instead we generate 2 lookups:

```
   0: (b7) r6 = 0
   1: (7b) *(u64 *)(r10 -8) = r6
   2: (18) r1 = map[id:137]
   4: (bf) r2 = r10
   5: (07) r2 += -8
   6: (85) call __htab_map_lookup_elem#99808  <--- 1.lookup
   7: (15) if r0 == 0x0 goto pc+1
   8: (07) r0 += 56
   9: (7b) *(u64 *)(r10 -16) = r6
  10: (18) r1 = map[id:137]
  12: (bf) r2 = r10
  13: (07) r2 += -16
  14: (85) call __htab_map_lookup_elem#99808  <--- 2.lookup
  15: (15) if r0 == 0x0 goto pc+1
  16: (07) r0 += 56
  17: (b7) r1 = 1
  18: (15) if r0 == 0x0 goto pc+2
  19: (79) r1 = *(u64 *)(r0 +0)
  20: (07) r1 += 1
  21: (7b) *(u64 *)(r10 -8) = r1
  22: (18) r1 = map[id:137]
  24: (bf) r2 = r10
  25: (07) r2 += -16
  26: (bf) r3 = r10
  27: (07) r3 += -8
  28: (b7) r4 = 0
  29: (85) call htab_map_update_elem#104752
  30: (b7) r0 = 0
  31: (95) exit

```
Please notice the '1.lookup' result is discarded and '2.lookup'
takes over.

It's because for ++/-- we generate the lookup within the
code generation so the accept call is superfluous and generates
unneeded code.

With the fix the code is with single lookup:

```
   0: (b7) r1 = 0
   1: (7b) *(u64 *)(r10 -16) = r1
   2: (18) r1 = map[id:139]
   4: (bf) r2 = r10
   5: (07) r2 += -16
   6: (85) call __htab_map_lookup_elem#99808   <--- lookup
   7: (15) if r0 == 0x0 goto pc+1
   8: (07) r0 += 56
   9: (b7) r1 = 1
  10: (15) if r0 == 0x0 goto pc+2
  11: (79) r1 = *(u64 *)(r0 +0)
  12: (07) r1 += 1
  13: (7b) *(u64 *)(r10 -8) = r1
  14: (18) r1 = map[id:139]
  16: (bf) r2 = r10
  17: (07) r2 += -16
  18: (bf) r3 = r10
  19: (07) r3 += -8
  20: (b7) r4 = 0
  21: (85) call htab_map_update_elem#104752
  22: (b7) r0 = 0
  23: (95) exit
```
It's not big deal for Varibles case, because the double
load was optimized out:

```
  Before optimization
  -------------------
  define i64 @"tracepoint:syscalls:sys_enter_write"(i8*) section "s_tracepoint:syscalls:sys_enter_write_1" {
  entry:
    %printf_args = alloca %printf_t
    %"$local" = alloca i64
    %1 = bitcast i64* %"$local" to i8*
    call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
    store i64 0, i64* %"$local"
    %get_ns = call i64 inttoptr (i64 5 to i64 ()*)()
    %2 = bitcast i64* %"$local" to i8*
    call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
    store i64 %get_ns, i64* %"$local"
    %3 = load i64, i64* %"$local"    <--- 1.load
    %4 = load i64, i64* %"$local"    <--- 2.load
  ...
```

It's also now a little bit faster, checked with following command:

`  # perf stat -r 5 bpftrace -e 'tracepoint:syscalls:sys_enter_write { @write++; }' -c 'perf bench sched messaging -l 20000'`

Before:

  ```
Performance counter stats for 'bpftrace -e tracepoint:syscalls:sys_enter_write { @write++; } -c perf bench sched messaging -l 20000' (5 runs):

       2,392,396.71 msec task-clock                #   39.686 CPUs utilized            ( +-  0.68% )
        141,660,095      context-switches          #    0.059 M/sec                    ( +-  0.68% )
         53,586,928      cpu-migrations            #    0.022 M/sec                    ( +-  2.05% )
             46,323      page-faults               #    0.019 K/sec                    ( +-  0.47% )
  5,965,553,694,245      cycles                    #    2.494 GHz                      ( +-  0.68% )
  1,380,288,001,056      instructions              #    0.23  insn per cycle           ( +-  0.30% )
    295,619,937,390      branches                  #  123.566 M/sec                    ( +-  0.31% )
      4,498,686,547      branch-misses             #    1.52% of all branches          ( +-  0.13% )

             60.284 +- 0.409 seconds time elapsed  ( +-  0.68% )


```
After:
```
   Performance counter stats for 'bpftrace -e tracepoint:syscalls:sys_enter_write { @write++; } -c perf bench sched messaging -l 20000' (5 runs):

        2,193,764.69 msec task-clock                #   39.641 CPUs utilized            ( +-  0.98% )
         142,394,795      context-switches          #    0.065 M/sec                    ( +-  0.64% )
          54,758,486      cpu-migrations            #    0.025 M/sec                    ( +-  1.93% )
              46,414      page-faults               #    0.021 K/sec                    ( +-  0.13% )
   5,469,947,744,340      cycles                    #    2.493 GHz                      ( +-  0.98% )
   1,348,131,458,957      instructions              #    0.25  insn per cycle           ( +-  0.19% )
     288,773,429,973      branches                  #  131.634 M/sec                    ( +-  0.20% )
       4,487,594,062      branch-misses             #    1.55% of all branches          ( +-  0.32% )

              55.341 +- 0.519 seconds time elapsed  ( +-  0.94% )
```