### PR TITLE
Reuse `cat` and `system` ID when expanding probes

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1286,6 +1286,8 @@ void CodegenLLVM::visit(Probe &probe)
      * can restore it for the next pass (printf_id_, time_id_).
      */
     int starting_printf_id_ = printf_id_;
+    int starting_cat_id_ = cat_id_;
+    int starting_system_id_ = system_id_;
     int starting_time_id_ = time_id_;
     int starting_join_id_ = join_id_;
 
@@ -1302,6 +1304,8 @@ void CodegenLLVM::visit(Probe &probe)
       tracepoint_struct_ = "";
       for (auto &match_ : matches) {
         printf_id_ = starting_printf_id_;
+        cat_id_ = starting_cat_id_;
+        system_id_ = starting_system_id_;
         time_id_ = starting_time_id_;
         join_id_ = starting_join_id_;
 

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1285,11 +1285,11 @@ void CodegenLLVM::visit(Probe &probe)
      * We begin by saving state that gets changed by the codegen pass, so we
      * can restore it for the next pass (printf_id_, time_id_).
      */
-    int starting_printf_id_ = printf_id_;
-    int starting_cat_id_ = cat_id_;
-    int starting_system_id_ = system_id_;
-    int starting_time_id_ = time_id_;
-    int starting_join_id_ = join_id_;
+    int starting_printf_id = printf_id_;
+    int starting_cat_id = cat_id_;
+    int starting_system_id = system_id_;
+    int starting_time_id = time_id_;
+    int starting_join_id = join_id_;
 
     for (auto attach_point : *probe.attach_points) {
       current_attach_point_ = attach_point;
@@ -1303,11 +1303,11 @@ void CodegenLLVM::visit(Probe &probe)
 
       tracepoint_struct_ = "";
       for (auto &match_ : matches) {
-        printf_id_ = starting_printf_id_;
-        cat_id_ = starting_cat_id_;
-        system_id_ = starting_system_id_;
-        time_id_ = starting_time_id_;
-        join_id_ = starting_join_id_;
+        printf_id_ = starting_printf_id;
+        cat_id_ = starting_cat_id;
+        system_id_ = starting_system_id;
+        time_id_ = starting_time_id;
+        join_id_ = starting_join_id;
 
         std::string full_func_id = match_;
 

--- a/tests/codegen/regression.cpp
+++ b/tests/codegen/regression.cpp
@@ -1,0 +1,35 @@
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "bpforc.h"
+#include "bpftrace.h"
+#include "clang_parser.h"
+#include "codegen_llvm.h"
+#include "driver.h"
+#include "semantic_analyser.h"
+
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+using ::testing::_;
+
+
+TEST(codegen, regression_957)
+{
+  MockBPFtrace bpftrace;
+  Driver driver(bpftrace);
+
+  ASSERT_EQ(driver.parse_str("t:syscalls:sys_enter_wait* { cat(\"%s\", probe); }"), 0);
+  ast::SemanticAnalyser semantics(driver.root_, bpftrace);
+  ASSERT_EQ(semantics.analyse(), 0);
+  ASSERT_EQ(semantics.create_maps(true), 0);
+  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  codegen.compile();
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace


### PR DESCRIPTION
As `system` and `cat` work basically the same as `printf` we need to use
the same `id` reuse trick.

trigger:

```
tracepoint:syscalls:sys_enter_open,tracepoint:syscalls:sys_enter_openat
{
  if (str(args->filename) == "") {
    cat("");
  }
}
```

Results in:

```
terminate called after throwing an instance of 'std::out_of_range'
  what():  vector::_M_range_check: __n (which is 1) >= this->size() (which is 1)
Aborted
```

Closes #957