### PR TITLE
Fix clang warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -37,7 +37,6 @@ set (CMAKE_CXX_STANDARD 14)
 set (CMAKE_CXX_STANDARD_REQUIRED ON)
 set (CMAKE_CXX_EXTENSIONS OFF)
 
-add_compile_options("-Wno-format-security")
 add_compile_options("-Wall")
 add_compile_options("-Wextra")
 add_compile_options("-Wundef")

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -509,7 +509,8 @@ void CodegenLLVM::visit(Call &call)
     // arg0
     b_.SetInsertPoint(notzero);
     b_.CreateStore(b_.getInt64(asyncactionint(AsyncAction::join)), perfdata);
-    b_.CreateStore(b_.getInt64(join_id_), b_.CreateGEP(perfdata, {b_.getInt64(8)}));
+    b_.CreateStore(b_.getInt64(join_id_),
+                   b_.CreateGEP(perfdata, b_.getInt64(8)));
     join_id_++;
     AllocaInst *arr = b_.CreateAllocaBPF(b_.getInt64Ty(), call.func+"_r0");
     b_.CreateProbeRead(arr, 8, expr_);

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -3,13 +3,13 @@
 #include "ast.h"
 #include "bpforc.h"
 #include "parser.tab.hh"
-#include "signal.h"
 #include "tracepoint_format_parser.h"
 #include "types.h"
 #include "utils.h"
 #include <algorithm>
 #include <arpa/inet.h>
-#include <time.h>
+#include <csignal>
+#include <ctime>
 
 #include <llvm/Support/TargetRegistry.h>
 #include <llvm/IR/Constants.h>

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1420,15 +1420,15 @@ void CodegenLLVM::visit(Probe &probe)
       {b_.getInt8PtrTy()}, // struct pt_regs *ctx
       false);
 
