### PR TITLE
error message for verification buffer size

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -528,10 +528,10 @@ void AttachedProbe::load_prog()
       std::cerr << std::endl << "Error log: " << std::endl << log_buf << std::endl;
       if (errno == ENOSPC) {
         std::stringstream errmsg;
-          errmsg << "Error: Failed to load program, verification log buffer "
-            << "not big enough, try increasing the BPFTRACE_LOG_SIZE "
-            << "environment variable beyond the current value of "
-            << probe_.log_size << " bytes";
+        errmsg << "Error: Failed to load program, verification log buffer "
+               << "not big enough, try increasing the BPFTRACE_LOG_SIZE "
+               << "environment variable beyond the current value of "
+               << probe_.log_size << " bytes";
 
         throw std::runtime_error(errmsg.str());
       }

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -528,9 +528,10 @@ void AttachedProbe::load_prog()
       std::cerr << std::endl << "Error log: " << std::endl << log_buf << std::endl;
       if (errno == ENOSPC) {
         std::stringstream errmsg;
-          errmsg << "Error: Verification buffer not big enough, try increasing "
-            << "BPFTRACE_LOG_SIZE environment variable beyond the current "
-            << "value of " << probe_.log_size << " bytes";
+          errmsg << "Error: Verification log buffer not big enough, try "
+            << "increasing the BPFTRACE_LOG_SIZE environment variable "
+            << "beyond the current value of " << probe_.log_size
+            << " bytes";
 
         throw std::runtime_error(errmsg.str());
       }

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -528,10 +528,10 @@ void AttachedProbe::load_prog()
       std::cerr << std::endl << "Error log: " << std::endl << log_buf << std::endl;
       if (errno == ENOSPC) {
         std::stringstream errmsg;
-          errmsg << "Error: Verification log buffer not big enough, try "
-            << "increasing the BPFTRACE_LOG_SIZE environment variable "
-            << "beyond the current value of " << probe_.log_size
-            << " bytes";
+          errmsg << "Error: Failed to load program, verification log buffer "
+            << "not big enough, try increasing the BPFTRACE_LOG_SIZE "
+            << "environment variable beyond the current value of "
+            << probe_.log_size << " bytes";
 
         throw std::runtime_error(errmsg.str());
       }

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -527,7 +527,12 @@ void AttachedProbe::load_prog()
     if (bt_verbose) {
       std::cerr << std::endl << "Error log: " << std::endl << log_buf << std::endl;
       if (errno == ENOSPC) {
-        std::cerr << "Error: No space left on device, try increasing BPFTRACE_LOG_SIZE environment variable" << std::endl;
+        // TODO: Can we extract the current value of bpftrace.log_size_ here to
+        // print it out?
+        std::cerr << "Error: Verification buffer not big enough, try "
+                  << "increasing BPFTRACE_LOG_SIZE environment variable "
+                  << "beyond its current value"
+                  << std::endl;
       }
     }
     throw std::runtime_error("Error loading program: " + probe_.name + (bt_verbose ? "" : " (try -v)"));

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -527,12 +527,12 @@ void AttachedProbe::load_prog()
     if (bt_verbose) {
       std::cerr << std::endl << "Error log: " << std::endl << log_buf << std::endl;
       if (errno == ENOSPC) {
-        // TODO: Can we extract the current value of bpftrace.log_size_ here to
-        // print it out?
-        std::cerr << "Error: Verification buffer not big enough, try "
-                  << "increasing BPFTRACE_LOG_SIZE environment variable "
-                  << "beyond its current value"
-                  << std::endl;
+        std::stringstream errmsg;
+          errmsg << "Error: Verification buffer not big enough, try increasing "
+            << "BPFTRACE_LOG_SIZE environment variable beyond the current "
+            << "value of " << probe_.log_size << " bytes";
+
+        throw std::runtime_error(errmsg.str());
       }
     }
     throw std::runtime_error("Error loading program: " + probe_.name + (bt_verbose ? "" : " (try -v)"));


### PR DESCRIPTION
Should we throw a separate `std::runtime_error()` with this message in this case and skip the normal exception?