### PR TITLE
Bitfield support

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,7 @@ add_executable(bpftrace
   output.cpp
   printf.cpp
   resolve_cgroupid.cpp
+  struct.cpp
   tracepoint_format_parser.cpp
   types.cpp
   utils.cpp

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -506,7 +506,16 @@ void SemanticAnalyser::visit(Call &call)
           // Promote to 64-bit if it's not an array type
           if (!ty.IsArray())
             ty.size = 8;
-          args.push_back({ .type =  ty, .offset = 0 });
+          args.push_back(Field{
+            .type =  ty,
+            .offset = 0,
+            .is_bitfield = false,
+            .bitfield = Bitfield{
+              .read_bytes = 0,
+              .access_rshift = 0,
+              .mask = 0,
+            },
+          });
         }
         buf << verify_format_string(fmt.str, args);
 

--- a/src/struct.cpp
+++ b/src/struct.cpp
@@ -1,0 +1,15 @@
+#include "struct.h"
+
+namespace bpftrace {
+
+bool Bitfield::operator==(const Bitfield &other) const {
+  return read_bytes == other.read_bytes
+    && mask == other.mask
+    && access_rshift == other.access_rshift;
+}
+
+bool Bitfield::operator!=(const Bitfield &other) const {
+  return !(*this == other);
+}
+
+} // namespace bpftrace

--- a/src/struct.h
+++ b/src/struct.h
@@ -5,17 +5,15 @@
 
 namespace bpftrace {
 
-class Field {
-public:
+struct Field {
   SizedType type;
   int offset;
 };
 
 using FieldsMap = std::map<std::string, Field>;
 
-class Struct
+struct Struct
 {
-public:
   int size;
   FieldsMap fields;
 };

--- a/src/struct.h
+++ b/src/struct.h
@@ -5,9 +5,24 @@
 
 namespace bpftrace {
 
+struct Bitfield {
+  bool operator==(const Bitfield &other) const;
+  bool operator!=(const Bitfield &other) const;
+
+  // Read `read_bytes` bytes starting from this field's offset
+  size_t read_bytes;
+  // Then rshift the resulting value by `access_rshift` to get field value
+  size_t access_rshift;
+  // Then logical AND `mask` to mask out everything but this bitfield
+  size_t mask;
+};
+
 struct Field {
   SizedType type;
   int offset;
+
+  bool is_bitfield;
+  Bitfield bitfield;
 };
 
 using FieldsMap = std::map<std::string, Field>;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,6 +45,7 @@ add_executable(bpftrace_test
   ${CMAKE_SOURCE_DIR}/src/printf.cpp
   ${CMAKE_SOURCE_DIR}/src/resolve_cgroupid.cpp
   ${CMAKE_SOURCE_DIR}/src/ast/semantic_analyser.cpp
+  ${CMAKE_SOURCE_DIR}/src/struct.cpp
   ${CMAKE_SOURCE_DIR}/src/tracepoint_format_parser.cpp
   ${CMAKE_SOURCE_DIR}/src/types.cpp
   ${CMAKE_SOURCE_DIR}/src/utils.cpp

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -113,3 +113,9 @@ RUN bpftrace --unsafe -v -e 'tracepoint:sched:sched_switch { system("echo foo");
 EXPECT end
 TIMEOUT 5
 AFTER  sleep 2; pkill -SIGINT bpftrace
+
+NAME bitfield access
+RUN bpftrace -v -e 'struct Foo { unsigned int a:4, b:8, c:3, d:1, e:16; } uprobe:./testprogs/bitfield_test:func{ $foo = (struct Foo *)arg0; printf("%d %d %d %d %d\n", $foo->a, $foo->b, $foo->c, $foo->d, $foo->e); exit()}'
+EXPECT 1 2 5 0 65535
+TIMEOUT 5
+AFTER ./testprogs/bitfield_test

--- a/tests/testprogs/bitfield_test.c
+++ b/tests/testprogs/bitfield_test.c
@@ -1,0 +1,26 @@
+struct Foo
+{
+  unsigned int a:4,
+               b:8,
+               c:3,
+               d:1,
+               e:16;
+};
+
+__attribute__((noinline)) unsigned int func(struct Foo *foo)
+{
+  return foo->b;
+}
+
+int main()
+{
+  struct Foo foo;
+  foo.a = 1;
+  foo.b = 2;
+  foo.c = 5;
+  foo.d = 0;
+  foo.e = 65535;
+  func(&foo);
+
+  return 0;
+}


### PR DESCRIPTION
Bitfields are a pretty commonly used C feature (especially in kernel
land). Having bpftrace support would make bpftrace easier to use for
kernel developers.

Example script:
```

kprobe:ip_send_check{
  printf("version is %x, ihl is %x\n", ((struct iphdr*)arg0)->version, ((struct iphdr*)arg0)->ihl);
}
```

`struct iphdr*` is defined as:
```
struct iphdr {
	__u8	ihl:4,
		version:4;
        ...
```

Before, we'd get the following output:
```
Attaching 1 probe...
version is 45, ihl is 45
version is 45, ihl is 45
version is 45, ihl is 45
...
```

Now we get:
```
Attaching 1 probe...
version is 4, ihl is 5
version is 4, ihl is 5
version is 4, ihl is 5
version is 4, ihl is 5
...
```

This closes #969 .