### PR TITLE
Add support to attach kprobe to offset

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,24 +33,24 @@ matrix:
       env: LLVM_VERSION=5.0 BASE=alpine TYPE=Release STATIC_LINKING=ON STATIC_LIBC=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*:codegen.args_multiple_tracepoints*:codegen.logical_and_or_different_type"
 
     - name: "LLVM 6 Debug"
-      env: LLVM_VERSION=6.0 BASE=bionic TYPE=Debug RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup
+      env: LLVM_VERSION=6.0 BASE=bionic TYPE=Debug RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup,probe.kprobe_offset_fail_size
     - name: "LLVM 6 Release"
-      env: LLVM_VERSION=6.0 BASE=bionic TYPE=Release RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup
+      env: LLVM_VERSION=6.0 BASE=bionic TYPE=Release RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup,probe.kprobe_offset_fail_size
 
     - name: "LLVM 7 Debug"
-      env: LLVM_VERSION=7 BASE=bionic TYPE=Debug RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup
+      env: LLVM_VERSION=7 BASE=bionic TYPE=Debug RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup,probe.kprobe_offset_fail_size
     - name: "LLVM 7 Release"
-      env: LLVM_VERSION=7 BASE=bionic TYPE=Release RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup
+      env: LLVM_VERSION=7 BASE=bionic TYPE=Release RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup,probe.kprobe_offset_fail_size
 
     - name: "LLVM 8 Debug"
-      env: LLVM_VERSION=8 BASE=bionic TYPE=Debug RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup
+      env: LLVM_VERSION=8 BASE=bionic TYPE=Debug RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup,probe.kprobe_offset_fail_size
     - name: "LLVM 8 Release"
-      env: LLVM_VERSION=8 BASE=bionic TYPE=Release RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup
+      env: LLVM_VERSION=8 BASE=bionic TYPE=Release RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup,probe.kprobe_offset_fail_size
 
     - name: "Static+glibc-2.27 Debian-linked LLVM 8 Debug"
-      env: LLVM_VERSION=8 BASE=bionic-glibc STATIC_LINKING=ON STATIC_LIBC=OFF EMBED_LLVM=OFF EMBED_CLANG=ON EMBED_LIBCLANG_ONLY=ON TYPE=Debug RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup
+      env: LLVM_VERSION=8 BASE=bionic-glibc STATIC_LINKING=ON STATIC_LIBC=OFF EMBED_LLVM=OFF EMBED_CLANG=ON EMBED_LIBCLANG_ONLY=ON TYPE=Debug RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup,probe.kprobe_offset_fail_size
     - name: "Static+glibc-2.27 Debian-linked LLVM 8 Release"
-      env: LLVM_VERSION=8 BASE=bionic-glibc STATIC_LINKING=ON STATIC_LIBC=OFF EMBED_LLVM=OFF EMBED_CLANG=ON EMBED_LIBCLANG_ONLY=ON TYPE=Release RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup
+      env: LLVM_VERSION=8 BASE=bionic-glibc STATIC_LINKING=ON STATIC_LIBC=OFF EMBED_LLVM=OFF EMBED_CLANG=ON EMBED_LIBCLANG_ONLY=ON TYPE=Release RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup,probe.kprobe_offset_fail_size
 
 install:
   - sudo apt-get install linux-headers-$(uname -r)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,9 +69,9 @@ if(HAVE_BFD_DISASM)
   endif(STATIC_LINKING)
 endif(HAVE_BFD_DISASM)
 
-if (ALLOW_UNSAFE_UPROBE)
-  target_compile_definitions(bpftrace PRIVATE HAVE_UNSAFE_UPROBE)
-endif(ALLOW_UNSAFE_UPROBE)
+if (ALLOW_UNSAFE_PROBE)
+  target_compile_definitions(bpftrace PRIVATE HAVE_UNSAFE_PROBE)
+endif(ALLOW_UNSAFE_PROBE)
 
 target_link_libraries(bpftrace arch ast parser resources)
 

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -358,18 +358,26 @@ AttachPoint::AttachPoint(const std::string &provider,
 }
 
 AttachPoint::AttachPoint(const std::string &provider,
-                         const std::string &target,
+                         const std::string &str,
                          uint64_t val,
                          location loc)
