### PR TITLE
Remove static vanilla builds from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,21 +52,6 @@ matrix:
     - name: "Static+glibc-2.27 Debian-linked LLVM 8 Release"
       env: LLVM_VERSION=8 BASE=bionic-glibc STATIC_LINKING=ON STATIC_LIBC=OFF EMBED_LLVM=OFF EMBED_CLANG=ON EMBED_LIBCLANG_ONLY=ON TYPE=Release RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup
 
-    # This job exists to warm the build cache, it will succeed on timeout so that
-    # it can upload its progress and continue in a subsequent run. It shares a
-    # cache with the Release version of this step, which will still fail on
-    # timeout until the cache is warm. To warm the cache trigger a rebuild 1-3
-    # times, either through the UI or with an empty commit.
-    - name: "Static+glibc-2.27 Vanilla LLVM 8 - LLVM artifact cache build - Release"
-      env: LLVM_VERSION=8 BASE=bionic-glibc STATIC_LINKING=ON STATIC_LIBC=OFF EMBED_LLVM=ON EMBED_CLANG=ON TYPE=Release RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup
-      install:
-        - docker build --build-arg LLVM_VERSION=$LLVM_VERSION -t bpftrace-builder-$BASE-llvm-$LLVM_VERSION -f docker/Dockerfile.$BASE docker/
-      script:
-        - sudo docker run --privileged --rm -it -v ${PWD}:${PWD} -v /sys/kernel/debug:/sys/kernel/debug:rw -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -e STATIC_LINKING=$STATIC_LINKING -e STATIC_LIBC=$STATIC_LIBC -e EMBED_LLVM=$EMBED_LLVM -e EMBED_CLANG=$EMBED_CLANG -e EMBED_LIBCLANG_ONLY=$EMBED_LIBCLANG_ONLY -e LLVM_VERSION=$LLVM_VERSION -e DEPS_ONLY=ON -e CI_TIMEOUT=2400 bpftrace-builder-$BASE-llvm-$LLVM_VERSION ${PWD}/build-$TYPE-$BASE $TYPE -j`getconf _NPROCESSORS_ONLN`
-
-    - name: "Static+glibc-2.27 Vanilla LLVM 8 Release"
-      env: LLVM_VERSION=8 BASE=bionic-glibc STATIC_LINKING=ON STATIC_LIBC=OFF EMBED_LLVM=ON EMBED_CLANG=ON TYPE=Release RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup
-
 install:
   - sudo apt-get install linux-headers-$(uname -r)
   - docker build --build-arg LLVM_VERSION=$LLVM_VERSION -t bpftrace-builder-$BASE-llvm-$LLVM_VERSION -f docker/Dockerfile.$BASE docker/


### PR DESCRIPTION
@danobi I noticed that every pull request is now failing on its first few commits.

This is definitely going to cause a headache if people are wondering why this build is always failing in their PRs. I didn't foresee this, I didn't realize each PR would have its own cache.

Building just libclang is fine and should be cached for future runs, but I think we should just run the full static build on github actions.