### PR TITLE
Add abstraction for stack pointer offset

### DIFF
--- a/src/arch/aarch64.cpp
+++ b/src/arch/aarch64.cpp
@@ -85,6 +85,11 @@ int pc_offset()
   return offset("pc");
 }
 
+int sp_offset()
+{
+  return offset("sp");
+}
+
 std::string name()
 {
   return std::string("aarch64");

--- a/src/arch/arch.h
+++ b/src/arch/arch.h
@@ -10,6 +10,7 @@ int max_arg();
 int arg_offset(int arg_num);
 int ret_offset();
 int pc_offset();
+int sp_offset();
 std::string name();
 
 } // namespace arch

--- a/src/arch/ppc64.cpp
+++ b/src/arch/ppc64.cpp
@@ -94,6 +94,11 @@ int pc_offset()
   return offset("nip");
 }
 
+int sp_offset()
+{
+  return offset("r1");
+}
+
 std::string name()
 {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__

--- a/src/arch/x86_64.cpp
+++ b/src/arch/x86_64.cpp
@@ -75,6 +75,11 @@ int pc_offset()
   return offset("ip");
 }
 
+int sp_offset()
+{
+  return offset("sp");
+}
+
 std::string name()
 {
   return std::string("x86_64");

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -201,7 +201,7 @@ void CodegenLLVM::visit(Builtin &builtin)
   else if (!builtin.ident.compare(0, 4, "sarg") && builtin.ident.size() == 5 &&
       builtin.ident.at(4) >= '0' && builtin.ident.at(4) <= '9')
   {
-    int sp_offset = arch::offset("sp");
+    int sp_offset = arch::sp_offset();
     if (sp_offset == -1)
     {
       std::cerr << "negative offset for stack pointer" << std::endl;


### PR DESCRIPTION
The name of the stack pointer register can vary across architectures. This introduces an abstraction to get the correct stack pointer register offset depending on the current architecture.