### PR TITLE
Warn when doing signed division

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -774,8 +774,7 @@ void SemanticAnalyser::visit(Binop &binop)
         // in kernel sources
         switch (binop.op) {
           case bpftrace::Parser::token::DIV:
-            buf << "signed division can lead to undefined behavior"
-                << std::endl;
+            buf << "signed division can lead to undefined behavior";
             bpftrace_.warning(out_, binop.loc, buf.str());
             break;
           default:

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1062,6 +1062,18 @@ TEST(semantic_analyser, signed_int_arithmetic_warnings)
   test_for_warning("kprobe:f { @ = arg0 / 1 }", msg, invert);
 }
 
+TEST(semantic_analyser, signed_int_division_warnings)
+{
+  bool invert = true;
+  std::string msg = "signed division";
+  test_for_warning("kprobe:f { @ = -1 / 1 }", msg);
+  test_for_warning("kprobe:f { @ = 1 / -1 }", msg);
+
+  // These should not trigger a warning
+  test_for_warning("kprobe:f { @ = 1 / 1 }", msg, invert);
+  test_for_warning("kprobe:f { @ = -(1 / 1) }", msg, invert);
+}
+
 TEST(semantic_analyser, map_as_lookup_table)
 {
   // Initializing a map should not lead to usage issues


### PR DESCRIPTION
There isn't a signed division operation for bpf. Right now we just do
unsigned division but that gets weird for operands < 0 (as the MSB is
interpreted as a really large number).

Warn on such cases.

Example after change:

    $ sudo ./build/src/bpftrace -e 'BEGIN { printf("%d\n", 5 / -5); }'
    stdin:1:26-27: WARNING: signed division can lead to undefined behavior

    BEGIN { printf("%d\n", 5 / -5); }
                         ~
    Attaching 1 probe...
    0
    ^C