### PR TITLE
Dynamic memory watchpoints

### DIFF
--- a/src/arch/aarch64.cpp
+++ b/src/arch/aarch64.cpp
@@ -147,5 +147,15 @@ std::string name()
   return std::string("aarch64");
 }
 
+std::vector<std::string> invalid_watchpoint_modes()
+{
+  // See arch/arm/kernel/hw_breakpoint.c:arch_build_bp_info in kernel source
+  return std::vector<std::string>{
+    "rx",
+    "wx",
+    "rwx",
+  };
+}
+
 } // namespace arch
 } // namespace bpftrace

--- a/src/arch/arch.h
+++ b/src/arch/arch.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <vector>
 
 namespace bpftrace {
 namespace arch {
@@ -13,6 +14,8 @@ int pc_offset();
 int sp_offset();
 int arg_stack_offset();
 std::string name();
+// Each string is lexicographically sorted by character
+std::vector<std::string> invalid_watchpoint_modes();
 
 } // namespace arch
 } // namespace bpftrace

--- a/src/arch/ppc64.cpp
+++ b/src/arch/ppc64.cpp
@@ -127,5 +127,11 @@ std::string name()
 #endif // __BYTE_ORDER__
 }
 
+std::vector<std::string> invalid_watchpoint_modes()
+{
+  throw std::runtime_error(
+      "Watchpoints are not supported on this architecture");
+}
+
 } // namespace arch
 } // namespace bpftrace

--- a/src/arch/s390.cpp
+++ b/src/arch/s390.cpp
@@ -92,5 +92,11 @@ std::string name()
   return std::string("s390x");
 }
 
+std::vector<std::string> invalid_watchpoint_modes()
+{
+  throw std::runtime_error(
+      "Watchpoints are not supported on this architecture");
+}
+
 } // namespace arch
 } // namespace bpftrace

--- a/src/arch/x86_64.cpp
+++ b/src/arch/x86_64.cpp
@@ -87,5 +87,16 @@ std::string name()
   return std::string("x86_64");
 }
 
+std::vector<std::string> invalid_watchpoint_modes()
+{
+  // See intel developer manual, Volume 3, section 17.2.4
+  return std::vector<std::string>{
+    "r",
+    "rx",
+    "wx",
+    "rwx",
+  };
+}
+
 } // namespace arch
 } // namespace bpftrace

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -494,8 +494,9 @@ public:
   std::string func;
   usdt_probe_entry usdt; // resolved USDT entry, used to support arguments with wildcard matches
   int freq = 0;
-  uint64_t len = 0; // for watchpoint probes, the width of watched addr
-  std::string mode; // for watchpoint probes, the watch mode
+  uint64_t len = 0;   // for watchpoint probes, the width of watched addr
+  std::string mode;   // for watchpoint probes, the watch mode
+  bool async = false; // for watchpoint probes, if it's an async watchpoint
   bool need_expansion = false;
   uint64_t address = 0;
   uint64_t func_offset = 0;

--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -140,5 +140,19 @@ struct Watchpoint
   }
 } __attribute__((packed));
 
+struct WatchpointUnwatch
+{
+  uint64_t action_id;
+  uint64_t addr;
+
+  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b)
+  {
+    return {
+      b.getInt64Ty(), // asyncid
+      b.getInt64Ty(), // addr
+    };
+  }
+} __attribute__((packed));
+
 } // namespace AsyncEvent
 } // namespace bpftrace

--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -124,5 +124,21 @@ struct HelperError
   }
 } __attribute__((packed));
 
+struct Watchpoint
+{
+  uint64_t action_id;
+  uint64_t watchpoint_idx;
+  uint64_t addr;
+
+  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b)
+  {
+    return {
+      b.getInt64Ty(), // asyncid
+      b.getInt64Ty(), // watchpoint_idx
+      b.getInt64Ty(), // addr
+    };
+  }
+} __attribute__((packed));
+
 } // namespace AsyncEvent
 } // namespace bpftrace

--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -82,6 +82,8 @@ int AttachPointParser::parse_attachpoint(AttachPoint &ap)
       return hardware_parser();
     case ProbeType::watchpoint:
       return watchpoint_parser();
+    case ProbeType::asyncwatchpoint:
+      return watchpoint_parser(true);
     case ProbeType::kfunc:
     case ProbeType::kretfunc:
       return kfunc_parser();
@@ -542,7 +544,7 @@ std::optional<uint64_t> AttachPointParser::stoull(const std::string &str)
   }
 }
 
-int AttachPointParser::watchpoint_parser()
+int AttachPointParser::watchpoint_parser(bool async)
 {
   if (parts_.size() != 4)
   {
@@ -594,6 +596,8 @@ int AttachPointParser::watchpoint_parser()
   ap_->target = bpftrace_.get_watchpoint_binary_path().value_or("");
 
   ap_->mode = parts_[3];
+
+  ap_->async = async;
 
   return 0;
 }

--- a/src/ast/attachpoint_parser.h
+++ b/src/ast/attachpoint_parser.h
@@ -43,7 +43,7 @@ private:
   int interval_parser();
   int software_parser();
   int hardware_parser();
-  int watchpoint_parser();
+  int watchpoint_parser(bool async = false);
   int kfunc_parser();
 
   std::optional<uint64_t> stoull(const std::string &str);

--- a/src/ast/attachpoint_parser.h
+++ b/src/ast/attachpoint_parser.h
@@ -46,6 +46,8 @@ private:
   int watchpoint_parser();
   int kfunc_parser();
 
+  std::optional<uint64_t> stoull(const std::string &str);
+
   Program *root_{ nullptr }; // Non-owning pointer
   BPFtrace &bpftrace_;
   std::ostream &sink_;

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1033,6 +1033,25 @@ void CodegenLLVM::visit(Call &call)
     expr_ = buf;
     expr_deleter_ = [this, buf]() { b_.CreateLifetimeEnd(buf); };
   }
