### PR TITLE
Fix `sigint under heavy load` runtime test

### DIFF
--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -97,4 +97,4 @@ NAME sigint under heavy load
 RUN ./bpftrace --unsafe -v -e 'tracepoint:sched:sched_switch { system("echo foo"); } END { printf("end"); }'
 EXPECT end
 TIMEOUT 5
-AFTER  sleep 2; killall -s INT bpftrace
+AFTER  sleep 2; pkill -SIGINT bpftrace


### PR DESCRIPTION
Default ubuntu bionic container doesn't have `killall` utility.
Use `pkill` instead because that comes by default.