### PR TITLE
Differentiate between regular structs and typedef'd structs

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -112,10 +112,10 @@ bpftrace|perf           { return Parser::make_STACK_MODE(yytext, loc); }
 "$"[0-9]+               { return Parser::make_PARAM(yytext, loc); }
 "$"#                    { return Parser::make_PARAMCOUNT(loc); }
 "#"[^!].*               { return Parser::make_CPREPROC(yytext, loc); }
-"if"                    { return Parser::make_IF(yytext, loc); }
-"else"                  { return Parser::make_ELSE(yytext, loc); }
+"if"                    { return Parser::make_IF(loc); }
+"else"                  { return Parser::make_ELSE(loc); }
 "?"                     { return Parser::make_QUES(loc); }
-"unroll"                { return Parser::make_UNROLL(yytext, loc); }
+"unroll"                { return Parser::make_UNROLL(loc); }
 
 \"                      { yy_push_state(STR, yyscanner); buffer.clear(); }
 <STR>{
@@ -141,26 +141,32 @@ bpftrace|perf           { return Parser::make_STACK_MODE(yytext, loc); }
   .                     driver.error(loc, "invalid character"); yy_pop_state(yyscanner);
 }
 
-struct|union            yy_push_state(STRUCT, yyscanner); buffer.clear(); struct_type = yytext;
-enum                    yy_push_state(ENUM, yyscanner); buffer.clear();
-<STRUCT,BRACE,ENUM>{
-  "*"|")"               { if (YY_START == STRUCT) {
+struct|union|enum       yy_push_state(STRUCT, yyscanner); buffer.clear(); struct_type = yytext;
+<STRUCT,BRACE>{
+  "*"|")"               {
+                          if (YY_START == STRUCT)
+                          {
+                            // Finished parsing the typename of a cast
+                            // Put the cast type into a canonical form by trimming
+                            // and then inserting a single space.
                             yy_pop_state(yyscanner);
                             unput(yytext[0]);
-                            return Parser::make_IDENT(trim(buffer), loc);
+                            return Parser::make_IDENT(struct_type + " " + trim(buffer), loc);
                           }
                           buffer += yytext[0];
                         }
   "{"                   yy_push_state(BRACE, yyscanner); buffer += '{';
-  "}"|"};"              { buffer += yytext;
+  "}"|"};"              {
+                          buffer += yytext;
                           yy_pop_state(yyscanner);
-                          if (YY_START == STRUCT) {
+                          if (YY_START == STRUCT)
+                          {
+                            // Finished parsing a struct definition
+                            // Trimming isn't needed here since the typenames
+                            // will go through Clang before we get them back
+                            // anyway.
                             yy_pop_state(yyscanner);
-                            return Parser::make_STRUCT(struct_type + buffer, loc);
-                          }
-                          if (YY_START == ENUM) {
-                            yy_pop_state(yyscanner);
-                            return Parser::make_ENUM("enum " + buffer, loc);
+                            return Parser::make_STRUCT_DEFN(struct_type + buffer, loc);
                           }
                         }
   .                     buffer += yytext[0];
@@ -168,7 +174,8 @@ enum                    yy_push_state(ENUM, yyscanner); buffer.clear();
 }
 
 {ident}                 {
-                          if (driver.bpftrace_.macros_.count(yytext) != 0) {
+                          if (driver.bpftrace_.macros_.count(yytext) != 0)
+                          {
                             const char *s = driver.bpftrace_.macros_[yytext].c_str();
                             int z;
                             // NOTE(mmarchini) workaround for simple recursive
@@ -176,9 +183,12 @@ enum                    yy_push_state(ENUM, yyscanner); buffer.clear();
                             // example, with operators) will go into an
                             // infinite loop. Yes, we should fix that in the
                             // future.
-                            if (strcmp(s, yytext) == 0) {
+                            if (strcmp(s, yytext) == 0)
+                            {
                               return Parser::make_IDENT(yytext, loc);
-                            } else {
+                            }
+                            else
+                            {
                               for (z=strlen(s) - 1; z >= 0; z--)
                                 unput(s[z]);
                             }

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -85,6 +85,11 @@ void yyerror(bpftrace::Driver &driver, const char *s);
   BNOT       "~"
   DOT        "."
   PTR        "->"
+  IF         "if"
+  ELSE       "else"
+  UNROLL     "unroll"
+  STRUCT     "struct"
+  UNION      "union"
 ;
 
 %token <std::string> BUILTIN "builtin"
@@ -93,7 +98,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %token <std::string> IDENT "identifier"
 %token <std::string> PATH "path"
 %token <std::string> CPREPROC "preprocessor directive"
-%token <std::string> STRUCT "struct"
+%token <std::string> STRUCT_DEFN "struct definition"
 %token <std::string> ENUM "enum"
 %token <std::string> STRING "string"
 %token <std::string> MAP "map"
@@ -102,9 +107,6 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %token <long> INT "integer"
 %token <long> CINT "colon surrounded integer"
 %token <std::string> STACK_MODE "stack_mode"
-%nonassoc <std::string> IF "if"
-%nonassoc <std::string> ELSE "else"
-%nonassoc <std::string> UNROLL "unroll"
 
 %type <std::string> c_definitions
 %type <ast::ProbeList *> probes
@@ -147,10 +149,10 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 program : c_definitions probes { driver.root_ = new ast::Program($1, $2); }
         ;
 
-c_definitions : CPREPROC c_definitions { $$ = $1 + "\n" + $2; }
-              | STRUCT c_definitions   { $$ = $1 + ";\n" + $2; }
-              | ENUM c_definitions     { $$ = $1 + ";\n" + $2; }
-              |                        { $$ = std::string(); }
+c_definitions : CPREPROC c_definitions    { $$ = $1 + "\n" + $2; }
+              | STRUCT_DEFN c_definitions { $$ = $1 + ";\n" + $2; }
+              | ENUM c_definitions        { $$ = $1 + ";\n" + $2; }
+              |                           { $$ = std::string(); }
               ;
 
 probes : probes probe { $$ = $1; $1->push_back($2); }

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -113,7 +113,7 @@ bool TracepointFormatParser::parse(ast::Program *program)
 
 std::string TracepointFormatParser::get_struct_name(const std::string &category, const std::string &event_name)
 {
-  return "_tracepoint_" + category + "_" + event_name;
+  return "struct _tracepoint_" + category + "_" + event_name;
 }
 
 std::string TracepointFormatParser::parse_field(const std::string &line)
@@ -182,7 +182,7 @@ std::string TracepointFormatParser::adjust_integer_types(const std::string &fiel
 
 std::string TracepointFormatParser::get_tracepoint_struct(std::istream &format_file, const std::string &category, const std::string &event_name)
 {
-  std::string format_struct = "struct " + get_struct_name(category, event_name) + "\n{\n";
+  std::string format_struct = get_struct_name(category, event_name) + "\n{\n";
 
   for (std::string line; getline(format_file, line); )
   {

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -34,25 +34,25 @@ TEST(clang_parser, integers)
   StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs.size(), 1U);
-  ASSERT_EQ(structs.count("Foo"), 1U);
+  ASSERT_EQ(structs.count("struct Foo"), 1U);
 
-  EXPECT_EQ(structs["Foo"].size, 12);
-  ASSERT_EQ(structs["Foo"].fields.size(), 3U);
-  ASSERT_EQ(structs["Foo"].fields.count("x"), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("y"), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("z"), 1U);
+  EXPECT_EQ(structs["struct Foo"].size, 12);
+  ASSERT_EQ(structs["struct Foo"].fields.size(), 3U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("x"), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("y"), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("z"), 1U);
 
-  EXPECT_EQ(structs["Foo"].fields["x"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["x"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["x"].offset, 0);
+  EXPECT_EQ(structs["struct Foo"].fields["x"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["x"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["x"].offset, 0);
 
-  EXPECT_EQ(structs["Foo"].fields["y"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["y"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["y"].offset, 4);
+  EXPECT_EQ(structs["struct Foo"].fields["y"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["y"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["y"].offset, 4);
 
-  EXPECT_EQ(structs["Foo"].fields["z"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["z"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["z"].offset, 8);
+  EXPECT_EQ(structs["struct Foo"].fields["z"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["z"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["z"].offset, 8);
 }
 
 TEST(clang_parser, c_union)
@@ -63,30 +63,30 @@ TEST(clang_parser, c_union)
   StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs.size(), 1U);
-  ASSERT_EQ(structs.count("Foo"), 1U);
+  ASSERT_EQ(structs.count("union Foo"), 1U);
 
-  EXPECT_EQ(structs["Foo"].size, 8);
-  ASSERT_EQ(structs["Foo"].fields.size(), 4U);
-  ASSERT_EQ(structs["Foo"].fields.count("c"), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("s"), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("i"), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("l"), 1U);
+  EXPECT_EQ(structs["union Foo"].size, 8);
+  ASSERT_EQ(structs["union Foo"].fields.size(), 4U);
+  ASSERT_EQ(structs["union Foo"].fields.count("c"), 1U);
+  ASSERT_EQ(structs["union Foo"].fields.count("s"), 1U);
+  ASSERT_EQ(structs["union Foo"].fields.count("i"), 1U);
+  ASSERT_EQ(structs["union Foo"].fields.count("l"), 1U);
 
-  EXPECT_EQ(structs["Foo"].fields["c"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["c"].type.size, 1U);
-  EXPECT_EQ(structs["Foo"].fields["c"].offset, 0);
+  EXPECT_EQ(structs["union Foo"].fields["c"].type.type, Type::integer);
+  EXPECT_EQ(structs["union Foo"].fields["c"].type.size, 1U);
+  EXPECT_EQ(structs["union Foo"].fields["c"].offset, 0);
 
-  EXPECT_EQ(structs["Foo"].fields["s"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["s"].type.size, 2U);
-  EXPECT_EQ(structs["Foo"].fields["s"].offset, 0);
+  EXPECT_EQ(structs["union Foo"].fields["s"].type.type, Type::integer);
+  EXPECT_EQ(structs["union Foo"].fields["s"].type.size, 2U);
+  EXPECT_EQ(structs["union Foo"].fields["s"].offset, 0);
 
-  EXPECT_EQ(structs["Foo"].fields["i"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["i"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["i"].offset, 0);
+  EXPECT_EQ(structs["union Foo"].fields["i"].type.type, Type::integer);
+  EXPECT_EQ(structs["union Foo"].fields["i"].type.size, 4U);
+  EXPECT_EQ(structs["union Foo"].fields["i"].offset, 0);
 
-  EXPECT_EQ(structs["Foo"].fields["l"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["l"].type.size, 8U);
-  EXPECT_EQ(structs["Foo"].fields["l"].offset, 0);
+  EXPECT_EQ(structs["union Foo"].fields["l"].type.type, Type::integer);
+  EXPECT_EQ(structs["union Foo"].fields["l"].type.size, 8U);
+  EXPECT_EQ(structs["union Foo"].fields["l"].offset, 0);
 }
 
 TEST(clang_parser, c_enum)
@@ -96,9 +96,16 @@ TEST(clang_parser, c_enum)
 
   StructMap &structs = bpftrace.structs_;
 
-  EXPECT_EQ(structs["Foo"].fields["e"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["e"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["e"].offset, 0);
+  ASSERT_EQ(structs.size(), 1U);
+  ASSERT_EQ(structs.count("struct Foo"), 1U);
+
+  EXPECT_EQ(structs["struct Foo"].size, 4);
+  ASSERT_EQ(structs["struct Foo"].fields.size(), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("e"), 1U);
+
+  EXPECT_EQ(structs["struct Foo"].fields["e"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["e"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["e"].offset, 0);
 }
 
 TEST(clang_parser, integer_ptr)
@@ -109,17 +116,17 @@ TEST(clang_parser, integer_ptr)
   StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs.size(), 1U);
-  ASSERT_EQ(structs.count("Foo"), 1U);
+  ASSERT_EQ(structs.count("struct Foo"), 1U);
 
-  EXPECT_EQ(structs["Foo"].size, 8);
-  ASSERT_EQ(structs["Foo"].fields.size(), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("x"), 1U);
+  EXPECT_EQ(structs["struct Foo"].size, 8);
+  ASSERT_EQ(structs["struct Foo"].fields.size(), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("x"), 1U);
 
-  EXPECT_EQ(structs["Foo"].fields["x"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["x"].type.size, sizeof(uintptr_t));
-  EXPECT_EQ(structs["Foo"].fields["x"].type.is_pointer, true);
-  EXPECT_EQ(structs["Foo"].fields["x"].type.pointee_size, sizeof(int));
-  EXPECT_EQ(structs["Foo"].fields["x"].offset, 0);
+  EXPECT_EQ(structs["struct Foo"].fields["x"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["x"].type.size, sizeof(uintptr_t));
+  EXPECT_EQ(structs["struct Foo"].fields["x"].type.is_pointer, true);
+  EXPECT_EQ(structs["struct Foo"].fields["x"].type.pointee_size, sizeof(int));
+  EXPECT_EQ(structs["struct Foo"].fields["x"].offset, 0);
 }
 
 TEST(clang_parser, string_ptr)
@@ -130,17 +137,17 @@ TEST(clang_parser, string_ptr)
   StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs.size(), 1U);
-  ASSERT_EQ(structs.count("Foo"), 1U);
+  ASSERT_EQ(structs.count("struct Foo"), 1U);
 
-  EXPECT_EQ(structs["Foo"].size, 8);
-  ASSERT_EQ(structs["Foo"].fields.size(), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("str"), 1U);
+  EXPECT_EQ(structs["struct Foo"].size, 8);
+  ASSERT_EQ(structs["struct Foo"].fields.size(), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("str"), 1U);
 
-  EXPECT_EQ(structs["Foo"].fields["str"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["str"].type.size, sizeof(uintptr_t));
-  EXPECT_EQ(structs["Foo"].fields["str"].type.is_pointer, true);
-  EXPECT_EQ(structs["Foo"].fields["str"].type.pointee_size, 1U);
-  EXPECT_EQ(structs["Foo"].fields["str"].offset, 0);
+  EXPECT_EQ(structs["struct Foo"].fields["str"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["str"].type.size, sizeof(uintptr_t));
+  EXPECT_EQ(structs["struct Foo"].fields["str"].type.is_pointer, true);
+  EXPECT_EQ(structs["struct Foo"].fields["str"].type.pointee_size, 1U);
+  EXPECT_EQ(structs["struct Foo"].fields["str"].offset, 0);
 }
 
 TEST(clang_parser, string_array)
@@ -151,15 +158,15 @@ TEST(clang_parser, string_array)
   StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs.size(), 1U);
-  ASSERT_EQ(structs.count("Foo"), 1U);
+  ASSERT_EQ(structs.count("struct Foo"), 1U);
 
-  EXPECT_EQ(structs["Foo"].size, 32);
-  ASSERT_EQ(structs["Foo"].fields.size(), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("str"), 1U);
+  EXPECT_EQ(structs["struct Foo"].size, 32);
+  ASSERT_EQ(structs["struct Foo"].fields.size(), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("str"), 1U);
 
-  EXPECT_EQ(structs["Foo"].fields["str"].type.type, Type::string);
-  EXPECT_EQ(structs["Foo"].fields["str"].type.size, 32U);
-  EXPECT_EQ(structs["Foo"].fields["str"].offset, 0);
+  EXPECT_EQ(structs["struct Foo"].fields["str"].type.type, Type::string);
+  EXPECT_EQ(structs["struct Foo"].fields["str"].type.size, 32U);
+  EXPECT_EQ(structs["struct Foo"].fields["str"].offset, 0);
 }
 
 TEST(clang_parser, nested_struct_named)
@@ -170,17 +177,17 @@ TEST(clang_parser, nested_struct_named)
   StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs.size(), 2U);
-  ASSERT_EQ(structs.count("Foo"), 1U);
-  ASSERT_EQ(structs.count("Bar"), 1U);
+  ASSERT_EQ(structs.count("struct Foo"), 1U);
+  ASSERT_EQ(structs.count("struct Bar"), 1U);
 
-  EXPECT_EQ(structs["Foo"].size, 4);
-  ASSERT_EQ(structs["Foo"].fields.size(), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("bar"), 1U);
+  EXPECT_EQ(structs["struct Foo"].size, 4);
+  ASSERT_EQ(structs["struct Foo"].fields.size(), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("bar"), 1U);
 
-  EXPECT_EQ(structs["Foo"].fields["bar"].type.type, Type::cast);
-  EXPECT_EQ(structs["Foo"].fields["bar"].type.cast_type, "Bar");
-  EXPECT_EQ(structs["Foo"].fields["bar"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["bar"].offset, 0);
+  EXPECT_EQ(structs["struct Foo"].fields["bar"].type.type, Type::cast);
+  EXPECT_EQ(structs["struct Foo"].fields["bar"].type.cast_type, "struct Bar");
+  EXPECT_EQ(structs["struct Foo"].fields["bar"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["bar"].offset, 0);
 }
 
 TEST(clang_parser, nested_struct_ptr_named)
@@ -191,19 +198,19 @@ TEST(clang_parser, nested_struct_ptr_named)
   StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs.size(), 2U);
-  ASSERT_EQ(structs.count("Foo"), 1U);
-  ASSERT_EQ(structs.count("Bar"), 1U);
+  ASSERT_EQ(structs.count("struct Foo"), 1U);
+  ASSERT_EQ(structs.count("struct Bar"), 1U);
 
-  EXPECT_EQ(structs["Foo"].size, 8);
-  ASSERT_EQ(structs["Foo"].fields.size(), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("bar"), 1U);
+  EXPECT_EQ(structs["struct Foo"].size, 8);
+  ASSERT_EQ(structs["struct Foo"].fields.size(), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("bar"), 1U);
 
-  EXPECT_EQ(structs["Foo"].fields["bar"].type.type, Type::cast);
-  EXPECT_EQ(structs["Foo"].fields["bar"].type.cast_type, "Bar");
-  EXPECT_EQ(structs["Foo"].fields["bar"].type.size, sizeof(uintptr_t));
-  EXPECT_EQ(structs["Foo"].fields["bar"].type.is_pointer, true);
-  EXPECT_EQ(structs["Foo"].fields["bar"].type.pointee_size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["bar"].offset, 0);
+  EXPECT_EQ(structs["struct Foo"].fields["bar"].type.type, Type::cast);
+  EXPECT_EQ(structs["struct Foo"].fields["bar"].type.cast_type, "struct Bar");
+  EXPECT_EQ(structs["struct Foo"].fields["bar"].type.size, sizeof(uintptr_t));
+  EXPECT_EQ(structs["struct Foo"].fields["bar"].type.is_pointer, true);
+  EXPECT_EQ(structs["struct Foo"].fields["bar"].type.pointee_size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["bar"].offset, 0);
 }
 
 TEST(clang_parser, nested_struct_no_type)
@@ -213,25 +220,30 @@ TEST(clang_parser, nested_struct_no_type)
   // since they are called bar and baz
   parse("struct Foo { struct { int x; } bar; union { int y; } baz; }", bpftrace);
 
-  std::string bar = "Foo::(anonymous at definitions.h:1:14)";
-  std::string baz = "Foo::(anonymous at definitions.h:1:37)";
+  std::string bar = "struct Foo::(anonymous at definitions.h:1:14)";
+  std::string baz = "union Foo::(anonymous at definitions.h:1:37)";
 
   StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs.size(), 3U);
-  ASSERT_EQ(structs.count("Foo"), 1U);
+  ASSERT_EQ(structs.count("struct Foo"), 1U);
   ASSERT_EQ(structs.count(bar), 1U);
   ASSERT_EQ(structs.count(baz), 1U);
 
-  EXPECT_EQ(structs["Foo"].size, 8);
-  ASSERT_EQ(structs["Foo"].fields.size(), 2U);
-  ASSERT_EQ(structs["Foo"].fields.count("bar"), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("baz"), 1U);
+  EXPECT_EQ(structs["struct Foo"].size, 8);
+  ASSERT_EQ(structs["struct Foo"].fields.size(), 2U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("bar"), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("baz"), 1U);
 
-  EXPECT_EQ(structs["Foo"].fields["bar"].type.type, Type::cast);
-  EXPECT_EQ(structs["Foo"].fields["bar"].type.cast_type, bar);
-  EXPECT_EQ(structs["Foo"].fields["bar"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["bar"].offset, 0);
+  EXPECT_EQ(structs["struct Foo"].fields["bar"].type.type, Type::cast);
+  EXPECT_EQ(structs["struct Foo"].fields["bar"].type.cast_type, bar);
+  EXPECT_EQ(structs["struct Foo"].fields["bar"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["bar"].offset, 0);
+
+  EXPECT_EQ(structs["struct Foo"].fields["baz"].type.type, Type::cast);
+  EXPECT_EQ(structs["struct Foo"].fields["baz"].type.cast_type, baz);
+  EXPECT_EQ(structs["struct Foo"].fields["baz"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["baz"].offset, 4);
 
   EXPECT_EQ(structs[bar].size, 4);
   ASSERT_EQ(structs[bar].fields.size(), 1U);
@@ -240,12 +252,6 @@ TEST(clang_parser, nested_struct_no_type)
   EXPECT_EQ(structs[bar].fields["x"].type.type, Type::integer);
   EXPECT_EQ(structs[bar].fields["x"].type.size, 4U);
   EXPECT_EQ(structs[bar].fields["x"].offset, 0);
-
-
-  EXPECT_EQ(structs["Foo"].fields["baz"].type.type, Type::cast);
-  EXPECT_EQ(structs["Foo"].fields["baz"].type.cast_type, baz);
-  EXPECT_EQ(structs["Foo"].fields["baz"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["baz"].offset, 4);
 
   EXPECT_EQ(structs[baz].size, 4);
   ASSERT_EQ(structs[baz].fields.size(), 1U);
@@ -270,33 +276,33 @@ TEST(clang_parser, nested_struct_unnamed_fields)
   StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs.size(), 2U);
-  ASSERT_EQ(structs.count("Foo"), 1U);
-  ASSERT_EQ(structs.count("Bar"), 1U);
+  ASSERT_EQ(structs.count("struct Foo"), 1U);
+  ASSERT_EQ(structs.count("struct Bar"), 1U);
 
-  EXPECT_EQ(structs["Foo"].size, 12);
-  ASSERT_EQ(structs["Foo"].fields.size(), 3U);
-  ASSERT_EQ(structs["Foo"].fields.count("x"), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("y"), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("a"), 1U);
+  EXPECT_EQ(structs["struct Foo"].size, 12);
+  ASSERT_EQ(structs["struct Foo"].fields.size(), 3U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("x"), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("y"), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("a"), 1U);
 
-  EXPECT_EQ(structs["Foo"].fields["x"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["x"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["x"].offset, 0);
-  EXPECT_EQ(structs["Foo"].fields["y"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["y"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["y"].offset, 4);
-  EXPECT_EQ(structs["Foo"].fields["a"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["a"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["a"].offset, 8);
+  EXPECT_EQ(structs["struct Foo"].fields["x"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["x"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["x"].offset, 0);
+  EXPECT_EQ(structs["struct Foo"].fields["y"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["y"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["y"].offset, 4);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].offset, 8);
 
 
-  EXPECT_EQ(structs["Bar"].size, 4);
-  EXPECT_EQ(structs["Bar"].fields.size(), 1U);
-  EXPECT_EQ(structs["Bar"].fields.count("z"), 1U);
+  EXPECT_EQ(structs["struct Bar"].size, 4);
+  EXPECT_EQ(structs["struct Bar"].fields.size(), 1U);
+  EXPECT_EQ(structs["struct Bar"].fields.count("z"), 1U);
 
-  EXPECT_EQ(structs["Bar"].fields["z"].type.type, Type::integer);
-  EXPECT_EQ(structs["Bar"].fields["z"].type.size, 4U);
-  EXPECT_EQ(structs["Bar"].fields["z"].offset, 0);
+  EXPECT_EQ(structs["struct Bar"].fields["z"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Bar"].fields["z"].type.size, 4U);
+  EXPECT_EQ(structs["struct Bar"].fields["z"].offset, 0);
 }
 
 TEST(clang_parser, nested_struct_anon_union_struct)
@@ -317,35 +323,35 @@ TEST(clang_parser, nested_struct_anon_union_struct)
   StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs.size(), 1U);
-  ASSERT_EQ(structs.count("Foo"), 1U);
+  ASSERT_EQ(structs.count("struct Foo"), 1U);
 
-  EXPECT_EQ(structs["Foo"].size, 16);
-  ASSERT_EQ(structs["Foo"].fields.size(), 5U);
-  ASSERT_EQ(structs["Foo"].fields.count("_xy"), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("x"), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("y"), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("a"), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("z"), 1U);
+  EXPECT_EQ(structs["struct Foo"].size, 16);
+  ASSERT_EQ(structs["struct Foo"].fields.size(), 5U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("_xy"), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("x"), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("y"), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("a"), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("z"), 1U);
 
-  EXPECT_EQ(structs["Foo"].fields["_xy"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["_xy"].type.size, 8U);
-  EXPECT_EQ(structs["Foo"].fields["_xy"].offset, 0);
+  EXPECT_EQ(structs["struct Foo"].fields["_xy"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["_xy"].type.size, 8U);
+  EXPECT_EQ(structs["struct Foo"].fields["_xy"].offset, 0);
 
-  EXPECT_EQ(structs["Foo"].fields["x"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["x"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["x"].offset, 0);
+  EXPECT_EQ(structs["struct Foo"].fields["x"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["x"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["x"].offset, 0);
 
-  EXPECT_EQ(structs["Foo"].fields["y"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["y"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["y"].offset, 4);
+  EXPECT_EQ(structs["struct Foo"].fields["y"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["y"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["y"].offset, 4);
 
-  EXPECT_EQ(structs["Foo"].fields["a"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["a"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["a"].offset, 8);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].offset, 8);
 
-  EXPECT_EQ(structs["Foo"].fields["z"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["z"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["z"].offset, 12);
+  EXPECT_EQ(structs["struct Foo"].fields["z"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["z"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["z"].offset, 12);
 }
 
 TEST(clang_parser, bitfields)
@@ -356,37 +362,37 @@ TEST(clang_parser, bitfields)
   StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs.size(), 1U);
-  ASSERT_EQ(structs.count("Foo"), 1U);
+  ASSERT_EQ(structs.count("struct Foo"), 1U);
 
-  EXPECT_EQ(structs["Foo"].size, 4);
-  ASSERT_EQ(structs["Foo"].fields.size(), 3U);
-  ASSERT_EQ(structs["Foo"].fields.count("a"), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("b"), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("c"), 1U);
+  EXPECT_EQ(structs["struct Foo"].size, 4);
+  ASSERT_EQ(structs["struct Foo"].fields.size(), 3U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("a"), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("b"), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("c"), 1U);
 
-  EXPECT_EQ(structs["Foo"].fields["a"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["a"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["a"].offset, 0);
-  EXPECT_TRUE(structs["Foo"].fields["a"].is_bitfield);
-  EXPECT_EQ(structs["Foo"].fields["a"].bitfield.read_bytes, 0x1U);
-  EXPECT_EQ(structs["Foo"].fields["a"].bitfield.access_rshift, 0U);
-  EXPECT_EQ(structs["Foo"].fields["a"].bitfield.mask, 0xFFU);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].offset, 0);
+  EXPECT_TRUE(structs["struct Foo"].fields["a"].is_bitfield);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].bitfield.read_bytes, 0x1U);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].bitfield.access_rshift, 0U);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].bitfield.mask, 0xFFU);
 
-  EXPECT_EQ(structs["Foo"].fields["b"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["b"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["b"].offset, 1);
-  EXPECT_TRUE(structs["Foo"].fields["b"].is_bitfield);
-  EXPECT_EQ(structs["Foo"].fields["b"].bitfield.read_bytes, 0x1U);
-  EXPECT_EQ(structs["Foo"].fields["b"].bitfield.access_rshift, 0U);
-  EXPECT_EQ(structs["Foo"].fields["b"].bitfield.mask, 0xFFU);
+  EXPECT_EQ(structs["struct Foo"].fields["b"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["b"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["b"].offset, 1);
+  EXPECT_TRUE(structs["struct Foo"].fields["b"].is_bitfield);
+  EXPECT_EQ(structs["struct Foo"].fields["b"].bitfield.read_bytes, 0x1U);
+  EXPECT_EQ(structs["struct Foo"].fields["b"].bitfield.access_rshift, 0U);
+  EXPECT_EQ(structs["struct Foo"].fields["b"].bitfield.mask, 0xFFU);
 
-  EXPECT_EQ(structs["Foo"].fields["c"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["c"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["c"].offset, 2);
-  EXPECT_TRUE(structs["Foo"].fields["c"].is_bitfield);
-  EXPECT_EQ(structs["Foo"].fields["c"].bitfield.read_bytes, 0x2U);
-  EXPECT_EQ(structs["Foo"].fields["c"].bitfield.access_rshift, 0U);
-  EXPECT_EQ(structs["Foo"].fields["c"].bitfield.mask, 0xFFFFU);
+  EXPECT_EQ(structs["struct Foo"].fields["c"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["c"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["c"].offset, 2);
+  EXPECT_TRUE(structs["struct Foo"].fields["c"].is_bitfield);
+  EXPECT_EQ(structs["struct Foo"].fields["c"].bitfield.read_bytes, 0x2U);
+  EXPECT_EQ(structs["struct Foo"].fields["c"].bitfield.access_rshift, 0U);
+  EXPECT_EQ(structs["struct Foo"].fields["c"].bitfield.mask, 0xFFFFU);
 }
 
 TEST(clang_parser, bitfields_uneven_fields)
@@ -397,55 +403,55 @@ TEST(clang_parser, bitfields_uneven_fields)
   StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs.size(), 1U);
-  ASSERT_EQ(structs.count("Foo"), 1U);
+  ASSERT_EQ(structs.count("struct Foo"), 1U);
 
-  EXPECT_EQ(structs["Foo"].size, 4);
-  ASSERT_EQ(structs["Foo"].fields.size(), 5U);
-  ASSERT_EQ(structs["Foo"].fields.count("a"), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("b"), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("c"), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("d"), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("e"), 1U);
+  EXPECT_EQ(structs["struct Foo"].size, 4);
+  ASSERT_EQ(structs["struct Foo"].fields.size(), 5U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("a"), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("b"), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("c"), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("d"), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("e"), 1U);
 
-  EXPECT_EQ(structs["Foo"].fields["a"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["a"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["a"].offset, 0);
-  EXPECT_TRUE(structs["Foo"].fields["a"].is_bitfield);
-  EXPECT_EQ(structs["Foo"].fields["a"].bitfield.read_bytes, 1U);
-  EXPECT_EQ(structs["Foo"].fields["a"].bitfield.access_rshift, 0U);
-  EXPECT_EQ(structs["Foo"].fields["a"].bitfield.mask, 0x1U);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].offset, 0);
+  EXPECT_TRUE(structs["struct Foo"].fields["a"].is_bitfield);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].bitfield.read_bytes, 1U);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].bitfield.access_rshift, 0U);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].bitfield.mask, 0x1U);
 
-  EXPECT_EQ(structs["Foo"].fields["b"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["b"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["b"].offset, 0);
-  EXPECT_TRUE(structs["Foo"].fields["b"].is_bitfield);
-  EXPECT_EQ(structs["Foo"].fields["b"].bitfield.read_bytes, 1U);
-  EXPECT_EQ(structs["Foo"].fields["b"].bitfield.access_rshift, 1U);
-  EXPECT_EQ(structs["Foo"].fields["b"].bitfield.mask, 0x1U);
+  EXPECT_EQ(structs["struct Foo"].fields["b"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["b"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["b"].offset, 0);
+  EXPECT_TRUE(structs["struct Foo"].fields["b"].is_bitfield);
+  EXPECT_EQ(structs["struct Foo"].fields["b"].bitfield.read_bytes, 1U);
+  EXPECT_EQ(structs["struct Foo"].fields["b"].bitfield.access_rshift, 1U);
+  EXPECT_EQ(structs["struct Foo"].fields["b"].bitfield.mask, 0x1U);
 
-  EXPECT_EQ(structs["Foo"].fields["c"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["c"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["c"].offset, 0);
-  EXPECT_TRUE(structs["Foo"].fields["c"].is_bitfield);
-  EXPECT_EQ(structs["Foo"].fields["c"].bitfield.read_bytes, 1U);
-  EXPECT_EQ(structs["Foo"].fields["c"].bitfield.access_rshift, 2U);
-  EXPECT_EQ(structs["Foo"].fields["c"].bitfield.mask, 0x7U);
+  EXPECT_EQ(structs["struct Foo"].fields["c"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["c"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["c"].offset, 0);
+  EXPECT_TRUE(structs["struct Foo"].fields["c"].is_bitfield);
+  EXPECT_EQ(structs["struct Foo"].fields["c"].bitfield.read_bytes, 1U);
+  EXPECT_EQ(structs["struct Foo"].fields["c"].bitfield.access_rshift, 2U);
+  EXPECT_EQ(structs["struct Foo"].fields["c"].bitfield.mask, 0x7U);
 
-  EXPECT_EQ(structs["Foo"].fields["d"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["d"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["d"].offset, 0);
-  EXPECT_TRUE(structs["Foo"].fields["d"].is_bitfield);
-  EXPECT_EQ(structs["Foo"].fields["d"].bitfield.read_bytes, 4U);
-  EXPECT_EQ(structs["Foo"].fields["d"].bitfield.access_rshift, 5U);
-  EXPECT_EQ(structs["Foo"].fields["d"].bitfield.mask, 0xFFFFFU);
+  EXPECT_EQ(structs["struct Foo"].fields["d"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["d"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["d"].offset, 0);
+  EXPECT_TRUE(structs["struct Foo"].fields["d"].is_bitfield);
+  EXPECT_EQ(structs["struct Foo"].fields["d"].bitfield.read_bytes, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["d"].bitfield.access_rshift, 5U);
+  EXPECT_EQ(structs["struct Foo"].fields["d"].bitfield.mask, 0xFFFFFU);
 
-  EXPECT_EQ(structs["Foo"].fields["e"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["e"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["e"].offset, 3);
-  EXPECT_TRUE(structs["Foo"].fields["e"].is_bitfield);
-  EXPECT_EQ(structs["Foo"].fields["e"].bitfield.read_bytes, 1U);
-  EXPECT_EQ(structs["Foo"].fields["e"].bitfield.access_rshift, 1U);
-  EXPECT_EQ(structs["Foo"].fields["e"].bitfield.mask, 0x7FU);
+  EXPECT_EQ(structs["struct Foo"].fields["e"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["e"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["e"].offset, 3);
+  EXPECT_TRUE(structs["struct Foo"].fields["e"].is_bitfield);
+  EXPECT_EQ(structs["struct Foo"].fields["e"].bitfield.read_bytes, 1U);
+  EXPECT_EQ(structs["struct Foo"].fields["e"].bitfield.access_rshift, 1U);
+  EXPECT_EQ(structs["struct Foo"].fields["e"].bitfield.mask, 0x7FU);
 }
 
 TEST(clang_parser, bitfields_with_padding)
@@ -456,30 +462,30 @@ TEST(clang_parser, bitfields_with_padding)
   StructMap &structs = bpftrace.structs_;
 
   ASSERT_EQ(structs.size(), 1U);
-  ASSERT_EQ(structs.count("Foo"), 1U);
+  ASSERT_EQ(structs.count("struct Foo"), 1U);
 
-  EXPECT_EQ(structs["Foo"].size, 16);
-  ASSERT_EQ(structs["Foo"].fields.size(), 4U);
-  ASSERT_EQ(structs["Foo"].fields.count("pad"), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("a"), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("b"), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("end"), 1U);
+  EXPECT_EQ(structs["struct Foo"].size, 16);
+  ASSERT_EQ(structs["struct Foo"].fields.size(), 4U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("pad"), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("a"), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("b"), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("end"), 1U);
 
-  EXPECT_EQ(structs["Foo"].fields["a"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["a"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["a"].offset, 4);
-  EXPECT_TRUE(structs["Foo"].fields["a"].is_bitfield);
-  EXPECT_EQ(structs["Foo"].fields["a"].bitfield.read_bytes, 4U);
-  EXPECT_EQ(structs["Foo"].fields["a"].bitfield.access_rshift, 0U);
-  EXPECT_EQ(structs["Foo"].fields["a"].bitfield.mask, 0xFFFFFFFU);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].offset, 4);
+  EXPECT_TRUE(structs["struct Foo"].fields["a"].is_bitfield);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].bitfield.read_bytes, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].bitfield.access_rshift, 0U);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].bitfield.mask, 0xFFFFFFFU);
 
-  EXPECT_EQ(structs["Foo"].fields["b"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["b"].type.size, 4U);
-  EXPECT_EQ(structs["Foo"].fields["b"].offset, 7);
-  EXPECT_TRUE(structs["Foo"].fields["b"].is_bitfield);
-  EXPECT_EQ(structs["Foo"].fields["b"].bitfield.read_bytes, 1U);
-  EXPECT_EQ(structs["Foo"].fields["b"].bitfield.access_rshift, 4U);
-  EXPECT_EQ(structs["Foo"].fields["b"].bitfield.mask, 0xFU);
+  EXPECT_EQ(structs["struct Foo"].fields["b"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["b"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["b"].offset, 7);
+  EXPECT_TRUE(structs["struct Foo"].fields["b"].is_bitfield);
+  EXPECT_EQ(structs["struct Foo"].fields["b"].bitfield.read_bytes, 1U);
+  EXPECT_EQ(structs["struct Foo"].fields["b"].bitfield.access_rshift, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["b"].bitfield.mask, 0xFU);
 }
 
 TEST(clang_parser, builtin_headers)
@@ -490,25 +496,25 @@ TEST(clang_parser, builtin_headers)
 
   StructMap &structs = bpftrace.structs_;
 
-  ASSERT_EQ(structs.count("Foo"), 1U);
+  ASSERT_EQ(structs.count("struct Foo"), 1U);
 
-  EXPECT_EQ(structs["Foo"].size, 24);
-  ASSERT_EQ(structs["Foo"].fields.size(), 3U);
-  ASSERT_EQ(structs["Foo"].fields.count("x"), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("y"), 1U);
-  ASSERT_EQ(structs["Foo"].fields.count("z"), 1U);
+  EXPECT_EQ(structs["struct Foo"].size, 24);
+  ASSERT_EQ(structs["struct Foo"].fields.size(), 3U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("x"), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("y"), 1U);
+  ASSERT_EQ(structs["struct Foo"].fields.count("z"), 1U);
 
-  EXPECT_EQ(structs["Foo"].fields["x"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["x"].type.size, 8U);
-  EXPECT_EQ(structs["Foo"].fields["x"].offset, 0);
+  EXPECT_EQ(structs["struct Foo"].fields["x"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["x"].type.size, 8U);
+  EXPECT_EQ(structs["struct Foo"].fields["x"].offset, 0);
 
-  EXPECT_EQ(structs["Foo"].fields["y"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["y"].type.size, 8U);
-  EXPECT_EQ(structs["Foo"].fields["y"].offset, 8);
+  EXPECT_EQ(structs["struct Foo"].fields["y"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["y"].type.size, 8U);
+  EXPECT_EQ(structs["struct Foo"].fields["y"].offset, 8);
 
-  EXPECT_EQ(structs["Foo"].fields["z"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo"].fields["z"].type.size, 8U);
-  EXPECT_EQ(structs["Foo"].fields["z"].offset, 16);
+  EXPECT_EQ(structs["struct Foo"].fields["z"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo"].fields["z"].type.size, 8U);
+  EXPECT_EQ(structs["struct Foo"].fields["z"].offset, 16);
 }
 
 TEST(clang_parser, macro_preprocessor)
@@ -591,53 +597,53 @@ TEST_F(clang_parser_btf, btf)
   ASSERT_EQ(structs.count("Foo2"), 1U);
   ASSERT_EQ(structs.count("Foo3"), 1U);
 
-  EXPECT_EQ(structs["Foo1"].size, 16);
-  ASSERT_EQ(structs["Foo1"].fields.size(), 3U);
-  ASSERT_EQ(structs["Foo1"].fields.count("a"), 1U);
-  ASSERT_EQ(structs["Foo1"].fields.count("b"), 1U);
-  ASSERT_EQ(structs["Foo1"].fields.count("c"), 1U);
+  EXPECT_EQ(structs["struct Foo1"].size, 16);
+  ASSERT_EQ(structs["struct Foo1"].fields.size(), 3U);
+  ASSERT_EQ(structs["struct Foo1"].fields.count("a"), 1U);
+  ASSERT_EQ(structs["struct Foo1"].fields.count("b"), 1U);
+  ASSERT_EQ(structs["struct Foo1"].fields.count("c"), 1U);
 
-  EXPECT_EQ(structs["Foo1"].fields["a"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo1"].fields["a"].type.size, 4U);
-  EXPECT_EQ(structs["Foo1"].fields["a"].offset, 0);
+  EXPECT_EQ(structs["struct Foo1"].fields["a"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo1"].fields["a"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo1"].fields["a"].offset, 0);
 
-  EXPECT_EQ(structs["Foo1"].fields["b"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo1"].fields["b"].type.size, 1U);
-  EXPECT_EQ(structs["Foo1"].fields["b"].offset, 4);
+  EXPECT_EQ(structs["struct Foo1"].fields["b"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo1"].fields["b"].type.size, 1U);
+  EXPECT_EQ(structs["struct Foo1"].fields["b"].offset, 4);
 
-  EXPECT_EQ(structs["Foo1"].fields["c"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo1"].fields["c"].type.size, 8U);
-  EXPECT_EQ(structs["Foo1"].fields["c"].offset, 8);
+  EXPECT_EQ(structs["struct Foo1"].fields["c"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo1"].fields["c"].type.size, 8U);
+  EXPECT_EQ(structs["struct Foo1"].fields["c"].offset, 8);
 
-  EXPECT_EQ(structs["Foo2"].size, 24);
-  ASSERT_EQ(structs["Foo2"].fields.size(), 2U);
-  ASSERT_EQ(structs["Foo2"].fields.count("a"), 1U);
-  ASSERT_EQ(structs["Foo2"].fields.count("f"), 1U);
+  EXPECT_EQ(structs["struct Foo2"].size, 24);
+  ASSERT_EQ(structs["struct Foo2"].fields.size(), 2U);
+  ASSERT_EQ(structs["struct Foo2"].fields.count("a"), 1U);
+  ASSERT_EQ(structs["struct Foo2"].fields.count("f"), 1U);
 
-  EXPECT_EQ(structs["Foo2"].fields["a"].type.type, Type::integer);
-  EXPECT_EQ(structs["Foo2"].fields["a"].type.size, 4U);
-  EXPECT_EQ(structs["Foo2"].fields["a"].offset, 0);
+  EXPECT_EQ(structs["struct Foo2"].fields["a"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct Foo2"].fields["a"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo2"].fields["a"].offset, 0);
 
-  EXPECT_EQ(structs["Foo2"].fields["f"].type.type, Type::cast);
-  EXPECT_EQ(structs["Foo2"].fields["f"].type.size, 16U);
-  EXPECT_EQ(structs["Foo2"].fields["f"].offset, 8);
+  EXPECT_EQ(structs["struct Foo2"].fields["f"].type.type, Type::cast);
+  EXPECT_EQ(structs["struct Foo2"].fields["f"].type.size, 16U);
+  EXPECT_EQ(structs["struct Foo2"].fields["f"].offset, 8);
 
-  EXPECT_EQ(structs["Foo3"].size, 16);
-  ASSERT_EQ(structs["Foo3"].fields.size(), 2U);
-  ASSERT_EQ(structs["Foo3"].fields.count("foo1"), 1U);
-  ASSERT_EQ(structs["Foo3"].fields.count("foo2"), 1U);
+  EXPECT_EQ(structs["struct Foo3"].size, 16);
+  ASSERT_EQ(structs["struct Foo3"].fields.size(), 2U);
+  ASSERT_EQ(structs["struct Foo3"].fields.count("foo1"), 1U);
+  ASSERT_EQ(structs["struct Foo3"].fields.count("foo2"), 1U);
 
-  EXPECT_EQ(structs["Foo3"].fields["foo1"].type.type, Type::cast);
-  EXPECT_EQ(structs["Foo3"].fields["foo1"].type.size, 8U);
-  EXPECT_EQ(structs["Foo3"].fields["foo1"].type.is_pointer, true);
-  EXPECT_EQ(structs["Foo3"].fields["foo1"].type.cast_type, "Foo1");
-  EXPECT_EQ(structs["Foo3"].fields["foo1"].offset, 0);
+  EXPECT_EQ(structs["struct Foo3"].fields["foo1"].type.type, Type::cast);
+  EXPECT_EQ(structs["struct Foo3"].fields["foo1"].type.size, 8U);
+  EXPECT_EQ(structs["struct Foo3"].fields["foo1"].type.is_pointer, true);
+  EXPECT_EQ(structs["struct Foo3"].fields["foo1"].type.cast_type, "Foo1");
+  EXPECT_EQ(structs["struct Foo3"].fields["foo1"].offset, 0);
 
-  EXPECT_EQ(structs["Foo3"].fields["foo2"].type.type, Type::cast);
-  EXPECT_EQ(structs["Foo3"].fields["foo2"].type.size, 8U);
-  EXPECT_EQ(structs["Foo3"].fields["foo2"].type.is_pointer, true);
-  EXPECT_EQ(structs["Foo3"].fields["foo2"].type.cast_type, "Foo2");
-  EXPECT_EQ(structs["Foo3"].fields["foo2"].offset, 8);
+  EXPECT_EQ(structs["struct Foo3"].fields["foo2"].type.type, Type::cast);
+  EXPECT_EQ(structs["struct Foo3"].fields["foo2"].type.size, 8U);
+  EXPECT_EQ(structs["struct Foo3"].fields["foo2"].type.is_pointer, true);
+  EXPECT_EQ(structs["struct Foo3"].fields["foo2"].type.cast_type, "Foo2");
+  EXPECT_EQ(structs["struct Foo3"].fields["foo2"].offset, 8);
 }
 
 TEST_F(clang_parser_btf, btf_field_struct)
@@ -656,6 +662,45 @@ TEST_F(clang_parser_btf, btf_field_struct)
   EXPECT_NE(bpftrace.btf_set_.find("int"), bpftrace.btf_set_.end());
 }
 #endif // HAVE_LIBBPF_BTF_DUMP
+
+TEST(clang_parser, struct_typedef)
+{
+  // Make sure we can differentiate between "struct max_align_t {}" and
+  // "typedef struct {} max_align_t"
+  BPFtrace bpftrace;
+  parse("#include <__stddef_max_align_t.h>\n"
+        "struct max_align_t { int x; };", bpftrace);
+
+  StructMap &structs = bpftrace.structs_;
+
+  ASSERT_EQ(structs.size(), 2U);
+  ASSERT_EQ(structs.count("struct max_align_t"), 1U);
+  ASSERT_EQ(structs.count("max_align_t"), 1U);
+
+  // Non-typedef'd struct
+  EXPECT_EQ(structs["struct max_align_t"].size, 4);
+  ASSERT_EQ(structs["struct max_align_t"].fields.size(), 1U);
+  ASSERT_EQ(structs["struct max_align_t"].fields.count("x"), 1U);
+
+  EXPECT_EQ(structs["struct max_align_t"].fields["x"].type.type, Type::integer);
+  EXPECT_EQ(structs["struct max_align_t"].fields["x"].type.size, 4U);
+  EXPECT_EQ(structs["struct max_align_t"].fields["x"].offset, 0);
+
+  // typedef'd struct (defined in __stddef_max_align_t.h builtin header)
+  EXPECT_EQ(structs["max_align_t"].size, 32);
+  ASSERT_EQ(structs["max_align_t"].fields.size(), 2U);
+  ASSERT_EQ(structs["max_align_t"].fields.count("__clang_max_align_nonce1"), 1U);
+  ASSERT_EQ(structs["max_align_t"].fields.count("__clang_max_align_nonce2"), 1U);
+
+  EXPECT_EQ(structs["max_align_t"].fields["__clang_max_align_nonce1"].type.type, Type::integer);
+  EXPECT_EQ(structs["max_align_t"].fields["__clang_max_align_nonce1"].type.size, 8U);
+  EXPECT_EQ(structs["max_align_t"].fields["__clang_max_align_nonce1"].offset, 0);
+
+  // double are not parsed correctly yet so these fields are junk for now
+  EXPECT_EQ(structs["max_align_t"].fields["__clang_max_align_nonce2"].type.type, Type::none);
+  EXPECT_EQ(structs["max_align_t"].fields["__clang_max_align_nonce2"].type.size, 0U);
+  EXPECT_EQ(structs["max_align_t"].fields["__clang_max_align_nonce2"].offset, 16);
+}
 
 } // namespace clang_parser
 } // namespace test

--- a/tests/codegen/args_multiple_tracepoints.cpp
+++ b/tests/codegen/args_multiple_tracepoints.cpp
@@ -71,7 +71,7 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"tracepoint:syscalls:sys_enter_open"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_open_1" {
 entry:
   %"@_val" = alloca i64, align 8
-  %_tracepoint_syscalls_sys_enter_open.filename = alloca i64, align 8
+  %"struct _tracepoint_syscalls_sys_enter_open.filename" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %"@_key" = alloca [64 x i8], align 1
   %1 = getelementptr inbounds [64 x i8], [64 x i8]* %"@_key", i64 0, i64 0
@@ -80,10 +80,10 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %2, i8 0, i64 64, i1 false)
   %3 = add i8* %0, i64 16
-  %4 = bitcast i64* %_tracepoint_syscalls_sys_enter_open.filename to i8*
+  %4 = bitcast i64* %"struct _tracepoint_syscalls_sys_enter_open.filename" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_open.filename, i64 8, i8* %3)
-  %5 = load i64, i64* %_tracepoint_syscalls_sys_enter_open.filename, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_syscalls_sys_enter_open.filename", i64 8, i8* %3)
+  %5 = load i64, i64* %"struct _tracepoint_syscalls_sys_enter_open.filename", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %5)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %1, i8* nonnull align 1 %2, i64 64, i1 false)
@@ -121,7 +121,7 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture r
 define i64 @"tracepoint:syscalls:sys_enter_openat"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_openat_2" {
 entry:
   %"@_val" = alloca i64, align 8
-  %_tracepoint_syscalls_sys_enter_openat.filename = alloca i64, align 8
+  %"struct _tracepoint_syscalls_sys_enter_openat.filename" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %"@_key" = alloca [64 x i8], align 1
   %1 = getelementptr inbounds [64 x i8], [64 x i8]* %"@_key", i64 0, i64 0
@@ -130,10 +130,10 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %2, i8 0, i64 64, i1 false)
   %3 = add i8* %0, i64 24
-  %4 = bitcast i64* %_tracepoint_syscalls_sys_enter_openat.filename to i8*
+  %4 = bitcast i64* %"struct _tracepoint_syscalls_sys_enter_openat.filename" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_openat.filename, i64 8, i8* %3)
-  %5 = load i64, i64* %_tracepoint_syscalls_sys_enter_openat.filename, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_syscalls_sys_enter_openat.filename", i64 8, i8* %3)
+  %5 = load i64, i64* %"struct _tracepoint_syscalls_sys_enter_openat.filename", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %5)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %1, i8* nonnull align 1 %2, i64 64, i1 false)
@@ -172,7 +172,7 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"tracepoint:syscalls:sys_enter_open"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_open_1" {
 entry:
   %"@_val" = alloca i64, align 8
-  %_tracepoint_syscalls_sys_enter_open.filename = alloca i64, align 8
+  %"struct _tracepoint_syscalls_sys_enter_open.filename" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %"@_key" = alloca [64 x i8], align 1
   %1 = getelementptr inbounds [64 x i8], [64 x i8]* %"@_key", i64 0, i64 0
@@ -181,10 +181,10 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.memset.p0i8.i64(i8* nonnull %2, i8 0, i64 64, i32 1, i1 false)
   %3 = add i8* %0, i64 16
-  %4 = bitcast i64* %_tracepoint_syscalls_sys_enter_open.filename to i8*
+  %4 = bitcast i64* %"struct _tracepoint_syscalls_sys_enter_open.filename" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_open.filename, i64 8, i8* %3)
-  %5 = load i64, i64* %_tracepoint_syscalls_sys_enter_open.filename, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_syscalls_sys_enter_open.filename", i64 8, i8* %3)
+  %5 = load i64, i64* %"struct _tracepoint_syscalls_sys_enter_open.filename", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %5)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %1, i8* nonnull %2, i64 64, i32 1, i1 false)
@@ -222,7 +222,7 @@ declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture r
 define i64 @"tracepoint:syscalls:sys_enter_openat"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_openat_2" {
 entry:
   %"@_val" = alloca i64, align 8
-  %_tracepoint_syscalls_sys_enter_openat.filename = alloca i64, align 8
+  %"struct _tracepoint_syscalls_sys_enter_openat.filename" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %"@_key" = alloca [64 x i8], align 1
   %1 = getelementptr inbounds [64 x i8], [64 x i8]* %"@_key", i64 0, i64 0
@@ -231,10 +231,10 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.memset.p0i8.i64(i8* nonnull %2, i8 0, i64 64, i32 1, i1 false)
   %3 = add i8* %0, i64 24
-  %4 = bitcast i64* %_tracepoint_syscalls_sys_enter_openat.filename to i8*
+  %4 = bitcast i64* %"struct _tracepoint_syscalls_sys_enter_openat.filename" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_openat.filename, i64 8, i8* %3)
-  %5 = load i64, i64* %_tracepoint_syscalls_sys_enter_openat.filename, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_syscalls_sys_enter_openat.filename", i64 8, i8* %3)
+  %5 = load i64, i64* %"struct _tracepoint_syscalls_sys_enter_openat.filename", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %5)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %1, i8* nonnull %2, i64 64, i32 1, i1 false)

--- a/tests/codegen/args_multiple_tracepoints_wild.cpp
+++ b/tests/codegen/args_multiple_tracepoints_wild.cpp
@@ -94,15 +94,15 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"tracepoint:syscalls:sys_enter_recvfrom"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_recvfrom_1" {
 entry:
   %"@_val" = alloca i64, align 8
-  %_tracepoint_syscalls_sys_enter_recvfrom.flags = alloca i64, align 8
+  %"struct _tracepoint_syscalls_sys_enter_recvfrom.flags" = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
   %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = add i8* %0, i64 40
-  %3 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags to i8*
+  %3 = bitcast i64* %"struct _tracepoint_syscalls_sys_enter_recvfrom.flags" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvfrom.flags, i64 8, i8* %2)
-  %4 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_syscalls_sys_enter_recvfrom.flags", i64 8, i8* %2)
+  %4 = load i64, i64* %"struct _tracepoint_syscalls_sys_enter_recvfrom.flags", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   store i64 %4, i8* %1, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
@@ -133,15 +133,15 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 define i64 @"tracepoint:syscalls:sys_enter_recvmmsg"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_recvmmsg_2" {
 entry:
   %"@_val" = alloca i64, align 8
-  %_tracepoint_syscalls_sys_enter_recvmmsg.flags = alloca i64, align 8
+  %"struct _tracepoint_syscalls_sys_enter_recvmmsg.flags" = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
   %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = add i8* %0, i64 40
-  %3 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvmmsg.flags to i8*
+  %3 = bitcast i64* %"struct _tracepoint_syscalls_sys_enter_recvmmsg.flags" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmmsg.flags, i64 8, i8* %2)
-  %4 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvmmsg.flags, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_syscalls_sys_enter_recvmmsg.flags", i64 8, i8* %2)
+  %4 = load i64, i64* %"struct _tracepoint_syscalls_sys_enter_recvmmsg.flags", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   store i64 %4, i8* %1, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
@@ -169,15 +169,15 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
 define i64 @"tracepoint:syscalls:sys_enter_recvmsg"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_recvmsg_3" {
 entry:
   %"@_val" = alloca i64, align 8
-  %_tracepoint_syscalls_sys_enter_recvmsg.flags = alloca i64, align 8
+  %"struct _tracepoint_syscalls_sys_enter_recvmsg.flags" = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
   %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = add i8* %0, i64 32
-  %3 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvmsg.flags to i8*
+  %3 = bitcast i64* %"struct _tracepoint_syscalls_sys_enter_recvmsg.flags" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmsg.flags, i64 8, i8* %2)
-  %4 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvmsg.flags, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_syscalls_sys_enter_recvmsg.flags", i64 8, i8* %2)
+  %4 = load i64, i64* %"struct _tracepoint_syscalls_sys_enter_recvmsg.flags", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   store i64 %4, i8* %1, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
@@ -215,15 +215,15 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"tracepoint:syscalls:sys_enter_recvfrom"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_recvfrom_1" {
 entry:
   %"@_val" = alloca i64, align 8
-  %_tracepoint_syscalls_sys_enter_recvfrom.flags = alloca i64, align 8
+  %"struct _tracepoint_syscalls_sys_enter_recvfrom.flags" = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
   %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = add i8* %0, i64 40
-  %3 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags to i8*
+  %3 = bitcast i64* %"struct _tracepoint_syscalls_sys_enter_recvfrom.flags" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvfrom.flags, i64 8, i8* %2)
-  %4 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvfrom.flags, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_syscalls_sys_enter_recvfrom.flags", i64 8, i8* %2)
+  %4 = load i64, i64* %"struct _tracepoint_syscalls_sys_enter_recvfrom.flags", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   store i64 %4, i8* %1, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
@@ -254,15 +254,15 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 define i64 @"tracepoint:syscalls:sys_enter_recvmmsg"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_recvmmsg_2" {
 entry:
   %"@_val" = alloca i64, align 8
-  %_tracepoint_syscalls_sys_enter_recvmmsg.flags = alloca i64, align 8
+  %"struct _tracepoint_syscalls_sys_enter_recvmmsg.flags" = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
   %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = add i8* %0, i64 40
-  %3 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvmmsg.flags to i8*
+  %3 = bitcast i64* %"struct _tracepoint_syscalls_sys_enter_recvmmsg.flags" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmmsg.flags, i64 8, i8* %2)
-  %4 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvmmsg.flags, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_syscalls_sys_enter_recvmmsg.flags", i64 8, i8* %2)
+  %4 = load i64, i64* %"struct _tracepoint_syscalls_sys_enter_recvmmsg.flags", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   store i64 %4, i8* %1, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
@@ -290,15 +290,15 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
 define i64 @"tracepoint:syscalls:sys_enter_recvmsg"(i8*) local_unnamed_addr section "s_tracepoint:syscalls:sys_enter_recvmsg_3" {
 entry:
   %"@_val" = alloca i64, align 8
-  %_tracepoint_syscalls_sys_enter_recvmsg.flags = alloca i64, align 8
+  %"struct _tracepoint_syscalls_sys_enter_recvmsg.flags" = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
   %1 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = add i8* %0, i64 32
-  %3 = bitcast i64* %_tracepoint_syscalls_sys_enter_recvmsg.flags to i8*
+  %3 = bitcast i64* %"struct _tracepoint_syscalls_sys_enter_recvmsg.flags" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %_tracepoint_syscalls_sys_enter_recvmsg.flags, i64 8, i8* %2)
-  %4 = load i64, i64* %_tracepoint_syscalls_sys_enter_recvmsg.flags, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_syscalls_sys_enter_recvmsg.flags", i64 8, i8* %2)
+  %4 = load i64, i64* %"struct _tracepoint_syscalls_sys_enter_recvmsg.flags", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   store i64 %4, i8* %1, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)

--- a/tests/codegen/call_ntop_char16.cpp
+++ b/tests/codegen/call_ntop_char16.cpp
@@ -6,7 +6,7 @@ namespace codegen {
 
 TEST(codegen, call_ntop_char16)
 {
-  test("struct inet { unsigned char addr[16] } kprobe:f { @x = ntop(((inet*)0)->addr); }",
+  test("struct inet { unsigned char addr[16] } kprobe:f { @x = ntop(((struct inet*)0)->addr); }",
 
 #if LLVM_VERSION_MAJOR < 6
 R"EXPECTED(%inet_t = type { i64, [16 x i8] }

--- a/tests/codegen/call_ntop_char4.cpp
+++ b/tests/codegen/call_ntop_char4.cpp
@@ -6,7 +6,7 @@ namespace codegen {
 
 TEST(codegen, call_ntop_char4)
 {
-  test("struct inet { unsigned char addr[4] } kprobe:f { @x = ntop(((inet*)0)->addr); }",
+  test("struct inet { unsigned char addr[4] } kprobe:f { @x = ntop(((struct inet*)0)->addr); }",
 
 #if LLVM_VERSION_MAJOR < 6
 R"EXPECTED(%inet_t = type { i64, [16 x i8] }

--- a/tests/codegen/call_printf.cpp
+++ b/tests/codegen/call_printf.cpp
@@ -6,7 +6,7 @@ namespace codegen {
 
 TEST(codegen, call_printf)
 {
-  test("struct Foo { char c; long l; } kprobe:f { $foo = (Foo*)0; printf(\"%c %lu\\n\", $foo->c, $foo->l) }",
+  test("struct Foo { char c; long l; } kprobe:f { $foo = (struct Foo*)0; printf(\"%c %lu\\n\", $foo->c, $foo->l) }",
 
 #if LLVM_VERSION_MAJOR < 7
 R"EXPECTED(%printf_t = type { i64, i64, i64 }
@@ -19,23 +19,23 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
-  %Foo.l = alloca i64, align 8
-  %Foo.c = alloca i8, align 1
+  %"struct Foo.l" = alloca i64, align 8
+  %"struct Foo.c" = alloca i8, align 1
   %printf_args = alloca %printf_t, align 8
   %1 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.memset.p0i8.i64(i8* nonnull %2, i8 0, i64 16, i32 8, i1 false)
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %Foo.c)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %Foo.c, i64 1, i64 0)
-  %3 = load i8, i8* %Foo.c, align 1
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %Foo.c)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %"struct Foo.c")
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %"struct Foo.c", i64 1, i64 0)
+  %3 = load i8, i8* %"struct Foo.c", align 1
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %"struct Foo.c")
   %4 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
   store i8 %3, i64* %4, align 8
-  %5 = bitcast i64* %Foo.l to i8*
+  %5 = bitcast i64* %"struct Foo.l" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.l, i64 8, i64 8)
-  %6 = load i64, i64* %Foo.l, align 8
+  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct Foo.l", i64 8, i64 8)
+  %6 = load i64, i64* %"struct Foo.l", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   %7 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2
   store i64 %6, i64* %7, align 8
@@ -66,23 +66,23 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
-  %Foo.l = alloca i64, align 8
-  %Foo.c = alloca i8, align 1
+  %"struct Foo.l" = alloca i64, align 8
+  %"struct Foo.c" = alloca i8, align 1
   %printf_args = alloca %printf_t, align 8
   %1 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %2, i8 0, i64 16, i1 false)
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %Foo.c)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %Foo.c, i64 1, i64 0)
-  %3 = load i8, i8* %Foo.c, align 1
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %Foo.c)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %"struct Foo.c")
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %"struct Foo.c", i64 1, i64 0)
+  %3 = load i8, i8* %"struct Foo.c", align 1
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %"struct Foo.c")
   %4 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
   store i8 %3, i64* %4, align 8
-  %5 = bitcast i64* %Foo.l to i8*
+  %5 = bitcast i64* %"struct Foo.l" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.l, i64 8, i64 8)
-  %6 = load i64, i64* %Foo.l, align 8
+  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct Foo.l", i64 8, i64 8)
+  %6 = load i64, i64* %"struct Foo.l", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   %7 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2
   store i64 %6, i64* %7, align 8

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -40,7 +40,7 @@ TEST(codegen, printf_offsets)
   Driver driver(bpftrace);
 
   // TODO (mmarchini): also test printf with a string argument
-  ASSERT_EQ(driver.parse_str("struct Foo { char c; int i; } kprobe:f { $foo = (Foo*)0; printf(\"%c %u\\n\", $foo->c, $foo->i) }"), 0);
+  ASSERT_EQ(driver.parse_str("struct Foo { char c; int i; } kprobe:f { $foo = (struct Foo*)0; printf(\"%c %u\\n\", $foo->c, $foo->i) }"), 0);
   ClangParser clang;
   clang.parse(driver.root_, bpftrace);
   ast::SemanticAnalyser semantics(driver.root_, bpftrace);

--- a/tests/codegen/logical_and_or_different_type.cpp
+++ b/tests/codegen/logical_and_or_different_type.cpp
@@ -19,10 +19,10 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 define i64 @BEGIN(i8*) local_unnamed_addr section "s_BEGIN_1" {
 entry:
-  %Foo.m16 = alloca i32, align 4
-  %Foo.m8 = alloca i32, align 4
-  %Foo.m6 = alloca i32, align 4
-  %Foo.m = alloca i32, align 4
+  %"struct Foo.m16" = alloca i32, align 4
+  %"struct Foo.m8" = alloca i32, align 4
+  %"struct Foo.m6" = alloca i32, align 4
+  %"struct Foo.m" = alloca i32, align 4
   %printf_args = alloca %printf_t, align 8
   %"$foo" = alloca i32, align 4
   %tmpcast = bitcast i32* %"$foo" to [4 x i8]*
@@ -34,36 +34,36 @@ entry:
   store i32 %2, i32* %"$foo", align 4
   %3 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %4 = bitcast i32* %Foo.m to i8*
+  %4 = bitcast i32* %"struct Foo.m" to i8*
   %5 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
   store i64 0, i64* %5, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m, i64 4, [4 x i8]* nonnull %tmpcast)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"struct Foo.m", i64 4, [4 x i8]* nonnull %tmpcast)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %6 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
   store i64 0, i64* %6, align 8
-  %7 = bitcast i32* %Foo.m6 to i8*
+  %7 = bitcast i32* %"struct Foo.m6" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m6, i64 4, [4 x i8]* nonnull %tmpcast)
-  %8 = load i32, i32* %Foo.m6, align 4
+  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"struct Foo.m6", i64 4, [4 x i8]* nonnull %tmpcast)
+  %8 = load i32, i32* %"struct Foo.m6", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   %rhs_true_cond = icmp ne i32 %8, 0
   %"&&_result5.0" = zext i1 %rhs_true_cond to i64
   %9 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2
   store i64 %"&&_result5.0", i64* %9, align 8
-  %10 = bitcast i32* %Foo.m8 to i8*
+  %10 = bitcast i32* %"struct Foo.m8" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
-  %probe_read9 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m8, i64 4, [4 x i8]* nonnull %tmpcast)
-  %11 = load i32, i32* %Foo.m8, align 4
+  %probe_read9 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"struct Foo.m8", i64 4, [4 x i8]* nonnull %tmpcast)
+  %11 = load i32, i32* %"struct Foo.m8", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
   %lhs_true_cond10 = icmp ne i32 %11, 0
   %"||_result.0" = zext i1 %lhs_true_cond10 to i64
   %12 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 3
   store i64 %"||_result.0", i64* %12, align 8
-  %13 = bitcast i32* %Foo.m16 to i8*
+  %13 = bitcast i32* %"struct Foo.m16" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %13)
-  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m16, i64 4, [4 x i8]* nonnull %tmpcast)
-  %14 = load i32, i32* %Foo.m16, align 4
+  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"struct Foo.m16", i64 4, [4 x i8]* nonnull %tmpcast)
+  %14 = load i32, i32* %"struct Foo.m16", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %13)
   %rhs_true_cond18 = icmp ne i32 %14, 0
   %"||_result15.0" = zext i1 %rhs_true_cond18 to i64
@@ -96,10 +96,10 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 define i64 @BEGIN(i8*) local_unnamed_addr section "s_BEGIN_1" {
 entry:
-  %Foo.m16 = alloca i32, align 4
-  %Foo.m8 = alloca i32, align 4
-  %Foo.m6 = alloca i32, align 4
-  %Foo.m = alloca i32, align 4
+  %"struct Foo.m16" = alloca i32, align 4
+  %"struct Foo.m8" = alloca i32, align 4
+  %"struct Foo.m6" = alloca i32, align 4
+  %"struct Foo.m" = alloca i32, align 4
   %printf_args = alloca %printf_t, align 8
   %"$foo" = alloca i32, align 4
   %tmpcast = bitcast i32* %"$foo" to [4 x i8]*
@@ -111,36 +111,36 @@ entry:
   store i32 %2, i32* %"$foo", align 4
   %3 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %4 = bitcast i32* %Foo.m to i8*
+  %4 = bitcast i32* %"struct Foo.m" to i8*
   %5 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
   store i64 0, i64* %5, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m, i64 4, [4 x i8]* nonnull %tmpcast)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"struct Foo.m", i64 4, [4 x i8]* nonnull %tmpcast)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %6 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
   store i64 0, i64* %6, align 8
-  %7 = bitcast i32* %Foo.m6 to i8*
+  %7 = bitcast i32* %"struct Foo.m6" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m6, i64 4, [4 x i8]* nonnull %tmpcast)
-  %8 = load i32, i32* %Foo.m6, align 4
+  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"struct Foo.m6", i64 4, [4 x i8]* nonnull %tmpcast)
+  %8 = load i32, i32* %"struct Foo.m6", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   %rhs_true_cond = icmp ne i32 %8, 0
   %"&&_result5.0" = zext i1 %rhs_true_cond to i64
   %9 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2
   store i64 %"&&_result5.0", i64* %9, align 8
-  %10 = bitcast i32* %Foo.m8 to i8*
+  %10 = bitcast i32* %"struct Foo.m8" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
-  %probe_read9 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m8, i64 4, [4 x i8]* nonnull %tmpcast)
-  %11 = load i32, i32* %Foo.m8, align 4
+  %probe_read9 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"struct Foo.m8", i64 4, [4 x i8]* nonnull %tmpcast)
+  %11 = load i32, i32* %"struct Foo.m8", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
   %lhs_true_cond10 = icmp ne i32 %11, 0
   %"||_result.0" = zext i1 %lhs_true_cond10 to i64
   %12 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 3
   store i64 %"||_result.0", i64* %12, align 8
-  %13 = bitcast i32* %Foo.m16 to i8*
+  %13 = bitcast i32* %"struct Foo.m16" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %13)
-  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.m16, i64 4, [4 x i8]* nonnull %tmpcast)
-  %14 = load i32, i32* %Foo.m16, align 4
+  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"struct Foo.m16", i64 4, [4 x i8]* nonnull %tmpcast)
+  %14 = load i32, i32* %"struct Foo.m16", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %13)
   %rhs_true_cond18 = icmp ne i32 %14, 0
   %"||_result15.0" = zext i1 %rhs_true_cond18 to i64

--- a/tests/codegen/struct_char.cpp
+++ b/tests/codegen/struct_char.cpp
@@ -18,7 +18,7 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %Foo.x = alloca i8, align 1
+  %"struct Foo.x" = alloca i8, align 1
   %"$foo" = alloca [1 x i8], align 1
   %1 = getelementptr inbounds [1 x i8], [1 x i8]* %"$foo", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
@@ -26,10 +26,10 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i8, i8 addrspace(64)* null, align 536870912
   store i8 %2, i8* %1, align 1
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %Foo.x)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %Foo.x, i64 1, [1 x i8]* nonnull %"$foo")
-  %3 = load i8, i8* %Foo.x, align 1
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %Foo.x)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %"struct Foo.x")
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %"struct Foo.x", i64 1, [1 x i8]* nonnull %"$foo")
+  %3 = load i8, i8* %"struct Foo.x", align 1
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %"struct Foo.x")
   %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
@@ -64,7 +64,7 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %Foo.x = alloca i8, align 1
+  %"struct Foo.x" = alloca i8, align 1
   %"$foo" = alloca [1 x i8], align 1
   %1 = getelementptr inbounds [1 x i8], [1 x i8]* %"$foo", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
@@ -72,10 +72,10 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i8, i8 addrspace(64)* null, align 536870912
   store i8 %2, i8* %1, align 1
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %Foo.x)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %Foo.x, i64 1, [1 x i8]* nonnull %"$foo")
-  %3 = load i8, i8* %Foo.x, align 1
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %Foo.x)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %"struct Foo.x")
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %"struct Foo.x", i64 1, [1 x i8]* nonnull %"$foo")
+  %3 = load i8, i8* %"struct Foo.x", align 1
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %"struct Foo.x")
   %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
@@ -104,7 +104,7 @@ attributes #1 = { argmemonly nounwind }
   test("struct Foo { char x; }"
        "kprobe:f"
        "{"
-       "  $foo = (Foo)0;"
+       "  $foo = (struct Foo)0;"
        "  @x = $foo.x;"
        "}",
        expected);
@@ -119,11 +119,11 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %Foo.x = alloca i8, align 1
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %Foo.x)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %Foo.x, i64 1, i64 0)
-  %1 = load i8, i8* %Foo.x, align 1
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %Foo.x)
+  %"struct Foo.x" = alloca i8, align 1
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %"struct Foo.x")
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %"struct Foo.x", i64 1, i64 0)
+  %1 = load i8, i8* %"struct Foo.x", align 1
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %"struct Foo.x")
   %2 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
@@ -148,7 +148,7 @@ attributes #1 = { argmemonly nounwind }
   test("struct Foo { char x; }"
        "kprobe:f"
        "{"
-       "  $foo = (Foo*)0;"
+       "  $foo = (struct Foo*)0;"
        "  @x = $foo->x;"
        "}",
        expected);

--- a/tests/codegen/struct_integer_ptr.cpp
+++ b/tests/codegen/struct_integer_ptr.cpp
@@ -18,7 +18,7 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %deref = alloca i32, align 4
-  %Foo.x = alloca i64, align 8
+  %"struct Foo.x" = alloca i64, align 8
   %"$foo" = alloca i64, align 8
   %tmpcast = bitcast i64* %"$foo" to [8 x i8]*
   %1 = bitcast i64* %"$foo" to i8*
@@ -27,10 +27,10 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i64, i64 addrspace(64)* null, align 536870912
   store i64 %2, i64* %"$foo", align 8
-  %3 = bitcast i64* %Foo.x to i8*
+  %3 = bitcast i64* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, [8 x i8]* nonnull %tmpcast)
-  %4 = load i64, i64* %Foo.x, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct Foo.x", i64 8, [8 x i8]* nonnull %tmpcast)
+  %4 = load i64, i64* %"struct Foo.x", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i32* %deref to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
@@ -72,7 +72,7 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %deref = alloca i32, align 4
-  %Foo.x = alloca i64, align 8
+  %"struct Foo.x" = alloca i64, align 8
   %"$foo" = alloca i64, align 8
   %tmpcast = bitcast i64* %"$foo" to [8 x i8]*
   %1 = bitcast i64* %"$foo" to i8*
@@ -81,10 +81,10 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i64, i64 addrspace(64)* null, align 536870912
   store i64 %2, i64* %"$foo", align 8
-  %3 = bitcast i64* %Foo.x to i8*
+  %3 = bitcast i64* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, [8 x i8]* nonnull %tmpcast)
-  %4 = load i64, i64* %Foo.x, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct Foo.x", i64 8, [8 x i8]* nonnull %tmpcast)
+  %4 = load i64, i64* %"struct Foo.x", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i32* %deref to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
@@ -119,7 +119,7 @@ attributes #1 = { argmemonly nounwind }
   test("struct Foo { int *x; }"
        "kprobe:f"
        "{"
-       "  $foo = (Foo)0;"
+       "  $foo = (struct Foo)0;"
        "  @x = *$foo.x;"
        "}",
        expected);
@@ -135,11 +135,11 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %deref = alloca i32, align 4
-  %Foo.x = alloca i64, align 8
-  %1 = bitcast i64* %Foo.x to i8*
+  %"struct Foo.x" = alloca i64, align 8
+  %1 = bitcast i64* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, i64 0)
-  %2 = load i64, i64* %Foo.x, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct Foo.x", i64 8, i64 0)
+  %2 = load i64, i64* %"struct Foo.x", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i32* %deref to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
@@ -170,7 +170,7 @@ attributes #1 = { argmemonly nounwind }
   test("struct Foo { int *x; }"
        "kprobe:f"
        "{"
-       "  $foo = (Foo*)0;"
+       "  $foo = (struct Foo*)0;"
        "  @x = *$foo->x;"
        "}",
        expected);

--- a/tests/codegen/struct_integers.cpp
+++ b/tests/codegen/struct_integers.cpp
@@ -17,7 +17,7 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %Foo.x = alloca i32, align 4
+  %"struct Foo.x" = alloca i32, align 4
   %"$foo" = alloca i32, align 4
   %tmpcast = bitcast i32* %"$foo" to [4 x i8]*
   %1 = bitcast i32* %"$foo" to i8*
@@ -26,10 +26,10 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i32, i32 addrspace(64)* null, align 536870912
   store i32 %2, i32* %"$foo", align 4
-  %3 = bitcast i32* %Foo.x to i8*
+  %3 = bitcast i32* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.x, i64 4, [4 x i8]* nonnull %tmpcast)
-  %4 = load i32, i32* %Foo.x, align 4
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"struct Foo.x", i64 4, [4 x i8]* nonnull %tmpcast)
+  %4 = load i32, i32* %"struct Foo.x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
@@ -65,7 +65,7 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %Foo.x = alloca i32, align 4
+  %"struct Foo.x" = alloca i32, align 4
   %"$foo" = alloca i32, align 4
   %tmpcast = bitcast i32* %"$foo" to [4 x i8]*
   %1 = bitcast i32* %"$foo" to i8*
@@ -74,10 +74,10 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i32, i32 addrspace(64)* null, align 536870912
   store i32 %2, i32* %"$foo", align 4
-  %3 = bitcast i32* %Foo.x to i8*
+  %3 = bitcast i32* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.x, i64 4, [4 x i8]* nonnull %tmpcast)
-  %4 = load i32, i32* %Foo.x, align 4
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"struct Foo.x", i64 4, [4 x i8]* nonnull %tmpcast)
+  %4 = load i32, i32* %"struct Foo.x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
@@ -107,7 +107,7 @@ attributes #1 = { argmemonly nounwind }
   test("struct Foo { int x; }"
        "kprobe:f"
        "{"
-       "  $foo = (Foo)0;"
+       "  $foo = (struct Foo)0;"
        "  @x = $foo.x;"
        "}",
        expected);
