### PR TITLE
clang_parser: workaround for asm_inline in 5.4+ kernel headers

### DIFF
--- a/resources/clang_workarounds.h
+++ b/resources/clang_workarounds.h
@@ -1,3 +1,6 @@
+#ifndef __CLANG_WORKAROUNDS_H
+#define __CLANG_WORKAROUNDS_H
+
 // linux/types.h is included by default, which will bring
 // in asm_volatile_goto definition if permitted based on
 // compiler setup and kernel configs.
@@ -8,12 +11,19 @@
 // able to parse our headers.
 //
 // From: https://github.com/iovisor/bcc/pull/2133/files
-
-#ifndef __ASM_GOTO_WORKAROUND_H
-#define __ASM_GOTO_WORKAROUND_H
 #include <linux/types.h>
 #ifdef asm_volatile_goto
 #undef asm_volatile_goto
 #define asm_volatile_goto(x...) asm volatile("invalid use of asm_volatile_goto")
 #endif
+
+// In Linux 5.4 asm_inline was introduced, but it's not supported by clang.
+// Redefine it to just asm to enable successful compilation.
+//
+// From: https://github.com/iovisor/bcc/pull/2547
+#ifdef asm_inline
+#undef asm_inline
+#define asm_inline asm
+#endif
+
 #endif

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -487,9 +487,9 @@ bool ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<s
       .Length = stdint_h_len,
     },
     {
-      .Filename = "/bpftrace/include/" ASM_GOTO_WORKAROUND_H,
-      .Contents = asm_goto_workaround_h,
-      .Length = asm_goto_workaround_h_len,
+      .Filename = "/bpftrace/include/" CLANG_WORKAROUNDS_H,
+      .Contents = clang_workarounds_h,
+      .Length = clang_workarounds_h_len,
     },
   };
 

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -449,47 +449,46 @@ bool ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<s
   if (input.size() == 0)
     return true; // We occasionally get crashes in libclang otherwise
 
-  CXUnsavedFile unsaved_files[] =
-  {
+  CXUnsavedFile unsaved_files[] = {
     {
-      .Filename = "definitions.h",
-      .Contents = input.c_str(),
-      .Length = input.size(),
+        .Filename = "definitions.h",
+        .Contents = input.c_str(),
+        .Length = input.size(),
     },
     {
-      .Filename = "/bpftrace/include/__stddef_max_align_t.h",
-      .Contents = __stddef_max_align_t_h,
-      .Length = __stddef_max_align_t_h_len,
+        .Filename = "/bpftrace/include/__stddef_max_align_t.h",
+        .Contents = __stddef_max_align_t_h,
+        .Length = __stddef_max_align_t_h_len,
     },
     {
-      .Filename = "/bpftrace/include/float.h",
-      .Contents = float_h,
-      .Length = float_h_len,
+        .Filename = "/bpftrace/include/float.h",
+        .Contents = float_h,
+        .Length = float_h_len,
     },
     {
-      .Filename = "/bpftrace/include/limits.h",
-      .Contents = limits_h,
-      .Length = limits_h_len,
+        .Filename = "/bpftrace/include/limits.h",
+        .Contents = limits_h,
+        .Length = limits_h_len,
     },
     {
-      .Filename = "/bpftrace/include/stdarg.h",
-      .Contents = stdarg_h,
-      .Length = stdarg_h_len,
+        .Filename = "/bpftrace/include/stdarg.h",
+        .Contents = stdarg_h,
+        .Length = stdarg_h_len,
     },
     {
-      .Filename = "/bpftrace/include/stddef.h",
-      .Contents = stddef_h,
-      .Length = stddef_h_len,
+        .Filename = "/bpftrace/include/stddef.h",
+        .Contents = stddef_h,
+        .Length = stddef_h_len,
     },
     {
-      .Filename = "/bpftrace/include/stdint.h",
-      .Contents = stdint_h,
-      .Length = stdint_h_len,
+        .Filename = "/bpftrace/include/stdint.h",
+        .Contents = stdint_h,
+        .Length = stdint_h_len,
     },
     {
-      .Filename = "/bpftrace/include/" CLANG_WORKAROUNDS_H,
-      .Contents = clang_workarounds_h,
-      .Length = clang_workarounds_h_len,
+        .Filename = "/bpftrace/include/" CLANG_WORKAROUNDS_H,
+        .Contents = clang_workarounds_h,
+        .Length = clang_workarounds_h_len,
     },
   };
 

--- a/src/clang_parser.h
+++ b/src/clang_parser.h
@@ -3,7 +3,7 @@
 #include "bpftrace.h"
 #include <clang-c/Index.h>
 
-#define ASM_GOTO_WORKAROUND_H "asm_goto_workaround.h"
+#define CLANG_WORKAROUNDS_H "clang_workarounds.h"
 
 namespace bpftrace {
 

--- a/src/headers.h
+++ b/src/headers.h
@@ -15,7 +15,7 @@ extern const char stddef_h[];
 extern const unsigned stddef_h_len;
 extern const char stdint_h[];
 extern const unsigned stdint_h_len;
-extern const char asm_goto_workaround_h[];
-extern const unsigned asm_goto_workaround_h_len;
+extern const char clang_workarounds_h[];
+extern const unsigned clang_workarounds_h_len;
 
 } // namespace bpftrace

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -470,7 +470,7 @@ int main(int argc, char *argv[])
       extra_flags = get_kernel_cflags(utsname.machine, ksrc, kobj);
   }
   extra_flags.push_back("-include");
-  extra_flags.push_back(ASM_GOTO_WORKAROUND_H);
+  extra_flags.push_back(CLANG_WORKAROUNDS_H);
 
   for (auto dir : include_dirs)
   {


### PR DESCRIPTION
Upstream kernel introduced `asm_inline` in:
https://github.com/torvalds/linux/commit/eb111869301e15b737315a46c913ae82bd19eb9d

However, clang doesn't support this, so we redefine `asm_inline` to `asm`.
BCC introduced this workaround in:
https://github.com/iovisor/bcc/commit/2d1497cde1cc9835f759a707b42dea83bee378b8

Here is the same workaround for bpftrace.

The following errors occur without this workaround:
```
$ sudo /usr/share/bpftrace/tools/runqlat.bt
/lib/modules/5.4.12-200.fc31.x86_64/source/arch/x86/include/asm/segment.h:266:2: error: expected '(' after 'asm'
/lib/modules/5.4.12-200.fc31.x86_64/source/arch/x86/include/asm/page_64.h:49:2: error: expected '(' after 'asm'
/lib/modules/5.4.12-200.fc31.x86_64/source/arch/x86/include/asm/special_insns.h:205:2: error: expected '(' after 'asm'
```

Thanks to Ivan Babrou for the original workaround in BCC, and to fbs to show me where to apply this workaround in bpftrace.