### PR TITLE
semantic_analyser: validate use of calls as map keys

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -28,6 +28,7 @@ class Variable;
 class Expression : public Node {
 public:
   SizedType type;
+  Map *key_for_map = nullptr;
   Map *map = nullptr; // Only set when this expression is assigned to a map
   Variable *var = nullptr; // Set when this expression is assigned to a variable
   bool is_literal = false;
@@ -120,10 +121,16 @@ public:
 
 class Map : public Expression {
 public:
-  explicit Map(std::string &ident) : ident(ident), vargs(nullptr) { is_map = true; }
   explicit Map(std::string &ident, location loc) : Expression(loc), ident(ident), vargs(nullptr) { is_map = true; }
   Map(std::string &ident, ExpressionList *vargs) : ident(ident), vargs(vargs) { is_map = true; }
-  Map(std::string &ident, ExpressionList *vargs, location loc) : Expression(loc), ident(ident), vargs(vargs) { is_map = true; }
+  Map(std::string &ident, ExpressionList *vargs, location loc) : Expression(loc), ident(ident), vargs(vargs)
+  {
+    is_map = true;
+    for (auto expr : *vargs)
+    {
+      expr->key_for_map = this;
+    }
+  }
   std::string ident;
   ExpressionList *vargs;
   bool skip_key_validation = false;

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -260,14 +260,14 @@ void SemanticAnalyser::visit(Call &call)
   }
 
   if (call.func == "hist") {
-    check_assignment(call, true, false);
+    if (!check_assignment(call, true, false, false)) return;
     check_nargs(call, 1);
     check_arg(call, Type::integer, 0);
 
     call.type = SizedType(Type::hist, 8);
   }
   else if (call.func == "lhist") {
-    check_assignment(call, true, false);
+    if (!check_assignment(call, true, false, false)) return;
     if (check_nargs(call, 4)) {
       check_arg(call, Type::integer, 0, false);
       check_arg(call, Type::integer, 1, true);
@@ -305,14 +305,14 @@ void SemanticAnalyser::visit(Call &call)
     call.type = SizedType(Type::lhist, 8);
   }
   else if (call.func == "count") {
-    check_assignment(call, true, false);
+    if (!check_assignment(call, true, false, false)) return;
     check_nargs(call, 0);
 
     call.type = SizedType(Type::count, 8);
   }
   else if (call.func == "sum") {
     bool sign = false;
-    check_assignment(call, true, false);
+    if (!check_assignment(call, true, false, false)) return;
     if (check_nargs(call, 1)) {
       sign = call.vargs->at(0)->type.is_signed;
     }
@@ -320,7 +320,7 @@ void SemanticAnalyser::visit(Call &call)
   }
   else if (call.func == "min") {
     bool sign = false;
-    check_assignment(call, true, false);
+    if (!check_assignment(call, true, false, false)) return;
     if (check_nargs(call, 1)) {
       sign = call.vargs->at(0)->type.is_signed;
     }
@@ -328,24 +328,24 @@ void SemanticAnalyser::visit(Call &call)
   }
   else if (call.func == "max") {
     bool sign = false;
-    check_assignment(call, true, false);
+    if (!check_assignment(call, true, false, false)) return;
     if (check_nargs(call, 1)) {
       sign = call.vargs->at(0)->type.is_signed;
     }
     call.type = SizedType(Type::max, 8, sign);
   }
   else if (call.func == "avg") {
-    check_assignment(call, true, false);
+    if (!check_assignment(call, true, false, false)) return;
     check_nargs(call, 1);
     call.type = SizedType(Type::avg, 8, true);
   }
   else if (call.func == "stats") {
-    check_assignment(call, true, false);
+    if (!check_assignment(call, true, false, false)) return;
     check_nargs(call, 1);
     call.type = SizedType(Type::stats, 8, true);
   }
   else if (call.func == "delete") {
-    check_assignment(call, false, false);
+    if (!check_assignment(call, false, false, false)) return;
     if (check_nargs(call, 1)) {
       auto &arg = *call.vargs->at(0);
       if (!arg.is_map)
@@ -411,7 +411,7 @@ void SemanticAnalyser::visit(Call &call)
     call.type.is_internal = true;
   }
   else if (call.func == "join") {
-    check_assignment(call, false, false);
+    if (!check_assignment(call, false, false, false)) return;
     check_varargs(call, 1, 2);
     check_arg(call, Type::integer, 0);
     call.type = SizedType(Type::none, 0);
@@ -474,7 +474,7 @@ void SemanticAnalyser::visit(Call &call)
     call.type = SizedType(Type::integer, 8);
   }
   else if (call.func == "printf" || call.func == "system" || call.func == "cat") {
-    check_assignment(call, false, false);
+    if (!check_assignment(call, false, false, false)) return;
     if (check_varargs(call, 1, 7)) {
       check_arg(call, Type::string, 0, true);
       if (is_final_pass()) {
@@ -505,7 +505,7 @@ void SemanticAnalyser::visit(Call &call)
     check_nargs(call, 0);
   }
   else if (call.func == "print") {
-    check_assignment(call, false, false);
+    if (!check_assignment(call, false, false, false)) return;
     if (check_varargs(call, 1, 3)) {
       auto &arg = *call.vargs->at(0);
       if (!arg.is_map)
@@ -527,7 +527,7 @@ void SemanticAnalyser::visit(Call &call)
     }
   }
   else if (call.func == "clear") {
-    check_assignment(call, false, false);
+    if (!check_assignment(call, false, false, false)) return;
     if (check_nargs(call, 1)) {
       auto &arg = *call.vargs->at(0);
       if (!arg.is_map)
@@ -543,7 +543,7 @@ void SemanticAnalyser::visit(Call &call)
     }
   }
   else if (call.func == "zero") {
-    check_assignment(call, false, false);
+    if (!check_assignment(call, false, false, false)) return;
     if (check_nargs(call, 1)) {
       auto &arg = *call.vargs->at(0);
       if (!arg.is_map)
@@ -559,7 +559,7 @@ void SemanticAnalyser::visit(Call &call)
     }
   }
   else if (call.func == "time") {
-    check_assignment(call, false, false);
+    if (!check_assignment(call, false, false, false)) return;
     if (check_varargs(call, 0, 1)) {
       if (is_final_pass()) {
         if (call.vargs && call.vargs->size() > 0) {
@@ -582,7 +582,10 @@ void SemanticAnalyser::visit(Call &call)
   }
   else if (call.func == "signal") {
 #ifdef HAVE_SEND_SIGNAL
-    check_assignment(call, false, false);
+    if (!check_assignment(call, false, false, false)) {
+      return;
+    }
+
     if (!check_varargs(call, 1, 1)) {
       return;
     }
@@ -1470,14 +1473,41 @@ bool SemanticAnalyser::is_final_pass() const
   return pass_ == num_passes_;
 }
 
-bool SemanticAnalyser::check_assignment(const Call &call, bool want_map, bool want_var)
+bool SemanticAnalyser::check_assignment(const Call &call, bool want_map, bool want_var, bool want_map_key)
 {
   std::stringstream buf;
-  if (want_map && want_var)
+  if (want_map && want_var && want_map_key)
+  {
+    if (!call.map && !call.var && !call.key_for_map)
+    {
+      buf << call.func << "() should be assigned to a map or a variable, or be used as a map key";
+      bpftrace_.error(err_, call.loc, buf.str());
+      return false;
+    }
+  }
+  else if (want_map && want_var)
   {
     if (!call.map && !call.var)
     {
       buf << call.func << "() should be assigned to a map or a variable";
+      bpftrace_.error(err_, call.loc, buf.str());
+      return false;
+    }
+  }
+  else if (want_map && want_map_key)
+  {
+    if (!call.map && !call.key_for_map)
+    {
+      buf << call.func << "() should be assigned to a map or be used as a map key";
+      bpftrace_.error(err_, call.loc, buf.str());
+      return false;
+    }
+  }
+  else if (want_var && want_map_key)
+  {
+    if (!call.var && !call.key_for_map)
+    {
+      buf << call.func << "() should be assigned to a variable or be used as a map key";
       bpftrace_.error(err_, call.loc, buf.str());
       return false;
     }
@@ -1500,11 +1530,20 @@ bool SemanticAnalyser::check_assignment(const Call &call, bool want_map, bool wa
       return false;
     }
   }
+  else if (want_map_key)
+  {
+    if (!call.key_for_map)
+    {
+      buf << call.func << "() should be used as a map key";
+      bpftrace_.error(err_, call.loc, buf.str());
+      return false;
+    }
+  }
   else
   {
-    if (call.map || call.var)
+    if (call.map || call.var || call.key_for_map)
     {
-      buf << call.func << "() should not be used in an assignment";
+      buf << call.func << "() should not be used in an assignment or as a map key";
       bpftrace_.error(err_, call.loc, buf.str());
       return false;
     }

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -58,7 +58,7 @@ private:
 
   bool is_final_pass() const;
 
-  bool check_assignment(const Call &call, bool want_map, bool want_var);
+  bool check_assignment(const Call &call, bool want_map, bool want_var, bool want_map_key);
   bool check_nargs(const Call &call, size_t expected_nargs);
   bool check_varargs(const Call &call, size_t min_nargs, size_t max_nargs);
   bool check_arg(const Call &call, Type type, int arg_num, bool want_literal=false);

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -289,6 +289,8 @@ TEST(semantic_analyser, call_hist)
   test("kprobe:f { @x = hist(1); }", 0);
   test("kprobe:f { @x = hist(); }", 1);
   test("kprobe:f { hist(1); }", 1);
+  test("kprobe:f { $x = hist(1); }", 1);
+  test("kprobe:f { @x[hist(1)] = 1; }", 1);
 }
 
 TEST(semantic_analyser, call_lhist)
@@ -301,6 +303,8 @@ TEST(semantic_analyser, call_lhist)
   test("kprobe:f { @ = lhist(5, 0, 10, 1, 2); }", 1);
   test("kprobe:f { lhist(-10, -10, 10, 1); }", 1);
   test("kprobe:f { @ = lhist(-10, -10, 10, 1); }", 10); // must be positive
+  test("kprobe:f { $x = lhist(); }", 1);
+  test("kprobe:f { @[lhist()] = 1; }", 1);
 }
 
 TEST(semantic_analyser, call_count)
@@ -308,6 +312,8 @@ TEST(semantic_analyser, call_count)
   test("kprobe:f { @x = count(); }", 0);
   test("kprobe:f { @x = count(1); }", 1);
   test("kprobe:f { count(); }", 1);
+  test("kprobe:f { $x = count(); }", 1);
+  test("kprobe:f { @[count()] = 1; }", 1);
 }
 
 TEST(semantic_analyser, call_sum)
@@ -316,6 +322,8 @@ TEST(semantic_analyser, call_sum)
   test("kprobe:f { @x = sum(); }", 1);
   test("kprobe:f { @x = sum(123, 456); }", 1);
   test("kprobe:f { sum(123); }", 1);
+  test("kprobe:f { $x = sum(123); }", 1);
+  test("kprobe:f { @[sum(123)] = 1; }", 1);
 }
 
 TEST(semantic_analyser, call_min)
@@ -323,6 +331,8 @@ TEST(semantic_analyser, call_min)
   test("kprobe:f { @x = min(123); }", 0);
   test("kprobe:f { @x = min(); }", 1);
   test("kprobe:f { min(123); }", 1);
+  test("kprobe:f { $x = min(123); }", 1);
+  test("kprobe:f { @[min(123)] = 1; }", 1);
 }
 
 TEST(semantic_analyser, call_max)
@@ -330,6 +340,8 @@ TEST(semantic_analyser, call_max)
   test("kprobe:f { @x = max(123); }", 0);
   test("kprobe:f { @x = max(); }", 1);
   test("kprobe:f { max(123); }", 1);
+  test("kprobe:f { $x = max(123); }", 1);
+  test("kprobe:f { @[max(123)] = 1; }", 1);
 }
 
 TEST(semantic_analyser, call_avg)
@@ -337,6 +349,8 @@ TEST(semantic_analyser, call_avg)
   test("kprobe:f { @x = avg(123); }", 0);
   test("kprobe:f { @x = avg(); }", 1);
   test("kprobe:f { avg(123); }", 1);
+  test("kprobe:f { $x = avg(123); }", 1);
+  test("kprobe:f { @[avg(123)] = 1; }", 1);
 }
 
 TEST(semantic_analyser, call_stats)
@@ -344,6 +358,8 @@ TEST(semantic_analyser, call_stats)
   test("kprobe:f { @x = stats(123); }", 0);
   test("kprobe:f { @x = stats(); }", 1);
   test("kprobe:f { stats(123); }", 1);
+  test("kprobe:f { $x = stats(123); }", 1);
+  test("kprobe:f { @[stats(123)] = 1; }", 1);
 }
 
 TEST(semantic_analyser, call_delete)
@@ -353,12 +369,16 @@ TEST(semantic_analyser, call_delete)
   test("kprobe:f { delete(); }", 1);
   test("kprobe:f { @y = delete(@x); }", 1);
   test("kprobe:f { $y = delete(@x); }", 1);
+  test("kprobe:f { @[delete(@x)] = 1; }", 1);
 }
 
 TEST(semantic_analyser, call_exit)
 {
   test("kprobe:f { exit(); }", 0);
   test("kprobe:f { exit(1); }", 1);
+  test("kprobe:f { @a = exit(1); }", 1);
+  test("kprobe:f { $a = exit(1); }", 1);
+  test("kprobe:f { @[exit(1)] = 1; }", 1);
 }
 
 TEST(semantic_analyser, call_print)
@@ -372,6 +392,10 @@ TEST(semantic_analyser, call_print)
   test("kprobe:f { print(@x); @x[1,2] = count(); }", 0);
   test("kprobe:f { @x[1,2] = count(); print(@x); }", 0);
   test("kprobe:f { @x[1,2] = count(); print(@x[3,4]); }", 1);
+
+  test("kprobe:f { @x = count(); @ = print(@x); }", 1);
+  test("kprobe:f { @x = count(); $y = print(@x); }", 1);
+  test("kprobe:f { @x = count(); @[print(@x)] = 1; }", 1);
 }
 
 TEST(semantic_analyser, call_clear)