@@ -123,11 +123,11 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %Foo.x = alloca i32, align 4
-  %1 = bitcast i32* %Foo.x to i8*
+  %"struct Foo.x" = alloca i32, align 4
+  %1 = bitcast i32* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Foo.x, i64 4, i64 0)
-  %2 = load i32, i32* %Foo.x, align 4
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"struct Foo.x", i64 4, i64 0)
+  %2 = load i32, i32* %"struct Foo.x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
@@ -153,7 +153,7 @@ attributes #1 = { argmemonly nounwind }
   test("struct Foo { int x; }"
        "kprobe:f"
        "{"
-       "  $foo = (Foo*)0;"
+       "  $foo = (struct Foo*)0;"
        "  @x = $foo->x;"
        "}",
        expected);

--- a/tests/codegen/struct_long.cpp
+++ b/tests/codegen/struct_long.cpp
@@ -17,7 +17,7 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %Foo.x = alloca i64, align 8
+  %"struct Foo.x" = alloca i64, align 8
   %"$foo" = alloca i64, align 8
   %tmpcast = bitcast i64* %"$foo" to [8 x i8]*
   %1 = bitcast i64* %"$foo" to i8*
@@ -26,10 +26,10 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i64, i64 addrspace(64)* null, align 536870912
   store i64 %2, i64* %"$foo", align 8
