### PR TITLE
fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,13 +167,13 @@ bpftrace contains various tools, which also serve as examples of programming in 
 - tools/[swapin.bt](tools/swapin.bt): Show swapins by process. [Examples](tools/swapin_example.txt).
 - tools/[syncsnoop.bt](tools/syncsnoop.bt): Trace sync() variety of syscalls. [Examples](tools/syncsnoop_example.txt).
 - tools/[syscount.bt](tools/syscount.bt): Count system calls. [Examples](tools/syscount_example.txt).
-- tools/[tcpaccept](tools/tcpaccept.bt): Trace TCP passive connections (accept()). [Examples](tools/tcpaccept_example.txt).
-- tools/[tcpconnect](tools/tcpconnect.bt): Trace TCP active connections (connect()). [Examples](tools/tcpconnect_example.txt).
-- tools/[tcpdrop](tools/tcpdrop.bt): Trace kernel-based TCP packet drops with details. [Examples](tools/tcpdrop_example.txt).
-- tools/[tcplife](tools/tcplife.bt): Trace TCP session lifespans with connection details. [Examples](tools/tcplife_example.txt).
-- tools/[tcpretrans](tools/tcpretrans.bt): Trace TCP retransmits. [Examples](tools/tcpretrans_example.txt).
-- tools/[tcpsynbl](tools/tcpsynbl.bt): Show TCP SYN backlog as a histogram. [Examples](tools/tcpsynbl_example.txt).
-- tools/[threadsnoop](tools/threadsnoop.bt): List new thread creation. [Examples](tools/threadsnoop_example.txt).
+- tools/[tcpaccept.bt](tools/tcpaccept.bt): Trace TCP passive connections (accept()). [Examples](tools/tcpaccept_example.txt).
+- tools/[tcpconnect.bt](tools/tcpconnect.bt): Trace TCP active connections (connect()). [Examples](tools/tcpconnect_example.txt).
+- tools/[tcpdrop.bt](tools/tcpdrop.bt): Trace kernel-based TCP packet drops with details. [Examples](tools/tcpdrop_example.txt).
+- tools/[tcplife.bt](tools/tcplife.bt): Trace TCP session lifespans with connection details. [Examples](tools/tcplife_example.txt).
+- tools/[tcpretrans.bt](tools/tcpretrans.bt): Trace TCP retransmits. [Examples](tools/tcpretrans_example.txt).
+- tools/[tcpsynbl.bt](tools/tcpsynbl.bt): Show TCP SYN backlog as a histogram. [Examples](tools/tcpsynbl_example.txt).
+- tools/[threadsnoop.bt](tools/threadsnoop.bt): List new thread creation. [Examples](tools/threadsnoop_example.txt).
 - tools/[vfscount.bt](tools/vfscount.bt): Count VFS calls. [Examples](tools/vfscount_example.txt).
 - tools/[vfsstat.bt](tools/vfsstat.bt): Count some VFS calls, with per-second summaries. [Examples](tools/vfsstat_example.txt).
 - tools/[writeback.bt](tools/writeback.bt): Trace file system writeback events with details. [Examples](tools/writeback_example.txt).

--- a/tools/bashreadline_example.txt
+++ b/tools/bashreadline_example.txt
@@ -4,7 +4,7 @@ Demonstrations of bashreadline, the Linux bpftrace/eBPF version.
 This prints bash commands from all running bash shells on the system. For
 example:
 
-# bashreadline.bt
+# ./bashreadline.bt
 Attaching 2 probes...
 Tracing bash commands... Hit Ctrl-C to end.
 TIME      PID    COMMAND

--- a/tools/biolatency_example.txt
+++ b/tools/biolatency_example.txt
@@ -3,7 +3,7 @@ Demonstrations of biolatency, the Linux BPF/bpftrace version.
 
 This traces block I/O, and shows latency as a power-of-2 histogram. For example:
 
