### PR TITLE
Silenced unsigned/signed comparison warning

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1914,8 +1914,12 @@ void BPFtrace::log_with_location(std::string level, std::ostream &out, const loc
   }
   out << std::endl;
 
-  for (unsigned int x = 0; x < srcline.size() && x < (l.end.column - 1); x++) {
-    char marker = (x < (l.begin.column - 1)) ? ' ' : '~';
+  for (unsigned int x = 0;
+       x < srcline.size() && x < (static_cast<unsigned int>(l.end.column) - 1);
+       x++)
+  {
+    char marker = (x < (static_cast<unsigned int>(l.begin.column) - 1)) ? ' '
+                                                                        : '~';
     if (srcline[x] == '\t') {
       out << std::string(4, marker);
     } else {


### PR DESCRIPTION
The new bison release ( https://fossies.org/linux/bison/NEWS ) changed
`counter_type` from unsigned int to int:
```
In C++, line numbers and columns are now represented as 'int' not
'unsigned', so that integer overflow on positions is easily checkable via
'gcc -fsanitize=undefined' and the like.  This affects the API for
positions.  The default position and location classes now expose
'counter_type' (int), used to define line and column numbers.
```

We know column numbers can never be negative, so cast it to unsigned as
positive int -> unsigned will always fit.