### PR TITLE
Fix negative number handling of min/max

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -211,7 +211,7 @@ void CodegenLLVM::visit(Call &call)
   {
     Map &map = *call.map;
     AllocaInst *key = getMapKey(map);
-    Value *oldval = b_.CreateMapLookupElem(map, key);
+    Value *oldval = b_.CreateMapLookupElemValue(map, key);
     AllocaInst *newval = b_.CreateAllocaBPF(map.type, map.ident + "_val");
     b_.CreateStore(b_.CreateAdd(oldval, b_.getInt64(1)), newval);
     b_.CreateMapUpdateElem(map, key, newval);
@@ -225,7 +225,7 @@ void CodegenLLVM::visit(Call &call)
   {
     Map &map = *call.map;
     AllocaInst *key = getMapKey(map);
-    Value *oldval = b_.CreateMapLookupElem(map, key);
+    Value *oldval = b_.CreateMapLookupElemValue(map, key);
     AllocaInst *newval = b_.CreateAllocaBPF(map.type, map.ident + "_val");
 
     call.vargs->front()->accept(*this);
@@ -243,7 +243,7 @@ void CodegenLLVM::visit(Call &call)
   {
     Map &map = *call.map;
     AllocaInst *key = getMapKey(map);
-    Value *oldval = b_.CreateMapLookupElem(map, key);
+    Value *oldval = b_.CreateMapLookupElemValue(map, key);
     AllocaInst *newval = b_.CreateAllocaBPF(map.type, map.ident + "_val");
 
     // Store the max of (0xffffffff - val), so that our SGE comparison with uninitialized
@@ -271,7 +271,7 @@ void CodegenLLVM::visit(Call &call)
   {
     Map &map = *call.map;
     AllocaInst *key = getMapKey(map);
-    Value *oldval = b_.CreateMapLookupElem(map, key);
+    Value *oldval = b_.CreateMapLookupElemValue(map, key);
     AllocaInst *newval = b_.CreateAllocaBPF(map.type, map.ident + "_val");
 
     Function *parent = b_.GetInsertBlock()->getParent();
@@ -299,7 +299,7 @@ void CodegenLLVM::visit(Call &call)
     Map &map = *call.map;
 
     AllocaInst *count_key = getHistMapKey(map, b_.getInt64(0));
-    Value *count_old = b_.CreateMapLookupElem(map, count_key);
+    Value *count_old = b_.CreateMapLookupElemValue(map, count_key);
     AllocaInst *count_new = b_.CreateAllocaBPF(map.type, map.ident + "_num");
     b_.CreateStore(b_.CreateAdd(count_old, b_.getInt64(1)), count_new);
     b_.CreateMapUpdateElem(map, count_key, count_new);
@@ -307,7 +307,7 @@ void CodegenLLVM::visit(Call &call)
     b_.CreateLifetimeEnd(count_new);
 
     AllocaInst *total_key = getHistMapKey(map, b_.getInt64(1));
-    Value *total_old = b_.CreateMapLookupElem(map, total_key);
+    Value *total_old = b_.CreateMapLookupElemValue(map, total_key);
     AllocaInst *total_new = b_.CreateAllocaBPF(map.type, map.ident + "_val");
     call.vargs->front()->accept(*this);
     // promote int to 64-bit
@@ -329,7 +329,7 @@ void CodegenLLVM::visit(Call &call)
     Value *log2 = b_.CreateCall(log2_func, expr_, "log2");
     AllocaInst *key = getHistMapKey(map, log2);
 
-    Value *oldval = b_.CreateMapLookupElem(map, key);
+    Value *oldval = b_.CreateMapLookupElemValue(map, key);
     AllocaInst *newval = b_.CreateAllocaBPF(map.type, map.ident + "_val");
     b_.CreateStore(b_.CreateAdd(oldval, b_.getInt64(1)), newval);
     b_.CreateMapUpdateElem(map, key, newval);
@@ -370,7 +370,7 @@ void CodegenLLVM::visit(Call &call)
 
     AllocaInst *key = getHistMapKey(map, linear);
 
-    Value *oldval = b_.CreateMapLookupElem(map, key);
+    Value *oldval = b_.CreateMapLookupElemValue(map, key);
     AllocaInst *newval = b_.CreateAllocaBPF(map.type, map.ident + "_val");
     b_.CreateStore(b_.CreateAdd(oldval, b_.getInt64(1)), newval);
     b_.CreateMapUpdateElem(map, key, newval);
@@ -692,7 +692,7 @@ void CodegenLLVM::visit(Call &call)
 void CodegenLLVM::visit(Map &map)
 {
   AllocaInst *key = getMapKey(map);
-  expr_ = b_.CreateMapLookupElem(map, key);
+  expr_ = b_.CreateMapLookupElemValue(map, key);
   b_.CreateLifetimeEnd(key);
 }
 
@@ -855,7 +855,7 @@ void CodegenLLVM::visit(Unop &unop)
         {
           Map &map = static_cast<Map&>(*unop.expr);
           AllocaInst *key = getMapKey(map);
-          Value *oldval = b_.CreateMapLookupElem(map, key);
+          Value *oldval = b_.CreateMapLookupElemValue(map, key);
           AllocaInst *newval = b_.CreateAllocaBPF(map.type, map.ident + "_newval");
           if (is_increment)
             b_.CreateStore(b_.CreateAdd(oldval, b_.getInt64(1)), newval);

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -38,7 +38,8 @@ public:
   llvm::ConstantInt *GetIntSameSize(uint64_t C, llvm::Value *expr);
   CallInst   *CreateBpfPseudoCall(int mapfd);
   CallInst   *CreateBpfPseudoCall(Map &map);
-  Value      *CreateMapLookupElem(Map &map, AllocaInst *key);
+  CallInst   *CreateMapLookupElem(Map &map, AllocaInst *key);
+  Value      *CreateMapLookupElemValue(Map &map, AllocaInst *key);
   void        CreateMapUpdateElem(Map &map, AllocaInst *key, Value *val);
   void        CreateMapDeleteElem(Map &map, AllocaInst *key);
   void        CreateProbeRead(AllocaInst *dst, size_t size, Value *src);
@@ -59,6 +60,7 @@ public:
   CallInst   *CreateGetJoinMap(Value *ctx);
   void        CreateGetCurrentComm(AllocaInst *buf, size_t size);
   void        CreatePerfEventOutput(Value *ctx, Value *data, size_t size);
+  Constant   *GetNULLPtr();
 
 private:
   Module &module_;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -966,6 +966,7 @@ int BPFtrace::clear_map(IMap &map)
 // zero a map
 int BPFtrace::zero_map(IMap &map)
 {
+  uint32_t nvalues = map.is_per_cpu_type() ? ncpus_ : 1;
   std::vector<uint8_t> old_key;
   try
   {
@@ -992,12 +993,7 @@ int BPFtrace::zero_map(IMap &map)
     old_key = key;
   }
 
-  int value_size = map.type_.size;
-  if (map.type_.type == Type::count || map.type_.type == Type::sum ||
-      map.type_.type == Type::min || map.type_.type == Type::max ||
-      map.type_.type == Type::avg || map.type_.type == Type::hist ||
-      map.type_.type == Type::lhist || map.type_.type == Type::stats )
-    value_size *= ncpus_;
+  int value_size = map.type_.size * nvalues;
   std::vector<uint8_t> zero(value_size, 0);
   for (auto &key : keys)
   {
@@ -1015,6 +1011,7 @@ int BPFtrace::zero_map(IMap &map)
 
 std::string BPFtrace::map_value_to_str(IMap &map, std::vector<uint8_t> value, uint32_t div)
 {
+  uint32_t nvalues = map.is_per_cpu_type() ? ncpus_ : 1;
   if (map.type_.type == Type::kstack)
     return get_stack(*(uint64_t*)value.data(), false, map.type_.stack_type, 8);
   else if (map.type_.type == Type::ustack)
@@ -1030,17 +1027,17 @@ std::string BPFtrace::map_value_to_str(IMap &map, std::vector<uint8_t> value, ui
   else if (map.type_.type == Type::string)
     return std::string(reinterpret_cast<const char*>(value.data()));
   else if (map.type_.type == Type::count)
-    return std::to_string(reduce_value<uint64_t>(value, ncpus_) / div);
+    return std::to_string(reduce_value<uint64_t>(value, nvalues) / div);
   else if (map.type_.type == Type::sum || map.type_.type == Type::integer) {
     if (map.type_.is_signed)
-      return std::to_string(reduce_value<int64_t>(value, ncpus_) / div);
+      return std::to_string(reduce_value<int64_t>(value, nvalues) / div);
 
-    return std::to_string(reduce_value<uint64_t>(value, ncpus_) / div);
+    return std::to_string(reduce_value<uint64_t>(value, nvalues) / div);
   }
   else if (map.type_.type == Type::min)
-    return std::to_string(min_value(value, ncpus_) / div);
+    return std::to_string(min_value(value, nvalues) / div);
   else if (map.type_.type == Type::max)
-    return std::to_string(max_value(value, ncpus_) / div);
+    return std::to_string(max_value(value, nvalues) / div);
   else if (map.type_.type == Type::probe)
     return resolve_probe(*(uint64_t*)value.data());
   else
@@ -1049,6 +1046,7 @@ std::string BPFtrace::map_value_to_str(IMap &map, std::vector<uint8_t> value, ui
 
 int BPFtrace::print_map(IMap &map, uint32_t top, uint32_t div)
 {
+  uint32_t nvalues = map.is_per_cpu_type() ? ncpus_ : 1;
   std::vector<uint8_t> old_key;
   try
   {
@@ -1067,9 +1065,7 @@ int BPFtrace::print_map(IMap &map, uint32_t top, uint32_t div)
   while (bpf_get_next_key(map.mapfd_, old_key.data(), key.data()) == 0)
   {
     int value_size = map.type_.size;
-    if (map.type_.type == Type::count || map.type_.type == Type::sum ||
-        map.type_.type == Type::min || map.type_.type == Type::max || map.type_.type == Type::integer)
-      value_size *= ncpus_;
+    value_size *= nvalues;
     auto value = std::vector<uint8_t>(value_size);
     int err = bpf_lookup_elem(map.mapfd_, key.data(), value.data());
     if (err == -1)
@@ -1095,22 +1091,22 @@ int BPFtrace::print_map(IMap &map, uint32_t top, uint32_t div)
     std::sort(values_by_key.begin(), values_by_key.end(), [&](auto &a, auto &b)
     {
       if (is_signed)
-        return reduce_value<int64_t>(a.second, ncpus_) < reduce_value<int64_t>(b.second, ncpus_);
-      return reduce_value<uint64_t>(a.second, ncpus_) < reduce_value<uint64_t>(b.second, ncpus_);
+        return reduce_value<int64_t>(a.second, nvalues) < reduce_value<int64_t>(b.second, nvalues);
+      return reduce_value<uint64_t>(a.second, nvalues) < reduce_value<uint64_t>(b.second, nvalues);
     });
   }
   else if (map.type_.type == Type::min)
   {
     std::sort(values_by_key.begin(), values_by_key.end(), [&](auto &a, auto &b)
     {
-      return min_value(a.second, ncpus_) < min_value(b.second, ncpus_);
+      return min_value(a.second, nvalues) < min_value(b.second, nvalues);
     });
   }
   else if (map.type_.type == Type::max)
   {
     std::sort(values_by_key.begin(), values_by_key.end(), [&](auto &a, auto &b)
     {
-      return max_value(a.second, ncpus_) < max_value(b.second, ncpus_);
+      return max_value(a.second, nvalues) < max_value(b.second, nvalues);
     });
   }
   else
@@ -1131,6 +1127,7 @@ int BPFtrace::print_map_hist(IMap &map, uint32_t top, uint32_t div)
   // e.g. A map defined as: @x[1, 2] = @hist(3);
   // would actually be stored with the key: [1, 2, 3]
 
+  uint32_t nvalues = map.is_per_cpu_type() ? ncpus_ : 1;
   std::vector<uint8_t> old_key;
   try
   {
@@ -1154,7 +1151,7 @@ int BPFtrace::print_map_hist(IMap &map, uint32_t top, uint32_t div)
     for (size_t i=0; i<map.key_.size(); i++)
       key_prefix.at(i) = key.at(i);
 
-    int value_size = map.type_.size * ncpus_;
+    int value_size = map.type_.size * nvalues;
     auto value = std::vector<uint8_t>(value_size);
     int err = bpf_lookup_elem(map.mapfd_, key.data(), value.data());
     if (err == -1)
@@ -1177,7 +1174,7 @@ int BPFtrace::print_map_hist(IMap &map, uint32_t top, uint32_t div)
       else
         values_by_key[key_prefix] = std::vector<uint64_t>(1002);
     }
-    values_by_key[key_prefix].at(bucket) = reduce_value<uint64_t>(value, ncpus_);
+    values_by_key[key_prefix].at(bucket) = reduce_value<uint64_t>(value, nvalues);
 
     old_key = key;
   }
@@ -1206,6 +1203,7 @@ int BPFtrace::print_map_hist(IMap &map, uint32_t top, uint32_t div)
 
 int BPFtrace::print_map_stats(IMap &map)
 {
+  uint32_t nvalues = map.is_per_cpu_type() ? ncpus_ : 1;
   // stats() and avg() maps add an extra 8 bytes onto the end of their key for
   // storing the bucket number.
 
@@ -1232,7 +1230,7 @@ int BPFtrace::print_map_stats(IMap &map)
     for (size_t i=0; i<map.key_.size(); i++)
       key_prefix.at(i) = key.at(i);
 
-    int value_size = map.type_.size * ncpus_;
+    int value_size = map.type_.size * nvalues;
     auto value = std::vector<uint8_t>(value_size);
     int err = bpf_lookup_elem(map.mapfd_, key.data(), value.data());
     if (err == -1)
@@ -1252,7 +1250,7 @@ int BPFtrace::print_map_stats(IMap &map)
       // New key - create a list of buckets for it
       values_by_key[key_prefix] = std::vector<int64_t>(2);
     }
-    values_by_key[key_prefix].at(bucket) = reduce_value<int64_t>(value, ncpus_);
+    values_by_key[key_prefix].at(bucket) = reduce_value<int64_t>(value, nvalues);
 
     old_key = key;
   }
@@ -1360,20 +1358,20 @@ int BPFtrace::spawn_child(const std::vector<std::string>& args, int *notify_trac
 }
 
 template <typename T>
-T BPFtrace::reduce_value(const std::vector<uint8_t> &value, int ncpus)
+T BPFtrace::reduce_value(const std::vector<uint8_t> &value, int nvalues)
 {
   T sum = 0;
-  for (int i=0; i<ncpus; i++)
+  for (int i=0; i<nvalues; i++)
   {
     sum += *(const T*)(value.data() + i*sizeof(T*));
   }
   return sum;
 }
 
-uint64_t BPFtrace::max_value(const std::vector<uint8_t> &value, int ncpus)
+uint64_t BPFtrace::max_value(const std::vector<uint8_t> &value, int nvalues)
 {
   uint64_t val, max = 0;
-  for (int i=0; i<ncpus; i++)
+  for (int i=0; i<nvalues; i++)
   {
     val = *(const uint64_t*)(value.data() + i*sizeof(uint64_t*));
     if (val > max)
@@ -1382,10 +1380,10 @@ uint64_t BPFtrace::max_value(const std::vector<uint8_t> &value, int ncpus)
   return max;
 }
 
-int64_t BPFtrace::min_value(const std::vector<uint8_t> &value, int ncpus)
+int64_t BPFtrace::min_value(const std::vector<uint8_t> &value, int nvalues)
 {
   int64_t val, max = 0, retval;
-  for (int i=0; i<ncpus; i++)
+  for (int i=0; i<nvalues; i++)
   {
     val = *(const int64_t*)(value.data() + i*sizeof(int64_t*));
     if (val > max)
@@ -1412,12 +1410,8 @@ std::vector<uint8_t> BPFtrace::find_empty_key(IMap &map, size_t size) const
 {
   if (size == 0) size = 8;
   auto key = std::vector<uint8_t>(size);
-  int value_size = map.type_.size;
-  if (map.type_.type == Type::count || map.type_.type == Type::hist ||
-      map.type_.type == Type::sum || map.type_.type == Type::min ||
-      map.type_.type == Type::max || map.type_.type == Type::avg ||
-      map.type_.type == Type::stats || map.type_.type == Type::lhist)
-    value_size *= ncpus_;
+  uint32_t nvalues = map.is_per_cpu_type() ? ncpus_ : 1;
+  int value_size = map.type_.size * nvalues;
   auto value = std::vector<uint8_t>(value_size);
 
   if (bpf_lookup_elem(map.mapfd_, key.data(), value.data()))

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -185,9 +185,9 @@ private:
   int print_map_stats(IMap &map);
   int print_hist(const std::vector<uint64_t> &values, uint32_t div) const;
   int print_lhist(const std::vector<uint64_t> &values, int min, int max, int step) const;
-  template <typename T> static T reduce_value(const std::vector<uint8_t> &value, int ncpus);
-  static int64_t min_value(const std::vector<uint8_t> &value, int ncpus);
-  static uint64_t max_value(const std::vector<uint8_t> &value, int ncpus);
+  template <typename T> static T reduce_value(const std::vector<uint8_t> &value, int nvalues);
+  static int64_t min_value(const std::vector<uint8_t> &value, int nvalues);
+  static uint64_t max_value(const std::vector<uint8_t> &value, int nvalues);
   static uint64_t read_address_from_output(std::string output);
   std::vector<uint8_t> find_empty_key(IMap &map, size_t size) const;
   static int spawn_child(const std::vector<std::string>& args, int *notify_trace_start_pipe_fd);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -185,9 +185,8 @@ private:
   int print_map_stats(IMap &map);
   int print_hist(const std::vector<uint64_t> &values, uint32_t div) const;
   int print_lhist(const std::vector<uint64_t> &values, int min, int max, int step) const;
+
   template <typename T> static T reduce_value(const std::vector<uint8_t> &value, int nvalues);
-  static int64_t min_value(const std::vector<uint8_t> &value, int nvalues);
-  static uint64_t max_value(const std::vector<uint8_t> &value, int nvalues);
   static uint64_t read_address_from_output(std::string output);
   std::vector<uint8_t> find_empty_key(IMap &map, size_t size) const;
   static int spawn_child(const std::vector<std::string>& args, int *notify_trace_start_pipe_fd);

--- a/src/imap.h
+++ b/src/imap.h
@@ -21,6 +21,9 @@ public:
   SizedType type_;
   MapKey key_;
   enum bpf_map_type map_type_;
+  bool is_per_cpu_type() {
+    return map_type_ == BPF_MAP_TYPE_PERCPU_HASH || map_type_ == BPF_MAP_TYPE_PERCPU_ARRAY;
+  }
 
   // used by lhist(). TODO: move to separate Map object.
   int lqmin;

--- a/src/imap.h
+++ b/src/imap.h
@@ -20,6 +20,7 @@ public:
   std::string name_;
   SizedType type_;
   MapKey key_;
+  enum bpf_map_type map_type_;
 
   // used by lhist(). TODO: move to separate Map object.
   int lqmin;

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -36,26 +36,25 @@ Map::Map(const std::string &name, const SizedType &type, const MapKey &key, int 
   if (key_size == 0)
     key_size = 8;
 
-  enum bpf_map_type map_type;
   if ((type.type == Type::hist || type.type == Type::lhist || type.type == Type::count ||
       type.type == Type::sum || type.type == Type::min || type.type == Type::max ||
       type.type == Type::avg || type.type == Type::stats) &&
       (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)))
   {
-      map_type = BPF_MAP_TYPE_PERCPU_HASH;
+      map_type_ = BPF_MAP_TYPE_PERCPU_HASH;
   }
   else if (type.type == Type::join)
   {
-    map_type = BPF_MAP_TYPE_PERCPU_ARRAY;
+    map_type_ = BPF_MAP_TYPE_PERCPU_ARRAY;
     max_entries = 1;
     key_size = 4;
   }
   else
-    map_type = BPF_MAP_TYPE_HASH;
+    map_type_ = BPF_MAP_TYPE_HASH;
 
   int value_size = type.size;
   int flags = 0;
-  mapfd_ = create_map(map_type, name.c_str(), key_size, value_size, max_entries, flags);
+  mapfd_ = create_map(map_type_, name.c_str(), key_size, value_size, max_entries, flags);
   if (mapfd_ < 0)
   {
     std::cerr << "Error creating map: '" << name_ << "': " << strerror(errno)
@@ -94,6 +93,7 @@ Map::Map(const SizedType &type) {
 Map::Map(enum bpf_map_type map_type)
 {
   int key_size, value_size, max_entries, flags;
+  map_type_ = map_type;
 
   std::string name;
 #ifdef DEBUG

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -37,8 +37,7 @@ Map::Map(const std::string &name, const SizedType &type, const MapKey &key, int 
     key_size = 8;
 
   if ((type.type == Type::hist || type.type == Type::lhist || type.type == Type::count ||
-      type.type == Type::sum || type.type == Type::min || type.type == Type::max ||
-      type.type == Type::avg || type.type == Type::stats) &&
+      type.type == Type::sum || type.type == Type::avg || type.type == Type::stats) &&
       (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)))
   {
       map_type_ = BPF_MAP_TYPE_PERCPU_HASH;

--- a/tests/codegen/call_avg.cpp
+++ b/tests/codegen/call_avg.cpp
@@ -45,22 +45,22 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   %4 = bitcast i64* %"@x_key2" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 1, i64* %"@x_key2", align 8
-  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem4 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo3, i64* nonnull %"@x_key2")
-  %map_lookup_cond9 = icmp eq i8* %lookup_elem4, null
-  br i1 %map_lookup_cond9, label %lookup_merge7, label %lookup_success5
+  %pseudo7 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem8 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo7, i64* nonnull %"@x_key2")
+  %map_lookup_cond9 = icmp eq i8* %lookup_elem8, null
+  br i1 %map_lookup_cond9, label %lookup_merge5, label %lookup_success3
 
-lookup_success5:                                  ; preds = %lookup_merge
-  %5 = load i64, i8* %lookup_elem4, align 8
-  br label %lookup_merge7
+lookup_success3:                                  ; preds = %lookup_merge
+  %5 = load i64, i8* %lookup_elem8, align 8
+  br label %lookup_merge5
 
-lookup_merge7:                                    ; preds = %lookup_merge, %lookup_success5
-  %lookup_elem_val8.0 = phi i64 [ %5, %lookup_success5 ], [ 0, %lookup_merge ]
+lookup_merge5:                                    ; preds = %lookup_merge, %lookup_success3
+  %lookup_elem_val6.0 = phi i64 [ %5, %lookup_success3 ], [ 0, %lookup_merge ]
   %6 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %7 = lshr i64 %get_pid_tgid, 32
-  %8 = add i64 %7, %lookup_elem_val8.0
+  %8 = add i64 %7, %lookup_elem_val6.0
   store i64 %8, i64* %"@x_val", align 8
   %pseudo10 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem11 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo10, i64* nonnull %"@x_key2", i64* nonnull %"@x_val", i64 0)

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -62,16 +62,24 @@ EXPECT @.*\[.*\]\:\s[0-9]*
 TIMEOUT 5
 AFTER cat /dev/null
 
-NAME min
-RUN bpftrace -v -e 'kprobe:vfs_read { @bytes[comm] = min(arg2); exit();}'
-EXPECT @.*\[.*\]\:\s[0-9]*
+NAME min negative value
+RUN bpftrace -v -e 'i:ms:100 { @=min(100); min(-444); exit() }'
+EXPECT @.*-444
 TIMEOUT 5
-AFTER cat /dev/null
 
-NAME max
-RUN bpftrace -v -e 'kprobe:vfs_read { @bytes[comm] = max(arg2); exit();}'
-EXPECT @.*\[.*\]\:\s[0-9]*
-AFTER cat /dev/null
+NAME max negative value
+RUN bpftrace -v -e 'i:ms:100 { @=max(-1000); max(-444); exit() }'
+EXPECT @.*-444
+TIMEOUT 5
+
+NAME max zero value
+RUN bpftrace -v -e 'i:ms:100 { @=max(0); exit() }'
+EXPECT @: *0
+TIMEOUT 5
+
+NAME max 64 bit values
+RUN bpftrace -v -e 'i:ms:100 { @=max(100); @=max(9223372036854775807); exit() }'
+EXPECT @: *9223372036854775807
 TIMEOUT 5
 
 NAME stats


### PR DESCRIPTION
This is based on the work in #909, the first 3 commits are from that

Some of the variable names have changed which breaks the codegen tests, I will fix those when there is an agreement that this is the best fix for min/max 

------


The `min` and `max` functions had some issues. `min` only supported a 32 bit
range and `max` only did positive numbers.

The most significant change in this commit is the switch from a per-cpu
to a "normal" hash. Per-cpu hashes are zero filled once the first key is
written, which makes it impossible to differentiate between an actual
zero and a "no value zero" making it impossible to `max` negative numbers.

The downside is that all the benefits of per-cpu hashes are lost now
too, making max less suited for the highly concurrent use cases.

An alternative could be to initialize the per_cpu hash ourselves with
an appropriate initial value based on the function and whether the value
is signed or not. But that means we have to do proper warning and
support type casting, which isn't possible yet. It would also add
complexity without a clear benefit or use case.
The `min` and `max` functions are not used in any of the examples at the
moment

Fixes #892
Fixes #983