-# biolatency.bt
+# ./biolatency.bt
 Attaching 3 probes...
 Tracing block device I/O... Hit Ctrl-C to end.
 ^C

--- a/tools/biosnoop_example.txt
+++ b/tools/biosnoop_example.txt
@@ -4,7 +4,7 @@ Demonstrations of biosnoop, the Linux BPF/bpftrace version.
 This traces block I/O, and shows the issuing process (at least, the process
 that was on-CPU at the time of queue insert) and the latency of the I/O:
 
-# biosnoop.bt
+# ./biosnoop.bt
 Attaching 4 probes...
 TIME(ms)     COMM             PID    LAT(ms)
 611          bash             4179        10
@@ -35,7 +35,7 @@ program start.
 
 An example of some background flushing:
 
-# biosnoop.bt
+# ./biosnoop.bt
 Attaching 4 probes...
 TIME(ms)     COMM             PID    LAT(ms)
 2966         jbd2/nvme0n1-8   615          0

--- a/tools/bitesize_example.txt
+++ b/tools/bitesize_example.txt
@@ -4,7 +4,7 @@ Demonstrations of bitesize, the Linux bpftrace/eBPF version.
 This traces disk I/O via the block I/O interface, and prints a summary of I/O
 sizes as histograms for each process name. For example:
 
-# bitesize.bt
+# ./bitesize.bt
 Attaching 3 probes...
 Tracing block device I/O... Hit Ctrl-C to end.
 ^C

--- a/tools/capable_example.txt
+++ b/tools/capable_example.txt
@@ -4,7 +4,7 @@ Demonstrations of capable, the Linux bpftrace/eBPF version.
 capable traces calls to the kernel cap_capable() function, which does security
 capability checks, and prints details for each call. For example:
 
-# capable.bt
+# ./capable.bt
 TIME      UID    PID    COMM             CAP  NAME                 AUDIT
 22:11:23  114    2676   snmpd            12   CAP_NET_ADMIN        1
 22:11:23  0      6990   run              24   CAP_SYS_RESOURCE     1

--- a/tools/cpuwalk_example.txt
+++ b/tools/cpuwalk_example.txt
@@ -4,7 +4,7 @@ Demonstrations of cpuwalk, the Linux bpftrace/eBPF version.
 cpuwalk samples which CPUs processes are running on, and prints a summary
 histogram. For example, here is a Linux kernel build on a 36-CPU server:
 
-# cpuwalk.bt
+# ./cpuwalk.bt
 Attaching 2 probes...
 Sampling CPU at 99hz... Hit Ctrl-C to end.
 ^C
@@ -52,7 +52,7 @@ This shows that all 36 CPUs were active, with some busier than others.
 
 Compare that output to the following workload from an application:
 
-# cpuwalk.bt
+# ./cpuwalk.bt
 Attaching 2 probes...
 Sampling CPU at 99hz... Hit Ctrl-C to end.
 ^C

--- a/tools/dcsnoop_example.txt
+++ b/tools/dcsnoop_example.txt
@@ -5,7 +5,7 @@ dcsnoop traces directory entry cache (dcache) lookups, and can be used for
 further investigation beyond dcstat(8). The output is likely verbose, as
 dcache lookups are likely frequent. For example:
 
-# dcsnoop.bt
+# ./dcsnoop.bt
 Attaching 4 probes...
 Tracing dcache lookups... Hit Ctrl-C to end.
 TIME     PID    COMM             T FILE

--- a/tools/execsnoop_example.txt
+++ b/tools/execsnoop_example.txt
@@ -3,7 +3,7 @@ Demonstrations of execsnoop, the Linux BPF/bpftrace version.
 
 Tracing all new process execution (via exec()):
 
-# execsnoop.bt
+# ./execsnoop.bt
 Attaching 3 probes...
 TIME(ms)   PID   ARGS
 2460       3466  ls --color=auto -lh execsnoop.bt execsnoop.bt.0 execsnoop.bt.1

