### PR TITLE
Remove unneeded `probe_read`s from `strcmp`

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -392,14 +392,10 @@ Value *IRBuilderBPF::CreateStrncmp(Value* val, std::string str, uint64_t n, bool
   for (size_t i = 0; i < n; i++)
   {
     BasicBlock *char_eq = BasicBlock::Create(module_.getContext(), "strcmp.loop", parent);
-    AllocaInst *val_char = CreateAllocaBPF(getInt8Ty(), "strcmp.char");
     Value *ptr = CreateAdd(
         val,
         getInt64(i));
-    CreateProbeRead(val_char, 1, ptr);
-
-    Value *l = CreateLoad(getInt8Ty(), val_char);
-    CreateLifetimeEnd(store);
+    Value *l = CreateLoad(getInt8Ty(), ptr);
     Value *r = getInt8(c_str[i]);
     Value *cmp = CreateICmpNE(l, r, "strcmp.cmp");
     CreateCondBr(cmp, str_ne, char_eq);

--- a/tests/codegen/string_equal_comparison.cpp
+++ b/tests/codegen/string_equal_comparison.cpp
@@ -18,34 +18,27 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kretprobe:vfs_read"(i8* nocapture readnone) local_unnamed_addr section "s_kretprobe:vfs_read_1" {
 entry:
   %"@_val" = alloca i64, align 8
-  %comm17 = alloca [16 x i8], align 1
+  %comm9 = alloca [16 x i8], align 1
   %"@_key" = alloca [16 x i8], align 1
-  %strcmp.char14 = alloca i8, align 1
-  %strcmp.char10 = alloca i8, align 1
-  %strcmp.char6 = alloca i8, align 1
-  %strcmp.char2 = alloca i8, align 1
-  %strcmp.char = alloca i8, align 1
   %comm = alloca [16 x i8], align 1
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i8 0, i64 16, i1 false)
   %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char, i64 1, [16 x i8]* nonnull %comm)
-  %2 = load i8, i8* %strcmp.char, align 1
+  %2 = load i8, [16 x i8]* %comm, align 1
   %strcmp.cmp = icmp eq i8 %2, 115
   br i1 %strcmp.cmp, label %strcmp.loop, label %pred_false
 
-pred_false:                                       ; preds = %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %entry
+pred_false:                                       ; preds = %strcmp.loop5, %strcmp.loop3, %strcmp.loop1, %strcmp.loop, %entry
   ret i64 0
 
-pred_true:                                        ; preds = %strcmp.loop9
+pred_true:                                        ; preds = %strcmp.loop5
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %comm17, i64 0, i64 0
+  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %comm9, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %4, i8 0, i64 16, i1 false)
-  %get_comm18 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm17, i64 16)
+  %get_comm10 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm9, i64 16)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %3, i8* nonnull align 1 %4, i64 16, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
@@ -53,36 +46,28 @@ pred_true:                                        ; preds = %strcmp.loop9
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 strcmp.loop:                                      ; preds = %entry
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char2)
   %5 = add [16 x i8]* %comm, i64 1
-  %probe_read3 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char2, i64 1, [16 x i8]* %5)
-  %6 = load i8, i8* %strcmp.char2, align 1
-  %strcmp.cmp4 = icmp eq i8 %6, 115
-  br i1 %strcmp.cmp4, label %strcmp.loop1, label %pred_false
+  %6 = load i8, [16 x i8]* %5, align 1
+  %strcmp.cmp2 = icmp eq i8 %6, 115
+  br i1 %strcmp.cmp2, label %strcmp.loop1, label %pred_false
 
 strcmp.loop1:                                     ; preds = %strcmp.loop
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char6)
   %7 = add [16 x i8]* %comm, i64 2