+  else if (call.func == "unwatch")
+  {
+    Expression *addr = call.vargs->at(0);
+    addr->accept(*this);
+
+    auto elements = AsyncEvent::WatchpointUnwatch().asLLVMType(b_);
+    StructType *unwatch_struct = b_.GetStructType("unwatch_t", elements, true);
+    AllocaInst *buf = b_.CreateAllocaBPF(unwatch_struct, "unwatch");
+    size_t struct_size = layout_.getTypeAllocSize(unwatch_struct);
+
+    b_.CreateStore(b_.getInt64(asyncactionint(AsyncAction::watchpoint_detach)),
+                   b_.CreateGEP(buf, { b_.getInt64(0), b_.getInt32(0) }));
+    b_.CreateStore(
+        b_.CreateIntCast(expr_, b_.getInt64Ty(), false /* unsigned */),
+        b_.CreateGEP(buf, { b_.getInt64(0), b_.getInt32(1) }));
+    b_.CreatePerfEventOutput(ctx_, buf, struct_size);
+    b_.CreateLifetimeEnd(buf);
+    expr_ = nullptr;
+  }
   else
   {
     LOG(FATAL) << "missing codegen for function \"" << call.func << "\"";

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <iostream>
+#include <optional>
 #include <ostream>
 
 #include "bpftrace.h"
@@ -55,7 +56,6 @@ public:
   AllocaInst *getMapKey(Map &map);
   AllocaInst *getHistMapKey(Map &map, Value *log2);
   int         getNextIndexForProbe(const std::string &probe_name);
-  std::string getSectionNameForProbe(const std::string &probe_name, int index);
   Value      *createLogicalAnd(Binop &binop);
   Value      *createLogicalOr(Binop &binop);
 
@@ -105,7 +105,9 @@ private:
                      const std::string &full_func_id,
                      const std::string &section_name,
                      FunctionType *func_type,
-                     bool expansion);
+                     bool expansion,
+                     std::optional<int> usdt_location_index = std::nullopt);
+
   [[nodiscard]] ScopedExprDeleter accept(Node *node);
 
   void compareStructure(SizedType &our_type, llvm::Type *llvm_type);

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -131,6 +131,7 @@ private:
   // of the "real" probe the setup probe is to be replaced by.
   void generateWatchpointSetupProbe(FunctionType *func_type,
                                     const std::string &expanded_probe_name,
+                                    int arg_num,
                                     int index);
 
   Node *root_ = nullptr;
@@ -159,6 +160,7 @@ private:
   uint64_t join_id_ = 0;
   int system_id_ = 0;
   int non_map_print_id_ = 0;
+  uint64_t watchpoint_id_ = 0;
 
   Function *linear_func_ = nullptr;
   Function *log2_func_ = nullptr;

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -119,6 +119,20 @@ private:
   void binop_buf(Binop &binop);
   void binop_int(Binop &binop);
 
+  // Every time we see a watchpoint that specifies a function + arg pair, we
+  // generate a special "setup" probe that:
+  //
+  // * sends SIGSTOP to the tracee
+  // * pulls out the function arg
+  // * sends an asyncaction to the bpftrace runtime and specifies the arg value
+  //   and which of the "real" probes to attach to the addr in the arg
+  //
+  // We need a separate "setup" probe per probe because we hard code the index
+  // of the "real" probe the setup probe is to be replaced by.
+  void generateWatchpointSetupProbe(FunctionType *func_type,
+                                    const std::string &expanded_probe_name,
+                                    int index);
+
   Node *root_ = nullptr;
   LLVMContext context_;
   std::unique_ptr<Module> module_;

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1207,6 +1207,14 @@ void SemanticAnalyser::visit(Call &call)
 
     call.type = CreateMacAddress();
   }
+  else if (call.func == "unwatch")
+  {
+    if (check_nargs(call, 1))
+      check_arg(call, Type::integer, 0);
+
+    // Return type cannot be used
+    call.type = SizedType(Type::none, 0);
+  }
   else
   {
     LOG(ERROR, call.loc, err_) << "Unknown function: '" << call.func << "'";

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -202,6 +202,7 @@ AddrSpace SemanticAnalyser::find_addrspace(ProbeType pt)
     case ProbeType::software:
     case ProbeType::hardware:
     case ProbeType::watchpoint:
+    case ProbeType::asyncwatchpoint:
       // Will trigger a warning in selectProbeReadHelper.
       return AddrSpace::none;
   }
@@ -2401,7 +2402,8 @@ void SemanticAnalyser::visit(AttachPoint &ap)
     else if (ap.freq < 0)
       LOG(ERROR, ap.loc, err_) << "software count should be a positive integer";
   }
