### PR TITLE
Print arbitrary data safely

### DIFF
--- a/README.md
+++ b/README.md
@@ -293,6 +293,7 @@ Functions:
 - `stats(int n)` - Return the count, average, and total for this value
 - `delete(@x)` - Delete the map element passed in as an argument
 - `str(char *s [, int length])` - Returns the string pointed to by `s`
+- `buf(void *d, int length)` - Returns a hex-formatted string of the data pointed to by `d`
 - `printf(char *fmt, ...)` - Print formatted to stdout
 - `print(@x[, int top [, int div]])` - Print a map, with optional top entry count and divisor
 - `clear(@x)` - Delete all key/values from a map

--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -59,5 +59,19 @@ struct Time
   }
 } __attribute__((packed));
 
+struct Buf
+{
+  uint8_t length;
+  uint8_t* content;
+
+  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b, size_t length)
+  {
+    return {
+      b.getInt8Ty(),                               // buffer length
+      llvm::ArrayType::get(b.getInt8Ty(), length), // buffer content
+    };
+  }
+};
+
 } // namespace AsyncEvent
 } // namespace bpftrace

--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -62,7 +62,7 @@ struct Time
 struct Buf
 {
   uint8_t length;
-  uint8_t* content;
+  char content[];
 
   std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b, size_t length)
   {
@@ -71,7 +71,7 @@ struct Buf
       llvm::ArrayType::get(b.getInt8Ty(), length), // buffer content
     };
   }
-};
+} __attribute__((packed));
 
 } // namespace AsyncEvent
 } // namespace bpftrace

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -316,6 +316,13 @@ void IRBuilderBPF::CreateMapDeleteElem(Map &map, AllocaInst *key)
 
 void IRBuilderBPF::CreateProbeRead(AllocaInst *dst, size_t size, Value *src)
 {
+  return CreateProbeRead(dst, getInt32(size), src);
+}
+
+void IRBuilderBPF::CreateProbeRead(AllocaInst *dst,
+                                   llvm::Value *size,
+                                   Value *src)
+{
   // int bpf_probe_read(void *dst, int size, void *src)
   // Return: 0 on success or negative error
   FunctionType *proberead_func_type = FunctionType::get(
@@ -325,7 +332,7 @@ void IRBuilderBPF::CreateProbeRead(AllocaInst *dst, size_t size, Value *src)
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_probe_read),
       proberead_func_ptr_type);
-  CreateCall(proberead_func, { dst, getInt32(size), src }, "probe_read");
+  CreateCall(proberead_func, { dst, size, src }, "probe_read");
 }
 
 Constant *IRBuilderBPF::createProbeReadStrFn(llvm::Type *dst, llvm::Type *src)

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -243,7 +243,7 @@ Value *IRBuilderBPF::CreateMapLookupElem(int mapfd, AllocaInst *key, SizedType &
       "map_lookup_cond");
   CreateCondBr(condition, lookup_success_block, lookup_failure_block);
 
-  bool is_array = (type.type == Type::string ||
+  bool is_array = (type.type == Type::string || type.type == Type::buffer ||
                    (type.type == Type::cast && !type.is_pointer) ||
                    type.type == Type::inet || type.type == Type::usym);
 

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -62,6 +62,7 @@ public:
   void        CreateMapUpdateElem(Map &map, AllocaInst *key, Value *val);
   void        CreateMapDeleteElem(Map &map, AllocaInst *key);
   void        CreateProbeRead(AllocaInst *dst, size_t size, Value *src);
+  void        CreateProbeRead(AllocaInst *dst, llvm::Value *size, Value *src);
   CallInst   *CreateProbeReadStr(AllocaInst *dst, llvm::Value *size, Value *src);
   CallInst   *CreateProbeReadStr(AllocaInst *dst, size_t size, Value *src);
   CallInst   *CreateProbeReadStr(Value *dst, size_t size, Value *src);

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -534,6 +534,58 @@ void SemanticAnalyser::visit(Call &call)
       }
     }
   }
