### PR TITLE
Call llvm.lifetime.end after memcpy if the expression is not a variable

### DIFF
--- a/tests/codegen/args_multiple_tracepoints.cpp
+++ b/tests/codegen/args_multiple_tracepoints.cpp
@@ -13,10 +13,11 @@ TEST(codegen, args_multiple_tracepoints)
   auto bpftrace = get_mock_bpftrace();
 
   test(*bpftrace,
-      "tracepoint:sched:sched_one,tracepoint:sched:sched_two { @[args->common_field] = count(); }",
+       "tracepoint:sched:sched_one,tracepoint:sched:sched_two { "
+       "@[args->common_field] = count(); }",
 
 #if LLVM_VERSION_MAJOR > 6
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -25,17 +26,17 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"tracepoint:sched:sched_one"(i8*) local_unnamed_addr section "s_tracepoint:sched:sched_one_1" {
 entry:
   %"@_val" = alloca i64, align 8
-  %"struct _tracepoint_sched_sched_one.common_field" = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
-  %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = add i8* %0, i64 8
-  %3 = bitcast i64* %"struct _tracepoint_sched_sched_one.common_field" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_one.common_field", i64 8, i8* %2)
-  %4 = load i64, i64* %"struct _tracepoint_sched_sched_one.common_field", align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  store i64 %4, i8* %1, align 8
+  %"struct _tracepoint_sched_sched_one.common_field" = alloca i64, align 8
+  %1 = add i8* %0, i64 8
+  %2 = bitcast i64* %"struct _tracepoint_sched_sched_one.common_field" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_one.common_field", i64 8, i8* %1)
+  %3 = load i64, i64* %"struct _tracepoint_sched_sched_one.common_field", align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  %4 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 %3, [8 x i8]* %"@_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
@@ -53,7 +54,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
 }
@@ -64,17 +65,17 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 define i64 @"tracepoint:sched:sched_two"(i8*) local_unnamed_addr section "s_tracepoint:sched:sched_two_2" {
 entry:
   %"@_val" = alloca i64, align 8
-  %"struct _tracepoint_sched_sched_two.common_field" = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
-  %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = add i8* %0, i64 16
-  %3 = bitcast i64* %"struct _tracepoint_sched_sched_two.common_field" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_two.common_field", i64 8, i8* %2)
-  %4 = load i64, i64* %"struct _tracepoint_sched_sched_two.common_field", align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  store i64 %4, i8* %1, align 8
+  %"struct _tracepoint_sched_sched_two.common_field" = alloca i64, align 8
+  %1 = add i8* %0, i64 16
+  %2 = bitcast i64* %"struct _tracepoint_sched_sched_two.common_field" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_two.common_field", i64 8, i8* %1)
+  %3 = load i64, i64* %"struct _tracepoint_sched_sched_two.common_field", align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  %4 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 %3, [8 x i8]* %"@_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
@@ -92,7 +93,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
 }
@@ -101,7 +102,7 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #else
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -110,17 +111,17 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"tracepoint:sched:sched_one"(i8*) local_unnamed_addr section "s_tracepoint:sched:sched_one_1" {
 entry:
   %"@_val" = alloca i64, align 8
-  %"struct _tracepoint_sched_sched_one.common_field" = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
-  %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = add i8* %0, i64 8
-  %3 = bitcast i64* %"struct _tracepoint_sched_sched_one.common_field" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_one.common_field", i64 8, i8* %2)
-  %4 = load i64, i64* %"struct _tracepoint_sched_sched_one.common_field", align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  store i64 %4, i8* %1, align 8
+  %"struct _tracepoint_sched_sched_one.common_field" = alloca i64, align 8
+  %1 = add i8* %0, i64 8
+  %2 = bitcast i64* %"struct _tracepoint_sched_sched_one.common_field" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_one.common_field", i64 8, i8* %1)
+  %3 = load i64, i64* %"struct _tracepoint_sched_sched_one.common_field", align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  %4 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 %3, [8 x i8]* %"@_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
@@ -138,7 +139,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
 }
@@ -149,17 +150,17 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 define i64 @"tracepoint:sched:sched_two"(i8*) local_unnamed_addr section "s_tracepoint:sched:sched_two_2" {
 entry:
   %"@_val" = alloca i64, align 8
-  %"struct _tracepoint_sched_sched_two.common_field" = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
-  %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = add i8* %0, i64 16
-  %3 = bitcast i64* %"struct _tracepoint_sched_sched_two.common_field" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_two.common_field", i64 8, i8* %2)
-  %4 = load i64, i64* %"struct _tracepoint_sched_sched_two.common_field", align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  store i64 %4, i8* %1, align 8
+  %"struct _tracepoint_sched_sched_two.common_field" = alloca i64, align 8
+  %1 = add i8* %0, i64 16
+  %2 = bitcast i64* %"struct _tracepoint_sched_sched_two.common_field" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_two.common_field", i64 8, i8* %1)
+  %3 = load i64, i64* %"struct _tracepoint_sched_sched_two.common_field", align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  %4 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 %3, [8 x i8]* %"@_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
@@ -177,7 +178,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
 }

--- a/tests/codegen/args_multiple_tracepoints_wild.cpp
+++ b/tests/codegen/args_multiple_tracepoints_wild.cpp
@@ -13,10 +13,10 @@ TEST(codegen, args_multiple_tracepoints_wild)
   auto bpftrace = get_mock_bpftrace();
 
   test(*bpftrace,
-      "tracepoint:sched:sched_* { @[args->common_field] = count(); }",
+       "tracepoint:sched:sched_* { @[args->common_field] = count(); }",
 
 #if LLVM_VERSION_MAJOR > 6
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -25,17 +25,17 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"tracepoint:sched:sched_one"(i8*) local_unnamed_addr section "s_tracepoint:sched:sched_one_1" {
 entry:
   %"@_val" = alloca i64, align 8
-  %"struct _tracepoint_sched_sched_one.common_field" = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
-  %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = add i8* %0, i64 8
-  %3 = bitcast i64* %"struct _tracepoint_sched_sched_one.common_field" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_one.common_field", i64 8, i8* %2)
-  %4 = load i64, i64* %"struct _tracepoint_sched_sched_one.common_field", align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  store i64 %4, i8* %1, align 8
+  %"struct _tracepoint_sched_sched_one.common_field" = alloca i64, align 8
+  %1 = add i8* %0, i64 8
+  %2 = bitcast i64* %"struct _tracepoint_sched_sched_one.common_field" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_one.common_field", i64 8, i8* %1)
+  %3 = load i64, i64* %"struct _tracepoint_sched_sched_one.common_field", align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  %4 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 %3, [8 x i8]* %"@_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
@@ -53,7 +53,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
 }
@@ -64,17 +64,17 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 define i64 @"tracepoint:sched:sched_two"(i8*) local_unnamed_addr section "s_tracepoint:sched:sched_two_2" {
 entry:
   %"@_val" = alloca i64, align 8
-  %"struct _tracepoint_sched_sched_two.common_field" = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
-  %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = add i8* %0, i64 16
-  %3 = bitcast i64* %"struct _tracepoint_sched_sched_two.common_field" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_two.common_field", i64 8, i8* %2)
-  %4 = load i64, i64* %"struct _tracepoint_sched_sched_two.common_field", align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  store i64 %4, i8* %1, align 8
+  %"struct _tracepoint_sched_sched_two.common_field" = alloca i64, align 8
+  %1 = add i8* %0, i64 16
+  %2 = bitcast i64* %"struct _tracepoint_sched_sched_two.common_field" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_two.common_field", i64 8, i8* %1)
+  %3 = load i64, i64* %"struct _tracepoint_sched_sched_two.common_field", align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  %4 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 %3, [8 x i8]* %"@_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
@@ -92,7 +92,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
 }
@@ -101,7 +101,7 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #else
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -110,17 +110,17 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"tracepoint:sched:sched_one"(i8*) local_unnamed_addr section "s_tracepoint:sched:sched_one_1" {
 entry:
   %"@_val" = alloca i64, align 8
-  %"struct _tracepoint_sched_sched_one.common_field" = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
-  %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = add i8* %0, i64 8
-  %3 = bitcast i64* %"struct _tracepoint_sched_sched_one.common_field" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_one.common_field", i64 8, i8* %2)
-  %4 = load i64, i64* %"struct _tracepoint_sched_sched_one.common_field", align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  store i64 %4, i8* %1, align 8
+  %"struct _tracepoint_sched_sched_one.common_field" = alloca i64, align 8
+  %1 = add i8* %0, i64 8
+  %2 = bitcast i64* %"struct _tracepoint_sched_sched_one.common_field" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_one.common_field", i64 8, i8* %1)
+  %3 = load i64, i64* %"struct _tracepoint_sched_sched_one.common_field", align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  %4 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 %3, [8 x i8]* %"@_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
@@ -138,7 +138,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
 }
@@ -149,17 +149,17 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 define i64 @"tracepoint:sched:sched_two"(i8*) local_unnamed_addr section "s_tracepoint:sched:sched_two_2" {
 entry:
   %"@_val" = alloca i64, align 8
-  %"struct _tracepoint_sched_sched_two.common_field" = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
-  %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = add i8* %0, i64 16
-  %3 = bitcast i64* %"struct _tracepoint_sched_sched_two.common_field" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_two.common_field", i64 8, i8* %2)
-  %4 = load i64, i64* %"struct _tracepoint_sched_sched_two.common_field", align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  store i64 %4, i8* %1, align 8
+  %"struct _tracepoint_sched_sched_two.common_field" = alloca i64, align 8
+  %1 = add i8* %0, i64 16
+  %2 = bitcast i64* %"struct _tracepoint_sched_sched_two.common_field" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_two.common_field", i64 8, i8* %1)
+  %3 = load i64, i64* %"struct _tracepoint_sched_sched_two.common_field", align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  %4 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 %3, [8 x i8]* %"@_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
@@ -177,7 +177,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
 }

--- a/tests/codegen/call_ntop_key.cpp
+++ b/tests/codegen/call_ntop_key.cpp
@@ -9,7 +9,9 @@ TEST(codegen, call_ntop_key)
   test("kprobe:f { @x[ntop(2, 0xFFFFFFFF)] = count()}",
 
 #if LLVM_VERSION_MAJOR < 6
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(%inet_t = type { i64, [16 x i8] }
+
+; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -18,35 +20,33 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
-  %"@x_key" = alloca [24 x i8], align 8
-  %1 = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 0
+  %inet = alloca %inet_t, align 8
+  %1 = bitcast %inet_t* %inet to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %inet.sroa.0.0..sroa_cast = bitcast [24 x i8]* %"@x_key" to i64*
-  store i64 2, i64* %inet.sroa.0.0..sroa_cast, align 8
-  %inet.sroa.3.0..sroa_idx = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 8
-  %inet.sroa.3.0..sroa_cast = bitcast i8* %inet.sroa.3.0..sroa_idx to i32*
-  store i32 -1, i32* %inet.sroa.3.0..sroa_cast, align 8
-  %inet.sroa.5.0..sroa_idx = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 12
-  call void @llvm.memset.p0i8.i64(i8* %inet.sroa.5.0..sroa_idx, i8 0, i64 12, i32 4, i1 false)
+  store i64 2, %inet_t* %inet, align 8
+  %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
+  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
+  call void @llvm.memset.p0i8.i64(i8* %3, i8 0, i64 16, i32 8, i1 false)
+  store i32 -1, [16 x i8]* %2, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [24 x i8]* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, %inet_t* nonnull %inet)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %2 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %2, 1
+  %4 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %4, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %3 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %5 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [24 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, %inet_t* nonnull %inet, i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0
 }
 
@@ -60,7 +60,9 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #elif LLVM_VERSION_MAJOR > 6
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(%inet_t = type { i64, [16 x i8] }
+
+; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -69,35 +71,33 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
-  %"@x_key" = alloca [24 x i8], align 8
-  %1 = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 0
+  %inet = alloca %inet_t, align 8
+  %1 = bitcast %inet_t* %inet to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %inet.sroa.0.0..sroa_cast = bitcast [24 x i8]* %"@x_key" to i64*
-  store i64 2, i64* %inet.sroa.0.0..sroa_cast, align 8
-  %inet.sroa.3.0..sroa_idx = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 8
-  %inet.sroa.3.0..sroa_cast = bitcast i8* %inet.sroa.3.0..sroa_idx to i32*
-  store i32 -1, i32* %inet.sroa.3.0..sroa_cast, align 8
-  %inet.sroa.5.0..sroa_idx = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 12
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 4 %inet.sroa.5.0..sroa_idx, i8 0, i64 12, i1 false)
+  store i64 2, %inet_t* %inet, align 8
+  %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
+  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %3, i8 0, i64 16, i1 false)
+  store i32 -1, [16 x i8]* %2, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [24 x i8]* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, %inet_t* nonnull %inet)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %2 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %2, 1
+  %4 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %4, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %3 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %5 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [24 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, %inet_t* nonnull %inet, i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0
 }
 
@@ -111,7 +111,9 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #else
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(%inet_t = type { i64, [16 x i8] }
+
+; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -120,35 +122,33 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
-  %"@x_key" = alloca [24 x i8], align 8
-  %1 = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 0
+  %inet = alloca %inet_t, align 8
+  %1 = bitcast %inet_t* %inet to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %inet.sroa.0.0..sroa_cast = bitcast [24 x i8]* %"@x_key" to i64*
-  store i64 2, i64* %inet.sroa.0.0..sroa_cast, align 8
-  %inet.sroa.3.0..sroa_idx = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 8
-  %inet.sroa.3.0..sroa_cast = bitcast i8* %inet.sroa.3.0..sroa_idx to i32*
-  store i32 -1, i32* %inet.sroa.3.0..sroa_cast, align 8
-  %inet.sroa.5.0..sroa_idx = getelementptr inbounds [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 12
-  call void @llvm.memset.p0i8.i64(i8* nonnull %inet.sroa.5.0..sroa_idx, i8 0, i64 12, i32 4, i1 false)
+  store i64 2, %inet_t* %inet, align 8
+  %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
+  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
+  call void @llvm.memset.p0i8.i64(i8* nonnull %3, i8 0, i64 16, i32 8, i1 false)
+  store i32 -1, [16 x i8]* %2, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [24 x i8]* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, %inet_t* nonnull %inet)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %2 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %2, 1
+  %4 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %4, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %3 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %5 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [24 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, %inet_t* nonnull %inet, i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0
 }
 

--- a/tests/codegen/call_usym_key.cpp
+++ b/tests/codegen/call_usym_key.cpp
@@ -8,7 +8,7 @@ TEST(codegen, call_usym_key)
 {
   test("kprobe:f { @x[usym(0)] = count() }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -17,35 +17,33 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
-  %"@x_key" = alloca [16 x i8], align 8
-  %1 = getelementptr inbounds [16 x i8], [16 x i8]* %"@x_key", i64 0, i64 0
+  %usym = alloca [16 x i8], align 8
+  %1 = getelementptr inbounds [16 x i8], [16 x i8]* %usym, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %get_pid_tgid = tail call i64 inttoptr (i64 14 to i64 ()*)()
   %2 = lshr i64 %get_pid_tgid, 32
-  %usym.sroa.0.0..sroa_cast = bitcast [16 x i8]* %"@x_key" to i64*
-  store i64 0, i64* %usym.sroa.0.0..sroa_cast, align 8
-  %usym.sroa.4.0..sroa_idx = getelementptr inbounds [16 x i8], [16 x i8]* %"@x_key", i64 0, i64 8
-  %usym.sroa.4.0..sroa_cast = bitcast i8* %usym.sroa.4.0..sroa_idx to i64*
-  store i64 %2, i64* %usym.sroa.4.0..sroa_cast, align 8
+  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %usym, i64 0, i64 8
+  store i64 0, [16 x i8]* %usym, align 8
+  store i64 %2, i8* %3, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %usym)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %3 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %3, 1
+  %4 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %4, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %4 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  %5 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [16 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [16 x i8]* nonnull %usym, i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0
 }
 

--- a/tests/codegen/literal_strncmp.cpp
+++ b/tests/codegen/literal_strncmp.cpp
@@ -19,7 +19,6 @@ define i64 @"kretprobe:vfs_read"(i8* nocapture readnone) local_unnamed_addr sect
 entry:
   %"@_val" = alloca i64, align 8
   %comm3 = alloca [16 x i8], align 1
-  %"@_key" = alloca [16 x i8], align 1
   %comm = alloca [16 x i8], align 1
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
@@ -27,44 +26,46 @@ entry:
   %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   %2 = load i8, [16 x i8]* %comm, align 1
   %strcmp.cmp = icmp eq i8 %2, 115
-  br i1 %strcmp.cmp, label %strcmp.loop, label %pred_true
+  br i1 %strcmp.cmp, label %strcmp.loop, label %pred_true.critedge
 
 pred_false:                                       ; preds = %strcmp.loop
   ret i64 0
 
-pred_true:                                        ; preds = %strcmp.loop, %entry
-  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %"@_key", i64 0, i64 0
+pred_true.critedge:                               ; preds = %entry
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  br label %pred_true
+
+pred_true:                                        ; preds = %strcmp.loop, %pred_true.critedge
+  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %comm3, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %comm3, i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %4, i8 0, i64 16, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %3, i8 0, i64 16, i1 false)
   %get_comm4 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm3, i64 16)
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %3, i8* nonnull align 1 %4, i64 16, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %comm3)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 strcmp.loop:                                      ; preds = %entry
-  %5 = add [16 x i8]* %comm, i64 1
-  %6 = load i8, [16 x i8]* %5, align 1
-  %strcmp.cmp2 = icmp eq i8 %6, 115
+  %4 = add [16 x i8]* %comm, i64 1
+  %5 = load i8, [16 x i8]* %4, align 1
+  %strcmp.cmp2 = icmp eq i8 %5, 115
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   br i1 %strcmp.cmp2, label %pred_false, label %pred_true
 
 lookup_success:                                   ; preds = %pred_true
