### PR TITLE
Add builtin: cpid

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1196,6 +1196,7 @@ bpftrace -e 'watchpoint::0x10000000:8:rw { printf("hit!\n"); }' -c ~/binary
 - `curtask` - Current task struct as a u64
 - `rand` - Random number as a u32
 - `cgroup` - Cgroup ID of the current process
+- `cpid` - Child pid(u32), only valid with the `-c command` flag
 - `$1`, `$2`, ..., `$N`, `$#`. - Positional parameters for the bpftrace program
 
 Many of these are discussed in other sections (use search).

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -214,6 +214,15 @@ void CodegenLLVM::visit(Builtin &builtin)
   {
     expr_ = ctx_;
   }
+  else if (builtin.ident == "cpid")
+  {
+    pid_t cpid = bpftrace_.child_pid();
+    if (cpid < 1) {
+      std::cerr << "BUG: Invalid cpid: " << cpid << std::endl;
+      abort();
+    }
+    expr_ = b_.getInt32(cpid);
+  }
   else if (builtin.ident == "ctx")
   {
     // undocumented builtin: for debugging

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -212,6 +212,12 @@ void SemanticAnalyser::visit(Builtin &builtin)
   else if (builtin.ident == "username") {
     builtin.type = SizedType(Type::username, 8);
   }
+  else if (builtin.ident == "cpid") {
+    if (! bpftrace_.has_child_cmd()) {
+      buf << "cpid cannot be used without child command";
+    }
+    builtin.type = SizedType(Type::integer, 4);
+  }
   else if (builtin.ident == "args") {
     probe_->need_expansion = true;
     for (auto &attach_point : *probe_->attach_points)

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -106,9 +106,9 @@ public:
   void warning(std::ostream &out, const location &l, const std::string &m);
   void log_with_location(std::string, std::ostream &, const location &, const std::string &);
   bool has_child_cmd() { return cmd_.size() != 0; }
-  virtual pid_t child_pid() { return child_pids_.size() ? child_pids_.front() : 0; }
+  virtual pid_t child_pid() { return child_pid_; };
   int spawn_child();
-  void kill_children();
+  void kill_child();
 
   std::string cmd_;
   int pid_{0};
@@ -170,9 +170,10 @@ private:
   std::map<std::string, std::pair<int, void *>> exe_sym_; // exe -> (pid, cache)
   int ncpus_;
   int online_cpus_;
-  std::vector<pid_t> child_pids_;
   std::vector<std::string> params_;
   int next_probe_id_ = 0;
+
+  pid_t child_pid_ = 0;
   bool child_running_ = false; // true when `CHILD_GO` has been sent (child execve)
   int child_start_pipe_ = -1;
 

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -105,6 +105,10 @@ public:
   void error(std::ostream &out, const location &l, const std::string &m);
   void warning(std::ostream &out, const location &l, const std::string &m);
   void log_with_location(std::string, std::ostream &, const location &, const std::string &);
+  bool has_child_cmd() { return cmd_.size() != 0; }
+  virtual pid_t child_pid() { return child_pids_.size() ? child_pids_.front() : 0; }
+  int spawn_child();
+  void kill_children();
 
   std::string cmd_;
   int pid_{0};
@@ -166,9 +170,11 @@ private:
   std::map<std::string, std::pair<int, void *>> exe_sym_; // exe -> (pid, cache)
   int ncpus_;
   int online_cpus_;
-  std::vector<int> child_pids_;
+  std::vector<pid_t> child_pids_;
   std::vector<std::string> params_;
   int next_probe_id_ = 0;
+  bool child_running_ = false; // true when `CHILD_GO` has been sent (child execve)
+  int child_start_pipe_ = -1;
 
   std::string src_;
   std::string filename_;
@@ -190,7 +196,6 @@ private:
   static uint64_t max_value(const std::vector<uint8_t> &value, int ncpus);
   static uint64_t read_address_from_output(std::string output);
   std::vector<uint8_t> find_empty_key(IMap &map, size_t size) const;
-  static int spawn_child(const std::vector<std::string>& args, int *notify_trace_start_pipe_fd);
   static bool is_pid_alive(int pid);
 };
 

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -47,7 +47,7 @@ path   :(\\.|[_\-\./a-zA-Z0-9#\*])*:
   <<EOF>>               yy_pop_state(yyscanner); driver.error(loc, "end of file during comment");
 }
 
-pid|tid|cgroup|uid|gid|nsecs|cpu|comm|kstack|stack|ustack|arg[0-9]|sarg[0-9]|retval|func|probe|curtask|rand|ctx|username|args|elapsed {
+pid|tid|cgroup|uid|gid|nsecs|cpu|comm|kstack|stack|ustack|arg[0-9]|sarg[0-9]|retval|func|probe|curtask|rand|ctx|username|args|elapsed|cpid {
                           return Parser::make_BUILTIN(yytext, loc); }
 bpftrace|perf {
                           return Parser::make_STACK_MODE(yytext, loc); }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -489,6 +489,9 @@ int main(int argc, char *argv[])
   if (err)
     return err;
 
+  if (bpftrace.has_child_cmd() && (bpftrace.spawn_child() < 0))
+    return 1;
+
   ast::CodegenLLVM llvm(driver.root_, bpftrace);
   auto bpforc = llvm.compile(bt_debug);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -485,12 +485,12 @@ int main(int argc, char *argv[])
   if (err)
     return err;
 
+  if (bpftrace.has_child_cmd() && (bpftrace.spawn_child() < 0))
+    return 1;
+
   err = semantics.create_maps(bt_debug != DebugLevel::kNone);
   if (err)
     return err;
-
-  if (bpftrace.has_child_cmd() && (bpftrace.spawn_child() < 0))
-    return 1;
 
   ast::CodegenLLVM llvm(driver.root_, bpftrace);
   auto bpforc = llvm.compile(bt_debug);

--- a/tests/codegen/builtin_cpid.cpp
+++ b/tests/codegen/builtin_cpid.cpp
@@ -1,0 +1,49 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, builtin_cpid)
+{
+  MockBPFtrace bpftrace;
+  bpftrace.cmd_ = "sleep 1";
+  ON_CALL(bpftrace, child_pid())
+    .WillByDefault(Return(1337));
+
+  test(bpftrace, "kprobe:f { @ = cpid }",
+
+R"EXPECTED(; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
+entry:
+  %"@_val" = alloca i64, align 8
+  %"@_key" = alloca i64, align 8
+  %1 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  store i64 0, i64* %"@_key", align 8
+  %2 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  store i64 1337, i64* %"@_val", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -19,6 +19,7 @@ namespace codegen {
 class MockBPFtrace : public BPFtrace {
 public:
   MOCK_METHOD1(add_probe, int(ast::Probe &p));
+  MOCK_METHOD0(child_pid, int(void));
   MOCK_METHOD3(find_wildcard_matches, std::set<std::string>(
         const std::string &prefix,
         const std::string &func,

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -102,3 +102,8 @@ NAME increment/decrement variable
 RUN bpftrace -e 'BEGIN { $x = 10; printf("%d", $x++); printf(" %d", ++$x); printf(" %d", $x--); printf(" %d\n", --$x); exit(); }'
 EXPECT 10 12 12 10
 TIMEOUT 1
+
+NAME spawn child
+RUN bpftrace -e 'i:ms:500 { printf("%d\n", cpid); }' -c 'sleep 1'
+EXPECT [0-9]+
+TIMEOUT 1

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -124,7 +124,10 @@ TEST(semantic_analyser, builtin_variables)
   test("kprobe:f { probe }", 0);
   test("tracepoint:a:b { args }", 0);
   test("kprobe:f { fake }", 1);
+}
 
+TEST(semantic_analyser, builtin_cpid)
+{
   auto bpftrace = get_mock_bpftrace();
   test(*bpftrace, "i:ms:100 { printf(\"%d\\n\", cpid); }", 1, false);
   test(*bpftrace, "i:ms:100 { @=cpid }", 1, false);

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -124,6 +124,15 @@ TEST(semantic_analyser, builtin_variables)
   test("kprobe:f { probe }", 0);
   test("tracepoint:a:b { args }", 0);
   test("kprobe:f { fake }", 1);
+
+  auto bpftrace = get_mock_bpftrace();
+  test(*bpftrace, "i:ms:100 { printf(\"%d\\n\", cpid); }", 1, false);
+  test(*bpftrace, "i:ms:100 { @=cpid }", 1, false);
+  test(*bpftrace, "i:ms:100 { $a=cpid }", 1, false);
+  bpftrace->cmd_ = "sleep 1";
+  test(*bpftrace, "i:ms:100 { printf(\"%d\\n\", cpid); }", 0, false);
+  test(*bpftrace, "i:ms:100 { @=cpid }", 0, false);
+  test(*bpftrace, "i:ms:100 { $a=cpid }", 0, false);
 }
 
 TEST(semantic_analyser, builtin_functions)
@@ -1258,8 +1267,6 @@ TEST(semantic_analyser, signal)
   test("k:f { signal(\"SIGABC\"); }", 1, false);
   test("k:f { signal(\"ABC\"); }", 1, false);
 }
-
-
 } // namespace semantic_analyser
 } // namespace test
 } // namespace bpftrace


### PR DESCRIPTION
This adds the `cpid` builtin which makes the pid of the spawned child
command available to programs:

```
bpftrace -e '
tracepoint:syscalls:sys_enter_openat /pid == cpid/
{
  printf("%d :: %s\n", cpid, str(args->filename));
}' -c ls
22804 :: /etc/ld.so.cache
22804 :: /lib/x86_64-linux-gnu/libselinux.so.1
22804 :: /lib/x86_64-linux-gnu/libc.so.6
```



Fixes: #298