### PR TITLE
Correctly parse enums

### DIFF
--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -199,6 +199,8 @@ static SizedType get_sized_type(CXType clang_type)
     case CXType_LongLong:
     case CXType_Int:
       return SizedType(Type::integer, size, true);
+    case CXType_Enum:
+      return SizedType(Type::integer, size);
     case CXType_Pointer:
     {
       auto pointee_type = clang_getPointeeType(clang_type);

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -84,6 +84,18 @@ TEST(clang_parser, c_union)
   EXPECT_EQ(structs["Foo"].fields["l"].offset, 0);
 }
 
+TEST(clang_parser, c_enum)
+{
+  BPFtrace bpftrace;
+  parse("enum E {NONE}; struct Foo { enum E e; }", bpftrace);
+
+  StructMap &structs = bpftrace.structs_;
+
+  EXPECT_EQ(structs["Foo"].fields["e"].type.type, Type::integer);
+  EXPECT_EQ(structs["Foo"].fields["e"].type.size, 4U);
+  EXPECT_EQ(structs["Foo"].fields["e"].offset, 0);
+}
+
 TEST(clang_parser, integer_ptr)
 {
   BPFtrace bpftrace;


### PR DESCRIPTION
Enums were previously unsupported. `get_sized_type` would drop into the
default case and return no type. This would make the semantic analyser
reject any probes using an enum as it cannot figure out how much data to
access and how to interpret it.