-  %7 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %7, 1
+  %6 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %6, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %pred_true, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %pred_true ]
-  %8 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
+  %7 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo5, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo5, [16 x i8]* nonnull %comm3, i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
 }
 
@@ -73,9 +74,6 @@ declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
@@ -91,7 +89,6 @@ define i64 @"kretprobe:vfs_read"(i8* nocapture readnone) local_unnamed_addr sect
 entry:
   %"@_val" = alloca i64, align 8
   %comm3 = alloca [16 x i8], align 1
-  %"@_key" = alloca [16 x i8], align 1
   %comm = alloca [16 x i8], align 1
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
@@ -99,44 +96,46 @@ entry:
   %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   %2 = load i8, [16 x i8]* %comm, align 1
   %strcmp.cmp = icmp eq i8 %2, 115
-  br i1 %strcmp.cmp, label %strcmp.loop, label %pred_true
+  br i1 %strcmp.cmp, label %strcmp.loop, label %pred_true.critedge
 
 pred_false:                                       ; preds = %strcmp.loop
   ret i64 0
 
-pred_true:                                        ; preds = %strcmp.loop, %entry
-  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %"@_key", i64 0, i64 0
+pred_true.critedge:                               ; preds = %entry
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  br label %pred_true
+
+pred_true:                                        ; preds = %strcmp.loop, %pred_true.critedge
+  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %comm3, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %comm3, i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  call void @llvm.memset.p0i8.i64(i8* nonnull %4, i8 0, i64 16, i32 1, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* nonnull %3, i8 0, i64 16, i32 1, i1 false)
   %get_comm4 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm3, i64 16)
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %3, i8* nonnull %4, i64 16, i32 1, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %comm3)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 strcmp.loop:                                      ; preds = %entry
-  %5 = add [16 x i8]* %comm, i64 1
-  %6 = load i8, [16 x i8]* %5, align 1
-  %strcmp.cmp2 = icmp eq i8 %6, 115
+  %4 = add [16 x i8]* %comm, i64 1
+  %5 = load i8, [16 x i8]* %4, align 1
+  %strcmp.cmp2 = icmp eq i8 %5, 115
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   br i1 %strcmp.cmp2, label %pred_false, label %pred_true
 
 lookup_success:                                   ; preds = %pred_true
