### PR TITLE
Type fixes

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -215,7 +215,13 @@ Value *IRBuilderBPF::CreateMapLookupElem(int mapfd, AllocaInst *key, SizedType &
   if (is_array)
     CREATE_MEMCPY(value, call, type.size, 1);
   else
-    CreateStore(CreateLoad(getInt64Ty(), call), value);
+  {
+    assert(value->getType()->isPointerTy() &&
+           (value->getType()->getElementType() == getInt64Ty()));
+    // createMapLookup  returns an u8*
+    auto *cast = CreatePointerCast(call, value->getType(), "cast");
+    CreateStore(CreateLoad(getInt64Ty(), cast), value);
+  }
   CreateBr(lookup_merge_block);
 
   SetInsertPoint(lookup_failure_block);
@@ -234,21 +240,26 @@ Value *IRBuilderBPF::CreateMapLookupElem(int mapfd, AllocaInst *key, SizedType &
 
 void IRBuilderBPF::CreateMapUpdateElem(Map &map, AllocaInst *key, Value *val)
 {
-  Value *map_ptr = CreateBpfPseudoCall(map);
+  Value *mapid = CreateBpfPseudoCall(map);
+
+  assert(key->getType()->isPointerTy());
+  assert(mapid->getType()->isIntegerTy());
+  assert(val->getType()->isPointerTy());
+
   Value *flags = getInt64(0);
 
-  // int map_update_elem(&map, &key, &value, flags)
-  // Return: 0 on success or negative error
+  // int map_update_elem(struct bpf_map * map, void *key, void * value, u64
+  // flags) Return: 0 on success or negative error
   FunctionType *update_func_type = FunctionType::get(
       getInt64Ty(),
-      {getInt8PtrTy(), getInt8PtrTy(), getInt8PtrTy(), getInt64Ty()},
+      { getInt64Ty(), key->getType(), val->getType(), getInt64Ty() },
       false);
   PointerType *update_func_ptr_type = PointerType::get(update_func_type, 0);
   Constant *update_func = ConstantExpr::getCast(
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_map_update_elem),
       update_func_ptr_type);
-  CreateCall(update_func, {map_ptr, key, val, flags}, "update_elem");
+  CreateCall(update_func, { mapid, key, val, flags }, "update_elem");
 }
 
 void IRBuilderBPF::CreateMapDeleteElem(Map &map, AllocaInst *key)

--- a/tests/codegen/args_multiple_tracepoints.cpp
+++ b/tests/codegen/args_multiple_tracepoints.cpp
@@ -38,7 +38,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %3, [8 x i8]* %"@_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -77,7 +77,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %3, [8 x i8]* %"@_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -123,7 +123,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %3, [8 x i8]* %"@_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -162,7 +162,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %3, [8 x i8]* %"@_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 

--- a/tests/codegen/args_multiple_tracepoints.cpp
+++ b/tests/codegen/args_multiple_tracepoints.cpp
@@ -43,7 +43,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %5 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %5 = load i64, i64* %cast, align 8
   %phitmp = add i64 %5, 1
   br label %lookup_merge
 
@@ -53,7 +54,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
@@ -82,7 +83,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %5 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %5 = load i64, i64* %cast, align 8
   %phitmp = add i64 %5, 1
   br label %lookup_merge
 
@@ -92,7 +94,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
@@ -128,7 +130,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %5 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %5 = load i64, i64* %cast, align 8
   %phitmp = add i64 %5, 1
   br label %lookup_merge
 
@@ -138,7 +141,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
@@ -167,7 +170,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %5 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %5 = load i64, i64* %cast, align 8
   %phitmp = add i64 %5, 1
   br label %lookup_merge
 
@@ -177,7 +181,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0

--- a/tests/codegen/args_multiple_tracepoints_wild.cpp
+++ b/tests/codegen/args_multiple_tracepoints_wild.cpp
@@ -37,7 +37,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %3, [8 x i8]* %"@_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -76,7 +76,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %3, [8 x i8]* %"@_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -122,7 +122,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %3, [8 x i8]* %"@_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -161,7 +161,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %3, [8 x i8]* %"@_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 

--- a/tests/codegen/args_multiple_tracepoints_wild.cpp
+++ b/tests/codegen/args_multiple_tracepoints_wild.cpp
@@ -42,7 +42,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %5 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %5 = load i64, i64* %cast, align 8
   %phitmp = add i64 %5, 1
   br label %lookup_merge
 
@@ -52,7 +53,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
@@ -81,7 +82,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %5 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %5 = load i64, i64* %cast, align 8
   %phitmp = add i64 %5, 1
   br label %lookup_merge
 
@@ -91,7 +93,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
@@ -127,7 +129,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %5 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %5 = load i64, i64* %cast, align 8
   %phitmp = add i64 %5, 1
   br label %lookup_merge
 
@@ -137,7 +140,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
@@ -166,7 +169,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %5 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %5 = load i64, i64* %cast, align 8
   %phitmp = add i64 %5, 1
   br label %lookup_merge
 
@@ -176,7 +180,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0

--- a/tests/codegen/bitshift_left.cpp
+++ b/tests/codegen/bitshift_left.cpp
@@ -8,7 +8,7 @@ TEST(codegen, bitshift_left)
 {
   test("kprobe:f { @x = 1 << 10; }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -25,7 +25,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 1024, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/bitshift_right.cpp
+++ b/tests/codegen/bitshift_right.cpp
@@ -8,7 +8,7 @@ TEST(codegen, bitshift_right)
 {
   test("kprobe:f { @x = 1024 >> 9; }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -25,7 +25,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 2, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/bitwise_not.cpp
+++ b/tests/codegen/bitwise_not.cpp
@@ -8,7 +8,7 @@ namespace codegen {
 TEST(codegen, bitwise_not)
 {
   test("BEGIN { @x = ~10; }",
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -25,7 +25,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 -11, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0
@@ -37,7 +37,6 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
-
 }
 
 } // namespace codegen

--- a/tests/codegen/builtin_arg.cpp
+++ b/tests/codegen/builtin_arg.cpp
@@ -8,7 +8,7 @@ TEST(codegen, builtin_arg)
 {
   test("kprobe:f { @x = arg0; @y = arg2 }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -29,7 +29,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %arg0, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %4 = getelementptr i8, i8* %0, i64 96
@@ -41,7 +41,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %arg2, i64* %"@y_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
+  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0

--- a/tests/codegen/builtin_comm.cpp
+++ b/tests/codegen/builtin_comm.cpp
@@ -9,7 +9,7 @@ TEST(codegen, builtin_comm)
   test("kprobe:f { @x = comm }",
 
 #if LLVM_VERSION_MAJOR < 7
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -27,7 +27,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [16 x i8]* nonnull %comm, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [16 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [16 x i8]* nonnull %comm, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -43,7 +43,7 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #else
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -61,7 +61,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [16 x i8]* nonnull %comm, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [16 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [16 x i8]* nonnull %comm, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0

--- a/tests/codegen/builtin_cpid.cpp
+++ b/tests/codegen/builtin_cpid.cpp
@@ -16,9 +16,10 @@ TEST(codegen, builtin_cpid)
   ON_CALL(bpftrace, child_pid())
     .WillByDefault(Return(1337));
 
-  test(bpftrace, "kprobe:f { @ = cpid }",
+  test(bpftrace,
+       "kprobe:f { @ = cpid }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -35,7 +36,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 1337, i64* %"@_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/builtin_cpu.cpp
+++ b/tests/codegen/builtin_cpu.cpp
@@ -8,7 +8,7 @@ TEST(codegen, builtin_cpu)
 {
   test("kprobe:f { @x = cpu }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -26,7 +26,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 %get_cpu_id, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/builtin_ctx.cpp
+++ b/tests/codegen/builtin_ctx.cpp
@@ -8,7 +8,7 @@ TEST(codegen, builtin_ctx)
 {
   test("kprobe:f { @x = ctx }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -26,7 +26,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %2, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/builtin_curtask.cpp
+++ b/tests/codegen/builtin_curtask.cpp
@@ -8,7 +8,7 @@ TEST(codegen, builtin_curtask)
 {
   test("kprobe:f { @x = curtask }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -26,7 +26,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 %get_cur_task, i64* %"@x_ptr", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_ptr", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_ptr", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/builtin_elapsed.cpp
+++ b/tests/codegen/builtin_elapsed.cpp
@@ -28,7 +28,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %2 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %2 = load i64, i64* %cast, align 8
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
@@ -43,7 +44,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %3, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0

--- a/tests/codegen/builtin_elapsed.cpp
+++ b/tests/codegen/builtin_elapsed.cpp
@@ -23,7 +23,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 0, i64* %elapsed_key, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, i64* nonnull %elapsed_key)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* nonnull %elapsed_key)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 

--- a/tests/codegen/builtin_func.cpp
+++ b/tests/codegen/builtin_func.cpp
@@ -8,7 +8,7 @@ TEST(codegen, builtin_func)
 {
   test("kprobe:f { @x = func }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -27,7 +27,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %func, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0
@@ -45,7 +45,7 @@ TEST(codegen, builtin_func_uprobe)
 {
   test("uprobe:/bin/sh:f { @x = func }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -72,7 +72,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store [16 x i8]* %func1, [16 x i8]* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [16 x i8]* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [16 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [16 x i8]* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0

--- a/tests/codegen/builtin_func_wild.cpp
+++ b/tests/codegen/builtin_func_wild.cpp
@@ -12,9 +12,9 @@ TEST(codegen, builtin_func_wild)
   auto bpftrace = get_mock_bpftrace();
 
   test(*bpftrace,
-      "kprobe:do_execve* { @x = func }",
+       "kprobe:do_execve* { @x = func }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -33,7 +33,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %func, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/builtin_kstack.cpp
+++ b/tests/codegen/builtin_kstack.cpp
@@ -8,7 +8,7 @@ TEST(codegen, builtin_kstack)
 {
   test("kprobe:f { @x = kstack }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -27,7 +27,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 %get_stackid, i64* %"@x_val", align 8
   %pseudo1 = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/builtin_nsecs.cpp
+++ b/tests/codegen/builtin_nsecs.cpp
@@ -8,7 +8,7 @@ TEST(codegen, builtin_nsecs)
 {
   test("kprobe:f { @x = nsecs }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -26,7 +26,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 %get_ns, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/builtin_pid_tid.cpp
+++ b/tests/codegen/builtin_pid_tid.cpp
@@ -8,7 +8,7 @@ TEST(codegen, builtin_pid_tid)
 {
   test("kprobe:f { @x = pid; @y = tid }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -29,7 +29,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to i64 ()*)()
@@ -41,7 +41,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %4, i64* %"@y_val", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem3 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo2, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
+  %update_elem3 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0

--- a/tests/codegen/builtin_probe.cpp
+++ b/tests/codegen/builtin_probe.cpp
@@ -10,9 +10,9 @@ TEST(codegen, builtin_probe)
   auto bpftrace = get_mock_bpftrace();
 
   test(*bpftrace,
-      "tracepoint:sched:sched_one { @x = probe }",
+       "tracepoint:sched:sched_one { @x = probe }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -29,7 +29,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/builtin_probe_wild.cpp
+++ b/tests/codegen/builtin_probe_wild.cpp
@@ -12,9 +12,9 @@ TEST(codegen, builtin_probe_wild)
   auto bpftrace = get_mock_bpftrace();
 
   test(*bpftrace,
-      "tracepoint:sched:sched_on* { @x = probe }",
+       "tracepoint:sched:sched_on* { @x = probe }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -31,7 +31,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/builtin_rand.cpp
+++ b/tests/codegen/builtin_rand.cpp
@@ -8,7 +8,7 @@ TEST(codegen, builtin_rand)
 {
   test("kprobe:f { @x = rand }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -26,7 +26,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 %get_random, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/builtin_retval.cpp
+++ b/tests/codegen/builtin_retval.cpp
@@ -8,7 +8,7 @@ TEST(codegen, builtin_retval)
 {
   test("kretprobe:f { @x = retval }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -27,7 +27,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %retval, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/builtin_sarg.cpp
+++ b/tests/codegen/builtin_sarg.cpp
@@ -8,7 +8,7 @@ TEST(codegen, builtin_sarg)
 {
   test("kprobe:f { @x = sarg0; @y = sarg2 }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -37,7 +37,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %4, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   %reg_sp1 = load i64, i8* %1, align 8
@@ -54,7 +54,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %11)
   store i64 %9, i64* %"@y_val", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo3, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo3, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %11)
   ret i64 0

--- a/tests/codegen/builtin_uid_gid.cpp
+++ b/tests/codegen/builtin_uid_gid.cpp
@@ -8,7 +8,7 @@ TEST(codegen, builtin_uid_gid)
 {
   test("kprobe:f { @x = uid; @y = gid }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -29,7 +29,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %get_uid_gid1 = call i64 inttoptr (i64 15 to i64 ()*)()
@@ -41,7 +41,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %4, i64* %"@y_val", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem3 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo2, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
+  %update_elem3 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0

--- a/tests/codegen/builtin_username.cpp
+++ b/tests/codegen/builtin_username.cpp
@@ -8,7 +8,7 @@ TEST(codegen, builtin_username)
 {
   test("kprobe:f { @x = username; @y = gid}",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -29,7 +29,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %get_uid_gid1 = call i64 inttoptr (i64 15 to i64 ()*)()
@@ -41,7 +41,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %4, i64* %"@y_val", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem3 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo2, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
+  %update_elem3 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0

--- a/tests/codegen/builtin_ustack.cpp
+++ b/tests/codegen/builtin_ustack.cpp
@@ -8,7 +8,7 @@ TEST(codegen, builtin_ustack)
 {
   test("kprobe:f { @x = ustack }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -30,7 +30,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %2, i64* %"@x_val", align 8
   %pseudo1 = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/call_avg.cpp
+++ b/tests/codegen/call_avg.cpp
@@ -29,7 +29,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %2 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %2 = load i64, i64* %cast, align 8
   %phitmp = add i64 %2, 1
   br label %lookup_merge
 
@@ -39,7 +40,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %lookup_elem_val.0, i64* %"@x_num", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_num", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_num", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %4 = bitcast i64* %"@x_key2" to i8*
@@ -51,7 +52,8 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   br i1 %map_lookup_cond9, label %lookup_merge7, label %lookup_success5
 
 lookup_success5:                                  ; preds = %lookup_merge
-  %5 = load i64, i8* %lookup_elem4, align 8
+  %cast10 = bitcast i8* %lookup_elem4 to i64*
+  %5 = load i64, i64* %cast10, align 8
   br label %lookup_merge7
 
 lookup_merge7:                                    ; preds = %lookup_merge, %lookup_success5
@@ -62,8 +64,8 @@ lookup_merge7:                                    ; preds = %lookup_merge, %look
   %7 = lshr i64 %get_pid_tgid, 32
   %8 = add i64 %7, %lookup_elem_val8.0
   store i64 %8, i64* %"@x_val", align 8
-  %pseudo10 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem11 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo10, i64* nonnull %"@x_key2", i64* nonnull %"@x_val", i64 0)
+  %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem12 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo11, i64* nonnull %"@x_key2", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0

--- a/tests/codegen/call_avg.cpp
+++ b/tests/codegen/call_avg.cpp
@@ -8,7 +8,7 @@ TEST(codegen, call_avg)
 {
   test("kprobe:f { @x = avg(pid) }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -24,7 +24,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, i64* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -46,7 +46,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 1, i64* %"@x_key2", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem4 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo3, i64* nonnull %"@x_key2")
+  %lookup_elem4 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo3, i64* nonnull %"@x_key2")
   %map_lookup_cond9 = icmp eq i8* %lookup_elem4, null
   br i1 %map_lookup_cond9, label %lookup_merge7, label %lookup_success5
 

--- a/tests/codegen/call_cgroup.cpp
+++ b/tests/codegen/call_cgroup.cpp
@@ -6,9 +6,10 @@ namespace codegen {
 
 TEST(codegen, call_cgroup)
 {
-test("tracepoint:syscalls:sys_enter_openat /cgroup == 0x100000001/ { @x = cgroup }",
+  test("tracepoint:syscalls:sys_enter_openat /cgroup == 0x100000001/ { @x = "
+       "cgroup }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -34,7 +35,7 @@ pred_true:                                        ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %get_cgroup_id1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/call_clear.cpp
+++ b/tests/codegen/call_clear.cpp
@@ -8,7 +8,7 @@ TEST(codegen, call_clear)
 {
   test("BEGIN { @x = 1; } kprobe:f { clear(@x); }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -25,7 +25,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/call_count.cpp
+++ b/tests/codegen/call_count.cpp
@@ -27,7 +27,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %2 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %2 = load i64, i64* %cast, align 8
   %phitmp = add i64 %2, 1
   br label %lookup_merge
 
@@ -37,7 +38,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/call_count.cpp
+++ b/tests/codegen/call_count.cpp
@@ -8,7 +8,7 @@ TEST(codegen, call_count)
 {
   test("kprobe:f { @x = count() }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -22,7 +22,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, i64* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 

--- a/tests/codegen/call_delete.cpp
+++ b/tests/codegen/call_delete.cpp
@@ -8,7 +8,7 @@ TEST(codegen, call_delete)
 {
   test("kprobe:f { @x = 1; delete(@x) }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -26,7 +26,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = bitcast i64* %"@x_key1" to i8*

--- a/tests/codegen/call_hist.cpp
+++ b/tests/codegen/call_hist.cpp
@@ -8,7 +8,7 @@ TEST(codegen, call_hist)
 {
   test("kprobe:f { @x = hist(pid) }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -55,7 +55,7 @@ log2.exit:                                        ; preds = %entry, %hist.is_not
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %26)
   store i64 %log22, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, i64* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 

--- a/tests/codegen/call_hist.cpp
+++ b/tests/codegen/call_hist.cpp
@@ -60,7 +60,8 @@ log2.exit:                                        ; preds = %entry, %hist.is_not
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %log2.exit
-  %27 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %27 = load i64, i64* %cast, align 8
   %phitmp = add i64 %27, 1
   br label %lookup_merge
 
@@ -70,7 +71,7 @@ lookup_merge:                                     ; preds = %log2.exit, %lookup_
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %28)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %26)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %28)
   ret i64 0

--- a/tests/codegen/call_kstack.cpp
+++ b/tests/codegen/call_kstack.cpp
@@ -27,7 +27,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 %get_stackid, i64* %"@x_val", align 8
   %pseudo1 = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
@@ -39,7 +39,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %get_stackid3, i64* %"@y_val", align 8
   %pseudo4 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem5 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo4, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
+  %update_elem5 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo4, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/call_lhist.cpp
+++ b/tests/codegen/call_lhist.cpp
@@ -8,7 +8,7 @@ TEST(codegen, call_lhist)
 {
   test("kprobe:f { @x = lhist(pid, 0, 100, 1) }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -28,7 +28,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %linear3, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, i64* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 

--- a/tests/codegen/call_lhist.cpp
+++ b/tests/codegen/call_lhist.cpp
@@ -33,7 +33,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %5 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %5 = load i64, i64* %cast, align 8
   %phitmp = add i64 %5, 1
   br label %lookup_merge
 
@@ -43,7 +44,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo2, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0

--- a/tests/codegen/call_max.cpp
+++ b/tests/codegen/call_max.cpp
@@ -27,7 +27,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %2 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %2 = load i64, i64* %cast, align 8
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
@@ -47,7 +48,7 @@ min.lt:                                           ; preds = %lookup_merge, %min.
 min.ge:                                           ; preds = %lookup_merge
   store i64 %4, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   br label %min.lt
 }
 

--- a/tests/codegen/call_max.cpp
+++ b/tests/codegen/call_max.cpp
@@ -8,7 +8,7 @@ TEST(codegen, call_max)
 {
   test("kprobe:f { @x = max(pid) }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -22,7 +22,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, i64* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 

--- a/tests/codegen/call_min.cpp
+++ b/tests/codegen/call_min.cpp
@@ -27,7 +27,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %2 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %2 = load i64, i64* %cast, align 8
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
@@ -48,7 +49,7 @@ min.lt:                                           ; preds = %lookup_merge, %min.
 min.ge:                                           ; preds = %lookup_merge
   store i64 %5, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   br label %min.lt
 }
 

--- a/tests/codegen/call_min.cpp
+++ b/tests/codegen/call_min.cpp
@@ -8,7 +8,7 @@ TEST(codegen, call_min)
 {
   test("kprobe:f { @x = min(pid) }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -22,7 +22,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, i64* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 

--- a/tests/codegen/call_ntop_char16.cpp
+++ b/tests/codegen/call_ntop_char16.cpp
@@ -6,10 +6,11 @@ namespace codegen {
 
 TEST(codegen, call_ntop_char16)
 {
-  test("struct inet { unsigned char addr[16] } kprobe:f { @x = ntop(((struct inet*)0)->addr); }",
+  test("struct inet { unsigned char addr[16] } kprobe:f { @x = ntop(((struct "
+       "inet*)0)->addr); }",
 
 #if LLVM_VERSION_MAJOR < 6
-R"EXPECTED(%inet_t = type { i64, [16 x i8] }
+       R"EXPECTED(%inet_t = type { i64, [16 x i8] }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
@@ -32,7 +33,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %inet_t*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -48,7 +49,7 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #elif LLVM_VERSION_MAJOR > 6
-R"EXPECTED(%inet_t = type { i64, [16 x i8] }
+       R"EXPECTED(%inet_t = type { i64, [16 x i8] }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
@@ -71,7 +72,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %inet_t*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -87,7 +88,7 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #else
-R"EXPECTED(%inet_t = type { i64, [16 x i8] }
+       R"EXPECTED(%inet_t = type { i64, [16 x i8] }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
@@ -110,7 +111,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %inet_t*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -131,5 +132,3 @@ attributes #1 = { argmemonly nounwind }
 } // namespace codegen
 } // namespace test
 } // namespace bpftrace
-
-

--- a/tests/codegen/call_ntop_char4.cpp
+++ b/tests/codegen/call_ntop_char4.cpp
@@ -6,10 +6,11 @@ namespace codegen {
 
 TEST(codegen, call_ntop_char4)
 {
-  test("struct inet { unsigned char addr[4] } kprobe:f { @x = ntop(((struct inet*)0)->addr); }",
+  test("struct inet { unsigned char addr[4] } kprobe:f { @x = ntop(((struct "
+       "inet*)0)->addr); }",
 
 #if LLVM_VERSION_MAJOR < 6
-R"EXPECTED(%inet_t = type { i64, [16 x i8] }
+       R"EXPECTED(%inet_t = type { i64, [16 x i8] }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
@@ -32,7 +33,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %inet_t*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -48,7 +49,7 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #elif LLVM_VERSION_MAJOR > 6
-R"EXPECTED(%inet_t = type { i64, [16 x i8] }
+       R"EXPECTED(%inet_t = type { i64, [16 x i8] }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
@@ -71,7 +72,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %inet_t*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -87,7 +88,7 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #else
-R"EXPECTED(%inet_t = type { i64, [16 x i8] }
+       R"EXPECTED(%inet_t = type { i64, [16 x i8] }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
@@ -110,7 +111,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %inet_t*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -131,4 +132,3 @@ attributes #1 = { argmemonly nounwind }
 } // namespace codegen
 } // namespace test
 } // namespace bpftrace
-

--- a/tests/codegen/call_ntop_key.cpp
+++ b/tests/codegen/call_ntop_key.cpp
@@ -34,7 +34,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %4 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %4 = load i64, i64* %cast, align 8
   %phitmp = add i64 %4, 1
   br label %lookup_merge
 
@@ -44,7 +45,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, %inet_t* nonnull %inet, i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, %inet_t*, i64*, i64)*)(i64 %pseudo1, %inet_t* nonnull %inet, i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0
@@ -85,7 +86,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %4 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %4 = load i64, i64* %cast, align 8
   %phitmp = add i64 %4, 1
   br label %lookup_merge
 
@@ -95,7 +97,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, %inet_t* nonnull %inet, i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, %inet_t*, i64*, i64)*)(i64 %pseudo1, %inet_t* nonnull %inet, i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0
@@ -136,7 +138,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %4 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %4 = load i64, i64* %cast, align 8
   %phitmp = add i64 %4, 1
   br label %lookup_merge
 
@@ -146,7 +149,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, %inet_t* nonnull %inet, i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, %inet_t*, i64*, i64)*)(i64 %pseudo1, %inet_t* nonnull %inet, i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0

--- a/tests/codegen/call_ntop_key.cpp
+++ b/tests/codegen/call_ntop_key.cpp
@@ -29,7 +29,7 @@ entry:
   call void @llvm.memset.p0i8.i64(i8* %3, i8 0, i64 16, i32 8, i1 false)
   store i32 -1, [16 x i8]* %2, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, %inet_t* nonnull %inet)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, %inet_t*)*)(i64 %pseudo, %inet_t* nonnull %inet)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -80,7 +80,7 @@ entry:
   call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %3, i8 0, i64 16, i1 false)
   store i32 -1, [16 x i8]* %2, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, %inet_t* nonnull %inet)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, %inet_t*)*)(i64 %pseudo, %inet_t* nonnull %inet)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -131,7 +131,7 @@ entry:
   call void @llvm.memset.p0i8.i64(i8* nonnull %3, i8 0, i64 16, i32 8, i1 false)
   store i32 -1, [16 x i8]* %2, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, %inet_t* nonnull %inet)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, %inet_t*)*)(i64 %pseudo, %inet_t* nonnull %inet)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 

--- a/tests/codegen/call_print.cpp
+++ b/tests/codegen/call_print.cpp
@@ -9,7 +9,7 @@ TEST(codegen, call_print)
   test("BEGIN { @x = 1; } kprobe:f { print(@x); }",
 
 #if LLVM_VERSION_MAJOR > 6
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -26,7 +26,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0
@@ -63,7 +63,7 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #elif LLVM_VERSION_MAJOR == 6
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -80,7 +80,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0
@@ -117,7 +117,7 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #else
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -134,7 +134,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/call_reg.cpp
+++ b/tests/codegen/call_reg.cpp
@@ -8,7 +8,7 @@ TEST(codegen, call_reg) // Identical to builtin_func apart from variable names
 {
   test("kprobe:f { @x = reg(\"ip\") }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -27,7 +27,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %reg_ip, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/call_stats.cpp
+++ b/tests/codegen/call_stats.cpp
@@ -8,7 +8,7 @@ TEST(codegen, call_stats)
 {
   test("kprobe:f { @x = stats(pid) }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -24,7 +24,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, i64* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -46,7 +46,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 1, i64* %"@x_key2", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem4 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo3, i64* nonnull %"@x_key2")
+  %lookup_elem4 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo3, i64* nonnull %"@x_key2")
   %map_lookup_cond9 = icmp eq i8* %lookup_elem4, null
   br i1 %map_lookup_cond9, label %lookup_merge7, label %lookup_success5
 

--- a/tests/codegen/call_stats.cpp
+++ b/tests/codegen/call_stats.cpp
@@ -29,7 +29,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %2 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %2 = load i64, i64* %cast, align 8
   %phitmp = add i64 %2, 1
   br label %lookup_merge
 
@@ -39,7 +40,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %lookup_elem_val.0, i64* %"@x_num", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_num", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_num", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %4 = bitcast i64* %"@x_key2" to i8*
@@ -51,7 +52,8 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   br i1 %map_lookup_cond9, label %lookup_merge7, label %lookup_success5
 
 lookup_success5:                                  ; preds = %lookup_merge
-  %5 = load i64, i8* %lookup_elem4, align 8
+  %cast10 = bitcast i8* %lookup_elem4 to i64*
+  %5 = load i64, i64* %cast10, align 8
   br label %lookup_merge7
 
 lookup_merge7:                                    ; preds = %lookup_merge, %lookup_success5
@@ -62,8 +64,8 @@ lookup_merge7:                                    ; preds = %lookup_merge, %look
   %7 = lshr i64 %get_pid_tgid, 32
   %8 = add i64 %7, %lookup_elem_val8.0
   store i64 %8, i64* %"@x_val", align 8
-  %pseudo10 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem11 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo10, i64* nonnull %"@x_key2", i64* nonnull %"@x_val", i64 0)
+  %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem12 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo11, i64* nonnull %"@x_key2", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0

--- a/tests/codegen/call_str.cpp
+++ b/tests/codegen/call_str.cpp
@@ -9,7 +9,7 @@ TEST(codegen, call_str)
   test("kprobe:f { @x = str(arg0) }",
 
 #if LLVM_VERSION_MAJOR < 7
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -29,7 +29,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -45,7 +45,7 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #else
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -65,7 +65,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0

--- a/tests/codegen/call_str_2_expr.cpp
+++ b/tests/codegen/call_str_2_expr.cpp
@@ -9,7 +9,7 @@ TEST(codegen, call_str_2_expr)
   test("kprobe:f { @x = str(arg0, arg1) }",
 
 #if LLVM_VERSION_MAJOR < 7
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -34,7 +34,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
@@ -50,7 +50,7 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #else
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -75,7 +75,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/call_str_2_lit.cpp
+++ b/tests/codegen/call_str_2_lit.cpp
@@ -9,7 +9,7 @@ TEST(codegen, call_str_2_lit)
   test("kprobe:f { @x = str(arg0, 6) }",
 
 #if LLVM_VERSION_MAJOR < 7
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -29,7 +29,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -45,7 +45,7 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #else
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -65,7 +65,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0

--- a/tests/codegen/call_sum.cpp
+++ b/tests/codegen/call_sum.cpp
@@ -8,7 +8,7 @@ TEST(codegen, call_sum)
 {
   test("kprobe:f { @x = sum(pid) }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -22,7 +22,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, i64* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 

--- a/tests/codegen/call_sum.cpp
+++ b/tests/codegen/call_sum.cpp
@@ -27,7 +27,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %2 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %2 = load i64, i64* %cast, align 8
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
@@ -39,7 +40,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   %5 = add i64 %4, %lookup_elem_val.0
   store i64 %5, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/call_ustack.cpp
+++ b/tests/codegen/call_ustack.cpp
@@ -30,7 +30,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %2, i64* %"@x_val", align 8
   %pseudo1 = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
@@ -45,7 +45,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %6, i64* %"@y_val", align 8
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem6 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo5, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
+  %update_elem6 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo5, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0

--- a/tests/codegen/call_usym_key.cpp
+++ b/tests/codegen/call_usym_key.cpp
@@ -26,7 +26,7 @@ entry:
   store i64 0, [16 x i8]* %usym, align 8
   store i64 %2, i8* %3, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %usym)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [16 x i8]*)*)(i64 %pseudo, [16 x i8]* nonnull %usym)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 

--- a/tests/codegen/call_usym_key.cpp
+++ b/tests/codegen/call_usym_key.cpp
@@ -31,7 +31,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %4 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %4 = load i64, i64* %cast, align 8
   %phitmp = add i64 %4, 1
   br label %lookup_merge
 
@@ -41,7 +42,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, [16 x i8]* nonnull %usym, i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo1, [16 x i8]* nonnull %usym, i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0

--- a/tests/codegen/call_zero.cpp
+++ b/tests/codegen/call_zero.cpp
@@ -8,7 +8,7 @@ TEST(codegen, call_zero)
 {
   test("BEGIN { @x = 1; } kprobe:f { zero(@x); }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -25,7 +25,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/comparison_extend.cpp
+++ b/tests/codegen/comparison_extend.cpp
@@ -9,7 +9,7 @@ TEST(codegen, comparison_extend)
   // Make sure i1 is zero extended
   test("kprobe:f { @ = 1 < arg0 }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -30,7 +30,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %3, i64* %"@_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0
@@ -42,7 +42,6 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
-
 }
 
 } // namespace codegen

--- a/tests/codegen/dereference.cpp
+++ b/tests/codegen/dereference.cpp
@@ -8,7 +8,7 @@ TEST(codegen, dereference)
 {
   test("kprobe:f { @x = *1234 }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -31,7 +31,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %2, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/enum.cpp
+++ b/tests/codegen/enum.cpp
@@ -8,7 +8,7 @@ TEST(codegen, enum_declaration)
 {
   test("enum { a = 42, b } k:f { @a = a; @b = b }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -27,7 +27,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 42, i64* %"@a_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@a_key", i64* nonnull %"@a_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@a_key", i64* nonnull %"@a_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = bitcast i64* %"@b_key" to i8*
@@ -37,7 +37,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 43, i64* %"@b_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@b_key", i64* nonnull %"@b_val", i64 0)
+  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@b_key", i64* nonnull %"@b_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/int_propagation.cpp
+++ b/tests/codegen/int_propagation.cpp
@@ -28,7 +28,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 1234, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = bitcast i64* %"@x_key1" to i8*
@@ -40,7 +40,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %4 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %4 = load i64, i64* %cast, align 8
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
@@ -53,7 +54,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %lookup_elem_val.0, i64* %"@y_val", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo3, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo3, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0

--- a/tests/codegen/int_propagation.cpp
+++ b/tests/codegen/int_propagation.cpp
@@ -8,7 +8,7 @@ TEST(codegen, int_propagation)
 {
   test("kprobe:f { @x = 1234; @y = @x }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -35,7 +35,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key1", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo2, i64* nonnull %"@x_key1")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo2, i64* nonnull %"@x_key1")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 

--- a/tests/codegen/intcast_assign_var.cpp
+++ b/tests/codegen/intcast_assign_var.cpp
@@ -8,7 +8,7 @@ TEST(codegen, intcast_retval)
 {
   // Make sure the result is truncated to 32 bit and sign extended to 64
   test("kretprobe:f { @=(int32)retval }",
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -29,7 +29,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %3, i64* %"@_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/intcast_retval.cpp
+++ b/tests/codegen/intcast_retval.cpp
@@ -27,7 +27,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %2 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %2 = load i64, i64* %cast, align 8
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
@@ -40,8 +41,8 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   %5 = ashr exact i64 %sext, 32
   %6 = add i64 %5, %lookup_elem_val.0
   store i64 %6, i64* %"@_val", align 8
-  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/intcast_retval.cpp
+++ b/tests/codegen/intcast_retval.cpp
@@ -8,7 +8,7 @@ TEST(codegen, intcast_call)
 {
   // Casting should work inside a call
   test("kretprobe:f { @=sum((int32)retval) }",
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -22,7 +22,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 0, i64* %"@_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, i64* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 

--- a/tests/codegen/intptrcast_assign_var.cpp
+++ b/tests/codegen/intptrcast_assign_var.cpp
@@ -7,7 +7,7 @@ namespace codegen {
 TEST(codegen, intptrcast_assign_var)
 {
   test("kretprobe:f { @=*(int8*)(reg(\"bp\")-1) }",
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -33,7 +33,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %5, i64* %"@_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0

--- a/tests/codegen/intptrcast_call.cpp
+++ b/tests/codegen/intptrcast_call.cpp
@@ -8,7 +8,7 @@ TEST(codegen, intptrcast_call)
 {
   // Casting should work inside a call
   test("kretprobe:f { @=sum(*(int8*)(reg(\"bp\")-1)) }",
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -23,7 +23,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 0, i64* %"@_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, i64* nonnull %"@_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 

--- a/tests/codegen/intptrcast_call.cpp
+++ b/tests/codegen/intptrcast_call.cpp
@@ -28,7 +28,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %2 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %2 = load i64, i64* %cast, align 8
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
@@ -46,7 +47,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   %8 = add i64 %lookup_elem_val.0, %7
   store i64 %8, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/literal_strncmp.cpp
+++ b/tests/codegen/literal_strncmp.cpp
@@ -53,7 +53,8 @@ strcmp.loop:                                      ; preds = %entry
   br i1 %strcmp.cmp2, label %pred_false, label %pred_true
 
 lookup_success:                                   ; preds = %pred_true
-  %6 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %6 = load i64, i64* %cast, align 8
   %phitmp = add i64 %6, 1
   br label %lookup_merge
 
@@ -63,7 +64,7 @@ lookup_merge:                                     ; preds = %pred_true, %lookup_
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo5, [16 x i8]* nonnull %comm3, i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo5, [16 x i8]* nonnull %comm3, i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
@@ -123,7 +124,8 @@ strcmp.loop:                                      ; preds = %entry
   br i1 %strcmp.cmp2, label %pred_false, label %pred_true
 
 lookup_success:                                   ; preds = %pred_true
-  %6 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %6 = load i64, i64* %cast, align 8
   %phitmp = add i64 %6, 1
   br label %lookup_merge
 
@@ -133,7 +135,7 @@ lookup_merge:                                     ; preds = %pred_true, %lookup_
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo5, [16 x i8]* nonnull %comm3, i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo5, [16 x i8]* nonnull %comm3, i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0

--- a/tests/codegen/literal_strncmp.cpp
+++ b/tests/codegen/literal_strncmp.cpp
@@ -41,7 +41,7 @@ pred_true:                                        ; preds = %strcmp.loop, %pred_
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %3, i8 0, i64 16, i1 false)
   %get_comm4 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm3, i64 16)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %comm3)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [16 x i8]*)*)(i64 %pseudo, [16 x i8]* nonnull %comm3)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -111,7 +111,7 @@ pred_true:                                        ; preds = %strcmp.loop, %pred_
   call void @llvm.memset.p0i8.i64(i8* nonnull %3, i8 0, i64 16, i32 1, i1 false)
   %get_comm4 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm3, i64 16)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %comm3)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [16 x i8]*)*)(i64 %pseudo, [16 x i8]* nonnull %comm3)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 

--- a/tests/codegen/logical_and.cpp
+++ b/tests/codegen/logical_and.cpp
@@ -8,7 +8,7 @@ TEST(codegen, logical_and)
 {
   test("kprobe:f { @x = pid != 1234 && pid != 1235 }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -41,7 +41,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %"&&_result.0", i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/logical_not.cpp
+++ b/tests/codegen/logical_not.cpp
@@ -7,7 +7,7 @@ namespace codegen {
 TEST(codegen, logical_not)
 {
   test("BEGIN { @x = !10; @y = !0; }",
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -26,7 +26,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = bitcast i64* %"@y_key" to i8*
@@ -36,7 +36,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 1, i64* %"@y_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
+  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/logical_or.cpp
+++ b/tests/codegen/logical_or.cpp
@@ -8,7 +8,7 @@ TEST(codegen, logical_or)
 {
   test("kprobe:f { @x = pid == 1234 || pid == 1235 }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -41,7 +41,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %"||_result.0", i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/macro_definition.cpp
+++ b/tests/codegen/macro_definition.cpp
@@ -8,7 +8,7 @@ TEST(codegen, macro_definition)
 {
   test("#define FOO 100\nk:f { @ = FOO }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -25,7 +25,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 100, i64* %"@_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/map_assign_int.cpp
+++ b/tests/codegen/map_assign_int.cpp
@@ -8,7 +8,7 @@ TEST(codegen, map_assign_int)
 {
   test("kprobe:f { @x = 1; }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -25,7 +25,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/map_assign_string.cpp
+++ b/tests/codegen/map_assign_string.cpp
@@ -9,7 +9,7 @@ TEST(codegen, map_assign_string)
   test("kprobe:f { @x = \"blah\"; }",
 
 #if LLVM_VERSION_MAJOR > 6
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -34,7 +34,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -50,7 +50,7 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #elif LLVM_VERSION_MAJOR == 6
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -75,7 +75,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -91,7 +91,7 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #else
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -116,7 +116,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0

--- a/tests/codegen/map_increment_decrement.cpp
+++ b/tests/codegen/map_increment_decrement.cpp
@@ -8,7 +8,7 @@ TEST(codegen, map_increment_decrement)
 {
   test("BEGIN { @x = 10; @x++; ++@x; @x--; --@x; }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -40,7 +40,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key1", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo2, i64* nonnull %"@x_key1")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo2, i64* nonnull %"@x_key1")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -62,7 +62,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@x_key5", align 8
   %pseudo6 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem7 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo6, i64* nonnull %"@x_key5")
+  %lookup_elem7 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo6, i64* nonnull %"@x_key5")
   %map_lookup_cond12 = icmp eq i8* %lookup_elem7, null
   br i1 %map_lookup_cond12, label %lookup_merge10, label %lookup_success8
 
@@ -84,7 +84,7 @@ lookup_merge10:                                   ; preds = %lookup_merge, %look
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 0, i64* %"@x_key16", align 8
   %pseudo17 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem18 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo17, i64* nonnull %"@x_key16")
+  %lookup_elem18 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo17, i64* nonnull %"@x_key16")
   %map_lookup_cond23 = icmp eq i8* %lookup_elem18, null
   br i1 %map_lookup_cond23, label %lookup_merge21, label %lookup_success19
 
@@ -106,7 +106,7 @@ lookup_merge21:                                   ; preds = %lookup_merge10, %lo
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %12)
   store i64 0, i64* %"@x_key27", align 8
   %pseudo28 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem29 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo28, i64* nonnull %"@x_key27")
+  %lookup_elem29 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo28, i64* nonnull %"@x_key27")
   %map_lookup_cond34 = icmp eq i8* %lookup_elem29, null
   br i1 %map_lookup_cond34, label %lookup_merge32, label %lookup_success30
 

--- a/tests/codegen/map_increment_decrement.cpp
+++ b/tests/codegen/map_increment_decrement.cpp
@@ -16,11 +16,11 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 define i64 @BEGIN(i8* nocapture readnone) local_unnamed_addr section "s_BEGIN_1" {
 entry:
-  %"@x_newval35" = alloca i64, align 8
-  %"@x_key27" = alloca i64, align 8
-  %"@x_newval24" = alloca i64, align 8
-  %"@x_key16" = alloca i64, align 8
-  %"@x_newval13" = alloca i64, align 8
+  %"@x_newval38" = alloca i64, align 8
+  %"@x_key29" = alloca i64, align 8
+  %"@x_newval26" = alloca i64, align 8
+  %"@x_key17" = alloca i64, align 8
+  %"@x_newval14" = alloca i64, align 8
   %"@x_key5" = alloca i64, align 8
   %"@x_newval" = alloca i64, align 8
   %"@x_key1" = alloca i64, align 8
@@ -33,7 +33,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 10, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = bitcast i64* %"@x_key1" to i8*
@@ -45,7 +45,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %4 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %4 = load i64, i64* %cast, align 8
   %phitmp = add i64 %4, 1
   br label %lookup_merge
 
@@ -55,7 +56,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %lookup_elem_val.0, i64* %"@x_newval", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo3, i64* nonnull %"@x_key1", i64* nonnull %"@x_newval", i64 0)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo3, i64* nonnull %"@x_key1", i64* nonnull %"@x_newval", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   %6 = bitcast i64* %"@x_key5" to i8*
@@ -67,61 +68,64 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   br i1 %map_lookup_cond12, label %lookup_merge10, label %lookup_success8
 
 lookup_success8:                                  ; preds = %lookup_merge
-  %7 = load i64, i8* %lookup_elem7, align 8
-  %phitmp38 = add i64 %7, 1
+  %cast13 = bitcast i8* %lookup_elem7 to i64*
+  %7 = load i64, i64* %cast13, align 8
+  %phitmp41 = add i64 %7, 1
   br label %lookup_merge10
 
 lookup_merge10:                                   ; preds = %lookup_merge, %lookup_success8
-  %lookup_elem_val11.0 = phi i64 [ %phitmp38, %lookup_success8 ], [ 1, %lookup_merge ]
-  %8 = bitcast i64* %"@x_newval13" to i8*
+  %lookup_elem_val11.0 = phi i64 [ %phitmp41, %lookup_success8 ], [ 1, %lookup_merge ]
+  %8 = bitcast i64* %"@x_newval14" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
-  store i64 %lookup_elem_val11.0, i64* %"@x_newval13", align 8
-  %pseudo14 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem15 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo14, i64* nonnull %"@x_key5", i64* nonnull %"@x_newval13", i64 0)
+  store i64 %lookup_elem_val11.0, i64* %"@x_newval14", align 8
+  %pseudo15 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem16 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo15, i64* nonnull %"@x_key5", i64* nonnull %"@x_newval14", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
-  %9 = bitcast i64* %"@x_key16" to i8*
+  %9 = bitcast i64* %"@x_key17" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
-  store i64 0, i64* %"@x_key16", align 8
-  %pseudo17 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem18 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo17, i64* nonnull %"@x_key16")
-  %map_lookup_cond23 = icmp eq i8* %lookup_elem18, null
-  br i1 %map_lookup_cond23, label %lookup_merge21, label %lookup_success19
+  store i64 0, i64* %"@x_key17", align 8
+  %pseudo18 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem19 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo18, i64* nonnull %"@x_key17")
+  %map_lookup_cond24 = icmp eq i8* %lookup_elem19, null
+  br i1 %map_lookup_cond24, label %lookup_merge22, label %lookup_success20
 
-lookup_success19:                                 ; preds = %lookup_merge10
-  %10 = load i64, i8* %lookup_elem18, align 8
-  %phitmp39 = add i64 %10, -1
-  br label %lookup_merge21
+lookup_success20:                                 ; preds = %lookup_merge10
+  %cast25 = bitcast i8* %lookup_elem19 to i64*
+  %10 = load i64, i64* %cast25, align 8
+  %phitmp42 = add i64 %10, -1
+  br label %lookup_merge22
 
-lookup_merge21:                                   ; preds = %lookup_merge10, %lookup_success19
-  %lookup_elem_val22.0 = phi i64 [ %phitmp39, %lookup_success19 ], [ -1, %lookup_merge10 ]
-  %11 = bitcast i64* %"@x_newval24" to i8*
+lookup_merge22:                                   ; preds = %lookup_merge10, %lookup_success20
+  %lookup_elem_val23.0 = phi i64 [ %phitmp42, %lookup_success20 ], [ -1, %lookup_merge10 ]
+  %11 = bitcast i64* %"@x_newval26" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %11)
-  store i64 %lookup_elem_val22.0, i64* %"@x_newval24", align 8
-  %pseudo25 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem26 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo25, i64* nonnull %"@x_key16", i64* nonnull %"@x_newval24", i64 0)
+  store i64 %lookup_elem_val23.0, i64* %"@x_newval26", align 8
+  %pseudo27 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem28 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo27, i64* nonnull %"@x_key17", i64* nonnull %"@x_newval26", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %11)
-  %12 = bitcast i64* %"@x_key27" to i8*
+  %12 = bitcast i64* %"@x_key29" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %12)
-  store i64 0, i64* %"@x_key27", align 8
-  %pseudo28 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem29 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo28, i64* nonnull %"@x_key27")
-  %map_lookup_cond34 = icmp eq i8* %lookup_elem29, null
-  br i1 %map_lookup_cond34, label %lookup_merge32, label %lookup_success30
+  store i64 0, i64* %"@x_key29", align 8
+  %pseudo30 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem31 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo30, i64* nonnull %"@x_key29")
+  %map_lookup_cond36 = icmp eq i8* %lookup_elem31, null
+  br i1 %map_lookup_cond36, label %lookup_merge34, label %lookup_success32
 
-lookup_success30:                                 ; preds = %lookup_merge21
-  %13 = load i64, i8* %lookup_elem29, align 8
-  %phitmp40 = add i64 %13, -1
-  br label %lookup_merge32
+lookup_success32:                                 ; preds = %lookup_merge22
+  %cast37 = bitcast i8* %lookup_elem31 to i64*
+  %13 = load i64, i64* %cast37, align 8
+  %phitmp43 = add i64 %13, -1
+  br label %lookup_merge34
 
-lookup_merge32:                                   ; preds = %lookup_merge21, %lookup_success30
-  %lookup_elem_val33.0 = phi i64 [ %phitmp40, %lookup_success30 ], [ -1, %lookup_merge21 ]
-  %14 = bitcast i64* %"@x_newval35" to i8*
+lookup_merge34:                                   ; preds = %lookup_merge22, %lookup_success32
+  %lookup_elem_val35.0 = phi i64 [ %phitmp43, %lookup_success32 ], [ -1, %lookup_merge22 ]
+  %14 = bitcast i64* %"@x_newval38" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %14)
-  store i64 %lookup_elem_val33.0, i64* %"@x_newval35", align 8
-  %pseudo36 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem37 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo36, i64* nonnull %"@x_key27", i64* nonnull %"@x_newval35", i64 0)
+  store i64 %lookup_elem_val35.0, i64* %"@x_newval38", align 8
+  %pseudo39 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem40 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo39, i64* nonnull %"@x_key29", i64* nonnull %"@x_newval38", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %12)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %14)
   ret i64 0

--- a/tests/codegen/map_key_int.cpp
+++ b/tests/codegen/map_key_int.cpp
@@ -8,7 +8,7 @@ TEST(codegen, map_key_int)
 {
   test("kprobe:f { @x[11,22,33] = 44 }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -29,7 +29,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 44, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, [24 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [24 x i8]*, i64*, i64)*)(i64 %pseudo, [24 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/map_key_probe.cpp
+++ b/tests/codegen/map_key_probe.cpp
@@ -33,7 +33,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %2 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %2 = load i64, i64* %cast, align 8
   %phitmp = add i64 %2, 1
   br label %lookup_merge
 
@@ -47,7 +48,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo2, [8 x i8]* nonnull %"@x_key1", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo2, [8 x i8]* nonnull %"@x_key1", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
@@ -70,7 +71,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %2 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %2 = load i64, i64* %cast, align 8
   %phitmp = add i64 %2, 1
   br label %lookup_merge
 
@@ -84,7 +86,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo2, [8 x i8]* nonnull %"@x_key1", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo2, [8 x i8]* nonnull %"@x_key1", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
@@ -98,4 +100,3 @@ attributes #1 = { argmemonly nounwind }
 } // namespace codegen
 } // namespace test
 } // namespace bpftrace
-

--- a/tests/codegen/map_key_probe.cpp
+++ b/tests/codegen/map_key_probe.cpp
@@ -28,7 +28,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 0, [8 x i8]* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -65,7 +65,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 1, [8 x i8]* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [8 x i8]* nonnull %"@x_key")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@x_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 

--- a/tests/codegen/map_key_string.cpp
+++ b/tests/codegen/map_key_string.cpp
@@ -32,7 +32,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 44, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, [128 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [128 x i8]*, i64*, i64)*)(i64 %pseudo, [128 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0
@@ -71,7 +71,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 44, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, [128 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [128 x i8]*, i64*, i64)*)(i64 %pseudo, [128 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0
@@ -110,7 +110,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 44, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, [128 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [128 x i8]*, i64*, i64)*)(i64 %pseudo, [128 x i8]* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/optional_positional_parameter.cpp
+++ b/tests/codegen/optional_positional_parameter.cpp
@@ -9,7 +9,7 @@ TEST(codegen, optional_positional_parameter)
   test("BEGIN { @x = $1; @y = str($2) }",
 
 #if LLVM_VERSION_MAJOR > 6
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -29,7 +29,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
@@ -43,7 +43,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@y_key", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem3 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo2, i64* nonnull %"@y_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem3 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo2, i64* nonnull %"@y_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0
@@ -59,7 +59,7 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #else
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -79,7 +79,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
@@ -93,7 +93,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@y_key", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem3 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo2, i64* nonnull %"@y_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem3 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo2, i64* nonnull %"@y_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/pred_binop.cpp
+++ b/tests/codegen/pred_binop.cpp
@@ -8,7 +8,7 @@ TEST(codegen, pred_binop)
 {
   test("kprobe:f / pid == 1234 / { @x = 1 }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -34,7 +34,7 @@ pred_true:                                        ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/string_equal_comparison.cpp
+++ b/tests/codegen/string_equal_comparison.cpp
@@ -37,7 +37,7 @@ pred_true:                                        ; preds = %strcmp.loop5
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %3, i8 0, i64 16, i1 false)
   %get_comm10 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm9, i64 16)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %comm9)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [16 x i8]*)*)(i64 %pseudo, [16 x i8]* nonnull %comm9)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -120,7 +120,7 @@ pred_true:                                        ; preds = %strcmp.loop5
   call void @llvm.memset.p0i8.i64(i8* nonnull %3, i8 0, i64 16, i32 1, i1 false)
   %get_comm10 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm9, i64 16)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %comm9)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [16 x i8]*)*)(i64 %pseudo, [16 x i8]* nonnull %comm9)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 

--- a/tests/codegen/string_equal_comparison.cpp
+++ b/tests/codegen/string_equal_comparison.cpp
@@ -66,7 +66,8 @@ strcmp.loop5:                                     ; preds = %strcmp.loop3
   br i1 %strcmp.cmp8, label %pred_true, label %pred_false
 
 lookup_success:                                   ; preds = %pred_true
-  %12 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %12 = load i64, i64* %cast, align 8
   %phitmp = add i64 %12, 1
   br label %lookup_merge
 
@@ -76,7 +77,7 @@ lookup_merge:                                     ; preds = %pred_true, %lookup_
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %13)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo11, [16 x i8]* nonnull %comm9, i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo11, [16 x i8]* nonnull %comm9, i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %13)
   ret i64 0
@@ -149,7 +150,8 @@ strcmp.loop5:                                     ; preds = %strcmp.loop3
   br i1 %strcmp.cmp8, label %pred_true, label %pred_false
 
 lookup_success:                                   ; preds = %pred_true
-  %12 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %12 = load i64, i64* %cast, align 8
   %phitmp = add i64 %12, 1
   br label %lookup_merge
 
@@ -159,7 +161,7 @@ lookup_merge:                                     ; preds = %pred_true, %lookup_
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %13)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo11, [16 x i8]* nonnull %comm9, i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo11, [16 x i8]* nonnull %comm9, i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %13)
   ret i64 0

--- a/tests/codegen/string_not_equal_comparison.cpp
+++ b/tests/codegen/string_not_equal_comparison.cpp
@@ -66,7 +66,8 @@ strcmp.loop5:                                     ; preds = %strcmp.loop3
   br i1 %strcmp.cmp8, label %pred_false, label %pred_true
 
 lookup_success:                                   ; preds = %pred_true
-  %12 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %12 = load i64, i64* %cast, align 8
   %phitmp = add i64 %12, 1
   br label %lookup_merge
 
@@ -76,7 +77,7 @@ lookup_merge:                                     ; preds = %pred_true, %lookup_
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %13)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo11, [16 x i8]* nonnull %comm9, i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo11, [16 x i8]* nonnull %comm9, i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %13)
   ret i64 0
@@ -149,7 +150,8 @@ strcmp.loop5:                                     ; preds = %strcmp.loop3
   br i1 %strcmp.cmp8, label %pred_false, label %pred_true
 
 lookup_success:                                   ; preds = %pred_true
-  %12 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %12 = load i64, i64* %cast, align 8
   %phitmp = add i64 %12, 1
   br label %lookup_merge
 
@@ -159,7 +161,7 @@ lookup_merge:                                     ; preds = %pred_true, %lookup_
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %13)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo11, [16 x i8]* nonnull %comm9, i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo11, [16 x i8]* nonnull %comm9, i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %13)
   ret i64 0

--- a/tests/codegen/string_not_equal_comparison.cpp
+++ b/tests/codegen/string_not_equal_comparison.cpp
@@ -37,7 +37,7 @@ pred_true:                                        ; preds = %strcmp.loop5, %strc
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %3, i8 0, i64 16, i1 false)
   %get_comm10 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm9, i64 16)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %comm9)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [16 x i8]*)*)(i64 %pseudo, [16 x i8]* nonnull %comm9)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -120,7 +120,7 @@ pred_true:                                        ; preds = %strcmp.loop5, %strc
   call void @llvm.memset.p0i8.i64(i8* nonnull %3, i8 0, i64 16, i32 1, i1 false)
   %get_comm10 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm9, i64 16)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, [16 x i8]* nonnull %comm9)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [16 x i8]*)*)(i64 %pseudo, [16 x i8]* nonnull %comm9)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 

--- a/tests/codegen/string_propagation.cpp
+++ b/tests/codegen/string_propagation.cpp
@@ -37,7 +37,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key1" to i8*
@@ -64,7 +64,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@y_key", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo3, i64* nonnull %"@y_key", [64 x i8]* nonnull %lookup_elem_val, i64 0)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo3, i64* nonnull %"@y_key", [64 x i8]* nonnull %lookup_elem_val, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
@@ -111,7 +111,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key1" to i8*
@@ -138,7 +138,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@y_key", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo3, i64* nonnull %"@y_key", [64 x i8]* nonnull %lookup_elem_val, i64 0)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo3, i64* nonnull %"@y_key", [64 x i8]* nonnull %lookup_elem_val, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
@@ -185,7 +185,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key1" to i8*
@@ -212,7 +212,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@y_key", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo3, i64* nonnull %"@y_key", [64 x i8]* nonnull %lookup_elem_val, i64 0)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo3, i64* nonnull %"@y_key", [64 x i8]* nonnull %lookup_elem_val, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/string_propagation.cpp
+++ b/tests/codegen/string_propagation.cpp
@@ -9,7 +9,7 @@ TEST(codegen, string_propagation)
   test("kprobe:f { @x = \"asdf\"; @y = @x }",
 
 #if LLVM_VERSION_MAJOR > 6
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -44,7 +44,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key1", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo2, i64* nonnull %"@x_key1")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo2, i64* nonnull %"@x_key1")
   %4 = getelementptr inbounds [64 x i8], [64 x i8]* %lookup_elem_val, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
@@ -83,7 +83,7 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #elif LLVM_VERSION_MAJOR == 6
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -118,7 +118,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key1", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo2, i64* nonnull %"@x_key1")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo2, i64* nonnull %"@x_key1")
   %4 = getelementptr inbounds [64 x i8], [64 x i8]* %lookup_elem_val, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
@@ -157,7 +157,7 @@ attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
 #else
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -192,7 +192,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key1", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo2, i64* nonnull %"@x_key1")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo2, i64* nonnull %"@x_key1")
   %4 = getelementptr inbounds [64 x i8], [64 x i8]* %lookup_elem_val, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null

--- a/tests/codegen/strncmp.cpp
+++ b/tests/codegen/strncmp.cpp
@@ -70,7 +70,7 @@ pred_true.critedge:                               ; preds = %strcmp.loop87, %str
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 1, i64* %"@_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   ret i64 0
@@ -371,7 +371,7 @@ pred_true.critedge:                               ; preds = %strcmp.loop87, %str
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 1, i64* %"@_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   ret i64 0

--- a/tests/codegen/struct_char.cpp
+++ b/tests/codegen/struct_char.cpp
@@ -38,7 +38,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %5, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
@@ -84,7 +84,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %5, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
@@ -132,7 +132,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %3, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/struct_integer_ptr.cpp
+++ b/tests/codegen/struct_integer_ptr.cpp
@@ -45,7 +45,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 %8, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   ret i64 0
@@ -99,7 +99,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 %8, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   ret i64 0
@@ -154,7 +154,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %6, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0

--- a/tests/codegen/struct_integers.cpp
+++ b/tests/codegen/struct_integers.cpp
@@ -39,7 +39,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %6, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
@@ -87,7 +87,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %6, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
@@ -111,7 +111,6 @@ attributes #1 = { argmemonly nounwind }
        "  @x = $foo.x;"
        "}",
        expected);
-
 
   expected = R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
@@ -137,7 +136,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %4, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0

--- a/tests/codegen/struct_long.cpp
+++ b/tests/codegen/struct_long.cpp
@@ -38,7 +38,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %4, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
@@ -85,7 +85,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %4, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
@@ -133,7 +133,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %2, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/struct_nested_struct_anon.cpp
+++ b/tests/codegen/struct_nested_struct_anon.cpp
@@ -40,7 +40,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %6, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
@@ -88,7 +88,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %6, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
@@ -137,7 +137,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %4, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0

--- a/tests/codegen/struct_nested_struct_named.cpp
+++ b/tests/codegen/struct_nested_struct_named.cpp
@@ -39,7 +39,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %6, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
@@ -87,7 +87,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %6, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
@@ -136,7 +136,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %4, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0

--- a/tests/codegen/struct_nested_struct_ptr_named.cpp
+++ b/tests/codegen/struct_nested_struct_ptr_named.cpp
@@ -45,7 +45,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 %8, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   ret i64 0
@@ -99,7 +99,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 %8, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   ret i64 0
@@ -154,7 +154,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %6, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0

--- a/tests/codegen/struct_save.cpp
+++ b/tests/codegen/struct_save.cpp
@@ -23,7 +23,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([12 x i8]* nonnull %"@foo_val", i64 12, i64 0)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@foo_key", [12 x i8]* nonnull %"@foo_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [12 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@foo_key", [12 x i8]* nonnull %"@foo_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0

--- a/tests/codegen/struct_save_nested.cpp
+++ b/tests/codegen/struct_save_nested.cpp
@@ -37,7 +37,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@foo_key1", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo2, i64* nonnull %"@foo_key1")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo2, i64* nonnull %"@foo_key1")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -64,7 +64,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@foo_key5", align 8
   %pseudo6 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %lookup_elem7 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo6, i64* nonnull %"@foo_key5")
+  %lookup_elem7 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo6, i64* nonnull %"@foo_key5")
   %map_lookup_cond12 = icmp eq i8* %lookup_elem7, null
   br i1 %map_lookup_cond12, label %lookup_merge10, label %lookup_success8
 

--- a/tests/codegen/struct_save_nested.cpp
+++ b/tests/codegen/struct_save_nested.cpp
@@ -30,7 +30,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* nonnull %"@foo_val", i64 16, i64 0)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@foo_key", [16 x i8]* nonnull %"@foo_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [16 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@foo_key", [16 x i8]* nonnull %"@foo_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = bitcast i64* %"@foo_key1" to i8*
@@ -57,7 +57,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@bar_key", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo3, i64* nonnull %"@bar_key", [8 x i8]* nonnull %tmpcast, i64 0)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [8 x i8]*, i64)*)(i64 %pseudo3, i64* nonnull %"@bar_key", [8 x i8]* nonnull %tmpcast, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %6 = bitcast i64* %"@foo_key5" to i8*
@@ -86,7 +86,7 @@ lookup_merge10:                                   ; preds = %lookup_merge, %look
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %lookup_elem_val11.sroa.3.0, i64* %"@x_val", align 8
   %pseudo14 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
-  %update_elem15 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo14, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem15 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo14, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0

--- a/tests/codegen/struct_save_string.cpp
+++ b/tests/codegen/struct_save_string.cpp
@@ -27,7 +27,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([32 x i8]* nonnull %"@foo_val", i64 32, i64 0)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@foo_key", [32 x i8]* nonnull %"@foo_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [32 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@foo_key", [32 x i8]* nonnull %"@foo_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = bitcast i64* %"@foo_key1" to i8*
@@ -54,7 +54,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@str_key", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo3, i64* nonnull %"@str_key", i8* nonnull %4, i64 0)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i8*, i64)*)(i64 %pseudo3, i64* nonnull %"@str_key", i8* nonnull %4, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
@@ -93,7 +93,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([32 x i8]* nonnull %"@foo_val", i64 32, i64 0)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@foo_key", [32 x i8]* nonnull %"@foo_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [32 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@foo_key", [32 x i8]* nonnull %"@foo_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = bitcast i64* %"@foo_key1" to i8*
@@ -120,7 +120,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@str_key", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo3, i64* nonnull %"@str_key", i8* nonnull %4, i64 0)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i8*, i64)*)(i64 %pseudo3, i64* nonnull %"@str_key", i8* nonnull %4, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0

--- a/tests/codegen/struct_save_string.cpp
+++ b/tests/codegen/struct_save_string.cpp
@@ -34,7 +34,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@foo_key1", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo2, i64* nonnull %"@foo_key1")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo2, i64* nonnull %"@foo_key1")
   %4 = getelementptr inbounds [32 x i8], [32 x i8]* %lookup_elem_val, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
@@ -100,7 +100,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@foo_key1", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo2, i64* nonnull %"@foo_key1")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo2, i64* nonnull %"@foo_key1")
   %4 = getelementptr inbounds [32 x i8], [32 x i8]* %lookup_elem_val, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null

--- a/tests/codegen/struct_short.cpp
+++ b/tests/codegen/struct_short.cpp
@@ -39,7 +39,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %6, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
@@ -87,7 +87,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %6, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
@@ -112,7 +112,7 @@ attributes #1 = { argmemonly nounwind }
        "}",
        expected);
 
-expected = R"EXPECTED(; Function Attrs: nounwind
+  expected = R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -136,7 +136,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %4, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0

--- a/tests/codegen/struct_string_array.cpp
+++ b/tests/codegen/struct_string_array.cpp
@@ -30,7 +30,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@mystr_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [32 x i8]* nonnull %"struct Foo.str", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [32 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [32 x i8]* nonnull %"struct Foo.str", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0
@@ -72,7 +72,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@mystr_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [32 x i8]* nonnull %"struct Foo.str", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [32 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [32 x i8]* nonnull %"struct Foo.str", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0
@@ -117,7 +117,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@mystr_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [32 x i8]* nonnull %"struct Foo.str", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [32 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [32 x i8]* nonnull %"struct Foo.str", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0

--- a/tests/codegen/struct_string_ptr.cpp
+++ b/tests/codegen/struct_string_ptr.cpp
@@ -39,7 +39,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@mystr_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0
@@ -87,7 +87,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@mystr_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0
@@ -137,7 +137,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@mystr_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -177,7 +177,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@mystr_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [64 x i8]* nonnull %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@mystr_key", [64 x i8]* nonnull %str, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0

--- a/tests/codegen/ternary_int.cpp
+++ b/tests/codegen/ternary_int.cpp
@@ -8,7 +8,7 @@ TEST(codegen, ternary_int)
 {
   test("kprobe:f { @x = pid < 10000 ? 1 : 2; }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -28,7 +28,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 %., i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0

--- a/tests/codegen/ternary_str.cpp
+++ b/tests/codegen/ternary_str.cpp
@@ -48,7 +48,7 @@ done:                                             ; preds = %right, %left
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %buf, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %buf, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -103,7 +103,7 @@ done:                                             ; preds = %right, %left
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %buf, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %buf, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
@@ -144,7 +144,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %buf, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %buf, i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0

--- a/tests/codegen/unroll.cpp
+++ b/tests/codegen/unroll.cpp
@@ -16,17 +16,17 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 define i64 @BEGIN(i8* nocapture readnone) local_unnamed_addr section "s_BEGIN_1" {
 entry:
-  %"@i_val52" = alloca i64, align 8
-  %"@i_key51" = alloca i64, align 8
-  %"@i_key43" = alloca i64, align 8
-  %"@i_val40" = alloca i64, align 8
-  %"@i_key39" = alloca i64, align 8
-  %"@i_key31" = alloca i64, align 8
-  %"@i_val28" = alloca i64, align 8
-  %"@i_key27" = alloca i64, align 8
-  %"@i_key19" = alloca i64, align 8
-  %"@i_val16" = alloca i64, align 8
-  %"@i_key15" = alloca i64, align 8
+  %"@i_val56" = alloca i64, align 8
+  %"@i_key55" = alloca i64, align 8
+  %"@i_key46" = alloca i64, align 8
+  %"@i_val43" = alloca i64, align 8
+  %"@i_key42" = alloca i64, align 8
+  %"@i_key33" = alloca i64, align 8
+  %"@i_val30" = alloca i64, align 8
+  %"@i_key29" = alloca i64, align 8
+  %"@i_key20" = alloca i64, align 8
+  %"@i_val17" = alloca i64, align 8
+  %"@i_key16" = alloca i64, align 8
   %"@i_key7" = alloca i64, align 8
   %"@i_val4" = alloca i64, align 8
   %"@i_key3" = alloca i64, align 8
@@ -40,7 +40,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@i_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@i_key", i64* nonnull %"@i_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@i_key", i64* nonnull %"@i_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %3 = bitcast i64* %"@i_key1" to i8*
@@ -52,7 +52,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
-  %4 = load i64, i8* %lookup_elem, align 8
+  %cast = bitcast i8* %lookup_elem to i64*
+  %4 = load i64, i64* %cast, align 8
   %phitmp = add i64 %4, 1
   br label %lookup_merge
 
@@ -66,7 +67,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %lookup_elem_val.0, i64* %"@i_val4", align 8
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem6 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo5, i64* nonnull %"@i_key3", i64* nonnull %"@i_val4", i64 0)
+  %update_elem6 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo5, i64* nonnull %"@i_key3", i64* nonnull %"@i_val4", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   %7 = bitcast i64* %"@i_key7" to i8*
@@ -78,99 +79,103 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   br i1 %map_lookup_cond14, label %lookup_merge12, label %lookup_success10
 
 lookup_success10:                                 ; preds = %lookup_merge
-  %8 = load i64, i8* %lookup_elem9, align 8
-  %phitmp55 = add i64 %8, 1
+  %cast15 = bitcast i8* %lookup_elem9 to i64*
+  %8 = load i64, i64* %cast15, align 8
+  %phitmp59 = add i64 %8, 1
   br label %lookup_merge12
 
 lookup_merge12:                                   ; preds = %lookup_merge, %lookup_success10
-  %lookup_elem_val13.0 = phi i64 [ %phitmp55, %lookup_success10 ], [ 1, %lookup_merge ]
+  %lookup_elem_val13.0 = phi i64 [ %phitmp59, %lookup_success10 ], [ 1, %lookup_merge ]
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
-  %9 = bitcast i64* %"@i_key15" to i8*
+  %9 = bitcast i64* %"@i_key16" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
-  store i64 0, i64* %"@i_key15", align 8
-  %10 = bitcast i64* %"@i_val16" to i8*
+  store i64 0, i64* %"@i_key16", align 8
+  %10 = bitcast i64* %"@i_val17" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
-  store i64 %lookup_elem_val13.0, i64* %"@i_val16", align 8
-  %pseudo17 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem18 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo17, i64* nonnull %"@i_key15", i64* nonnull %"@i_val16", i64 0)
+  store i64 %lookup_elem_val13.0, i64* %"@i_val17", align 8
+  %pseudo18 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem19 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo18, i64* nonnull %"@i_key16", i64* nonnull %"@i_val17", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
-  %11 = bitcast i64* %"@i_key19" to i8*
+  %11 = bitcast i64* %"@i_key20" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %11)
-  store i64 0, i64* %"@i_key19", align 8
-  %pseudo20 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem21 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo20, i64* nonnull %"@i_key19")
-  %map_lookup_cond26 = icmp eq i8* %lookup_elem21, null
-  br i1 %map_lookup_cond26, label %lookup_merge24, label %lookup_success22
+  store i64 0, i64* %"@i_key20", align 8
+  %pseudo21 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem22 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo21, i64* nonnull %"@i_key20")
+  %map_lookup_cond27 = icmp eq i8* %lookup_elem22, null
+  br i1 %map_lookup_cond27, label %lookup_merge25, label %lookup_success23
 
-lookup_success22:                                 ; preds = %lookup_merge12
-  %12 = load i64, i8* %lookup_elem21, align 8
-  %phitmp56 = add i64 %12, 1
-  br label %lookup_merge24
+lookup_success23:                                 ; preds = %lookup_merge12
+  %cast28 = bitcast i8* %lookup_elem22 to i64*
+  %12 = load i64, i64* %cast28, align 8
+  %phitmp60 = add i64 %12, 1
+  br label %lookup_merge25
 
-lookup_merge24:                                   ; preds = %lookup_merge12, %lookup_success22
-  %lookup_elem_val25.0 = phi i64 [ %phitmp56, %lookup_success22 ], [ 1, %lookup_merge12 ]
+lookup_merge25:                                   ; preds = %lookup_merge12, %lookup_success23
+  %lookup_elem_val26.0 = phi i64 [ %phitmp60, %lookup_success23 ], [ 1, %lookup_merge12 ]
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %11)
-  %13 = bitcast i64* %"@i_key27" to i8*
+  %13 = bitcast i64* %"@i_key29" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %13)
-  store i64 0, i64* %"@i_key27", align 8
-  %14 = bitcast i64* %"@i_val28" to i8*
+  store i64 0, i64* %"@i_key29", align 8
+  %14 = bitcast i64* %"@i_val30" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %14)
-  store i64 %lookup_elem_val25.0, i64* %"@i_val28", align 8
-  %pseudo29 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem30 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo29, i64* nonnull %"@i_key27", i64* nonnull %"@i_val28", i64 0)
+  store i64 %lookup_elem_val26.0, i64* %"@i_val30", align 8
+  %pseudo31 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem32 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo31, i64* nonnull %"@i_key29", i64* nonnull %"@i_val30", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %13)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %14)
-  %15 = bitcast i64* %"@i_key31" to i8*
+  %15 = bitcast i64* %"@i_key33" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %15)
-  store i64 0, i64* %"@i_key31", align 8
-  %pseudo32 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem33 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo32, i64* nonnull %"@i_key31")
-  %map_lookup_cond38 = icmp eq i8* %lookup_elem33, null
-  br i1 %map_lookup_cond38, label %lookup_merge36, label %lookup_success34
+  store i64 0, i64* %"@i_key33", align 8
+  %pseudo34 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem35 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo34, i64* nonnull %"@i_key33")
+  %map_lookup_cond40 = icmp eq i8* %lookup_elem35, null
+  br i1 %map_lookup_cond40, label %lookup_merge38, label %lookup_success36
 
-lookup_success34:                                 ; preds = %lookup_merge24
-  %16 = load i64, i8* %lookup_elem33, align 8
-  %phitmp57 = add i64 %16, 1
-  br label %lookup_merge36
+lookup_success36:                                 ; preds = %lookup_merge25
+  %cast41 = bitcast i8* %lookup_elem35 to i64*
+  %16 = load i64, i64* %cast41, align 8
+  %phitmp61 = add i64 %16, 1
+  br label %lookup_merge38
 
-lookup_merge36:                                   ; preds = %lookup_merge24, %lookup_success34
-  %lookup_elem_val37.0 = phi i64 [ %phitmp57, %lookup_success34 ], [ 1, %lookup_merge24 ]
+lookup_merge38:                                   ; preds = %lookup_merge25, %lookup_success36
+  %lookup_elem_val39.0 = phi i64 [ %phitmp61, %lookup_success36 ], [ 1, %lookup_merge25 ]
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %15)
-  %17 = bitcast i64* %"@i_key39" to i8*
+  %17 = bitcast i64* %"@i_key42" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %17)
-  store i64 0, i64* %"@i_key39", align 8
-  %18 = bitcast i64* %"@i_val40" to i8*
+  store i64 0, i64* %"@i_key42", align 8
+  %18 = bitcast i64* %"@i_val43" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %18)
-  store i64 %lookup_elem_val37.0, i64* %"@i_val40", align 8
-  %pseudo41 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem42 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo41, i64* nonnull %"@i_key39", i64* nonnull %"@i_val40", i64 0)
+  store i64 %lookup_elem_val39.0, i64* %"@i_val43", align 8
+  %pseudo44 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem45 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo44, i64* nonnull %"@i_key42", i64* nonnull %"@i_val43", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %17)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %18)
-  %19 = bitcast i64* %"@i_key43" to i8*
+  %19 = bitcast i64* %"@i_key46" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %19)
-  store i64 0, i64* %"@i_key43", align 8
-  %pseudo44 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem45 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo44, i64* nonnull %"@i_key43")
-  %map_lookup_cond50 = icmp eq i8* %lookup_elem45, null
-  br i1 %map_lookup_cond50, label %lookup_merge48, label %lookup_success46
+  store i64 0, i64* %"@i_key46", align 8
+  %pseudo47 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem48 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo47, i64* nonnull %"@i_key46")
+  %map_lookup_cond53 = icmp eq i8* %lookup_elem48, null
+  br i1 %map_lookup_cond53, label %lookup_merge51, label %lookup_success49
 
-lookup_success46:                                 ; preds = %lookup_merge36
-  %20 = load i64, i8* %lookup_elem45, align 8
-  %phitmp58 = add i64 %20, 1
-  br label %lookup_merge48
+lookup_success49:                                 ; preds = %lookup_merge38
+  %cast54 = bitcast i8* %lookup_elem48 to i64*
+  %20 = load i64, i64* %cast54, align 8
+  %phitmp62 = add i64 %20, 1
+  br label %lookup_merge51
 
-lookup_merge48:                                   ; preds = %lookup_merge36, %lookup_success46
-  %lookup_elem_val49.0 = phi i64 [ %phitmp58, %lookup_success46 ], [ 1, %lookup_merge36 ]
+lookup_merge51:                                   ; preds = %lookup_merge38, %lookup_success49
+  %lookup_elem_val52.0 = phi i64 [ %phitmp62, %lookup_success49 ], [ 1, %lookup_merge38 ]
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %19)
-  %21 = bitcast i64* %"@i_key51" to i8*
+  %21 = bitcast i64* %"@i_key55" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %21)
-  store i64 0, i64* %"@i_key51", align 8
-  %22 = bitcast i64* %"@i_val52" to i8*
+  store i64 0, i64* %"@i_key55", align 8
+  %22 = bitcast i64* %"@i_val56" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %22)
-  store i64 %lookup_elem_val49.0, i64* %"@i_val52", align 8
-  %pseudo53 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem54 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo53, i64* nonnull %"@i_key51", i64* nonnull %"@i_val52", i64 0)
+  store i64 %lookup_elem_val52.0, i64* %"@i_val56", align 8
+  %pseudo57 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem58 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo57, i64* nonnull %"@i_key55", i64* nonnull %"@i_val56", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %21)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %22)
   ret i64 0

