### PR TITLE
USDT NS fixes

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1560,7 +1560,7 @@ void SemanticAnalyser::visit(AttachPoint &ap)
       error("usdt probe must have a target function or wildcard", ap.loc);
 
     if (ap.target != "") {
-      auto paths = resolve_binary_path(ap.target);
+      auto paths = resolve_binary_path(ap.target, bpftrace_.pid_);
       switch (paths.size())
       {
       case 0:

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -201,7 +201,7 @@ void list_probes(const BPFtrace &bpftrace, const std::string &search_input)
     std::string usdt_path = search.substr(search.find(":")+1, search.size());
     usdt_path_list = usdt_path.find(":") == std::string::npos;
     usdt_path = usdt_path.substr(0, usdt_path.find(":"));
-    auto paths = resolve_binary_path(usdt_path);
+    auto paths = resolve_binary_path(usdt_path, bpftrace.pid_);
     switch (paths.size())
     {
     case 0:

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -628,9 +628,20 @@ resolve_binary_path(const std::string &cmd, const char *env_paths, int pid)
 std::string path_for_pid_mountns(int pid, const std::string &path)
 {
   std::ostringstream pid_relative_path;
-  std::string root =
-      (path.length() >= 1 && path.at(0) == '/') ? "/root" : "/root/";
-  pid_relative_path << "/proc/" << pid << root << path;
+  char pid_root[64];
+
+  snprintf(pid_root, sizeof(pid_root), "/proc/%d/root", pid);
+
+  if (path.find(pid_root) != 0)
+  {
+    std::string sep = (path.length() >= 1 && path.at(0) == '/') ? "" : "/";
+    pid_relative_path << pid_root << sep << path;
+  }
+  else
+  {
+    // The path is already relative to the pid's root
+    pid_relative_path << path;
+  }
   return pid_relative_path.str();
 }
 

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -150,3 +150,19 @@ EXPECT tracetest_testprobe_semaphore: 1
 TIMEOUT 5
 BEFORE ./testprogs/usdt_semaphore_test
 REQUIRES ./testprogs/usdt_semaphore_test should_not_skip
+
+NAME "usdt probes - list probes by pid in separate mountns"
+RUN bpftrace -l 'usdt:*' -p $(pidof usdt_test)
+EXPECT usdt:.*/tmp/bpftrace-unshare-mountns-test/usdt_test:tracetest:testprobe
+TIMEOUT 5
+BEFORE ./testprogs/mountns_wrapper usdt_test
+
+# TODO(dalehamel): re-enable this test
+# This test relies on the latest version of bcc (expected to be released as 0.13.0)
+# Once we build against this version with USDT fixes, we should re-enable this test.
+NAME "usdt probes - attach to fully specified probe by pid in separate mountns"
+RUN bpftrace -e 'usdt:/tmp/bpftrace-unshare-mountns-test/usdt_test:tracetest:testprobe { printf("here\n" ); exit(); }' -p $(pidof usdt_test)
+EXPECT here
+TIMEOUT 5
+BEFORE ./testprogs/mountns_wrapper usdt_test
+REQUIRES bash -c "exit 1"


### PR DESCRIPTION
Fixes #1071 (ignore #1084 )

This functionality use to work in bpftrace 0.9.2 with BCC up to 0.11.0, It seems to now be broken. Once bcc 0.13.0 is released and bpftrace uses it, it should work again.

Most of the bugs were introduced in bcc, so the only extra handling needed in bpftrace seems to be to check the mount namespace when resolving binaries, like we already do for uprobes.

This also builds off of #1021
