### PR TITLE
Fix map field access

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1108,6 +1108,14 @@ void CodegenLLVM::visit(AssignMapStatement &assignment)
     {
       val = expr;
     }
+    else if (assignment.expr->type.is_pointer)
+    {
+      // expr currently contains a pointer to the struct
+      // and that's what we are saving
+      AllocaInst *dst = b_.CreateAllocaBPF(map.type, map.ident + "_ptr");
+      b_.CreateStore(expr, dst);
+      val = dst;
+    }
     else
     {
       // expr currently contains a pointer to the struct

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -202,21 +202,21 @@ Value *IRBuilderBPF::CreateMapLookupElem(Map &map, AllocaInst *key)
   CreateCondBr(condition, lookup_success_block, lookup_failure_block);
 
   SetInsertPoint(lookup_success_block);
-  if (map.type.type == Type::string || map.type.type == Type::cast || map.type.type == Type::inet)
+  if (map.type.type == Type::string || (map.type.type == Type::cast && !map.type.is_pointer) || map.type.type == Type::inet)
     CREATE_MEMCPY(value, call, map.type.size, 1);
   else
     CreateStore(CreateLoad(getInt64Ty(), call), value);
   CreateBr(lookup_merge_block);
 
   SetInsertPoint(lookup_failure_block);
-  if (map.type.type == Type::string || map.type.type == Type::cast || map.type.type == Type::inet)
+  if (map.type.type == Type::string || (map.type.type == Type::cast && !map.type.is_pointer) || map.type.type == Type::inet)
     CreateMemSet(value, getInt8(0), map.type.size, 1);
   else
     CreateStore(getInt64(0), value);
   CreateBr(lookup_merge_block);
 
   SetInsertPoint(lookup_merge_block);
-  if (map.type.type == Type::string || map.type.type == Type::cast || map.type.type == Type::inet)
+  if (map.type.type == Type::string || (map.type.type == Type::cast && !map.type.is_pointer) || map.type.type == Type::inet)
     return value;
 
   return CreateLoad(value);

--- a/tests/codegen/builtin_curtask.cpp
+++ b/tests/codegen/builtin_curtask.cpp
@@ -16,17 +16,17 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_ptr" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %get_cur_task = tail call i64 inttoptr (i64 35 to i64 ()*)()
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 0, i64* %"@x_key", align 8
-  %2 = bitcast i64* %"@x_val" to i8*
+  %2 = bitcast i64* %"@x_ptr" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"@x_val", i64 8, i64 %get_cur_task)
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  store i64 %get_cur_task, i64* %"@x_ptr", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_ptr", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -37,7 +37,6 @@ TIMEOUT 5
 AFTER dd if=/dev/random bs=3 count=1
 
 NAME tracepoint arg casts in predicates
-RUN bpftrace -v -e 'tracepoint:syscalls:sys_enter_wait4 /args->ru/ { @ru[tid] = args->ru; } tracepoint:syscalls:sys_exit_wait4 /@ru[tid]/ { @++; exit(); }'
-EXPECT @
+RUN bpftrace -v -e 'tracepoint:syscalls:sys_enter_wait4 /args->ru/ { @ru[tid] = args->ru; } tracepoint:syscalls:sys_exit_wait4 /@ru[tid]/ { @++; exit(); }' -c ./testprogs/wait4_ru
+EXPECT @: 1
 TIMEOUT 5
-AFTER sleep 1 || wait $!

--- a/tests/testprogs/wait4_ru.c
+++ b/tests/testprogs/wait4_ru.c
@@ -1,0 +1,21 @@
+#include <sys/types.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/time.h>
+#include <sys/resource.h>
+#include <sys/wait.h>
+#include <stdlib.h>
+
+int main(void)
+{
+  struct rusage rusage;
+  pid_t pid;
+
+  pid = fork();
+  if (pid == 0) {
+    exit(0);
+  }
+
+  wait4(pid, NULL, 0, &rusage);
+  return 0;
+}


### PR DESCRIPTION
@javierhonduco reported inconsistencies when dereferencing
map that was assigned cast pointer.

Following code:
```
  #include <linux/mm.h>

  kprobe:do_wp_page
  {
    @a = (struct vm_fault*)arg0;
    printf("%llx %llx\n", @a->address, @a->address);
    printf("------\n");
  }

```
would return different values for same field, like:
`  ffffc90006836000 1db70`

The problem is that we don't distinguish if the assignment expression
is pointer, in which case we want to pass along only the pointer and
not read the whole cast struct.

The pointer checks were missing also in CreateMapLookupElem,
when we need to treat pointer cast map values as numbers and
not as values of their structs.

Fixes #930