-  %3 = bitcast i64* %Foo.x to i8*
+  %3 = bitcast i64* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, [8 x i8]* nonnull %tmpcast)
-  %4 = load i64, i64* %Foo.x, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct Foo.x", i64 8, [8 x i8]* nonnull %tmpcast)
+  %4 = load i64, i64* %"struct Foo.x", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
@@ -64,7 +64,7 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %Foo.x = alloca i64, align 8
+  %"struct Foo.x" = alloca i64, align 8
   %"$foo" = alloca i64, align 8
   %tmpcast = bitcast i64* %"$foo" to [8 x i8]*
   %1 = bitcast i64* %"$foo" to i8*
@@ -73,10 +73,10 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i64, i64 addrspace(64)* null, align 536870912
   store i64 %2, i64* %"$foo", align 8
-  %3 = bitcast i64* %Foo.x to i8*
+  %3 = bitcast i64* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, [8 x i8]* nonnull %tmpcast)
-  %4 = load i64, i64* %Foo.x, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct Foo.x", i64 8, [8 x i8]* nonnull %tmpcast)
+  %4 = load i64, i64* %"struct Foo.x", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
@@ -105,7 +105,7 @@ attributes #1 = { argmemonly nounwind }
   test("struct Foo { long x; }"
        "kprobe:f"
        "{"
-       "  $foo = (Foo)0;"
+       "  $foo = (struct Foo)0;"
        "  @x = $foo.x;"
        "}",
        expected);
