### PR TITLE
Runtime test fixes

### DIFF
--- a/tests/runtime-tests.sh
+++ b/tests/runtime-tests.sh
@@ -2,9 +2,9 @@
 
 set -e;
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1
 
-BPFTRACE_RUNTIME_TEST_EXECUTABLE=${BPFTRACE_RUNTIME_TEST_EXECUTABLE:-$DIR/../src/};
+BPFTRACE_RUNTIME_TEST_EXECUTABLE=${BPFTRACE_RUNTIME_TEST_EXECUTABLE:-../src/};
 export BPFTRACE_RUNTIME_TEST_EXECUTABLE;
 
 python3 main.py $@

--- a/tests/runtime/intptrcast
+++ b/tests/runtime/intptrcast
@@ -1,11 +1,11 @@
 NAME Sum casted value
-RUN bpftrace -v -e 'uprobe:.*/testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("sp")+8)); exit();}'
+RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("sp")+8)); exit();}'
 EXPECT ^@: 3258
 TIMEOUT 5
 AFTER ./testprogs/intptrcast
 
 NAME Casting ints
-RUN bpftrace -v -e 'uprobe:.*/testprogs/intptrcast:fn { $a=*(uint16*)(reg("sp")+8); printf("%d\n", $a); exit();}'
+RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("sp")+8); printf("%d\n", $a); exit();}'
 EXPECT 3258
 TIMEOUT 5
 AFTER ./testprogs/intptrcast

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -94,7 +94,7 @@ EXPECT .*
 TIMEOUT 1
 
 NAME sigint under heavy load
-RUN ./bpftrace --unsafe -v -e 'tracepoint:sched:sched_switch { system("echo foo"); } END { printf("end"); }'
+RUN bpftrace --unsafe -v -e 'tracepoint:sched:sched_switch { system("echo foo"); } END { printf("end"); }'
 EXPECT end
 TIMEOUT 5
 AFTER  sleep 2; pkill -SIGINT bpftrace


### PR DESCRIPTION
This makes it possible to run the runtime tests from any directory, it currently fails:
```
~/bpftrace$ sudo ./tests/runtime-tests.sh
python3: can't open file 'main.py': [Errno 2] No such file or directory
```