### PR TITLE
Uretprobe at  address

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -316,7 +316,7 @@ public:
               location loc=location())
     : Node(loc), provider(probetypeName(provider)), target(target), need_expansion(true)
   {
-    if (this->provider == "uprobe")
+    if (this->provider == "uprobe" || this->provider == "uretprobe")
       address = val;
     else
       freq = val;

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1224,9 +1224,12 @@ void SemanticAnalyser::visit(AttachPoint &ap)
   }
   else if (ap.provider == "uprobe" || ap.provider == "uretprobe") {
     if (ap.target == "")
-      err_ << "uprobes should have a target" << std::endl;
+      err_ << ap.provider << " should have a target" << std::endl;
     if (ap.func == "" && ap.address == 0)
-      err_ << "uprobes should be attached to a function or address" << std::endl;
+      err_ << ap.provider << " should be attached to a function and/or address" << std::endl;
+
+    if (ap.provider == "uretprobe" && ap.func_offset != 0)
+      err_ << "uretprobes can not be attached to a function offset" << std::endl;
 
     auto paths = resolve_binary_path(ap.target);
     if (paths.size() > 1)

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -307,6 +307,13 @@ void AttachedProbe::resolve_offset_uprobe(bool safe_mode)
       throw std::runtime_error("Could not resolve symbol: " + probe_.path + ":" + symbol);
   }
 
+  if (probe_.type == ProbeType::uretprobe && func_offset != 0) {
+    std::stringstream msg;
+    msg << "uretprobes cannot be attached at function offset. "
+        << "(address resolved to: " << symbol << "+" << func_offset << ")";
+    throw std::runtime_error(msg.str());
+  }
+
   if (func_offset >= sym.size) {
     std::stringstream ss;
     ss << sym.size;

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -61,6 +61,16 @@ TEST(ast, probe_name_uprobe)
   AttachPointList attach_points5 = { &ap5 };
   Probe uprobe5(&attach_points5, nullptr, nullptr);
   EXPECT_EQ(uprobe5.name(), "uprobe:/bin/sh:10");
+
+  AttachPoint ap6("ur", "/bin/sh", (uint64_t) 10);
+  AttachPointList attach_points6 = { &ap6 };
+  Probe uprobe6(&attach_points6, nullptr, nullptr);
+  EXPECT_EQ(uprobe6.name(), "uretprobe:/bin/sh:10");
+
+  AttachPoint ap7("uretprobe", "/bin/sh", (uint64_t)1000);
+  AttachPointList attach_points7 = { &ap7 };
+  Probe uprobe7(&attach_points7, nullptr, nullptr);
+  EXPECT_EQ(uprobe7.name(), "uretprobe:/bin/sh:1000");
 }
 
 TEST(ast, probe_name_usdt)

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -836,7 +836,13 @@ TEST(semantic_analyser, uprobe)
   test("uprobe { 1 }", 1);
 
   test("uretprobe:/bin/sh:f { 1 }", 0);
+  test("ur:/bin/sh:f { 1 }", 0);
   test("uretprobe:sh:f { 1 }", 0);
+  test("ur:sh:f { 1 }", 0);
+  test("uretprobe:/bin/sh:0x10 { 1 }", 0);
+  test("ur:/bin/sh:0x10 { 1 }", 0);
+  test("uretprobe:/bin/sh:f+0x10 { 1 }", 1);
+  test("ur:/bin/sh:f+0x10 { 1 }", 1);
   test("uretprobe:/notexistfile:f { 1 }", 1);
   test("uretprobe:notexistfile:f { 1 }", 1);
   test("uretprobe:f { 1 }", 1);


### PR DESCRIPTION
This makes it possible to attach an uretprobe at an address:

```
$ bpftrace -e 'ur:/bin/bash:0xaed00 {}'
```

Attaching at a function offset is not allowed as it does not work (the
kernel does allow it):

```
$ bpftrace -e  'ur:/bin/bash:main+3 {}'
uretprobes can not be attached to a function offset
```

Neither is attaching to an address that is not the start of a function:

```
$ bpftrace -e  'ur:/bin/bash:0xaed03 {}'
Attaching 1 probe...
uretprobes cannot be attached at function offset. (address resolved to: readline+3)
```