-  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char6, i64 1, [16 x i8]* %7)
-  %8 = load i8, i8* %strcmp.char6, align 1
-  %strcmp.cmp8 = icmp eq i8 %8, 104
-  br i1 %strcmp.cmp8, label %strcmp.loop5, label %pred_false
+  %8 = load i8, [16 x i8]* %7, align 1
+  %strcmp.cmp4 = icmp eq i8 %8, 104
+  br i1 %strcmp.cmp4, label %strcmp.loop3, label %pred_false
 
-strcmp.loop5:                                     ; preds = %strcmp.loop1
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char10)
+strcmp.loop3:                                     ; preds = %strcmp.loop1
   %9 = add [16 x i8]* %comm, i64 3
-  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char10, i64 1, [16 x i8]* %9)
-  %10 = load i8, i8* %strcmp.char10, align 1
-  %strcmp.cmp12 = icmp eq i8 %10, 100
-  br i1 %strcmp.cmp12, label %strcmp.loop9, label %pred_false
+  %10 = load i8, [16 x i8]* %9, align 1
+  %strcmp.cmp6 = icmp eq i8 %10, 100
+  br i1 %strcmp.cmp6, label %strcmp.loop5, label %pred_false
 
-strcmp.loop9:                                     ; preds = %strcmp.loop5
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char14)
+strcmp.loop5:                                     ; preds = %strcmp.loop3
   %11 = add [16 x i8]* %comm, i64 4
-  %probe_read15 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char14, i64 1, [16 x i8]* %11)
-  %12 = load i8, i8* %strcmp.char14, align 1
-  %strcmp.cmp16 = icmp eq i8 %12, 0
-  br i1 %strcmp.cmp16, label %pred_true, label %pred_false
+  %12 = load i8, [16 x i8]* %11, align 1
+  %strcmp.cmp8 = icmp eq i8 %12, 0
+  br i1 %strcmp.cmp8, label %pred_true, label %pred_false
 
 lookup_success:                                   ; preds = %pred_true
   %13 = load i64, i8* %lookup_elem, align 8
@@ -94,8 +79,8 @@ lookup_merge:                                     ; preds = %pred_true, %lookup_
   %14 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %14)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
-  %pseudo19 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo19, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo11, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %14)
   ret i64 0
@@ -123,34 +108,27 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kretprobe:vfs_read"(i8* nocapture readnone) local_unnamed_addr section "s_kretprobe:vfs_read_1" {
 entry:
   %"@_val" = alloca i64, align 8
-  %comm17 = alloca [16 x i8], align 1
+  %comm9 = alloca [16 x i8], align 1
   %"@_key" = alloca [16 x i8], align 1
-  %strcmp.char14 = alloca i8, align 1
-  %strcmp.char10 = alloca i8, align 1
-  %strcmp.char6 = alloca i8, align 1
-  %strcmp.char2 = alloca i8, align 1
-  %strcmp.char = alloca i8, align 1
   %comm = alloca [16 x i8], align 1
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 16, i32 1, i1 false)
   %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char, i64 1, [16 x i8]* nonnull %comm)
-  %2 = load i8, i8* %strcmp.char, align 1
+  %2 = load i8, [16 x i8]* %comm, align 1
   %strcmp.cmp = icmp eq i8 %2, 115
   br i1 %strcmp.cmp, label %strcmp.loop, label %pred_false
 
-pred_false:                                       ; preds = %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %entry
+pred_false:                                       ; preds = %strcmp.loop5, %strcmp.loop3, %strcmp.loop1, %strcmp.loop, %entry
   ret i64 0
 
-pred_true:                                        ; preds = %strcmp.loop9
+pred_true:                                        ; preds = %strcmp.loop5
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %comm17, i64 0, i64 0
+  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %comm9, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.memset.p0i8.i64(i8* nonnull %4, i8 0, i64 16, i32 1, i1 false)
-  %get_comm18 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm17, i64 16)
+  %get_comm10 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm9, i64 16)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %3, i8* nonnull %4, i64 16, i32 1, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
@@ -158,36 +136,28 @@ pred_true:                                        ; preds = %strcmp.loop9
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 strcmp.loop:                                      ; preds = %entry
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char2)
   %5 = add [16 x i8]* %comm, i64 1
