### PR TITLE
Use a load instruction to access a context field [v2]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,9 +28,9 @@ matrix:
     # String comparisons and args multiple tracepoints tests are the exception
     # - they are just broken in debug builds.
     - name: "Static LLVM 5 Debug"
-      env: LLVM_VERSION=5.0 BASE=alpine TYPE=Debug STATIC_LINKING=ON STATIC_LIBC=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*:codegen.string_equal_comparison:codegen.string_not_equal_comparison:codegen.literal_strncmp:codegen.strncmp:codegen.args_multiple_tracepoints*:codegen.logical_and_or_different_type"
+      env: LLVM_VERSION=5.0 BASE=alpine TYPE=Debug STATIC_LINKING=ON STATIC_LIBC=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*:codegen.string_equal_comparison:codegen.string_not_equal_comparison:codegen.literal_strncmp:codegen.strncmp:codegen.args_multiple_tracepoints*:codegen.logical_and_or_different_type:codegen.builtin_ctx_field"
     - name: "Static LLVM 5 Release"
-      env: LLVM_VERSION=5.0 BASE=alpine TYPE=Release STATIC_LINKING=ON STATIC_LIBC=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*:codegen.args_multiple_tracepoints*:codegen.logical_and_or_different_type"
+      env: LLVM_VERSION=5.0 BASE=alpine TYPE=Release STATIC_LINKING=ON STATIC_LIBC=ON TEST_ARGS="--gtest_filter=codegen.*:-codegen.call_ntop_char4:codegen.call_ntop_char16:codegen.call_printf:codegen.enum_declaration:codegen.macro_definition:codegen.printf_offsets:codegen.struct_*:codegen.args_multiple_tracepoints*:codegen.logical_and_or_different_type:codegen.builtin_ctx_field"
 
     - name: "LLVM 6 Debug"
       env: LLVM_VERSION=6.0 BASE=bionic TYPE=Debug RUN_ALL_TESTS=1 RUNTIME_TEST_DISABLE=builtin.cgroup,probe.kprobe_offset_fail_size

--- a/src/ast/field_analyser.h
+++ b/src/ast/field_analyser.h
@@ -11,7 +11,10 @@ namespace ast {
 class FieldAnalyser : public Visitor {
 public:
   explicit FieldAnalyser(Node *root, BPFtrace &bpftrace)
-    : type_(""), root_(root), bpftrace_(bpftrace)
+      : type_(""),
+        root_(root),
+        bpftrace_(bpftrace),
+        prog_type_(BPF_PROG_TYPE_UNSPEC)
   { }
 
   void visit(Integer &integer) override;
@@ -45,6 +48,7 @@ private:
   std::string    type_;
   Node          *root_;
   BPFtrace      &bpftrace_;
+  bpf_prog_type prog_type_;
 };
 
 } // namespace ast

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -11,9 +11,13 @@
 #if LLVM_VERSION_MAJOR >= 5 && LLVM_VERSION_MAJOR < 7
 #define CREATE_MEMCPY(dst, src, size, algn)                                    \
   CreateMemCpy((dst), (src), (size), (algn))
+#define CREATE_MEMCPY_VOLATILE(dst, src, size, algn)                           \
+  CreateMemCpy((dst), (src), (size), (algn), true)
 #elif LLVM_VERSION_MAJOR >= 7
 #define CREATE_MEMCPY(dst, src, size, algn)                                    \
   CreateMemCpy((dst), (algn), (src), (algn), (size))
+#define CREATE_MEMCPY_VOLATILE(dst, src, size, algn)                           \
+  CreateMemCpy((dst), (algn), (src), (algn), (size), true)
 #else
 #error Unsupported LLVM version
 #endif

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -74,6 +74,21 @@ bpf_prog_type progtype(ProbeType t)
   }
 }
 
+std::string progtypeName(bpf_prog_type t)
+{
+  switch (t)
+  {
+    // clang-format off
+    case BPF_PROG_TYPE_KPROBE:     return "BPF_PROG_TYPE_KPROBE";     break;
+    case BPF_PROG_TYPE_TRACEPOINT: return "BPF_PROG_TYPE_TRACEPOINT"; break;
+    case BPF_PROG_TYPE_PERF_EVENT: return "BPF_PROG_TYPE_PERF_EVENT"; break;
+    // clang-format on
+    default:
+      std::cerr << "invalid program type: " << t << std::endl;
+      abort();
+  }
+}
+
 void check_banned_kretprobes(std::string const& kprobe_name) {
   if (banned_kretprobes.find(kprobe_name) != banned_kretprobes.end()) {
     std::cerr << "error: kretprobe:" << kprobe_name << " can't be used as it might lock up your system." << std::endl;

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -12,6 +12,7 @@ namespace bpftrace {
 
 bpf_probe_attach_type attachtype(ProbeType t);
 bpf_prog_type progtype(ProbeType t);
+std::string progtypeName(bpf_prog_type t);
 
 class AttachedProbe
 {

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -17,6 +17,10 @@ std::ostream &operator<<(std::ostream &os, const SizedType &type)
   {
     os << type.cast_type;
   }
+  else if (type.type == Type::ctx)
+  {
+    os << "(ctx) " << type.cast_type;
+  }
   else if (type.type == Type::integer)
   {
     os << (type.is_signed ? "" : "unsigned ") << "int" << 8*type.size;
@@ -58,9 +62,9 @@ bool SizedType::operator==(const SizedType &t) const
 
 bool SizedType::IsArray() const
 {
-  return type == Type::array || type == Type::string ||
-         type == Type::usym  || type == Type::inet ||
-         (type == Type::cast && !is_pointer);
+  return type == Type::array || type == Type::string || type == Type::usym ||
+         type == Type::inet ||
+         ((type == Type::cast || type == Type::ctx) && !is_pointer);
 }
 
 bool SizedType::IsStack() const
@@ -72,6 +76,7 @@ std::string typestr(Type t)
 {
   switch (t)
   {
+    // clang-format off
     case Type::none:     return "none";     break;
     case Type::integer:  return "integer";  break;
     case Type::hist:     return "hist";     break;
@@ -94,6 +99,8 @@ std::string typestr(Type t)
     case Type::inet:     return "inet";     break;
     case Type::stack_mode:return "stack mode";break;
     case Type::array:    return "array";    break;
+    case Type::ctx:      return "ctx";      break;
+    // clang-format on
     default:
       std::cerr << "call or probe type not found" << std::endl;
       abort();

--- a/src/types.h
+++ b/src/types.h
@@ -16,6 +16,7 @@ const int COMM_SIZE = 16;
 
 enum class Type
 {
+  // clang-format off
   none,
   integer,
   hist,
@@ -38,6 +39,9 @@ enum class Type
   inet,
   stack_mode,
   array,
+  // BPF program context; needing a different access method to satisfy the verifier
+  ctx,
+  // clang-format on
 };
 
 std::ostream &operator<<(std::ostream &os, Type type);

--- a/tests/codegen/args_multiple_tracepoints.cpp
+++ b/tests/codegen/args_multiple_tracepoints.cpp
@@ -30,7 +30,7 @@ entry:
   %1 = ptrtoint i8* %0 to i64
   %2 = add i64 %1, 8
   %3 = inttoptr i64 %2 to i64*
-  %4 = load i64, i64* %3, align 8
+  %4 = load volatile i64, i64* %3, align 8
   %5 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %4, [8 x i8]* %"@_key", align 8
@@ -67,7 +67,7 @@ entry:
   %1 = ptrtoint i8* %0 to i64
   %2 = add i64 %1, 16
   %3 = inttoptr i64 %2 to i64*
-  %4 = load i64, i64* %3, align 8
+  %4 = load volatile i64, i64* %3, align 8
   %5 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %4, [8 x i8]* %"@_key", align 8
@@ -111,7 +111,7 @@ entry:
   %1 = ptrtoint i8* %0 to i64
   %2 = add i64 %1, 8
   %3 = inttoptr i64 %2 to i64*
-  %4 = load i64, i64* %3, align 8
+  %4 = load volatile i64, i64* %3, align 8
   %5 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %4, [8 x i8]* %"@_key", align 8
@@ -148,7 +148,7 @@ entry:
   %1 = ptrtoint i8* %0 to i64
   %2 = add i64 %1, 16
   %3 = inttoptr i64 %2 to i64*
-  %4 = load i64, i64* %3, align 8
+  %4 = load volatile i64, i64* %3, align 8
   %5 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %4, [8 x i8]* %"@_key", align 8

--- a/tests/codegen/args_multiple_tracepoints.cpp
+++ b/tests/codegen/args_multiple_tracepoints.cpp
@@ -27,36 +27,33 @@ define i64 @"tracepoint:sched:sched_one"(i8*) local_unnamed_addr section "s_trac
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
-  %"struct _tracepoint_sched_sched_one.common_field" = alloca i64, align 8
-  %1 = add i8* %0, i64 8
-  %2 = bitcast i64* %"struct _tracepoint_sched_sched_one.common_field" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_one.common_field", i64 8, i8* %1)
-  %3 = load i64, i64* %"struct _tracepoint_sched_sched_one.common_field", align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
-  %4 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  store i64 %3, [8 x i8]* %"@_key", align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %1 = ptrtoint i8* %0 to i64
+  %2 = add i64 %1, 8
+  %3 = inttoptr i64 %2 to i64*
+  %4 = load i64, i64* %3, align 8
+  %5 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  store i64 %4, [8 x i8]* %"@_key", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %5 = load i64, i64* %cast, align 8
-  %phitmp = add i64 %5, 1
+  %6 = load i64, i64* %cast, align 8
+  %phitmp = add i64 %6, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %6 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %7 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
 }
 
@@ -67,36 +64,33 @@ define i64 @"tracepoint:sched:sched_two"(i8*) local_unnamed_addr section "s_trac
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
-  %"struct _tracepoint_sched_sched_two.common_field" = alloca i64, align 8
-  %1 = add i8* %0, i64 16
-  %2 = bitcast i64* %"struct _tracepoint_sched_sched_two.common_field" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_two.common_field", i64 8, i8* %1)
-  %3 = load i64, i64* %"struct _tracepoint_sched_sched_two.common_field", align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
-  %4 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  store i64 %3, [8 x i8]* %"@_key", align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %1 = ptrtoint i8* %0 to i64
+  %2 = add i64 %1, 16
+  %3 = inttoptr i64 %2 to i64*
+  %4 = load i64, i64* %3, align 8
+  %5 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  store i64 %4, [8 x i8]* %"@_key", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %5 = load i64, i64* %cast, align 8
-  %phitmp = add i64 %5, 1
+  %6 = load i64, i64* %cast, align 8
+  %phitmp = add i64 %6, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %6 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %7 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
 }
 
@@ -114,36 +108,33 @@ define i64 @"tracepoint:sched:sched_one"(i8*) local_unnamed_addr section "s_trac
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
-  %"struct _tracepoint_sched_sched_one.common_field" = alloca i64, align 8
-  %1 = add i8* %0, i64 8
-  %2 = bitcast i64* %"struct _tracepoint_sched_sched_one.common_field" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_one.common_field", i64 8, i8* %1)
-  %3 = load i64, i64* %"struct _tracepoint_sched_sched_one.common_field", align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
-  %4 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  store i64 %3, [8 x i8]* %"@_key", align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %1 = ptrtoint i8* %0 to i64
+  %2 = add i64 %1, 8
+  %3 = inttoptr i64 %2 to i64*
+  %4 = load i64, i64* %3, align 8
+  %5 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  store i64 %4, [8 x i8]* %"@_key", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %5 = load i64, i64* %cast, align 8
-  %phitmp = add i64 %5, 1
+  %6 = load i64, i64* %cast, align 8
+  %phitmp = add i64 %6, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %6 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %7 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
 }
 
@@ -154,36 +145,33 @@ define i64 @"tracepoint:sched:sched_two"(i8*) local_unnamed_addr section "s_trac
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
-  %"struct _tracepoint_sched_sched_two.common_field" = alloca i64, align 8
-  %1 = add i8* %0, i64 16
-  %2 = bitcast i64* %"struct _tracepoint_sched_sched_two.common_field" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_two.common_field", i64 8, i8* %1)
-  %3 = load i64, i64* %"struct _tracepoint_sched_sched_two.common_field", align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
-  %4 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  store i64 %3, [8 x i8]* %"@_key", align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %1 = ptrtoint i8* %0 to i64
+  %2 = add i64 %1, 16
+  %3 = inttoptr i64 %2 to i64*
+  %4 = load i64, i64* %3, align 8
+  %5 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  store i64 %4, [8 x i8]* %"@_key", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %5 = load i64, i64* %cast, align 8
-  %phitmp = add i64 %5, 1
+  %6 = load i64, i64* %cast, align 8
+  %phitmp = add i64 %6, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %6 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %7 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
 }
 

--- a/tests/codegen/args_multiple_tracepoints_wild.cpp
+++ b/tests/codegen/args_multiple_tracepoints_wild.cpp
@@ -29,7 +29,7 @@ entry:
   %1 = ptrtoint i8* %0 to i64
   %2 = add i64 %1, 8
   %3 = inttoptr i64 %2 to i64*
-  %4 = load i64, i64* %3, align 8
+  %4 = load volatile i64, i64* %3, align 8
   %5 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %4, [8 x i8]* %"@_key", align 8
@@ -66,7 +66,7 @@ entry:
   %1 = ptrtoint i8* %0 to i64
   %2 = add i64 %1, 16
   %3 = inttoptr i64 %2 to i64*
-  %4 = load i64, i64* %3, align 8
+  %4 = load volatile i64, i64* %3, align 8
   %5 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %4, [8 x i8]* %"@_key", align 8
@@ -110,7 +110,7 @@ entry:
   %1 = ptrtoint i8* %0 to i64
   %2 = add i64 %1, 8
   %3 = inttoptr i64 %2 to i64*
-  %4 = load i64, i64* %3, align 8
+  %4 = load volatile i64, i64* %3, align 8
   %5 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %4, [8 x i8]* %"@_key", align 8
@@ -147,7 +147,7 @@ entry:
   %1 = ptrtoint i8* %0 to i64
   %2 = add i64 %1, 16
   %3 = inttoptr i64 %2 to i64*
-  %4 = load i64, i64* %3, align 8
+  %4 = load volatile i64, i64* %3, align 8
   %5 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 %4, [8 x i8]* %"@_key", align 8

--- a/tests/codegen/args_multiple_tracepoints_wild.cpp
+++ b/tests/codegen/args_multiple_tracepoints_wild.cpp
@@ -26,36 +26,33 @@ define i64 @"tracepoint:sched:sched_one"(i8*) local_unnamed_addr section "s_trac
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
-  %"struct _tracepoint_sched_sched_one.common_field" = alloca i64, align 8
-  %1 = add i8* %0, i64 8
-  %2 = bitcast i64* %"struct _tracepoint_sched_sched_one.common_field" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_one.common_field", i64 8, i8* %1)
-  %3 = load i64, i64* %"struct _tracepoint_sched_sched_one.common_field", align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
-  %4 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  store i64 %3, [8 x i8]* %"@_key", align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %1 = ptrtoint i8* %0 to i64
+  %2 = add i64 %1, 8
+  %3 = inttoptr i64 %2 to i64*
+  %4 = load i64, i64* %3, align 8
+  %5 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  store i64 %4, [8 x i8]* %"@_key", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %5 = load i64, i64* %cast, align 8
-  %phitmp = add i64 %5, 1
+  %6 = load i64, i64* %cast, align 8
+  %phitmp = add i64 %6, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %6 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %7 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
 }
 
@@ -66,36 +63,33 @@ define i64 @"tracepoint:sched:sched_two"(i8*) local_unnamed_addr section "s_trac
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
-  %"struct _tracepoint_sched_sched_two.common_field" = alloca i64, align 8
-  %1 = add i8* %0, i64 16
-  %2 = bitcast i64* %"struct _tracepoint_sched_sched_two.common_field" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_two.common_field", i64 8, i8* %1)
-  %3 = load i64, i64* %"struct _tracepoint_sched_sched_two.common_field", align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
-  %4 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  store i64 %3, [8 x i8]* %"@_key", align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %1 = ptrtoint i8* %0 to i64
+  %2 = add i64 %1, 16
+  %3 = inttoptr i64 %2 to i64*
+  %4 = load i64, i64* %3, align 8
+  %5 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  store i64 %4, [8 x i8]* %"@_key", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %5 = load i64, i64* %cast, align 8
-  %phitmp = add i64 %5, 1
+  %6 = load i64, i64* %cast, align 8
+  %phitmp = add i64 %6, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %6 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %7 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
 }
 
@@ -113,36 +107,33 @@ define i64 @"tracepoint:sched:sched_one"(i8*) local_unnamed_addr section "s_trac
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
-  %"struct _tracepoint_sched_sched_one.common_field" = alloca i64, align 8
-  %1 = add i8* %0, i64 8
-  %2 = bitcast i64* %"struct _tracepoint_sched_sched_one.common_field" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_one.common_field", i64 8, i8* %1)
-  %3 = load i64, i64* %"struct _tracepoint_sched_sched_one.common_field", align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
-  %4 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  store i64 %3, [8 x i8]* %"@_key", align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %1 = ptrtoint i8* %0 to i64
+  %2 = add i64 %1, 8
+  %3 = inttoptr i64 %2 to i64*
+  %4 = load i64, i64* %3, align 8
+  %5 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  store i64 %4, [8 x i8]* %"@_key", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %5 = load i64, i64* %cast, align 8
-  %phitmp = add i64 %5, 1
+  %6 = load i64, i64* %cast, align 8
+  %phitmp = add i64 %6, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %6 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %7 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
 }
 