-  %7 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %7, 1
+  %6 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %6, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %pred_true, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %pred_true ]
-  %8 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
+  %7 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo5, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo5, [16 x i8]* nonnull %comm3, i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
 }
 
@@ -145,9 +144,6 @@ declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i32, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/map_key_probe.cpp
+++ b/tests/codegen/map_key_probe.cpp
@@ -10,9 +10,10 @@ TEST(codegen, map_key_probe)
   auto bpftrace = get_mock_bpftrace();
 
   test(*bpftrace,
-      "tracepoint:sched:sched_one,tracepoint:sched:sched_two { @x[probe] = @x[probe] + 1 }",
+       "tracepoint:sched:sched_one,tracepoint:sched:sched_two { @x[probe] = "
+       "@x[probe] + 1 }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -25,7 +26,7 @@ entry:
   %"@x_key" = alloca [8 x i8], align 8
   %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@x_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 0, i8* %1, align 8
+  store i64 0, [8 x i8]* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
@@ -41,7 +42,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = getelementptr inbounds [8 x i8], [8 x i8]* %"@x_key1", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  store i64 0, i8* %3, align 8
+  store i64 0, [8 x i8]* %"@x_key1", align 8
   %4 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
@@ -62,7 +63,7 @@ entry:
   %"@x_key" = alloca [8 x i8], align 8
   %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@x_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 1, i8* %1, align 8
+  store i64 1, [8 x i8]* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
@@ -78,7 +79,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = getelementptr inbounds [8 x i8], [8 x i8]* %"@x_key1", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  store i64 1, i8* %3, align 8
+  store i64 1, [8 x i8]* %"@x_key1", align 8
   %4 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8

--- a/tests/codegen/map_key_string.cpp
+++ b/tests/codegen/map_key_string.cpp
@@ -9,7 +9,7 @@ TEST(codegen, map_key_string)
   test("kprobe:f { @x[\"a\", \"b\"] = 44 }",
 
 #if LLVM_VERSION_MAJOR > 6
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -22,13 +22,13 @@ entry:
   %1 = getelementptr inbounds [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i8 97, i8* %1, align 1
-  %str.sroa.3.0..sroa_idx = getelementptr inbounds [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 1
+  %str.sroa.4.0..sroa_idx = getelementptr inbounds [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 1
   %str1.sroa.0.0..sroa_idx = getelementptr inbounds [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 64
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %str.sroa.3.0..sroa_idx, i8 0, i64 63, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %str.sroa.4.0..sroa_idx, i8 0, i64 63, i1 false)
   store i8 98, i8* %str1.sroa.0.0..sroa_idx, align 1
-  %str1.sroa.3.0..sroa_idx = getelementptr inbounds [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 65
+  %str1.sroa.4.0..sroa_idx = getelementptr inbounds [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 65
   %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %str1.sroa.3.0..sroa_idx, i8 0, i64 63, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %str1.sroa.4.0..sroa_idx, i8 0, i64 63, i1 false)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 44, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
@@ -48,7 +48,7 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #elif LLVM_VERSION_MAJOR == 6
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -61,13 +61,13 @@ entry:
   %1 = getelementptr inbounds [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i8 97, i8* %1, align 1
-  %str.sroa.3.0..sroa_idx = getelementptr inbounds [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 1
+  %str.sroa.4.0..sroa_idx = getelementptr inbounds [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 1
   %str1.sroa.0.0..sroa_idx = getelementptr inbounds [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 64
-  call void @llvm.memset.p0i8.i64(i8* nonnull %str.sroa.3.0..sroa_idx, i8 0, i64 63, i32 1, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* nonnull %str.sroa.4.0..sroa_idx, i8 0, i64 63, i32 1, i1 false)
   store i8 98, i8* %str1.sroa.0.0..sroa_idx, align 1
-  %str1.sroa.3.0..sroa_idx = getelementptr inbounds [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 65
+  %str1.sroa.4.0..sroa_idx = getelementptr inbounds [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 65
   %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.memset.p0i8.i64(i8* nonnull %str1.sroa.3.0..sroa_idx, i8 0, i64 63, i32 1, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* nonnull %str1.sroa.4.0..sroa_idx, i8 0, i64 63, i32 1, i1 false)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 44, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
@@ -87,7 +87,7 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #else
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -100,13 +100,13 @@ entry:
   %1 = getelementptr inbounds [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i8 97, i8* %1, align 1
-  %str.sroa.3.0..sroa_idx = getelementptr inbounds [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 1
+  %str.sroa.4.0..sroa_idx = getelementptr inbounds [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 1
   %str1.sroa.0.0..sroa_idx = getelementptr inbounds [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 64
-  call void @llvm.memset.p0i8.i64(i8* %str.sroa.3.0..sroa_idx, i8 0, i64 63, i32 1, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* %str.sroa.4.0..sroa_idx, i8 0, i64 63, i32 1, i1 false)
   store i8 98, i8* %str1.sroa.0.0..sroa_idx, align 1
-  %str1.sroa.3.0..sroa_idx = getelementptr inbounds [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 65
+  %str1.sroa.4.0..sroa_idx = getelementptr inbounds [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 65
   %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.memset.p0i8.i64(i8* %str1.sroa.3.0..sroa_idx, i8 0, i64 63, i32 1, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* %str1.sroa.4.0..sroa_idx, i8 0, i64 63, i32 1, i1 false)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 44, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)

--- a/tests/codegen/string_equal_comparison.cpp
+++ b/tests/codegen/string_equal_comparison.cpp
@@ -9,7 +9,7 @@ TEST(codegen, string_equal_comparison)
   test("kretprobe:vfs_read /comm == \"sshd\"/ { @[comm] = count(); }",
 
 #if LLVM_VERSION_MAJOR > 6
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -19,7 +19,6 @@ define i64 @"kretprobe:vfs_read"(i8* nocapture readnone) local_unnamed_addr sect
 entry:
   %"@_val" = alloca i64, align 8
   %comm9 = alloca [16 x i8], align 1
-  %"@_key" = alloca [16 x i8], align 1
   %comm = alloca [16 x i8], align 1
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
@@ -33,56 +32,53 @@ pred_false:                                       ; preds = %strcmp.loop5, %strc
   ret i64 0
 
 pred_true:                                        ; preds = %strcmp.loop5
-  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %"@_key", i64 0, i64 0
+  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %comm9, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %comm9, i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %4, i8 0, i64 16, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %3, i8 0, i64 16, i1 false)
   %get_comm10 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm9, i64 16)
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %3, i8* nonnull align 1 %4, i64 16, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %comm9)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 strcmp.loop:                                      ; preds = %entry
-  %5 = add [16 x i8]* %comm, i64 1
-  %6 = load i8, [16 x i8]* %5, align 1
-  %strcmp.cmp2 = icmp eq i8 %6, 115
+  %4 = add [16 x i8]* %comm, i64 1
+  %5 = load i8, [16 x i8]* %4, align 1
+  %strcmp.cmp2 = icmp eq i8 %5, 115
   br i1 %strcmp.cmp2, label %strcmp.loop1, label %pred_false
 
 strcmp.loop1:                                     ; preds = %strcmp.loop
-  %7 = add [16 x i8]* %comm, i64 2
-  %8 = load i8, [16 x i8]* %7, align 1
-  %strcmp.cmp4 = icmp eq i8 %8, 104
+  %6 = add [16 x i8]* %comm, i64 2
+  %7 = load i8, [16 x i8]* %6, align 1
+  %strcmp.cmp4 = icmp eq i8 %7, 104
   br i1 %strcmp.cmp4, label %strcmp.loop3, label %pred_false
 
 strcmp.loop3:                                     ; preds = %strcmp.loop1
-  %9 = add [16 x i8]* %comm, i64 3
-  %10 = load i8, [16 x i8]* %9, align 1
-  %strcmp.cmp6 = icmp eq i8 %10, 100
+  %8 = add [16 x i8]* %comm, i64 3
+  %9 = load i8, [16 x i8]* %8, align 1
+  %strcmp.cmp6 = icmp eq i8 %9, 100
   br i1 %strcmp.cmp6, label %strcmp.loop5, label %pred_false
 
 strcmp.loop5:                                     ; preds = %strcmp.loop3
-  %11 = add [16 x i8]* %comm, i64 4
-  %12 = load i8, [16 x i8]* %11, align 1
-  %strcmp.cmp8 = icmp eq i8 %12, 0
+  %10 = add [16 x i8]* %comm, i64 4
+  %11 = load i8, [16 x i8]* %10, align 1
+  %strcmp.cmp8 = icmp eq i8 %11, 0
   br i1 %strcmp.cmp8, label %pred_true, label %pred_false
 
 lookup_success:                                   ; preds = %pred_true
-  %13 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %13, 1
+  %12 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %12, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %pred_true, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %pred_true ]
-  %14 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %14)
+  %13 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %13)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo11, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo11, [16 x i8]* nonnull %comm9, i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %14)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %13)
   ret i64 0
 }
 
@@ -92,14 +88,11 @@ declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #1
-
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #else
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -109,7 +102,6 @@ define i64 @"kretprobe:vfs_read"(i8* nocapture readnone) local_unnamed_addr sect
 entry:
   %"@_val" = alloca i64, align 8
   %comm9 = alloca [16 x i8], align 1
-  %"@_key" = alloca [16 x i8], align 1
   %comm = alloca [16 x i8], align 1
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
@@ -123,56 +115,53 @@ pred_false:                                       ; preds = %strcmp.loop5, %strc
   ret i64 0
 
 pred_true:                                        ; preds = %strcmp.loop5
-  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %"@_key", i64 0, i64 0
+  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %comm9, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %comm9, i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  call void @llvm.memset.p0i8.i64(i8* nonnull %4, i8 0, i64 16, i32 1, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* nonnull %3, i8 0, i64 16, i32 1, i1 false)
   %get_comm10 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm9, i64 16)
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %3, i8* nonnull %4, i64 16, i32 1, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %comm9)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 strcmp.loop:                                      ; preds = %entry
-  %5 = add [16 x i8]* %comm, i64 1
-  %6 = load i8, [16 x i8]* %5, align 1
-  %strcmp.cmp2 = icmp eq i8 %6, 115
+  %4 = add [16 x i8]* %comm, i64 1
+  %5 = load i8, [16 x i8]* %4, align 1
+  %strcmp.cmp2 = icmp eq i8 %5, 115
   br i1 %strcmp.cmp2, label %strcmp.loop1, label %pred_false
 
 strcmp.loop1:                                     ; preds = %strcmp.loop
-  %7 = add [16 x i8]* %comm, i64 2
-  %8 = load i8, [16 x i8]* %7, align 1
-  %strcmp.cmp4 = icmp eq i8 %8, 104
+  %6 = add [16 x i8]* %comm, i64 2
+  %7 = load i8, [16 x i8]* %6, align 1
+  %strcmp.cmp4 = icmp eq i8 %7, 104
   br i1 %strcmp.cmp4, label %strcmp.loop3, label %pred_false
 
 strcmp.loop3:                                     ; preds = %strcmp.loop1
-  %9 = add [16 x i8]* %comm, i64 3
-  %10 = load i8, [16 x i8]* %9, align 1
-  %strcmp.cmp6 = icmp eq i8 %10, 100
+  %8 = add [16 x i8]* %comm, i64 3
+  %9 = load i8, [16 x i8]* %8, align 1
+  %strcmp.cmp6 = icmp eq i8 %9, 100
   br i1 %strcmp.cmp6, label %strcmp.loop5, label %pred_false
 
 strcmp.loop5:                                     ; preds = %strcmp.loop3
-  %11 = add [16 x i8]* %comm, i64 4
-  %12 = load i8, [16 x i8]* %11, align 1
-  %strcmp.cmp8 = icmp eq i8 %12, 0
+  %10 = add [16 x i8]* %comm, i64 4
+  %11 = load i8, [16 x i8]* %10, align 1
+  %strcmp.cmp8 = icmp eq i8 %11, 0
   br i1 %strcmp.cmp8, label %pred_true, label %pred_false
 
 lookup_success:                                   ; preds = %pred_true
-  %13 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %13, 1
+  %12 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %12, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %pred_true, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %pred_true ]
-  %14 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %14)
+  %13 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %13)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo11, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo11, [16 x i8]* nonnull %comm9, i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %14)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %13)
   ret i64 0
 }
 
@@ -181,9 +170,6 @@ declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i32, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/string_not_equal_comparison.cpp
+++ b/tests/codegen/string_not_equal_comparison.cpp
@@ -9,7 +9,7 @@ TEST(codegen, string_not_equal_comparison)
   test("kretprobe:vfs_read /comm != \"sshd\"/ { @[comm] = count(); }",
 
 #if LLVM_VERSION_MAJOR > 6
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -19,7 +19,6 @@ define i64 @"kretprobe:vfs_read"(i8* nocapture readnone) local_unnamed_addr sect
 entry:
   %"@_val" = alloca i64, align 8
   %comm9 = alloca [16 x i8], align 1
-  %"@_key" = alloca [16 x i8], align 1
   %comm = alloca [16 x i8], align 1
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
@@ -33,56 +32,53 @@ pred_false:                                       ; preds = %strcmp.loop5
   ret i64 0
 
 pred_true:                                        ; preds = %strcmp.loop5, %strcmp.loop3, %strcmp.loop1, %strcmp.loop, %entry
-  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %"@_key", i64 0, i64 0
+  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %comm9, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %comm9, i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %4, i8 0, i64 16, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %3, i8 0, i64 16, i1 false)
   %get_comm10 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm9, i64 16)
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %3, i8* nonnull align 1 %4, i64 16, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %comm9)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 strcmp.loop:                                      ; preds = %entry
-  %5 = add [16 x i8]* %comm, i64 1
-  %6 = load i8, [16 x i8]* %5, align 1
-  %strcmp.cmp2 = icmp eq i8 %6, 115
+  %4 = add [16 x i8]* %comm, i64 1
+  %5 = load i8, [16 x i8]* %4, align 1
+  %strcmp.cmp2 = icmp eq i8 %5, 115
   br i1 %strcmp.cmp2, label %strcmp.loop1, label %pred_true
 
 strcmp.loop1:                                     ; preds = %strcmp.loop