-  else if (ap.provider == "watchpoint") {
+  else if (ap.provider == "watchpoint" || ap.provider == "asyncwatchpoint")
+  {
     if (ap.func.size())
     {
       if (bpftrace_.pid() <= 0 && !has_child_)
@@ -2411,6 +2413,8 @@ void SemanticAnalyser::visit(AttachPoint &ap)
         LOG(ERROR, ap.loc, err_)
             << arch::name() << " doesn't support arg" << ap.address;
     }
+    else if (ap.provider == "asyncwatchpoint")
+      LOG(ERROR, ap.loc, err_) << ap.provider << " requires a function name";
     else if (!ap.address)
       LOG(ERROR, ap.loc, err_)
           << "watchpoint must be attached to a non-zero address";
@@ -2882,6 +2886,7 @@ bool SemanticAnalyser::check_available(const Call &call, const AttachPoint &ap)
       case ProbeType::software:
       case ProbeType::hardware:
       case ProbeType::watchpoint:
+      case ProbeType::asyncwatchpoint:
         return true;
       case ProbeType::invalid:
       case ProbeType::tracepoint:
@@ -2907,6 +2912,7 @@ bool SemanticAnalyser::check_available(const Call &call, const AttachPoint &ap)
       case ProbeType::software:
       case ProbeType::hardware:
       case ProbeType::watchpoint:
+      case ProbeType::asyncwatchpoint:
       case ProbeType::kfunc:
       case ProbeType::kretfunc:
         return false;
@@ -2933,6 +2939,7 @@ bool SemanticAnalyser::check_available(const Call &call, const AttachPoint &ap)
       case ProbeType::software:
       case ProbeType::hardware:
       case ProbeType::watchpoint:
+      case ProbeType::asyncwatchpoint:
         return false;
     }
   }

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -246,6 +246,11 @@ AttachedProbe::~AttachedProbe()
     close(progfd_);
 }
 