-  %probe_read3 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char2, i64 1, [16 x i8]* %5)
-  %6 = load i8, i8* %strcmp.char2, align 1
-  %strcmp.cmp4 = icmp eq i8 %6, 115
-  br i1 %strcmp.cmp4, label %strcmp.loop1, label %pred_false
+  %6 = load i8, [16 x i8]* %5, align 1
+  %strcmp.cmp2 = icmp eq i8 %6, 115
+  br i1 %strcmp.cmp2, label %strcmp.loop1, label %pred_false
 
 strcmp.loop1:                                     ; preds = %strcmp.loop
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char6)
   %7 = add [16 x i8]* %comm, i64 2
-  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char6, i64 1, [16 x i8]* %7)
-  %8 = load i8, i8* %strcmp.char6, align 1
-  %strcmp.cmp8 = icmp eq i8 %8, 104
-  br i1 %strcmp.cmp8, label %strcmp.loop5, label %pred_false
+  %8 = load i8, [16 x i8]* %7, align 1
+  %strcmp.cmp4 = icmp eq i8 %8, 104
+  br i1 %strcmp.cmp4, label %strcmp.loop3, label %pred_false
 
-strcmp.loop5:                                     ; preds = %strcmp.loop1
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char10)
+strcmp.loop3:                                     ; preds = %strcmp.loop1
   %9 = add [16 x i8]* %comm, i64 3
-  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char10, i64 1, [16 x i8]* %9)
-  %10 = load i8, i8* %strcmp.char10, align 1
-  %strcmp.cmp12 = icmp eq i8 %10, 100
-  br i1 %strcmp.cmp12, label %strcmp.loop9, label %pred_false
+  %10 = load i8, [16 x i8]* %9, align 1
+  %strcmp.cmp6 = icmp eq i8 %10, 100
+  br i1 %strcmp.cmp6, label %strcmp.loop5, label %pred_false
 
-strcmp.loop9:                                     ; preds = %strcmp.loop5
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char14)
+strcmp.loop5:                                     ; preds = %strcmp.loop3
   %11 = add [16 x i8]* %comm, i64 4
-  %probe_read15 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char14, i64 1, [16 x i8]* %11)
-  %12 = load i8, i8* %strcmp.char14, align 1
-  %strcmp.cmp16 = icmp eq i8 %12, 0
-  br i1 %strcmp.cmp16, label %pred_true, label %pred_false
+  %12 = load i8, [16 x i8]* %11, align 1
+  %strcmp.cmp8 = icmp eq i8 %12, 0
+  br i1 %strcmp.cmp8, label %pred_true, label %pred_false
 
 lookup_success:                                   ; preds = %pred_true
   %13 = load i64, i8* %lookup_elem, align 8
@@ -199,8 +169,8 @@ lookup_merge:                                     ; preds = %pred_true, %lookup_
   %14 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %14)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
-  %pseudo19 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo19, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo11, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %14)
   ret i64 0

--- a/tests/codegen/string_not_equal_comparison.cpp
+++ b/tests/codegen/string_not_equal_comparison.cpp
@@ -18,34 +18,27 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kretprobe:vfs_read"(i8* nocapture readnone) local_unnamed_addr section "s_kretprobe:vfs_read_1" {
 entry:
   %"@_val" = alloca i64, align 8
-  %comm17 = alloca [16 x i8], align 1
+  %comm9 = alloca [16 x i8], align 1
   %"@_key" = alloca [16 x i8], align 1
-  %strcmp.char14 = alloca i8, align 1
-  %strcmp.char10 = alloca i8, align 1
-  %strcmp.char6 = alloca i8, align 1
-  %strcmp.char2 = alloca i8, align 1
-  %strcmp.char = alloca i8, align 1
   %comm = alloca [16 x i8], align 1
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i8 0, i64 16, i1 false)
   %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char, i64 1, [16 x i8]* nonnull %comm)
