### PR TITLE
Minor btf cleanups

### DIFF
--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -240,7 +240,7 @@ std::string BTF::c_def(std::unordered_set<std::string>& set)
   return ret;
 }
 
-std::string BTF::type_of(std::string name, std::string field)
+std::string BTF::type_of(const std::string& name, const std::string& field)
 {
   __s32 type_id = btf__find_by_name(btf, name.c_str());
 
@@ -296,8 +296,10 @@ BTF::~BTF() { }
 
 std::string BTF::c_def(std::unordered_set<std::string>& set __attribute__((__unused__))) { return std::string(""); }
 
-std::string BTF::type_of(std::string name __attribute__((__unused__)),
-                         std::string field __attribute__((__unused__))) { return std::string(""); }
+std::string BTF::type_of(const std::string& name __attribute__((__unused__)),
+                         const std::string& field __attribute__((__unused__))) {
+  return std::string("");
+}
 
 } // namespace bpftrace
 

--- a/src/btf.h
+++ b/src/btf.h
@@ -21,7 +21,7 @@ public:
 
   bool has_data(void);
   std::string c_def(std::unordered_set<std::string>& set);
-  std::string type_of(std::string name, std::string field);
+  std::string type_of(const std::string& name, const std::string& field);
 
 private:
   struct btf *btf;

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -567,10 +567,11 @@ class clang_parser_btf : public ::testing::Test {
   {
     // clear the environment and remove the temp file
     unsetenv("BPFTRACE_BTF_TEST");
-    std::remove(path_);
+    if (path_)
+      std::remove(path_);
   }
 
-  char *path_;
+  char *path_ = nullptr;
 };
 
 TEST_F(clang_parser_btf, btf)


### PR DESCRIPTION
Two minor cleanups:
* use const refs whenever possible
* handle uninitialized use of path_
  * TearDown() can be called even if SetUp() fails. In this case, we'd
    call std::remove(path_) where path_ is uninitialized