### PR TITLE
Add missing kernel option in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -35,6 +35,7 @@ CONFIG_BPF_SYSCALL=y
 CONFIG_BPF_JIT=y
 CONFIG_HAVE_EBPF_JIT=y
 CONFIG_BPF_EVENTS=y
+CONFIG_FTRACE_SYSCALLS=y
 ```
 
 This can be verified by running the `check_kernel_features` script from the


### PR DESCRIPTION
Option CONFIG_FTRACE_SYSCALLS is checked in the [`check_kernel_features`](https://github.com/iovisor/bpftrace/blob/master/scripts/check_kernel_features.sh) script, but it is not present in [INSTALL.md](https://github.com/iovisor/bpftrace/blob/master/INSTALL.md).

I am suggesting here to add `CONFIG_FTRACE_SYSCALLS=y` as a requirement in INSTALL.md