--- a/tests/codegen/unroll.cpp
+++ b/tests/codegen/unroll.cpp
@@ -8,7 +8,7 @@ TEST(codegen, unroll)
 {
   test("BEGIN { @i = 0; unroll(5) { @i += 1 } }",
 
-R"EXPECTED(; Function Attrs: nounwind
+       R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
@@ -47,7 +47,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@i_key1", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo2, i64* nonnull %"@i_key1")
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo2, i64* nonnull %"@i_key1")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -73,7 +73,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 0, i64* %"@i_key7", align 8
   %pseudo8 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem9 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo8, i64* nonnull %"@i_key7")
+  %lookup_elem9 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo8, i64* nonnull %"@i_key7")
   %map_lookup_cond14 = icmp eq i8* %lookup_elem9, null
   br i1 %map_lookup_cond14, label %lookup_merge12, label %lookup_success10
 
@@ -99,7 +99,7 @@ lookup_merge12:                                   ; preds = %lookup_merge, %look
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %11)
   store i64 0, i64* %"@i_key19", align 8
   %pseudo20 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem21 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo20, i64* nonnull %"@i_key19")
+  %lookup_elem21 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo20, i64* nonnull %"@i_key19")
   %map_lookup_cond26 = icmp eq i8* %lookup_elem21, null
   br i1 %map_lookup_cond26, label %lookup_merge24, label %lookup_success22
 