--- a/tools/gethostlatency_example.txt
+++ b/tools/gethostlatency_example.txt
@@ -5,7 +5,7 @@ This traces host name lookup calls (getaddrinfo(), gethostbyname(), and
 gethostbyname2()), and shows the PID and command performing the lookup, the
 latency (duration) of the call in milliseconds, and the host string:
 
-# gethostlatency.bt
+# ./gethostlatency.bt
 Attaching 7 probes...
 Tracing getaddr/gethost calls... Hit Ctrl-C to end.
 TIME      PID    COMM              LATms HOST

--- a/tools/killsnoop_example.txt
+++ b/tools/killsnoop_example.txt
@@ -1,9 +1,10 @@
 Demonstrations of killsnoop, the Linux bpftrace/eBPF version.
 
 
+
 This traces signals sent via the kill() syscall. For example:
 
-# killsnoop.bt
+# ./killsnoop.bt
 Attaching 3 probes...
 Tracing kill() signals... Hit Ctrl-C to end.
 TIME      PID    COMM             SIG  TPID   RESULT

--- a/tools/loads_example.txt
+++ b/tools/loads_example.txt
@@ -5,7 +5,7 @@ This is a simple tool that prints the system load averages, to three decimal
 places each (not that it really matters), as a demonstration of fetching
 kernel structures from bpftrace:
 
-# loads.bt
+# ./loads.bt
 Attaching 2 probes...
 Reading load averages... Hit Ctrl-C to end.
 21:29:17 load averages: 2.091 2.048 1.947

--- a/tools/mdflush_example.txt
+++ b/tools/mdflush_example.txt
@@ -4,7 +4,7 @@ Demonstrations of mdflush, the Linux bpftrace/eBPF version.
 The mdflush tool traces flushes at the md driver level, and prints details
 including the time of the flush:
 
-# mdflush.bt
+# ./mdflush.bt
 Tracing md flush requests... Hit Ctrl-C to end.
 TIME     PID    COMM             DEVICE
 03:13:49 16770  sync             md0

--- a/tools/oomkill_example.txt
+++ b/tools/oomkill_example.txt
@@ -4,7 +4,7 @@ Demonstrations of oomkill, the Linux bpftrace/eBPF version.
 oomkill is a simple program that traces the Linux out-of-memory (OOM) killer,
 and shows basic details on one line per OOM kill:
 
-# oomkill
+# ./oomkill.bt
 Tracing oom_kill_process()... Ctrl-C to end.
 21:03:39 Triggered by PID 3297 ("ntpd"), OOM kill of PID 22516 ("perl"), 3850642 pages, loadavg: 0.99 0.39 0.30 3/282 22724
 21:03:48 Triggered by PID 22517 ("perl"), OOM kill of PID 22517 ("perl"), 3850642 pages, loadavg: 0.99 0.41 0.30 2/282 22932

--- a/tools/opensnoop_example.txt
+++ b/tools/opensnoop_example.txt
@@ -4,7 +4,7 @@ Demonstrations of opensnoop, the Linux bpftrace/eBPF version.
 opensnoop traces the open() syscall system-wide, and prints various details.
 Example output:
 
-# opensnoop.bt
+# ./opensnoop.bt
 Attaching 3 probes...
 Tracing open syscalls... Hit Ctrl-C to end.
 PID    COMM               FD ERR PATH

--- a/tools/pidpersec_example.txt
+++ b/tools/pidpersec_example.txt
@@ -3,7 +3,7 @@ Demonstrations of pidpersec, the Linux bpftrace/eBPF version.
 
 Tracing new procesess:
 
-# pidpersec.bt
+# ./pidpersec.bt
 Attaching 4 probes...
 Tracing new processes... Hit Ctrl-C to end.
 22:29:50 PIDs/sec: @: 121
@@ -29,7 +29,7 @@ new processes per second.
 The following example shows a Linux build launched at 6:33:40, on a 36 CPU
 server, with make -j36:
 
