### PR TITLE
Consider a non null-terminated and/or short Type::string value

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1812,12 +1812,12 @@ void BPFtrace::sort_by_key(std::vector<SizedType> key_args,
     }
     else if (arg.type == Type::string)
     {
-      std::stable_sort(values_by_key.begin(), values_by_key.end(), [&](auto &a, auto &b)
-      {
-        return strncmp((const char*)(a.first.data() + arg_offset),
-                       (const char*)(b.first.data() + arg_offset),
-                       STRING_SIZE) < 0;
-      });
+      std::stable_sort(
+          values_by_key.begin(), values_by_key.end(), [&](auto &a, auto &b) {
+            return strncmp((const char *)(a.first.data() + arg_offset),
+                           (const char *)(b.first.data() + arg_offset),
+                           arg.size) < 0;
+          });
     }
 
     // Other types don't get sorted

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -1,5 +1,7 @@
-#include "mapkey.h"
+#include <cstring>
+
 #include "bpftrace.h"
+#include "mapkey.h"
 #include "utils.h"
 
 namespace bpftrace {
@@ -94,7 +96,10 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
     case Type::probe:
       return bpftrace.probe_ids_[read_data<uint64_t>(data)];
     case Type::string:
-      return std::string((const char*)data);
+    {
+      auto p = static_cast<const char *>(data);
+      return std::string(p, strnlen(p, arg.size));
+    }
     case Type::cast:
       if (arg.is_pointer) {
         // use case: show me these pointer values

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -21,6 +21,15 @@ std::ostream &operator<<(std::ostream &os, const SizedType &type)
   {
     os << (type.is_signed ? "" : "unsigned ") << "int" << 8*type.size;
   }
+  else if (type.type == Type::array)
+  {
+    os << (type.is_signed ? "" : "unsigned ") << "int" << 8 * type.pointee_size;
+    os << "[" << type.size << "]";
+  }
+  else if (type.type == Type::string)
+  {
+    os << type.type << "[" << type.size << "]";
+  }
   else
   {
     os << type.type;

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -73,6 +73,11 @@ RUN bpftrace -v -e 'struct F {char s[8];} u:./testprogs/string_args:print { @=st
 EXPECT @: 0
 TIMEOUT 5
 
+NAME short non null-terminated string print
+RUN bpftrace -v -e 'struct F {char s[5];} u:./testprogs/string_args:print { $a = ((struct F*)arg0)->s; printf("%s %s\n", $a, $a); }' -c ./testprogs/string_args
+EXPECT hello hello
+TIMEOUT 5
+
 NAME optional_positional_int
 RUN bpftrace -e 'BEGIN { printf("-%d-\n", $1); exit() }'
 EXPECT -0-


### PR DESCRIPTION
Type::string value can be non null-terminated and/or its length can be less than `STRING_SIZE` (64).
Fix the codes which do not take these into account.

------

This fixes errors like the following.

- Target program
```c
#include <stdio.h>

struct a {
    char v[4];
};

void f(struct a* a){
    printf("%c\n", a->v[0]);
}

int main(){
    struct a a = { .v = {0x30, 0x31, 0x32, 0x33} };
    f(&a);
    return 0;
}
```

- error 1
```
%sudo ./src/bpftrace -e 'struct a { char v[4]; } u:./a.out:f { $a = ((struct a*)arg0)->v; printf("%s %s\n", $a, $a); }'
Attaching 1 probe...
01230123 0123
```

- error 2

```
% sudo ./src/bpftrace -e 'struct a { char v[4]; } u:./a.out:f { @[((struct a*)arg0)->v] = count(); }'
Attaching 1 uprobe...
Running...
^C

@[0123U]: 1
```
