### PR TITLE
Fix 'may be used uninitialized' build warning in bfd-disasm.cpp

### DIFF
--- a/src/bfd-disasm.cpp
+++ b/src/bfd-disasm.cpp
@@ -13,7 +13,7 @@
 
 namespace bpftrace {
 
-BfdDisasm::BfdDisasm(std::string &path) : size(0)
+BfdDisasm::BfdDisasm(std::string &path) : size_(0)
 {
   fd_ = open(path.c_str(), O_RDONLY);
 
@@ -21,7 +21,7 @@ BfdDisasm::BfdDisasm(std::string &path) : size(0)
     struct stat st;
 
     if (fstat(fd_, &st) == 0)
-      size = st.st_size;
+      size_ = st.st_size;
   }
 }
 
@@ -108,7 +108,7 @@ AlignState BfdDisasm::is_aligned(uint64_t offset, uint64_t pc)
 {
   AlignState aligned = AlignState::Fail;
   // 100 bytes should be enough to cover next instruction behind pc
-  uint64_t size = std::min(pc + 100, size);
+  uint64_t size = std::min(pc + 100, size_);
   void *buf;
 
   if (fd_ < 0)

--- a/src/bfd-disasm.h
+++ b/src/bfd-disasm.h
@@ -14,7 +14,7 @@ public:
 
 private:
   int fd_ = -1;
-  uint64_t size;
+  uint64_t size_;
 };
 
 } // namespace bpftrace


### PR DESCRIPTION
Fix the following warning:

src/bfd-disasm.cpp: In member function ‘virtual bpftrace::AlignState
bpftrace::BfdDisasm::is_aligned(uint64_t, uint64_t)’:
src/bfd-disasm.cpp:111:12: warning: ‘size’ may be used uninitialized in
this function [-Wmaybe-uninitialized]
  111 |   uint64_t size = std::min(pc + 100, size);
      |            ^~~~

It seems that std::min() is using the local 'size' variable instead of
the instance 'size' variable. Let's make the things more clear by using
a different name for the instance one: 'size_'.