### PR TITLE
Various BTF enhancements

### DIFF
--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -228,11 +228,54 @@ std::string BTF::c_def(std::unordered_set<std::string>& set)
     const struct btf_type *t = btf__type_by_id(btf, id);
     const char *str = btf_str(btf, t->name_off);
 
-    auto it = myset.find(str);
-    if (it != myset.end())
+    /*
+     * TODO(danobi): Only resolve necessary types. This can be
+     * accomlished by doing something like:
+     *
+     *    for (...) {
+     *      const struct btf_type *t = ...
+     *      const char *str = ...
+     *
+     *      if (myset.find(str) != myset.end()) {
+     *        btf_dump__dump_type(...);
+     *        myset.erase(str);
+     *
+     *        <dump required forward declared types>
+     *      }
+     *    }
+     *
+     * Care are must be taken to fully resolve any accesses
+     * via a pointer. libbpf currently does not fully resolve types
+     * that are used as a pointer. For example, if in the kernel there
+     * was:
+     *
+     *    struct Bar {
+     *      int x;
+     *    };
+     *
+     *    struct Foo {
+     *      struct Bar *b;
+     *    };
+     *
+     * b would not be fully resolved. Instead, libbpf will dump a
+     * forward declaration. So the libbpf output would look like:
+     *
+     *    struct Bar;
+     *    struct Foo {
+     *      struct Bar *b;
+     *    }
+     *
+     * So for now, we read in every type BTF exposes. It's slower
+     * and less memory efficient, but it's more ergonomic for the
+     * user to not have to do an explicit cast every time they
+     * access a pointer.
+     */
+
+    for (id = 1; id <= max; id++)
     {
+      const struct btf_type *t = btf__type_by_id(btf, id);
+      const char *str = btf_str(btf, t->name_off);
       btf_dump__dump_type(dump, id);
-      myset.erase(it);
     }
   }
 


### PR DESCRIPTION
This change allows the user to do
```
kprobe:vfs_open
{
        printf("open path: %s\n", str(((path *)arg0)->dentry->d_name.name));
}
```
rather than
```
kprobe:vfs_open
{
        $dentry = ((dentry *)((path *)arg0)->dentry);
        printf("open path: %s\n", str($dentry->d_name.name));
}
```
Note the explicit second cast.

However, there's a cost for this. For the before and after, respectively:
```
Command exited with non-zero status 124
        Command being timed: "timeout 2 trunk/platform007/00921df/bin/bpftrace /home/dlxu/scratch/bpftrace/scripts/path.bt --btf"
        User time (seconds): 0.02
        System time (seconds): 0.08
        Percent of CPU this job got: 5%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:02.12
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 42292
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 2731
        Voluntary context switches: 8149
        Involuntary context switches: 2
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 124

Command exited with non-zero status 124
        Command being timed: "timeout 2 trunk/platform007/00921df/bin/bpftrace /home/dlxu/scratch/bpftrace/scripts/path.bt --btf"
        User time (seconds): 0.55
        System time (seconds): 0.10
        Percent of CPU this job got: 30%
        Elapsed (wall clock) time (h:mm:ss or m:ss): 0:02.14
        Average shared text size (kbytes): 0
        Average unshared data size (kbytes): 0
        Average stack size (kbytes): 0
        Average total size (kbytes): 0
        Maximum resident set size (kbytes): 78624
        Average resident set size (kbytes): 0
        Major (requiring I/O) page faults: 0
        Minor (reclaiming a frame) page faults: 14921
        Voluntary context switches: 5324
        Involuntary context switches: 2
        Swaps: 0
        File system inputs: 0
        File system outputs: 0
        Socket messages sent: 0
        Socket messages received: 0
        Signals delivered: 0
        Page size (bytes): 4096
        Exit status: 124

```

Two salient metrics:
* peak RSS: 42292KB -> 78624KB
* user time: 0.02s -> 0.55s

Would appreciate thoughts.