-  %7 = add [16 x i8]* %comm, i64 2
-  %8 = load i8, [16 x i8]* %7, align 1
-  %strcmp.cmp4 = icmp eq i8 %8, 104
+  %6 = add [16 x i8]* %comm, i64 2
+  %7 = load i8, [16 x i8]* %6, align 1
+  %strcmp.cmp4 = icmp eq i8 %7, 104
   br i1 %strcmp.cmp4, label %strcmp.loop3, label %pred_true
 
 strcmp.loop3:                                     ; preds = %strcmp.loop1
-  %9 = add [16 x i8]* %comm, i64 3
-  %10 = load i8, [16 x i8]* %9, align 1
-  %strcmp.cmp6 = icmp eq i8 %10, 100
+  %8 = add [16 x i8]* %comm, i64 3
+  %9 = load i8, [16 x i8]* %8, align 1
+  %strcmp.cmp6 = icmp eq i8 %9, 100
   br i1 %strcmp.cmp6, label %strcmp.loop5, label %pred_true
 
 strcmp.loop5:                                     ; preds = %strcmp.loop3
-  %11 = add [16 x i8]* %comm, i64 4
-  %12 = load i8, [16 x i8]* %11, align 1
-  %strcmp.cmp8 = icmp eq i8 %12, 0
+  %10 = add [16 x i8]* %comm, i64 4
+  %11 = load i8, [16 x i8]* %10, align 1
+  %strcmp.cmp8 = icmp eq i8 %11, 0
   br i1 %strcmp.cmp8, label %pred_false, label %pred_true
 
 lookup_success:                                   ; preds = %pred_true