-# pidpersec.bt
+# ./pidpersec.bt
 Attaching 4 probes...
 Tracing new processes... Hit Ctrl-C to end.
 06:33:38 PIDs/sec:

--- a/tools/runqlat_example.txt
+++ b/tools/runqlat_example.txt
@@ -5,7 +5,7 @@ This traces time spent waiting in the CPU scheduler for a turn on-CPU. This
 metric is often called run queue latency, or scheduler latency. This tool shows
 this latency as a power-of-2 histogram in nanoseconds. For example:
 
-# runqlat.bt
+# ./runqlat.bt
 Attaching 5 probes...
 Tracing CPU scheduler... Hit Ctrl-C to end.
 ^C
@@ -50,7 +50,7 @@ the CPU caches should be hotter.
 I'll now add a single-threaded CPU bound workload to this system, and bind
 it on one CPU:
 
-# runqlat.bt
+# ./runqlat.bt
 Attaching 5 probes...
 Tracing CPU scheduler... Hit Ctrl-C to end.
 ^C
@@ -86,7 +86,7 @@ That didn't make much difference.
 Now I'll add a second single-threaded CPU workload, and bind it to the same
 CPU, causing contention:
 
-# runqlat.bt
+# ./runqlat.bt
 Attaching 5 probes...
 Tracing CPU scheduler... Hit Ctrl-C to end.
 ^C
@@ -121,7 +121,7 @@ wait its turn on the one CPU.
 
 Now I'l run 10 CPU-bound throuds on one CPU:
 
-# runqlat.bt
+# ./runqlat.bt
 Attaching 5 probes...
 Tracing CPU scheduler... Hit Ctrl-C to end.
 ^C

--- a/tools/runqlen_example.txt
+++ b/tools/runqlen_example.txt
@@ -5,7 +5,7 @@ This tool samples the length of the CPU scheduler run queues, showing these
 sampled lengths as a histogram. This can be used to characterize demand for
 CPU resources. For example:
 
-# runqlen.bt 
+# ./runqlen.bt 
 Attaching 2 probes...
 Sampling run queue length at 99 Hertz... Hit Ctrl-C to end.
 ^C

--- a/tools/setuids_example.txt
+++ b/tools/setuids_example.txt
@@ -5,7 +5,7 @@ This tool traces privilege escalation via setuid syscalls (setuid(2),
 setfsuid(2), retresuid(2)). For example, here are the setuid calls during an
 ssh login:
 
-# setuids.bt
+# ./setuids.bt
 Attaching 7 probes...
 Tracing setuid(2) family syscalls. Hit Ctrl-C to end.
 TIME     PID    COMM             UID    SYSCALL   ARGS (RET)

--- a/tools/statsnoop_example.txt
+++ b/tools/statsnoop_example.txt
@@ -4,7 +4,7 @@ Demonstrations of statsnoop, the Linux bpftrace/eBPF version.
 statsnoop traces different stat() syscalls system-wide, and prints details.
 Example output:
 
-# statsnoop.bt
+# ./statsnoop.bt
 Attaching 9 probes...
 Tracing stat syscalls... Hit Ctrl-C to end.
 PID    COMM             ERR PATH

--- a/tools/swapin_example.txt
+++ b/tools/swapin_example.txt
@@ -4,7 +4,7 @@ Demonstrations of swapin, the Linux BCC/eBPF version.
 This tool counts swapins by process, to show which process is affected by
 swapping. For example:
 
-# swapin.bt 
+# ./swapin.bt 
 Attaching 2 probes...
 13:36:59
 

--- a/tools/syncsnoop_example.txt
+++ b/tools/syncsnoop_example.txt
@@ -3,7 +3,7 @@ Demonstrations of syncsnoop, the Linux bpftrace/eBPF version.
 
 Tracing file system sync events:
 
-# syncsnoop.bt
+# ./syncsnoop.bt
 Attaching 7 probes...
 Tracing sync syscalls... Hit Ctrl-C to end.
 TIME      PID    COMM             EVENT

