### PR TITLE
Make `uprobes - list probes by pid` test more quiet

### DIFF
--- a/tests/runtime/uprobe
+++ b/tests/runtime/uprobe
@@ -19,7 +19,7 @@ EXPECT uprobe:./testprogs/uprobe_test:function1
 TIMEOUT 5
 
 NAME "uprobes - list probes by pid"
-RUN bpftrace -l -p $(pidof uprobe_test)
+RUN bpftrace -l -p $(pidof uprobe_test) | grep -e '^uprobe'
 EXPECT uprobe:.*/testprogs/uprobe_test:function1
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test


### PR DESCRIPTION
Doing a `bpftrace -l -p $PID` lists all the kprobes as well. This spams
the terminal with thousands of lines of output, making it hard to debug
other tests.

Make this test more quiet by doing some preprocessing.