@@ -120,11 +120,11 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %Foo.x = alloca i64, align 8
-  %1 = bitcast i64* %Foo.x to i8*
+  %"struct Foo.x" = alloca i64, align 8
+  %1 = bitcast i64* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.x, i64 8, i64 0)
-  %2 = load i64, i64* %Foo.x, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct Foo.x", i64 8, i64 0)
+  %2 = load i64, i64* %"struct Foo.x", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
@@ -149,7 +149,7 @@ attributes #1 = { argmemonly nounwind }
   test("struct Foo { long x; }"
        "kprobe:f"
        "{"
-       "  $foo = (Foo*)0;"
+       "  $foo = (struct Foo*)0;"
        "  @x = $foo->x;"
        "}",
        expected);

--- a/tests/codegen/struct_nested_struct_anon.cpp
+++ b/tests/codegen/struct_nested_struct_anon.cpp
@@ -18,7 +18,7 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %"Foo::(anonymous at definitions.h:1:14).x" = alloca i32, align 4
+  %"struct Foo::(anonymous at definitions.h:1:14).x" = alloca i32, align 4
   %"$foo" = alloca i32, align 4
   %tmpcast = bitcast i32* %"$foo" to [4 x i8]*
   %1 = bitcast i32* %"$foo" to i8*
