### PR TITLE
Consider signed array

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -936,7 +936,7 @@ void SemanticAnalyser::visit(ArrayAccess &arr)
     }
   }
 
-  arr.type = SizedType(type.elem_type, type.pointee_size);
+  arr.type = SizedType(type.elem_type, type.pointee_size, type.is_signed);
 }
 
 void SemanticAnalyser::visit(Binop &binop)

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -261,6 +261,7 @@ static SizedType get_sized_type(CXType clang_type)
         auto sized_type = SizedType(Type::array, size);
         sized_type.pointee_size = type.size;
         sized_type.elem_type = type.type;
+        sized_type.is_signed = type.is_signed;
         return sized_type;
       } else {
         return SizedType(Type::none, 0);


### PR DESCRIPTION
A type of ArrayAccess is unsigned unconditionally. Fix it.

Example:

```c
struct a { int x[3]; };
int f(struct a *a){
  return a->x[0];
}
int main(){
   struct a a = { .x = {-1, -2, -3} };
   f(&a);
   return 0;
}
```

```
% gcc -O0 -fno-omit-frame-pointer a.c
% sudo ./src/bpftrace -e 'struct x { int x[3] } u:./a.out:f { @ = ((struct x*)arg0)->x[0]; }'
Attaching 1 probe...
^C

@: 4294967295 // This value becomes -1 with this patch
```