### PR TITLE
Use a load instruction to access a context field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,9 +18,9 @@ matrix:
     # String comparisons and args multiple tracepoints tests are the exception
     # - they are just broken in debug builds.
     - name: "Static LLVM 5 Debug"
-      env: LLVM_VERSION=5.0 BASE=alpine TYPE=Debug STATIC_LINKING=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*:codegen.string_equal_comparison:codegen.string_not_equal_comparison:codegen.args_multiple_tracepoints*:codegen.logical_and_or_different_type"
+      env: LLVM_VERSION=5.0 BASE=alpine TYPE=Debug STATIC_LINKING=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*:codegen.string_equal_comparison:codegen.string_not_equal_comparison:codegen.args_multiple_tracepoints*:codegen.logical_and_or_different_type:codegen.perf_ctx*"
     - name: "Static LLVM 5 Release"
-      env: LLVM_VERSION=5.0 BASE=alpine TYPE=Release STATIC_LINKING=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*:codegen.args_multiple_tracepoints*:codegen.logical_and_or_different_type"
+      env: LLVM_VERSION=5.0 BASE=alpine TYPE=Release STATIC_LINKING=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*:codegen.args_multiple_tracepoints*:codegen.logical_and_or_different_type:codegen.perf_ctx*"
 
     - name: "LLVM 6 Debug"
       env: LLVM_VERSION=6.0 BASE=bionic TYPE=Debug RUN_ALL_TESTS=1

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -176,6 +176,7 @@ public:
   FieldAccess(Expression *expr, const std::string &field, location loc) : Expression(loc), expr(expr), field(field) { }
   Expression *expr;
   std::string field;
+  bool is_context_access = false;
 
   void accept(Visitor &v) override;
 };

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1733,7 +1733,7 @@ bool SemanticAnalyser::is_context_access(Expression *expr, bool is_pointer_deref
   {
     // Exclude an access such as args->a->b
     if ((p->op != Parser::token::MUL) || !is_pointer_dereferenced)
-      return is_context_access(p->expr, (p->op == Parser::token::MUL) | is_pointer_dereferenced);
+      return is_context_access(p->expr, (p->op == Parser::token::MUL) || is_pointer_dereferenced);
   }
   return false;
 }

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -57,6 +57,7 @@ private:
   const int num_passes_ = 10;
 
   bool is_final_pass() const;
+  bool is_context_access(Expression *expr, bool is_pointer_dereferenced=false);
 
   bool check_assignment(const Call &call, bool want_map, bool want_var, bool want_map_key);
   bool check_nargs(const Call &call, size_t expected_nargs);
@@ -69,7 +70,7 @@ private:
   void assign_map_type(const Map &map, const SizedType &type);
 
   Probe *probe_;
-  std::map<std::string, SizedType> variable_val_;
+  std::map<std::string, Expression*> variable_;
   std::map<std::string, SizedType> map_val_;
   std::map<std::string, MapKey> map_key_;
   std::map<std::string, ExpressionList> map_args_;

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -57,6 +57,7 @@ private:
   const int num_passes_ = 10;
 
   bool is_final_pass() const;
+  bool is_context(Expression *expr);
   bool is_context_access(Expression *expr, bool is_pointer_dereferenced=false);
 
   bool check_assignment(const Call &call, bool want_map, bool want_var, bool want_map_key);

--- a/tests/codegen/args_multiple_tracepoints.cpp
+++ b/tests/codegen/args_multiple_tracepoints.cpp
@@ -71,7 +71,6 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"tracepoint:syscalls:sys_enter_open"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_open_1" {
 entry:
   %"@_val" = alloca i64, align 8
-  %_tracepoint_syscalls_sys_enter_open.filename = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %"@_key" = alloca [64 x i8], align 1
   %1 = getelementptr inbounds [64 x i8], [64 x i8]* %"@_key", i64 0, i64 0
@@ -80,12 +79,8 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %2, i8 0, i64 64, i1 false)
   %3 = add i8* %0, i64 16
-  %4 = bitcast i64* %_tracepoint_syscalls_sys_enter_open.filename to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_open.filename, i64 8, i8* %3)
-  %5 = load i64, i64* %_tracepoint_syscalls_sys_enter_open.filename, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %5)
+  %4 = load i64, i8* %3, align 8
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %4)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %1, i8* nonnull align 1 %2, i64 64, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [64 x i8]* nonnull %"@_key")
@@ -93,19 +88,19 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %6 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %6, 1
+  %5 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %5, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %7 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
+  %6 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [64 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
 }
 