-  %2 = load i8, i8* %strcmp.char, align 1
+  %2 = load i8, [16 x i8]* %comm, align 1
   %strcmp.cmp = icmp eq i8 %2, 115
   br i1 %strcmp.cmp, label %strcmp.loop, label %pred_true
 
-pred_false:                                       ; preds = %strcmp.loop9
+pred_false:                                       ; preds = %strcmp.loop5
   ret i64 0
 
-pred_true:                                        ; preds = %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %entry
+pred_true:                                        ; preds = %strcmp.loop5, %strcmp.loop3, %strcmp.loop1, %strcmp.loop, %entry
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %comm17, i64 0, i64 0
+  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %comm9, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %4, i8 0, i64 16, i1 false)
-  %get_comm18 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm17, i64 16)
+  %get_comm10 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm9, i64 16)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %3, i8* nonnull align 1 %4, i64 16, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
@@ -53,36 +46,28 @@ pred_true:                                        ; preds = %strcmp.loop9, %strc
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 strcmp.loop:                                      ; preds = %entry
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char2)
   %5 = add [16 x i8]* %comm, i64 1
-  %probe_read3 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char2, i64 1, [16 x i8]* %5)
-  %6 = load i8, i8* %strcmp.char2, align 1
-  %strcmp.cmp4 = icmp eq i8 %6, 115
-  br i1 %strcmp.cmp4, label %strcmp.loop1, label %pred_true
+  %6 = load i8, [16 x i8]* %5, align 1
+  %strcmp.cmp2 = icmp eq i8 %6, 115
+  br i1 %strcmp.cmp2, label %strcmp.loop1, label %pred_true
 
 strcmp.loop1:                                     ; preds = %strcmp.loop
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char6)
   %7 = add [16 x i8]* %comm, i64 2
-  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char6, i64 1, [16 x i8]* %7)
-  %8 = load i8, i8* %strcmp.char6, align 1
-  %strcmp.cmp8 = icmp eq i8 %8, 104
-  br i1 %strcmp.cmp8, label %strcmp.loop5, label %pred_true
+  %8 = load i8, [16 x i8]* %7, align 1
+  %strcmp.cmp4 = icmp eq i8 %8, 104
+  br i1 %strcmp.cmp4, label %strcmp.loop3, label %pred_true
 
-strcmp.loop5:                                     ; preds = %strcmp.loop1
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char10)
+strcmp.loop3:                                     ; preds = %strcmp.loop1
   %9 = add [16 x i8]* %comm, i64 3
-  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char10, i64 1, [16 x i8]* %9)
-  %10 = load i8, i8* %strcmp.char10, align 1
-  %strcmp.cmp12 = icmp eq i8 %10, 100
-  br i1 %strcmp.cmp12, label %strcmp.loop9, label %pred_true
+  %10 = load i8, [16 x i8]* %9, align 1
+  %strcmp.cmp6 = icmp eq i8 %10, 100
+  br i1 %strcmp.cmp6, label %strcmp.loop5, label %pred_true
 
-strcmp.loop9:                                     ; preds = %strcmp.loop5
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char14)
+strcmp.loop5:                                     ; preds = %strcmp.loop3
   %11 = add [16 x i8]* %comm, i64 4
-  %probe_read15 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char14, i64 1, [16 x i8]* %11)
-  %12 = load i8, i8* %strcmp.char14, align 1
-  %strcmp.cmp16 = icmp eq i8 %12, 0
-  br i1 %strcmp.cmp16, label %pred_false, label %pred_true
+  %12 = load i8, [16 x i8]* %11, align 1
+  %strcmp.cmp8 = icmp eq i8 %12, 0
+  br i1 %strcmp.cmp8, label %pred_false, label %pred_true
 
 lookup_success:                                   ; preds = %pred_true
   %13 = load i64, i8* %lookup_elem, align 8
