### PR TITLE
Fix some compiler warnings

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1413,8 +1413,8 @@ int SemanticAnalyser::analyse()
 
 int SemanticAnalyser::create_maps(bool debug)
 {
-  int failed_maps = 0;
-  auto is_invalid_map = [](int a) { return (int)(a < 0); };
+  uint32_t failed_maps = 0;
+  auto is_invalid_map = [](int a) -> uint8_t { return a < 0 ? 1 : 0; };
   for (auto &map_val : map_val_)
   {
     std::string map_name = map_val.first;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -331,7 +331,7 @@ void BPFtrace::kill_child()
   if (child_running_) {
     kill(child_pid(), SIGTERM);
   } else {
-    write(child_start_pipe_, &CHILD_EXIT_QUIETLY, 1);
+    (void)write(child_start_pipe_, &CHILD_EXIT_QUIETLY, 1);
     close(child_start_pipe_);
   }
 }


### PR DESCRIPTION
Saw these when troubleshooting CI:

```
home/travis/build/iovisor/bpftrace/src/ast/semantic_analyser.cpp:1501:3: warning: assuming signed overflow does not occur when simplifying conditional [-Wstrict-overflow]

   if (failed_maps > 0)

   ^~
```
```
/home/travis/build/iovisor/bpftrace/src/bpftrace.cpp:334:10: warning: ignoring return value of 'ssize_t write(int, const void*, size_t)', declared with attribute warn_unused_result [-Wunused-result]

     write(child_start_pipe_, &CHILD_EXIT_QUIETLY, 1);

     ~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```