### PR TITLE
Handle SIGTERM gracefully

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -37,7 +37,7 @@ namespace bpftrace {
 
 DebugLevel bt_debug = DebugLevel::kNone;
 bool bt_verbose = false;
-volatile sig_atomic_t BPFtrace::sigint_recv = false;
+volatile sig_atomic_t BPFtrace::exitsig_recv = false;
 
 int format(char * s, size_t n, const char * fmt, std::vector<std::unique_ptr<IPrintable>> &args) {
   int ret = -1;
@@ -804,7 +804,7 @@ void BPFtrace::poll_perf_events(int epollfd, bool drain)
   while (true)
   {
     int ready = epoll_wait(epollfd, events.data(), online_cpus_, 100);
-    if (ready < 0 && errno == EINTR && !BPFtrace::sigint_recv) {
+    if (ready < 0 && errno == EINTR && !BPFtrace::exitsig_recv) {
       // We received an interrupt not caused by SIGINT, skip and run again
       continue;
     }

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -107,8 +107,8 @@ public:
   std::string cmd_;
   int pid_{0};
   bool finalize_ = false;
-  // Global variable checking if a sigint was received
-  static volatile sig_atomic_t sigint_recv;
+  // Global variable checking if an exit signal was received
+  static volatile sig_atomic_t exitsig_recv;
 
   std::map<std::string, std::unique_ptr<IMap>> maps_;
   std::map<std::string, Struct> structs_;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -461,10 +461,11 @@ int main(int argc, char *argv[])
   if (bt_debug != DebugLevel::kNone)
     return 0;
 
-  // Signal handler that lets us know SIGINT was called.
+  // Signal handler that lets us know an exit signal was received.
   struct sigaction act = {};
-  act.sa_handler = [](int) { BPFtrace::sigint_recv = true; };
+  act.sa_handler = [](int) { BPFtrace::exitsig_recv = true; };
   sigaction(SIGINT, &act, NULL);
+  sigaction(SIGTERM, &act, NULL);
 
   uint64_t num_probes = bpftrace.num_probes();
   if (num_probes == 0)


### PR DESCRIPTION
SIGINT is usually sent users by on an interactive terminal. SIGTERM is
usually sent by process managers like systemd. Since bpftrace has JSON
output now, we expect people to start scripting / automating with
bpftrace. It'd be great if we could gracefully handle exits in automated
scenarious.