@@ -125,7 +125,7 @@ lookup_merge24:                                   ; preds = %lookup_merge12, %lo
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %15)
   store i64 0, i64* %"@i_key31", align 8
   %pseudo32 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem33 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo32, i64* nonnull %"@i_key31")
+  %lookup_elem33 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo32, i64* nonnull %"@i_key31")
   %map_lookup_cond38 = icmp eq i8* %lookup_elem33, null
   br i1 %map_lookup_cond38, label %lookup_merge36, label %lookup_success34
 
@@ -151,7 +151,7 @@ lookup_merge36:                                   ; preds = %lookup_merge24, %lo
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %19)
   store i64 0, i64* %"@i_key43", align 8
   %pseudo44 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem45 = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo44, i64* nonnull %"@i_key43")
+  %lookup_elem45 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo44, i64* nonnull %"@i_key43")
   %map_lookup_cond50 = icmp eq i8* %lookup_elem45, null
   br i1 %map_lookup_cond50, label %lookup_merge48, label %lookup_success46
 

--- a/tests/codegen/variable.cpp
+++ b/tests/codegen/variable.cpp
@@ -35,13 +35,13 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [16 x i8]* nonnull %"$var", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [16 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [16 x i8]* nonnull %"$var", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %4 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@y_key", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@y_key", [16 x i8]* nonnull %"$var", i64 0)
+  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [16 x i8]*, i64)*)(i64 %pseudo1, i64* nonnull %"@y_key", [16 x i8]* nonnull %"$var", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
 }
@@ -85,13 +85,13 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [16 x i8]* nonnull %"$var", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [16 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [16 x i8]* nonnull %"$var", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %4 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@y_key", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i8*, i8*, i8*, i64)*)(i64 %pseudo1, i64* nonnull %"@y_key", [16 x i8]* nonnull %"$var", i64 0)
+  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [16 x i8]*, i64)*)(i64 %pseudo1, i64* nonnull %"@y_key", [16 x i8]* nonnull %"$var", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
 }


### PR DESCRIPTION
As @mmarchini  found in #711  there are quite a few type issues which usually work fine but break LLVM (segfault / oom) in edge cases. I bumped into these too while trying to implement while loops (segfaults in weird place) so figured I'd give them a go.

These are just the first 2, there are a lot more of them but once the `*map` ones are out of the way the rest should cause a lot less codegen changes.

Once everything is done adding `llvm-as` to the testing phase might useful as it spots a lot of these issues for us, e.g.:

```
llvm-as-7: bad.ll:162:27: error: constant expression type mismatch
  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i8*, i8*)*)(i64 %pseudo, i64* %"@_key")
```