### PR TITLE
Fix flaky watchpoint test

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -324,6 +324,11 @@ void BPFtrace::request_finalize()
 {
   finalize_ = true;
   attached_probes_.clear();
+
+  for (int pid : child_pids_)
+  {
+    kill(pid, SIGTERM);
+  }
 }
 
 void perf_event_printer(void *cb_cookie, void *data, int size __attribute__((unused)))

--- a/tests/runtime/watchpoint
+++ b/tests/runtime/watchpoint
@@ -1,4 +1,4 @@
 NAME watchpoint - absolute address
-RUN bpftrace -v -e 'watchpoint::0x10000000:8:w { printf("hit!\n"); }' -c ./testprogs/watchpoint
+RUN bpftrace -v -e 'watchpoint::0x10000000:8:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint
 EXPECT hit!
 TIMEOUT 5

--- a/tests/testprogs/watchpoint.c
+++ b/tests/testprogs/watchpoint.c
@@ -17,5 +17,9 @@ int main() {
     return 1;
   }
 
-  *((volatile uint8_t*)addr) = 2;
+
+  uint8_t i = 0;
+  while (1) {
+    *((volatile uint8_t*)addr) = i++;
+  }
 }


### PR DESCRIPTION
I'm not sure this will fix the flakiness on the runtime watchpoint test (I couldn't reproduce the issue on my machine), but it's worth a try. I'll rerun the CI a few times to see if the issue stops happening.