@@ -27,10 +27,10 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i32, i32 addrspace(64)* null, align 536870912
   store i32 %2, i32* %"$foo", align 4
-  %3 = bitcast i32* %"Foo::(anonymous at definitions.h:1:14).x" to i8*
+  %3 = bitcast i32* %"struct Foo::(anonymous at definitions.h:1:14).x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"Foo::(anonymous at definitions.h:1:14).x", i64 4, [4 x i8]* nonnull %tmpcast)
-  %4 = load i32, i32* %"Foo::(anonymous at definitions.h:1:14).x", align 4
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"struct Foo::(anonymous at definitions.h:1:14).x", i64 4, [4 x i8]* nonnull %tmpcast)
+  %4 = load i32, i32* %"struct Foo::(anonymous at definitions.h:1:14).x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
@@ -66,7 +66,7 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %"Foo::(anonymous at definitions.h:1:14).x" = alloca i32, align 4
+  %"struct Foo::(anonymous at definitions.h:1:14).x" = alloca i32, align 4
   %"$foo" = alloca i32, align 4
   %tmpcast = bitcast i32* %"$foo" to [4 x i8]*
   %1 = bitcast i32* %"$foo" to i8*
@@ -75,10 +75,10 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i32, i32 addrspace(64)* null, align 536870912
   store i32 %2, i32* %"$foo", align 4