+  else if (call.func == "buf")
+  {
+    if (!check_varargs(call, 1, 2))
+      return;
+
+    auto &arg = *call.vargs->at(0);
+    if (!(arg.type.type == Type::integer || arg.type.type == Type::string ||
+          arg.type.type == Type::array))
+      error(call.func +
+                "() expects an integer, string, or array argument but saw " +
+                typestr(arg.type.type),
+            call.loc);
+
+    size_t max_buffer_size = bpftrace_.strlen_;
+    size_t buffer_size = max_buffer_size;
+
+    if (call.vargs->size() == 1)
+      if (arg.type.type == Type::array)
+        buffer_size = arg.type.pointee_size * arg.type.size;
+      else
+        error(call.func + "() expects a length argument for non-array type " +
+                  typestr(arg.type.type),
+              call.loc);
+    else
+    {
+      if (is_final_pass())
+        check_arg(call, Type::integer, 1, false);
+
+      auto &size_arg = *call.vargs->at(1);
+      if (size_arg.is_literal)
+        buffer_size = static_cast<Integer &>(size_arg).n;
+    }
+
+    if (buffer_size > max_buffer_size)
+    {
+      if (is_final_pass())
+        warning(call.func + "() length is too long and will be shortened to " +
+                    std::to_string(bpftrace_.strlen_) +
+                    " bytes (see BPFTRACE_STRLEN)",
+                call.loc);
+
+      buffer_size = max_buffer_size;
+    }
+
+    buffer_size++; // extra byte is used to embed the length of the buffer
+    call.type = SizedType(Type::buffer, buffer_size);
+
+    if (auto *param = dynamic_cast<PositionalParameter *>(call.vargs->at(0)))
+    {
+      param->is_in_str = true;
+    }
+  }
   else if (call.func == "ksym" || call.func == "usym") {
     if (check_nargs(call, 1)) {
       // allow symbol lookups on casts (eg, function pointers)

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -46,6 +46,17 @@ constexpr char CHILD_EXIT_QUIETLY = '\0';
 constexpr char CHILD_GO = 'g';
 
 int format(char * s, size_t n, const char * fmt, std::vector<std::unique_ptr<IPrintable>> &args) {
+  // Args have been made safe for printing by now, so replace nonstandard format
+  // specifiers with %s
+  std::string str = std::string(fmt);
+  size_t start_pos = 0;
+  while ((start_pos = str.find("%r", start_pos)) != std::string::npos)
+  {
+    str.replace(start_pos, 2, "%s");
+    start_pos += 2;
+  }
+  fmt = str.c_str();
+
   int ret = -1;
   switch(args.size()) {
     case 0:

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -656,8 +656,9 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(const std::vec
       }
       case Type::buffer:
         arg_values.push_back(std::make_unique<PrintableString>(resolve_buf(
-            reinterpret_cast<char *>(arg_data + arg.offset + sizeof(uint8_t)),
-            reinterpret_cast<uint8_t>(*(arg_data + arg.offset)))));
+            reinterpret_cast<AsyncEvent::Buf *>(arg_data + arg.offset)->content,
+            reinterpret_cast<AsyncEvent::Buf *>(arg_data + arg.offset)
+                ->length)));
         break;
       case Type::ksym:
         arg_values.push_back(

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -101,6 +101,7 @@ public:
     return *maps_[map_ids_[id]].get();
   };
   std::string get_stack(uint64_t stackidpid, bool ustack, StackType stack_type, int indent=0);
+  std::string resolve_buf(char *buf, size_t size);
   std::string resolve_ksym(uintptr_t addr, bool show_offset=false);
   std::string resolve_usym(uintptr_t addr, int pid, bool show_offset=false, bool show_module=false);
   std::string resolve_inet(int af, const uint8_t* inet) const;

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -29,7 +29,7 @@ vspace  [\n\r]
 space   {hspace}|{vspace}
 path    :(\\.|[_\-\./a-zA-Z0-9#\*])*:
 builtin arg[0-9]|args|cgroup|comm|cpid|cpu|ctx|curtask|elapsed|func|gid|nsecs|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
-call    avg|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|ksym|lhist|max|min|ntop|override|print|printf|reg|signal|stats|str|strncmp|sum|system|time|uaddr|usym|zero
+call    avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|ksym|lhist|max|min|ntop|override|print|printf|reg|signal|stats|str|strncmp|sum|system|time|uaddr|usym|zero
 
 /* Don't add to this! Use builtin OR call not both */
 call_and_builtin kstack|ustack

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -100,6 +100,11 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
       auto p = static_cast<const char *>(data);
       return std::string(p, strnlen(p, arg.size));
     }
+    case Type::buffer:
+    {
+      auto p = static_cast<const char *>(data) + 1;
+      return hex_format_buffer(p, arg.size - 1);
+    }
     case Type::cast:
       if (arg.is_pointer) {
         // use case: show me these pointer values

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -375,10 +375,14 @@ void JsonOutput::map(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t div,
       out_ << "\"" << json_escape(str_join(args, ",")) << "\": ";
     }
 
-    if (map.type_.type == Type::kstack || map.type_.type == Type::ustack || map.type_.type == Type::ksym ||
-        map.type_.type == Type::usym || map.type_.type == Type::inet || map.type_.type == Type::username ||
-        map.type_.type == Type::string || map.type_.type == Type::probe) {
-        out_ << "\"" << json_escape(bpftrace.map_value_to_str(map, value, div)) << "\"";
+    if (map.type_.type == Type::kstack || map.type_.type == Type::ustack ||
+        map.type_.type == Type::ksym || map.type_.type == Type::usym ||
+        map.type_.type == Type::inet || map.type_.type == Type::username ||
+        map.type_.type == Type::string || map.type_.type == Type::buffer ||
+        map.type_.type == Type::probe)
+    {
+      out_ << "\"" << json_escape(bpftrace.map_value_to_str(map, value, div))
+           << "\"";
     }
     else {
       out_ << bpftrace.map_value_to_str(map, value, div);

--- a/src/printf_format_types.h
+++ b/src/printf_format_types.h
@@ -4,6 +4,8 @@
 
 namespace bpftrace {
 
+// clang-format off
+
 // valid printf length + specifier combinations
 // it's done like this because as of this writing, C++ doesn't have a builtin way to do
 // compile time string concatenation. here is the Python 3 code that generates this map:
@@ -12,9 +14,11 @@ namespace bpftrace {
 // specifiers = ("d", "u", "x", "X", "p")
 //
 // print("{\"s\", Type::string},")
+// print("{\"r\", Type::buffer},")
 // print(",\n".join([f"{{\"{l+s}\", Type::integer}}" for l in lengths for s in specifiers]))
 const std::unordered_map<std::string, Type> printf_format_types = {
   {"s", Type::string},
+  {"r", Type::buffer},
   {"c", Type::integer},
   {"d", Type::integer},
   {"u", Type::integer},
@@ -57,5 +61,7 @@ const std::unordered_map<std::string, Type> printf_format_types = {
   {"tX", Type::integer},
   {"tp", Type::integer}
 };
+
+// clang-format on
 
 } // namespace bpftrace

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -30,7 +30,7 @@ std::ostream &operator<<(std::ostream &os, const SizedType &type)
     os << (type.is_signed ? "" : "unsigned ") << "int" << 8 * type.pointee_size;
     os << "[" << type.size << "]";
   }
-  else if (type.type == Type::string)
+  else if (type.type == Type::string || type.type == Type::buffer)
   {
     os << type.type << "[" << type.size << "]";
   }
@@ -63,7 +63,7 @@ bool SizedType::operator==(const SizedType &t) const
 bool SizedType::IsArray() const
 {
   return type == Type::array || type == Type::string || type == Type::usym ||
-         type == Type::inet ||
+         type == Type::inet || type == Type::buffer ||
          ((type == Type::cast || type == Type::ctx) && !is_pointer);
 }
 
@@ -100,6 +100,7 @@ std::string typestr(Type t)
     case Type::stack_mode:return "stack mode";break;
     case Type::array:    return "array";    break;
     case Type::ctx:      return "ctx";      break;
+    case Type::buffer:   return "buffer";   break;
     // clang-format on
     default:
       std::cerr << "call or probe type not found" << std::endl;

--- a/src/types.h
+++ b/src/types.h
@@ -41,6 +41,7 @@ enum class Type
   array,
   // BPF program context; needing a different access method to satisfy the verifier
   ctx,
+  buffer,
   // clang-format on
 };
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -826,4 +826,21 @@ pid_t parse_pid(const std::string &str)
   }
 }
 
+std::string hex_format_buffer(const char *buf, size_t size)
+{
+  // Allow enough space for every byte to be sanitized in the form "\x00"
+  char s[size * 4 + 1];
+
+  size_t offset = 0;
+  for (size_t i = 0; i < size; i++)
+    if (buf[i] >= 32 && buf[i] <= 126)
+      offset += sprintf(s + offset, "%c", ((const uint8_t *)buf)[i]);
+    else
+      offset += sprintf(s + offset, "\\x%02x", ((const uint8_t *)buf)[i]);
+
+  s[offset] = '\0';
+
+  return std::string(s);
+}
+
 } // namespace bpftrace

--- a/src/utils.h
+++ b/src/utils.h
@@ -149,6 +149,7 @@ std::string str_join(const std::vector<std::string> &list,
 bool is_numeric(const std::string &str);
 bool symbol_has_cpp_mangled_signature(const std::string &sym_name);
 pid_t parse_pid(const std::string &str);
+std::string hex_format_buffer(const char *buf, size_t size);
 
 // trim from end of string (right)
 inline std::string &rtrim(std::string &s)

--- a/tests/codegen/call_buf.cpp
+++ b/tests/codegen/call_buf.cpp
@@ -1,0 +1,31 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, call_buf_implicit_size)
+{
+  test("struct x { int c[4] }; kprobe:f { $foo = (struct x*)0; @x = "
+       "buf($foo->c); }",
+
+       NAME);
+}
+
+TEST(codegen, call_buf_size_literal)
+{
+  test("kprobe:f { @x = buf(arg0, 1) }",
+
+       NAME);
+}
+
+TEST(codegen, call_buf_size_nonliteral)
+{
+  test("kprobe:f { @x = buf(arg0, arg1) }",
+
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/call_buf_implicit_size.ll
+++ b/tests/codegen/llvm/call_buf_implicit_size.ll
@@ -1,0 +1,42 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%buffer_16_t = type { i8, [16 x i8] }
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
+entry:
+  %"@x_key" = alloca i64, align 8
+  %buffer = alloca %buffer_16_t, align 8
+  %1 = getelementptr inbounds %buffer_16_t, %buffer_16_t* %buffer, i64 0, i32 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  store i8 16, i8* %1, align 8
+  %2 = getelementptr inbounds %buffer_16_t, %buffer_16_t* %buffer, i64 0, i32 1
+  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %3, i8 0, i64 16, i1 false)
+  %probe_read = call i64 inttoptr (i64 4 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* nonnull %2, i8 16, i64 0)
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 0, i64* %"@x_key", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %buffer_16_t*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %buffer_16_t* nonnull %buffer, i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/call_buf_size_literal.ll
+++ b/tests/codegen/llvm/call_buf_size_literal.ll
@@ -1,0 +1,40 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%buffer_1_t = type { i8, [1 x i8] }
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
+entry:
+  %"@x_key" = alloca i64, align 8
+  %buffer = alloca %buffer_1_t, align 8
+  %1 = getelementptr inbounds %buffer_1_t, %buffer_1_t* %buffer, i64 0, i32 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  store i64 1, i8* %1, align 8
+  %2 = getelementptr inbounds %buffer_1_t, %buffer_1_t* %buffer, i64 0, i32 1
+  %3 = getelementptr i8, i8* %0, i64 112
+  %4 = bitcast i8* %3 to i64*
+  %arg0 = load volatile i64, i64* %4, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 ([1 x i8]*, i32, i64)*)([1 x i8]* nonnull %2, i64 1, i64 %arg0)
+  %5 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  store i64 0, i64* %"@x_key", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %buffer_1_t*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %buffer_1_t* nonnull %buffer, i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/call_buf_size_nonliteral.ll
+++ b/tests/codegen/llvm/call_buf_size_nonliteral.ll
@@ -1,0 +1,50 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%buffer_64_t = type { i8, [64 x i8] }
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
+entry:
+  %"@x_key" = alloca i64, align 8
+  %buffer = alloca %buffer_64_t, align 8
+  %1 = getelementptr i8, i8* %0, i64 104
+  %2 = bitcast i8* %1 to i64*
+  %arg1 = load volatile i64, i64* %2, align 8
+  %3 = icmp ult i64 %arg1, 64
+  %length.select = select i1 %3, i64 %arg1, i64 64
+  %4 = getelementptr inbounds %buffer_64_t, %buffer_64_t* %buffer, i64 0, i32 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 %length.select, i8* %4, align 8
+  %5 = getelementptr inbounds %buffer_64_t, %buffer_64_t* %buffer, i64 0, i32 1
+  %6 = getelementptr inbounds [64 x i8], [64 x i8]* %5, i64 0, i64 0
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %6, i8 0, i64 64, i1 false)
+  %7 = getelementptr i8, i8* %0, i64 112
+  %8 = bitcast i8* %7 to i64*
+  %arg0 = load volatile i64, i64* %8, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* nonnull %5, i64 %length.select, i64 %arg0)
+  %9 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
+  store i64 0, i64* %"@x_key", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %buffer_64_t*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %buffer_64_t* nonnull %buffer, i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -39,6 +39,21 @@ AFTER ls
 EXPECT P: /*.
 TIMEOUT 5
 
+NAME buf
+RUN bpftrace -v -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r\n", buf($s->a, 4), buf($s->b, 4), buf($s->c), buf($s->d)); exit(); }' -c ./testprogs/complex_struct
+EXPECT P: \\x09\\x08\\x07\\x06-\\x05\\x04\\x03\\x02-\\x01\\x02\\x03\\x04-\\x05\\x00\\x00\\x00\\x06\\x00\\x00\\x00\\x07\\x00\\x00\\x00\\x08\\x00\\x00\\x00
+TIMEOUT 5
+
+NAME buf_map_key
+RUN bpftrace -v -e 'i:ms:100 { @[buf("ok_key", 6)] = 1; exit(); }'
+EXPECT @\[ok_key\]: 1
+TIMEOUT 5
+
+NAME buf_map_value
+RUN bpftrace -v -e 'i:ms:100 { @ = buf("ok_value", 8); exit(); }'
+EXPECT @: ok_value
+TIMEOUT 5
+
 NAME ksym
 RUN bpftrace -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("ip"))); exit();}'
 EXPECT do_nanosleep

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -4,7 +4,12 @@ EXPECT \@a: 10
 TIMEOUT 5
 
 NAME global_string
-RUN bpftrace -v -e 'i:ms:1 {@a = "hi"; printf("%s\\n", @a); exit();}'
+RUN bpftrace -v -e 'i:ms:1 {@a = "hi"; printf("%s\n", @a); exit();}'
+EXPECT @a: hi
+TIMEOUT 5
+
+NAME global_buf
+RUN bpftrace -v -e 'i:ms:1 {@a = buf("hi", 2); printf("%r\n", @a); exit();}'
 EXPECT @a: hi
 TIMEOUT 5
 
@@ -16,6 +21,16 @@ TIMEOUT 5
 NAME local_string
 RUN bpftrace -v -e 'i:ms:1  {$a = "hi"; printf("a=%s\n", $a); exit();}'
 EXPECT a=hi
+TIMEOUT 5
+
+NAME local_buf
+RUN bpftrace -v -e 'i:ms:1 {$a = buf("hi", 2); printf("a=%r\n", $a); exit();}'
+EXPECT a=hi
+TIMEOUT 5
+
+NAME buf_equality
+RUN bpftrace -v -e 'i:ms:1 {$a = buf("hi", 2); $b = buf("bye", 3); printf("equal=%d, unequal=%d\n", $a == $a, $a != $b); exit();}'
+EXPECT equal=1, unequal=1
 TIMEOUT 5
 
 NAME global_associative_arrays

--- a/tests/testprogs/complex_struct.c
+++ b/tests/testprogs/complex_struct.c
@@ -1,0 +1,28 @@
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+struct Foo
+{
+  char* a;
+  char b[4];
+  uint8_t c[4];
+  int d[4];
+};
+
+void func(struct Foo* foo)
+{
+  (void)foo;
+}
+
+int main()
+{
+  struct Foo foo = { .a = malloc(4),
+                     .b = { 5, 4, 3, 2 },
+                     .c = { 1, 2, 3, 4 },
+                     .d = { 5, 6, 7, 8 } };
+  strcpy(foo.a, "\x09\x08\x07\x06");
+  func(&foo);
+  free(foo.a);
+  return 0;
+}


### PR DESCRIPTION
Fixes #659. This PR introduces a built-in function `buf` that sanitizes arbitrary data so that it's safe to print. The function is similar in implementation to `str` and shares its constraints on length. The differences mostly stem from not using `CreateProbeReadStr` (can't expect the buffer to end on a zero byte) and sorting out the necessary plumbing.

I couldn't find a straightforward way to pass the buffer's length to userspace independently from the buffer itself, so I've embedded it as the first byte in the buffer. Feels a bit odd, but it's simple and works.

I'm opening this as a draft because it still needs docs and perhaps another test. It's ready for initial feedback, though.

```
sudo src/bpftrace -e 'tracepoint:syscalls:sys_enter_sendto { printf("%s\n", buf(args->buff, args->len)); }' -c 'ping 8.8.8.8 -c1'
Attaching 1 probe...
PING 8.8.8.8 (8.8.8.8) 56(84) bytes of data.
\x08\x00\xb1\x85D\xc3\x00\x01\xceQ.^\x00\x00\x00\x0073\x0f\x00\x00\x00\x00\x00\x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f !"#$%&'()*+,-./0123456
64 bytes from 8.8.8.8: icmp_seq=1 ttl=52 time=20.5 ms

--- 8.8.8.8 ping statistics ---
1 packets transmitted, 1 received, 0% packet loss, time 0ms
rtt min/avg/max/mdev = 20.474/20.474/20.474/0.000 ms
```