### PR TITLE
json output: Make output more consistent

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -552,12 +552,13 @@ void JsonOutput::map_stats(BPFtrace &bpftrace, IMap &map,
 
 void JsonOutput::message(MessageType type, const std::string& msg, bool nl __attribute__((unused))) const
 {
-  out_ << "{\"type\": \"" << type << "\", \"msg\": \"" << json_escape(msg) << "\"}" << std::endl;
+  out_ << "{\"type\": \"" << type << "\", \"data\": \"" << json_escape(msg) << "\"}" << std::endl;
 }
 
 void JsonOutput::message(MessageType type, const std::string& field, uint64_t value) const
 {
-  out_ << "{\"type\": \"" << type << "\", \"" << field << "\": " << value << "}" << std::endl;
+  out_ << "{\"type\": \"" << type << "\", \"data\": " <<  "{\"" << field
+       << "\": " << value << "}" << "}" << std::endl;
 }
 
 void JsonOutput::lost_events(uint64_t lost) const

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -55,30 +55,30 @@ TIMEOUT 5
 
 NAME printf
 RUN bpftrace -f json -v -e 'BEGIN { printf("test %d", 5); exit(); }'
-EXPECT ^{"type": "printf", "msg": "test 5"}$
+EXPECT ^{"type": "printf", "data": "test 5"}$
 TIMEOUT 5
 
 NAME printf_escaping
 RUN bpftrace -f json -v -e 'BEGIN { printf("test \r \n \t \\ \" bar"); exit(); }'
-EXPECT ^{"type": "printf", "msg": "test \\r \\n \\t \\\\ \\\" bar"}$
+EXPECT ^{"type": "printf", "data": "test \\r \\n \\t \\\\ \\\" bar"}$
 TIMEOUT 5
 
 NAME time
 RUN bpftrace -f json -v -e 'BEGIN { time(); exit(); }'
-EXPECT ^{"type": "time", "msg": "[0-9]*:[0-9]*:[0-9]*\\n"}$
+EXPECT ^{"type": "time", "data": "[0-9]*:[0-9]*:[0-9]*\\n"}$
 TIMEOUT 5
 
 NAME syscall
 RUN bpftrace --unsafe -v -f json -e 'BEGIN { system("echo a b c"); exit(); }'
-EXPECT ^{"type": "syscall", "msg": "a b c\\n"}$
+EXPECT ^{"type": "syscall", "data": "a b c\\n"}$
 TIMEOUT 5
 
 NAME join_delim
 RUN bpftrace --unsafe -f json -e 'tracepoint:syscalls:sys_enter_execve { join(args->argv, ","); exit(); }' -c "/bin/echo 'A'"
-EXPECT ^{"type": "join", "msg": "/bin/echo,'A'"}
+EXPECT ^{"type": "join", "data": "/bin/echo,'A'"}
 TIMEOUT 5
 
 NAME cat
 RUN bpftrace -v -f json -e 'BEGIN { cat("/proc/uptime"); exit(); }'
-EXPECT ^{"type": "cat", "msg": "[0-9]*.[0-9]* [0-9]*.[0-9]*\\n"}$
+EXPECT ^{"type": "cat", "data": "[0-9]*.[0-9]* [0-9]*.[0-9]*\\n"}$
 TIMEOUT 5


### PR DESCRIPTION
Before, there were two JSON output formats:

    {"type": <foo>, "msg": <bar> }

and

    {"type": <foo>, "data": <bar> }

This makes parsing kind of weird as you have to keep maps of type:format
in your parsing code. That means you have to be extra vigilant about
watching for new json output types. It's true that you have to know the
type to parse `data` on a eg. a `map`, but I think the less specialized
parsing the better.

This patch makes the output consistent. Now every message looks like:

    {"type": <foo>, "data": <bar> }

This change requires that we nest some information. For example,
`attached_probes` and `lost_events` now look like:

    {"type": "attached_probes", "data": {"probes": 1}}