### PR TITLE
Make resolve_binary_paths include non-executable libs in its result

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -13,8 +13,9 @@
 #include <tuple>
 #include <unistd.h>
 
-#include "utils.h"
+#include "bcc_elf.h"
 #include "bcc_usdt.h"
+#include "utils.h"
 
 namespace {
 
@@ -602,7 +603,8 @@ resolve_binary_path(const std::string &cmd, const char *env_paths, int pid)
       rel_path = path_for_pid_mountns(pid, path);
     else
       rel_path = path;
-    if (access(rel_path.c_str(), X_OK) == 0)
+    if (bcc_elf_is_exe(rel_path.c_str()) ||
+        bcc_elf_is_shared_obj(rel_path.c_str()))
       valid_executable_paths.push_back(rel_path);
   }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -180,6 +180,22 @@ foreach(testprog ${testprogs})
 endforeach()
 add_custom_target(testprogs DEPENDS ${compiled_testprogs})
 
+# Similarly compile all test libs
+file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testlibs/)
+file(GLOB testlibs testlibs/*.c)
+set(compiled_testlibs "")
+foreach(testlib_source ${testlibs})
+  get_filename_component(testlib_name ${testlib_source} NAME_WE)
+  add_library(${testlib_name} SHARED ${testlib_source})
+  set_target_properties(${testlib_name} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testlibs/ COMPILE_FLAGS "-g -O0")
+  # clear the executable bit
+  add_custom_command(TARGET ${testlib_name}
+    POST_BUILD
+    COMMAND chmod -x ${CMAKE_CURRENT_BINARY_DIR}/testlibs/lib${testlib_name}.so)
+  list(APPEND compiled_testlibs ${CMAKE_CURRENT_BINARY_DIR}/testlibs/lib${testlib_name}.so)
+endforeach()
+add_custom_target(testlibs DEPENDS ${compiled_testlibs})
+
 configure_file(runtime-tests.sh runtime-tests.sh COPYONLY)
 configure_file(main.py main.py COPYONLY)
 configure_file(parser.py parser.py COPYONLY)
@@ -204,7 +220,7 @@ endforeach()
 add_custom_target(
   runtime-tests
   COMMAND ./runtime-tests.sh
-  DEPENDS ${compiled_testprogs} ${CMAKE_BINARY_DIR}/src/bpftrace
+  DEPENDS ${compiled_testprogs} ${compiled_testlibs} ${CMAKE_BINARY_DIR}/src/bpftrace
 )
 add_test(NAME runtime_test COMMAND ./runtime-tests.sh)
 

--- a/tests/runtime/uprobe
+++ b/tests/runtime/uprobe
@@ -46,3 +46,13 @@ RUN bpftrace -e 'uprobe:/tmp/bpftrace-unshare-mountns-test/uprobe_test:function1
 EXPECT Attaching 1 probe...
 TIMEOUT 5
 BEFORE ./testprogs/mountns_wrapper uprobe_test
+
+NAME "uprobes - list probes in non-executable library"
+RUN bpftrace -l 'uprobe:./testlibs/libsimple.so:fun'
+EXPECT uprobe:./testlibs/libsimple.so:fun
+TIMEOUT 5
+
+NAME "uprobes - probe function in non-executable library"
+RUN bpftrace -e 'uprobe:./testlibs/libsimple.so:fun {}'
+EXPECT Attaching 1 probe...
+TIMEOUT 5

--- a/tests/testlibs/simple.c
+++ b/tests/testlibs/simple.c
@@ -1,0 +1,3 @@
+__attribute__((__visibility__("default"))) void fun()
+{
+}


### PR DESCRIPTION
Turns out that shared objects do not have to be executable and bcc provides
implementations of elf checks that take that into account. For example on my
Android phone, when running:
```
  bpftrace -e 'uprobe:/system/lib64/libc.so:malloc {}'
```
I get the following error:
```
  stdin:1:1-36: ERROR: uprobe target file '/system/lib64/libc.so' does not exist or is not executable
  uprobe:/system/lib64/libc.so:malloc {}
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

With this change the command runs as expected.