+const Probe &AttachedProbe::probe() const
+{
+  return probe_;
+}
+
 std::string AttachedProbe::eventprefix() const
 {
   switch (attachtype(probe_.type))

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -70,10 +70,17 @@ bpf_prog_type progtype(ProbeType t)
     case ProbeType::uretprobe:  return BPF_PROG_TYPE_KPROBE; break;
     case ProbeType::usdt:       return BPF_PROG_TYPE_KPROBE; break;
     case ProbeType::tracepoint: return BPF_PROG_TYPE_TRACEPOINT; break;
-    case ProbeType::profile:      return BPF_PROG_TYPE_PERF_EVENT; break;
-    case ProbeType::interval:      return BPF_PROG_TYPE_PERF_EVENT; break;
+    case ProbeType::profile:
+      return BPF_PROG_TYPE_PERF_EVENT;
+      break;
+    case ProbeType::interval:
+      return BPF_PROG_TYPE_PERF_EVENT;
+      break;
     case ProbeType::software:   return BPF_PROG_TYPE_PERF_EVENT; break;
     case ProbeType::watchpoint: return BPF_PROG_TYPE_PERF_EVENT; break;
+    case ProbeType::asyncwatchpoint:
+      return BPF_PROG_TYPE_PERF_EVENT;
+      break;
     case ProbeType::hardware:   return BPF_PROG_TYPE_PERF_EVENT; break;
     case ProbeType::kfunc:
       return static_cast<enum ::bpf_prog_type>(libbpf::BPF_PROG_TYPE_TRACING);
@@ -196,6 +203,7 @@ AttachedProbe::AttachedProbe(Probe &probe,
       attach_usdt(pid, feature);
       break;
     case ProbeType::watchpoint:
+    case ProbeType::asyncwatchpoint:
       attach_watchpoint(pid, probe.mode);
       break;
     default:
@@ -239,6 +247,7 @@ AttachedProbe::~AttachedProbe()
     case ProbeType::interval:
     case ProbeType::software:
     case ProbeType::watchpoint:
+    case ProbeType::asyncwatchpoint:
     case ProbeType::hardware:
       break;
     case ProbeType::invalid:

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -1,3 +1,7 @@
+#ifndef _GNU_SOURCE
+#define _GNU_SOURCE
+#endif
+
 #include <cstring>
 #include <elf.h>
 #include <fcntl.h>
@@ -7,9 +11,15 @@
 #include <linux/limits.h>
 #include <linux/perf_event.h>
 #include <regex>
+#include <sys/ioctl.h>
+#include <sys/syscall.h>
 #include <sys/utsname.h>
 #include <tuple>
 #include <unistd.h>
+
+#include <bcc/bcc_elf.h>
+#include <bcc/bcc_syms.h>
+#include <bcc/bcc_usdt.h>
 
 #include "attached_probe.h"
 #include "bpftrace.h"
@@ -17,10 +27,6 @@
 #include "list.h"
 #include "log.h"
 #include "usdt.h"
-#include <bcc/bcc_elf.h>
-#include <bcc/bcc_syms.h>
-#include <bcc/bcc_usdt.h>
-#include <linux/perf_event.h>
 
 namespace libbpf {
 #undef __BPF_FUNC_MAPPER
@@ -1127,10 +1133,34 @@ void AttachedProbe::attach_watchpoint(int pid, const std::string& mode)
 
   for (int cpu : cpus)
   {
-    int perf_event_fd = bpf_attach_perf_event_raw(
-        progfd_, &attr, pid, cpu, -1, 0);
+    // We copy paste the code from bcc's bpf_attach_perf_event_raw here
+    // because we need to know the exact error codes (and also we don't
+    // want bcc's noisy error messages).
+    int perf_event_fd = syscall(
+        __NR_perf_event_open, &attr, pid, cpu, -1, PERF_FLAG_FD_CLOEXEC);
     if (perf_event_fd < 0)
-      throw std::runtime_error("Error attaching probe: " + probe_.name);
+    {
+      if (errno == ENOSPC)
+        throw EnospcException("No more HW registers left");
+      else
+        throw std::system_error(errno,
+                                std::generic_category(),
+                                "Error attaching probe: " + probe_.name);
+    }
+    if (ioctl(perf_event_fd, PERF_EVENT_IOC_SET_BPF, progfd_) != 0)
+    {
+      close(perf_event_fd);
+      throw std::system_error(errno,
+                              std::generic_category(),
+                              "Error attaching probe: " + probe_.name);
+    }
+    if (ioctl(perf_event_fd, PERF_EVENT_IOC_ENABLE, 0) != 0)
+    {
+      close(perf_event_fd);
+      throw std::system_error(errno,
+                              std::generic_category(),
+                              "Error attaching probe: " + probe_.name);
+    }
 
     perf_event_fds_.push_back(perf_event_fd);
   }

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -30,6 +30,8 @@ public:
   AttachedProbe(const AttachedProbe &) = delete;
   AttachedProbe &operator=(const AttachedProbe &) = delete;
 
+  const Probe &probe() const;
+
 private:
   std::string eventprefix() const;
   std::string eventname() const;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -415,6 +415,13 @@ std::set<std::string> BPFtrace::find_wildcard_matches(
       func = attach_point.target + ":" + attach_point.func;
       break;
     }
+    case ProbeType::watchpoint:
+    {
+      symbol_stream = std::make_unique<std::istringstream>(
+          extract_func_symbols_from_path(attach_point.target));
+      func = attach_point.target + ":" + attach_point.func;
+      break;
+    }
     case ProbeType::tracepoint:
     {
       symbol_stream = get_symbols_from_file(

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1727,6 +1727,24 @@ uint64_t BPFtrace::max_value(const std::vector<uint8_t> &value, int nvalues)
   return max;
 }
 
+std::optional<std::string> BPFtrace::get_watchpoint_binary_path() const
+{
+  if (child_)
+  {
+    // We can ignore all error checking here b/c child.cpp:validate_cmd() has
+    // already done it
+    auto args = split_string(cmd_, ' ', /* remove_empty= */ true);
+    assert(!args.empty());
+    return resolve_binary_path(args[0]).front();
+  }
+  else if (pid())
+    return "/proc/" + std::to_string(pid()) + "/exe";
+  else
+  {
+    return std::nullopt;
+  }
+}
+
 int64_t BPFtrace::min_value(const std::vector<uint8_t> &value, int nvalues)
 {
   int64_t val, max = 0, retval;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -134,6 +134,7 @@ public:
   void request_finalize();
   bool is_aslr_enabled(int pid);
   std::string get_string_literal(const ast::Expression *expr) const;
+  std::optional<std::string> get_watchpoint_binary_path() const;
 
   std::string cmd_;
   bool finalize_ = false;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -99,6 +99,9 @@ public:
   }
   virtual ~BPFtrace();
   virtual int add_probe(ast::Probe &p);
+  Probe generateWatchpointSetupProbe(const std::string &func,
+                                     const ast::AttachPoint &ap,
+                                     const ast::Probe &probe);
   int num_probes() const;
   int run(std::unique_ptr<BpfOrc> bpforc);
   int print_maps();

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -30,7 +30,7 @@ vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#\*])*:
 builtin  arg[0-9]|args|cgroup|comm|cpid|cpu|ctx|curtask|elapsed|func|gid|nsecs|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
-call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|reg|signal|sizeof|stats|str|strftime|strncmp|sum|system|time|uaddr|uptr|usym|zero|path
+call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|reg|signal|sizeof|stats|str|strftime|strncmp|sum|system|time|uaddr|uptr|usym|zero|path|unwatch
 
 /* Don't add to this! Use builtin OR call not both */
 call_and_builtin kstack|ustack

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -230,6 +230,9 @@ std::string probetypeName(ProbeType t)
     case ProbeType::software:    return "software";    break;
     case ProbeType::hardware:    return "hardware";    break;
     case ProbeType::watchpoint:  return "watchpoint";  break;
+    case ProbeType::asyncwatchpoint:
+      return "asyncwatchpoint";
+      break;
     case ProbeType::kfunc:       return "kfunc";       break;
     case ProbeType::kretfunc:    return "kretfunc";    break;
   }

--- a/src/types.h
+++ b/src/types.h
@@ -484,7 +484,8 @@ enum class AsyncAction
   join,
   helper_error,
   print_non_map,
-  strftime
+  strftime,
+  watchpoint_attach,
   // clang-format on
 };
 

--- a/src/types.h
+++ b/src/types.h
@@ -486,6 +486,7 @@ enum class AsyncAction
   print_non_map,
   strftime,
   watchpoint_attach,
+  watchpoint_detach,
   // clang-format on
 };
 

--- a/src/types.h
+++ b/src/types.h
@@ -409,6 +409,7 @@ enum class ProbeType
   software,
   hardware,
   watchpoint,
+  asyncwatchpoint,
   kfunc,
   kretfunc,
 };
@@ -422,8 +423,7 @@ struct ProbeItem
   ProbeType type;
 };
 
-const std::vector<ProbeItem> PROBE_LIST =
-{
+const std::vector<ProbeItem> PROBE_LIST = {
   { "kprobe", "k", ProbeType::kprobe },
   { "kretprobe", "kr", ProbeType::kretprobe },
   { "uprobe", "u", ProbeType::uprobe },
@@ -437,6 +437,7 @@ const std::vector<ProbeItem> PROBE_LIST =
   { "software", "s", ProbeType::software },
   { "hardware", "h", ProbeType::hardware },
   { "watchpoint", "w", ProbeType::watchpoint },
+  { "asyncwatchpoint", "aw", ProbeType::asyncwatchpoint },
   { "kfunc", "f", ProbeType::kfunc },
   { "kretfunc", "fr", ProbeType::kretfunc },
 };
@@ -464,6 +465,7 @@ struct Probe
   pid_t pid = -1;
   uint64_t len = 0;             // for watchpoint probes, size of region
   std::string mode;             // for watchpoint probes, watch mode (rwx)
+  bool async = false; // for watchpoint probes, if it's an async watchpoint
   uint64_t address = 0;
   uint64_t func_offset = 0;
 };

