### PR TITLE
semantic_analyser: fix gcc build error on xenial

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -992,14 +992,14 @@ void SemanticAnalyser::visit(Cast &cast)
   cast.expr->accept(*this);
 
   const std::map<std::string, std::tuple<size_t, bool>> intcasts = {
-      {"uint8", {1, false}},
-      {"int8", {1, true}},
-      {"uint16", {2, false}},
-      {"int16", {2, true}},
-      {"uint32", {4, false}},
-      {"int32", {4, true}},
-      {"uint64", {8, false}},
-      {"int64", {8, true}},
+      {"uint8", std::tuple<size_t, bool>{1, false}},
+      {"int8", std::tuple<size_t, bool>{1, true}},
+      {"uint16", std::tuple<size_t, bool>{2, false}},
+      {"int16", std::tuple<size_t, bool>{2, true}},
+      {"uint32", std::tuple<size_t, bool>{4, false}},
+      {"int32", std::tuple<size_t, bool>{4, true}},
+      {"uint64", std::tuple<size_t, bool>{8, false}},
+      {"int64", std::tuple<size_t, bool>{8, true}},
   };
 
   auto k_v = intcasts.find(cast.cast_type);


### PR DESCRIPTION
The following error is happening on xenial (with gcc 5.4.0):

  ./src/ast/semantic_analyser.cpp:1003:3: error: converting to ‘const std::tuple<long unsigned int, bool>’ from initializer list would use explicit constructor ‘constexpr std::tuple<_T1, _T2>::tuple(_U1&&, _U2&&) [with _U1 = int; _U2 = bool; <template-parameter-2-3> = void; _T1 = long unsigned int; _T2 = bool]’
     };
     ^

Using Uniform initialization instead of implicit initializer_list to
tuple casting fixes the issue.