@@ -153,36 +144,33 @@ define i64 @"tracepoint:sched:sched_two"(i8*) local_unnamed_addr section "s_trac
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca [8 x i8], align 8
-  %"struct _tracepoint_sched_sched_two.common_field" = alloca i64, align 8
-  %1 = add i8* %0, i64 16
-  %2 = bitcast i64* %"struct _tracepoint_sched_sched_two.common_field" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_sched_sched_two.common_field", i64 8, i8* %1)
-  %3 = load i64, i64* %"struct _tracepoint_sched_sched_two.common_field", align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
-  %4 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  store i64 %3, [8 x i8]* %"@_key", align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %1 = ptrtoint i8* %0 to i64
+  %2 = add i64 %1, 16
+  %3 = inttoptr i64 %2 to i64*
+  %4 = load i64, i64* %3, align 8
+  %5 = getelementptr inbounds [8 x i8], [8 x i8]* %"@_key", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  store i64 %4, [8 x i8]* %"@_key", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* nonnull %"@_key")
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %5 = load i64, i64* %cast, align 8
-  %phitmp = add i64 %5, 1
+  %6 = load i64, i64* %cast, align 8
+  %phitmp = add i64 %6, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %6 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %7 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
 }
 

--- a/tests/codegen/builtin_arg.cpp
+++ b/tests/codegen/builtin_arg.cpp
@@ -14,14 +14,14 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:f_1" {
+define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@y_val" = alloca i64, align 8
   %"@y_key" = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %1 = getelementptr i8, i8* %0, i64 112
-  %arg0 = load i64, i8* %1, align 8
+  %arg0 = load volatile i64, i8* %1, align 8
   %2 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
@@ -33,7 +33,7 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %4 = getelementptr i8, i8* %0, i64 96
-  %arg2 = load i64, i8* %4, align 8
+  %arg2 = load volatile i64, i8* %4, align 8
   %5 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@y_key", align 8

--- a/tests/codegen/builtin_ctx.cpp
+++ b/tests/codegen/builtin_ctx.cpp
@@ -6,7 +6,7 @@ namespace codegen {
 
 TEST(codegen, builtin_ctx)
 {
-  test("kprobe:f { @x = ctx }",
+  test("kprobe:f { @x = (uint64)ctx; }",
 
        R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
@@ -18,17 +18,17 @@ define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  %cast = zext i8* %0 to i64
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 0, i64* %"@x_key", align 8
-  %2 = zext i8* %0 to i64
-  %3 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  store i64 %2, i64* %"@x_val", align 8
+  %2 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  store i64 %cast, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   ret i64 0
 }
 

--- a/tests/codegen/builtin_ctx.cpp
+++ b/tests/codegen/builtin_ctx.cpp
@@ -18,17 +18,17 @@ define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %cast = zext i8* %0 to i64
-  %1 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 0, i64* %"@x_key", align 8
-  %2 = bitcast i64* %"@x_val" to i8*
+  %1 = ptrtoint i8* %0 to i64
+  %2 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  store i64 %cast, i64* %"@x_val", align 8
+  store i64 0, i64* %"@x_key", align 8
+  %3 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 %1, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0
 }
 

--- a/tests/codegen/builtin_ctx_field.cpp
+++ b/tests/codegen/builtin_ctx_field.cpp
@@ -1,0 +1,118 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, builtin_ctx_field)
+{
+  std::string structs = "struct c {char c} struct x { long a; short b[4]; "
+                        "struct c c; struct c *d; char e[4]}";
+  test(structs + "kprobe:f { $x = (struct x*)ctx; @a = $x->a; @b = $x->b[0]; "
+                 "@c = $x->c.c; @d = $x->d->c; @e = $x->e;}",
+       R"EXPECTED(; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
+entry:
+  %"@e_key" = alloca i64, align 8
+  %"struct x.e" = alloca i32, align 4
+  %tmpcast = bitcast i32* %"struct x.e" to [4 x i8]*
+  %"@d_val" = alloca i64, align 8
+  %"@d_key" = alloca i64, align 8
+  %"struct c.c" = alloca i8, align 1
+  %"@c_val" = alloca i64, align 8
+  %"@c_key" = alloca i64, align 8
+  %"@b_val" = alloca i64, align 8
+  %"@b_key" = alloca i64, align 8
+  %"@a_val" = alloca i64, align 8
+  %"@a_key" = alloca i64, align 8
+  %1 = ptrtoint i8* %0 to i64
+  %2 = bitcast i8* %0 to i64*
+  %3 = load i64, i64* %2, align 8
+  %4 = bitcast i64* %"@a_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 0, i64* %"@a_key", align 8
+  %5 = bitcast i64* %"@a_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  store i64 %3, i64* %"@a_val", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@a_key", i64* nonnull %"@a_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  %6 = add i64 %1, 8
+  %7 = inttoptr i64 %6 to i16*
+  %8 = load i16, i16* %7, align 2
+  %9 = bitcast i64* %"@b_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
+  store i64 0, i64* %"@b_key", align 8
+  %10 = sext i16 %8 to i64
+  %11 = bitcast i64* %"@b_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %11)
+  store i64 %10, i64* %"@b_val", align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@b_key", i64* nonnull %"@b_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %11)
+  %12 = add i64 %1, 16
+  %13 = inttoptr i64 %12 to i8*
+  %14 = load i8, i8* %13, align 1
+  %15 = bitcast i64* %"@c_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %15)
+  store i64 0, i64* %"@c_key", align 8
+  %16 = sext i8 %14 to i64
+  %17 = bitcast i64* %"@c_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %17)
+  store i64 %16, i64* %"@c_val", align 8
+  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo3, i64* nonnull %"@c_key", i64* nonnull %"@c_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %15)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %17)
+  %18 = add i64 %1, 24
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load i64, i64* %19, align 8
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %"struct c.c")
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %"struct c.c", i64 1, i64 %20)
+  %21 = load i8, i8* %"struct c.c", align 1
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %"struct c.c")
+  %22 = bitcast i64* %"@d_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %22)
+  store i64 0, i64* %"@d_key", align 8
+  %23 = sext i8 %21 to i64
+  %24 = bitcast i64* %"@d_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %24)
+  store i64 %23, i64* %"@d_val", align 8
+  %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 4)
+  %update_elem6 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo5, i64* nonnull %"@d_key", i64* nonnull %"@d_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %22)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %24)
+  %25 = add i64 %1, 32
+  %26 = bitcast i32* %"struct x.e" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %26)
+  %27 = inttoptr i64 %25 to i32*
+  %28 = load i32, i32* %27, align 1
+  store i32 %28, i32* %"struct x.e", align 4
+  %29 = bitcast i64* %"@e_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %29)
+  store i64 0, i64* %"@e_key", align 8
+  %pseudo7 = call i64 @llvm.bpf.pseudo(i64 1, i64 5)
+  %update_elem8 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [4 x i8]*, i64)*)(i64 %pseudo7, i64* nonnull %"@e_key", [4 x i8]* nonnull %tmpcast, i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %29)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %26)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/builtin_ctx_field.cpp
+++ b/tests/codegen/builtin_ctx_field.cpp
@@ -10,6 +10,8 @@ TEST(codegen, builtin_ctx_field)
                         "struct c c; struct c *d; char e[4]}";
   test(structs + "kprobe:f { $x = (struct x*)ctx; @a = $x->a; @b = $x->b[0]; "
                  "@c = $x->c.c; @d = $x->d->c; @e = $x->e;}",
+
+#if LLVM_VERSION_MAJOR > 6
        R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
@@ -19,8 +21,7 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@e_key" = alloca i64, align 8
-  %"struct x.e" = alloca i32, align 4
-  %tmpcast = bitcast i32* %"struct x.e" to [4 x i8]*
+  %"struct x.e" = alloca [4 x i8], align 1
   %"@d_val" = alloca i64, align 8
   %"@d_key" = alloca i64, align 8
   %"struct c.c" = alloca i8, align 1
@@ -32,7 +33,7 @@ entry:
   %"@a_key" = alloca i64, align 8
   %1 = ptrtoint i8* %0 to i64
   %2 = bitcast i8* %0 to i64*
-  %3 = load i64, i64* %2, align 8
+  %3 = load volatile i64, i64* %2, align 8
   %4 = bitcast i64* %"@a_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@a_key", align 8
@@ -45,7 +46,7 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   %6 = add i64 %1, 8
   %7 = inttoptr i64 %6 to i16*
-  %8 = load i16, i16* %7, align 2
+  %8 = load volatile i16, i16* %7, align 2
   %9 = bitcast i64* %"@b_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 0, i64* %"@b_key", align 8
@@ -59,7 +60,7 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %11)
   %12 = add i64 %1, 16
   %13 = inttoptr i64 %12 to i8*
