### PR TITLE
Fix CI clang-format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -21,7 +21,8 @@ AlwaysBreakTemplateDeclarations: false
 BinPackArguments: false
 BinPackParameters: false
 BraceWrapping:
-  AfterCaseLabel:        true
+  # AfterCaseLabel was added in clang9
+  #AfterCaseLabel:        true
   AfterClass:            true
   AfterControlStatement: true
   AfterEnum:             true


### PR DESCRIPTION
Most people are still on clang8. This flag was introduced in clang9.