### PR TITLE
Make `strncmp` codegen unsigned

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -411,7 +411,7 @@ Value *IRBuilderBPF::CreateStrncmp(Value* val, std::string str, uint64_t n, bool
   SetInsertPoint(str_ne);
   Value *result = CreateLoad(store);
   CreateLifetimeEnd(store);
-  result = CreateIntCast(result, getInt64Ty(), true);
+  result = CreateIntCast(result, getInt64Ty(), false);
   return result;
 }
 
@@ -485,7 +485,7 @@ Value *IRBuilderBPF::CreateStrncmp(Value* val1, Value* val2, uint64_t n, bool in
 
   Value *result = CreateLoad(store);
   CreateLifetimeEnd(store);
-  result = CreateIntCast(result, getInt64Ty(), true);
+  result = CreateIntCast(result, getInt64Ty(), false);
 
   return result;
 }


### PR DESCRIPTION
`strncmp` result is unsigned in the semantic analyser but signed in
codegen, which results in UINT_MAX when printing:

```
bpftrace -e 'i:s:1 { @=strncmp("a", "b", 1); exit(); }'

@: 18446744073709551615
```

Making it unsigned makes it consistent with the binops which are
unsigned too.