### PR TITLE
Fix umask build issue

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -36,4 +36,5 @@ RUN cd /bcc && mkdir build && cd build && cmake .. && make install -j4 && \
 
 
 COPY build.sh /build.sh
+RUN chmod 755 /build.sh
 ENTRYPOINT ["/bin/sh", "/build.sh"]

--- a/docker/Dockerfile.bionic
+++ b/docker/Dockerfile.bionic
@@ -34,4 +34,5 @@ RUN apt-get update && apt-get install -y \
       systemtap-sdt-dev
 
 COPY build.sh /build.sh
+RUN chmod 755 /build.sh
 ENTRYPOINT ["bash", "/build.sh"]

--- a/docker/Dockerfile.fedora30
+++ b/docker/Dockerfile.fedora30
@@ -14,4 +14,5 @@ RUN dnf install -y \
     systemtap-sdt-devel
 
 COPY build.sh /build.sh
+RUN chmod 755 /build.sh
 ENTRYPOINT ["/bin/sh", "/build.sh"]


### PR DESCRIPTION
Explicitly set the mode of /build.sh to 755 in order to guarantee that
it can be executed in the image no matter what the umask of the user
that is invoking the build is.

This fixes #860.