-  %14 = load i8, i8* %13, align 1
+  %14 = load volatile i8, i8* %13, align 1
   %15 = bitcast i64* %"@c_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %15)
   store i64 0, i64* %"@c_key", align 8
@@ -73,7 +74,7 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %17)
   %18 = add i64 %1, 24
   %19 = inttoptr i64 %18 to i64*
-  %20 = load i64, i64* %19, align 8
+  %20 = load volatile i64, i64* %19, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %"struct c.c")
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %"struct c.c", i64 1, i64 %20)
   %21 = load i8, i8* %"struct c.c", align 1
@@ -90,16 +91,16 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %22)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %24)
   %25 = add i64 %1, 32
-  %26 = bitcast i32* %"struct x.e" to i8*
+  %26 = getelementptr inbounds [4 x i8], [4 x i8]* %"struct x.e", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %26)
-  %27 = inttoptr i64 %25 to i32*
-  %28 = load i32, i32* %27, align 1
-  store i32 %28, i32* %"struct x.e", align 4
+  %27 = inttoptr i64 %25 to [4 x i8]*
+  %28 = getelementptr inbounds [4 x i8], [4 x i8]* %27, i64 0, i64 0
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %26, i8* align 1 %28, i64 4, i1 true)
   %29 = bitcast i64* %"@e_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %29)
   store i64 0, i64* %"@e_key", align 8
   %pseudo7 = call i64 @llvm.bpf.pseudo(i64 1, i64 5)
-  %update_elem8 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [4 x i8]*, i64)*)(i64 %pseudo7, i64* nonnull %"@e_key", [4 x i8]* nonnull %tmpcast, i64 0)
+  %update_elem8 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [4 x i8]*, i64)*)(i64 %pseudo7, i64* nonnull %"@e_key", [4 x i8]* nonnull %"struct x.e", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %29)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %26)
   ret i64 0
@@ -108,9 +109,117 @@ entry:
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #1
+
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }
 )EXPECTED");
+#else
+       R"EXPECTED(; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
+entry:
+  %"@e_key" = alloca i64, align 8
+  %"struct x.e" = alloca [4 x i8], align 1
+  %"@d_val" = alloca i64, align 8
+  %"@d_key" = alloca i64, align 8
+  %"struct c.c" = alloca i8, align 1
+  %"@c_val" = alloca i64, align 8
+  %"@c_key" = alloca i64, align 8
+  %"@b_val" = alloca i64, align 8
+  %"@b_key" = alloca i64, align 8
+  %"@a_val" = alloca i64, align 8
+  %"@a_key" = alloca i64, align 8
+  %1 = ptrtoint i8* %0 to i64
+  %2 = bitcast i8* %0 to i64*
+  %3 = load volatile i64, i64* %2, align 8
+  %4 = bitcast i64* %"@a_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 0, i64* %"@a_key", align 8
+  %5 = bitcast i64* %"@a_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  store i64 %3, i64* %"@a_val", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@a_key", i64* nonnull %"@a_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  %6 = add i64 %1, 8
+  %7 = inttoptr i64 %6 to i16*
+  %8 = load volatile i16, i16* %7, align 2
+  %9 = bitcast i64* %"@b_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
+  store i64 0, i64* %"@b_key", align 8
+  %10 = sext i16 %8 to i64
+  %11 = bitcast i64* %"@b_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %11)
+  store i64 %10, i64* %"@b_val", align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@b_key", i64* nonnull %"@b_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %11)
+  %12 = add i64 %1, 16
+  %13 = inttoptr i64 %12 to i8*
+  %14 = load volatile i8, i8* %13, align 1
+  %15 = bitcast i64* %"@c_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %15)
+  store i64 0, i64* %"@c_key", align 8
+  %16 = sext i8 %14 to i64
+  %17 = bitcast i64* %"@c_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %17)
+  store i64 %16, i64* %"@c_val", align 8
+  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo3, i64* nonnull %"@c_key", i64* nonnull %"@c_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %15)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %17)
+  %18 = add i64 %1, 24
+  %19 = inttoptr i64 %18 to i64*
+  %20 = load volatile i64, i64* %19, align 8
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %"struct c.c")
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %"struct c.c", i64 1, i64 %20)
+  %21 = load i8, i8* %"struct c.c", align 1
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %"struct c.c")
+  %22 = bitcast i64* %"@d_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %22)
+  store i64 0, i64* %"@d_key", align 8
+  %23 = sext i8 %21 to i64
+  %24 = bitcast i64* %"@d_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %24)
+  store i64 %23, i64* %"@d_val", align 8
+  %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 4)
+  %update_elem6 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo5, i64* nonnull %"@d_key", i64* nonnull %"@d_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %22)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %24)
+  %25 = add i64 %1, 32
+  %26 = getelementptr inbounds [4 x i8], [4 x i8]* %"struct x.e", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %26)
+  %27 = inttoptr i64 %25 to [4 x i8]*
+  %28 = getelementptr inbounds [4 x i8], [4 x i8]* %27, i64 0, i64 0
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %26, i8* %28, i64 4, i32 1, i1 true)
+  %29 = bitcast i64* %"@e_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %29)
+  store i64 0, i64* %"@e_key", align 8
+  %pseudo7 = call i64 @llvm.bpf.pseudo(i64 1, i64 5)
+  %update_elem8 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [4 x i8]*, i64)*)(i64 %pseudo7, i64* nonnull %"@e_key", [4 x i8]* nonnull %"struct x.e", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %29)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %26)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i32, i1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }
+)EXPECTED");
+#endif
 }
 
 } // namespace codegen

--- a/tests/codegen/builtin_func.cpp
+++ b/tests/codegen/builtin_func.cpp
@@ -14,12 +14,12 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:f_1" {
+define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %1 = getelementptr i8, i8* %0, i64 128
-  %func = load i64, i8* %1, align 8
+  %func = load volatile i64, i8* %1, align 8
   %2 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8
@@ -54,13 +54,13 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"uprobe:/bin/sh:f"(i8* nocapture readonly) local_unnamed_addr section "s_uprobe:/bin/sh:f_1" {
+define i64 @"uprobe:/bin/sh:f"(i8*) local_unnamed_addr section "s_uprobe:/bin/sh:f_1" {
 entry:
   %"@x_val" = alloca [16 x i8], align 8
   %"@x_key" = alloca i64, align 8
   %func1 = alloca [16 x i8], align 8
   %1 = getelementptr i8, i8* %0, i64 128
-  %func = load i64, i8* %1, align 8
+  %func = load volatile i64, i8* %1, align 8
   %2 = getelementptr inbounds [16 x i8], [16 x i8]* %func1, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   %get_pid_tgid = tail call i64 inttoptr (i64 14 to i64 ()*)()

--- a/tests/codegen/builtin_func_wild.cpp
+++ b/tests/codegen/builtin_func_wild.cpp
@@ -20,12 +20,12 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kprobe:do_execve*"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:do_execve*_1" {
+define i64 @"kprobe:do_execve*"(i8*) local_unnamed_addr section "s_kprobe:do_execve*_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %1 = getelementptr i8, i8* %0, i64 128
-  %func = load i64, i8* %1, align 8
+  %func = load volatile i64, i8* %1, align 8
   %2 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/builtin_retval.cpp
+++ b/tests/codegen/builtin_retval.cpp
@@ -14,12 +14,12 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kretprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kretprobe:f_1" {
+define i64 @"kretprobe:f"(i8*) local_unnamed_addr section "s_kretprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %1 = getelementptr i8, i8* %0, i64 80
-  %retval = load i64, i8* %1, align 8
+  %retval = load volatile i64, i8* %1, align 8
   %2 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/builtin_sarg.cpp
+++ b/tests/codegen/builtin_sarg.cpp
@@ -14,7 +14,7 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:f_1" {
+define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@y_val" = alloca i64, align 8
   %"@y_key" = alloca i64, align 8
@@ -23,7 +23,7 @@ entry:
   %"@x_key" = alloca i64, align 8
   %sarg0 = alloca i64, align 8
   %1 = getelementptr i8, i8* %0, i64 152
-  %reg_sp = load i64, i8* %1, align 8
+  %reg_sp = load volatile i64, i8* %1, align 8
   %2 = bitcast i64* %sarg0 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   %3 = add i64 %reg_sp, 8
@@ -40,7 +40,7 @@ entry:
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
-  %reg_sp1 = load i64, i8* %1, align 8
+  %reg_sp1 = load volatile i64, i8* %1, align 8
   %7 = bitcast i64* %sarg2 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   %8 = add i64 %reg_sp1, 24

--- a/tests/codegen/call_override_return.cpp
+++ b/tests/codegen/call_override_return.cpp
@@ -12,7 +12,7 @@ TEST(codegen, call_override)
       R"EXPECTED(define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %1 = getelementptr i8, i8* %0, i64 112
-  %arg0 = load i64, i8* %1, align 8
+  %arg0 = load volatile i64, i8* %1, align 8
   %override = tail call i64 inttoptr (i64 58 to i64 (i8*, i64)*)(i8* %0, i64 %arg0)
   ret i64 0
 }

--- a/tests/codegen/call_reg.cpp
+++ b/tests/codegen/call_reg.cpp
@@ -14,12 +14,12 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:f_1" {
+define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %1 = getelementptr i8, i8* %0, i64 128
-  %reg_ip = load i64, i8* %1, align 8
+  %reg_ip = load volatile i64, i8* %1, align 8
   %2 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/call_signal.cpp
+++ b/tests/codegen/call_signal.cpp
@@ -6,16 +6,18 @@ namespace codegen {
 
 TEST(codegen, call_signal)
 {
-  test("k:f { signal(arg0); }",
-R"EXPECTED(define i64 @"kprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:f_1" {
+  test(
+      "k:f { signal(arg0); }",
+      R"EXPECTED(define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %1 = getelementptr i8, i8* %0, i64 112
-  %arg0 = load i64, i8* %1, align 8
+  %arg0 = load volatile i64, i8* %1, align 8
   %2 = trunc i64 %arg0 to i32
   %signal = tail call i64 inttoptr (i64 109 to i64 (i32)*)(i32 %2)
   ret i64 0
 }
-)EXPECTED", false);
+)EXPECTED",
+      false);
 }
 
 } // namespace codegen

--- a/tests/codegen/call_str.cpp
+++ b/tests/codegen/call_str.cpp
@@ -15,7 +15,7 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:f_1" {
+define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
@@ -23,7 +23,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 64, i32 1, i1 false)
   %2 = getelementptr i8, i8* %0, i64 112
-  %arg0 = load i64, i8* %2, align 8
+  %arg0 = load volatile i64, i8* %2, align 8
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %arg0)
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
@@ -51,7 +51,7 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:f_1" {
+define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
@@ -59,7 +59,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i8 0, i64 64, i1 false)
   %2 = getelementptr i8, i8* %0, i64 112
-  %arg0 = load i64, i8* %2, align 8
+  %arg0 = load volatile i64, i8* %2, align 8
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %arg0)
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)

--- a/tests/codegen/call_str_2_expr.cpp
+++ b/tests/codegen/call_str_2_expr.cpp
@@ -15,12 +15,12 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:f_1" {
+define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %1 = getelementptr i8, i8* %0, i64 104
-  %arg1 = load i64, i8* %1, align 8
+  %arg1 = load volatile i64, i8* %1, align 8
   %2 = add i64 %arg1, 1
   %3 = icmp ult i64 %2, 64
   %str.min.select = select i1 %3, i64 %2, i64 64
@@ -28,7 +28,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.memset.p0i8.i64(i8* nonnull %4, i8 0, i64 64, i32 1, i1 false)
   %5 = getelementptr i8, i8* %0, i64 112
-  %arg0 = load i64, i8* %5, align 8
+  %arg0 = load volatile i64, i8* %5, align 8
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 %str.min.select, i64 %arg0)
   %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