@@ -94,8 +79,8 @@ lookup_merge:                                     ; preds = %pred_true, %lookup_
   %14 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %14)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
-  %pseudo19 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo19, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo11, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %14)
   ret i64 0
@@ -123,34 +108,27 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kretprobe:vfs_read"(i8* nocapture readnone) local_unnamed_addr section "s_kretprobe:vfs_read_1" {
 entry:
   %"@_val" = alloca i64, align 8
-  %comm17 = alloca [16 x i8], align 1
+  %comm9 = alloca [16 x i8], align 1
   %"@_key" = alloca [16 x i8], align 1
-  %strcmp.char14 = alloca i8, align 1
-  %strcmp.char10 = alloca i8, align 1
-  %strcmp.char6 = alloca i8, align 1
-  %strcmp.char2 = alloca i8, align 1
-  %strcmp.char = alloca i8, align 1
   %comm = alloca [16 x i8], align 1
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 16, i32 1, i1 false)
   %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char, i64 1, [16 x i8]* nonnull %comm)
-  %2 = load i8, i8* %strcmp.char, align 1
+  %2 = load i8, [16 x i8]* %comm, align 1
   %strcmp.cmp = icmp eq i8 %2, 115
   br i1 %strcmp.cmp, label %strcmp.loop, label %pred_true
 
-pred_false:                                       ; preds = %strcmp.loop9
+pred_false:                                       ; preds = %strcmp.loop5
   ret i64 0
 
-pred_true:                                        ; preds = %strcmp.loop9, %strcmp.loop5, %strcmp.loop1, %strcmp.loop, %entry
+pred_true:                                        ; preds = %strcmp.loop5, %strcmp.loop3, %strcmp.loop1, %strcmp.loop, %entry
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %comm17, i64 0, i64 0
+  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %comm9, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.memset.p0i8.i64(i8* nonnull %4, i8 0, i64 16, i32 1, i1 false)
-  %get_comm18 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm17, i64 16)
+  %get_comm10 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm9, i64 16)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %3, i8* nonnull %4, i64 16, i32 1, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
@@ -158,36 +136,28 @@ pred_true:                                        ; preds = %strcmp.loop9, %strc
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 strcmp.loop:                                      ; preds = %entry
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char2)
   %5 = add [16 x i8]* %comm, i64 1
-  %probe_read3 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char2, i64 1, [16 x i8]* %5)
-  %6 = load i8, i8* %strcmp.char2, align 1
-  %strcmp.cmp4 = icmp eq i8 %6, 115
-  br i1 %strcmp.cmp4, label %strcmp.loop1, label %pred_true
+  %6 = load i8, [16 x i8]* %5, align 1
+  %strcmp.cmp2 = icmp eq i8 %6, 115
+  br i1 %strcmp.cmp2, label %strcmp.loop1, label %pred_true
 
 strcmp.loop1:                                     ; preds = %strcmp.loop
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char6)
   %7 = add [16 x i8]* %comm, i64 2
-  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char6, i64 1, [16 x i8]* %7)
-  %8 = load i8, i8* %strcmp.char6, align 1
-  %strcmp.cmp8 = icmp eq i8 %8, 104
-  br i1 %strcmp.cmp8, label %strcmp.loop5, label %pred_true
+  %8 = load i8, [16 x i8]* %7, align 1
+  %strcmp.cmp4 = icmp eq i8 %8, 104
+  br i1 %strcmp.cmp4, label %strcmp.loop3, label %pred_true
 
-strcmp.loop5:                                     ; preds = %strcmp.loop1
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char10)
+strcmp.loop3:                                     ; preds = %strcmp.loop1
   %9 = add [16 x i8]* %comm, i64 3