-  %13 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %13, 1
+  %12 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %12, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %pred_true, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %pred_true ]
-  %14 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %14)
+  %13 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %13)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo11, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo11, [16 x i8]* nonnull %comm9, i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %14)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %13)
   ret i64 0
 }
 
@@ -92,14 +88,11 @@ declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #1
-
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #else
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -109,7 +102,6 @@ define i64 @"kretprobe:vfs_read"(i8* nocapture readnone) local_unnamed_addr sect
 entry:
   %"@_val" = alloca i64, align 8
   %comm9 = alloca [16 x i8], align 1
-  %"@_key" = alloca [16 x i8], align 1
   %comm = alloca [16 x i8], align 1
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
@@ -123,56 +115,53 @@ pred_false:                                       ; preds = %strcmp.loop5
   ret i64 0
 
 pred_true:                                        ; preds = %strcmp.loop5, %strcmp.loop3, %strcmp.loop1, %strcmp.loop, %entry
-  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %"@_key", i64 0, i64 0
+  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %comm9, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %comm9, i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  call void @llvm.memset.p0i8.i64(i8* nonnull %4, i8 0, i64 16, i32 1, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* nonnull %3, i8 0, i64 16, i32 1, i1 false)
   %get_comm10 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm9, i64 16)
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %3, i8* nonnull %4, i64 16, i32 1, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %comm9)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 strcmp.loop:                                      ; preds = %entry
-  %5 = add [16 x i8]* %comm, i64 1
-  %6 = load i8, [16 x i8]* %5, align 1
-  %strcmp.cmp2 = icmp eq i8 %6, 115
+  %4 = add [16 x i8]* %comm, i64 1
+  %5 = load i8, [16 x i8]* %4, align 1
+  %strcmp.cmp2 = icmp eq i8 %5, 115
   br i1 %strcmp.cmp2, label %strcmp.loop1, label %pred_true
 
 strcmp.loop1:                                     ; preds = %strcmp.loop
