### PR TITLE
Store BPF_MAP_TYPE in map object

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -961,6 +961,7 @@ int BPFtrace::clear_map(IMap &map)
 // zero a map
 int BPFtrace::zero_map(IMap &map)
 {
+  uint32_t nvalues = map.is_per_cpu_type() ? ncpus_ : 1;
   std::vector<uint8_t> old_key;
   try
   {
@@ -987,12 +988,7 @@ int BPFtrace::zero_map(IMap &map)
     old_key = key;
   }
 
-  int value_size = map.type_.size;
-  if (map.type_.type == Type::count || map.type_.type == Type::sum ||
-      map.type_.type == Type::min || map.type_.type == Type::max ||
-      map.type_.type == Type::avg || map.type_.type == Type::hist ||
-      map.type_.type == Type::lhist || map.type_.type == Type::stats )
-    value_size *= ncpus_;
+  int value_size = map.type_.size * nvalues;
   std::vector<uint8_t> zero(value_size, 0);
   for (auto &key : keys)
   {
@@ -1010,6 +1006,7 @@ int BPFtrace::zero_map(IMap &map)
 
 std::string BPFtrace::map_value_to_str(IMap &map, std::vector<uint8_t> value, uint32_t div)
 {
+  uint32_t nvalues = map.is_per_cpu_type() ? ncpus_ : 1;
   if (map.type_.type == Type::kstack)
     return get_stack(*(uint64_t*)value.data(), false, map.type_.stack_type, 8);
   else if (map.type_.type == Type::ustack)
@@ -1025,17 +1022,17 @@ std::string BPFtrace::map_value_to_str(IMap &map, std::vector<uint8_t> value, ui
   else if (map.type_.type == Type::string)
     return std::string(reinterpret_cast<const char*>(value.data()));
   else if (map.type_.type == Type::count)
-    return std::to_string(reduce_value<uint64_t>(value, ncpus_) / div);
+    return std::to_string(reduce_value<uint64_t>(value, nvalues) / div);
   else if (map.type_.type == Type::sum || map.type_.type == Type::integer) {
     if (map.type_.is_signed)
-      return std::to_string(reduce_value<int64_t>(value, ncpus_) / div);
+      return std::to_string(reduce_value<int64_t>(value, nvalues) / div);
 
-    return std::to_string(reduce_value<uint64_t>(value, ncpus_) / div);
+    return std::to_string(reduce_value<uint64_t>(value, nvalues) / div);
   }
   else if (map.type_.type == Type::min)
-    return std::to_string(min_value(value, ncpus_) / div);
+    return std::to_string(min_value(value, nvalues) / div);
   else if (map.type_.type == Type::max)
-    return std::to_string(max_value(value, ncpus_) / div);
+    return std::to_string(max_value(value, nvalues) / div);
   else if (map.type_.type == Type::probe)
     return resolve_probe(*(uint64_t*)value.data());
   else
@@ -1044,6 +1041,7 @@ std::string BPFtrace::map_value_to_str(IMap &map, std::vector<uint8_t> value, ui
 
 int BPFtrace::print_map(IMap &map, uint32_t top, uint32_t div)
 {
+  uint32_t nvalues = map.is_per_cpu_type() ? ncpus_ : 1;
   std::vector<uint8_t> old_key;
   try
   {
@@ -1062,9 +1060,7 @@ int BPFtrace::print_map(IMap &map, uint32_t top, uint32_t div)
   while (bpf_get_next_key(map.mapfd_, old_key.data(), key.data()) == 0)
   {
     int value_size = map.type_.size;
-    if (map.type_.type == Type::count || map.type_.type == Type::sum ||
-        map.type_.type == Type::min || map.type_.type == Type::max || map.type_.type == Type::integer)
-      value_size *= ncpus_;
+    value_size *= nvalues;
     auto value = std::vector<uint8_t>(value_size);
     int err = bpf_lookup_elem(map.mapfd_, key.data(), value.data());
     if (err == -1)
@@ -1090,22 +1086,22 @@ int BPFtrace::print_map(IMap &map, uint32_t top, uint32_t div)
     std::sort(values_by_key.begin(), values_by_key.end(), [&](auto &a, auto &b)
     {
       if (is_signed)
-        return reduce_value<int64_t>(a.second, ncpus_) < reduce_value<int64_t>(b.second, ncpus_);
-      return reduce_value<uint64_t>(a.second, ncpus_) < reduce_value<uint64_t>(b.second, ncpus_);
+        return reduce_value<int64_t>(a.second, nvalues) < reduce_value<int64_t>(b.second, nvalues);
+      return reduce_value<uint64_t>(a.second, nvalues) < reduce_value<uint64_t>(b.second, nvalues);
     });
   }
   else if (map.type_.type == Type::min)
   {
     std::sort(values_by_key.begin(), values_by_key.end(), [&](auto &a, auto &b)
     {
-      return min_value(a.second, ncpus_) < min_value(b.second, ncpus_);
+      return min_value(a.second, nvalues) < min_value(b.second, nvalues);
     });
   }
   else if (map.type_.type == Type::max)
   {
     std::sort(values_by_key.begin(), values_by_key.end(), [&](auto &a, auto &b)
     {
-      return max_value(a.second, ncpus_) < max_value(b.second, ncpus_);
+      return max_value(a.second, nvalues) < max_value(b.second, nvalues);
     });
   }
   else
@@ -1126,6 +1122,7 @@ int BPFtrace::print_map_hist(IMap &map, uint32_t top, uint32_t div)
   // e.g. A map defined as: @x[1, 2] = @hist(3);
   // would actually be stored with the key: [1, 2, 3]
 
+  uint32_t nvalues = map.is_per_cpu_type() ? ncpus_ : 1;
   std::vector<uint8_t> old_key;
   try
   {
@@ -1149,7 +1146,7 @@ int BPFtrace::print_map_hist(IMap &map, uint32_t top, uint32_t div)
     for (size_t i=0; i<map.key_.size(); i++)
       key_prefix.at(i) = key.at(i);
 
-    int value_size = map.type_.size * ncpus_;
+    int value_size = map.type_.size * nvalues;
     auto value = std::vector<uint8_t>(value_size);
     int err = bpf_lookup_elem(map.mapfd_, key.data(), value.data());
     if (err == -1)
@@ -1172,7 +1169,7 @@ int BPFtrace::print_map_hist(IMap &map, uint32_t top, uint32_t div)
       else
         values_by_key[key_prefix] = std::vector<uint64_t>(1002);
     }
-    values_by_key[key_prefix].at(bucket) = reduce_value<uint64_t>(value, ncpus_);
+    values_by_key[key_prefix].at(bucket) = reduce_value<uint64_t>(value, nvalues);
 
     old_key = key;
   }
@@ -1201,6 +1198,7 @@ int BPFtrace::print_map_hist(IMap &map, uint32_t top, uint32_t div)
 
 int BPFtrace::print_map_stats(IMap &map)
 {
+  uint32_t nvalues = map.is_per_cpu_type() ? ncpus_ : 1;
   // stats() and avg() maps add an extra 8 bytes onto the end of their key for
   // storing the bucket number.
 
@@ -1227,7 +1225,7 @@ int BPFtrace::print_map_stats(IMap &map)
     for (size_t i=0; i<map.key_.size(); i++)
       key_prefix.at(i) = key.at(i);
 
-    int value_size = map.type_.size * ncpus_;
+    int value_size = map.type_.size * nvalues;
     auto value = std::vector<uint8_t>(value_size);
     int err = bpf_lookup_elem(map.mapfd_, key.data(), value.data());
     if (err == -1)
@@ -1247,7 +1245,7 @@ int BPFtrace::print_map_stats(IMap &map)
       // New key - create a list of buckets for it
       values_by_key[key_prefix] = std::vector<int64_t>(2);
     }
-    values_by_key[key_prefix].at(bucket) = reduce_value<int64_t>(value, ncpus_);
+    values_by_key[key_prefix].at(bucket) = reduce_value<int64_t>(value, nvalues);
 
     old_key = key;
   }
@@ -1355,20 +1353,20 @@ int BPFtrace::spawn_child(const std::vector<std::string>& args, int *notify_trac
 }
 
 template <typename T>
-T BPFtrace::reduce_value(const std::vector<uint8_t> &value, int ncpus)
+T BPFtrace::reduce_value(const std::vector<uint8_t> &value, int nvalues)
 {
   T sum = 0;
-  for (int i=0; i<ncpus; i++)
+  for (int i=0; i<nvalues; i++)
   {
     sum += *(const T*)(value.data() + i*sizeof(T*));
   }
   return sum;
 }
 
-uint64_t BPFtrace::max_value(const std::vector<uint8_t> &value, int ncpus)
+uint64_t BPFtrace::max_value(const std::vector<uint8_t> &value, int nvalues)
 {
   uint64_t val, max = 0;
-  for (int i=0; i<ncpus; i++)
+  for (int i=0; i<nvalues; i++)
   {
     val = *(const uint64_t*)(value.data() + i*sizeof(uint64_t*));
     if (val > max)
@@ -1377,10 +1375,10 @@ uint64_t BPFtrace::max_value(const std::vector<uint8_t> &value, int ncpus)
   return max;
 }
 
-int64_t BPFtrace::min_value(const std::vector<uint8_t> &value, int ncpus)
+int64_t BPFtrace::min_value(const std::vector<uint8_t> &value, int nvalues)
 {
   int64_t val, max = 0, retval;
-  for (int i=0; i<ncpus; i++)
+  for (int i=0; i<nvalues; i++)
   {
     val = *(const int64_t*)(value.data() + i*sizeof(int64_t*));
     if (val > max)
@@ -1407,12 +1405,8 @@ std::vector<uint8_t> BPFtrace::find_empty_key(IMap &map, size_t size) const
 {
   if (size == 0) size = 8;
   auto key = std::vector<uint8_t>(size);
-  int value_size = map.type_.size;
-  if (map.type_.type == Type::count || map.type_.type == Type::hist ||
-      map.type_.type == Type::sum || map.type_.type == Type::min ||
-      map.type_.type == Type::max || map.type_.type == Type::avg ||
-      map.type_.type == Type::stats || map.type_.type == Type::lhist)
-    value_size *= ncpus_;
+  uint32_t nvalues = map.is_per_cpu_type() ? ncpus_ : 1;
+  int value_size = map.type_.size * nvalues;
   auto value = std::vector<uint8_t>(value_size);
 
   if (bpf_lookup_elem(map.mapfd_, key.data(), value.data()))

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -184,9 +184,9 @@ private:
   int print_map_stats(IMap &map);
   int print_hist(const std::vector<uint64_t> &values, uint32_t div) const;
   int print_lhist(const std::vector<uint64_t> &values, int min, int max, int step) const;
-  template <typename T> static T reduce_value(const std::vector<uint8_t> &value, int ncpus);
-  static int64_t min_value(const std::vector<uint8_t> &value, int ncpus);
-  static uint64_t max_value(const std::vector<uint8_t> &value, int ncpus);
+  template <typename T> static T reduce_value(const std::vector<uint8_t> &value, int nvalues);
+  static int64_t min_value(const std::vector<uint8_t> &value, int nvalues);
+  static uint64_t max_value(const std::vector<uint8_t> &value, int nvalues);
   static uint64_t read_address_from_output(std::string output);
   std::vector<uint8_t> find_empty_key(IMap &map, size_t size) const;
   static int spawn_child(const std::vector<std::string>& args, int *notify_trace_start_pipe_fd);

--- a/src/imap.h
+++ b/src/imap.h
@@ -21,6 +21,9 @@ public:
   SizedType type_;
   MapKey key_;
   enum bpf_map_type map_type_;
+  bool is_per_cpu_type() {
+    return map_type_ == BPF_MAP_TYPE_PERCPU_HASH || map_type_ == BPF_MAP_TYPE_PERCPU_ARRAY;
+  }
 
   // used by lhist(). TODO: move to separate Map object.
   int lqmin;

--- a/src/imap.h
+++ b/src/imap.h
@@ -20,6 +20,7 @@ public:
   std::string name_;
   SizedType type_;
   MapKey key_;
+  enum bpf_map_type map_type_;
 
   // used by lhist(). TODO: move to separate Map object.
   int lqmin;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -36,26 +36,25 @@ Map::Map(const std::string &name, const SizedType &type, const MapKey &key, int 
   if (key_size == 0)
     key_size = 8;
 
-  enum bpf_map_type map_type;
   if ((type.type == Type::hist || type.type == Type::lhist || type.type == Type::count ||
       type.type == Type::sum || type.type == Type::min || type.type == Type::max ||
       type.type == Type::avg || type.type == Type::stats) &&
       (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)))
   {
-      map_type = BPF_MAP_TYPE_PERCPU_HASH;
+      map_type_ = BPF_MAP_TYPE_PERCPU_HASH;
   }
   else if (type.type == Type::join)
   {
-    map_type = BPF_MAP_TYPE_PERCPU_ARRAY;
+    map_type_ = BPF_MAP_TYPE_PERCPU_ARRAY;
     max_entries = 1;
     key_size = 4;
   }
   else
-    map_type = BPF_MAP_TYPE_HASH;
+    map_type_ = BPF_MAP_TYPE_HASH;
 
   int value_size = type.size;
   int flags = 0;
-  mapfd_ = create_map(map_type, name.c_str(), key_size, value_size, max_entries, flags);
+  mapfd_ = create_map(map_type_, name.c_str(), key_size, value_size, max_entries, flags);
   if (mapfd_ < 0)
   {
     std::cerr << "Error creating map: '" << name_ << "': " << strerror(errno)
@@ -94,6 +93,7 @@ Map::Map(const SizedType &type) {
 Map::Map(enum bpf_map_type map_type)
 {
   int key_size, value_size, max_entries, flags;
+  map_type_ = map_type;
 
   std::string name;
 #ifdef DEBUG


### PR DESCRIPTION
I noticed that the exact map type with which the map was created isn't stored anywhere. Because of this the code has to guess the type of the value, which means having to maintain a few big if statements in multiple files, which can lead to bugs.

This  changes that by storing the MAP_TYPE in the map object and providing a helper to determine whether it is a PER_CPU  type or not.

It additionally fixes a bug where PER_CPU is assumed even though it isn't on kernel < 4.6.0. This doesn't impact the user as the vector is initialized to 0 and is also what we geet for "no value for this CPU". 
