### PR TITLE
Allow to specify only the filename (if it's in the CWD) for uprobes

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -600,7 +600,12 @@ allowing for a PID whose mount namespace should be optionally considered.
 static std::vector<std::string>
 resolve_binary_path(const std::string &cmd, const char *env_paths, int pid)
 {
-  std::vector<std::string> candidate_paths = { cmd };
+  std::vector<std::string> candidate_paths;
+
+  if (cmd[0] != '/' && cmd[0] != '.')
+    candidate_paths.push_back("./" + cmd);
+  else
+    candidate_paths.push_back(cmd);
 
   if (env_paths != nullptr && cmd.find("/") == std::string::npos)
     for (const auto& path : split_string(env_paths, ':'))


### PR DESCRIPTION
Given an a.out binary in the current working directory, it's possible to
list the uprobes using the syntax 'uprobe:a.out':

$ bpftrace -lv 'uprobe:a.out'|grep main
uprobe:a.out:main

But wasn't possible to attach to it using the same syntax...

Before:

$ bpftrace -e 'uprobe:a.out:main {printf("ok\n");}'
Attaching 1 probe...
Could not resolve symbol: a.out:main

After:

$ bpftrace -e 'uprobe:a.out:main {printf("ok\n");}'
Attaching 1 probe...
^C