@@ -121,7 +116,6 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture r
 define i64 @"tracepoint:syscalls:sys_enter_openat"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_openat_2" {
 entry:
   %"@_val" = alloca i64, align 8
-  %_tracepoint_syscalls_sys_enter_openat.filename = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %"@_key" = alloca [64 x i8], align 1
   %1 = getelementptr inbounds [64 x i8], [64 x i8]* %"@_key", i64 0, i64 0
@@ -130,12 +124,8 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %2, i8 0, i64 64, i1 false)
   %3 = add i8* %0, i64 24
-  %4 = bitcast i64* %_tracepoint_syscalls_sys_enter_openat.filename to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_openat.filename, i64 8, i8* %3)
-  %5 = load i64, i64* %_tracepoint_syscalls_sys_enter_openat.filename, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %5)
+  %4 = load i64, i8* %3, align 8
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %4)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %1, i8* nonnull align 1 %2, i64 64, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [64 x i8]* nonnull %"@_key")
@@ -143,19 +133,19 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %6 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %6, 1
+  %5 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %5, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %7 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
+  %6 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [64 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
 }
 
@@ -172,7 +162,6 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"tracepoint:syscalls:sys_enter_open"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_open_1" {
 entry:
   %"@_val" = alloca i64, align 8
-  %_tracepoint_syscalls_sys_enter_open.filename = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %"@_key" = alloca [64 x i8], align 1
   %1 = getelementptr inbounds [64 x i8], [64 x i8]* %"@_key", i64 0, i64 0
@@ -181,12 +170,8 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.memset.p0i8.i64(i8* nonnull %2, i8 0, i64 64, i32 1, i1 false)
   %3 = add i8* %0, i64 16
-  %4 = bitcast i64* %_tracepoint_syscalls_sys_enter_open.filename to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_open.filename, i64 8, i8* %3)
-  %5 = load i64, i64* %_tracepoint_syscalls_sys_enter_open.filename, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %5)
+  %4 = load i64, i8* %3, align 8
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %4)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %1, i8* nonnull %2, i64 64, i32 1, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [64 x i8]* nonnull %"@_key")
@@ -194,19 +179,19 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %6 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %6, 1
+  %5 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %5, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %7 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
+  %6 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [64 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
 }
 
@@ -222,7 +207,6 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture r
 define i64 @"tracepoint:syscalls:sys_enter_openat"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_openat_2" {
 entry:
   %"@_val" = alloca i64, align 8
-  %_tracepoint_syscalls_sys_enter_openat.filename = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %"@_key" = alloca [64 x i8], align 1
   %1 = getelementptr inbounds [64 x i8], [64 x i8]* %"@_key", i64 0, i64 0
@@ -231,12 +215,8 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.memset.p0i8.i64(i8* nonnull %2, i8 0, i64 64, i32 1, i1 false)
   %3 = add i8* %0, i64 24
-  %4 = bitcast i64* %_tracepoint_syscalls_sys_enter_openat.filename to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_openat.filename, i64 8, i8* %3)
-  %5 = load i64, i64* %_tracepoint_syscalls_sys_enter_openat.filename, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %5)
+  %4 = load i64, i8* %3, align 8
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %4)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %1, i8* nonnull %2, i64 64, i32 1, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [64 x i8]* nonnull %"@_key")
@@ -244,19 +224,19 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %6 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %6, 1
+  %5 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %5, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %7 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
+  %6 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [64 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
 }
 

--- a/tests/codegen/args_multiple_tracepoints_wild.cpp
+++ b/tests/codegen/args_multiple_tracepoints_wild.cpp
@@ -94,36 +94,31 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"tracepoint:syscalls:sys_enter_recvfrom"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_recvfrom_1" {
 entry:
   %"@_val" = alloca i64, align 8
-  %_tracepoint_syscalls_sys_enter_recvfrom.flags = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
   %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = add i8* %0, i64 40
-  %3 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvfrom.flags, i64 8, i8* %2)
-  %4 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  store i64 %4, i8* %1, align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %3 = load i64, i8* %2, align 8
+  store i64 %3, i8* %1, align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %5 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %5, 1
+  %4 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %4, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %6 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %5 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0
 }
 
