### PR TITLE
Silence test suite

### DIFF
--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -20,7 +20,6 @@ void setup_mock_bpftrace(MockBPFtrace &bpftrace)
                             "my_one\n"
                             "my_two\n";
         auto myval = std::unique_ptr<std::istream>(new std::istringstream(ksyms));
-        printf("doing ok\n");
         return myval;
       });
 

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -13,7 +13,8 @@ using Printer = ast::Printer;
 void test_parse_failure(const std::string &input)
 {
   BPFtrace bpftrace;
-  Driver driver(bpftrace);
+  std::stringstream out;
+  Driver driver(bpftrace, out);
   ASSERT_EQ(driver.parse_str(input), 1);
 }
 


### PR DESCRIPTION
This removes some of the "junk" from the tests:

```
[ RUN      ] Parser.call_builtin
stdin:1:7-12: ERROR: Unknown function: nsecs
k:f { nsecs(); }
      ~~~~~
stdin:1:7-12: ERROR: Unknown function: nsecs
k:f { nsecs  (); }
      ~~~~~
```

Fixes: #456