-    : Node(loc),
-      provider(probetypeName(provider)),
-      target(target),
-      need_expansion(true)
+    : Node(loc), provider(probetypeName(provider)), need_expansion(true)
 {
   if (this->provider == "uprobe" || this->provider == "uretprobe")
+  {
+    target = str;
     address = val;
+  }
+  else if (this->provider == "kprobe")
+  {
+    func = str;
+    func_offset = val;
+  }
   else
+  {
+    target = str;
     freq = val;
+  }
 }
 
 AttachPoint::AttachPoint(const std::string &provider,

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -278,7 +278,7 @@ public:
               bool need_expansion,
               location loc = location());
   AttachPoint(const std::string &provider,
-              const std::string &target,
+              const std::string &str,
               uint64_t val,
               location loc = location());
   AttachPoint(const std::string &provider,

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -24,9 +24,10 @@ private:
   std::string eventprefix() const;
   std::string eventname() const;
   static std::string sanitise(const std::string &str);
+  void resolve_offset_kprobe(bool safe_mode);
   void resolve_offset_uprobe(bool safe_mode);
   void load_prog();
-  void attach_kprobe();
+  void attach_kprobe(bool safe_mode);
   void attach_uprobe(bool safe_mode);
   void attach_usdt(int pid);
   void attach_tracepoint();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -63,6 +63,7 @@ void usage()
   std::cerr << "    BPFTRACE_MAX_PROBES       [default: 512] max number of probes" << std::endl;
   std::cerr << "    BPFTRACE_LOG_SIZE         [default: 409600] log size in bytes" << std::endl;
   std::cerr << "    BPFTRACE_NO_USER_SYMBOLS  [default: 0] disable user symbol resolution" << std::endl;
+  std::cerr << "    BPFTRACE_VMLINUX          [default: None] vmlinux path used for kernel symbol resolution" << std::endl;
   std::cerr << "    BPFTRACE_BTF              [default: None] BTF file" << std::endl;
   std::cerr << std::endl;
   std::cerr << "EXAMPLES:" << std::endl;

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -170,6 +170,7 @@ attach_points : attach_points "," attach_point { $$ = $1; $1->push_back($3); }
 
 attach_point : ident                            { $$ = new ast::AttachPoint($1, @$); }
              | ident ":" wildcard               { $$ = new ast::AttachPoint($1, $3, @$); }
+             | ident ":" wildcard PLUS INT      { $$ = new ast::AttachPoint($1, $3, $5, @$); }
              | ident PATH STRING                { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, false, @$); }
              | ident PATH wildcard              { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, true, @$); }
              | ident PATH wildcard PLUS INT     { $$ = new ast::AttachPoint($1, $2.substr(1, $2.size()-2), $3, (uint64_t) $5, @$); }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -74,6 +74,20 @@ std::vector<std::string> expand_wildcard_paths(const std::vector<std::string>& p
 
 namespace bpftrace {
 
+//'borrowed' from libbpf's bpf_core_find_kernel_btf
+// from Andrii Nakryiko
+const struct vmlinux_location vmlinux_locs[] = {
+  { "/sys/kernel/btf/vmlinux", true },
+  { "/boot/vmlinux-%1$s", false },
+  { "/lib/modules/%1$s/vmlinux-%1$s", false },
+  { "/lib/modules/%1$s/build/vmlinux", false },
+  { "/usr/lib/modules/%1$s/kernel/vmlinux", false },
+  { "/usr/lib/debug/boot/vmlinux-%1$s", false },
+  { "/usr/lib/debug/boot/vmlinux-%1$s.debug", false },
+  { "/usr/lib/debug/lib/modules/%1$s/vmlinux", false },
+  { nullptr, false },
+};
+
 static bool provider_cache_loaded = false;
 
 // Maps all providers of pid to vector of tracepoints on that provider

--- a/src/utils.h
+++ b/src/utils.h
@@ -10,6 +10,14 @@
 
 namespace bpftrace {
 
+struct vmlinux_location
+{
+  const char *path; // path with possible "%s" format to be replaced current
+                    // release
+  bool raw;         // file is either as ELF (false) or raw BTF data (true)
+};
+extern const struct vmlinux_location vmlinux_locs[];
+
 typedef enum _USDT_TUPLE_ORDER_
 {
   USDT_PATH_INDEX,

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -33,6 +33,12 @@ TEST(ast, probe_name_kprobe)
   AttachPointList attach_points2 = { &ap1, &ap2 };
   Probe kprobe2(&attach_points2, nullptr, nullptr);
   EXPECT_EQ(kprobe2.name(), "kprobe:sys_read,kprobe:sys_write");
+
+  AttachPoint ap3("kprobe", "sys_read", (uint64_t)10);
+  AttachPointList attach_points3 = { &ap1, &ap2, &ap3 };
+  Probe kprobe3(&attach_points3, nullptr, nullptr);
+  EXPECT_EQ(kprobe3.name(),
+            "kprobe:sys_read,kprobe:sys_write,kprobe:sys_read+10");
 }
 
 TEST(ast, probe_name_uprobe)

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -19,6 +19,16 @@ EXPECT first second
 TIMEOUT 5
 AFTER /bin/bash -c "sleep 1e-6"; /bin/bash -c "sleep 1e-6"
 
+NAME kprobe_offset
+RUN bpftrace -v -e 'kprobe:vfs_read+0 { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+EXPECT SUCCESS kprobe_offset [0-9][0-9]*
+TIMEOUT 5
+
+NAME kprobe_offset_fail_size
+RUN bpftrace -v -e 'kprobe:vfs_read+1000000 { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+EXPECT Offset outside the function bounds \('vfs_read' size is*
+TIMEOUT 5
+
 NAME kretprobe
 RUN bpftrace -v -e 'kretprobe:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT SUCCESS kretprobe [0-9][0-9]*


### PR DESCRIPTION
Example: `bpftrace -e 'kprobe:do_sys_open+9 { ... }'`.

This is based on the support of attaching uprobe to offset (#803).  The
offset is checked whether it is an instruction boundary using vmlinux.
The environment variable `BPFTRACE_VMLINUX` can be used to specify
vmlinux file.  ALLOW_UNSAFE_UPROBE option is renamed to
ALLOW_UNSASFE_PROBE so that it supports both uprobe and kprobe.

Closes #42 