-  %3 = bitcast i32* %"Foo::(anonymous at definitions.h:1:14).x" to i8*
+  %3 = bitcast i32* %"struct Foo::(anonymous at definitions.h:1:14).x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"Foo::(anonymous at definitions.h:1:14).x", i64 4, [4 x i8]* nonnull %tmpcast)
-  %4 = load i32, i32* %"Foo::(anonymous at definitions.h:1:14).x", align 4
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"struct Foo::(anonymous at definitions.h:1:14).x", i64 4, [4 x i8]* nonnull %tmpcast)
+  %4 = load i32, i32* %"struct Foo::(anonymous at definitions.h:1:14).x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
@@ -108,7 +108,7 @@ attributes #1 = { argmemonly nounwind }
   test("struct Foo { struct { int x; } bar; }"
        "kprobe:f"
        "{"
-       "  $foo = (Foo)0;"
+       "  $foo = (struct Foo)0;"
        "  @x = $foo.bar.x;"
        "}",
        expected);
@@ -123,11 +123,11 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %"Foo::(anonymous at definitions.h:1:14).x" = alloca i32, align 4
-  %1 = bitcast i32* %"Foo::(anonymous at definitions.h:1:14).x" to i8*
+  %"struct Foo::(anonymous at definitions.h:1:14).x" = alloca i32, align 4
+  %1 = bitcast i32* %"struct Foo::(anonymous at definitions.h:1:14).x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"Foo::(anonymous at definitions.h:1:14).x", i64 4, i64 0)
-  %2 = load i32, i32* %"Foo::(anonymous at definitions.h:1:14).x", align 4
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"struct Foo::(anonymous at definitions.h:1:14).x", i64 4, i64 0)
+  %2 = load i32, i32* %"struct Foo::(anonymous at definitions.h:1:14).x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
@@ -153,7 +153,7 @@ attributes #1 = { argmemonly nounwind }
   test("struct Foo { struct { int x; } bar; }"
        "kprobe:f"
        "{"
-       "  $foo = (Foo*)0;"
+       "  $foo = (struct Foo*)0;"
        "  @x = $foo->bar.x;"
        "}",
        expected);

