### PR TITLE
Use subprocess.Popen text mode

### DIFF
--- a/tests/utils.py
+++ b/tests/utils.py
@@ -110,6 +110,7 @@ class Utils(object):
                 stderr=subprocess.STDOUT,
                 env=env,
                 preexec_fn=os.setsid,
+                universal_newlines=True,
                 bufsize=1
             )
 
@@ -118,7 +119,7 @@ class Utils(object):
             output = ""
 
             while p.poll() is None:
-                nextline = p.stdout.readline().decode('utf-8', 'ignore')
+                nextline = p.stdout.readline()
                 output += nextline
                 if nextline == "Running...\n":
                     signal.alarm(test.timeout or DEFAULT_TIMEOUT)
@@ -126,7 +127,7 @@ class Utils(object):
                         after = subprocess.Popen(test.after, shell=True, preexec_fn=os.setsid)
                     break
 
-            output += p.communicate()[0].decode('utf-8', 'ignore')
+            output += p.communicate()[0]
 
             signal.alarm(0)
             result = re.search(test.expect, output, re.M)
@@ -136,7 +137,7 @@ class Utils(object):
             # bpftrace process might still be alive
             if p.poll() is None:
                 os.killpg(os.getpgid(p.pid), signal.SIGKILL)
-            output += p.communicate()[0].decode('utf-8', 'ignore')
+            output += p.communicate()[0]
             result = re.search(test.expect, output)
             if not result:
                 print(fail("[  TIMEOUT ] ") + "%s.%s" % (test.suite, test.name))


### PR DESCRIPTION
I was getting these warnings when running runtime tests:
```
/usr/lib/python3.8/subprocess.py:844: RuntimeWarning: line buffering
(buffering=1) isn't supported in binary mode, the default buffer size
will be used
```

I read the python docs, and it seems to imply that bufsize is only
effective if you use text mode. You can turn text mode on with
`universal_newlines` or `text` (`text` is a cosmetic flag and newer than
`universal_newlines`, so less backwards compatible).

It seems we're always decoding to utf8 anyways, so let's just let python
do it for us.