### PR TITLE
Strip trailing newline from error message

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1835,6 +1835,12 @@ void BPFtrace::log_with_location(std::string level, std::ostream &out, const loc
     out << filename_ << ":";
   }
 
+  std::string msg(m);
+
+  if (! msg.empty() && msg[msg.length() -1 ] == '\n') {
+    msg.erase(msg.length()-1);
+  }
+
   // print only the message if location info wasn't set
   if (l.begin.line == 0) {
     out << level << ": " << m << std::endl;


### PR DESCRIPTION
The original error printing, which is still used a lot, required a new
line at the end but the one with location support adds it's own. This
can be confusing and can lead to extra newlines in the output.