-  %7 = add [16 x i8]* %comm, i64 2
-  %8 = load i8, [16 x i8]* %7, align 1
-  %strcmp.cmp4 = icmp eq i8 %8, 104
+  %6 = add [16 x i8]* %comm, i64 2
+  %7 = load i8, [16 x i8]* %6, align 1
+  %strcmp.cmp4 = icmp eq i8 %7, 104
   br i1 %strcmp.cmp4, label %strcmp.loop3, label %pred_true
 
 strcmp.loop3:                                     ; preds = %strcmp.loop1
-  %9 = add [16 x i8]* %comm, i64 3
-  %10 = load i8, [16 x i8]* %9, align 1
-  %strcmp.cmp6 = icmp eq i8 %10, 100
+  %8 = add [16 x i8]* %comm, i64 3
+  %9 = load i8, [16 x i8]* %8, align 1
+  %strcmp.cmp6 = icmp eq i8 %9, 100
   br i1 %strcmp.cmp6, label %strcmp.loop5, label %pred_true
 
 strcmp.loop5:                                     ; preds = %strcmp.loop3
-  %11 = add [16 x i8]* %comm, i64 4
-  %12 = load i8, [16 x i8]* %11, align 1
-  %strcmp.cmp8 = icmp eq i8 %12, 0
+  %10 = add [16 x i8]* %comm, i64 4
+  %11 = load i8, [16 x i8]* %10, align 1
+  %strcmp.cmp8 = icmp eq i8 %11, 0
   br i1 %strcmp.cmp8, label %pred_false, label %pred_true
 
 lookup_success:                                   ; preds = %pred_true
