### PR TITLE
Add support to cast to a pointer of integer

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -957,7 +957,22 @@ void CodegenLLVM::visit(Unop &unop)
   }
   else if (type.type == Type::cast)
   {
-    // Do nothing
+    switch (unop.op) {
+      case bpftrace::Parser::token::MUL:
+      {
+        if (type.is_pointer && unop.type.type == Type::integer)
+        {
+          int size = unop.type.size;
+          AllocaInst *dst = b_.CreateAllocaBPF(unop.type, "deref");
+          b_.CreateProbeRead(dst, size, expr_);
+          expr_ = b_.CreateLoad(dst);
+          b_.CreateLifetimeEnd(dst);
+        }
+        break;
+      }
+      default:
+        ; // Do nothing
+    }
   }
   else
   {

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -928,7 +928,7 @@ void SemanticAnalyser::visit(Unop &unop)
           return;
         }
         if (k_v != intcasts.end()) {
-          auto v = k_v->second;
+          auto &v = k_v->second;
           unop.type = SizedType(Type::integer, std::get<0>(v), std::get<1>(v), k_v->first);
         } else {
           cast_size = bpftrace_.structs_[type.cast_type].size;
@@ -1091,7 +1091,7 @@ void SemanticAnalyser::visit(Cast &cast)
   }
 
   if (k_v != intcasts.end()) {
-    auto v = k_v->second;
+    auto &v = k_v->second;
     cast.type = SizedType(Type::integer, std::get<0>(v), std::get<1>(v), k_v->first);
 
     auto rhs = cast.expr->type.type;

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -17,6 +17,17 @@
 namespace bpftrace {
 namespace ast {
 
+const std::map<std::string, std::tuple<size_t, bool>> intcasts = {
+    {"uint8", std::tuple<size_t, bool>{1, false}},
+    {"int8", std::tuple<size_t, bool>{1, true}},
+    {"uint16", std::tuple<size_t, bool>{2, false}},
+    {"int16", std::tuple<size_t, bool>{2, true}},
+    {"uint32", std::tuple<size_t, bool>{4, false}},
+    {"int32", std::tuple<size_t, bool>{4, true}},
+    {"uint64", std::tuple<size_t, bool>{8, false}},
+    {"int64", std::tuple<size_t, bool>{8, true}},
+};
+
 void SemanticAnalyser::visit(Integer &integer)
 {
   integer.type = SizedType(Type::integer, 8, true);
@@ -910,12 +921,19 @@ void SemanticAnalyser::visit(Unop &unop)
   if (unop.op == Parser::token::MUL) {
     if (type.type == Type::cast) {
       if (type.is_pointer) {
-        if (bpftrace_.structs_.count(type.cast_type) == 0) {
+        int cast_size;
+        auto k_v = intcasts.find(type.cast_type);
+        if (k_v == intcasts.end() && bpftrace_.structs_.count(type.cast_type) == 0) {
           err_ << "Unknown struct/union: '" << type.cast_type << "'" << std::endl;
           return;
         }
-        int cast_size = bpftrace_.structs_[type.cast_type].size;
-        unop.type = SizedType(Type::cast, cast_size, type.cast_type);
+        if (k_v != intcasts.end()) {
+          auto v = k_v->second;
+          unop.type = SizedType(Type::integer, std::get<0>(v), std::get<1>(v), k_v->first);
+        } else {
+          cast_size = bpftrace_.structs_[type.cast_type].size;
+          unop.type = SizedType(Type::cast, cast_size, type.cast_type);
+        }
         unop.type.is_tparg = type.is_tparg;
       }
       else {
@@ -1057,18 +1075,21 @@ void SemanticAnalyser::visit(Cast &cast)
 {
   cast.expr->accept(*this);
 
-  const std::map<std::string, std::tuple<size_t, bool>> intcasts = {
-      {"uint8", std::tuple<size_t, bool>{1, false}},
-      {"int8", std::tuple<size_t, bool>{1, true}},
-      {"uint16", std::tuple<size_t, bool>{2, false}},
-      {"int16", std::tuple<size_t, bool>{2, true}},
-      {"uint32", std::tuple<size_t, bool>{4, false}},
-      {"int32", std::tuple<size_t, bool>{4, true}},
-      {"uint64", std::tuple<size_t, bool>{8, false}},
-      {"int64", std::tuple<size_t, bool>{8, true}},
-  };
-
   auto k_v = intcasts.find(cast.cast_type);
+  int cast_size;
+
+  if (k_v == intcasts.end() && bpftrace_.structs_.count(cast.cast_type) == 0) {
+    err_ << "Unknown struct/union: '" << cast.cast_type << "'" << std::endl;
+    return;
+  }
+
+  if (cast.is_pointer) {
+    cast_size = sizeof(uintptr_t);
+    cast.type = SizedType(Type::cast, cast_size, cast.cast_type);
+    cast.type.is_pointer = cast.is_pointer;
+    return;
+  }
+
   if (k_v != intcasts.end()) {
     auto v = k_v->second;
     cast.type = SizedType(Type::integer, std::get<0>(v), std::get<1>(v), k_v->first);
@@ -1081,18 +1102,7 @@ void SemanticAnalyser::visit(Cast &cast)
     return;
   }
 
-  if (bpftrace_.structs_.count(cast.cast_type) == 0) {
-    err_ << "Unknown struct/union: '" << cast.cast_type << "'" << std::endl;
-    return;
-  }
-
-  int cast_size;
-  if (cast.is_pointer) {
-    cast_size = sizeof(uintptr_t);
-  }
-  else {
-    cast_size = bpftrace_.structs_[cast.cast_type].size;
-  }
+  cast_size = bpftrace_.structs_[cast.cast_type].size;
   cast.type = SizedType(Type::cast, cast_size, cast.cast_type);
   cast.type.is_pointer = cast.is_pointer;
 }

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -17,7 +17,8 @@
 namespace bpftrace {
 namespace ast {
 
-const std::map<std::string, std::tuple<size_t, bool>> intcasts = {
+static const std::map<std::string, std::tuple<size_t, bool>>& getIntcasts() {
+  static const std::map<std::string, std::tuple<size_t, bool>> intcasts = {
     {"uint8", std::tuple<size_t, bool>{1, false}},
     {"int8", std::tuple<size_t, bool>{1, true}},
     {"uint16", std::tuple<size_t, bool>{2, false}},
@@ -26,7 +27,9 @@ const std::map<std::string, std::tuple<size_t, bool>> intcasts = {
     {"int32", std::tuple<size_t, bool>{4, true}},
     {"uint64", std::tuple<size_t, bool>{8, false}},
     {"int64", std::tuple<size_t, bool>{8, true}},
-};
+  };
+  return intcasts;
+}
 
 void SemanticAnalyser::visit(Integer &integer)
 {
@@ -922,6 +925,7 @@ void SemanticAnalyser::visit(Unop &unop)
     if (type.type == Type::cast) {
       if (type.is_pointer) {
         int cast_size;
+        auto &intcasts = getIntcasts();
         auto k_v = intcasts.find(type.cast_type);
         if (k_v == intcasts.end() && bpftrace_.structs_.count(type.cast_type) == 0) {
           err_ << "Unknown struct/union: '" << type.cast_type << "'" << std::endl;
@@ -1075,6 +1079,7 @@ void SemanticAnalyser::visit(Cast &cast)
 {
   cast.expr->accept(*this);
 
+  auto &intcasts = getIntcasts();
   auto k_v = intcasts.find(cast.cast_type);
   int cast_size;
 

--- a/tests/codegen/intptrcast_assign_var.cpp
+++ b/tests/codegen/intptrcast_assign_var.cpp
@@ -1,0 +1,52 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, intptrcast_assign_var)
+{
+  test("kretprobe:f { @=*(int8*)(reg(\"bp\")-1) }",
+R"EXPECTED(; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kretprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kretprobe:f_1" {
+entry:
+  %"@_val" = alloca i64, align 8
+  %"@_key" = alloca i64, align 8
+  %deref = alloca i8, align 1
+  %1 = getelementptr i8, i8* %0, i64 32
+  %reg_bp = load i64, i8* %1, align 8
+  %2 = add i64 %reg_bp, -1
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %deref)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %deref, i64 1, i64 %2)
+  %3 = load i8, i8* %deref, align 1
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %deref)
+  %4 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 0, i64* %"@_key", align 8
+  %5 = sext i8 %3 to i64
+  %6 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  store i64 %5, i64* %"@_val", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/intptrcast_call.cpp
+++ b/tests/codegen/intptrcast_call.cpp
@@ -1,0 +1,65 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, intptrcast_call)
+{
+  // Casting should work inside a call
+  test("kretprobe:f { @=sum(*(int8*)(reg(\"bp\")-1)) }",
+R"EXPECTED(; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kretprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kretprobe:f_1" {
+entry:
+  %deref = alloca i8, align 1
+  %"@_val" = alloca i64, align 8
+  %"@_key" = alloca i64, align 8
+  %1 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  store i64 0, i64* %"@_key", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, i64* nonnull %"@_key")
+  %map_lookup_cond = icmp eq i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
+
+lookup_success:                                   ; preds = %entry
+  %2 = load i64, i8* %lookup_elem, align 8
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %entry, %lookup_success
+  %lookup_elem_val.0 = phi i64 [ %2, %lookup_success ], [ 0, %entry ]
+  %3 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %4 = getelementptr i8, i8* %0, i64 32
+  %reg_bp = load i64, i8* %4, align 8
+  %5 = add i64 %reg_bp, -1
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %deref)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %deref, i64 1, i64 %5)
+  %6 = load i8, i8* %deref, align 1
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %deref)
+  %7 = sext i8 %6 to i64
+  %8 = add i64 %lookup_elem_val.0, %7
+  store i64 %8, i64* %"@_val", align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/runtime/intptrcast
+++ b/tests/runtime/intptrcast
@@ -1,11 +1,11 @@
 NAME Sum casted value
-RUN bpftrace -v -e 'k:vfs_read { @=sum(*(uint8*)(reg("bp")-1)); exit();}'
-EXPECT ^@: [0-9]*
+RUN bpftrace -v -e 'uprobe:.*/testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("sp")+8)); exit();}'
+EXPECT ^@: 3258
 TIMEOUT 5
-AFTER cat /dev/null
+AFTER ./testprogs/intptrcast
 
 NAME Casting ints
-RUN bpftrace -v -e 'k:vfs_read { $a=*(uint8*)(reg("bp")-1); printf("%d\n", $a); exit();}'
-EXPECT [0-9]*
+RUN bpftrace -v -e 'uprobe:.*/testprogs/intptrcast:fn { $a=*(uint16*)(reg("sp")+8); printf("%d\n", $a); exit();}'
+EXPECT 3258
 TIMEOUT 5
-AFTER cat /dev/null
+AFTER ./testprogs/intptrcast

--- a/tests/runtime/intptrcast
+++ b/tests/runtime/intptrcast
@@ -1,0 +1,11 @@
+NAME Sum casted value
+RUN bpftrace -v -e 'k:vfs_read { @=sum(*(uint8*)(reg("bp")-1)); exit();}'
+EXPECT ^@: [0-9]*
+TIMEOUT 5
+AFTER cat /dev/null
+
+NAME Casting ints
+RUN bpftrace -v -e 'k:vfs_read { $a=*(uint8*)(reg("bp")-1); printf("%d\n", $a); exit();}'
+EXPECT [0-9]*
+TIMEOUT 5
+AFTER cat /dev/null

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1194,6 +1194,33 @@ TEST(semantic_analyser, int_cast_usage)
   test("kprobe:f { @=avg((int32)\"abc\") }", 1);
 }
 
+TEST(semantic_analyser, intptr_cast_types)
+{
+  test("kretprobe:f { @ = *(int8*)retval }", 0);
+  test("kretprobe:f { @ = *(int16*)retval }", 0);
+  test("kretprobe:f { @ = *(int32*)retval }", 0);
+  test("kretprobe:f { @ = *(int64*)retval }", 0);
+  test("kretprobe:f { @ = *(uint8*)retval }", 0);
+  test("kretprobe:f { @ = *(uint16*)retval }", 0);
+  test("kretprobe:f { @ = *(uint32*)retval }", 0);
+  test("kretprobe:f { @ = *(uint64*)retval }", 0);
+
+  test("kretprobe:f { @ = *(int2*)retval }", 1);
+  test("kretprobe:f { @ = *(uint2*)retval }", 1);
+}
+
+TEST(semantic_analyser, intptr_cast_usage)
+{
+  test("kretprobe:f /(*(int32*) retval) < 0 / {}", 0);
+  test("kprobe:f /(*(int32*) arg0) < 0 / {}", 0);
+  test("kprobe:f { @=sum(*(int32*)arg0) }", 0);
+  test("kprobe:f { @=avg(*(int32*)arg0) }", 0);
+  test("kprobe:f { @=avg(*(int32*)arg0) }", 0);
+
+  // This is OK (@ = 0x636261)
+  test("kprobe:f { @=avg(*(int32*)\"abc\") }", 0);
+  test("kprobe:f { @=avg(*(int32*)123) }", 0);
+}
 
 TEST(semantic_analyser, signal)
 {

--- a/tests/testprogs/intptrcast.c
+++ b/tests/testprogs/intptrcast.c
@@ -1,0 +1,9 @@
+// a is on the stack
+int fn(short rdi, short rsi, short rdx, short rcx, short r8, short r9, short a) {
+    return rdi + rsi + rdx + rcx + r8 + r9 + a;
+}
+
+int main() {
+  fn(0x123, 0x456, 0x789, 0xabc, 0xdef, 0xfed, 0xcba);
+  return 0;
+}


### PR DESCRIPTION
An attempt to support casting to a pointer of int and then dereference. Closes #941.

example:
```
uprobe:./t.out:main+12 {
  $a = *(int8*)(reg("bp") - 1);
  printf("a=%d\n", $a);
}
```

<details>
<summary> Here is the output of `bpftrace -d` </summary>

```
Program
 uprobe:./t.out:main+12
  =
   variable: $a
   dereference
    (int8*)
     -
      call: reg
       string: bp
      int: 1
  call: printf
   string: a=%d\n
   variable: $a

; ModuleID = 'bpftrace'
source_filename = "bpftrace"
target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
target triple = "bpf-pc-linux"

%printf_t = type { i64, i64 }

; Function Attrs: nounwind
declare i64 @llvm.bpf.pseudo(i64, i64) #0

; Function Attrs: argmemonly nounwind
declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1

define i64 @"uprobe:./t.out:main+12"(i8*) local_unnamed_addr section "s_uprobe:./t.out:main+12_1" {
entry:
  %printf_args = alloca %printf_t, align 8
  %deref = alloca i8, align 1
  %1 = getelementptr i8, i8* %0, i64 32
  %reg_bp = load i64, i8* %1, align 8
  %2 = add i64 %reg_bp, -1
  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %deref)
  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %deref, i64 1, i64 %2)
  %3 = load i8, i8* %deref, align 1
  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %deref)
  %4 = bitcast %printf_t* %printf_args to i8*
  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
  %5 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
  %6 = bitcast %printf_t* %printf_args to i8*
  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %6, i8 0, i64 16, i1 false)
  store i8 %3, i64* %5, align 8
  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 16)
  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
  ret i64 0
}

; Function Attrs: argmemonly nounwind
declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

; Function Attrs: argmemonly nounwind
declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1

attributes #0 = { nounwind }
attributes #1 = { argmemonly nounwind }
```
</details>


Altough it seems work for the above example, I'm not sure this is the right way to do this.