### PR TITLE
Reimplement `elapsed`

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -165,7 +165,7 @@ CallInst *IRBuilderBPF::createMapLookup(int mapfd, AllocaInst *key)
       Instruction::IntToPtr,
       getInt64(BPF_FUNC_map_lookup_elem),
       lookup_func_ptr_type);
-  return CreateCall(lookup_func, {map_ptr, key}, "lookup_elem");
+  return CreateCall(lookup_func, { map_ptr, key }, "lookup_elem");
 }
 
 CallInst *IRBuilderBPF::CreateGetJoinMap(Value *ctx __attribute__((unused)))
@@ -173,7 +173,7 @@ CallInst *IRBuilderBPF::CreateGetJoinMap(Value *ctx __attribute__((unused)))
   AllocaInst *key = CreateAllocaBPF(getInt32Ty(), "key");
   CreateStore(getInt32(0), key);
 
-  CallInst * call = createMapLookup(bpftrace_.join_map_->mapfd_, key);
+  CallInst *call = createMapLookup(bpftrace_.join_map_->mapfd_, key);
   return call;
 }
 
@@ -184,7 +184,7 @@ Value *IRBuilderBPF::CreateMapLookupElem(Map &map, AllocaInst *key) {
 
 Value *IRBuilderBPF::CreateMapLookupElem(int mapfd, AllocaInst *key, SizedType &type)
 {
-  CallInst * call = createMapLookup(mapfd, key);
+  CallInst *call = createMapLookup(mapfd, key);
 
   // Check if result == 0
   Function *parent = GetInsertBlock()->getParent();
@@ -200,8 +200,8 @@ Value *IRBuilderBPF::CreateMapLookupElem(int mapfd, AllocaInst *key, SizedType &
   CreateCondBr(condition, lookup_success_block, lookup_failure_block);
 
   bool is_array = (type.type == Type::string ||
-                (type.type == Type::cast && !type.is_pointer) ||
-                type.type == Type::inet);
+                   (type.type == Type::cast && !type.is_pointer) ||
+                   type.type == Type::inet);
 
   SetInsertPoint(lookup_success_block);
   if (is_array)

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -40,6 +40,7 @@ public:
   CallInst   *CreateBpfPseudoCall(Map &map);
   Value      *CreateMapLookupElem(Map &map, AllocaInst *key);
   void        CreateMapUpdateElem(Map &map, AllocaInst *key, Value *val);
+  Value      *CreateMapLookupElem(int mapfd, AllocaInst *key, SizedType &type);
   void        CreateMapDeleteElem(Map &map, AllocaInst *key);
   void        CreateProbeRead(AllocaInst *dst, size_t size, Value *src);
   CallInst   *CreateProbeReadStr(AllocaInst *dst, llvm::Value *size, Value *src);
@@ -68,6 +69,7 @@ private:
   BPFtrace &bpftrace_;
 
   Value      *CreateUSDTReadArgument(Value *ctx, struct bcc_usdt_argument *argument, Builtin &builtin);
+  CallInst   *createMapLookup(int mapfd, AllocaInst *key);
 };
 
 } // namespace ast

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -39,8 +39,8 @@ public:
   CallInst   *CreateBpfPseudoCall(int mapfd);
   CallInst   *CreateBpfPseudoCall(Map &map);
   Value      *CreateMapLookupElem(Map &map, AllocaInst *key);
-  void        CreateMapUpdateElem(Map &map, AllocaInst *key, Value *val);
   Value      *CreateMapLookupElem(int mapfd, AllocaInst *key, SizedType &type);
+  void        CreateMapUpdateElem(Map &map, AllocaInst *key, Value *val);
   void        CreateMapDeleteElem(Map &map, AllocaInst *key);
   void        CreateProbeRead(AllocaInst *dst, size_t size, Value *src);
   CallInst   *CreateProbeReadStr(AllocaInst *dst, llvm::Value *size, Value *src);

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -77,6 +77,7 @@ private:
   std::map<std::string, ExpressionList> map_args_;
   std::unordered_set<StackType> needs_stackid_maps_;
   bool needs_join_map_ = false;
+  bool needs_elapsed_map_ = false;
   bool has_begin_probe_ = false;
   bool has_end_probe_ = false;
 };

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -703,6 +703,20 @@ int BPFtrace::run(std::unique_ptr<BpfOrc> bpforc)
   if (epollfd < 0)
     return epollfd;
 
+  if (elapsed_map_)
+  {
+    struct timespec ts;
+    clock_gettime(CLOCK_MONOTONIC, &ts);
+    auto nsec = 1000000000ULL * ts.tv_sec + ts.tv_nsec;
+    uint64_t key = 0;
+
+    if (bpf_update_elem(elapsed_map_->mapfd_, &key, &nsec, 0) < 0)
+    {
+      perror("Failed to write start time to elapsed map");
+      return -1;
+    }
+  }
+
   BEGIN_trigger();
 
   // The kernel appears to fire some probes in the order that they were

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -127,6 +127,7 @@ public:
   std::vector<std::tuple<std::string, std::vector<Field>>> cat_args_;
   std::unordered_map<StackType, std::unique_ptr<IMap>> stackid_maps_;
   std::unique_ptr<IMap> join_map_;
+  std::unique_ptr<IMap> elapsed_map_;
   std::unique_ptr<IMap> perf_event_map_;
   std::vector<std::string> probe_ids_;
   unsigned int join_argnum_;

--- a/tests/codegen/builtin_elapsed.cpp
+++ b/tests/codegen/builtin_elapsed.cpp
@@ -6,17 +6,55 @@ namespace codegen {
 
 TEST(codegen, builtin_elapsed)
 {
-  /*
-   * TODO: add test. The problem that needs fixing first is that the codegen
-   * includes this line:
-   *
-   * %1 = add i64 %get_ns, -956821864668979
-   *
-   * That's the bpftrace epoch time, hardcoded in BPF. Which is what we want.
-   * But it varies between runs of bpftrace, so this line will change every
-   * time, causing the test to fail. We need a way to ignore this number
-   * in the test.
-   */
+  test("i:s:1 { @ = elapsed; }",
+
+       R"EXPECTED(; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"interval:s:1"(i8* nocapture readnone) local_unnamed_addr section "s_interval:s:1_1" {
+entry:
+  %"@_val" = alloca i64, align 8
+  %"@_key" = alloca i64, align 8
+  %elapsed_key = alloca i64, align 8
+  %1 = bitcast i64* %elapsed_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  store i64 0, i64* %elapsed_key, align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, i64* nonnull %elapsed_key)
+  %map_lookup_cond = icmp eq i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
+
+lookup_success:                                   ; preds = %entry
+  %2 = load i64, i8* %lookup_elem, align 8
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %entry, %lookup_success
+  %lookup_elem_val.0 = phi i64 [ %2, %lookup_success ], [ 0, %entry ]
+  %get_ns = call i64 inttoptr (i64 5 to i64 ()*)()
+  %3 = sub i64 %get_ns, %lookup_elem_val.0
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  %4 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 0, i64* %"@_key", align 8
+  %5 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  store i64 %3, i64* %"@_val", align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
 }
 
 } // namespace codegen


### PR DESCRIPTION
This changes the `elapsed` builtin to make use of a "hidden" map instead of a compile time constant.

I've left the map type as `BPF_MAP_TYPE_HASH` as it is a read only workload.

Fixes #630 