@@ -383,6 +407,10 @@ TEST(semantic_analyser, call_clear)
   test("kprobe:f { clear(@x); @x[1,2] = count(); }", 0);
   test("kprobe:f { @x[1,2] = count(); clear(@x); }", 0);
   test("kprobe:f { @x[1,2] = count(); clear(@x[3,4]); }", 1);
+
+  test("kprobe:f { @x = count(); @ = clear(@x); }", 1);
+  test("kprobe:f { @x = count(); $y = clear(@x); }", 1);
+  test("kprobe:f { @x = count(); @[clear(@x)] = 1; }", 1);
 }
 
 TEST(semantic_analyser, call_zero)
@@ -394,6 +422,10 @@ TEST(semantic_analyser, call_zero)
   test("kprobe:f { zero(@x); @x[1,2] = count(); }", 0);
   test("kprobe:f { @x[1,2] = count(); zero(@x); }", 0);
   test("kprobe:f { @x[1,2] = count(); zero(@x[3,4]); }", 1);
+
+  test("kprobe:f { @x = count(); @ = zero(@x); }", 1);
+  test("kprobe:f { @x = count(); $y = zero(@x); }", 1);
+  test("kprobe:f { @x = count(); @[zero(@x)] = 1; }", 1);
 }
 
 TEST(semantic_analyser, call_time)
@@ -402,6 +434,8 @@ TEST(semantic_analyser, call_time)
   test("kprobe:f { time(\"%M:%S\"); }", 0);
   test("kprobe:f { time(\"%M:%S\", 1); }", 1);
   test("kprobe:f { @x = time(); }", 1);
+  test("kprobe:f { $x = time(); }", 1);
+  test("kprobe:f { @[time()] = 1; }", 1);
 }
 
 TEST(semantic_analyser, call_str)
@@ -522,6 +556,8 @@ TEST(semantic_analyser, call_cat)
   test("kprobe:f { cat(); }", 1);
   test("kprobe:f { cat(123); }", 1);
   test("kprobe:f { @x = cat(\"/proc/loadavg\"); }", 1);
+  test("kprobe:f { $x = cat(\"/proc/loadavg\"); }", 1);
+  test("kprobe:f { @[cat(\"/proc/loadavg\")] = 1; }", 1);
 }
 
 TEST(semantic_analyser, map_reassignment)


### PR DESCRIPTION
Stolen from #843 .

This closes #697 .
This closes #633 .