### PR TITLE
Implement `override_return`

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -79,6 +79,7 @@ discussion to other files in /docs, the /tools/\*\_examples.txt files, or blog p
     - [17. `cat()`: Print file content](#17-cat-print-file-content)
     - [18. `signal()`: Send a signal to the current task](#18-signal-send-a-signal-to-current-task)
     - [19. `strncmp()`: Compare first n characters of two strings](#19-strncmp-compare-first-n-characters-of-two-strings)
+    - [20. `override_return()`: Override return value](#18-override_return-override-return-value)
 - [Map Functions](#map-functions)
     - [1. Builtins](#1-builtins-2)
     - [2. `count()`: Count](#2-count-count)
@@ -2287,6 +2288,33 @@ Attaching 320 probes...
 @[mpv/vo, tracepoint:syscalls:sys_enter_recvmsg]: 15018
 @[mpv, tracepoint:syscalls:sys_enter_getpid]: 31178
 @[mpv, tracepoint:syscalls:sys_enter_futex]: 403868
+```
+
+## 20. `override_return()`: Override return value
+
+Syntax: `override_return(u64 rc)`
+
+Kernel: 4.16
+
+Supported Probe Types: kprobes
+
+The probed function will not be executed, instead a helper will be executed
+that will just return `rc`.
+
+```
+# bpftrace -e 'k:__x64_sys_getuid /comm == "id"/ { override_return(2<<21); }' --unsafe -c id
+uid=4194304 gid=0(root) euid=0(root) groups=0(root)
+```
+
+This feature only works on kernels compiled with `CONFIG_BPF_KPROBE_OVERRIDE`
+and only works on functions tagged `ALLOW_ERROR_INJECTION`.
+
+bpftrace does not test whether error injection is allowed for the probed
+function, instead if will fail to load the program into the kernel:
+
+```
+ioctl(PERF_EVENT_IOC_SET_BPF): Invalid argument
+Error attaching probe: 'kprobe:vfs_read'
 ```
 
 # Map Functions

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -802,6 +802,15 @@ void CodegenLLVM::visit(Call &call)
         b_.CreateLifetimeEnd(right_string);
     }
   }
+  else if (call.func == "override_return")
+  {
+    // int bpf_override_return(struct pt_regs *regs, u64 rc)
+    // returns: 0
+    auto &arg = *call.vargs->at(0);
+    arg.accept(*this);
+    expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), arg.type.is_signed);
+    b_.CreateOverrideReturn(ctx_, expr_);
+  }
   else
   {
     std::cerr << "missing codegen for function \"" << call.func << "\"" << std::endl;

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -668,5 +668,19 @@ void IRBuilderBPF::CreateSignal(Value *sig)
   CreateCall(signal_func, {sig}, "signal");
 }
 
+void IRBuilderBPF::CreateOverrideReturn(Value *ctx, Value *rc)
+{
+  // int bpf_override_return(struct pt_regs *regs, u64 rc)
+  // Return: 0
+  FunctionType *override_func_type = FunctionType::get(
+      getInt64Ty(), { getInt8PtrTy(), getInt64Ty() }, false);
+  PointerType *override_func_ptr_type = PointerType::get(override_func_type, 0);
+  Constant *override_func = ConstantExpr::getCast(Instruction::IntToPtr,
+                                                  getInt64(
+                                                      BPF_FUNC_override_return),
+                                                  override_func_ptr_type);
+  CreateCall(override_func, { ctx, rc }, "override_return");
+}
+
 } // namespace ast
 } // namespace bpftrace

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -64,6 +64,7 @@ public:
   void        CreateGetCurrentComm(AllocaInst *buf, size_t size);
   void        CreatePerfEventOutput(Value *ctx, Value *data, size_t size);
   void        CreateSignal(Value *sig);
+  void        CreateOverrideReturn(Value *ctx, Value *rc);
 
 private:
   Module &module_;

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -72,11 +72,24 @@ static bool detect_signal(void)
   return try_load("test_signal", BPF_PROG_TYPE_KPROBE, insns, sizeof(insns));
 }
 
+static bool detect_override_return(void)
+{
+  struct bpf_insn insns[] = {
+    BPF_LD_IMM64(BPF_REG_2, 11),
+    BPF_RAW_INSN(BPF_JMP | BPF_CALL, 0, 0, 0, libbpf::BPF_FUNC_override_return),
+    BPF_EXIT_INSN(),
+  };
+
+  return try_load(
+      "test_override_return", BPF_PROG_TYPE_KPROBE, insns, sizeof(insns));
+}
+
 BPFfeature::BPFfeature(void)
 {
   has_loop_ = detect_loop();
   has_signal_ = detect_signal();
   has_get_current_cgroup_id_ = detect_get_current_cgroup_id();
+  has_override_return_ = detect_override_return();
 }
 
 std::string BPFfeature::report(void)
@@ -87,6 +100,8 @@ std::string BPFfeature::report(void)
       << "  get_current_cgroup_id: "
       << to_str(has_helper_get_current_cgroup_id()) << std::endl
       << "  send_signal: " << to_str(has_helper_send_signal()) << std::endl
+      << "  override_return: " << to_str(has_helper_override_return())
+      << std::endl
       << std::endl
       << "Kernel features" << std::endl
       << "  Loop support: " << to_str(has_loop()) << std::endl

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -20,6 +20,10 @@ public:
   {
     return has_get_current_cgroup_id_;
   };
+  bool has_helper_override_return(void)
+  {
+    return has_override_return_;
+  };
   std::string report(void);
 
 protected:
@@ -28,6 +32,7 @@ protected:
   /* Helpers */
   bool has_signal_;
   bool has_get_current_cgroup_id_;
+  bool has_override_return_;
 };
 
 } // namespace bpftrace

--- a/src/utils.h
+++ b/src/utils.h
@@ -89,6 +89,7 @@ static std::vector<DeprecatedName> DEPRECATED_LIST =
 static std::vector<std::string> UNSAFE_BUILTIN_FUNCS = {
   "system",
   "signal",
+  "override_return",
 };
 
 bool get_uint64_env_var(const ::std::string &str, uint64_t &dest);

--- a/src/utils.h
+++ b/src/utils.h
@@ -86,8 +86,7 @@ static std::vector<DeprecatedName> DEPRECATED_LIST =
   { "sym", "ksym"},
 };
 
-static std::vector<std::string> UNSAFE_BUILTIN_FUNCS =
-{
+static std::vector<std::string> UNSAFE_BUILTIN_FUNCS = {
   "system",
   "signal",
 };

--- a/tests/codegen/call_override_return.cpp
+++ b/tests/codegen/call_override_return.cpp
@@ -1,0 +1,25 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, call_override_return)
+{
+  test(
+      "kprobe:f { override_return(arg0); }",
+
+      R"EXPECTED(define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
+entry:
+  %1 = getelementptr i8, i8* %0, i64 112
+  %arg0 = load i64, i8* %1, align 8
+  %override_return = tail call i64 inttoptr (i64 58 to i64 (i8*, i64)*)(i8* %0, i64 %arg0)
+  ret i64 0
+}
+)EXPECTED",
+      false);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/call_override_return_literal.cpp
+++ b/tests/codegen/call_override_return_literal.cpp
@@ -1,0 +1,23 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, call_override_return_literal)
+{
+  test(
+      "kprobe:f { override_return(-1); }",
+
+      R"EXPECTED(define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
+entry:
+  %override_return = tail call i64 inttoptr (i64 58 to i64 (i8*, i64)*)(i8* %0, i64 -1)
+  ret i64 0
+}
+)EXPECTED",
+      false);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -53,7 +53,8 @@ class MockBPFfeature : public BPFfeature
 public:
   MockBPFfeature(bool has_features = true)
   {
-    has_loop_ = has_signal_ = has_get_current_cgroup_id_ = has_features;
+    has_loop_ = has_signal_ = has_get_current_cgroup_id_ =
+        has_override_return_ = has_features;
   };
 };
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1388,12 +1388,27 @@ TEST(semantic_analyser, strncmp)
   // Test strncmp builtin
   test("i:s:1 { $a = \"bar\"; strncmp(\"foo\", $a, 1) }", 0);
   test("i:s:1 { strncmp(\"foo\", \"bar\", 1) }", 0);
-
   test("i:s:1 { strncmp(1) }", 1);
   test("i:s:1 { strncmp(1,1,1) }", 10);
   test("i:s:1 { strncmp(\"a\",1,1) }", 10);
   test("i:s:1 { strncmp(\"a\",\"a\",-1) }", 1);
   test("i:s:1 { strncmp(\"a\",\"a\",\"foo\") }", 1);
+}
+
+TEST(semantic_analyser, override_return)
+{
+  // literals
+  test("k:f { override_return(-1); }", 0, false);
+
+  // variables
+  test("k:f { override_return(arg0); }", 0, false);
+
+  // Probe types
+  test("kr:f { override_return(-1); }", 1, false);
+  test("u:f { override_return(-1); }", 1, false);
+  test("t:syscalls:sys_enter_openat { override_return(-1); }", 1, false);
+  test("i:s:1 { override_return(-1); }", 1, false);
+  test("p:hz:1 { override_return(-1); }", 1, false);
 }
 
 TEST(semantic_analyser, struct_member_keywords)


### PR DESCRIPTION
The implementation of this turned out quite straight forward.

I've chosen to skip testing whether the probed function can actually be overridden (using `/sys/kernel/debug/error_injection/list`) as I didn't see that much value in it. It is not a function that will be used often and the people that do use it are probably aware of the limitations. If someone has a strong opinion about it I'll happily implement it however.

This helper is not yet available in the CI so I've skipped the runtime tests. 

Example:

```
$ sudo bpftrace -e 'k:__x64_sys_getuid /comm == "id"/ { override_return(2<<21); }' --unsafe -c id
Attaching 1 probe...
uid=4194304 gid=0(root) euid=0(root) groups=0(root)
```

Fixes #720 