### PR TITLE
RFC: Add xlock increase code for count function

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -151,6 +151,18 @@ CallInst *IRBuilderBPF::CreateBpfPseudoCallFd(Map &map)
   return CreateBpfPseudoCallFd(mapfd);
 }
 
+CallInst *IRBuilderBPF::CreateBpfPseudoCallValue(int mapfd)
+{
+  Function *pseudo_func = module_.getFunction("llvm.bpf.pseudo");
+  return CreateCall(pseudo_func, {getInt64(BPF_PSEUDO_MAP_VALUE), getInt64(mapfd)}, "pseudo");
+}
+
+CallInst *IRBuilderBPF::CreateBpfPseudoCallValue(Map &map)
+{
+  int mapfd = bpftrace_.maps_[map.ident]->mapfd_;
+  return CreateBpfPseudoCallValue(mapfd);
+}
+
 CallInst *IRBuilderBPF::CreateGetJoinMap(Value *ctx __attribute__((unused)))
 {
   Value *map_ptr = CreateBpfPseudoCallFd(bpftrace_.join_map_->mapfd_);

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -36,8 +36,8 @@ public:
   AllocaInst *CreateAllocaBPF(int bytes, const std::string &name="");
   llvm::Type *GetType(const SizedType &stype);
   llvm::ConstantInt *GetIntSameSize(uint64_t C, llvm::Value *expr);
-  CallInst   *CreateBpfPseudoCall(int mapfd);
-  CallInst   *CreateBpfPseudoCall(Map &map);
+  CallInst   *CreateBpfPseudoCallFd(int mapfd);
+  CallInst   *CreateBpfPseudoCallFd(Map &map);
   Value      *CreateMapLookupElem(Map &map, AllocaInst *key);
   void        CreateMapUpdateElem(Map &map, AllocaInst *key, Value *val);
   void        CreateMapDeleteElem(Map &map, AllocaInst *key);

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -38,6 +38,8 @@ public:
   llvm::ConstantInt *GetIntSameSize(uint64_t C, llvm::Value *expr);
   CallInst   *CreateBpfPseudoCallFd(int mapfd);
   CallInst   *CreateBpfPseudoCallFd(Map &map);
+  CallInst   *CreateBpfPseudoCallValue(int mapfd);
+  CallInst   *CreateBpfPseudoCallValue(Map &map);
   Value      *CreateMapLookupElem(Map &map, AllocaInst *key);
   void        CreateMapUpdateElem(Map &map, AllocaInst *key, Value *val);
   void        CreateMapDeleteElem(Map &map, AllocaInst *key);

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1444,7 +1444,7 @@ int SemanticAnalyser::create_maps(bool debug)
         failed_maps += is_invalid_map(bpftrace_.maps_[map_name]->mapfd_);
       }
       else
-        bpftrace_.maps_[map_name] = std::make_unique<bpftrace::Map>(map_name, type, key, bpftrace_.mapmax_);
+        bpftrace_.maps_[map_name] = std::make_unique<bpftrace::Map>(map_name, type, key, bpftrace_.mapmax_, bpftrace_.has_global_data());
     }
   }
 

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -65,6 +65,25 @@ private:
   std::string msg_;
 };
 
+class BPFfeature
+{
+public:
+  static BPFfeature* getInstance(void)
+  {
+    if (!instance)
+      instance = new BPFfeature();
+    return instance;
+  }
+
+  bool has_global_data;
+
+  ~BPFfeature();
+
+private:
+  BPFfeature();
+  static BPFfeature* instance;
+};
+
 class BPFtrace
 {
 public:
@@ -159,6 +178,8 @@ public:
       int pid,
       const std::string &target) const;
   const std::string get_source_line(unsigned int);
+
+  bool has_global_data(void);
 
 protected:
   std::vector<Probe> probes_;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -110,6 +110,7 @@ public:
   int spawn_child();
   void kill_child();
 
+  std::string object_;
   std::string cmd_;
   int pid_{0};
   bool finalize_ = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -131,7 +131,7 @@ int main(int argc, char *argv[])
   bool listing = false;
   bool safe_mode = true;
   bool force_btf = false;
-  std::string script, search, file_name, output_file, output_format;
+  std::string script, search, file_name, output_file, output_format, object;
   OutputBufferConfig obc = OutputBufferConfig::UNSET;
   int c;
 