@@ -56,12 +56,12 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:f_1" {
+define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %1 = getelementptr i8, i8* %0, i64 104
-  %arg1 = load i64, i8* %1, align 8
+  %arg1 = load volatile i64, i8* %1, align 8
   %2 = add i64 %arg1, 1
   %3 = icmp ult i64 %2, 64
   %str.min.select = select i1 %3, i64 %2, i64 64
@@ -69,7 +69,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %4, i8 0, i64 64, i1 false)
   %5 = getelementptr i8, i8* %0, i64 112
-  %arg0 = load i64, i8* %5, align 8
+  %arg0 = load volatile i64, i8* %5, align 8
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 %str.min.select, i64 %arg0)
   %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)

--- a/tests/codegen/call_str_2_lit.cpp
+++ b/tests/codegen/call_str_2_lit.cpp
@@ -15,7 +15,7 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:f_1" {
+define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
@@ -23,7 +23,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 64, i32 1, i1 false)
   %2 = getelementptr i8, i8* %0, i64 112
-  %arg0 = load i64, i8* %2, align 8
+  %arg0 = load volatile i64, i8* %2, align 8
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 7, i64 %arg0)
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
@@ -51,7 +51,7 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:f_1" {
+define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
@@ -59,7 +59,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i8 0, i64 64, i1 false)
   %2 = getelementptr i8, i8* %0, i64 112
-  %arg0 = load i64, i8* %2, align 8
+  %arg0 = load volatile i64, i8* %2, align 8
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 7, i64 %arg0)
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)

--- a/tests/codegen/comparison_extend.cpp
+++ b/tests/codegen/comparison_extend.cpp
@@ -15,12 +15,12 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kprobe:f_1" {
+define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
   %1 = getelementptr i8, i8* %0, i64 112
-  %arg0 = load i64, i8* %1, align 8
+  %arg0 = load volatile i64, i8* %1, align 8
   %2 = icmp ugt i64 %arg0, 1
   %3 = zext i1 %2 to i64
   %4 = bitcast i64* %"@_key" to i8*

--- a/tests/codegen/intcast_assign_var.cpp
+++ b/tests/codegen/intcast_assign_var.cpp
@@ -14,12 +14,12 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kretprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kretprobe:f_1" {
+define i64 @"kretprobe:f"(i8*) local_unnamed_addr section "s_kretprobe:f_1" {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
   %1 = getelementptr i8, i8* %0, i64 80
-  %retval = load i64, i8* %1, align 8
+  %retval = load volatile i64, i8* %1, align 8
   %2 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@_key", align 8

--- a/tests/codegen/intcast_retval.cpp
+++ b/tests/codegen/intcast_retval.cpp
@@ -14,7 +14,7 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kretprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kretprobe:f_1" {
+define i64 @"kretprobe:f"(i8*) local_unnamed_addr section "s_kretprobe:f_1" {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
@@ -36,7 +36,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   %3 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   %4 = getelementptr i8, i8* %0, i64 80
-  %retval = load i64, i8* %4, align 8
+  %retval = load volatile i64, i8* %4, align 8
   %sext = shl i64 %retval, 32
   %5 = ashr exact i64 %sext, 32
   %6 = add i64 %5, %lookup_elem_val.0

--- a/tests/codegen/intptrcast_assign_var.cpp
+++ b/tests/codegen/intptrcast_assign_var.cpp
@@ -13,13 +13,13 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kretprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kretprobe:f_1" {
+define i64 @"kretprobe:f"(i8*) local_unnamed_addr section "s_kretprobe:f_1" {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
   %deref = alloca i8, align 1
   %1 = getelementptr i8, i8* %0, i64 32
-  %reg_bp = load i64, i8* %1, align 8
+  %reg_bp = load volatile i64, i8* %1, align 8
   %2 = add i64 %reg_bp, -1
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %deref)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %deref, i64 1, i64 %2)

--- a/tests/codegen/intptrcast_call.cpp
+++ b/tests/codegen/intptrcast_call.cpp
@@ -14,7 +14,7 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
-define i64 @"kretprobe:f"(i8* nocapture readonly) local_unnamed_addr section "s_kretprobe:f_1" {
+define i64 @"kretprobe:f"(i8*) local_unnamed_addr section "s_kretprobe:f_1" {
 entry:
   %deref = alloca i8, align 1
   %"@_val" = alloca i64, align 8
@@ -37,7 +37,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   %3 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   %4 = getelementptr i8, i8* %0, i64 32
-  %reg_bp = load i64, i8* %4, align 8
+  %reg_bp = load volatile i64, i8* %4, align 8
   %5 = add i64 %reg_bp, -1
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %deref)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %deref, i64 1, i64 %5)

--- a/tests/codegen/strncmp.cpp
+++ b/tests/codegen/strncmp.cpp
@@ -26,7 +26,6 @@ entry:
   %"@_key" = alloca i64, align 8
   %strcmp.char_r = alloca i8, align 1
   %strcmp.char_l = alloca i8, align 1
-  %"struct _tracepoint_file_filename.filename" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %comm = alloca [16 x i8], align 1
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
@@ -36,20 +35,18 @@ entry:
   %2 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %2, i8 0, i64 64, i1 false)
-  %3 = add i8* %0, i64 8
-  %4 = bitcast i64* %"struct _tracepoint_file_filename.filename" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_file_filename.filename", i64 8, i8* %3)
-  %5 = load i64, i64* %"struct _tracepoint_file_filename.filename", align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %5)
+  %3 = ptrtoint i8* %0 to i64
+  %4 = add i64 %3, 8
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5, align 8
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %6)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char_l)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char_r)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* nonnull %str)
-  %6 = load i8, i8* %strcmp.char_l, align 1
-  %probe_read2 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* nonnull %comm)
-  %7 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp = icmp eq i8 %6, %7
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* nonnull %str)
+  %7 = load i8, i8* %strcmp.char_l, align 1
+  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* nonnull %comm)
+  %8 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp = icmp eq i8 %7, %8
   br i1 %strcmp.cmp, label %strcmp.loop_null_cmp, label %pred_false.critedge
 
 pred_false.critedge:                              ; preds = %entry
@@ -60,249 +57,249 @@ pred_false.critedge:                              ; preds = %entry
 pred_false:                                       ; preds = %strcmp.false, %pred_false.critedge
   ret i64 0
 
-pred_true.critedge:                               ; preds = %strcmp.loop87, %strcmp.loop_null_cmp, %strcmp.loop_null_cmp4, %strcmp.loop_null_cmp10, %strcmp.loop_null_cmp16, %strcmp.loop_null_cmp22, %strcmp.loop_null_cmp28, %strcmp.loop_null_cmp34, %strcmp.loop_null_cmp40, %strcmp.loop_null_cmp46, %strcmp.loop_null_cmp52, %strcmp.loop_null_cmp58, %strcmp.loop_null_cmp64, %strcmp.loop_null_cmp70, %strcmp.loop_null_cmp76, %strcmp.loop_null_cmp82, %strcmp.loop_null_cmp88
+pred_true.critedge:                               ; preds = %strcmp.loop86, %strcmp.loop_null_cmp, %strcmp.loop_null_cmp3, %strcmp.loop_null_cmp9, %strcmp.loop_null_cmp15, %strcmp.loop_null_cmp21, %strcmp.loop_null_cmp27, %strcmp.loop_null_cmp33, %strcmp.loop_null_cmp39, %strcmp.loop_null_cmp45, %strcmp.loop_null_cmp51, %strcmp.loop_null_cmp57, %strcmp.loop_null_cmp63, %strcmp.loop_null_cmp69, %strcmp.loop_null_cmp75, %strcmp.loop_null_cmp81, %strcmp.loop_null_cmp87
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %strcmp.char_l)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %strcmp.char_r)
-  %8 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
-  store i64 0, i64* %"@_key", align 8
-  %9 = bitcast i64* %"@_val" to i8*
+  %9 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
+  store i64 0, i64* %"@_key", align 8
+  %10 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
   store i64 1, i64* %"@_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
   ret i64 0
 
-strcmp.false:                                     ; preds = %strcmp.loop87, %strcmp.loop81, %strcmp.loop75, %strcmp.loop69, %strcmp.loop63, %strcmp.loop57, %strcmp.loop51, %strcmp.loop45, %strcmp.loop39, %strcmp.loop33, %strcmp.loop27, %strcmp.loop21, %strcmp.loop15, %strcmp.loop9, %strcmp.loop3, %strcmp.loop
+strcmp.false:                                     ; preds = %strcmp.loop86, %strcmp.loop80, %strcmp.loop74, %strcmp.loop68, %strcmp.loop62, %strcmp.loop56, %strcmp.loop50, %strcmp.loop44, %strcmp.loop38, %strcmp.loop32, %strcmp.loop26, %strcmp.loop20, %strcmp.loop14, %strcmp.loop8, %strcmp.loop2, %strcmp.loop
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %strcmp.char_l)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %strcmp.char_r)
   br label %pred_false
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
-  %10 = add [64 x i8]* %str, i64 1
-  %probe_read5 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %10)
-  %11 = load i8, i8* %strcmp.char_l, align 1
-  %12 = add [16 x i8]* %comm, i64 1
-  %probe_read6 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %12)
-  %13 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp7 = icmp eq i8 %11, %13
-  br i1 %strcmp.cmp7, label %strcmp.loop_null_cmp4, label %strcmp.false
+  %11 = add [64 x i8]* %str, i64 1
+  %probe_read4 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %11)
+  %12 = load i8, i8* %strcmp.char_l, align 1
+  %13 = add [16 x i8]* %comm, i64 1
+  %probe_read5 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %13)
+  %14 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp6 = icmp eq i8 %12, %14
+  br i1 %strcmp.cmp6, label %strcmp.loop_null_cmp3, label %strcmp.false
 
 strcmp.loop_null_cmp:                             ; preds = %entry
-  %strcmp.cmp_null = icmp eq i8 %6, 0
+  %strcmp.cmp_null = icmp eq i8 %7, 0
   br i1 %strcmp.cmp_null, label %pred_true.critedge, label %strcmp.loop
 
-strcmp.loop3:                                     ; preds = %strcmp.loop_null_cmp4
-  %14 = add [64 x i8]* %str, i64 2
-  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %14)
-  %15 = load i8, i8* %strcmp.char_l, align 1
-  %16 = add [16 x i8]* %comm, i64 2
-  %probe_read12 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %16)
-  %17 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp13 = icmp eq i8 %15, %17
-  br i1 %strcmp.cmp13, label %strcmp.loop_null_cmp10, label %strcmp.false
+strcmp.loop2:                                     ; preds = %strcmp.loop_null_cmp3
+  %15 = add [64 x i8]* %str, i64 2
+  %probe_read10 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %15)
+  %16 = load i8, i8* %strcmp.char_l, align 1
+  %17 = add [16 x i8]* %comm, i64 2
+  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %17)
+  %18 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp12 = icmp eq i8 %16, %18
+  br i1 %strcmp.cmp12, label %strcmp.loop_null_cmp9, label %strcmp.false
 
-strcmp.loop_null_cmp4:                            ; preds = %strcmp.loop
-  %strcmp.cmp_null8 = icmp eq i8 %11, 0
-  br i1 %strcmp.cmp_null8, label %pred_true.critedge, label %strcmp.loop3
+strcmp.loop_null_cmp3:                            ; preds = %strcmp.loop
+  %strcmp.cmp_null7 = icmp eq i8 %12, 0
+  br i1 %strcmp.cmp_null7, label %pred_true.critedge, label %strcmp.loop2
 
-strcmp.loop9:                                     ; preds = %strcmp.loop_null_cmp10
-  %18 = add [64 x i8]* %str, i64 3
-  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %18)
-  %19 = load i8, i8* %strcmp.char_l, align 1
-  %20 = add [16 x i8]* %comm, i64 3
-  %probe_read18 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %20)
-  %21 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp19 = icmp eq i8 %19, %21
-  br i1 %strcmp.cmp19, label %strcmp.loop_null_cmp16, label %strcmp.false
+strcmp.loop8:                                     ; preds = %strcmp.loop_null_cmp9
+  %19 = add [64 x i8]* %str, i64 3
+  %probe_read16 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %19)
+  %20 = load i8, i8* %strcmp.char_l, align 1
+  %21 = add [16 x i8]* %comm, i64 3
+  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %21)
+  %22 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp18 = icmp eq i8 %20, %22
+  br i1 %strcmp.cmp18, label %strcmp.loop_null_cmp15, label %strcmp.false
 
-strcmp.loop_null_cmp10:                           ; preds = %strcmp.loop3
-  %strcmp.cmp_null14 = icmp eq i8 %15, 0
-  br i1 %strcmp.cmp_null14, label %pred_true.critedge, label %strcmp.loop9
+strcmp.loop_null_cmp9:                            ; preds = %strcmp.loop2
+  %strcmp.cmp_null13 = icmp eq i8 %16, 0
+  br i1 %strcmp.cmp_null13, label %pred_true.critedge, label %strcmp.loop8
 