-  for (auto &attach_point : *probe.attach_points) {
+  // Probe has at least one attach point (required by the parser)
+  auto &attach_point = (*probe.attach_points)[0];
 
-    // All usdt probes need expansion to be able to read arguments
-    if(probetype(attach_point->provider) == ProbeType::usdt)
-      probe.need_expansion = true;
+  // All usdt probes need expansion to be able to read arguments
+  if (probetype(attach_point->provider) == ProbeType::usdt)
+    probe.need_expansion = true;
 
-    current_attach_point_ = attach_point;
-    break;
-  }
+  current_attach_point_ = attach_point;
+
   /*
    * Most of the time, we can take a probe like kprobe:do_f* and build a
    * single BPF program for that, called "s_kprobe:do_f*", and attach it to

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -277,14 +277,15 @@ void SemanticAnalyser::visit(Builtin &builtin)
       auto matches = bpftrace_.find_wildcard_matches(attach_point->target,
                                                      attach_point->func,
                                                      *symbol_stream);
-      for (auto &match : matches) {
+      if (!matches.empty())
+      {
+        auto &match = *matches.begin();
         std::string tracepoint_struct = TracepointFormatParser::get_struct_name(
             attach_point->target, match);
         Struct &cstruct = bpftrace_.structs_[tracepoint_struct];
         builtin.type = SizedType(Type::cast, cstruct.size, tracepoint_struct);
         builtin.type.is_pointer = true;
         builtin.type.is_tparg = true;
-        break;
       }
     }
   }

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -62,7 +62,8 @@ void SemanticAnalyser::visit(PositionalParameter &param)
   {
     case PositionalParameterType::positional:
       if (param.n <= 0)
-        ERR("$" << param.n + " is not a valid parameter", param.loc);
+        ERR("$" << std::to_string(param.n) + " is not a valid parameter",
+            param.loc);
       if (is_final_pass()) {
         std::string pstr = bpftrace_.get_param(param.n, param.is_in_str);
         if (!is_numeric(pstr) && !param.is_in_str)

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <string>
+#include <tuple>
+#include <vector>
+
 #include "types.h"
 
 #include "libbpf.h"

--- a/src/bfd-disasm.cpp
+++ b/src/bfd-disasm.cpp
@@ -1,10 +1,10 @@
-#include <iostream>
-#include <stdlib.h>
-#include <unistd.h>
-#include <string.h>
-#include <sys/types.h>
-#include <sys/stat.h>
+#include <cstdlib>
+#include <cstring>
 #include <fcntl.h>
+#include <iostream>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 // bfd.h assumes everyone is using autotools and will error out unless
 // PACKAGE is defined. Some distros patch this check out.
 #define PACKAGE "bpftrace"

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -1,8 +1,8 @@
 #include <bcc/libbpf.h>
 #include <bpffeature.h>
+#include <cstddef>
+#include <cstdio>
 #include <fcntl.h>
-#include <stddef.h>
-#include <stdio.h>
 #include <unistd.h>
 
 #include "utils.h"

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -45,7 +45,7 @@ int format(char * s, size_t n, const char * fmt, std::vector<std::unique_ptr<IPr
   int ret = -1;
   switch(args.size()) {
     case 0:
-      ret = snprintf(s, n, fmt);
+      ret = snprintf(s, n, "%s", fmt);
       break;
     case 1:
       ret = snprintf(s, n, fmt, args.at(0)->value());

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1,11 +1,11 @@
-#include <assert.h>
+#include <arpa/inet.h>
+#include <cassert>
+#include <ctime>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <sstream>
 #include <sys/epoll.h>
-#include <time.h>
-#include <arpa/inet.h>
 
 #include <fcntl.h>
 #include <sys/prctl.h>

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -15,7 +15,10 @@
 #ifdef HAVE_LIBBPF_BTF_DUMP
 #include <linux/bpf.h>
 #include <linux/btf.h>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
 #include <bpf/btf.h>
+#pragma GCC diagnostic pop
 #include <bpf/libbpf.h>
 
 namespace bpftrace {

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -2,11 +2,11 @@
 #include "bpftrace.h"
 #include "types.h"
 #include "utils.h"
+#include <cstring>
 #include <fcntl.h>
 #include <iostream>
 #include <linux/limits.h>
 #include <regex>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/utsname.h>

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -1,5 +1,5 @@
+#include <cstring>
 #include <iostream>
-#include <string.h>
 
 #include "llvm/Config/llvm-config.h"
 

--- a/src/disasm.h
+++ b/src/disasm.h
@@ -17,6 +17,7 @@ class IDisasm
 {
 public:
   virtual AlignState is_aligned(uint64_t offset, uint64_t pc) = 0;
+  virtual ~IDisasm() = default;
 };
 
 class Disasm

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,13 +1,12 @@
-#include <iostream>
-#include <fstream>
-#include <signal.h>
-#include <sys/resource.h>
-#include <sys/utsname.h>
+#include <csignal>
 #include <cstdio>
 #include <cstring>
-#include <unistd.h>
-#include <string.h>
+#include <fstream>
 #include <getopt.h>
+#include <iostream>
+#include <sys/resource.h>
+#include <sys/utsname.h>
+#include <unistd.h>
 
 #include "bpffeature.h"
 #include "bpforc.h"

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -1,5 +1,6 @@
-#include "bpftrace.h"
 #include "mapkey.h"
+#include "bpftrace.h"
+#include "utils.h"
 
 namespace bpftrace {
 
@@ -63,37 +64,41 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
       switch (arg.size)
       {
         case 1:
-          return std::to_string(*(const int8_t*)data);
+          return std::to_string(read_data<int8_t>(data));
         case 2:
-          return std::to_string(*(const int16_t*)data);
+          return std::to_string(read_data<int16_t>(data));
         case 4:
-          return std::to_string(*(const int32_t*)data);
+          return std::to_string(read_data<int32_t>(data));
         case 8:
-          return std::to_string(*(const int64_t*)data);
+          return std::to_string(read_data<int64_t>(data));
         default:
           break;
       }
       break;
     case Type::kstack:
-      return bpftrace.get_stack(*(const uint64_t*)data, false, arg.stack_type, 4);
+      return bpftrace.get_stack(
+          read_data<uint64_t>(data), false, arg.stack_type, 4);
     case Type::ustack:
-      return bpftrace.get_stack(*(const uint64_t*)data, true, arg.stack_type, 4);
+      return bpftrace.get_stack(
+          read_data<uint64_t>(data), true, arg.stack_type, 4);
     case Type::ksym:
-      return bpftrace.resolve_ksym(*(const uint64_t*)data);
+      return bpftrace.resolve_ksym(read_data<uint64_t>(data));
     case Type::usym:
-      return bpftrace.resolve_usym(*(const uint64_t*)data, *(const uint64_t*)(arg_data + 8));
+      return bpftrace.resolve_usym(read_data<uint64_t>(data),
+                                   read_data<uint64_t>(arg_data + 8));
     case Type::inet:
-      return bpftrace.resolve_inet(*(const int64_t*)data, (const uint8_t*)(arg_data + 8));
+      return bpftrace.resolve_inet(read_data<int64_t>(data),
+                                   (const uint8_t *)(arg_data + 8));
     case Type::username:
-      return bpftrace.resolve_uid(*(const uint64_t*)data);
+      return bpftrace.resolve_uid(read_data<uint64_t>(data));
     case Type::probe:
-      return bpftrace.probe_ids_[*(const uint64_t*)data];
+      return bpftrace.probe_ids_[read_data<uint64_t>(data)];
     case Type::string:
       return std::string((const char*)data);
     case Type::cast:
       if (arg.is_pointer) {
         // use case: show me these pointer values
-        ptr << "0x" << std::hex << *(const int64_t*)data;
+        ptr << "0x" << std::hex << read_data<int64_t>(data);
         return ptr.str();
       }
       // fall through

--- a/src/printf.h
+++ b/src/printf.h
@@ -7,7 +7,7 @@
 
 namespace bpftrace {
 
-class Field;
+struct Field;
 
 std::string verify_format_string(const std::string& fmt,
                                  std::vector<Field> args);

--- a/src/signal.cpp
+++ b/src/signal.cpp
@@ -2,7 +2,7 @@
 #include <algorithm>
 #include <string>
 
-#include <signal.h>
+#include <csignal>
 
 namespace bpftrace {
 

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -1,7 +1,7 @@
+#include <cstring>
 #include <fstream>
-#include <iostream>
-#include <string.h>
 #include <glob.h>
+#include <iostream>
 
 #include "ast.h"
 #include "struct.h"

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,4 +1,4 @@
-#include <string.h>
+#include <cstring>
 
 #include <algorithm>
 #include <array>

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,8 +1,8 @@
 #pragma once
 
+#include <csignal>
 #include <cstring>
 #include <iostream>
-#include <signal.h>
 #include <sstream>
 #include <string>
 #include <sys/utsname.h>

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstring>
 #include <iostream>
 #include <signal.h>
 #include <sstream>
@@ -148,4 +149,13 @@ inline std::string &trim(std::string &s)
 }
 
 int signal_name_to_num(std::string &signal);
+
+template <typename T>
+T read_data(const void *src)
+{
+  T v;
+  std::memcpy(&v, src, sizeof(v));
+  return v;
+}
+
 } // namespace bpftrace

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -1,3 +1,5 @@
+#include <cstring>
+
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "bpftrace.h"
@@ -517,9 +519,11 @@ std::pair<std::vector<uint8_t>, std::vector<uint8_t>> key_value_pair_int(std::ve
 
   for (size_t i=0; i<key.size(); i++)
   {
-    *(uint64_t*)(key_data + sizeof(uint64_t)*i) = key.at(i);
+    uint64_t k = key.at(i);
+    std::memcpy(key_data + sizeof(uint64_t) * i, &k, sizeof(k));
   }
-  *(uint64_t*)val_data = val;
+  uint64_t v = val;
+  std::memcpy(val_data, &v, sizeof(v));
 
   return pair;
 }
@@ -537,7 +541,8 @@ std::pair<std::vector<uint8_t>, std::vector<uint8_t>> key_value_pair_str(std::ve
   {
     strncpy((char*)key_data + STRING_SIZE*i, key.at(i).c_str(), STRING_SIZE);
   }
-  *(uint64_t*)val_data = val;
+  uint64_t v = val;
+  std::memcpy(val_data, &v, sizeof(v));
 
   return pair;
 }
@@ -551,9 +556,10 @@ std::pair<std::vector<uint8_t>, std::vector<uint8_t>> key_value_pair_int_str(int
   uint8_t *key_data = pair.first.data();
   uint8_t *val_data = pair.second.data();
 
-  *(uint64_t*)key_data = myint;
+  uint64_t k = myint, v = val;
+  std::memcpy(key_data, &k, sizeof(k));
   strncpy((char*)key_data + sizeof(uint64_t), mystr.c_str(), STRING_SIZE);
-  *(uint64_t*)val_data = val;
+  std::memcpy(val_data, &v, sizeof(v));
 
   return pair;
 }

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -9,12 +9,17 @@ namespace test {
 
 class MockBPFtrace : public BPFtrace {
 public:
+#pragma GCC diagnostic push
+#ifdef __clang__
+#pragma GCC diagnostic ignored "-Winconsistent-missing-override"
+#endif
   MOCK_CONST_METHOD1(get_symbols_from_file,
       std::unique_ptr<std::istream>(const std::string &path));
   MOCK_CONST_METHOD2(get_symbols_from_usdt,
       std::unique_ptr<std::istream>(int pid, const std::string &target));
   MOCK_CONST_METHOD1(extract_func_symbols_from_path,
       std::string(const std::string &path));
+#pragma GCC diagnostic pop
   std::vector<Probe> get_probes()
   {
     return probes_;

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -1,8 +1,8 @@
 #include "utils.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include <cstring>
 #include <fcntl.h>
-#include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>


### PR DESCRIPTION
Closes #1093

The reason clang generates these warnings is clang adds more [compile options](https://github.com/llvm-mirror/clang/blob/master/include/clang/Basic/DiagnosticGroups.td) when `-Wall` and `-Wextra` is given than [gcc](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html). In addition, clang is more strict in general  (especially about `-Wcast-align`).

Some warnings come from header files (libbpf and gtest). Suppress these warnings using pragma.