### PR TITLE
Add support for C++ mangled symbols in uprobe names #687

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1,6 +1,7 @@
 #include <arpa/inet.h>
 #include <cassert>
 #include <ctime>
+#include <cxxabi.h>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -137,6 +138,26 @@ int BPFtrace::add_probe(ast::Probe &p)
       }
       attach_funcs.insert(attach_funcs.end(), matches.begin(), matches.end());
     }
+    else if (probetype(attach_point->provider) == ProbeType::uprobe &&
+             !attach_point->func.empty())
+    {
+      std::set<std::string> matches;
+
+      struct symbol sym = {};
+      int err = resolve_uname(attach_point->func, &sym, attach_point->target);
+      if (err < 0 || sym.address == 0)
+      {
+        // As the C++ language supports function overload, a given function name
+        // (without parameters) could have multiple matches even when no
+        // wildcards are used.
+        matches = find_symbol_matches(*attach_point);
+        attach_funcs.insert(attach_funcs.end(), matches.begin(), matches.end());
+      }
+      else
+      {
+        attach_funcs.push_back(attach_point->func);
+      }
+    }
     else
     {
       if (probetype(attach_point->provider) == ProbeType::usdt && !attach_point->ns.empty())
@@ -272,13 +293,78 @@ std::set<std::string> BPFtrace::find_wildcard_matches(
     }
 
     if (!wildcard_match(line, tokens, start_wildcard, end_wildcard))
+    {
+      if (symbol_has_cpp_mangled_signature(line))
+      {
+        char *demangled_name = abi::__cxa_demangle(
+            line.c_str(), nullptr, nullptr, nullptr);
+        if (demangled_name)
+        {
+          if (!wildcard_match(demangled_name, tokens, true, true))
+          {
+            free(demangled_name);
+          }
+          else
+          {
+            free(demangled_name);
+            goto out;
+          }
+        }
+      }
       continue;
-
+    }
+  out:
     // skip the ".part.N" kprobe variants, as they can't be traced:
     if (line.find(".part.") != std::string::npos)
       continue;
 
     matches.insert(line);
+  }
+  return matches;
+}
+
+std::set<std::string> BPFtrace::find_symbol_matches(
+    const ast::AttachPoint &attach_point) const
+{
+  std::unique_ptr<std::istream> symbol_stream;
+  std::string prefix, func;
+
+  symbol_stream = std::make_unique<std::istringstream>(
+      extract_func_symbols_from_path(attach_point.target));
+  func = attach_point.func;
+
+  std::string line;
+  std::set<std::string> matches;
+  while (std::getline(*symbol_stream, line))
+  {
+    if (line != func)
+    {
+      if (symbol_has_cpp_mangled_signature(line))
+      {
+        char *demangled_name = abi::__cxa_demangle(
+            line.c_str(), nullptr, nullptr, nullptr);
+        if (demangled_name)
+        {
+          std::string symbol_name;
+          // If the specified function name has a '(', try to match it against
+          // the full demangled symbol (including parameters), otherwise just
+          // against the function name (without parameters)
+          if (func.find('(') != std::string::npos)
+            symbol_name = demangled_name;
+          else
+            symbol_name =
+                std::string(demangled_name)
+                    .substr(0, std::string(demangled_name).find_first_of("("));
+          free(demangled_name);
+          if (symbol_name == func)
+            matches.insert(line);
+        }
+      }
+    }
+    else
+    {
+      matches.insert(line);
+    }
   }
   return matches;
 }

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -166,6 +166,8 @@ public:
       const std::string &prefix,
       const std::string &func,
       std::istream &symbol_stream) const;
+  std::set<std::string> find_symbol_matches(
+      const ast::AttachPoint &attach_point) const;
   virtual std::unique_ptr<std::istream> get_symbols_from_file(
       const std::string &path) const;
   virtual std::unique_ptr<std::istream> get_symbols_from_usdt(

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -759,4 +759,12 @@ bool is_numeric(const std::string &s)
   return !s.empty() && std::all_of(s.begin(), s.end(), ::isdigit);
 }
 
+bool symbol_has_cpp_mangled_signature(const std::string &sym_name)
+{
+  if (!sym_name.rfind("_Z", 0) || !sym_name.rfind("____Z", 0))
+    return true;
+  else
+    return false;
+}
+
 } // namespace bpftrace

--- a/src/utils.h
+++ b/src/utils.h
@@ -127,6 +127,7 @@ void cat_file(const char *filename, size_t, std::ostream &);
 std::string str_join(const std::vector<std::string> &list,
                      const std::string &delim);
 bool is_numeric(const std::string &str);
+bool symbol_has_cpp_mangled_signature(const std::string &sym_name);
 
 // trim from end of string (right)
 inline std::string &rtrim(std::string &s)

--- a/tests/codegen/builtin_func.cpp
+++ b/tests/codegen/builtin_func.cpp
@@ -43,7 +43,10 @@ attributes #1 = { argmemonly nounwind }
 
 TEST(codegen, builtin_func_uprobe)
 {
-  test("uprobe:/bin/sh:f { @x = func }",
+  auto bpftrace = get_mock_bpftrace();
+
+  test(*bpftrace,
+       "uprobe:/bin/sh:f { @x = func }",
 
        R"EXPECTED(; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -19,6 +19,17 @@ using ::testing::_;
 class MockBPFtrace : public BPFtrace {
 public:
   MOCK_METHOD1(add_probe, int(ast::Probe &p));
+
+  int resolve_uname(const std::string &name,
+                    struct symbol *sym,
+                    const std::string &path) const override
+  {
+    (void)path;
+    sym->name = name;
+    sym->address = 12345;
+    sym->size = 4;
+    return 0;
+  }
 };
 
 TEST(codegen, populate_sections)

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -37,7 +37,9 @@ void setup_mock_bpftrace(MockBPFtrace &bpftrace)
   std::string usyms = "first_open\n"
                       "second_open\n"
                       "open_as_well\n"
-                      "something_else\n";
+                      "something_else\n"
+                      "_Z11cpp_mangledi\n"
+                      "_Z11cpp_mangledv\n";
   ON_CALL(bpftrace, extract_func_symbols_from_path(_))
       .WillByDefault(Return(usyms));
 

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -35,7 +35,11 @@ public:
   {
     (void)path;
     sym->name = name;
-    if (name[0] > 'A' && name[0] < 'z')
+    if (name == "cpp_mangled" || name == "cpp_mangled(int)")
+    {
+      return -1;
+    }
+    else if (name[0] > 'A' && name[0] < 'z')
     {
       sym->address = 12345;
       sym->size = 4;


### PR DESCRIPTION
Allow to specify uprobe names using demangled C++ format (this is done
with the help of abi::__cxa_demangle() function).

Example:

$ nm -g a.out |grep foo
0000000000401151 T _Z3fooi
0000000000401146 T _Z3foov

$ nm -g --demangle a.out |grep foo
0000000000401151 T foo(int)
0000000000401146 T foo()

$ bpftrace -e 'uprobe:./a.out:foo {printf("ok\n");}'
Attaching 2 probes...
^C

$ bpftrace -e 'uprobe:./a.out:"foo()" {printf("ok\n");}'
Attaching 1 probe...
^C