-strcmp.loop15:                                    ; preds = %strcmp.loop_null_cmp16
-  %22 = add [64 x i8]* %str, i64 4
-  %probe_read23 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %22)
-  %23 = load i8, i8* %strcmp.char_l, align 1
-  %24 = add [16 x i8]* %comm, i64 4
-  %probe_read24 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %24)
-  %25 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp25 = icmp eq i8 %23, %25
-  br i1 %strcmp.cmp25, label %strcmp.loop_null_cmp22, label %strcmp.false
+strcmp.loop14:                                    ; preds = %strcmp.loop_null_cmp15
+  %23 = add [64 x i8]* %str, i64 4
+  %probe_read22 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %23)
+  %24 = load i8, i8* %strcmp.char_l, align 1
+  %25 = add [16 x i8]* %comm, i64 4
+  %probe_read23 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %25)
+  %26 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp24 = icmp eq i8 %24, %26
+  br i1 %strcmp.cmp24, label %strcmp.loop_null_cmp21, label %strcmp.false
 
-strcmp.loop_null_cmp16:                           ; preds = %strcmp.loop9
-  %strcmp.cmp_null20 = icmp eq i8 %19, 0
-  br i1 %strcmp.cmp_null20, label %pred_true.critedge, label %strcmp.loop15
+strcmp.loop_null_cmp15:                           ; preds = %strcmp.loop8
+  %strcmp.cmp_null19 = icmp eq i8 %20, 0
+  br i1 %strcmp.cmp_null19, label %pred_true.critedge, label %strcmp.loop14
 
-strcmp.loop21:                                    ; preds = %strcmp.loop_null_cmp22
-  %26 = add [64 x i8]* %str, i64 5
-  %probe_read29 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %26)
-  %27 = load i8, i8* %strcmp.char_l, align 1
-  %28 = add [16 x i8]* %comm, i64 5
-  %probe_read30 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %28)
-  %29 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp31 = icmp eq i8 %27, %29
-  br i1 %strcmp.cmp31, label %strcmp.loop_null_cmp28, label %strcmp.false
+strcmp.loop20:                                    ; preds = %strcmp.loop_null_cmp21
+  %27 = add [64 x i8]* %str, i64 5
+  %probe_read28 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %27)
+  %28 = load i8, i8* %strcmp.char_l, align 1
+  %29 = add [16 x i8]* %comm, i64 5
+  %probe_read29 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %29)
+  %30 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp30 = icmp eq i8 %28, %30
+  br i1 %strcmp.cmp30, label %strcmp.loop_null_cmp27, label %strcmp.false
 
-strcmp.loop_null_cmp22:                           ; preds = %strcmp.loop15
-  %strcmp.cmp_null26 = icmp eq i8 %23, 0
-  br i1 %strcmp.cmp_null26, label %pred_true.critedge, label %strcmp.loop21
+strcmp.loop_null_cmp21:                           ; preds = %strcmp.loop14
+  %strcmp.cmp_null25 = icmp eq i8 %24, 0
+  br i1 %strcmp.cmp_null25, label %pred_true.critedge, label %strcmp.loop20
 
-strcmp.loop27:                                    ; preds = %strcmp.loop_null_cmp28
-  %30 = add [64 x i8]* %str, i64 6
-  %probe_read35 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %30)
-  %31 = load i8, i8* %strcmp.char_l, align 1
-  %32 = add [16 x i8]* %comm, i64 6
-  %probe_read36 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %32)
-  %33 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp37 = icmp eq i8 %31, %33
-  br i1 %strcmp.cmp37, label %strcmp.loop_null_cmp34, label %strcmp.false
+strcmp.loop26:                                    ; preds = %strcmp.loop_null_cmp27
+  %31 = add [64 x i8]* %str, i64 6
+  %probe_read34 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %31)
+  %32 = load i8, i8* %strcmp.char_l, align 1
+  %33 = add [16 x i8]* %comm, i64 6
+  %probe_read35 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %33)
+  %34 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp36 = icmp eq i8 %32, %34
+  br i1 %strcmp.cmp36, label %strcmp.loop_null_cmp33, label %strcmp.false
 
-strcmp.loop_null_cmp28:                           ; preds = %strcmp.loop21
-  %strcmp.cmp_null32 = icmp eq i8 %27, 0
-  br i1 %strcmp.cmp_null32, label %pred_true.critedge, label %strcmp.loop27
+strcmp.loop_null_cmp27:                           ; preds = %strcmp.loop20
+  %strcmp.cmp_null31 = icmp eq i8 %28, 0
+  br i1 %strcmp.cmp_null31, label %pred_true.critedge, label %strcmp.loop26
 
-strcmp.loop33:                                    ; preds = %strcmp.loop_null_cmp34
-  %34 = add [64 x i8]* %str, i64 7
-  %probe_read41 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %34)
-  %35 = load i8, i8* %strcmp.char_l, align 1
-  %36 = add [16 x i8]* %comm, i64 7
-  %probe_read42 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %36)
-  %37 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp43 = icmp eq i8 %35, %37
-  br i1 %strcmp.cmp43, label %strcmp.loop_null_cmp40, label %strcmp.false
+strcmp.loop32:                                    ; preds = %strcmp.loop_null_cmp33
+  %35 = add [64 x i8]* %str, i64 7
+  %probe_read40 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %35)
+  %36 = load i8, i8* %strcmp.char_l, align 1
+  %37 = add [16 x i8]* %comm, i64 7
+  %probe_read41 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %37)
+  %38 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp42 = icmp eq i8 %36, %38
+  br i1 %strcmp.cmp42, label %strcmp.loop_null_cmp39, label %strcmp.false
 
-strcmp.loop_null_cmp34:                           ; preds = %strcmp.loop27
-  %strcmp.cmp_null38 = icmp eq i8 %31, 0
-  br i1 %strcmp.cmp_null38, label %pred_true.critedge, label %strcmp.loop33
+strcmp.loop_null_cmp33:                           ; preds = %strcmp.loop26
+  %strcmp.cmp_null37 = icmp eq i8 %32, 0
+  br i1 %strcmp.cmp_null37, label %pred_true.critedge, label %strcmp.loop32
 
-strcmp.loop39:                                    ; preds = %strcmp.loop_null_cmp40
-  %38 = add [64 x i8]* %str, i64 8
-  %probe_read47 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %38)
-  %39 = load i8, i8* %strcmp.char_l, align 1
-  %40 = add [16 x i8]* %comm, i64 8
-  %probe_read48 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %40)
-  %41 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp49 = icmp eq i8 %39, %41
-  br i1 %strcmp.cmp49, label %strcmp.loop_null_cmp46, label %strcmp.false
+strcmp.loop38:                                    ; preds = %strcmp.loop_null_cmp39
+  %39 = add [64 x i8]* %str, i64 8
+  %probe_read46 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %39)
+  %40 = load i8, i8* %strcmp.char_l, align 1
+  %41 = add [16 x i8]* %comm, i64 8
+  %probe_read47 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %41)
+  %42 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp48 = icmp eq i8 %40, %42
+  br i1 %strcmp.cmp48, label %strcmp.loop_null_cmp45, label %strcmp.false
 
-strcmp.loop_null_cmp40:                           ; preds = %strcmp.loop33
-  %strcmp.cmp_null44 = icmp eq i8 %35, 0
-  br i1 %strcmp.cmp_null44, label %pred_true.critedge, label %strcmp.loop39
+strcmp.loop_null_cmp39:                           ; preds = %strcmp.loop32
+  %strcmp.cmp_null43 = icmp eq i8 %36, 0
+  br i1 %strcmp.cmp_null43, label %pred_true.critedge, label %strcmp.loop38
 
-strcmp.loop45:                                    ; preds = %strcmp.loop_null_cmp46
-  %42 = add [64 x i8]* %str, i64 9
-  %probe_read53 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %42)
-  %43 = load i8, i8* %strcmp.char_l, align 1
-  %44 = add [16 x i8]* %comm, i64 9
-  %probe_read54 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %44)
-  %45 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp55 = icmp eq i8 %43, %45
-  br i1 %strcmp.cmp55, label %strcmp.loop_null_cmp52, label %strcmp.false
+strcmp.loop44:                                    ; preds = %strcmp.loop_null_cmp45
+  %43 = add [64 x i8]* %str, i64 9
+  %probe_read52 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %43)
+  %44 = load i8, i8* %strcmp.char_l, align 1
+  %45 = add [16 x i8]* %comm, i64 9
+  %probe_read53 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %45)
+  %46 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp54 = icmp eq i8 %44, %46
+  br i1 %strcmp.cmp54, label %strcmp.loop_null_cmp51, label %strcmp.false
 
-strcmp.loop_null_cmp46:                           ; preds = %strcmp.loop39
-  %strcmp.cmp_null50 = icmp eq i8 %39, 0
-  br i1 %strcmp.cmp_null50, label %pred_true.critedge, label %strcmp.loop45
+strcmp.loop_null_cmp45:                           ; preds = %strcmp.loop38
+  %strcmp.cmp_null49 = icmp eq i8 %40, 0
+  br i1 %strcmp.cmp_null49, label %pred_true.critedge, label %strcmp.loop44
 
-strcmp.loop51:                                    ; preds = %strcmp.loop_null_cmp52
-  %46 = add [64 x i8]* %str, i64 10
-  %probe_read59 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %46)
-  %47 = load i8, i8* %strcmp.char_l, align 1
-  %48 = add [16 x i8]* %comm, i64 10
-  %probe_read60 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %48)
-  %49 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp61 = icmp eq i8 %47, %49
-  br i1 %strcmp.cmp61, label %strcmp.loop_null_cmp58, label %strcmp.false
+strcmp.loop50:                                    ; preds = %strcmp.loop_null_cmp51
+  %47 = add [64 x i8]* %str, i64 10
+  %probe_read58 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %47)
+  %48 = load i8, i8* %strcmp.char_l, align 1
+  %49 = add [16 x i8]* %comm, i64 10
+  %probe_read59 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %49)
+  %50 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp60 = icmp eq i8 %48, %50
+  br i1 %strcmp.cmp60, label %strcmp.loop_null_cmp57, label %strcmp.false
 
-strcmp.loop_null_cmp52:                           ; preds = %strcmp.loop45
-  %strcmp.cmp_null56 = icmp eq i8 %43, 0
-  br i1 %strcmp.cmp_null56, label %pred_true.critedge, label %strcmp.loop51
+strcmp.loop_null_cmp51:                           ; preds = %strcmp.loop44
+  %strcmp.cmp_null55 = icmp eq i8 %44, 0
+  br i1 %strcmp.cmp_null55, label %pred_true.critedge, label %strcmp.loop50
 
-strcmp.loop57:                                    ; preds = %strcmp.loop_null_cmp58
-  %50 = add [64 x i8]* %str, i64 11
-  %probe_read65 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %50)
-  %51 = load i8, i8* %strcmp.char_l, align 1
-  %52 = add [16 x i8]* %comm, i64 11
-  %probe_read66 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %52)
-  %53 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp67 = icmp eq i8 %51, %53
-  br i1 %strcmp.cmp67, label %strcmp.loop_null_cmp64, label %strcmp.false
+strcmp.loop56:                                    ; preds = %strcmp.loop_null_cmp57
+  %51 = add [64 x i8]* %str, i64 11
+  %probe_read64 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %51)
+  %52 = load i8, i8* %strcmp.char_l, align 1
+  %53 = add [16 x i8]* %comm, i64 11
+  %probe_read65 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %53)
+  %54 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp66 = icmp eq i8 %52, %54
+  br i1 %strcmp.cmp66, label %strcmp.loop_null_cmp63, label %strcmp.false
 
-strcmp.loop_null_cmp58:                           ; preds = %strcmp.loop51
-  %strcmp.cmp_null62 = icmp eq i8 %47, 0
-  br i1 %strcmp.cmp_null62, label %pred_true.critedge, label %strcmp.loop57
+strcmp.loop_null_cmp57:                           ; preds = %strcmp.loop50
+  %strcmp.cmp_null61 = icmp eq i8 %48, 0
+  br i1 %strcmp.cmp_null61, label %pred_true.critedge, label %strcmp.loop56
 