--- a/src/utils.h
+++ b/src/utils.h
@@ -2,6 +2,7 @@
 
 #include <csignal>
 #include <cstring>
+#include <exception>
 #include <iostream>
 #include <optional>
 #include <sstream>
@@ -51,6 +52,14 @@ public:
 
 private:
   std::string msg_;
+};
+
+class EnospcException : public std::runtime_error
+{
+public:
+  // C++11 feature: bring base class constructor into scope to automatically
+  // forward constructor calls to base class
+  using std::runtime_error::runtime_error;
 };
 
 class StdioSilencer

--- a/src/utils.h
+++ b/src/utils.h
@@ -3,6 +3,7 @@
 #include <csignal>
 #include <cstring>
 #include <iostream>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <sys/utsname.h>
@@ -151,6 +152,22 @@ bool symbol_has_cpp_mangled_signature(const std::string &sym_name);
 pid_t parse_pid(const std::string &str);
 std::string hex_format_buffer(const char *buf, size_t size);
 std::string abs_path(const std::string &rel_path);
+
+// Generate object file section name for a given probe
+inline std::string get_section_name_for_probe(
+    const std::string &probe_name,
+    int index,
+    std::optional<int> usdt_location_index = std::nullopt)
+{
+  auto ret = "s_" + probe_name;
+
+  if (usdt_location_index)
+    ret += "_loc" + std::to_string(*usdt_location_index);
+
+  ret += "_" + std::to_string(index);
+
+  return ret;
+}
 
 // trim from end of string (right)
 inline std::string &rtrim(std::string &s)

--- a/src/utils.h
+++ b/src/utils.h
@@ -169,6 +169,20 @@ inline std::string get_section_name_for_probe(
   return ret;
 }
 