--- a/tools/syscount_example.txt
+++ b/tools/syscount_example.txt
@@ -4,7 +4,7 @@ Demonstrations of syscount, the Linux bpftrace/eBPF version.
 syscount counts system calls, and prints summaries of the top ten syscall IDs,
 and the top ten process names making syscalls. For example:
 
-# syscount.bt
+# ./syscount.bt
 Attaching 3 probes...
 Counting syscalls... Hit Ctrl-C to end.
 ^C

--- a/tools/tcpaccept_example.txt
+++ b/tools/tcpaccept_example.txt
@@ -5,7 +5,7 @@ This tool traces the kernel function accepting TCP socket connections (eg, a
 passive connection via accept(); not connect()). Some example output (IP
 addresses changed to protect the innocent):
 
-# ./tcpaccept
+# ./tcpaccept.bt
 Tracing tcp accepts. Hit Ctrl-C to end.
 TIME     PID     COMM           RADDR          RPORT LADDR          LPORT BL
 00:34:19 3949061 nginx          10.228.22.228  44226 10.229.20.169  8080  0/128

--- a/tools/tcpconnect_example.txt
+++ b/tools/tcpconnect_example.txt
@@ -5,7 +5,7 @@ This tool traces the kernel function performing active TCP connections
 (eg, via a connect() syscall; accept() are passive connections). Some example
 output (IP addresses changed to protect the innocent):
 
-# ./tcpconnect
+# ./tcpconnect.bt
 TIME     PID      COMM             SADDR          SPORT  DADDR          DPORT
 00:36:45 1798396  agent            127.0.0.1      5001   10.229.20.82   56114
 00:36:45 1798396  curl             127.0.0.1      10255  10.229.20.82   56606

--- a/tools/tcplife_example.txt
+++ b/tools/tcplife_example.txt
@@ -5,7 +5,7 @@ This tool shows the lifespan of TCP sessions, including througphut statistics,
 and for efficiency only instruments TCP state changes (rather than all packets).
 For example:
 
-# tcplife
+# ./tcplife.bt
 PID   COMM       LADDR           LPORT RADDR           RPORT TX_KB RX_KB MS
 20976 ssh        127.0.0.1       56766 127.0.0.1       22         6 10584 3059
 20977 sshd       127.0.0.1       22    127.0.0.1       56766  10584     6 3059

--- a/tools/vfscount_example.txt
+++ b/tools/vfscount_example.txt
@@ -3,7 +3,7 @@ Demonstrations of vfscount, the Linux bpftrace/eBPF version.
 
 Tracing all VFS calls:
 
-# vfscount.bt
+# ./vfscount.bt
 Attaching 54 probes...
 cannot attach kprobe, Invalid argument
 Warning: could not attach probe kprobe:vfs_dedupe_get_page.isra.21, skipping.

--- a/tools/vfsstat_example.txt
+++ b/tools/vfsstat_example.txt
@@ -4,7 +4,7 @@ Demonstrations of vfsstat, the Linux bpftrace/eBPF version.
 This traces some common VFS calls (see the script for the list) and prints
 per-second summaries.
 
-# vfsstat.bt
+# ./vfsstat.bt
 Attaching 8 probes...
 Tracing key VFS calls... Hit Ctrl-C to end.
 21:30:38

--- a/tools/writeback_example.txt
+++ b/tools/writeback_example.txt
@@ -5,7 +5,7 @@ This tool traces when the kernel writeback procedure is writing dirtied pages
 to disk, and shows details such as the time, device numbers, reason for the
 write back, and the duration. For example:
 
-# writeback.bt
+# ./writeback.bt
 Attaching 4 probes...
 Tracing writeback... Hit Ctrl-C to end.
 TIME      DEVICE   PAGES    REASON           ms


### PR DESCRIPTION
add file extension in README and fix typo in example text for correct name of script