### PR TITLE
Fix codegen for modulo operation

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -875,7 +875,11 @@ void CodegenLLVM::visit(Binop &binop)
       case bpftrace::Parser::token::MUL:   expr_ = b_.CreateMul    (lhs, rhs); break;
       case bpftrace::Parser::token::DIV:   expr_ = b_.CreateUDiv   (lhs, rhs); break;
       case bpftrace::Parser::token::MOD: {
-        expr_ = do_signed ? b_.CreateSRem(lhs, rhs) : b_.CreateURem(lhs, rhs);
+        // Always do an unsigned modulo operation here even if `do_signed`
+        // is true. bpf instruction set does not support signed divison.
+        // We already warn in the semantic analyser that signed modulo can
+        // lead to undefined behavior (because we will treat it as unsigned).
+        expr_ = b_.CreateURem(lhs, rhs);
         break;
       }
       case bpftrace::Parser::token::BAND:  expr_ = b_.CreateAnd    (lhs, rhs); break;

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -895,7 +895,8 @@ void SemanticAnalyser::visit(Binop &binop)
       //
       // SDIV is not implemented for bpf. See Documentation/bpf/bpf_design_QA
       // in kernel sources
-      if (binop.op == bpftrace::Parser::token::DIV) {
+      if (binop.op == bpftrace::Parser::token::DIV ||
+          binop.op == bpftrace::Parser::token::MOD) {
         // Convert operands to unsigned if possible
         if (lsign && left->is_literal && get_int_literal(left) >= 0)
           left->type.is_signed = lsign = false;

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -834,8 +834,8 @@ void SemanticAnalyser::visit(Binop &binop)
     }
     // Follow what C does
     else if (lhs == Type::integer && rhs == Type::integer) {
-      auto &left = binop.left;
-      auto &right = binop.right;
+      auto left = binop.left;
+      auto right = binop.right;
       long lval = static_cast<ast::Integer*>(binop.left)->n;
       long rval = static_cast<ast::Integer*>(binop.right)->n;
 

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -831,14 +831,17 @@ void SemanticAnalyser::visit(Binop &binop)
       buf << "comparing '" << lhs << "' ";
       buf << "with '" << rhs << "'";
       bpftrace_.error(err_, binop.left->loc + binop.right->loc, buf.str());
+      buf.str({});
     }
     // Follow what C does
     else if (lhs == Type::integer && rhs == Type::integer) {
+      auto get_int_literal = [](const auto expr) -> long {
+        return static_cast<ast::Integer*>(expr)->n;
+      };
       auto left = binop.left;
       auto right = binop.right;
-      long lval = static_cast<ast::Integer*>(binop.left)->n;
-      long rval = static_cast<ast::Integer*>(binop.right)->n;
 
+      // First check if operand signedness is the same
       if (lsign != rsign) {
         // Convert operands to unsigned if it helps make (lsign == rsign)
         //
@@ -849,12 +852,11 @@ void SemanticAnalyser::visit(Binop &binop)
         //
         // No warning should be emitted as we know that 10 can be
         // represented as unsigned int
-        if (lsign && !rsign && left->is_literal && lval >= 0) {
+        if (lsign && !rsign && left->is_literal && get_int_literal(left) >= 0) {
           left->type.is_signed = lsign = false;
-
         }
         // The reverse (10 < a) should also hold
-        else if (!lsign && rsign && right->is_literal && rval >= 0) {
+        else if (!lsign && rsign && right->is_literal && get_int_literal(right) >= 0) {
           right->type.is_signed = rsign = false;
         }
         else {
@@ -870,6 +872,7 @@ void SemanticAnalyser::visit(Binop &binop)
                 << binop.right->type << "'"
                 << " can lead to undefined behavior";
             bpftrace_.warning(out_, binop.loc, buf.str());
+            buf.str({});
             break;
           case bpftrace::Parser::token::PLUS:
           case bpftrace::Parser::token::MINUS:
@@ -880,22 +883,32 @@ void SemanticAnalyser::visit(Binop &binop)
                 << left->type << "' and '" << right->type << "'"
                 << " can lead to undefined behavior";
             bpftrace_.warning(out_, binop.loc, buf.str());
+            buf.str({});
             break;
           default:
             break;
           }
         }
       }
-      else if (lval < 0 || rval < 0) {
-        // SDIV is not implemented for bpf. See Documentation/bpf/bpf_design_QA
-        // in kernel sources
-        switch (binop.op) {
-          case bpftrace::Parser::token::DIV:
-            buf << "signed division can lead to undefined behavior";
-            bpftrace_.warning(out_, binop.loc, buf.str());
-            break;
-          default:
-            break;
+
+      // Next, warn on any operations that require signed division.
+      //
+      // SDIV is not implemented for bpf. See Documentation/bpf/bpf_design_QA
+      // in kernel sources
+      if (binop.op == bpftrace::Parser::token::DIV) {
+        // Convert operands to unsigned if possible
+        if (lsign && left->is_literal && get_int_literal(left) >= 0)
+          left->type.is_signed = lsign = false;
+        if (rsign && right->is_literal && get_int_literal(right) >= 0)
+          right->type.is_signed = rsign = false;
+
+        // If they're still signed, we have to warn
+        if (lsign || rsign) {
+          buf << "signed operands for '" << opstr(binop)
+              << "' can lead to undefined behavior "
+              << "(cast to unsigned to silence warning)";
+          bpftrace_.warning(out_, binop.loc, buf.str());
+          buf.str({});
         }
       }
     }
@@ -906,6 +919,7 @@ void SemanticAnalyser::visit(Binop &binop)
           << " operator can not be used on expressions of types " << lhs
           << ", " << rhs << std::endl;
       bpftrace_.error(err_, binop.loc, buf.str());
+      buf.str({});
     }
   }
 

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -17,3 +17,8 @@ TIMEOUT 5
 # AFTER ./testprogs/ntop
 # EXPECT v4: 127.0.0.1; v6: ffee:ffee:ddcc:ddcc:bbaa:bbaa:c0a8:1
 # TIMEOUT 1
+
+NAME modulo_operator
+RUN bpftrace -v -e 'BEGIN { @x = 4; printf("%d\n", @x % 2) }'
+EXPECT 0
+TIMEOUT 5

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1121,6 +1121,18 @@ TEST(semantic_analyser, signed_int_division_warnings)
   test_for_warning("kprobe:f { @ = -(1 / 1) }", msg, invert);
 }
 
+TEST(semantic_analyser, signed_int_modulo_warnings)
+{
+  bool invert = true;
+  std::string msg = "signed operands";
+  test_for_warning("kprobe:f { @ = -1 % 1 }", msg);
+  test_for_warning("kprobe:f { @ = 1 % -1 }", msg);
+
+  // These should not trigger a warning
+  test_for_warning("kprobe:f { @ = 1 % 1 }", msg, invert);
+  test_for_warning("kprobe:f { @ = -(1 % 1) }", msg, invert);
+}
+
 TEST(semantic_analyser, map_as_lookup_table)
 {
   // Initializing a map should not lead to usage issues

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1112,7 +1112,7 @@ TEST(semantic_analyser, signed_int_arithmetic_warnings)
 TEST(semantic_analyser, signed_int_division_warnings)
 {
   bool invert = true;
-  std::string msg = "signed division";
+  std::string msg = "signed operands";
   test_for_warning("kprobe:f { @ = -1 / 1 }", msg);
   test_for_warning("kprobe:f { @ = 1 / -1 }", msg);
 


### PR DESCRIPTION
There was a regression with the modulo operation. It turns out the srem
instruction does a signed division under the hood. Somewhat obvious
after the fact but easy to miss.

Example of previously broken script:

    BEGIN
    {
      @start = 0;
    }

    interval:ms:1
    {
      if ((@start % 200) == 0) {
        ++@start;
      }
    }

Compile error:

    Error: Unsupport signed division for DAG: 0x11d46d8: i64 = sdiv
    0x11d4d58, Constant:i64<200>Please convert to unsigned div/mod.
    ...