--- a/tests/codegen/struct_nested_struct_named.cpp
+++ b/tests/codegen/struct_nested_struct_named.cpp
@@ -17,7 +17,7 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %Bar.x = alloca i32, align 4
+  %"struct Bar.x" = alloca i32, align 4
   %"$foo" = alloca i32, align 4
   %tmpcast = bitcast i32* %"$foo" to [4 x i8]*
   %1 = bitcast i32* %"$foo" to i8*
@@ -26,10 +26,10 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i32, i32 addrspace(64)* null, align 536870912
   store i32 %2, i32* %"$foo", align 4
-  %3 = bitcast i32* %Bar.x to i8*
+  %3 = bitcast i32* %"struct Bar.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, [4 x i8]* nonnull %tmpcast)
-  %4 = load i32, i32* %Bar.x, align 4
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"struct Bar.x", i64 4, [4 x i8]* nonnull %tmpcast)
+  %4 = load i32, i32* %"struct Bar.x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
@@ -65,7 +65,7 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %Bar.x = alloca i32, align 4
+  %"struct Bar.x" = alloca i32, align 4
   %"$foo" = alloca i32, align 4
   %tmpcast = bitcast i32* %"$foo" to [4 x i8]*
   %1 = bitcast i32* %"$foo" to i8*
@@ -74,10 +74,10 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i32, i32 addrspace(64)* null, align 536870912
   store i32 %2, i32* %"$foo", align 4
-  %3 = bitcast i32* %Bar.x to i8*
+  %3 = bitcast i32* %"struct Bar.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, [4 x i8]* nonnull %tmpcast)
-  %4 = load i32, i32* %Bar.x, align 4
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"struct Bar.x", i64 4, [4 x i8]* nonnull %tmpcast)
+  %4 = load i32, i32* %"struct Bar.x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
@@ -107,7 +107,7 @@ attributes #1 = { argmemonly nounwind }
   test("struct Bar { int x; } struct Foo { struct Bar bar; }"
        "kprobe:f"
        "{"
-       "  $foo = (Foo)0;"
+       "  $foo = (struct Foo)0;"
        "  @x = $foo.bar.x;"
        "}",
        expected);
@@ -122,11 +122,11 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %Bar.x = alloca i32, align 4
-  %1 = bitcast i32* %Bar.x to i8*
+  %"struct Bar.x" = alloca i32, align 4
+  %1 = bitcast i32* %"struct Bar.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i64 0)
-  %2 = load i32, i32* %Bar.x, align 4
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"struct Bar.x", i64 4, i64 0)
+  %2 = load i32, i32* %"struct Bar.x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
@@ -152,7 +152,7 @@ attributes #1 = { argmemonly nounwind }
   test("struct Bar { int x; } struct Foo { struct Bar bar; }"
        "kprobe:f"
        "{"
-       "  $foo = (Foo*)0;"
+       "  $foo = (struct Foo*)0;"
        "  @x = $foo->bar.x;"
        "}",
        expected);

--- a/tests/codegen/struct_nested_struct_ptr_named.cpp
+++ b/tests/codegen/struct_nested_struct_ptr_named.cpp
@@ -17,8 +17,8 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %Bar.x = alloca i32, align 4
-  %Foo.bar = alloca i64, align 8
+  %"struct Bar.x" = alloca i32, align 4
+  %"struct Foo.bar" = alloca i64, align 8
   %"$foo" = alloca i64, align 8
   %tmpcast = bitcast i64* %"$foo" to [8 x i8]*
   %1 = bitcast i64* %"$foo" to i8*
@@ -27,15 +27,15 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i64, i64 addrspace(64)* null, align 536870912
   store i64 %2, i64* %"$foo", align 8
-  %3 = bitcast i64* %Foo.bar to i8*
+  %3 = bitcast i64* %"struct Foo.bar" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.bar, i64 8, [8 x i8]* nonnull %tmpcast)
-  %4 = load i64, i64* %Foo.bar, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct Foo.bar", i64 8, [8 x i8]* nonnull %tmpcast)
+  %4 = load i64, i64* %"struct Foo.bar", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  %5 = bitcast i32* %Bar.x to i8*
+  %5 = bitcast i32* %"struct Bar.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i64 %4)
-  %6 = load i32, i32* %Bar.x, align 4
+  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"struct Bar.x", i64 4, i64 %4)
+  %6 = load i32, i32* %"struct Bar.x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   %7 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
@@ -71,8 +71,8 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %Bar.x = alloca i32, align 4
-  %Foo.bar = alloca i64, align 8
+  %"struct Bar.x" = alloca i32, align 4
+  %"struct Foo.bar" = alloca i64, align 8
   %"$foo" = alloca i64, align 8
   %tmpcast = bitcast i64* %"$foo" to [8 x i8]*
   %1 = bitcast i64* %"$foo" to i8*
@@ -81,15 +81,15 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i64, i64 addrspace(64)* null, align 536870912
   store i64 %2, i64* %"$foo", align 8
-  %3 = bitcast i64* %Foo.bar to i8*
+  %3 = bitcast i64* %"struct Foo.bar" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.bar, i64 8, [8 x i8]* nonnull %tmpcast)
-  %4 = load i64, i64* %Foo.bar, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct Foo.bar", i64 8, [8 x i8]* nonnull %tmpcast)
+  %4 = load i64, i64* %"struct Foo.bar", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  %5 = bitcast i32* %Bar.x to i8*
+  %5 = bitcast i32* %"struct Bar.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i64 %4)
-  %6 = load i32, i32* %Bar.x, align 4
+  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"struct Bar.x", i64 4, i64 %4)
+  %6 = load i32, i32* %"struct Bar.x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   %7 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
@@ -119,7 +119,7 @@ attributes #1 = { argmemonly nounwind }
   test("struct Bar { int x; } struct Foo { struct Bar *bar; }"
        "kprobe:f"
        "{"
-       "  $foo = (Foo)0;"
+       "  $foo = (struct Foo)0;"
        "  @x = $foo.bar->x;"
        "}",
        expected);
@@ -134,17 +134,17 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %Bar.x = alloca i32, align 4
-  %Foo.bar = alloca i64, align 8
-  %1 = bitcast i64* %Foo.bar to i8*
+  %"struct Bar.x" = alloca i32, align 4
+  %"struct Foo.bar" = alloca i64, align 8
+  %1 = bitcast i64* %"struct Foo.bar" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.bar, i64 8, i64 0)
-  %2 = load i64, i64* %Foo.bar, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct Foo.bar", i64 8, i64 0)
+  %2 = load i64, i64* %"struct Foo.bar", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  %3 = bitcast i32* %Bar.x to i8*
+  %3 = bitcast i32* %"struct Bar.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %Bar.x, i64 4, i64 %2)
-  %4 = load i32, i32* %Bar.x, align 4
+  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i32* nonnull %"struct Bar.x", i64 4, i64 %2)
+  %4 = load i32, i32* %"struct Bar.x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
@@ -170,7 +170,7 @@ attributes #1 = { argmemonly nounwind }
   test("struct Bar { int x; } struct Foo { struct Bar *bar; }"
        "kprobe:f"
        "{"
-       "  $foo = (Foo*)0;"
+       "  $foo = (struct Foo*)0;"
        "  @x = $foo->bar->x;"
        "}",
        expected);

--- a/tests/codegen/struct_save.cpp
+++ b/tests/codegen/struct_save.cpp
@@ -39,14 +39,14 @@ attributes #1 = { argmemonly nounwind }
   test("struct Foo { int x, y, z; }"
        "kprobe:f"
        "{"
-       "  @foo = (Foo)0;"
+       "  @foo = (struct Foo)0;"
        "}",
        expected);
 
   test("struct Foo { int x, y, z; }"
        "kprobe:f"
        "{"
-       "  @foo = *(Foo*)0;"
+       "  @foo = *(struct Foo*)0;"
        "}",
        expected);
 }

--- a/tests/codegen/struct_save_nested.cpp
+++ b/tests/codegen/struct_save_nested.cpp
@@ -18,8 +18,8 @@ entry:
   %"@x_key" = alloca i64, align 8
   %"@foo_key5" = alloca i64, align 8
   %"@bar_key" = alloca i64, align 8
-  %internal_Foo.bar = alloca i64, align 8
-  %tmpcast = bitcast i64* %internal_Foo.bar to [8 x i8]*
+  %"internal_struct Foo.bar" = alloca i64, align 8
+  %tmpcast = bitcast i64* %"internal_struct Foo.bar" to [8 x i8]*
   %"@foo_key1" = alloca i64, align 8
   %"@foo_val" = alloca [16 x i8], align 1
   %"@foo_key" = alloca i64, align 8
@@ -50,9 +50,9 @@ lookup_success:                                   ; preds = %entry
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.sroa.3.0 = phi i64 [ %lookup_elem_val.sroa.3.0.copyload, %lookup_success ], [ 0, %entry ]
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  %4 = bitcast i64* %internal_Foo.bar to i8*
+  %4 = bitcast i64* %"internal_struct Foo.bar" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  store i64 %lookup_elem_val.sroa.3.0, i64* %internal_Foo.bar, align 8
+  store i64 %lookup_elem_val.sroa.3.0, i64* %"internal_struct Foo.bar", align 8
   %5 = bitcast i64* %"@bar_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@bar_key", align 8
@@ -102,7 +102,7 @@ attributes #1 = { argmemonly nounwind }
   test("struct Foo { int m; struct { int x; int y; } bar; int n; }"
        "kprobe:f"
        "{"
-       "  @foo = (Foo)0;"
+       "  @foo = (struct Foo)0;"
        "  @bar = @foo.bar;"
        "  @x = @foo.bar.x;"
        "}",

--- a/tests/codegen/struct_save_string.cpp
+++ b/tests/codegen/struct_save_string.cpp
@@ -143,7 +143,7 @@ attributes #1 = { argmemonly nounwind }
   test("struct Foo { char str[32]; }"
        "kprobe:f"
        "{"
-       "  @foo = (Foo)0;"
+       "  @foo = (struct Foo)0;"
        "  @str = @foo.str;"
        "}",
        expected);

--- a/tests/codegen/struct_short.cpp
+++ b/tests/codegen/struct_short.cpp
@@ -17,7 +17,7 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %Foo.x = alloca i16, align 2
+  %"struct Foo.x" = alloca i16, align 2
   %"$foo" = alloca i16, align 2
   %tmpcast = bitcast i16* %"$foo" to [2 x i8]*
   %1 = bitcast i16* %"$foo" to i8*
@@ -26,10 +26,10 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i16, i16 addrspace(64)* null, align 536870912
   store i16 %2, i16* %"$foo", align 2
-  %3 = bitcast i16* %Foo.x to i8*
+  %3 = bitcast i16* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i16* nonnull %Foo.x, i64 2, [2 x i8]* nonnull %tmpcast)
-  %4 = load i16, i16* %Foo.x, align 2
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i16* nonnull %"struct Foo.x", i64 2, [2 x i8]* nonnull %tmpcast)
+  %4 = load i16, i16* %"struct Foo.x", align 2
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
@@ -65,7 +65,7 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %Foo.x = alloca i16, align 2
+  %"struct Foo.x" = alloca i16, align 2
   %"$foo" = alloca i16, align 2
   %tmpcast = bitcast i16* %"$foo" to [2 x i8]*
   %1 = bitcast i16* %"$foo" to i8*
