### PR TITLE
 Only warn about missing BTF info in debug mode 

### DIFF
--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -172,7 +172,7 @@ BTF::BTF(void) : btf(nullptr), state(NODATA)
     libbpf_set_print(libbpf_print);
     state = OK;
   }
-  else
+  else if (bt_debug != DebugLevel::kNone)
   {
     std::cerr << "BTF: failed to find BTF data " << std::endl;
   }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,8 +40,8 @@ void usage()
   std::cerr << "OPTIONS:" << std::endl;
   std::cerr << "    -B MODE        output buffering mode ('full', 'none')" << std::endl;
   std::cerr << "    -f FORMAT      output format ('text', 'json')" << std::endl;
-  std::cerr << "    -d             debug info dry run" << std::endl;
   std::cerr << "    -o file        redirect bpftrace output to file" << std::endl;
+  std::cerr << "    -d             debug info dry run" << std::endl;
   std::cerr << "    -dd            verbose debug info dry run" << std::endl;
   std::cerr << "    -b             force BTF (BPF type format) processing" << std::endl;
   std::cerr << "    -e 'program'   execute this program" << std::endl;


### PR DESCRIPTION
Before:

    $ sudo ./build/src/bpftrace -e 'BEGIN { printf("hello world\n"); }'
    BTF: failed to find BTF data
    Attaching 1 probe...
    hello world
    ^C