-  %13 = load i64, i8* %lookup_elem, align 8
-  %phitmp = add i64 %13, 1
+  %12 = load i64, i8* %lookup_elem, align 8
+  %phitmp = add i64 %12, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %pred_true, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %pred_true ]
-  %14 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %14)
+  %13 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %13)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo11, [16 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo11, [16 x i8]* nonnull %comm9, i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %14)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %13)
   ret i64 0
 }
 
@@ -181,9 +170,6 @@ declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i32, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/ternary_str.cpp
+++ b/tests/codegen/ternary_str.cpp
@@ -9,7 +9,7 @@ TEST(codegen, ternary_str)
   test("kprobe:f { @x = pid < 10000 ? \"lo\" : \"hi\"; }",
 
 #if LLVM_VERSION_MAJOR > 6
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -27,18 +27,18 @@ entry:
 
 left:                                             ; preds = %entry
   store i8 108, i8* %1, align 1
-  %str.sroa.3.0..sroa_idx = getelementptr inbounds [64 x i8], [64 x i8]* %buf, i64 0, i64 1
-  store i8 111, i8* %str.sroa.3.0..sroa_idx, align 1
-  %str.sroa.4.0..sroa_idx = getelementptr inbounds [64 x i8], [64 x i8]* %buf, i64 0, i64 2
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %str.sroa.4.0..sroa_idx, i8 0, i64 61, i1 false)
+  %str.sroa.4.0..sroa_idx = getelementptr inbounds [64 x i8], [64 x i8]* %buf, i64 0, i64 1
+  store i8 111, i8* %str.sroa.4.0..sroa_idx, align 1
+  %str.sroa.5.0..sroa_idx = getelementptr inbounds [64 x i8], [64 x i8]* %buf, i64 0, i64 2
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %str.sroa.5.0..sroa_idx, i8 0, i64 61, i1 false)
   br label %done
 
 right:                                            ; preds = %entry
   store i8 104, i8* %1, align 1