@@ -133,72 +128,62 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 define i64 @"tracepoint:syscalls:sys_enter_recvmmsg"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_recvmmsg_2" {
 entry:
   %"@_val" = alloca i64, align 8
-  %_tracepoint_syscalls_sys_enter_recvmmsg.flags = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
   %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = add i8* %0, i64 40
-  %3 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvmmsg.flags to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmmsg.flags, i64 8, i8* %2)
-  %4 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvmmsg.flags, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  store i64 %4, i8* %1, align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %3 = load i64, i8* %2, align 8
+  store i64 %3, i8* %1, align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %5 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %5, 1
+  %4 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %4, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %6 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %5 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0
 }
 
 define i64 @"tracepoint:syscalls:sys_enter_recvmsg"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_recvmsg_3" {
 entry:
   %"@_val" = alloca i64, align 8
-  %_tracepoint_syscalls_sys_enter_recvmsg.flags = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
   %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = add i8* %0, i64 32
-  %3 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvmsg.flags to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmsg.flags, i64 8, i8* %2)
-  %4 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvmsg.flags, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  store i64 %4, i8* %1, align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %3 = load i64, i8* %2, align 8
+  store i64 %3, i8* %1, align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %5 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %5, 1
+  %4 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %4, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %6 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %5 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0
 }
 
@@ -215,36 +200,31 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"tracepoint:syscalls:sys_enter_recvfrom"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_recvfrom_1" {
 entry:
   %"@_val" = alloca i64, align 8
-  %_tracepoint_syscalls_sys_enter_recvfrom.flags = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
   %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = add i8* %0, i64 40
-  %3 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvfrom.flags, i64 8, i8* %2)
-  %4 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  store i64 %4, i8* %1, align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %3 = load i64, i8* %2, align 8
+  store i64 %3, i8* %1, align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %5 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %5, 1
+  %4 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %4, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %6 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %5 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0
 }
 
@@ -254,72 +234,62 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 define i64 @"tracepoint:syscalls:sys_enter_recvmmsg"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_recvmmsg_2" {
 entry:
   %"@_val" = alloca i64, align 8
-  %_tracepoint_syscalls_sys_enter_recvmmsg.flags = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
   %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = add i8* %0, i64 40
-  %3 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvmmsg.flags to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmmsg.flags, i64 8, i8* %2)
-  %4 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvmmsg.flags, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  store i64 %4, i8* %1, align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %3 = load i64, i8* %2, align 8
+  store i64 %3, i8* %1, align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %5 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %5, 1
+  %4 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %4, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %6 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %5 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0
 }
 
 define i64 @"tracepoint:syscalls:sys_enter_recvmsg"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_recvmsg_3" {
 entry:
   %"@_val" = alloca i64, align 8
-  %_tracepoint_syscalls_sys_enter_recvmsg.flags = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
   %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = add i8* %0, i64 32
-  %3 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvmsg.flags to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmsg.flags, i64 8, i8* %2)
-  %4 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvmsg.flags, align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  store i64 %4, i8* %1, align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %3 = load i64, i8* %2, align 8
+  store i64 %3, i8* %1, align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %5 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %5, 1
+  %4 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %4, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %6 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %5 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0
 }
 