-strcmp.loop63:                                    ; preds = %strcmp.loop_null_cmp64
-  %54 = add [64 x i8]* %str, i64 12
-  %probe_read71 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %54)
-  %55 = load i8, i8* %strcmp.char_l, align 1
-  %56 = add [16 x i8]* %comm, i64 12
-  %probe_read72 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %56)
-  %57 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp73 = icmp eq i8 %55, %57
-  br i1 %strcmp.cmp73, label %strcmp.loop_null_cmp70, label %strcmp.false
+strcmp.loop62:                                    ; preds = %strcmp.loop_null_cmp63
+  %55 = add [64 x i8]* %str, i64 12
+  %probe_read70 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %55)
+  %56 = load i8, i8* %strcmp.char_l, align 1
+  %57 = add [16 x i8]* %comm, i64 12
+  %probe_read71 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %57)
+  %58 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp72 = icmp eq i8 %56, %58
+  br i1 %strcmp.cmp72, label %strcmp.loop_null_cmp69, label %strcmp.false
 
-strcmp.loop_null_cmp64:                           ; preds = %strcmp.loop57
-  %strcmp.cmp_null68 = icmp eq i8 %51, 0
-  br i1 %strcmp.cmp_null68, label %pred_true.critedge, label %strcmp.loop63
+strcmp.loop_null_cmp63:                           ; preds = %strcmp.loop56
+  %strcmp.cmp_null67 = icmp eq i8 %52, 0
+  br i1 %strcmp.cmp_null67, label %pred_true.critedge, label %strcmp.loop62
 
-strcmp.loop69:                                    ; preds = %strcmp.loop_null_cmp70
-  %58 = add [64 x i8]* %str, i64 13
-  %probe_read77 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %58)
-  %59 = load i8, i8* %strcmp.char_l, align 1
-  %60 = add [16 x i8]* %comm, i64 13
-  %probe_read78 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %60)
-  %61 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp79 = icmp eq i8 %59, %61
-  br i1 %strcmp.cmp79, label %strcmp.loop_null_cmp76, label %strcmp.false
+strcmp.loop68:                                    ; preds = %strcmp.loop_null_cmp69
+  %59 = add [64 x i8]* %str, i64 13
+  %probe_read76 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %59)
+  %60 = load i8, i8* %strcmp.char_l, align 1
+  %61 = add [16 x i8]* %comm, i64 13
+  %probe_read77 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %61)
+  %62 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp78 = icmp eq i8 %60, %62
+  br i1 %strcmp.cmp78, label %strcmp.loop_null_cmp75, label %strcmp.false
 
-strcmp.loop_null_cmp70:                           ; preds = %strcmp.loop63
-  %strcmp.cmp_null74 = icmp eq i8 %55, 0
-  br i1 %strcmp.cmp_null74, label %pred_true.critedge, label %strcmp.loop69
+strcmp.loop_null_cmp69:                           ; preds = %strcmp.loop62
+  %strcmp.cmp_null73 = icmp eq i8 %56, 0
+  br i1 %strcmp.cmp_null73, label %pred_true.critedge, label %strcmp.loop68
 
-strcmp.loop75:                                    ; preds = %strcmp.loop_null_cmp76
-  %62 = add [64 x i8]* %str, i64 14
-  %probe_read83 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %62)
-  %63 = load i8, i8* %strcmp.char_l, align 1
-  %64 = add [16 x i8]* %comm, i64 14
-  %probe_read84 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %64)
-  %65 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp85 = icmp eq i8 %63, %65
-  br i1 %strcmp.cmp85, label %strcmp.loop_null_cmp82, label %strcmp.false
+strcmp.loop74:                                    ; preds = %strcmp.loop_null_cmp75
+  %63 = add [64 x i8]* %str, i64 14
+  %probe_read82 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %63)
+  %64 = load i8, i8* %strcmp.char_l, align 1
+  %65 = add [16 x i8]* %comm, i64 14
+  %probe_read83 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %65)
+  %66 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp84 = icmp eq i8 %64, %66
+  br i1 %strcmp.cmp84, label %strcmp.loop_null_cmp81, label %strcmp.false
 
-strcmp.loop_null_cmp76:                           ; preds = %strcmp.loop69
-  %strcmp.cmp_null80 = icmp eq i8 %59, 0
-  br i1 %strcmp.cmp_null80, label %pred_true.critedge, label %strcmp.loop75
+strcmp.loop_null_cmp75:                           ; preds = %strcmp.loop68
+  %strcmp.cmp_null79 = icmp eq i8 %60, 0
+  br i1 %strcmp.cmp_null79, label %pred_true.critedge, label %strcmp.loop74
 
-strcmp.loop81:                                    ; preds = %strcmp.loop_null_cmp82
-  %66 = add [64 x i8]* %str, i64 15
-  %probe_read89 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %66)
-  %67 = load i8, i8* %strcmp.char_l, align 1
-  %68 = add [16 x i8]* %comm, i64 15
-  %probe_read90 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %68)
-  %69 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp91 = icmp eq i8 %67, %69
-  br i1 %strcmp.cmp91, label %strcmp.loop_null_cmp88, label %strcmp.false
+strcmp.loop80:                                    ; preds = %strcmp.loop_null_cmp81
+  %67 = add [64 x i8]* %str, i64 15
+  %probe_read88 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %67)
+  %68 = load i8, i8* %strcmp.char_l, align 1
+  %69 = add [16 x i8]* %comm, i64 15
+  %probe_read89 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %69)
+  %70 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp90 = icmp eq i8 %68, %70
+  br i1 %strcmp.cmp90, label %strcmp.loop_null_cmp87, label %strcmp.false
 
-strcmp.loop_null_cmp82:                           ; preds = %strcmp.loop75
-  %strcmp.cmp_null86 = icmp eq i8 %63, 0
-  br i1 %strcmp.cmp_null86, label %pred_true.critedge, label %strcmp.loop81
+strcmp.loop_null_cmp81:                           ; preds = %strcmp.loop74
+  %strcmp.cmp_null85 = icmp eq i8 %64, 0
+  br i1 %strcmp.cmp_null85, label %pred_true.critedge, label %strcmp.loop80
 
-strcmp.loop87:                                    ; preds = %strcmp.loop_null_cmp88
-  %70 = add [64 x i8]* %str, i64 16
-  %probe_read95 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %70)
-  %71 = load i8, i8* %strcmp.char_l, align 1
-  %72 = add [16 x i8]* %comm, i64 16
-  %probe_read96 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %72)
-  %73 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp97 = icmp eq i8 %71, %73
-  br i1 %strcmp.cmp97, label %pred_true.critedge, label %strcmp.false
+strcmp.loop86:                                    ; preds = %strcmp.loop_null_cmp87
+  %71 = add [64 x i8]* %str, i64 16
+  %probe_read94 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %71)
+  %72 = load i8, i8* %strcmp.char_l, align 1
+  %73 = add [16 x i8]* %comm, i64 16
+  %probe_read95 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %73)
+  %74 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp96 = icmp eq i8 %72, %74
+  br i1 %strcmp.cmp96, label %pred_true.critedge, label %strcmp.false
 
-strcmp.loop_null_cmp88:                           ; preds = %strcmp.loop81
-  %strcmp.cmp_null92 = icmp eq i8 %67, 0
-  br i1 %strcmp.cmp_null92, label %pred_true.critedge, label %strcmp.loop87
+strcmp.loop_null_cmp87:                           ; preds = %strcmp.loop80
+  %strcmp.cmp_null91 = icmp eq i8 %68, 0
+  br i1 %strcmp.cmp_null91, label %pred_true.critedge, label %strcmp.loop86
 }
 
 ; Function Attrs: argmemonly nounwind
@@ -327,7 +324,6 @@ entry:
   %"@_key" = alloca i64, align 8
   %strcmp.char_r = alloca i8, align 1
   %strcmp.char_l = alloca i8, align 1
-  %"struct _tracepoint_file_filename.filename" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %comm = alloca [16 x i8], align 1
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
@@ -337,20 +333,18 @@ entry:
   %2 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.memset.p0i8.i64(i8* nonnull %2, i8 0, i64 64, i32 1, i1 false)
-  %3 = add i8* %0, i64 8
-  %4 = bitcast i64* %"struct _tracepoint_file_filename.filename" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct _tracepoint_file_filename.filename", i64 8, i8* %3)
-  %5 = load i64, i64* %"struct _tracepoint_file_filename.filename", align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %5)
+  %3 = ptrtoint i8* %0 to i64
+  %4 = add i64 %3, 8
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load i64, i64* %5, align 8
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %6)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char_l)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char_r)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* nonnull %str)
-  %6 = load i8, i8* %strcmp.char_l, align 1
-  %probe_read2 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* nonnull %comm)
-  %7 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp = icmp eq i8 %6, %7
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* nonnull %str)
+  %7 = load i8, i8* %strcmp.char_l, align 1
+  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* nonnull %comm)
+  %8 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp = icmp eq i8 %7, %8
   br i1 %strcmp.cmp, label %strcmp.loop_null_cmp, label %pred_false.critedge
 
 pred_false.critedge:                              ; preds = %entry
@@ -361,249 +355,249 @@ pred_false.critedge:                              ; preds = %entry
 pred_false:                                       ; preds = %strcmp.false, %pred_false.critedge
   ret i64 0
 
-pred_true.critedge:                               ; preds = %strcmp.loop87, %strcmp.loop_null_cmp, %strcmp.loop_null_cmp4, %strcmp.loop_null_cmp10, %strcmp.loop_null_cmp16, %strcmp.loop_null_cmp22, %strcmp.loop_null_cmp28, %strcmp.loop_null_cmp34, %strcmp.loop_null_cmp40, %strcmp.loop_null_cmp46, %strcmp.loop_null_cmp52, %strcmp.loop_null_cmp58, %strcmp.loop_null_cmp64, %strcmp.loop_null_cmp70, %strcmp.loop_null_cmp76, %strcmp.loop_null_cmp82, %strcmp.loop_null_cmp88
+pred_true.critedge:                               ; preds = %strcmp.loop86, %strcmp.loop_null_cmp, %strcmp.loop_null_cmp3, %strcmp.loop_null_cmp9, %strcmp.loop_null_cmp15, %strcmp.loop_null_cmp21, %strcmp.loop_null_cmp27, %strcmp.loop_null_cmp33, %strcmp.loop_null_cmp39, %strcmp.loop_null_cmp45, %strcmp.loop_null_cmp51, %strcmp.loop_null_cmp57, %strcmp.loop_null_cmp63, %strcmp.loop_null_cmp69, %strcmp.loop_null_cmp75, %strcmp.loop_null_cmp81, %strcmp.loop_null_cmp87
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %strcmp.char_l)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %strcmp.char_r)
-  %8 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
-  store i64 0, i64* %"@_key", align 8
-  %9 = bitcast i64* %"@_val" to i8*
+  %9 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
+  store i64 0, i64* %"@_key", align 8
+  %10 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
   store i64 1, i64* %"@_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
   ret i64 0
 
-strcmp.false:                                     ; preds = %strcmp.loop87, %strcmp.loop81, %strcmp.loop75, %strcmp.loop69, %strcmp.loop63, %strcmp.loop57, %strcmp.loop51, %strcmp.loop45, %strcmp.loop39, %strcmp.loop33, %strcmp.loop27, %strcmp.loop21, %strcmp.loop15, %strcmp.loop9, %strcmp.loop3, %strcmp.loop
+strcmp.false:                                     ; preds = %strcmp.loop86, %strcmp.loop80, %strcmp.loop74, %strcmp.loop68, %strcmp.loop62, %strcmp.loop56, %strcmp.loop50, %strcmp.loop44, %strcmp.loop38, %strcmp.loop32, %strcmp.loop26, %strcmp.loop20, %strcmp.loop14, %strcmp.loop8, %strcmp.loop2, %strcmp.loop
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %strcmp.char_l)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %strcmp.char_r)
   br label %pred_false
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
-  %10 = add [64 x i8]* %str, i64 1
-  %probe_read5 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %10)
-  %11 = load i8, i8* %strcmp.char_l, align 1
-  %12 = add [16 x i8]* %comm, i64 1
-  %probe_read6 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %12)
-  %13 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp7 = icmp eq i8 %11, %13
-  br i1 %strcmp.cmp7, label %strcmp.loop_null_cmp4, label %strcmp.false
+  %11 = add [64 x i8]* %str, i64 1
+  %probe_read4 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %11)
+  %12 = load i8, i8* %strcmp.char_l, align 1
+  %13 = add [16 x i8]* %comm, i64 1
+  %probe_read5 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %13)
+  %14 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp6 = icmp eq i8 %12, %14
+  br i1 %strcmp.cmp6, label %strcmp.loop_null_cmp3, label %strcmp.false
 
 strcmp.loop_null_cmp:                             ; preds = %entry
-  %strcmp.cmp_null = icmp eq i8 %6, 0
+  %strcmp.cmp_null = icmp eq i8 %7, 0
   br i1 %strcmp.cmp_null, label %pred_true.critedge, label %strcmp.loop
 
