### PR TITLE
Support "." in attach point function argument

### DIFF
--- a/src/parser.yy
+++ b/src/parser.yy
@@ -187,6 +187,7 @@ wildcard : wildcard ident    { $$ = $1 + $2; }
          | wildcard MUL      { $$ = $1 + "*"; }
          | wildcard LBRACKET { $$ = $1 + "["; }
          | wildcard RBRACKET { $$ = $1 + "]"; }
+         | wildcard DOT      { $$ = $1 + "."; }
          |                   { $$ = ""; }
          ;
 

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -959,6 +959,14 @@ TEST(Parser, wildcard_path)
        "  int: 1\n");
 }
 
+TEST(Parser, dot_in_func)
+{
+  test("uprobe:/my/go/program:runtime.main.func1 { 1; }",
+       "Program\n"
+       " uprobe:/my/go/program:runtime.main.func1\n"
+       "  int: 1\n");
+}
+
 TEST(Parser, wildcard_func)
 {
   test("usdt:/my/program:abc*cd { 1; }",


### PR DESCRIPTION
golang likes to use "." a lot in symbol names. Before, you would have to
quote your function, ie

    uprobe:/my/go/app:"runtime.main.func1" { 1 }

but that's a bit ugly.

Now you can do:

    uprobe:/my/go/app:runtime.main.func1 { 1 }

This closes #548 .