### PR TITLE
Create StderrSilencer helper class to redirect stderr

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -87,6 +87,26 @@ static void usdt_probe_each(struct bcc_usdt *usdt_probe)
   usdt_provider_cache[usdt_probe->provider].push_back(std::make_tuple(usdt_probe->bin_path, usdt_probe->provider, usdt_probe->name));
 }
 
+void StderrSilencer::silence()
+{
+  fflush(stderr);
+  old_stderr_ = dup(STDERR_FILENO);
+  int new_stderr_ = open("/dev/null", O_WRONLY);
+  dup2(new_stderr_, STDERR_FILENO);
+  close(new_stderr_);
+}
+
+StderrSilencer::~StderrSilencer()
+{
+  if (old_stderr_ != -1)
+  {
+    fflush(stderr);
+    dup2(old_stderr_, STDERR_FILENO);
+    close(old_stderr_);
+    old_stderr_ = -1;
+  }
+}
+
 usdt_probe_entry USDTHelper::find(
     int pid,
     const std::string &target,

--- a/src/utils.h
+++ b/src/utils.h
@@ -35,6 +35,17 @@ private:
   std::string msg_;
 };
 
+class StderrSilencer
+{
+public:
+  StderrSilencer() = default;
+  ~StderrSilencer();
+  void silence();
+
+private:
+  int old_stderr_ = -1;
+};
+
 class USDTHelper
 {
 public:


### PR DESCRIPTION
Moving this logic out to a helper class makes things a little more
C++-like and reusable.