-strcmp.loop3:                                     ; preds = %strcmp.loop_null_cmp4
-  %14 = add [64 x i8]* %str, i64 2
-  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %14)
-  %15 = load i8, i8* %strcmp.char_l, align 1
-  %16 = add [16 x i8]* %comm, i64 2
-  %probe_read12 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %16)
-  %17 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp13 = icmp eq i8 %15, %17
-  br i1 %strcmp.cmp13, label %strcmp.loop_null_cmp10, label %strcmp.false
+strcmp.loop2:                                     ; preds = %strcmp.loop_null_cmp3
+  %15 = add [64 x i8]* %str, i64 2
+  %probe_read10 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %15)
+  %16 = load i8, i8* %strcmp.char_l, align 1
+  %17 = add [16 x i8]* %comm, i64 2
+  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %17)
+  %18 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp12 = icmp eq i8 %16, %18
+  br i1 %strcmp.cmp12, label %strcmp.loop_null_cmp9, label %strcmp.false
 
-strcmp.loop_null_cmp4:                            ; preds = %strcmp.loop
-  %strcmp.cmp_null8 = icmp eq i8 %11, 0
-  br i1 %strcmp.cmp_null8, label %pred_true.critedge, label %strcmp.loop3
+strcmp.loop_null_cmp3:                            ; preds = %strcmp.loop
+  %strcmp.cmp_null7 = icmp eq i8 %12, 0
+  br i1 %strcmp.cmp_null7, label %pred_true.critedge, label %strcmp.loop2
 
-strcmp.loop9:                                     ; preds = %strcmp.loop_null_cmp10
-  %18 = add [64 x i8]* %str, i64 3
-  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %18)
-  %19 = load i8, i8* %strcmp.char_l, align 1
-  %20 = add [16 x i8]* %comm, i64 3
-  %probe_read18 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %20)
-  %21 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp19 = icmp eq i8 %19, %21
-  br i1 %strcmp.cmp19, label %strcmp.loop_null_cmp16, label %strcmp.false
+strcmp.loop8:                                     ; preds = %strcmp.loop_null_cmp9
+  %19 = add [64 x i8]* %str, i64 3
+  %probe_read16 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %19)
+  %20 = load i8, i8* %strcmp.char_l, align 1
+  %21 = add [16 x i8]* %comm, i64 3
+  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %21)
+  %22 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp18 = icmp eq i8 %20, %22
+  br i1 %strcmp.cmp18, label %strcmp.loop_null_cmp15, label %strcmp.false
 
-strcmp.loop_null_cmp10:                           ; preds = %strcmp.loop3
-  %strcmp.cmp_null14 = icmp eq i8 %15, 0
-  br i1 %strcmp.cmp_null14, label %pred_true.critedge, label %strcmp.loop9
+strcmp.loop_null_cmp9:                            ; preds = %strcmp.loop2
+  %strcmp.cmp_null13 = icmp eq i8 %16, 0
+  br i1 %strcmp.cmp_null13, label %pred_true.critedge, label %strcmp.loop8
 
-strcmp.loop15:                                    ; preds = %strcmp.loop_null_cmp16
-  %22 = add [64 x i8]* %str, i64 4
-  %probe_read23 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %22)
-  %23 = load i8, i8* %strcmp.char_l, align 1
-  %24 = add [16 x i8]* %comm, i64 4
-  %probe_read24 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %24)
-  %25 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp25 = icmp eq i8 %23, %25
-  br i1 %strcmp.cmp25, label %strcmp.loop_null_cmp22, label %strcmp.false
+strcmp.loop14:                                    ; preds = %strcmp.loop_null_cmp15
+  %23 = add [64 x i8]* %str, i64 4
+  %probe_read22 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %23)
+  %24 = load i8, i8* %strcmp.char_l, align 1
+  %25 = add [16 x i8]* %comm, i64 4
+  %probe_read23 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %25)
+  %26 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp24 = icmp eq i8 %24, %26
+  br i1 %strcmp.cmp24, label %strcmp.loop_null_cmp21, label %strcmp.false
 
-strcmp.loop_null_cmp16:                           ; preds = %strcmp.loop9
-  %strcmp.cmp_null20 = icmp eq i8 %19, 0
-  br i1 %strcmp.cmp_null20, label %pred_true.critedge, label %strcmp.loop15
+strcmp.loop_null_cmp15:                           ; preds = %strcmp.loop8
+  %strcmp.cmp_null19 = icmp eq i8 %20, 0
+  br i1 %strcmp.cmp_null19, label %pred_true.critedge, label %strcmp.loop14
 
-strcmp.loop21:                                    ; preds = %strcmp.loop_null_cmp22
-  %26 = add [64 x i8]* %str, i64 5
-  %probe_read29 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %26)
-  %27 = load i8, i8* %strcmp.char_l, align 1
-  %28 = add [16 x i8]* %comm, i64 5
-  %probe_read30 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %28)
-  %29 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp31 = icmp eq i8 %27, %29
-  br i1 %strcmp.cmp31, label %strcmp.loop_null_cmp28, label %strcmp.false
+strcmp.loop20:                                    ; preds = %strcmp.loop_null_cmp21
+  %27 = add [64 x i8]* %str, i64 5
+  %probe_read28 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %27)
+  %28 = load i8, i8* %strcmp.char_l, align 1
+  %29 = add [16 x i8]* %comm, i64 5
+  %probe_read29 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %29)
+  %30 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp30 = icmp eq i8 %28, %30
+  br i1 %strcmp.cmp30, label %strcmp.loop_null_cmp27, label %strcmp.false
 
-strcmp.loop_null_cmp22:                           ; preds = %strcmp.loop15
-  %strcmp.cmp_null26 = icmp eq i8 %23, 0
-  br i1 %strcmp.cmp_null26, label %pred_true.critedge, label %strcmp.loop21
+strcmp.loop_null_cmp21:                           ; preds = %strcmp.loop14
+  %strcmp.cmp_null25 = icmp eq i8 %24, 0
+  br i1 %strcmp.cmp_null25, label %pred_true.critedge, label %strcmp.loop20
 
-strcmp.loop27:                                    ; preds = %strcmp.loop_null_cmp28
-  %30 = add [64 x i8]* %str, i64 6
-  %probe_read35 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %30)
-  %31 = load i8, i8* %strcmp.char_l, align 1
-  %32 = add [16 x i8]* %comm, i64 6
-  %probe_read36 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %32)
-  %33 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp37 = icmp eq i8 %31, %33
-  br i1 %strcmp.cmp37, label %strcmp.loop_null_cmp34, label %strcmp.false
+strcmp.loop26:                                    ; preds = %strcmp.loop_null_cmp27
+  %31 = add [64 x i8]* %str, i64 6
+  %probe_read34 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %31)
+  %32 = load i8, i8* %strcmp.char_l, align 1
+  %33 = add [16 x i8]* %comm, i64 6
+  %probe_read35 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %33)
+  %34 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp36 = icmp eq i8 %32, %34
+  br i1 %strcmp.cmp36, label %strcmp.loop_null_cmp33, label %strcmp.false
 
-strcmp.loop_null_cmp28:                           ; preds = %strcmp.loop21
-  %strcmp.cmp_null32 = icmp eq i8 %27, 0
-  br i1 %strcmp.cmp_null32, label %pred_true.critedge, label %strcmp.loop27
+strcmp.loop_null_cmp27:                           ; preds = %strcmp.loop20
+  %strcmp.cmp_null31 = icmp eq i8 %28, 0
+  br i1 %strcmp.cmp_null31, label %pred_true.critedge, label %strcmp.loop26
 
-strcmp.loop33:                                    ; preds = %strcmp.loop_null_cmp34
-  %34 = add [64 x i8]* %str, i64 7
-  %probe_read41 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %34)
-  %35 = load i8, i8* %strcmp.char_l, align 1
-  %36 = add [16 x i8]* %comm, i64 7
-  %probe_read42 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %36)
-  %37 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp43 = icmp eq i8 %35, %37
-  br i1 %strcmp.cmp43, label %strcmp.loop_null_cmp40, label %strcmp.false
+strcmp.loop32:                                    ; preds = %strcmp.loop_null_cmp33
+  %35 = add [64 x i8]* %str, i64 7
+  %probe_read40 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %35)
+  %36 = load i8, i8* %strcmp.char_l, align 1
+  %37 = add [16 x i8]* %comm, i64 7
+  %probe_read41 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %37)
+  %38 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp42 = icmp eq i8 %36, %38
+  br i1 %strcmp.cmp42, label %strcmp.loop_null_cmp39, label %strcmp.false
 
-strcmp.loop_null_cmp34:                           ; preds = %strcmp.loop27
-  %strcmp.cmp_null38 = icmp eq i8 %31, 0
-  br i1 %strcmp.cmp_null38, label %pred_true.critedge, label %strcmp.loop33
+strcmp.loop_null_cmp33:                           ; preds = %strcmp.loop26
+  %strcmp.cmp_null37 = icmp eq i8 %32, 0
+  br i1 %strcmp.cmp_null37, label %pred_true.critedge, label %strcmp.loop32
 
-strcmp.loop39:                                    ; preds = %strcmp.loop_null_cmp40
-  %38 = add [64 x i8]* %str, i64 8
-  %probe_read47 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %38)
-  %39 = load i8, i8* %strcmp.char_l, align 1
-  %40 = add [16 x i8]* %comm, i64 8
-  %probe_read48 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %40)
-  %41 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp49 = icmp eq i8 %39, %41
-  br i1 %strcmp.cmp49, label %strcmp.loop_null_cmp46, label %strcmp.false
+strcmp.loop38:                                    ; preds = %strcmp.loop_null_cmp39
+  %39 = add [64 x i8]* %str, i64 8
+  %probe_read46 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %39)
+  %40 = load i8, i8* %strcmp.char_l, align 1
+  %41 = add [16 x i8]* %comm, i64 8
+  %probe_read47 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %41)
+  %42 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp48 = icmp eq i8 %40, %42
+  br i1 %strcmp.cmp48, label %strcmp.loop_null_cmp45, label %strcmp.false
 
-strcmp.loop_null_cmp40:                           ; preds = %strcmp.loop33
-  %strcmp.cmp_null44 = icmp eq i8 %35, 0
-  br i1 %strcmp.cmp_null44, label %pred_true.critedge, label %strcmp.loop39
+strcmp.loop_null_cmp39:                           ; preds = %strcmp.loop32
+  %strcmp.cmp_null43 = icmp eq i8 %36, 0
+  br i1 %strcmp.cmp_null43, label %pred_true.critedge, label %strcmp.loop38
 
-strcmp.loop45:                                    ; preds = %strcmp.loop_null_cmp46
-  %42 = add [64 x i8]* %str, i64 9
-  %probe_read53 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %42)
-  %43 = load i8, i8* %strcmp.char_l, align 1
-  %44 = add [16 x i8]* %comm, i64 9
-  %probe_read54 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %44)
-  %45 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp55 = icmp eq i8 %43, %45
-  br i1 %strcmp.cmp55, label %strcmp.loop_null_cmp52, label %strcmp.false
+strcmp.loop44:                                    ; preds = %strcmp.loop_null_cmp45
+  %43 = add [64 x i8]* %str, i64 9
+  %probe_read52 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %43)
+  %44 = load i8, i8* %strcmp.char_l, align 1
+  %45 = add [16 x i8]* %comm, i64 9
+  %probe_read53 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %45)
+  %46 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp54 = icmp eq i8 %44, %46
+  br i1 %strcmp.cmp54, label %strcmp.loop_null_cmp51, label %strcmp.false
 
-strcmp.loop_null_cmp46:                           ; preds = %strcmp.loop39
-  %strcmp.cmp_null50 = icmp eq i8 %39, 0
-  br i1 %strcmp.cmp_null50, label %pred_true.critedge, label %strcmp.loop45
+strcmp.loop_null_cmp45:                           ; preds = %strcmp.loop38
+  %strcmp.cmp_null49 = icmp eq i8 %40, 0
+  br i1 %strcmp.cmp_null49, label %pred_true.critedge, label %strcmp.loop44
 
-strcmp.loop51:                                    ; preds = %strcmp.loop_null_cmp52
-  %46 = add [64 x i8]* %str, i64 10
-  %probe_read59 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %46)
-  %47 = load i8, i8* %strcmp.char_l, align 1
-  %48 = add [16 x i8]* %comm, i64 10
-  %probe_read60 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %48)
-  %49 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp61 = icmp eq i8 %47, %49
-  br i1 %strcmp.cmp61, label %strcmp.loop_null_cmp58, label %strcmp.false
+strcmp.loop50:                                    ; preds = %strcmp.loop_null_cmp51
+  %47 = add [64 x i8]* %str, i64 10
+  %probe_read58 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %47)
+  %48 = load i8, i8* %strcmp.char_l, align 1
+  %49 = add [16 x i8]* %comm, i64 10
+  %probe_read59 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %49)
+  %50 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp60 = icmp eq i8 %48, %50
+  br i1 %strcmp.cmp60, label %strcmp.loop_null_cmp57, label %strcmp.false
 