-  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char10, i64 1, [16 x i8]* %9)
-  %10 = load i8, i8* %strcmp.char10, align 1
-  %strcmp.cmp12 = icmp eq i8 %10, 100
-  br i1 %strcmp.cmp12, label %strcmp.loop9, label %pred_true
+  %10 = load i8, [16 x i8]* %9, align 1
+  %strcmp.cmp6 = icmp eq i8 %10, 100
+  br i1 %strcmp.cmp6, label %strcmp.loop5, label %pred_true
 
-strcmp.loop9:                                     ; preds = %strcmp.loop5
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char14)
+strcmp.loop5:                                     ; preds = %strcmp.loop3
   %11 = add [16 x i8]* %comm, i64 4
-  %probe_read15 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char14, i64 1, [16 x i8]* %11)
-  %12 = load i8, i8* %strcmp.char14, align 1
-  %strcmp.cmp16 = icmp eq i8 %12, 0
-  br i1 %strcmp.cmp16, label %pred_false, label %pred_true
+  %12 = load i8, [16 x i8]* %11, align 1
+  %strcmp.cmp8 = icmp eq i8 %12, 0
+  br i1 %strcmp.cmp8, label %pred_false, label %pred_true
 
 lookup_success:                                   ; preds = %pred_true
   %13 = load i64, i8* %lookup_elem, align 8
@@ -199,8 +169,8 @@ lookup_merge:                                     ; preds = %pred_true, %lookup_
   %14 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %14)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
-  %pseudo19 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo19, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo11, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %14)
   ret i64 0

--- a/tests/codegen/strncmp.cpp
+++ b/tests/codegen/strncmp.cpp
@@ -18,18 +18,14 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kretprobe:vfs_read"(i8* nocapture readnone) local_unnamed_addr section "s_kretprobe:vfs_read_1" {
 entry:
   %"@_val" = alloca i64, align 8
-  %comm5 = alloca [16 x i8], align 1
+  %comm3 = alloca [16 x i8], align 1
   %"@_key" = alloca [16 x i8], align 1
-  %strcmp.char2 = alloca i8, align 1
-  %strcmp.char = alloca i8, align 1
   %comm = alloca [16 x i8], align 1
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i8 0, i64 16, i1 false)
   %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char, i64 1, [16 x i8]* nonnull %comm)
-  %2 = load i8, i8* %strcmp.char, align 1
+  %2 = load i8, [16 x i8]* %comm, align 1
   %strcmp.cmp = icmp eq i8 %2, 115
   br i1 %strcmp.cmp, label %strcmp.loop, label %pred_true
 
@@ -39,10 +35,10 @@ pred_false:                                       ; preds = %strcmp.loop
 pred_true:                                        ; preds = %strcmp.loop, %entry
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %comm5, i64 0, i64 0
+  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %comm3, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %4, i8 0, i64 16, i1 false)
-  %get_comm6 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm5, i64 16)
+  %get_comm4 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm3, i64 16)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %3, i8* nonnull align 1 %4, i64 16, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
@@ -50,12 +46,10 @@ pred_true:                                        ; preds = %strcmp.loop, %entry
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 strcmp.loop:                                      ; preds = %entry
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char2)
   %5 = add [16 x i8]* %comm, i64 1
-  %probe_read3 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char2, i64 1, [16 x i8]* %5)
-  %6 = load i8, i8* %strcmp.char2, align 1
-  %strcmp.cmp4 = icmp eq i8 %6, 115
-  br i1 %strcmp.cmp4, label %pred_false, label %pred_true
+  %6 = load i8, [16 x i8]* %5, align 1
+  %strcmp.cmp2 = icmp eq i8 %6, 115
+  br i1 %strcmp.cmp2, label %pred_false, label %pred_true
 
 lookup_success:                                   ; preds = %pred_true
   %7 = load i64, i8* %lookup_elem, align 8
@@ -67,8 +61,8 @@ lookup_merge:                                     ; preds = %pred_true, %lookup_
   %8 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
