### PR TITLE
Fix uprobe listing and attaching when target is in a separate mount namespace

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1341,7 +1341,7 @@ void SemanticAnalyser::visit(AttachPoint &ap)
     if (ap.provider == "uretprobe" && ap.func_offset != 0)
       error("uretprobes can not be attached to a function offset", ap.loc);
 
-    auto paths = resolve_binary_path(ap.target);
+    auto paths = resolve_binary_path(ap.target, bpftrace_.pid_);
     switch (paths.size())
     {
     case 0:

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -152,7 +152,7 @@ void list_probes(const BPFtrace &bpftrace, const std::string &search_input)
     if (bpftrace.pid_ > 0)
     {
       executable = get_pid_exe(bpftrace.pid_);
-      absolute_exe = executable;
+      absolute_exe = path_for_pid_mountns(bpftrace.pid_, executable);
     } else if (probe_name == "uprobe")
     {
       executable = search.substr(search.find(":") + 1, search.size());

--- a/src/utils.h
+++ b/src/utils.h
@@ -14,6 +14,22 @@ typedef enum _USDT_TUPLE_ORDER_ { USDT_PATH_INDEX, USDT_PROVIDER_INDEX, USDT_FNA
 typedef std::tuple<std::string, std::string, std::string> usdt_probe_entry;
 typedef std::vector<usdt_probe_entry> usdt_probe_list;
 
+class MountNSException : public std::exception
+{
+public:
+  MountNSException(const std::string &msg) : msg_(msg)
+  {
+  }
+
+  const char *what() const noexcept override
+  {
+    return msg_.c_str();
+  }
+
+private:
+  std::string msg_;
+};
+
 class USDTHelper
 {
 public:
@@ -78,6 +94,8 @@ std::string is_deprecated(std::string &str);
 bool is_unsafe_func(const std::string &func_name);
 std::string exec_system(const char* cmd);
 std::vector<std::string> resolve_binary_path(const std::string& cmd);
+std::vector<std::string> resolve_binary_path(const std::string &cmd, int pid);
+std::string path_for_pid_mountns(int pid, const std::string &path);
 void cat_file(const char *filename, size_t, std::ostream&);
 std::string str_join(const std::vector<std::string> &list, const std::string &delim);
 bool is_numeric(const std::string &str);

--- a/tests/runtime/uprobe
+++ b/tests/runtime/uprobe
@@ -34,3 +34,15 @@ RUN bpftrace -l 'uprobe:*' -p $(pidof uprobe_test)
 EXPECT uprobe:.*/testprogs/uprobe_test:function1
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
+
+NAME "uprobes - list probes by pid in separate mount namespace"
+RUN bpftrace -l -p $(pidof uprobe_test) | grep -e '^uprobe'
+EXPECT uprobe:.*/bpftrace-unshare-mountns-test/uprobe_test:function1
+TIMEOUT 5
+BEFORE ./testprogs/mountns_wrapper uprobe_test
+
+NAME "uprobes - attach to probe for executable in separate mount namespace"
+RUN bpftrace -e 'uprobe:/tmp/bpftrace-unshare-mountns-test/uprobe_test:function1 { printf("here\n" ); exit(); }' -p $(pidof uprobe_test)
+EXPECT Attaching 1 probe...
+TIMEOUT 5
+BEFORE ./testprogs/mountns_wrapper uprobe_test

--- a/tests/testprogs/mountns_wrapper.c
+++ b/tests/testprogs/mountns_wrapper.c
@@ -1,0 +1,76 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
+#include <errno.h>
+#include <libgen.h>
+#include <linux/limits.h>
+#include <sched.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#define errExit(msg)                                                           \
+  do                                                                           \
+  {                                                                            \
+    perror(msg);                                                               \
+    exit(EXIT_FAILURE);                                                        \
+  } while (0)
+
+/*
+Run another simple test program in a different mount namespace.
+
+usage: mountns_wrapper some_testprog
+
+The test program directory is bind-mounted into a path that is private to
+its mount namespace.
+
+bpftrace will run from the caller's mount namespace, before the unshare. This
+will cause bpftrace to not be able to see the path within its own mount
+namespace. To access the path, bpftrace must use /proc/PID/root, to see the
+mount namespace from the target PID's perspective.
+
+This is useful for both uprobe and USDT tests, to ensure that bpftrace can
+target processes running in containers, such as docker.
+
+LIMITATIONS: doesn't pass arguments to test program, as this hasn't been
+necessary yet.
+*/
+
+int main(int argc, char *argv[])
+{
+
+  const char *private_mount = "/tmp/bpftrace-unshare-mountns-test";
+  char dpath[PATH_MAX];
+  char exe[PATH_MAX];
+
+  if (argc != 2)
+    errExit("Must specify test program as only argument.");
+
+  // Enter a new mount namespace
+  if (unshare(CLONE_NEWNS) != 0)
+    errExit("Failed to unshare");
+
+  // Recursively set the mount namespace to private, so caller can't see
+  if (mount(NULL, "/", NULL, MS_REC | MS_PRIVATE, NULL) != 0)
+    errExit("Failed to make mount private");
+
+  // make a tempdir and bind mount containing testprog folder to it
+  if (mkdir(private_mount, 0770) != 0 && (errno != EEXIST))
+    errExit("Failed to make private mount dir");
+
+  int idx = readlink("/proc/self/exe", dpath, sizeof(dpath) - 1);
+  dpath[idx] = '\0';
+
+  char *dname = dirname(dpath);
+  if (mount(dname, private_mount, NULL, MS_BIND, NULL) != 0)
+    errExit("Failed to set up private bind mount");
+
+  snprintf(exe, PATH_MAX, "%s/%s", private_mount, argv[1]);
+  char *args[] = { exe, NULL };
+
+  return execvp(args[0], args);
+}


### PR DESCRIPTION
Fixes https://github.com/iovisor/bpftrace/issues/968, at least for uprobes.

I'll follow up with a separate issue and patches for USDT probes, which I think are being similarly mishandled when the target is in a separate mount namespace.

I wrote two new regression tests, which utilize a wrapper  (mountns_wrapper.c) that I made for the runtime tests which will create a new mount namespace, and privately bind mount the test program folder there. This simulates a docker container somewhat, as the path won't be visible to bpftrace, which is in a separate mount namespace. This is, I think, about the smallest, simplest wrapper I could use to reproduce the issue.

Both regression tests fail without my changes, and pass with them.

My changes are pretty simple:

* In the semantic analyzer, if a PID is specified, then the target path has /proc/PID/root prepended to it. This allows attaching to probes in where the binary being uprobed is in a different mount namespace. There don't seem to be any side effects to just prepending the /proc relative root path, as all of the other tests including runtime tests continue to pass.
* In the list code, there is already special handling for if a PID is specified. I just make the absolute path include the /proc/PID/root bits at the front, and it allows listing probes for a binary in a separate mount namespace.

@danobi @fbs @mmarchini please take a look when you have a chance