### PR TITLE
Remove the iterate-over-all-BTF-types workaround in BTF::c_def

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(ast
   irbuilderbpf.cpp
   printer.cpp
   semantic_analyser.cpp
+  field_analyser.cpp
 )
 
 if(HAVE_GET_CURRENT_CGROUP_ID)

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -5,11 +5,6 @@
 namespace bpftrace {
 namespace ast {
 
-std::unordered_set<std::string>& Expression::getResolve() {
-  static std::unordered_set<std::string> s;
-  return s;
-}
-
 void Integer::accept(Visitor &v) {
   v.visit(*this);
 }

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -5,7 +5,6 @@
 #include <map>
 #include <string>
 #include <vector>
-#include <unordered_set>
 
 #include "types.h"
 
@@ -36,7 +35,6 @@ public:
   bool is_map = false;
   Expression() : Node(){};
   Expression(location loc) : Node(loc){};
-  static std::unordered_set<std::string>& getResolve();
 };
 using ExpressionList = std::vector<Expression *>;
 
@@ -89,22 +87,12 @@ public:
 
 class Builtin : public Expression {
 public:
-  explicit Builtin(std::string ident) : ident(is_deprecated(ident)) {
-    resolve_curtask(ident);
-  }
-  explicit Builtin(std::string ident, location loc) : Expression(loc), ident(is_deprecated(ident)) {
-    resolve_curtask(ident);
-  }
+  explicit Builtin(std::string ident) : ident(is_deprecated(ident)) { }
+  explicit Builtin(std::string ident, location loc) : Expression(loc), ident(is_deprecated(ident)) { }
   std::string ident;
   int probe_id;
 
   void accept(Visitor &v) override;
-
-private:
-  void resolve_curtask(std::string& ident) {
-    if (ident == "curtask")
-      getResolve().insert("task_struct");
-  }
 };
 
 class Call : public Expression {
@@ -193,13 +181,9 @@ public:
 class Cast : public Expression {
 public:
   Cast(const std::string &type, bool is_pointer, Expression *expr)
-    : cast_type(type), is_pointer(is_pointer), expr(expr) {
-    getResolve().insert(type);
-  }
+    : cast_type(type), is_pointer(is_pointer), expr(expr) { }
   Cast(const std::string &type, bool is_pointer, Expression *expr, location loc)
-    : Expression(loc), cast_type(type), is_pointer(is_pointer), expr(expr) {
-    getResolve().insert(type);
-  }
+    : Expression(loc), cast_type(type), is_pointer(is_pointer), expr(expr) { }
   std::string cast_type;
   bool is_pointer;
   Expression *expr;

--- a/src/ast/field_analyser.cpp
+++ b/src/ast/field_analyser.cpp
@@ -105,7 +105,8 @@ void FieldAnalyser::visit(Unroll &unroll)
 void FieldAnalyser::visit(FieldAccess &acc)
 {
   acc.expr->accept(*this);
-  type_ = type_ + "::" + acc.field;
+  if (!type_.empty())
+    type_ = bpftrace_.btf_.type_of(type_, acc.field);
 }
 
 void FieldAnalyser::visit(Cast &cast)
@@ -160,7 +161,8 @@ void FieldAnalyser::visit(Program &program)
 
 int FieldAnalyser::analyse()
 {
-  root_->accept(*this);
+  if (bpftrace_.btf_.has_data())
+    root_->accept(*this);
   return 0;
 }
 

--- a/src/ast/field_analyser.cpp
+++ b/src/ast/field_analyser.cpp
@@ -27,8 +27,10 @@ void FieldAnalyser::visit(Identifier &identifier __attribute__((unused)))
 
 void FieldAnalyser::visit(Builtin &builtin)
 {
-  if (builtin.ident == "curtask")
+  if (builtin.ident == "curtask") {
     type_ = "task_struct";
+    bpftrace_.btf_set_.insert(type_);
+  }
 }
 
 void FieldAnalyser::visit(Call &call)
@@ -105,14 +107,18 @@ void FieldAnalyser::visit(Unroll &unroll)
 void FieldAnalyser::visit(FieldAccess &acc)
 {
   acc.expr->accept(*this);
-  if (!type_.empty())
+  if (!type_.empty()) {
     type_ = bpftrace_.btf_.type_of(type_, acc.field);
+    bpftrace_.btf_set_.insert(type_);
+  }
 }
 
 void FieldAnalyser::visit(Cast &cast)
 {
   cast.expr->accept(*this);
   type_ = cast.cast_type;
+  assert(!type_.empty());
+  bpftrace_.btf_set_.insert(type_);
 }
 
 void FieldAnalyser::visit(ExprStatement &expr)

--- a/src/ast/field_analyser.cpp
+++ b/src/ast/field_analyser.cpp
@@ -1,0 +1,168 @@
+#include <iostream>
+#include <cassert>
+#include "field_analyser.h"
+
+namespace bpftrace {
+namespace ast {
+
+void FieldAnalyser::visit(Integer &integer __attribute__((unused)))
+{
+}
+
+void FieldAnalyser::visit(PositionalParameter &param __attribute__((unused)))
+{
+}
+
+void FieldAnalyser::visit(String &string __attribute__((unused)))
+{
+}
+
+void FieldAnalyser::visit(StackMode &mode __attribute__((unused)))
+{
+}
+
+void FieldAnalyser::visit(Identifier &identifier __attribute__((unused)))
+{
+}
+
+void FieldAnalyser::visit(Builtin &builtin)
+{
+  if (builtin.ident == "curtask")
+    type_ = "task_struct";
+}
+
+void FieldAnalyser::visit(Call &call)
+{
+  if (call.vargs) {
+    for (Expression *expr : *call.vargs) {
+      expr->accept(*this);
+    }
+  }
+}
+
+void FieldAnalyser::visit(Map &map)
+{
+  MapKey key;
+  if (map.vargs) {
+    for (Expression *expr : *map.vargs) {
+      expr->accept(*this);
+    }
+  }
+}
+
+void FieldAnalyser::visit(Variable &var __attribute__((unused)))
+{
+}
+
+void FieldAnalyser::visit(ArrayAccess &arr)
+{
+  arr.expr->accept(*this);
+  arr.indexpr->accept(*this);
+}
+
+void FieldAnalyser::visit(Binop &binop)
+{
+  binop.left->accept(*this);
+  binop.right->accept(*this);
+}
+
+void FieldAnalyser::visit(Unop &unop)
+{
+  unop.expr->accept(*this);
+}
+
+void FieldAnalyser::visit(Ternary &ternary)
+{
+  ternary.cond->accept(*this);
+  ternary.left->accept(*this);
+  ternary.right->accept(*this);
+}
+
+void FieldAnalyser::visit(If &if_block)
+{
+  if_block.cond->accept(*this);
+
+  for (Statement *stmt : *if_block.stmts) {
+    stmt->accept(*this);
+  }
+
+  if (if_block.else_stmts) {
+    for (Statement *stmt : *if_block.else_stmts) {
+      stmt->accept(*this);
+    }
+  }
+}
+
+void FieldAnalyser::visit(Unroll &unroll)
+{
+  for (int i=0; i < unroll.var; i++) {
+    for (Statement *stmt : *unroll.stmts) {
+      stmt->accept(*this);
+    }
+  }
+}
+
+void FieldAnalyser::visit(FieldAccess &acc)
+{
+  acc.expr->accept(*this);
+  type_ = type_ + "::" + acc.field;
+}
+
+void FieldAnalyser::visit(Cast &cast)
+{
+  cast.expr->accept(*this);
+  type_ = cast.cast_type;
+}
+
+void FieldAnalyser::visit(ExprStatement &expr)
+{
+  expr.expr->accept(*this);
+}
+
+void FieldAnalyser::visit(AssignMapStatement &assignment)
+{
+  assignment.map->accept(*this);
+  assignment.expr->accept(*this);
+}
+
+void FieldAnalyser::visit(AssignVarStatement &assignment)
+{
+  assignment.expr->accept(*this);
+}
+
+void FieldAnalyser::visit(Predicate &pred)
+{
+  pred.expr->accept(*this);
+}
+
+void FieldAnalyser::visit(AttachPoint &ap __attribute__((unused)))
+{
+}
+
+void FieldAnalyser::visit(Probe &probe)
+{
+  for (AttachPoint *ap : *probe.attach_points) {
+    ap->accept(*this);
+  }
+  if (probe.pred) {
+    probe.pred->accept(*this);
+  }
+  for (Statement *stmt : *probe.stmts) {
+    stmt->accept(*this);
+  }
+}
+
+void FieldAnalyser::visit(Program &program)
+{
+  for (Probe *probe : *program.probes)
+    probe->accept(*this);
+}
+
+int FieldAnalyser::analyse()
+{
+  root_->accept(*this);
+  return 0;
+}
+
+} // namespace ast
+} // namespace bpftrace

--- a/src/ast/field_analyser.h
+++ b/src/ast/field_analyser.h
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <string>
+#include "ast.h"
+#include "bpftrace.h"
+
+namespace bpftrace {
+namespace ast {
+
+class FieldAnalyser : public Visitor {
+public:
+  explicit FieldAnalyser(Node *root, BPFtrace &bpftrace)
+    : type_(""), root_(root), bpftrace_(bpftrace)
+  { }
+
+  void visit(Integer &integer) override;
+  void visit(PositionalParameter &param) override;
+  void visit(String &string) override;
+  void visit(StackMode &mode) override;
+  void visit(Identifier &identifier) override;
+  void visit(Builtin &builtin) override;
+  void visit(Call &call) override;
+  void visit(Map &map) override;
+  void visit(Variable &var) override;
+  void visit(Binop &binop) override;
+  void visit(Unop &unop) override;
+  void visit(Ternary &ternary) override;
+  void visit(FieldAccess &acc) override;
+  void visit(ArrayAccess &arr) override;
+  void visit(Cast &cast) override;
+  void visit(ExprStatement &expr) override;
+  void visit(AssignMapStatement &assignment) override;
+  void visit(AssignVarStatement &assignment) override;
+  void visit(If &if_block) override;
+  void visit(Unroll &unroll) override;
+  void visit(Predicate &pred) override;
+  void visit(AttachPoint &ap) override;
+  void visit(Probe &probe) override;
+  void visit(Program &program) override;
+
+  int analyse();
+
+private:
+  std::string    type_;
+  Node          *root_;
+  BPFtrace      &bpftrace_;
+};
+
+} // namespace ast
+} // namespace bpftrace

--- a/src/ast/field_analyser.h
+++ b/src/ast/field_analyser.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <unordered_set>
 #include "ast.h"
 #include "bpftrace.h"
 

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -16,6 +16,7 @@
 #include "utils.h"
 #include "types.h"
 #include "output.h"
+#include "btf.h"
 
 namespace bpftrace {
 
@@ -158,6 +159,8 @@ public:
       int pid,
       const std::string &target) const;
   const std::string get_source_line(unsigned int);
+
+  BTF btf_;
 
 protected:
   std::vector<Probe> probes_;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -161,6 +161,7 @@ public:
   const std::string get_source_line(unsigned int);
 
   BTF btf_;
+  std::unordered_set<std::string> btf_set_;
 
 protected:
   std::vector<Probe> probes_;

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -228,54 +228,11 @@ std::string BTF::c_def(std::unordered_set<std::string>& set)
     const struct btf_type *t = btf__type_by_id(btf, id);
     const char *str = btf_str(btf, t->name_off);
 
-    /*
-     * TODO(danobi): Only resolve necessary types. This can be
-     * accomlished by doing something like:
-     *
-     *    for (...) {
-     *      const struct btf_type *t = ...
-     *      const char *str = ...
-     *
-     *      if (myset.find(str) != myset.end()) {
-     *        btf_dump__dump_type(...);
-     *        myset.erase(str);
-     *
-     *        <dump required forward declared types>
-     *      }
-     *    }
-     *
-     * Care are must be taken to fully resolve any accesses
-     * via a pointer. libbpf currently does not fully resolve types
-     * that are used as a pointer. For example, if in the kernel there
-     * was:
-     *
-     *    struct Bar {
-     *      int x;
-     *    };
-     *
-     *    struct Foo {
-     *      struct Bar *b;
-     *    };
-     *
-     * b would not be fully resolved. Instead, libbpf will dump a
-     * forward declaration. So the libbpf output would look like:
-     *
-     *    struct Bar;
-     *    struct Foo {
-     *      struct Bar *b;
-     *    }
-     *
-     * So for now, we read in every type BTF exposes. It's slower
-     * and less memory efficient, but it's more ergonomic for the
-     * user to not have to do an explicit cast every time they
-     * access a pointer.
-     */
-
-    for (id = 1; id <= max; id++)
+    auto it = myset.find(str);
+    if (it != myset.end())
     {
-      const struct btf_type *t = btf__type_by_id(btf, id);
-      const char *str = btf_str(btf, t->name_off);
       btf_dump__dump_type(dump, id);
+      myset.erase(it);
     }
   }
 

--- a/src/btf.h
+++ b/src/btf.h
@@ -21,6 +21,7 @@ public:
 
   bool has_data(void);
   std::string c_def(std::unordered_set<std::string>& set);
+  std::string type_of(std::string name, std::string field);
 
 private:
   struct btf *btf;

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -375,7 +375,7 @@ bool ClangParser::parse_btf_definitions(BPFtrace &bpftrace)
   if (ast::Expression::getResolve().size() == 0)
     return true;
 
-  BTF btf = BTF();
+  BTF &btf = bpftrace.btf_;
 
   if (!btf.has_data())
     return true;

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -9,6 +9,7 @@
 #include "utils.h"
 #include "headers.h"
 #include "btf.h"
+#include "field_analyser.h"
 
 namespace bpftrace {
 
@@ -372,7 +373,7 @@ bool ClangParser::visit_children(CXCursor &cursor, BPFtrace &bpftrace)
 
 bool ClangParser::parse_btf_definitions(BPFtrace &bpftrace)
 {
-  if (ast::Expression::getResolve().size() == 0)
+  if (!bpftrace.btf_set_.size())
     return true;
 
   BTF &btf = bpftrace.btf_;
@@ -380,7 +381,7 @@ bool ClangParser::parse_btf_definitions(BPFtrace &bpftrace)
   if (!btf.has_data())
     return true;
 
-  std::string input = btf.c_def(ast::Expression::getResolve());
+  std::string input = btf.c_def(bpftrace.btf_set_);
 
   CXUnsavedFile unsaved_files =
   {

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -11,7 +11,6 @@ namespace bpftrace {
 
 Driver::Driver(BPFtrace &bpftrace, std::ostream &o) : bpftrace_(bpftrace), out_(o)
 {
-  ast::Expression::getResolve().clear();
   yylex_init(&scanner_);
   parser_ = std::make_unique<Parser>(*this, scanner_);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@
 #include "list.h"
 #include "printer.h"
 #include "semantic_analyser.h"
+#include "field_analyser.h"
 #include "tracepoint_format_parser.h"
 #include "output.h"
 
@@ -348,6 +349,11 @@ int main(int argc, char *argv[])
 
   if (!is_root())
     return 1;
+
+  ast::FieldAnalyser fields(driver.root_, bpftrace);
+  err = fields.analyse();
+  if (err)
+    return err;
 
   // FIXME (mmarchini): maybe we don't want to always enforce an infinite
   // rlimit?

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -3,6 +3,8 @@
 #include "driver.h"
 #include "bpftrace.h"
 #include "struct.h"
+#include "field_analyser.h"
+#include <iostream>
 
 namespace bpftrace {
 namespace test {
@@ -16,6 +18,9 @@ static void parse(const std::string &input, BPFtrace &bpftrace, bool result = tr
   auto extended_input = input + probe;
   Driver driver(bpftrace);
   ASSERT_EQ(driver.parse_str(extended_input), 0);
+
+  ast::FieldAnalyser fields(driver.root_, bpftrace);
+  EXPECT_EQ(fields.analyse(), 0);
 
   ClangParser clang;
   ASSERT_EQ(clang.parse(driver.root_, bpftrace), result);
@@ -397,19 +402,45 @@ TEST(clang_parser, parse_fail)
 
 #include "btf_data.h"
 
-TEST(clang_parser, btf)
+class clang_parser_btf : public ::testing::Test {
+ protected:
+  void SetUp() override
+  {
+    char *path = strdup("/tmp/XXXXXX");
+    if (!path)
+      return;
+
+    int fd = mkstemp(path);
+    if (fd < 0)
+    {
+      std::remove(path);
+      return;
+    }
+
+    if (write(fd, btf_data, btf_data_len) != btf_data_len)
+    {
+      close(fd);
+      std::remove(path);
+      return;
+    }
+
+    close(fd);
+    setenv("BPFTRACE_BTF_TEST", path, true);
+    path_ = path;
+  }
+
+  void TearDown() override
+  {
+    // clear the environment and remove the temp file
+    unsetenv("BPFTRACE_BTF_TEST");
+    std::remove(path_);
+  }
+
+  char *path_;
+};
+
+TEST_F(clang_parser_btf, btf)
 {
-  char *path = strdup("/tmp/XXXXXX");
-  ASSERT_TRUE(path != NULL);
-
-  int fd = mkstemp(path);
-  ASSERT_TRUE(fd >= 0);
-
-  EXPECT_EQ(write(fd, btf_data, btf_data_len), btf_data_len);
-  close(fd);
-
-  ASSERT_EQ(setenv("BPFTRACE_BTF_TEST", path, true), 0);
-
   BPFtrace bpftrace;
   parse("", bpftrace, true,
         "kprobe:sys_read {\n"
@@ -417,10 +448,6 @@ TEST(clang_parser, btf)
         "  @x2 = (struct Foo2 *) curtask;\n"
         "  @x3 = (struct Foo3 *) curtask;\n"
         "}");
-
-  // clear the environment
-  unsetenv("BPFTRACE_BTF_TEST");
-  std::remove(path);
 
   StructMap &structs = bpftrace.structs_;
 
@@ -478,6 +505,21 @@ TEST(clang_parser, btf)
   EXPECT_EQ(structs["Foo3"].fields["foo2"].offset, 8);
 }
 
+TEST_F(clang_parser_btf, btf_field_struct)
+{
+  BPFtrace bpftrace;
+  parse("", bpftrace, true,
+        "kprobe:sys_read {\n"
+        "  @x3 = ((struct Foo3 *) curtask)->foo2->a;\n"
+        "}");
+
+  /* task_struct->Foo3->Foo2->int */
+  EXPECT_EQ(bpftrace.btf_set_.size(), 4U);
+  EXPECT_NE(bpftrace.btf_set_.find("task_struct"), bpftrace.btf_set_.end());
+  EXPECT_NE(bpftrace.btf_set_.find("Foo3"), bpftrace.btf_set_.end());
+  EXPECT_NE(bpftrace.btf_set_.find("Foo2"), bpftrace.btf_set_.end());
+  EXPECT_NE(bpftrace.btf_set_.find("int"), bpftrace.btf_set_.end());
+}
 #endif // HAVE_LIBBPF_BTF_DUMP
 
 } // namespace clang_parser


### PR DESCRIPTION
By adding FieldAnalyser class that goes through parsed AST via
Visitor interface and scans through field accesses and storing
their types. Only those are then used to be dumped via BTF.

This way we can get rid of the global set of BTF types and
the over-all-BTF-types iteration in BTF::c_def.