### PR TITLE
Remove dependency on 'command' shell builtin

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1229,13 +1229,17 @@ void SemanticAnalyser::visit(AttachPoint &ap)
       err_ << "uprobes should be attached to a function or address" << std::endl;
 
     auto paths = resolve_binary_path(ap.target);
-    if (paths.size() > 1)
-      err_ << "path '" << ap.target << "' must refer to a unique binary but matched " << paths.size() << std::endl;
-    ap.target = paths.front();
-    struct stat s;
-    if (stat(ap.target.c_str(), &s) != 0)
-      err_ << "failed to stat uprobe target file " << ap.target << ": "
-        << std::strerror(errno) << std::endl;
+    switch (paths.size())
+    {
+    case 0:
+      err_ << "uprobe target file '" << ap.target << "' does not exist or is not executable" << std::endl;
+      break;
+    case 1:
+      ap.target = paths.front();
+      break;
+    default:
+      err_ << "uprobe target file '" << ap.target << "' must refer to a unique binary but matched " << paths.size() << std::endl;
+    }
   }
   else if (ap.provider == "usdt") {
     if (ap.func == "")
@@ -1243,12 +1247,17 @@ void SemanticAnalyser::visit(AttachPoint &ap)
 
     if (ap.target != "") {
       auto paths = resolve_binary_path(ap.target);
-      if (paths.size() > 1)
-        err_ << "path '" << ap.target << "' must refer to a unique binary but matched " << paths.size() << std::endl;
-      ap.target = paths.front();
-      struct stat s;
-      if (stat(ap.target.c_str(), &s) != 0)
-        err_ << "usdt target file " << ap.target << " does not exist" << std::endl;
+      switch (paths.size())
+      {
+      case 0:
+        err_ << "usdt target file '" << ap.target << "' does not exist or is not executable" << std::endl;
+        break;
+      case 1:
+        ap.target = paths.front();
+        break;
+      default:
+        err_ << "usdt target file '" << ap.target << "' must refer to a unique binary but matched " << paths.size() << std::endl;
+      }
     }
 
     if (bpftrace_.pid_ > 0) {

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1291,13 +1291,20 @@ pid_t BPFtrace::spawn_child()
 
   auto args = split_string(cmd_, ' ');
   auto paths = resolve_binary_path(args[0]); // does path lookup on executable
-  if (paths.size() > 1)
+  switch (paths.size())
   {
+  case 0:
+    std::cerr << "path '" << args[0] << "' does not exist or is not executable" << std::endl;
+    return -1;
+  case 1:
+    args[0] = paths.front().c_str();
+    break;
+  default:
     std::cerr << "path '" << args[0] << "' must refer to a unique binary but matched "
               << paths.size() << " binaries" << std::endl;
     return -1;
   }
-  args[0] = paths.front().c_str();
+
 
   if (args.size() >= (maxargs - 1))
   {

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -160,15 +160,16 @@ void list_probes(const BPFtrace &bpftrace, const std::string &search_input)
       executable = executable.substr(0, executable.find(":"));
 
       auto paths = resolve_binary_path(executable);
-      if (paths.size() > 1)
+      switch (paths.size())
       {
-        std::cerr << "path '" << executable << "' must refer to a unique binary but matched " << paths.size() << std::endl;
+      case 0:
+        std::cerr << "uprobe target '" << executable << "' does not exist or is not executable" << std::endl;
         return;
-      }
-      absolute_exe = paths.front();
-      struct stat s;
-      if (stat(absolute_exe.c_str(), &s) != 0) {
-        std::cerr << "uprobe target " << executable << " does not exist" << std::endl;
+      case 1:
+        absolute_exe = paths.front();
+        break;
+      default:
+        std::cerr << "path '" << executable << "' must refer to a unique binary but matched " << paths.size() << std::endl;
         return;
       }
     }
@@ -201,12 +202,18 @@ void list_probes(const BPFtrace &bpftrace, const std::string &search_input)
     usdt_path_list = usdt_path.find(":") == std::string::npos;
     usdt_path = usdt_path.substr(0, usdt_path.find(":"));
     auto paths = resolve_binary_path(usdt_path);
-    if (paths.size() > 1)
+    switch (paths.size())
     {
-      std::cerr << "path '" << usdt_path << "' must refer to a unique binary but matched " << paths.size() << std::endl;
+    case 0:
+      std::cerr << "usdt target '" << usdt_path << "' does not exist or is not executable" << std::endl;
+      return;
+    case 1:
+      usdt_probes = USDTHelper::probes_for_path(paths.front());
+      break;
+    default:
+      std::cerr << "usdt target '" << usdt_path << "' must refer to a unique binary but matched " << paths.size() << std::endl;
       return;
     }
-    usdt_probes = USDTHelper::probes_for_path(paths.front());
   }
 
   for (auto const& usdt_probe : usdt_probes)

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -104,6 +104,6 @@ EXPECT 10 12 12 10
 TIMEOUT 1
 
 NAME spawn child
-RUN bpftrace -e 'i:ms:500 { printf("%d\n", cpid); }' -c 'sleep 1'
+RUN bpftrace -e 'i:ms:500 { printf("%d\n", cpid); }' -c '/bin/sleep 1'
 EXPECT [0-9]+
 TIMEOUT 1

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -59,7 +59,7 @@ EXPECT not equal
 TIMEOUT 5
 
 NAME string compare map lookup
-RUN bpftrace -v -e 't:syscalls:sys_enter_openat /comm == "cat"/ { @[comm] = 1; }' -c "cat /dev/null"
+RUN bpftrace -v -e 't:syscalls:sys_enter_openat /comm == "cat"/ { @[comm] = 1; }' -c "/bin/cat /dev/null"
 EXPECT @\[cat\]: 1
 TIMEOUT 5
 

--- a/tests/runtime/uprobe
+++ b/tests/runtime/uprobe
@@ -8,6 +8,11 @@ RUN bpftrace -l 'uprobe:./testprogs/uprobe_test:func*'
 EXPECT uprobe:./testprogs/uprobe_test:function1
 TIMEOUT 5
 
+NAME "uprobes - list probes with ambiguous wildcarded file fails"
+RUN bpftrace -l 'uprobe:./testprogs/u*:*'
+EXPECT must refer to a unique binary
+TIMEOUT 5
+
 NAME "uprobes - list probes by file with wildcarded file and filter"
 RUN bpftrace -l 'uprobe:./testprogs/uprobe_test*:func*'
 EXPECT uprobe:./testprogs/uprobe_test:function1

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -94,6 +94,11 @@ TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 
+NAME "usdt probes - attach to probe with ambiguous wildcard file fails"
+RUN bpftrace -e 'usdt:./testprogs/u*::* { printf("here\n" ); exit(); }'
+EXPECT must refer to a unique binary
+TIMEOUT 5
+
 NAME "usdt probes - attach to probe on multiple providers by wildcard and pid"
 RUN bpftrace -e 'usdt:::*probe2 { printf("here\n" ); exit(); }' -p $(pidof usdt_test)
 EXPECT Attaching 2 probes...


### PR DESCRIPTION
This is another PR towards reducing the number of times we shell out to external programs. The `command` shell builtin occasionally causes unexpected behavior (see #879), so I've replaced it with a more direct implementation.

There's enough code around binary path resolution now that we could move it out of utils.cpp, imo. Any strong feelings either way?