### PR TITLE
Define all `call`s in the lexer to avoid redefinition

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -17,15 +17,20 @@ static std::string buffer;
 using namespace bpftrace;
 %}
 
-ident  [_a-zA-Z][_a-zA-Z0-9]*
-map    @{ident}|@
-var    ${ident}
-int    [0-9]+|0[xX][0-9a-fA-F]+
-cint   :{int}:
-hspace [ \t]
-vspace [\n\r]
-space  {hspace}|{vspace}
-path   :(\\.|[_\-\./a-zA-Z0-9#\*])*:
+ident   [_a-zA-Z][_a-zA-Z0-9]*
+map     @{ident}|@
+var     ${ident}
+int     [0-9]+|0[xX][0-9a-fA-F]+
+cint    :{int}:
+hspace  [ \t]
+vspace  [\n\r]
+space   {hspace}|{vspace}
+path    :(\\.|[_\-\./a-zA-Z0-9#\*])*:
+builtin arg[0-9]|args|cgroup|comm|cpid|cpu|ctx|curtask|elapsed|func|gid|nsecs|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
+call    avg|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|ksym|lhist|max|min|ntop|override_return|print|printf|reg|signal|stats|str|strncmp|sum|sym|system|time|uaddr|usym|zero
+
+/* Don't add to this! Use builtin OR call not both */
+call_and_builtin stack|kstack|ustack
 %x STR
 %x STRUCT
 %x ENUM
@@ -47,10 +52,10 @@ path   :(\\.|[_\-\./a-zA-Z0-9#\*])*:
   <<EOF>>               yy_pop_state(yyscanner); driver.error(loc, "end of file during comment");
 }
 
-pid|tid|cgroup|uid|gid|nsecs|cpu|comm|kstack|stack|ustack|arg[0-9]|sarg[0-9]|retval|func|probe|curtask|rand|ctx|username|args|elapsed|cpid {
-                          return Parser::make_BUILTIN(yytext, loc); }
-bpftrace|perf {
-                          return Parser::make_STACK_MODE(yytext, loc); }
+bpftrace|perf           { return Parser::make_STACK_MODE(yytext, loc); }
+{builtin}               { return Parser::make_BUILTIN(yytext, loc); }
+{call}                  { return Parser::make_CALL(yytext, loc); }
+{call_and_builtin}      { return Parser::make_CALL_BUILTIN(yytext, loc); }
 {int}                   { return Parser::make_INT(strtoll(yytext, NULL, 0), loc); }
 {cint}                  { return Parser::make_CINT(strtoll(yytext+1, NULL, 0), loc); }
 {path}                  { return Parser::make_PATH(yytext, loc); }
@@ -170,6 +175,7 @@ enum                    yy_push_state(ENUM, yyscanner); buffer.clear();
                             return Parser::make_IDENT(yytext, loc);
                           }
                         }
+
 .                       { driver.error(loc, std::string("invalid character '") +
                                             std::string(yytext) + std::string("'")); }
 

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -297,12 +297,16 @@ ident : IDENT         { $$ = $1; }
       | STACK_MODE    { $$ = $1; }
       ;
 
-call : CALL "(" ")"               { $$ = new ast::Call($1, @$); }
-     | CALL "(" vargs ")"         { $$ = new ast::Call($1, $3, @$); }
-     | CALL_BUILTIN  "(" ")"      { $$ = new ast::Call($1, @$); }
-     | CALL_BUILTIN "(" vargs ")" { $$ = new ast::Call($1, $3, @$); }
-     | ident "(" ")"              { error(@1, "Unknown function: " + $1); YYERROR;  }
-     | ident "(" vargs ")"        { error(@1, "Unknown function: " + $1); YYERROR;  }
+call : CALL "(" ")"                 { $$ = new ast::Call($1, @$); }
+     | CALL "(" vargs ")"           { $$ = new ast::Call($1, $3, @$); }
+     | CALL_BUILTIN  "(" ")"        { $$ = new ast::Call($1, @$); }
+     | CALL_BUILTIN "(" vargs ")"   { $$ = new ast::Call($1, $3, @$); }
+     | IDENT "(" ")"                { error(@1, "Unknown function: " + $1); YYERROR;  }
+     | IDENT "(" vargs ")"          { error(@1, "Unknown function: " + $1); YYERROR;  }
+     | BUILTIN "(" ")"              { error(@1, "Unknown function: " + $1); YYERROR;  }
+     | BUILTIN "(" vargs ")"        { error(@1, "Unknown function: " + $1); YYERROR;  }
+     | STACK_MODE "(" ")"           { error(@1, "Unknown function: " + $1); YYERROR;  }
+     | STACK_MODE "(" vargs ")"     { error(@1, "Unknown function: " + $1); YYERROR;  }
      ;
 
 map : MAP               { $$ = new ast::Map($1, @$); }

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -294,6 +294,7 @@ ident : IDENT         { $$ = $1; }
       | BUILTIN       { $$ = $1; }
       | CALL          { $$ = $1; }
       | CALL_BUILTIN  { $$ = $1; }
+      | STACK_MODE    { $$ = $1; }
       ;
 
 call : CALL "(" ")"               { $$ = new ast::Call($1, @$); }

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -947,6 +947,44 @@ TEST(Parser, wildcard_path)
       "Program\n"
       " usdt:/my/program*foo:func\n"
       "  int: 1\n");
+  // Make sure calls or builtins don't cause issues
+  test("usdt:/my/program*avg:func { 1; }",
+       "Program\n"
+       " usdt:/my/program*avg:func\n"
+       "  int: 1\n");
+  test("usdt:/my/program*nsecs:func { 1; }",
+       "Program\n"
+       " usdt:/my/program*nsecs:func\n"
+       "  int: 1\n");
+}
+
+TEST(Parser, wildcard_func)
+{
+  test("usdt:/my/program:abc*cd { 1; }",
+       "Program\n"
+       " usdt:/my/program:abc*cd\n"
+       "  int: 1\n");
+  test("usdt:/my/program:abc*c*d { 1; }",
+       "Program\n"
+       " usdt:/my/program:abc*c*d\n"
+       "  int: 1\n");
+
+  std::string keywords[] = {
+    "arg0", "args", "curtask", "func", "gid" "rand", "uid",
+    "avg", "cat", "exit", "kaddr", "min", "printf", "usym",
+    "kstack", "ustack", "bpftrace", "perf", "uprobe", "kprobe",
+  };
+  for(auto kw : keywords)
+  {
+    test("usdt:/my/program:"+ kw +"*c*d { 1; }",
+         "Program\n"
+         " usdt:/my/program:"+ kw + "*c*d\n"
+         "  int: 1\n");
+    test("usdt:/my/program:abc*"+ kw +"*c*d { 1; }",
+         "Program\n"
+         " usdt:/my/program:abc*"+ kw + "*c*d\n"
+         "  int: 1\n");
+  }
 }
 
 TEST(Parser, short_map_name)

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1282,7 +1282,7 @@ TEST(semantic_analyser, struct_member_keywords)
   std::string keywords[] = {
     "arg0", "args", "curtask", "func", "gid" "rand", "uid",
     "avg", "cat", "exit", "kaddr", "min", "printf", "usym",
-    "kstack", "ustack"
+    "kstack", "ustack", "bpftrace", "perf", "uprobe", "kprobe",
   };
   for(auto kw : keywords)
   {


### PR DESCRIPTION
Fixes #692 
Fixes #926 