### PR TITLE
Fix func variable in uprobe

### DIFF
--- a/tests/codegen/builtin_func.cpp
+++ b/tests/codegen/builtin_func.cpp
@@ -41,6 +41,52 @@ attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 }
 
+TEST(codegen, builtin_func_uprobe)
+{
+  test("uprobe:/bin/bash:f { @x = func }",
+
+R"EXPECTED(; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"uprobe:/bin/bash:f"(i8* nocapture readonly) local_unnamed_addr section "s_uprobe:/bin/bash:f_1" {
+entry:
+  %"@x_val" = alloca [16 x i8], align 8
+  %"@x_key" = alloca i64, align 8
+  %func1 = alloca [16 x i8], align 8
+  %1 = getelementptr i8, i8* %0, i64 128
+  %func = load i64, i8* %1, align 8
+  %2 = getelementptr inbounds [16 x i8], [16 x i8]* %func1, i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  %get_pid_tgid = tail call i64 inttoptr (i64 14 to i64 ()*)()
+  %3 = lshr i64 %get_pid_tgid, 32
+  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %func1, i64 0, i64 8
+  store i64 %func, [16 x i8]* %func1, align 8
+  store i64 %3, i8* %4, align 8
+  %5 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  store i64 0, i64* %"@x_key", align 8
+  %6 = getelementptr inbounds [16 x i8], [16 x i8]* %"@x_val", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  store [16 x i8]* %func1, [16 x i8]* %"@x_val", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [16 x i8]* nonnull %"@x_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+}
+
+
 } // namespace codegen
 } // namespace test
 } // namespace bpftrace

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -74,6 +74,12 @@ RUN bpftrace -v -e 'k:vfs_read { printf("SUCCESS '$test' %s\n", func); exit(); }
 EXPECT SUCCESS func .*
 TIMEOUT 5
 
+NAME func_uprobe
+RUN bpftrace -v -e 'uprobe:./testprogs/uprobe_negative_retval:function1 { printf("SUCCESS %s\n", func); exit(); }'
+EXPECT SUCCESS function1
+AFTER ./testprogs/uprobe_negative_retval
+TIMEOUT 5
+
 NAME username
 RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %s\n", username); exit(); }'
 EXPECT SUCCESS username .*

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -121,6 +121,7 @@ TEST(semantic_analyser, builtin_variables)
   test("kprobe:f { sarg0 }", 0);
   test("kretprobe:f { retval }", 0);
   test("kprobe:f { func }", 0);
+  test("uprobe:/bin/sh:f { func }", 0);
   test("kprobe:f { probe }", 0);
   test("tracepoint:a:b { args }", 0);
   test("kprobe:f { fake }", 1);
@@ -538,6 +539,11 @@ TEST(semantic_analyser, call_func)
   test("kprobe:f { func(\"blah\"); }", 1);
   test("kprobe:f { func(); }", 1);
   test("kprobe:f { func(123); }", 1);
+  test("uprobe:/bin/sh:f { @[func] = count(); }", 0);
+  test("uprobe:/bin/sh:f { printf(\"%s\", func);  }", 0);
+  test("uprobe:/bin/sh:f { func(\"blah\"); }", 1);
+  test("uprobe:/bin/sh:f { func(); }", 1);
+  test("uprobe:/bin/sh:f { func(123); }", 1);
 }
 
 TEST(semantic_analyser, call_probe)


### PR DESCRIPTION
"func" is treated as usym in uprobe. Therefore pid is needed to be
stored along with the address.

Closes #977