-  %str1.sroa.3.0..sroa_idx = getelementptr inbounds [64 x i8], [64 x i8]* %buf, i64 0, i64 1
-  store i8 105, i8* %str1.sroa.3.0..sroa_idx, align 1
-  %str1.sroa.4.0..sroa_idx = getelementptr inbounds [64 x i8], [64 x i8]* %buf, i64 0, i64 2
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %str1.sroa.4.0..sroa_idx, i8 0, i64 61, i1 false)
+  %str1.sroa.4.0..sroa_idx = getelementptr inbounds [64 x i8], [64 x i8]* %buf, i64 0, i64 1
+  store i8 105, i8* %str1.sroa.4.0..sroa_idx, align 1
+  %str1.sroa.5.0..sroa_idx = getelementptr inbounds [64 x i8], [64 x i8]* %buf, i64 0, i64 2
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %str1.sroa.5.0..sroa_idx, i8 0, i64 61, i1 false)
   br label %done
 
 done:                                             ; preds = %right, %left
@@ -64,7 +64,7 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #elif LLVM_VERSION_MAJOR == 6
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -82,18 +82,18 @@ entry:
 
 left:                                             ; preds = %entry
   store i8 108, i8* %1, align 1
-  %str.sroa.3.0..sroa_idx = getelementptr inbounds [64 x i8], [64 x i8]* %buf, i64 0, i64 1
-  store i8 111, i8* %str.sroa.3.0..sroa_idx, align 1
-  %str.sroa.4.0..sroa_idx = getelementptr inbounds [64 x i8], [64 x i8]* %buf, i64 0, i64 2
-  call void @llvm.memset.p0i8.i64(i8* nonnull %str.sroa.4.0..sroa_idx, i8 0, i64 61, i32 1, i1 false)
+  %str.sroa.4.0..sroa_idx = getelementptr inbounds [64 x i8], [64 x i8]* %buf, i64 0, i64 1
+  store i8 111, i8* %str.sroa.4.0..sroa_idx, align 1
+  %str.sroa.5.0..sroa_idx = getelementptr inbounds [64 x i8], [64 x i8]* %buf, i64 0, i64 2
+  call void @llvm.memset.p0i8.i64(i8* nonnull %str.sroa.5.0..sroa_idx, i8 0, i64 61, i32 1, i1 false)
   br label %done
 
 right:                                            ; preds = %entry
   store i8 104, i8* %1, align 1
-  %str1.sroa.3.0..sroa_idx = getelementptr inbounds [64 x i8], [64 x i8]* %buf, i64 0, i64 1
-  store i8 105, i8* %str1.sroa.3.0..sroa_idx, align 1
-  %str1.sroa.4.0..sroa_idx = getelementptr inbounds [64 x i8], [64 x i8]* %buf, i64 0, i64 2
-  call void @llvm.memset.p0i8.i64(i8* nonnull %str1.sroa.4.0..sroa_idx, i8 0, i64 61, i32 1, i1 false)
+  %str1.sroa.4.0..sroa_idx = getelementptr inbounds [64 x i8], [64 x i8]* %buf, i64 0, i64 1
+  store i8 105, i8* %str1.sroa.4.0..sroa_idx, align 1
+  %str1.sroa.5.0..sroa_idx = getelementptr inbounds [64 x i8], [64 x i8]* %buf, i64 0, i64 2
+  call void @llvm.memset.p0i8.i64(i8* nonnull %str1.sroa.5.0..sroa_idx, i8 0, i64 61, i32 1, i1 false)
   br label %done
 
 done:                                             ; preds = %right, %left
@@ -119,7 +119,7 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #else
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -136,11 +136,11 @@ entry:
   %.sink128 = select i1 %2, i8 108, i8 104
   %.sink = select i1 %2, i8 111, i8 105
   store i8 %.sink128, i8* %1, align 1
-  %str1.sroa.3.0..sroa_idx = getelementptr inbounds [64 x i8], [64 x i8]* %buf, i64 0, i64 1
-  store i8 %.sink, i8* %str1.sroa.3.0..sroa_idx, align 1
-  %str1.sroa.4.0..sroa_idx = getelementptr inbounds [64 x i8], [64 x i8]* %buf, i64 0, i64 2
+  %str1.sroa.4.0..sroa_idx = getelementptr inbounds [64 x i8], [64 x i8]* %buf, i64 0, i64 1
+  store i8 %.sink, i8* %str1.sroa.4.0..sroa_idx, align 1
+  %str1.sroa.5.0..sroa_idx = getelementptr inbounds [64 x i8], [64 x i8]* %buf, i64 0, i64 2
   %3 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.memset.p0i8.i64(i8* %str1.sroa.4.0..sroa_idx, i8 0, i64 62, i32 1, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* %str1.sroa.5.0..sroa_idx, i8 0, i64 62, i32 1, i1 false)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)

--- a/tests/codegen/variable.cpp
+++ b/tests/codegen/variable.cpp
@@ -9,7 +9,7 @@ TEST(codegen, variable)
   test("kprobe:f { $var = comm; @x = $var; @y = $var }",
 
 #if LLVM_VERSION_MAJOR > 6
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -30,6 +30,7 @@ entry:
   %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %1, i8* nonnull align 1 %2, i64 16, i1 false)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
@@ -58,7 +59,7 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #else
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -79,6 +80,7 @@ entry:
   %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %1, i8* nonnull %2, i64 16, i32 1, i1 false)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8


### PR DESCRIPTION
Currently `AllocaInst` object returned by `CreateMapLookupElem()` or
`comm` is not marked with `llvm.lifetime.end` after memcpy. Therefore it
can easily consume the stack. For example:

```
% bpftrace -e 'BEGIN { @x = "foo"; unroll(10) { printf("%s\n", @x);} }'
error: <unknown>:0:0: in function BEGIN i64 (i8*): Looks like the BPF stack limit of 512 bytes is exceeded. Please move large on stack variables into BPF per-cpu array map.
```

This patch fixes it.