+inline std::string get_watchpoint_setup_probe_name(
+    const std::string &probe_name)
+{
+  return probe_name + "_wp_setup";
+}
+
+inline std::string get_section_name_for_watchpoint_setup(
+    const std::string &probe_name,
+    int index)
+{
+  return get_section_name_for_probe(get_watchpoint_setup_probe_name(probe_name),
+                                    index);
+}
+
 // trim from end of string (right)
 inline std::string &rtrim(std::string &s)
 {

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -1,9 +1,11 @@
 #pragma once
 
+#include "gmock/gmock.h"
+
 #include "bpffeature.h"
 #include "bpftrace.h"
 #include "child.h"
-#include "gmock/gmock.h"
+#include "procmon.h"
 
 namespace bpftrace {
 namespace test {
@@ -95,6 +97,25 @@ public:
   {
     (void)pause;
   };
+};
+
+class MockProcMon : public ProcMonBase
+{
+public:
+  MockProcMon(pid_t pid)
+  {
+    pid_ = pid;
+  }
+
+  ~MockProcMon() override = default;
+
+  bool is_alive(void) override
+  {
+    if (pid_ > 0)
+      return true;
+    else
+      return false;
+  }
 };
 
 } // namespace test

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1115,14 +1115,16 @@ TEST(Parser, hardware_probe)
 
 TEST(Parser, watchpoint_probe)
 {
-  test("watchpoint::1234:8:w { 1 }",
+  test("watchpoint:1234:8:w { 1 }",
        "Program\n"
        " watchpoint:1234:8:w\n"
        "  int: 1\n");
 
-  test_parse_failure("watchpoint::1b:8:w { 1 }");
-  test_parse_failure("watchpoint::1:8a:w { 1 }");
-  test_parse_failure("watchpoint::1b:8a:w { 1 }");
+  test_parse_failure("watchpoint:1b:8:w { 1 }");
+  test_parse_failure("watchpoint:1:8a:w { 1 }");
+  test_parse_failure("watchpoint:1b:8a:w { 1 }");
+  test_parse_failure("watchpoint:+arg0:8:rw { 1 }");
+  test_parse_failure("watchpoint:func1:8:rw { 1 }");
 }
 
 TEST(Parser, multiple_attach_points_kprobe)
@@ -1709,7 +1711,7 @@ TEST(Parser, abs_knl_address)
   char in_cstr[64];
   char out_cstr[64];
 
-  snprintf(in_cstr, sizeof(in_cstr), "watchpoint::0x%lx:4:w { 1; }", ULONG_MAX);
+  snprintf(in_cstr, sizeof(in_cstr), "watchpoint:0x%lx:4:w { 1; }", ULONG_MAX);
   snprintf(out_cstr,
            sizeof(out_cstr),
            "Program\n"

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1127,6 +1127,20 @@ TEST(Parser, watchpoint_probe)
   test_parse_failure("watchpoint:func1:8:rw { 1 }");
 }
 
+TEST(Parser, asyncwatchpoint_probe)
+{
+  test("asyncwatchpoint:1234:8:w { 1 }",
+       "Program\n"
+       " asyncwatchpoint:1234:8:w\n"
+       "  int: 1\n");
+
+  test_parse_failure("asyncwatchpoint:1b:8:w { 1 }");
+  test_parse_failure("asyncwatchpoint:1:8a:w { 1 }");
+  test_parse_failure("asyncwatchpoint:1b:8a:w { 1 }");
+  test_parse_failure("asyncwatchpoint:+arg0:8:rw { 1 }");
+  test_parse_failure("asyncwatchpoint:func1:8:rw { 1 }");
+}
+
 TEST(Parser, multiple_attach_points_kprobe)
 {
   test("BEGIN,kprobe:sys_open,uprobe:/bin/sh:foo,tracepoint:syscalls:sys_enter_* { 1 }",

--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -98,7 +98,7 @@ class TestParser(object):
             elif item_name == 'ARCH':
                 arch = [x.strip() for x in line.split("|")]
             elif item_name == 'REQUIRES_FEATURE':
-                features = {"loop", "btf", "probe_read_kernel", "dpath", "uprobe_refcount"}
+                features = {"loop", "btf", "probe_read_kernel", "dpath", "uprobe_refcount", "signal"}
 
                 for f in line.split(" "):
                     f = f.strip()

--- a/tests/runtime/engine/utils.py
+++ b/tests/runtime/engine/utils.py
@@ -103,6 +103,7 @@ class Utils(object):
         bpffeature["dpath"] = output.find("dpath: yes") != -1
         bpffeature["uprobe_refcount"] = \
             output.find("uprobe refcount (depends on Build:bcc bpf_attach_uprobe refcount): yes") != -1
+        bpffeature["signal"] = output.find("send_signal: yes") != -1
         return bpffeature
 
     @staticmethod

--- a/tests/runtime/scripts/watchpoint_multiattach.bt
+++ b/tests/runtime/scripts/watchpoint_multiattach.bt
@@ -1,0 +1,16 @@
+BEGIN
+{
+  @count = 0;
+}
+
+watchpoint:increment_0+arg0:4:w,
+watchpoint:increment_1+arg0:4:w,
+watchpoint:increment_2+arg0:4:w
+{
+  @count++;
+}
+
+END
+{
+  printf("count=%d\n", @count);
+}

--- a/tests/runtime/scripts/watchpoint_unwatch.bt
+++ b/tests/runtime/scripts/watchpoint_unwatch.bt
@@ -1,0 +1,21 @@
+BEGIN
+{
+  @count = 0;
+}
+
+uprobe:./testprogs/watchpoint_unwatch:increment
+{
+  @addr = (uint64)arg0;
+}
+
+watchpoint:increment+arg0:4:w
+{
+  printf("hello world\n");
+  @count++;
+  unwatch(@addr);
+}
+
+END
+{
+  printf("count=%d\n", @count);
+}

--- a/tests/runtime/watchpoint
+++ b/tests/runtime/watchpoint
@@ -15,34 +15,41 @@ NAME function_arg_addr
 RUN bpftrace -v -e 'watchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint_func
 EXPECT hit!
 TIMEOUT 5
+REQUIRES_FEATURE signal
 
 NAME function_arg_addr_process_flag
 RUN bpftrace -v -e 'watchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }' -p $(pidof watchpoint_func)
 BEFORE ./testprogs/watchpoint_func
 EXPECT hit!
 TIMEOUT 5
+REQUIRES_FEATURE signal
 
 NAME many_function_probes
 RUN bpftrace -e 'watchpoint:increment+arg0:4:w { printf("hit!\n") }' -c ./testprogs/watchpoint_func_many_probes
 EXPECT You are out of watchpoint registers
 TIMEOUT 5
+REQUIRES_FEATURE signal
 
 NAME unwatch
 RUN bpftrace runtime/scripts/watchpoint_unwatch.bt -c ./testprogs/watchpoint_unwatch
 EXPECT count=1
 TIMEOUT 5
+REQUIRES_FEATURE signal
 
 NAME function_multiattach
 RUN bpftrace -v runtime/scripts/watchpoint_multiattach.bt -c ./testprogs/watchpoint_func_wildcard
 EXPECT count=3
 TIMEOUT 5
+REQUIRES_FEATURE signal
 
 NAME wildcarded_function
 RUN bpftrace -v -e 'watchpoint:increment_*+arg0:4:w { printf("hit!\n") }' -c ./testprogs/watchpoint_func_wildcard
 EXPECT You are out of watchpoint registers
 TIMEOUT 5
+REQUIRES_FEATURE signal
 
 NAME unique_probe_bodies
 RUN bpftrace -v -e 'watchpoint:increment_*+arg0:4:w { printf("%s!\n", probe) }' -c ./testprogs/watchpoint_func_wildcard
 EXPECT .*increment_0:4:w!
 TIMEOUT 5
+REQUIRES_FEATURE signal

--- a/tests/runtime/watchpoint
+++ b/tests/runtime/watchpoint
@@ -1,5 +1,5 @@
 NAME watchpoint - absolute address
-RUN bpftrace -v -e 'watchpoint:0x10000000:8:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint
+RUN bpftrace -v -e 'watchpoint::0x10000000:8:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint
 EXPECT hit!
 ARCH aarch64|ppc64|ppc64le|x86_64
 TIMEOUT 5
@@ -10,3 +10,39 @@ EXPECT hit
 ARCH aarch64|ppc64|ppc64le|x86_64
 TIMEOUT 5
 REQUIRES awk '$3 == "jiffies" {got=1} END {exit !got}' /proc/kallsyms
+
+NAME function_arg_addr
+RUN bpftrace -v -e 'watchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint_func
+EXPECT hit!
+TIMEOUT 5
+
+NAME function_arg_addr_process_flag
+RUN bpftrace -v -e 'watchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }' -p $(pidof watchpoint_func)
+BEFORE ./testprogs/watchpoint_func
+EXPECT hit!
+TIMEOUT 5
+
+NAME many_function_probes
+RUN bpftrace -e 'watchpoint:increment+arg0:4:w { printf("hit!\n") }' -c ./testprogs/watchpoint_func_many_probes
+EXPECT You are out of watchpoint registers
+TIMEOUT 5
+
+NAME unwatch
+RUN bpftrace runtime/scripts/watchpoint_unwatch.bt -c ./testprogs/watchpoint_unwatch
+EXPECT count=1
+TIMEOUT 5
+
+NAME function_multiattach
+RUN bpftrace -v runtime/scripts/watchpoint_multiattach.bt -c ./testprogs/watchpoint_func_wildcard
+EXPECT count=3
+TIMEOUT 5
+
+NAME wildcarded_function
+RUN bpftrace -v -e 'watchpoint:increment_*+arg0:4:w { printf("hit!\n") }' -c ./testprogs/watchpoint_func_wildcard
+EXPECT You are out of watchpoint registers
+TIMEOUT 5
+
+NAME unique_probe_bodies
+RUN bpftrace -v -e 'watchpoint:increment_*+arg0:4:w { printf("%s!\n", probe) }' -c ./testprogs/watchpoint_func_wildcard
+EXPECT .*increment_0:4:w!
+TIMEOUT 5

--- a/tests/runtime/watchpoint
+++ b/tests/runtime/watchpoint
@@ -1,11 +1,11 @@
 NAME watchpoint - absolute address
-RUN bpftrace -v -e 'watchpoint::0x10000000:8:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint
+RUN bpftrace -v -e 'watchpoint:0x10000000:8:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint
 EXPECT hit!
 ARCH aarch64|ppc64|ppc64le|x86_64
 TIMEOUT 5
 
 NAME kwatchpoint - knl absolute address
-RUN bpftrace -v -e "watchpoint::0x$(awk '$3 == "jiffies" {print $1}' /proc/kallsyms):4:w { printf(\"hit\n\"); exit(); }"
+RUN bpftrace -v -e "watchpoint:0x$(awk '$3 == "jiffies" {print $1}' /proc/kallsyms):4:w { printf(\"hit\n\"); exit(); }"
 EXPECT hit
 ARCH aarch64|ppc64|ppc64le|x86_64
 TIMEOUT 5

--- a/tests/runtime/watchpoint
+++ b/tests/runtime/watchpoint
@@ -17,6 +17,12 @@ EXPECT hit!
 TIMEOUT 5
 REQUIRES_FEATURE signal
 
+NAME async_function_arg_addr
+RUN bpftrace -v -e 'asyncwatchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint_func
+EXPECT hit!
+TIMEOUT 5
+REQUIRES_FEATURE signal
+
 NAME function_arg_addr_process_flag
 RUN bpftrace -v -e 'watchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }' -p $(pidof watchpoint_func)
 BEFORE ./testprogs/watchpoint_func

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1781,6 +1781,21 @@ TEST(semantic_analyser, override)
   test("p:hz:1 { override(-1); }", 1, false);
 }
 
+TEST(semantic_analyser, unwatch)
+{
+  test("i:s:1 { unwatch(12345) }", 0);
+  test("i:s:1 { unwatch(0x1234) }", 0);
+  test("i:s:1 { $x = 1; unwatch($x); }", 0);
+  test("i:s:1 { @x = 1; @x++; unwatch(@x); }", 0);
+  test("k:f { unwatch(arg0); }", 0);
+  test("k:f { unwatch((int64)arg0); }", 0);
+  test("k:f { unwatch(*(int64*)arg0); }", 0);
+
+  test("i:s:1 { unwatch(\"asdf\") }", 10);
+  test("i:s:1 { @x[\"hi\"] = \"world\"; unwatch(@x[\"hi\"]) }", 10);
+  test("i:s:1 { printf(\"%d\", unwatch(2)) }", 10);
+}
+
 TEST(semantic_analyser, struct_member_keywords)
 {
   std::string keywords[] = {

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1270,6 +1270,23 @@ TEST(semantic_analyser, watchpoint_function)
   bpftrace->procmon_ = std::make_unique<MockProcMon>(0);
   test(*bpftrace, "watchpoint:func1+arg2:8:rw { 1 }", 1);
 }
+
+TEST(semantic_analyser, asyncwatchpoint)
+{
+  auto bpftrace = get_mock_bpftrace();
+  bpftrace->procmon_ = std::make_unique<MockProcMon>(123);
+
+  test(*bpftrace, "asyncwatchpoint:func1+arg2:8:rw { 1 }", 0);
+  test(*bpftrace, "aw:func1+arg2:8:rw { 1 }", 0);
+  test(*bpftrace, "aw:func1.one_two+arg2:8:rw { 1 }", 0);
+  test(*bpftrace, "asyncwatchpoint:func1+arg99999:8:rw { 1 }", 1);
+
+  // asyncwatchpoint's may not use absolute addresses
+  test(*bpftrace, "asyncwatchpoint:0x1234:8:rw { 1 }", 1);
+
+  bpftrace->procmon_ = std::make_unique<MockProcMon>(0);
+  test(*bpftrace, "watchpoint:func1+arg2:8:rw { 1 }", 1);
+}
 #endif // if defined(ARCH_X86_64) || defined(ARCH_AARCH64)
 
 TEST(semantic_analyser, args_builtin_wrong_use)

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1230,16 +1230,14 @@ TEST(semantic_analyser, tracepoint)
 
 TEST(semantic_analyser, watchpoint)
 {
-  test("watchpoint::0x1234:8:rw { 1 }", 0);
-  test("watchpoint:/dev/null:0x1234:8:rw { 1 }", 0);
-  test("watchpoint::0x1234:9:rw { 1 }", 1);
-  test("watchpoint::0x1234:8:rwx { 1 }", 1);
-  test("watchpoint::0x1234:8:rx { 1 }", 1);
-  test("watchpoint::0x1234:8:b { 1 }", 1);
-  test("watchpoint::0x1234:8:rww { 1 }", 1);
-  test("watchpoint::0x0:8:rww { 1 }", 1);
+  test("watchpoint:0x1234:8:rw { 1 }", 0);
+  test("watchpoint:0x1234:9:rw { 1 }", 1);
+  test("watchpoint:0x1234:8:rwx { 1 }", 1);
+  test("watchpoint:0x1234:8:rx { 1 }", 1);
+  test("watchpoint:0x1234:8:b { 1 }", 1);
+  test("watchpoint:0x1234:8:rww { 1 }", 1);
+  test("watchpoint:0x0:8:rww { 1 }", 1);
 }
-
 
 TEST(semantic_analyser, args_builtin_wrong_use)
 {

--- a/tests/testprogs/watchpoint_func.c
+++ b/tests/testprogs/watchpoint_func.c
@@ -1,0 +1,19 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+__attribute__((noinline)) void increment(__attribute__((unused)) int _, int *i)
+{
+  (*i)++;
+}
+
+int main()
+{
+  int *i = malloc(sizeof(int));
+  while (1)
+  {
+    increment(0, i);
+    (*i)++;
+    usleep(1000);
+  }
+}

--- a/tests/testprogs/watchpoint_func_many_probes.c
+++ b/tests/testprogs/watchpoint_func_many_probes.c
@@ -1,0 +1,16 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+__attribute__((noinline)) void increment(int *i)
+{
+  (*i)++;
+}
+
+int main()
+{
+  for (int i = 0; i < 20; ++i)
+  {
+    increment(malloc(sizeof(int)));
+  }
+}

--- a/tests/testprogs/watchpoint_func_wildcard.c
+++ b/tests/testprogs/watchpoint_func_wildcard.c
@@ -1,0 +1,58 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#define GEN_FUNC(x)                                                            \
+  __attribute__((noinline)) void increment_##x(int *i)                         \
+  {                                                                            \
+    (*i)++;                                                                    \
+  }
+
+#define CALL_FUNC(x) increment_##x(malloc(sizeof(int)))
+
+GEN_FUNC(0)
+GEN_FUNC(1)
+GEN_FUNC(2)
+GEN_FUNC(3)
+GEN_FUNC(4)
+GEN_FUNC(5)
+GEN_FUNC(6)
+GEN_FUNC(7)
+GEN_FUNC(8)
+GEN_FUNC(9)
+GEN_FUNC(10)
+GEN_FUNC(11)
+GEN_FUNC(12)
+GEN_FUNC(13)
+GEN_FUNC(14)
+GEN_FUNC(15)
+GEN_FUNC(16)
+GEN_FUNC(17)
+GEN_FUNC(18)
+GEN_FUNC(19)
+GEN_FUNC(20)
+
+int main()
+{
+  CALL_FUNC(0);
+  CALL_FUNC(1);
+  CALL_FUNC(2);
+  CALL_FUNC(3);
+  CALL_FUNC(4);
+  CALL_FUNC(5);
+  CALL_FUNC(6);
+  CALL_FUNC(7);
+  CALL_FUNC(8);
+  CALL_FUNC(9);
+  CALL_FUNC(10);
+  CALL_FUNC(11);
+  CALL_FUNC(12);
+  CALL_FUNC(13);
+  CALL_FUNC(14);
+  CALL_FUNC(15);
+  CALL_FUNC(16);
+  CALL_FUNC(17);
+  CALL_FUNC(18);
+  CALL_FUNC(19);
+  CALL_FUNC(20);
+}

--- a/tests/testprogs/watchpoint_unwatch.c
+++ b/tests/testprogs/watchpoint_unwatch.c
@@ -1,0 +1,23 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+__attribute__((noinline)) void increment(int *i)
+{
+  (*i)++;
+}
+
+int main()
+{
+  int *i = malloc(sizeof(int));
+  increment(i);
+
+  // Yes, this sleep sucks but unwatch is async and we have
+  // no way to delay the bpf prog
+  sleep(1);
+
+  (*i)++;
+  (*i)++;
+  (*i)++;
+  (*i)++;
+}


### PR DESCRIPTION
Commit 854cd4bc053c53 ("Add memory watchpoint probe prototype") added
support for memory watchpoint at absolute addresses. That was a good first
step, but it's fairly rare that users are working with fixed memory addresses.

This patchset adds support for much more powerful and dynamic memory
watchpoints. Consider the following example:
```
$ cat ~/scratch/printfloop.c
__attribute__((noinline))
void saysomething(int *i) {
  int x = *i;
  // do work
}

int main() {
  int *i = malloc(sizeof(int));
  *i = 0;
  while (1) {
    saysomething(i);
    (*i) = random();  // !!! corruption
    sleep(1);
  }
}
```

We could watch for the "corruption" by executing the following bpftrace
script:
```
$ sudo bpftrace -e 'watchpoint:saysomething+arg0:4:w { printf("saw a write\n"); }' \
    -c ./printfloop
Attaching 1 probe...
saw a write!
^C

```
where `saysomething` is the function to hook into, `arg0` is the argument
(identical to `arg0`, `arg1`, etc.) we treat as the target memory address,
`4` is the length of the memory watchpoint (4 bytes), and `w` as listen
for writes.

See individual commits for descriptions of the mechanics behind how
this feature works.

For full examples, see the attached runtime tests.

Note I didn't add codegen tests b/c watchpoints require a running
process to function and codegen tests don't support this kind of state.

### TODO
- [x] updated probe syntax
- [x] add `asyncwatchpoint` probe alias
- [x] final clang format pass
- [x] documentation
