### PR TITLE
Add ASAN build option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,6 +9,7 @@ set(bpftrace_VERSION_PATCH 3)
 set(STATIC_LINKING OFF CACHE BOOL "Build bpftrace as a statically linked executable")
 set(WARNINGS_AS_ERRORS OFF CACHE BOOL "Build with -Werror")
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+set(BUILD_ASAN OFF CACHE BOOL "Build bpftrace with -fsanitize=address")
 
 set (CMAKE_CXX_STANDARD 14)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -75,6 +75,12 @@ else()
 endif()
 target_link_libraries(bpftrace ${LIBELF_LIBRARIES})
 
+if (BUILD_ASAN)
+  target_compile_definitions(bpftrace PRIVATE BUILD_ASAN)
+  target_compile_options(bpftrace PUBLIC "-fsanitize=address")
+  target_link_options(bpftrace PUBLIC "-fsanitize=address")
+endif()
+
 install(TARGETS bpftrace DESTINATION bin)
 
 set(KERNEL_HEADERS_DIR "" CACHE PATH "Hard-code kernel headers directory")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -79,8 +79,8 @@ install(TARGETS bpftrace DESTINATION bin)
 
 set(KERNEL_HEADERS_DIR "" CACHE PATH "Hard-code kernel headers directory")
 if (KERNEL_HEADERS_DIR)
-MESSAGE(STATUS "Using KERNEL_HEADERS_DIR=${KERNEL_HEADERS_DIR}")
-target_compile_definitions(bpftrace PUBLIC KERNEL_HEADERS_DIR="${KERNEL_HEADERS_DIR}")
+  MESSAGE(STATUS "Using KERNEL_HEADERS_DIR=${KERNEL_HEADERS_DIR}")
+  target_compile_definitions(bpftrace PUBLIC KERNEL_HEADERS_DIR="${KERNEL_HEADERS_DIR}")
 endif()
 
 execute_process(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -85,6 +85,11 @@ static void enforce_infinite_rlimit() {
         "\"ulimit -l 8192\" to fix the problem" << std::endl;
 }
 
+#ifdef BUILD_ASAN
+static void cap_memory_limits()
+{
+}
+#else
 static void cap_memory_limits() {
   struct rlimit rl = {};
   int err;
@@ -102,6 +107,7 @@ static void cap_memory_limits() {
         "RLIMIT_RSS for bpftrace (these are a temporary precaution to stop " <<
         "accidental large program loads, and are not required" << std::endl;
 }
+#endif // BUILD_ASAN
 
 bool is_root()
 {


### PR DESCRIPTION
ASAN is incredibly useful to prevent entire classes of memory errors. For
example, when ASAN is enabled, it already shows us 35 memory leaks:

```
$  ~/dev/bpftrace git:(asan) ✗ sudo ./build/src/bpftrace -e 'BEGIN { printf("hi\n"); }'
[sudo] password for dxu:
Attaching 1 probe...
hi
^C

=================================================================
==758098==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 288 byte(s) in 4 object(s) allocated from:
    #0 0x7f72bbb5dcd8 in __interceptor_calloc /build/gcc/src/gcc/lib...
    #1 0x7f72b96665e5 in perf_reader_new (/usr/lib/libbcc.so.0+0x3e85e5)
    #2 0x7ffc5103b767  ([stack]+0x68767)

Direct leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x7f72bbb5f8f8 in operator new(unsigned long) /build/gcc/src/...
    #1 0x5631e1a566cd in bpftrace::Parser::parse() src/parser.yy:151
    #2 0x5631e18cae7e in bpftrace::Driver::parse() /home/dxu/dev/bpft...
    #3 0x5631e18dd8ac in main /home/dxu/dev/bpftrace/src/main.cpp:349
    #4 0x7f72b3eb5152 in __libc_start_main (/usr/lib/libc.so.6+0x27152)

Direct leak of 80 byte(s) in 1 object(s) allocated from:
    #0 0x7f72bbb5f8f8 in operator new(unsigned long) /build/gcc/src/g...
    #1 0x5631e1a566cd in bpftrace::Parser::parse() src/parser.yy:151
    #2 0x5631e18cae7e in bpftrace::Driver::parse() /home/dxu/dev/bpf...
    #3 0x5631e18df34f in main /home/dxu/dev/bpftrace/src/main.cpp:491
    #4 0x7f72b3eb5152 in __libc_start_main (/usr/lib/libc.so.6+0x27152)

[...]
```

The default is off for now b/c we have a lot of noisy leaks. Once those
are fixed, we should flip to on by default to be in preventative mode.

Note we also have to disable the rlimit protection b/c ASAN needs to
mmap a huge amount of the address space to work.