### PR TITLE
Introduce int casts

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1076,6 +1076,9 @@ void CodegenLLVM::visit(ArrayAccess &arr)
 void CodegenLLVM::visit(Cast &cast)
 {
   cast.expr->accept(*this);
+  if (cast.type.type == Type::integer) {
+    expr_ = b_.CreateIntCast(expr_, b_.getIntNTy(8 * cast.type.size), cast.type.is_signed, "cast");
+  }
 }
 
 void CodegenLLVM::visit(ExprStatement &expr)

--- a/tests/codegen/intcast_assign_var.cpp
+++ b/tests/codegen/intcast_assign_var.cpp
@@ -1,0 +1,48 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, intcast_retval)
+{
+  // Make sure the result is truncated to 32 bit and sign extended to 64
+  test("kretprobe:f { @=(int32)retval }",
+R"EXPECTED(; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kretprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kretprobe:f_1" {
+entry:
+  %"@_val" = alloca i64, align 8
+  %"@_key" = alloca i64, align 8
+  %1 = getelementptr i8, i8* %0, i64 80
+  %retval = load i64, i8* %1, align 8
+  %2 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  store i64 0, i64* %"@_key", align 8
+  %sext = shl i64 %retval, 32
+  %3 = ashr exact i64 %sext, 32
+  %4 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 %3, i64* %"@_val", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/intcast_retval.cpp
+++ b/tests/codegen/intcast_retval.cpp
@@ -1,0 +1,60 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, intcast_call)
+{
+  // Casting should work inside a call
+  test("kretprobe:f { @=sum((int32)retval) }",
+R"EXPECTED(; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kretprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kretprobe:f_1" {
+entry:
+  %"@_val" = alloca i64, align 8
+  %"@_key" = alloca i64, align 8
+  %1 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  store i64 0, i64* %"@_key", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, i64* nonnull %"@_key")
+  %map_lookup_cond = icmp eq i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
+
+lookup_success:                                   ; preds = %entry
+  %2 = load i64, i8* %lookup_elem, align 8
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %entry, %lookup_success
+  %lookup_elem_val.0 = phi i64 [ %2, %lookup_success ], [ 0, %entry ]
+  %3 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %4 = getelementptr i8, i8* %0, i64 80
+  %retval = load i64, i8* %4, align 8
+  %sext = shl i64 %retval, 32
+  %5 = ashr exact i64 %sext, 32
+  %6 = add i64 %5, %lookup_elem_val.0
+  store i64 %6, i64* %"@_val", align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/runtime/intcast
+++ b/tests/runtime/intcast
@@ -1,0 +1,16 @@
+NAME Casting retval should work
+RUN bpftrace -v -e 'ur:./testprogs/uprobe_negative_retval:main   /(int32)retval < 0/ { @[(int32)retval]=count(); exit();}'
+AFTER ./testprogs/uprobe_negative_retval
+EXPECT ^@\[-100\]: 1$
+TIMEOUT 5
+
+NAME Sum casted retval
+RUN bpftrace -v -e 'ur:./testprogs/uprobe_negative_retval:function1 { @=stats((int32)retval); exit();} ur:./testprogs/uprobe_negative_retval:main { exit() }'
+AFTER ./testprogs/uprobe_negative_retval
+EXPECT ^@: count 221, average -10, total -2210$
+TIMEOUT 5
+
+NAME Casting ints
+RUN bpftrace -v -e 'BEGIN{printf("Values: %d %d\n", (uint8) -10, (uint16) 131087); exit(); }'
+EXPECT Values: 246 15$
+TIMEOUT 5

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1131,6 +1131,32 @@ TEST(semantic_analyser, binop_sign)
   }
 }
 
+TEST(semantic_analyser, int_cast_types)
+{
+  test("kretprobe:f { @ = (int8)retval }", 0);
+  test("kretprobe:f { @ = (int16)retval }", 0);
+  test("kretprobe:f { @ = (int32)retval }", 0);
+  test("kretprobe:f { @ = (int64)retval }", 0);
+  test("kretprobe:f { @ = (uint8)retval }", 0);
+  test("kretprobe:f { @ = (uint16)retval }", 0);
+  test("kretprobe:f { @ = (uint32)retval }", 0);
+  test("kretprobe:f { @ = (uint64)retval }", 0);
+
+  test("kretprobe:f { @ = (int2)retval }", 1);
+  test("kretprobe:f { @ = (uint2)retval }", 1);
+}
+
+TEST(semantic_analyser, int_cast_usage)
+{
+  test("kretprobe:f /(int32) retval < 0 / {}", 0);
+  test("kprobe:f /(int32) arg0 < 0 / {}", 0);
+  test("kprobe:f { @=sum((int32)arg0) }", 0);
+  test("kprobe:f { @=avg((int32)arg0) }", 0);
+  test("kprobe:f { @=avg((int32)arg0) }", 0);
+
+  test("kprobe:f { @=avg((int32)\"abc\") }", 1);
+}
+
 
 } // namespace semantic_analyser
 } // namespace test

--- a/tests/testprogs/uprobe_negative_retval.c
+++ b/tests/testprogs/uprobe_negative_retval.c
@@ -1,0 +1,13 @@
+#include <unistd.h>
+
+__attribute__ ((noinline)) int function1(int x)
+{
+  return x;
+}
+
+int main(int argc __attribute__((unused)), char **argv __attribute__((unused))) {
+  for (int x = -120; x <= 100; x++) {
+    function1(x);
+  }
+  return -100;
+}


### PR DESCRIPTION
Currently all integers are 64 bits internally. This causes issues when
dealing with smaller (bitsize) values returned by the kernel. An example
is:

```
kr:sock_recvmsg /retval < 0/{
  @[comm, retval]++;
}
```

`sock_recvmsg` returns a 32 bits int which, depending on the CPU
architecture, gets zero extended to 64 bits. Because of the zero
extension predicate will always be false.
With int casts the user can tell bpftrace that it should cast the value
before doing the comparison.

As this casts types to integers these new casts are of `Type::integer`
instead of `Type::cast`. This keeps the amount of modifications needed
to a minimum as the code already knows how to handle integers. The
codegen is only a single truncate instruction, other parts of the
codegen cast to the required width when required.

One special case is mapkey. If we set the `size` of the underlying type
to 8 then the cast itself will not be performed. The fix for this is to
insert an additional cast forcing a cast up to 64bits. This is done by
rewriting the AST.
An alternative would be to not force 64bit map keys but that requires
more code without clear benefit.