@@ -142,6 +142,7 @@ int main(int argc, char *argv[])
     option{"unsafe", no_argument, nullptr, 'u'},
     option{"btf", no_argument, nullptr, 'b'},
     option{"include", required_argument, nullptr, '#'},
+    option{"elf", required_argument, nullptr, 'E'},
     option{nullptr, 0, nullptr, 0},  // Must be last
   };
   std::vector<std::string> include_dirs;
@@ -181,6 +182,9 @@ int main(int argc, char *argv[])
         break;
       case 'e':
         script = optarg;
+        break;
+      case 'E':
+        object = optarg;
         break;
       case 'p':
         pid_str = optarg;
@@ -280,6 +284,7 @@ int main(int argc, char *argv[])
 
   bpftrace.safe_mode_ = safe_mode;
   bpftrace.force_btf_ = force_btf;
+  bpftrace.object_ = object;
 
   // PID is currently only used for USDT probes that need enabling. Future work:
   // - make PID a filter for all probe types: pass to perf_event_open(), etc.

--- a/src/map.h
+++ b/src/map.h
@@ -6,9 +6,9 @@ namespace bpftrace {
 
 class Map : public IMap {
 public:
-  Map(const std::string &name, const SizedType &type, const MapKey &key, int max_entries)
-    : Map(name, type, key, 0, 0, 0, max_entries) {};
-  Map(const std::string &name, const SizedType &type, const MapKey &key, int min, int max, int step, int max_entries);
+  Map(const std::string &name, const SizedType &type, const MapKey &key, int max_entries, bool has_global_data = false)
+    : Map(name, type, key, 0, 0, 0, max_entries, has_global_data) {};
+  Map(const std::string &name, const SizedType &type, const MapKey &key, int min, int max, int step, int max_entries, bool has_global_data = false);
   Map(const SizedType &type);
   Map(enum bpf_map_type map_type);
   virtual ~Map() override;


### PR DESCRIPTION
hi,
I tried the global data together with locking increase on count
function and it seems to be working. I think there're probably
other areas this could be put in.

The code still needs some testing/changes, but would be great
to get some input before I dive in more.

thanks,
jirka

---
Changing the count generation code to use eBPF global
data and locked increase to speedup the count function.

Having following code:

```
  # cat count.bt
  tracepoint:syscalls:sys_enter_write
  {
        @write = count();
  }

```
We generate following code even for single value increase:

```
   0: (b7) r1 = 0
   1: (7b) *(u64 *)(r10 -16) = r1
   2: (18) r1 = map[id:536]
   4: (bf) r2 = r10
   5: (07) r2 += -16
   6: (85) call htab_percpu_map_lookup_elem#100624
   7: (b7) r1 = 1
   8: (15) if r0 == 0x0 goto pc+2
   9: (79) r1 = *(u64 *)(r0 +0)
  10: (07) r1 += 1
  11: (7b) *(u64 *)(r10 -8) = r1
  12: (18) r1 = map[id:536]
  14: (bf) r2 = r10
  15: (07) r2 += -16
  16: (bf) r3 = r10
  17: (07) r3 += -8
  18: (b7) r4 = 0
  19: (85) call htab_percpu_map_update_elem#102848
  20: (b7) r0 = 0
  21: (95) exit
```
By adding the possibility to operate directly on the map's
data and locked increase we can use just this code:

```
   0: (18) r1 = map[id:542][0]+0
   2: (b7) r2 = 1
   3: (db) lock *(u64 *)(r1 +0) += r2
   4: (b7) r0 = 0
   5: (95) exit
```
This of course speeds up the processing, without bpftrace involved:

```
  # perf bench sched messaging -l 100000
  # Running 'sched/messaging' benchmark:
  # 20 sender and receiver processes per group
  # 10 groups == 400 processes run

       Total time: 58.194 [sec]
```

With current code:

```
  # bpftrace count.bt -c 'perf bench sched messaging -l 100000'
  Attaching 1 probe...
  # Running 'sched/messaging' benchmark:
  # 20 sender and receiver processes per group
  # 10 groups == 400 processes run

       Total time: 180.127 [sec]

  @write: 400000726
```

With change applied:

```
  # bpftrace count.bt -c 'perf bench sched messaging -l 100000'
  Attaching 1 probe...
  # Running 'sched/messaging' benchmark:
  # 20 sender and receiver processes per group
  # 10 groups == 400 processes run

       Total time: 62.975 [sec]

  @write: 400000492

```