-  %pseudo7 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo7, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo5, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
@@ -96,18 +90,14 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kretprobe:vfs_read"(i8* nocapture readnone) local_unnamed_addr section "s_kretprobe:vfs_read_1" {
 entry:
   %"@_val" = alloca i64, align 8
-  %comm5 = alloca [16 x i8], align 1
+  %comm3 = alloca [16 x i8], align 1
   %"@_key" = alloca [16 x i8], align 1
-  %strcmp.char2 = alloca i8, align 1
-  %strcmp.char = alloca i8, align 1
   %comm = alloca [16 x i8], align 1
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 16, i32 1, i1 false)
   %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char, i64 1, [16 x i8]* nonnull %comm)
-  %2 = load i8, i8* %strcmp.char, align 1
+  %2 = load i8, [16 x i8]* %comm, align 1
   %strcmp.cmp = icmp eq i8 %2, 115
   br i1 %strcmp.cmp, label %strcmp.loop, label %pred_true
 
@@ -117,10 +107,10 @@ pred_false:                                       ; preds = %strcmp.loop
 pred_true:                                        ; preds = %strcmp.loop, %entry
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %comm5, i64 0, i64 0
+  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %comm3, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.memset.p0i8.i64(i8* nonnull %4, i8 0, i64 16, i32 1, i1 false)
-  %get_comm6 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm5, i64 16)
+  %get_comm4 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm3, i64 16)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %3, i8* nonnull %4, i64 16, i32 1, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
@@ -128,12 +118,10 @@ pred_true:                                        ; preds = %strcmp.loop, %entry
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 strcmp.loop:                                      ; preds = %entry
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char2)
   %5 = add [16 x i8]* %comm, i64 1
-  %probe_read3 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char2, i64 1, [16 x i8]* %5)
-  %6 = load i8, i8* %strcmp.char2, align 1
-  %strcmp.cmp4 = icmp eq i8 %6, 115
-  br i1 %strcmp.cmp4, label %pred_false, label %pred_true
+  %6 = load i8, [16 x i8]* %5, align 1
+  %strcmp.cmp2 = icmp eq i8 %6, 115
+  br i1 %strcmp.cmp2, label %pred_false, label %pred_true
 
 lookup_success:                                   ; preds = %pred_true
   %7 = load i64, i8* %lookup_elem, align 8
@@ -145,8 +133,8 @@ lookup_merge:                                     ; preds = %pred_true, %lookup_
   %8 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
-  %pseudo7 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo7, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo5, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -73,6 +73,11 @@ RUN bpftrace -v -e 'BEGIN { if (strncmp(str($1), str($2), 4) == 0) { printf("I g
 EXPECT I got hhvm-proc
 TIMEOUT 5
 
+NAME strncmp function argument
+RUN bpftrace -v -e 'struct F {char s[8];} u:./testprogs/string_args:print { @=strncmp(((struct F*)arg0)->s, "hello", 5); }' -c ./testprogs/string_args
+EXPECT @: 0
+TIMEOUT 5
+
 NAME optional_positional_int
 RUN bpftrace -e 'BEGIN { printf("-%d-\n", $1); exit() }'
 EXPECT -0-

--- a/tests/testprogs/string_args.c
+++ b/tests/testprogs/string_args.c
@@ -1,0 +1,12 @@
+void print(char * a, char * b)
+{
+  (void) a;
+  (void) b;
+}
+
+int main(void)
+{
+  char sa[] = "hello";
+  char sb[] = "world";
+  print(sa, sb);
+}


### PR DESCRIPTION
The way bpftrace currently works forces users to always copy strings to
the stack first (by using `str`) before any comparison can be done. As
the data is on the stack no `probe_read`s are required to access the
data.

This removes 30 instructions of which 4 `probe_reads` from a simple script
like `i:s:1 /comm == "sshd"/ { @=count() }`