### PR TITLE
Use llvm8 on alpine static builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,10 +17,13 @@ matrix:
     # of passing occasionally.
     # String comparisons and args multiple tracepoints tests are the exception
     # - they are just broken in debug builds.
-    - name: "Static LLVM 5 Debug"
-      env: LLVM_VERSION=5.0 BASE=alpine TYPE=Debug STATIC_LINKING=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*:codegen.string_equal_comparison:codegen.string_not_equal_comparison:codegen.args_multiple_tracepoints*"
-    - name: "Static LLVM 5 Release"
-      env: LLVM_VERSION=5.0 BASE=alpine TYPE=Release STATIC_LINKING=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*:codegen.args_multiple_tracepoints*"
+    #
+    # Update: since we're on LLVM 8 now, it is worth seeing if the excluded tests
+    # are still flakey.
+    - name: "Static LLVM 8 Debug"
+      env: LLVM_VERSION=8.0 BASE=alpine TYPE=Debug STATIC_LINKING=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*:codegen.string_equal_comparison:codegen.string_not_equal_comparison:codegen.args_multiple_tracepoints*"
+    - name: "Static LLVM 8 Release"
+      env: LLVM_VERSION=8.0 BASE=alpine TYPE=Release STATIC_LINKING=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*:codegen.args_multiple_tracepoints*"
 
     - name: "LLVM 6 Debug"
       env: LLVM_VERSION=6.0 BASE=bionic TYPE=Debug RUN_ALL_TESTS=1

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.10
 RUN apk add --update \
   bison \
   build-base \
@@ -10,15 +10,15 @@ RUN apk add --update \
   flex-dev \
   git \
   linux-headers \
-  llvm5-dev \
-  llvm5-static \
+  llvm8-dev \
+  llvm8-static \
   python \
   zlib-dev
 
 # Put LLVM directories where CMake expects them to be
-RUN ln -s /usr/lib/cmake/llvm5 /usr/lib/cmake/llvm
-RUN ln -s /usr/include/llvm5/llvm /usr/include/llvm
-RUN ln -s /usr/include/llvm5/llvm-c /usr/include/llvm-c
+RUN ln -s /usr/lib/cmake/llvm8 /usr/lib/cmake/llvm
+RUN ln -s /usr/include/llvm8/llvm /usr/include/llvm
+RUN ln -s /usr/include/llvm8/llvm-c /usr/include/llvm-c
 
 # Alpine currently does not have a package for bcc. Until they do,
 # we'll peg the alpine build to bcc v0.8.0


### PR DESCRIPTION
LLVM5 is old and probably the reason for flakiness on the CI. Upgrade to
8 is a no brainer.