--- a/tests/codegen/ctx_access.cpp
+++ b/tests/codegen/ctx_access.cpp
@@ -1,0 +1,89 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, perf_ctx)
+{
+  test(R"(#include <linux/bpf_perf_event.h>
+software:cpu:100000000 {  @x = ((struct bpf_perf_event_data*)ctx)->sample_period; })",
+
+R"EXPECTED(; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"software:cpu:100000000"(i8*) local_unnamed_addr section "s_software:cpu:100000000_1" {
+entry:
+  %"@x_val" = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  %1 = add i8* %0, i64 168
+  %2 = load i64, i8* %1, align 8
+  %3 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 0, i64* %"@x_key", align 8
+  %4 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 %2, i64* %"@x_val", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+}
+
+TEST(codegen, perf_ctx2)
+{
+  test(R"(#include <linux/bpf_perf_event.h>
+software:cpu:100000000 {
+  $perf_data = ((struct bpf_perf_event_data*)ctx);
+  @x = $perf_data->regs.rip;
+})",
+
+R"EXPECTED(; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"software:cpu:100000000"(i8*) local_unnamed_addr section "s_software:cpu:100000000_1" {
+entry:
+  %"@x_val" = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  %1 = add i8* %0, i64 128
+  %2 = inttoptr i64 %1 to i64*
+  %3 = load i64, i64* %2, align 8
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 0, i64* %"@x_key", align 8
+  %5 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  store i64 %3, i64* %"@x_val", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -100,11 +100,11 @@ TIMEOUT 5
 AFTER  sleep 2; pkill -SIGINT bpftrace
 
 NAME perf ctx access
-RUN ./bpftrace --include linux/bpf_perf_event.h -e 'software:cpu:100000000 { printf("%d\n", ((struct bpf_perf_event_data*)ctx)->sample_period); exit();}'
+RUN bpftrace --include linux/bpf_perf_event.h -e 'software:cpu:100000000 { printf("%d\n", ((struct bpf_perf_event_data*)ctx)->sample_period); exit();}'
 EXPECT 100000000
 TIMEOUT 5
 
 NAME perf ctx access2
-RUN ./bpftrace --include linux/bpf_perf_event.h -e 'software:cpu:100000000 { $a=(struct bpf_perf_event_data*)ctx; @x=$a->sample_period; exit(); }'
+RUN bpftrace --include linux/bpf_perf_event.h -e 'software:cpu:100000000 { $a=(struct bpf_perf_event_data*)ctx; @x=$a->sample_period; exit(); }'
 EXPECT @x: 100000000
 TIMEOUT 5

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -98,3 +98,13 @@ RUN bpftrace --unsafe -v -e 'tracepoint:sched:sched_switch { system("echo foo");
 EXPECT end
 TIMEOUT 5
 AFTER  sleep 2; pkill -SIGINT bpftrace
+
+NAME perf ctx access
+RUN ./bpftrace --include linux/bpf_perf_event.h -e 'software:cpu:100000000 { printf("%d\n", ((struct bpf_perf_event_data*)ctx)->sample_period); exit();}'
+EXPECT 100000000
+TIMEOUT 5
+
+NAME perf ctx access2
+RUN ./bpftrace --include linux/bpf_perf_event.h -e 'software:cpu:100000000 { $a=(struct bpf_perf_event_data*)ctx; @x=$a->sample_period; exit(); }'
+EXPECT @x: 100000000
+TIMEOUT 5

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1270,6 +1270,21 @@ TEST(semantic_analyser, signal)
   test("k:f { signal(\"SIGABC\"); }", 1, false);
   test("k:f { signal(\"ABC\"); }", 1, false);
 }
+
+TEST(semantic_analyser, perf_ctx)
+{
+  test(R"(#include <linux/bpf_perf_event.h>
+          software:faults:1000 / ((struct bpf_perf_event_data*)ctx)->sample_period / {})", 0);
+  test(R"(#include <linux/bpf_perf_event.h>
+          profile:ms:100 { @=((struct bpf_perf_event_data*)ctx)->sample_period;})", 0);
+  test(R"(#include <linux/bpf_perf_event.h>
+          hardware:cache-references:1000000 { @=((struct bpf_perf_event_data*)ctx)->regs.rip;})", 0);
+  test(R"(#include <linux/bpf_perf_event.h>
+          software:faults:1000 { $a=(struct bpf_perf_event_data*)ctx; @=$a->sample_period;})", 0);
+  test(R"(#include <linux/bpf_perf_event.h>
+          interval:s:1 { $a=(struct bpf_perf_event_data*)ctx; @=$a->regs.rip; })", 0);
+}
+
 } // namespace semantic_analyser
 } // namespace test
 } // namespace bpftrace


### PR DESCRIPTION
A BPF program should use a load instruction to access a context field
because the verifier may rewrite the access. Currently, such access is
performed by bpf_probe_read() except in the case of using reg(). With
this patch, context accesses like the followings use a load
instruction.

1. `tracepoint:syscalls:sys_enter_openat { @=args->filename; }`
2. `((struct perf_event_data*)ctx)->regs.ip`
3. `$a = ((struct perf_event_data*)ctx); $a->sample_period`

As of the first example, bytecode
```
0: (bf) r3 = r1
1: (07) r3 += 24
2: (bf) r1 = r10
3: (07) r1 += -8
4: (b7) r2 = 8
5: (85) call bpf_probe_read#4
...
```
becomes
```
0: (79) r1 = *(u64 *)(r1 +24)
...
```

Closes #945