@@ -74,10 +74,10 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %2 = load i16, i16 addrspace(64)* null, align 536870912
   store i16 %2, i16* %"$foo", align 2
-  %3 = bitcast i16* %Foo.x to i8*
+  %3 = bitcast i16* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i16* nonnull %Foo.x, i64 2, [2 x i8]* nonnull %tmpcast)
-  %4 = load i16, i16* %Foo.x, align 2
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i16* nonnull %"struct Foo.x", i64 2, [2 x i8]* nonnull %tmpcast)
+  %4 = load i16, i16* %"struct Foo.x", align 2
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
@@ -107,7 +107,7 @@ attributes #1 = { argmemonly nounwind }
   test("struct Foo { short x; }"
        "kprobe:f"
        "{"
-       "  $foo = (Foo)0;"
+       "  $foo = (struct Foo)0;"
        "  @x = $foo.x;"
        "}",
        expected);
@@ -122,11 +122,11 @@ define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kpr
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %Foo.x = alloca i16, align 2
-  %1 = bitcast i16* %Foo.x to i8*
+  %"struct Foo.x" = alloca i16, align 2
+  %1 = bitcast i16* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i16* nonnull %Foo.x, i64 2, i64 0)
-  %2 = load i16, i16* %Foo.x, align 2
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i16* nonnull %"struct Foo.x", i64 2, i64 0)
+  %2 = load i16, i16* %"struct Foo.x", align 2
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
@@ -152,7 +152,7 @@ attributes #1 = { argmemonly nounwind }
   test("struct Foo { short x; }"
        "kprobe:f"
        "{"
-       "  $foo = (Foo*)0;"
+       "  $foo = (struct Foo*)0;"
        "  @x = $foo->x;"
        "}",
        expected);

--- a/tests/codegen/struct_string_array.cpp
+++ b/tests/codegen/struct_string_array.cpp
@@ -16,21 +16,21 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@mystr_key" = alloca i64, align 8
-  %Foo.str = alloca [32 x i8], align 1
+  %"struct Foo.str" = alloca [32 x i8], align 1
   %"$foo" = alloca [32 x i8], align 1
   %1 = getelementptr inbounds [32 x i8], [32 x i8]* %"$foo", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i64 0, i64 32, i1 false)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memcpy.p0i8.p64i8.i64(i8* nonnull align 1 %1, i8 addrspace(64)* align 536870912 null, i64 32, i1 false)
-  %2 = getelementptr inbounds [32 x i8], [32 x i8]* %Foo.str, i64 0, i64 0
+  %2 = getelementptr inbounds [32 x i8], [32 x i8]* %"struct Foo.str", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([32 x i8]* nonnull %Foo.str, i64 32, [32 x i8]* nonnull %"$foo")
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([32 x i8]* nonnull %"struct Foo.str", i64 32, [32 x i8]* nonnull %"$foo")
   %3 = bitcast i64* %"@mystr_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@mystr_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [32 x i8]* nonnull %Foo.str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [32 x i8]* nonnull %"struct Foo.str", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0
@@ -58,21 +58,21 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@mystr_key" = alloca i64, align 8
-  %Foo.str = alloca [32 x i8], align 1
+  %"struct Foo.str" = alloca [32 x i8], align 1
   %"$foo" = alloca [32 x i8], align 1
   %1 = getelementptr inbounds [32 x i8], [32 x i8]* %"$foo", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i64 0, i64 32, i32 1, i1 false)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memcpy.p0i8.p64i8.i64(i8* nonnull %1, i8 addrspace(64)* null, i64 32, i32 1, i1 false)
-  %2 = getelementptr inbounds [32 x i8], [32 x i8]* %Foo.str, i64 0, i64 0
+  %2 = getelementptr inbounds [32 x i8], [32 x i8]* %"struct Foo.str", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([32 x i8]* nonnull %Foo.str, i64 32, [32 x i8]* nonnull %"$foo")
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([32 x i8]* nonnull %"struct Foo.str", i64 32, [32 x i8]* nonnull %"$foo")
   %3 = bitcast i64* %"@mystr_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@mystr_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [32 x i8]* nonnull %Foo.str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [32 x i8]* nonnull %"struct Foo.str", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0
@@ -95,7 +95,7 @@ attributes #1 = { argmemonly nounwind }
   test("struct Foo { char str[32]; }"
        "kprobe:f"
        "{"
-       "  $foo = (Foo)0;"
+       "  $foo = (struct Foo)0;"
        "  @mystr = $foo.str;"
        "}",
        expected);
@@ -109,15 +109,15 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@mystr_key" = alloca i64, align 8
-  %Foo.str = alloca [32 x i8], align 1
-  %1 = getelementptr inbounds [32 x i8], [32 x i8]* %Foo.str, i64 0, i64 0
+  %"struct Foo.str" = alloca [32 x i8], align 1
+  %1 = getelementptr inbounds [32 x i8], [32 x i8]* %"struct Foo.str", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([32 x i8]* nonnull %Foo.str, i64 32, i64 0)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([32 x i8]* nonnull %"struct Foo.str", i64 32, i64 0)
   %2 = bitcast i64* %"@mystr_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@mystr_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [32 x i8]* nonnull %Foo.str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [32 x i8]* nonnull %"struct Foo.str", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -133,7 +133,7 @@ attributes #1 = { argmemonly nounwind }
   test("struct Foo { char str[32]; }"
        "kprobe:f"
        "{"
-       "  $foo = (Foo*)0;"
+       "  $foo = (struct Foo*)0;"
        "  @mystr = $foo->str;"
        "}",
        expected);

--- a/tests/codegen/struct_string_ptr.cpp
+++ b/tests/codegen/struct_string_ptr.cpp
@@ -16,7 +16,7 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@mystr_key" = alloca i64, align 8
-  %Foo.str = alloca i64, align 8
+  %"struct Foo.str" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %"$foo" = alloca i64, align 8
   %tmpcast = bitcast i64* %"$foo" to [8 x i8]*
@@ -29,10 +29,10 @@ entry:
   %3 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %3, i8 0, i64 64, i1 false)
-  %4 = bitcast i64* %Foo.str to i8*
+  %4 = bitcast i64* %"struct Foo.str" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.str, i64 8, [8 x i8]* nonnull %tmpcast)
-  %5 = load i64, i64* %Foo.str, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct Foo.str", i64 8, [8 x i8]* nonnull %tmpcast)
+  %5 = load i64, i64* %"struct Foo.str", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %5)
   %6 = bitcast i64* %"@mystr_key" to i8*
@@ -64,7 +64,7 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@mystr_key" = alloca i64, align 8
-  %Foo.str = alloca i64, align 8
+  %"struct Foo.str" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %"$foo" = alloca i64, align 8
   %tmpcast = bitcast i64* %"$foo" to [8 x i8]*
@@ -77,10 +77,10 @@ entry:
   %3 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.memset.p0i8.i64(i8* nonnull %3, i8 0, i64 64, i32 1, i1 false)
-  %4 = bitcast i64* %Foo.str to i8*
+  %4 = bitcast i64* %"struct Foo.str" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.str, i64 8, [8 x i8]* nonnull %tmpcast)
-  %5 = load i64, i64* %Foo.str, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct Foo.str", i64 8, [8 x i8]* nonnull %tmpcast)
+  %5 = load i64, i64* %"struct Foo.str", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %5)
   %6 = bitcast i64* %"@mystr_key" to i8*
@@ -107,7 +107,7 @@ attributes #1 = { argmemonly nounwind }
   test("struct Foo { char *str; }"
        "kprobe:f"
        "{"
-       "  $foo = (Foo)0;"
+       "  $foo = (struct Foo)0;"
        "  @mystr = str($foo.str);"
        "}",
        expected);
@@ -122,15 +122,15 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@mystr_key" = alloca i64, align 8
-  %Foo.str = alloca i64, align 8
+  %"struct Foo.str" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %1 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i8 0, i64 64, i1 false)
-  %2 = bitcast i64* %Foo.str to i8*
+  %2 = bitcast i64* %"struct Foo.str" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.str, i64 8, i64 0)
-  %3 = load i64, i64* %Foo.str, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct Foo.str", i64 8, i64 0)
+  %3 = load i64, i64* %"struct Foo.str", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %3)
   %4 = bitcast i64* %"@mystr_key" to i8*
@@ -162,15 +162,15 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@mystr_key" = alloca i64, align 8
-  %Foo.str = alloca i64, align 8
+  %"struct Foo.str" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %1 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 64, i32 1, i1 false)
-  %2 = bitcast i64* %Foo.str to i8*
+  %2 = bitcast i64* %"struct Foo.str" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %Foo.str, i64 8, i64 0)
-  %3 = load i64, i64* %Foo.str, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct Foo.str", i64 8, i64 0)
+  %3 = load i64, i64* %"struct Foo.str", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %3)
   %4 = bitcast i64* %"@mystr_key" to i8*
@@ -198,7 +198,7 @@ attributes #1 = { argmemonly nounwind }
   test("struct Foo { char *str; }"
        "kprobe:f"
        "{"
-       "  $foo = (Foo*)0;"
+       "  $foo = (struct Foo*)0;"
        "  @mystr = str($foo->str);"
        "}",
        expected);

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -51,6 +51,18 @@ void setup_mock_bpftrace(MockBPFtrace &bpftrace)
                                 "nahprov:tp\n";
         return std::unique_ptr<std::istream>(new std::istringstream(usdt_syms));
       });
+
+  // Fill in some default tracepoint struct definitions
+  bpftrace.structs_["struct _tracepoint_sched_sched_one"] = Struct
+  {
+    .size = 4,
+    .fields = {{"common_field", Field {} }},
+  };
+  bpftrace.structs_["struct _tracepoint_sched_sched_two"] = Struct
+  {
+    .size = 4,
+    .fields = {{"common_field", Field {} }},
+  };
 }
 
 std::unique_ptr<MockBPFtrace> get_mock_bpftrace()

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1048,6 +1048,34 @@ TEST(Parser, brackets)
 
 TEST(Parser, cast)
 {
+  test("kprobe:sys_read { (struct mytype)arg0; }",
+      "Program\n"
+      " kprobe:sys_read\n"
+      "  (struct mytype)\n"
+      "   builtin: arg0\n");
+  test("kprobe:sys_read { (union mytype)arg0; }",
+      "Program\n"
+      " kprobe:sys_read\n"
+      "  (union mytype)\n"
+      "   builtin: arg0\n");
+}
+
+TEST(Parser, cast_ptr)
+{
+  test("kprobe:sys_read { (struct mytype*)arg0; }",
+      "Program\n"
+      " kprobe:sys_read\n"
+      "  (struct mytype*)\n"
+      "   builtin: arg0\n");
+  test("kprobe:sys_read { (union mytype*)arg0; }",
+      "Program\n"
+      " kprobe:sys_read\n"
+      "  (union mytype*)\n"
+      "   builtin: arg0\n");
+}
+
+TEST(Parser, cast_typedef)
+{
   test("kprobe:sys_read { (mytype)arg0; }",
       "Program\n"
       " kprobe:sys_read\n"
@@ -1055,7 +1083,7 @@ TEST(Parser, cast)
       "   builtin: arg0\n");
 }
 
-TEST(Parser, cast_ptr)
+TEST(Parser, cast_ptr_typedef)
 {
   test("kprobe:sys_read { (mytype*)arg0; }",
       "Program\n"

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -38,11 +38,6 @@ RUN bpftrace -v -e 'BEGIN { if (comm == "bpftrace") { printf("comm: %s\n", comm)
 EXPECT comm: bpftrace
 TIMEOUT 5
 
-NAME struct keyword optional when casting
-RUN bpftrace -v -e 'struct Bar { int x; } struct Foo { struct Bar *bar; } i:ms:1 { $foo = (struct Foo *)0; @x = $foo->bar->x; exit()}'
-EXPECT @x: 0
-TIMEOUT 5
-
 NAME struct positional string compare - equal returns true
 RUN bpftrace -v -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} exit();}' "hello" "hello"
 EXPECT I got hello

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -1,6 +1,6 @@
 # https://github.com/iovisor/bpftrace/pull/566#issuecomment-487295113
 NAME codegen_struct_save_nested
-RUN bpftrace -e 'struct Foo { int m; struct { int x; int y; } bar; int n; } BEGIN { @foo = (Foo)0; @bar = @foo.bar; @x = @foo.bar.x; printf("done\n"); exit(); }'
+RUN bpftrace -e 'struct Foo { int m; struct { int x; int y; } bar; int n; } BEGIN { @foo = (struct Foo)0; @bar = @foo.bar; @x = @foo.bar.x; printf("done\n"); exit(); }'
 EXPECT done
 TIMEOUT 1
 

--- a/tests/runtime/signed_ints
+++ b/tests/runtime/signed_ints
@@ -19,7 +19,7 @@ EXPECT @: -22$
 TIMEOUT 1
 
 NAME Comparison should print as 0 or 1
-RUN bpftrace -e 'struct x { uint64_t x; }; BEGIN { $a = ((x)0).x; printf("%d %d\n", $a > -1, $a < 1); exit(); }'
+RUN bpftrace -e 'struct x { uint64_t x; }; BEGIN { $a = ((struct x)0).x; printf("%d %d\n", $a > -1, $a < 1); exit(); }'
 EXPECT ^0 1$
 TIMEOUT 1
 


### PR DESCRIPTION
Casting now has the same semantics as in C - the shorthand
of leaving out the "struct" keyword is no longer valid.

    struct Foo { int x; }
    (struct Foo *)0  // valid
    (Foo *)0         // not valid

    typedef struct { int x; } Bar
    (Bar *)0         // valid
    (struct Bar *)0  // not valid

Fixes #682