-strcmp.loop_null_cmp52:                           ; preds = %strcmp.loop45
-  %strcmp.cmp_null56 = icmp eq i8 %43, 0
-  br i1 %strcmp.cmp_null56, label %pred_true.critedge, label %strcmp.loop51
+strcmp.loop_null_cmp51:                           ; preds = %strcmp.loop44
+  %strcmp.cmp_null55 = icmp eq i8 %44, 0
+  br i1 %strcmp.cmp_null55, label %pred_true.critedge, label %strcmp.loop50
 
-strcmp.loop57:                                    ; preds = %strcmp.loop_null_cmp58
-  %50 = add [64 x i8]* %str, i64 11
-  %probe_read65 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %50)
-  %51 = load i8, i8* %strcmp.char_l, align 1
-  %52 = add [16 x i8]* %comm, i64 11
-  %probe_read66 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %52)
-  %53 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp67 = icmp eq i8 %51, %53
-  br i1 %strcmp.cmp67, label %strcmp.loop_null_cmp64, label %strcmp.false
+strcmp.loop56:                                    ; preds = %strcmp.loop_null_cmp57
+  %51 = add [64 x i8]* %str, i64 11
+  %probe_read64 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %51)
+  %52 = load i8, i8* %strcmp.char_l, align 1
+  %53 = add [16 x i8]* %comm, i64 11
+  %probe_read65 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %53)
+  %54 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp66 = icmp eq i8 %52, %54
+  br i1 %strcmp.cmp66, label %strcmp.loop_null_cmp63, label %strcmp.false
 
-strcmp.loop_null_cmp58:                           ; preds = %strcmp.loop51
-  %strcmp.cmp_null62 = icmp eq i8 %47, 0
-  br i1 %strcmp.cmp_null62, label %pred_true.critedge, label %strcmp.loop57
+strcmp.loop_null_cmp57:                           ; preds = %strcmp.loop50
+  %strcmp.cmp_null61 = icmp eq i8 %48, 0
+  br i1 %strcmp.cmp_null61, label %pred_true.critedge, label %strcmp.loop56
 
-strcmp.loop63:                                    ; preds = %strcmp.loop_null_cmp64
-  %54 = add [64 x i8]* %str, i64 12
-  %probe_read71 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %54)
-  %55 = load i8, i8* %strcmp.char_l, align 1
-  %56 = add [16 x i8]* %comm, i64 12
-  %probe_read72 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %56)
-  %57 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp73 = icmp eq i8 %55, %57
-  br i1 %strcmp.cmp73, label %strcmp.loop_null_cmp70, label %strcmp.false
+strcmp.loop62:                                    ; preds = %strcmp.loop_null_cmp63
+  %55 = add [64 x i8]* %str, i64 12
+  %probe_read70 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %55)
+  %56 = load i8, i8* %strcmp.char_l, align 1
+  %57 = add [16 x i8]* %comm, i64 12
+  %probe_read71 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %57)
+  %58 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp72 = icmp eq i8 %56, %58
+  br i1 %strcmp.cmp72, label %strcmp.loop_null_cmp69, label %strcmp.false
 
-strcmp.loop_null_cmp64:                           ; preds = %strcmp.loop57
-  %strcmp.cmp_null68 = icmp eq i8 %51, 0
-  br i1 %strcmp.cmp_null68, label %pred_true.critedge, label %strcmp.loop63
+strcmp.loop_null_cmp63:                           ; preds = %strcmp.loop56
+  %strcmp.cmp_null67 = icmp eq i8 %52, 0
+  br i1 %strcmp.cmp_null67, label %pred_true.critedge, label %strcmp.loop62
 
-strcmp.loop69:                                    ; preds = %strcmp.loop_null_cmp70
-  %58 = add [64 x i8]* %str, i64 13
-  %probe_read77 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %58)
-  %59 = load i8, i8* %strcmp.char_l, align 1
-  %60 = add [16 x i8]* %comm, i64 13
-  %probe_read78 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %60)
-  %61 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp79 = icmp eq i8 %59, %61
-  br i1 %strcmp.cmp79, label %strcmp.loop_null_cmp76, label %strcmp.false
+strcmp.loop68:                                    ; preds = %strcmp.loop_null_cmp69
+  %59 = add [64 x i8]* %str, i64 13
+  %probe_read76 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %59)
+  %60 = load i8, i8* %strcmp.char_l, align 1
+  %61 = add [16 x i8]* %comm, i64 13
+  %probe_read77 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %61)
+  %62 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp78 = icmp eq i8 %60, %62
+  br i1 %strcmp.cmp78, label %strcmp.loop_null_cmp75, label %strcmp.false
 
-strcmp.loop_null_cmp70:                           ; preds = %strcmp.loop63
-  %strcmp.cmp_null74 = icmp eq i8 %55, 0
-  br i1 %strcmp.cmp_null74, label %pred_true.critedge, label %strcmp.loop69
+strcmp.loop_null_cmp69:                           ; preds = %strcmp.loop62
+  %strcmp.cmp_null73 = icmp eq i8 %56, 0
+  br i1 %strcmp.cmp_null73, label %pred_true.critedge, label %strcmp.loop68
 
-strcmp.loop75:                                    ; preds = %strcmp.loop_null_cmp76
-  %62 = add [64 x i8]* %str, i64 14
-  %probe_read83 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %62)
-  %63 = load i8, i8* %strcmp.char_l, align 1
-  %64 = add [16 x i8]* %comm, i64 14
-  %probe_read84 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %64)
-  %65 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp85 = icmp eq i8 %63, %65
-  br i1 %strcmp.cmp85, label %strcmp.loop_null_cmp82, label %strcmp.false
+strcmp.loop74:                                    ; preds = %strcmp.loop_null_cmp75
+  %63 = add [64 x i8]* %str, i64 14
+  %probe_read82 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %63)
+  %64 = load i8, i8* %strcmp.char_l, align 1
+  %65 = add [16 x i8]* %comm, i64 14
+  %probe_read83 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %65)
+  %66 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp84 = icmp eq i8 %64, %66
+  br i1 %strcmp.cmp84, label %strcmp.loop_null_cmp81, label %strcmp.false
 
-strcmp.loop_null_cmp76:                           ; preds = %strcmp.loop69
-  %strcmp.cmp_null80 = icmp eq i8 %59, 0
-  br i1 %strcmp.cmp_null80, label %pred_true.critedge, label %strcmp.loop75
+strcmp.loop_null_cmp75:                           ; preds = %strcmp.loop68
+  %strcmp.cmp_null79 = icmp eq i8 %60, 0
+  br i1 %strcmp.cmp_null79, label %pred_true.critedge, label %strcmp.loop74
 
-strcmp.loop81:                                    ; preds = %strcmp.loop_null_cmp82
-  %66 = add [64 x i8]* %str, i64 15
-  %probe_read89 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %66)
-  %67 = load i8, i8* %strcmp.char_l, align 1
-  %68 = add [16 x i8]* %comm, i64 15
-  %probe_read90 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %68)
-  %69 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp91 = icmp eq i8 %67, %69
-  br i1 %strcmp.cmp91, label %strcmp.loop_null_cmp88, label %strcmp.false
+strcmp.loop80:                                    ; preds = %strcmp.loop_null_cmp81
+  %67 = add [64 x i8]* %str, i64 15
+  %probe_read88 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %67)
+  %68 = load i8, i8* %strcmp.char_l, align 1
+  %69 = add [16 x i8]* %comm, i64 15
+  %probe_read89 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %69)
+  %70 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp90 = icmp eq i8 %68, %70
+  br i1 %strcmp.cmp90, label %strcmp.loop_null_cmp87, label %strcmp.false
 
-strcmp.loop_null_cmp82:                           ; preds = %strcmp.loop75
-  %strcmp.cmp_null86 = icmp eq i8 %63, 0
-  br i1 %strcmp.cmp_null86, label %pred_true.critedge, label %strcmp.loop81
+strcmp.loop_null_cmp81:                           ; preds = %strcmp.loop74
+  %strcmp.cmp_null85 = icmp eq i8 %64, 0
+  br i1 %strcmp.cmp_null85, label %pred_true.critedge, label %strcmp.loop80
 
-strcmp.loop87:                                    ; preds = %strcmp.loop_null_cmp88
-  %70 = add [64 x i8]* %str, i64 16
-  %probe_read95 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %70)
-  %71 = load i8, i8* %strcmp.char_l, align 1
-  %72 = add [16 x i8]* %comm, i64 16
-  %probe_read96 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %72)
-  %73 = load i8, i8* %strcmp.char_r, align 1
-  %strcmp.cmp97 = icmp eq i8 %71, %73
-  br i1 %strcmp.cmp97, label %pred_true.critedge, label %strcmp.false
+strcmp.loop86:                                    ; preds = %strcmp.loop_null_cmp87
+  %71 = add [64 x i8]* %str, i64 16
+  %probe_read94 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_l, i64 1, [64 x i8]* %71)
+  %72 = load i8, i8* %strcmp.char_l, align 1
+  %73 = add [16 x i8]* %comm, i64 16
+  %probe_read95 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i8* nonnull %strcmp.char_r, i64 1, [16 x i8]* %73)
+  %74 = load i8, i8* %strcmp.char_r, align 1
+  %strcmp.cmp96 = icmp eq i8 %72, %74
+  br i1 %strcmp.cmp96, label %pred_true.critedge, label %strcmp.false
 
-strcmp.loop_null_cmp88:                           ; preds = %strcmp.loop81
-  %strcmp.cmp_null92 = icmp eq i8 %67, 0
-  br i1 %strcmp.cmp_null92, label %pred_true.critedge, label %strcmp.loop87
+strcmp.loop_null_cmp87:                           ; preds = %strcmp.loop80
+  %strcmp.cmp_null91 = icmp eq i8 %68, 0
+  br i1 %strcmp.cmp_null91, label %pred_true.critedge, label %strcmp.loop86
 }
 
 ; Function Attrs: argmemonly nounwind

--- a/tests/codegen/strncmp.cpp
+++ b/tests/codegen/strncmp.cpp
@@ -38,7 +38,7 @@ entry:
   %3 = ptrtoint i8* %0 to i64
   %4 = add i64 %3, 8
   %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5, align 8
+  %6 = load volatile i64, i64* %5, align 8
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %6)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char_l)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char_r)
@@ -336,7 +336,7 @@ entry:
   %3 = ptrtoint i8* %0 to i64
   %4 = add i64 %3, 8
   %5 = inttoptr i64 %4 to i64*
-  %6 = load i64, i64* %5, align 8
+  %6 = load volatile i64, i64* %5, align 8
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %6)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char_l)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char_r)

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -118,6 +118,11 @@ EXPECT SUCCESS cgroup -?[0-9][0-9]*
 TIMEOUT 5
 MIN_KERNEL 4.18
 
+NAME ctx
+RUN bpftrace -v -e 'struct x {unsigned long x}; i:ms:1 { printf("SUCCESS '$test' %d\n", ((struct x*)ctx)->x); exit(); }'
+EXPECT SUCCESS ctx -?[0-9][0-9]*
+TIMEOUT 5
+
 NAME cat
 RUN bpftrace -e 'i:ms:1 { cat("/proc/loadavg"); exit(); }'
 EXPECT ^([0-9]+\.[0-9]+ ?)+.*$

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1492,6 +1492,10 @@ TEST(semantic_analyser, type_ctx)
   EXPECT_EQ(SizedType(Type::ctx, 32, false), unop->type);
   var = static_cast<ast::Variable *>(unop->expr);
   EXPECT_EQ(SizedType(Type::ctx, 8, false), var->type);
+
+  test(driver, "k:f, kr:f { @ = (uint64)ctx; }", 0);
+  test(driver, "k:f, i:s:1 { @ = (uint64)ctx; }", 1);
+  test(driver, "t:sched:sched_one { @ = (uint64)ctx; }", 1);
 }
 
 } // namespace semantic_analyser


### PR DESCRIPTION
This is a follow up of #988.

The previous approach is recursively traversing the AST to see if the Node accesses a context field. But it turns out that this approach has several problems. This PR, instead, introduces Type::ctx to propagate context information in a top-down way (idea by ajor). Type::ctx is basically the same as Type::cast. codegen emit load instructions in FieldAccess and ArrayAccess if the type is Type::ctx.

Please see each commit message for the details. I think all the previously discussed points are solved. 

One thing not previously discussed is the availability of  "ctx" in tracepoint. In this PR, "ctx" is concealed in tracepoint for simplicity. 

Closes #945
