### PR TITLE
Take first binary match for PATH lookup on uprobe and USDT

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1431,10 +1431,21 @@ void SemanticAnalyser::visit(AttachPoint &ap)
       ap.target = paths.front();
       break;
     default:
-      error("uprobe target file '" + ap.target +
-                "' must refer to a unique binary but matched " +
-                std::to_string(paths.size()),
-            ap.loc);
+      // If we are doing a PATH lookup (ie not glob), we follow shell
+      // behavior and take the first match.
+      if (ap.target.find("*") == std::string::npos)
+      {
+        warning("attaching to uprobe target file '" + paths.front() +
+                    "' but matched " + std::to_string(paths.size()) +
+                    " binaries",
+                ap.loc);
+        ap.target = paths.front();
+      }
+      else
+        error("uprobe target file '" + ap.target +
+                  "' must refer to a unique binary but matched " +
+                  std::to_string(paths.size()),
+              ap.loc);
     }
   }
   else if (ap.provider == "usdt") {
@@ -1454,10 +1465,21 @@ void SemanticAnalyser::visit(AttachPoint &ap)
         ap.target = paths.front();
         break;
       default:
-        error("usdt target file '" + ap.target +
-                  "' must refer to a unique binary but matched " +
-                  std::to_string(paths.size()),
-              ap.loc);
+        // If we are doing a PATH lookup (ie not glob), we follow shell
+        // behavior and take the first match.
+        if (ap.target.find("*") == std::string::npos)
+        {
+          warning("attaching to usdt target file '" + paths.front() +
+                      "' but matched " + std::to_string(paths.size()) +
+                      " binaries",
+                  ap.loc);
+          ap.target = paths.front();
+        }
+        else
+          error("usdt target file '" + ap.target +
+                    "' must refer to a unique binary but matched " +
+                    std::to_string(paths.size()),
+                ap.loc);
       }
     }
 


### PR DESCRIPTION
I was seeing unit test failures:

```
stdin:1:1-12: ERROR: uprobe target file 'sh' must refer to a unique binary but matched 5
uprobe:sh:f { 1 }
~~~~~~~~~~~
/home/dlxu/dev/bpftrace/tests/probe.cpp:33: Failure
Expected equality of these values:
  semantics.analyse()
    Which is: 1
  0
[  FAILED  ] probe.short_name (25 ms)
```

This patch modifies the logic such that if we're doing a PATH lookup, we
take the first match. Just like how the shell does it.

We also print a warning to the user.

This closes #1103.