### PR TITLE
Disable builtin.cgroup runtime test in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,26 +23,26 @@ matrix:
       env: LLVM_VERSION=5.0 BASE=alpine TYPE=Release STATIC_LINKING=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*:codegen.args_multiple_tracepoints*:codegen.logical_and_or_different_type"
 
     - name: "LLVM 6 Debug"
-      env: LLVM_VERSION=6.0 BASE=bionic TYPE=Debug RUN_ALL_TESTS=1
+      env: LLVM_VERSION=6.0 BASE=bionic TYPE=Debug RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup
     - name: "LLVM 6 Release"
-      env: LLVM_VERSION=6.0 BASE=bionic TYPE=Release RUN_ALL_TESTS=1
+      env: LLVM_VERSION=6.0 BASE=bionic TYPE=Release RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup
 
     - name: "LLVM 7 Debug"
-      env: LLVM_VERSION=7 BASE=bionic TYPE=Debug RUN_ALL_TESTS=1
+      env: LLVM_VERSION=7 BASE=bionic TYPE=Debug RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup
     - name: "LLVM 7 Release"
-      env: LLVM_VERSION=7 BASE=bionic TYPE=Release RUN_ALL_TESTS=1
+      env: LLVM_VERSION=7 BASE=bionic TYPE=Release RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup
 
     - name: "LLVM 8 Debug"
-      env: LLVM_VERSION=8 BASE=bionic TYPE=Debug RUN_ALL_TESTS=1
+      env: LLVM_VERSION=8 BASE=bionic TYPE=Debug RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup
     - name: "LLVM 8 Release"
-      env: LLVM_VERSION=8 BASE=bionic TYPE=Release RUN_ALL_TESTS=1
+      env: LLVM_VERSION=8 BASE=bionic TYPE=Release RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup
 
 install:
   - sudo apt-get install linux-headers-$(uname -r)
   - docker build --build-arg LLVM_VERSION=$LLVM_VERSION -t bpftrace-builder-$BASE-llvm-$LLVM_VERSION -f docker/Dockerfile.$BASE docker/
 
 script:
-  - sudo docker run --privileged --rm -it -v $(pwd):$(pwd) -v /sys/kernel/debug:/sys/kernel/debug:rw -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -e STATIC_LINKING=$STATIC_LINKING -e RUN_ALL_TESTS=$RUN_ALL_TESTS -e TEST_ARGS=$TEST_ARGS bpftrace-builder-$BASE-llvm-$LLVM_VERSION $(pwd)/build-$TYPE-$BASE $TYPE -j`getconf _NPROCESSORS_ONLN`
+  - sudo docker run --privileged --rm -it -v $(pwd):$(pwd) -v /sys/kernel/debug:/sys/kernel/debug:rw -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -e STATIC_LINKING=$STATIC_LINKING -e RUN_ALL_TESTS=$RUN_ALL_TESTS -e TEST_ARGS=$TEST_ARGS -e RUNTIME_TEST_DISABLE=$RUNTIME_TEST_DISABLE bpftrace-builder-$BASE-llvm-$LLVM_VERSION $(pwd)/build-$TYPE-$BASE $TYPE -j`getconf _NPROCESSORS_ONLN`
 
 notifications:
   irc:

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -39,6 +39,7 @@ class Utils(object):
     SKIP_KERNEL_VERSION = 2
     TIMEOUT = 3
     SKIP_REQUIREMENT_UNSATISFIED = 4
+    SKIP_ENVIRONMENT_DISABLED = 5
 
     @staticmethod
     def failed(status):
@@ -46,7 +47,11 @@ class Utils(object):
 
     @staticmethod
     def skipped(status):
-        return status in [Utils.SKIP_KERNEL_VERSION, Utils.SKIP_REQUIREMENT_UNSATISFIED]
+        return status in [
+            Utils.SKIP_KERNEL_VERSION,
+            Utils.SKIP_REQUIREMENT_UNSATISFIED,
+            Utils.SKIP_ENVIRONMENT_DISABLED,
+        ]
 
     @staticmethod
     def skip_reason(test, status):
@@ -54,6 +59,8 @@ class Utils(object):
             return "min Kernel: %s" % test.kernel
         elif status == Utils.SKIP_REQUIREMENT_UNSATISFIED:
             return "unmet condition: '%s'" % test.requirement
+        elif status == Utils.SKIP_ENVIRONMENT_DISABLED:
+            return "disabled by environment variable"
         else:
             raise ValueError("Invalid skip reason: %d" % status)
 
@@ -71,6 +78,11 @@ class Utils(object):
         if test.kernel and LooseVersion(test.kernel) > current_kernel:
             print(warn("[   SKIP   ] ") + "%s.%s" % (test.suite, test.name))
             return Utils.SKIP_KERNEL_VERSION
+
+        full_test_name = test.suite + "." + test.name
+        if full_test_name in os.getenv("RUNTIME_TEST_DISABLE", "").split(","):
+            print(warn("[   SKIP   ] ") + "%s.%s" % (test.suite, test.name))
+            return Utils.SKIP_ENVIRONMENT_DISABLED
 
         signal.signal(signal.SIGALRM, Utils.__handler)
 


### PR DESCRIPTION
It seems ubuntu diverges a bit from upstream linux for bpf helpers.
Despite already being at 5.0, the 5.0.0-1026-gcp kernel is missing
the cgroup helper. The cgroup helper should have been available in
v4.17-rc6-2000-gbf6fa2c893c5 as commit bf6fa2c893c5237b4
("bpf: implement bpf_get_current_cgroup_id() helper").

Rather than bump the kernel version requirement on the test again,
let's just disable this test indefinitely because I don't really know
how to predict when ubuntu will have this helper.