### PR TITLE
Make printing the LLVM IR from a debugger easier

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -9,7 +9,6 @@
 #include <arpa/inet.h>
 #include "tracepoint_format_parser.h"
 
-#include <llvm/Support/raw_os_ostream.h>
 #include <llvm/Support/TargetRegistry.h>
 #include <llvm/IR/Constants.h>
 #include <llvm/IR/LegacyPassManager.h>
@@ -1753,7 +1752,7 @@ std::unique_ptr<BpfOrc> CodegenLLVM::compile(DebugLevel debug, std::ostream &out
     raw_os_ostream llvm_ostream(out);
     llvm_ostream << "Before optimization\n";
     llvm_ostream << "-------------------\n\n";
-    module_->print(llvm_ostream, nullptr, false, true);
+    DumpIR(llvm_ostream);
   }
 
   PM.run(*module_.get());
@@ -1765,7 +1764,7 @@ std::unique_ptr<BpfOrc> CodegenLLVM::compile(DebugLevel debug, std::ostream &out
       llvm_ostream << "\nAfter optimization\n";
       llvm_ostream << "------------------\n\n";
     }
-    module_->print(llvm_ostream, nullptr, false, true);
+    DumpIR(llvm_ostream);
   }
 
   auto bpforc = std::make_unique<BpfOrc>(targetMachine);
@@ -1773,5 +1772,15 @@ std::unique_ptr<BpfOrc> CodegenLLVM::compile(DebugLevel debug, std::ostream &out
 
   return bpforc;
 }
+
+void CodegenLLVM::DumpIR() {
+  raw_os_ostream llvm_ostream(std::cout);
+  DumpIR(llvm_ostream);
+}
+
+void CodegenLLVM::DumpIR(raw_os_ostream &out) {
+  module_->print(out, nullptr, false, true);
+}
+
 } // namespace ast
 } // namespace bpftrace

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -8,6 +8,7 @@
 #include "irbuilderbpf.h"
 #include "map.h"
 
+#include <llvm/Support/raw_os_ostream.h>
 #include <llvm/ExecutionEngine/MCJIT.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Module.h>
@@ -60,6 +61,8 @@ public:
   Value      *createLogicalAnd(Binop &binop);
   Value      *createLogicalOr(Binop &binop);
 
+  void DumpIR();
+  void DumpIR(llvm::raw_os_ostream &out);
   void createLog2Function();
   void createLinearFunction();
   void createFormatStringCall(Call &call, int &id, CallArgs &call_args,


### PR DESCRIPTION
This makes it possible to print the IR while debugging codegen, e.g:

```
(gdb) b CodegenLLVM::visit
Breakpoint 1 at 0x250652: CodegenLLVM::visit. (24 locations)
(gdb) run
Starting program: /usr/local/sbin/bpftrace -e "i:s:1 { @=1}"
Breakpoint 1, bpftrace::ast::CodegenLLVM::visit (this=0x7fffffffe210, program=...) at /vagrant/src/ast/codegen_llvm.cpp:1361
(gdb) p DumpIR()
; ModuleID = 'bpftrace'
source_filename = "bpftrace"

define internal i64 @log2(i64) #1 section "helpers" {
entry:
  %1 = alloca i64
  %2 = alloca i64
```