### PR TITLE
Support octal and hexadecimal escape sequences in string

### DIFF
--- a/src/ast/printer.cpp
+++ b/src/ast/printer.cpp
@@ -1,3 +1,5 @@
+#include <cctype>
+#include <iomanip>
 #include <regex>
 
 #include "printer.h"
@@ -31,14 +33,34 @@ void Printer::visit(PositionalParameter &param)
 void Printer::visit(String &string)
 {
   std::string indent(depth_, ' ');
+  std::stringstream ss;
 
-  std::string str = string.str;
-  str = std::regex_replace(str, std::regex("\\\\"), "\\\\");
-  str = std::regex_replace(str, std::regex("\n"), "\\n");
-  str = std::regex_replace(str, std::regex("\t"), "\\t");
-  str = std::regex_replace(str, std::regex("\""), "\\\"");
+  for (char c: string.str)
+  {
+    // the argument of isprint() must be an unsigned char or EOF
+    int code = static_cast<unsigned char>(c);
+    if (std::isprint(code))
+      if (c == '\\')
+        ss << "\\\\";
+      else if (c == '"')
+        ss << "\\\"";
+      else
+        ss << c;
+    else
+    {
+      if (c == '\n')
+        ss << "\\n";
+      else if (c == '\t')
+        ss << "\\t";
+      else if (c == '\r')
+        ss << "\\r";
+      else
+        ss << "\\x" << std::setfill('0') << std::setw(2)
+           << std::hex << code;
+    }
+  }
 
-  out_ << indent << "string: " << str << std::endl;
+  out_ << indent << "string: " << ss.str() << std::endl;
 }
 
 void Printer::visit(StackMode &mode)

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -22,6 +22,8 @@ map     @{ident}|@
 var     ${ident}
 int     [0-9]+|0[xX][0-9a-fA-F]+
 cint    :{int}:
+hex     (x|X)[0-9a-fA-F]{1,2}
+oct     [0-7]{1,3}
 hspace  [ \t]
 vspace  [\n\r]
 space   {hspace}|{vspace}
@@ -123,6 +125,8 @@ bpftrace|perf           { return Parser::make_STACK_MODE(yytext, loc); }
   \\r                   buffer += '\r';
   \\\"                  buffer += '\"';
   \\\\                  buffer += '\\';
+  \\{oct}               buffer += strtoll(yytext+1, NULL, 8);
+  \\{hex}               buffer += strtoll(yytext+2, NULL, 16);
   \n                    driver.error(loc, "unterminated string"); yy_pop_state(yyscanner); loc.lines(1); loc.step();
   <<EOF>>               driver.error(loc, "unterminated string"); yy_pop_state(yyscanner);
   \\.                   { driver.error(loc, std::string("invalid escape character '") +

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -3,6 +3,7 @@
 %option reentrant
 %option stack
 %{
+#include <climits>
 #include "driver.h"
 #include "utils.h"
 #include "parser.tab.hh"
@@ -125,8 +126,14 @@ bpftrace|perf           { return Parser::make_STACK_MODE(yytext, loc); }
   \\r                   buffer += '\r';
   \\\"                  buffer += '\"';
   \\\\                  buffer += '\\';
-  \\{oct}               buffer += strtoll(yytext+1, NULL, 8);
-  \\{hex}               buffer += strtoll(yytext+2, NULL, 16);
+  \\{oct}               {
+                            long value = strtol(yytext+1, NULL, 8);
+                            if (value > UCHAR_MAX)
+                              driver.error(loc, std::string("octal escape sequence out of range. "
+                                           "The value will be truncated: ") + yytext);
+                            buffer += value;
+                        }
+  \\{hex}               buffer += strtol(yytext+2, NULL, 16);
   \n                    driver.error(loc, "unterminated string"); yy_pop_state(yyscanner); loc.lines(1); loc.step();
   <<EOF>>               driver.error(loc, "unterminated string"); yy_pop_state(yyscanner);
   \\.                   { driver.error(loc, std::string("invalid escape character '") +

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -805,10 +805,10 @@ TEST(Parser, usdt_namespaced_probe)
 
 TEST(Parser, escape_chars)
 {
-  test("kprobe:sys_open { \"newline\\nand tab\\tbackslash\\\\quote\\\"here\" }",
+  test("kprobe:sys_open { \"newline\\nand tab\\tbackslash\\\\quote\\\"here oct\\1009hex\\x309\" }",
       "Program\n"
       " kprobe:sys_open\n"
-      "  string: newline\\nand tab\\tbackslash\\\\quote\\\"here\n");
+      "  string: newline\\nand tab\\tbackslash\\\\quote\\\"here oct@9hex09\n");
 }
 
 TEST(Parser, begin_probe)

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -805,10 +805,10 @@ TEST(Parser, usdt_namespaced_probe)
 
 TEST(Parser, escape_chars)
 {
-  test("kprobe:sys_open { \"newline\\nand tab\\tbackslash\\\\quote\\\"here oct\\1009hex\\x309\" }",
+  test("kprobe:sys_open { \"newline\\nand tab\\tcr\\rbackslash\\\\quote\\\"here oct\\1009hex\\x309\" }",
       "Program\n"
       " kprobe:sys_open\n"
-      "  string: newline\\nand tab\\tbackslash\\\\quote\\\"here oct@9hex09\n");
+      "  string: newline\\nand tab\\tcr\\rbackslash\\\\quote\\\"here oct@9hex09\n");
 }
 
 TEST(Parser, begin_probe)


### PR DESCRIPTION
This is useful for printing ANSI escape codes.
e.g., `printf("\033[H\033[2J")` // clear screen
(This is possible using `system("clear")`, but it requires --unsafe.)