### PR TITLE
Warn if cmake is less than 3.13 when building with ASAN

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,6 +76,10 @@ endif()
 target_link_libraries(bpftrace ${LIBELF_LIBRARIES})
 
 if (BUILD_ASAN)
+  if(${CMAKE_VERSION} VERSION_LESS "3.13.0")
+    # target_link_options is supported in CMake 3.13 and newer
+    message("Please use CMake 3.13 or newer to enable ASAN")
+  endif()
   target_compile_definitions(bpftrace PRIVATE BUILD_ASAN)
   target_compile_options(bpftrace PUBLIC "-fsanitize=address")
   target_link_options(bpftrace PUBLIC "-fsanitize=address")


### PR DESCRIPTION
Building ASAN use `target_link_options` and it is supported in CMake
3.13 and newer. Print error message if cmake version is less than 3.13
when build with ASAN.

The output looks like

```
% cmake .. -DBUILD_ASAN=1
...
Please use CMake 3.13 or newer to enable ASAN
CMake Error at src/CMakeLists.txt:84 (target_link_options):
  Unknown CMake command "target_link_options".

-- Configuring incomplete, errors occurred!
```