### PR TITLE
Update vagrant boxes

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,13 @@ For build and install instructions, see [INSTALL.md](INSTALL.md).
 
 For development and testing a [Vagrantfile](Vagrantfile) is available.
 
+Make sure you have the `vbguest` plugin installed, it is required to correctly
+install the shared file system driver on the ubuntu boxes.
+
+```
+$ vagrant plugin install vagrant-vbguest
+```
+
 ## Examples
 
 Count system calls using tracepoints:

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,14 +30,14 @@ EOF
 
 Vagrant.configure("2") do |config|
   boxes = {
-    'ubuntu-18.04' => {
-      'image' => 'ubuntu/bionic64',
-      'scripts' => [ $ubuntu_18_deps, ],
+    'ubuntu-18.04'     => {
+      'image'          => 'ubuntu/bionic64',
+      'scripts'        => [ $ubuntu_18_deps, ],
     },
-    'ubuntu-19.10' => {
-      'image' => 'ubuntu/eoan64',
-      'scripts' => [ $ubuntu_18_deps, ],
-      'fix_console' => 1
+    'ubuntu-19.10'     => {
+      'image'          => 'ubuntu/eoan64',
+      'scripts'        => [ $ubuntu_18_deps, ],
+      'fix_console'    => 1
     },
     'fedora-31'        => {
       'image'          => 'fedora/31-cloud-base',

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -30,21 +30,22 @@ Vagrant.configure("2") do |config|
       'image' => 'ubuntu/bionic64',
       'scripts' => [ $ubuntu_18_deps, ],
     },
-    'ubuntu-18.10' => {
-      'image' => 'ubuntu/cosmic64',
+    'ubuntu-19.10' => {
+      'image' => 'ubuntu/eoan64',
       'scripts' => [ $ubuntu_18_deps, ],
+      'fix_console' => 1
     },
-    'ubuntu-19.04' => {
-      'image' => 'ubuntu/disco64',
-      'scripts' => [ $ubuntu_18_deps, ],
-    },
-  }
+}
   boxes.each do | name, params |
     config.vm.define name do |box|
       box.vm.box = params['image']
       box.vm.provider "virtualbox" do |v|
         v.memory = 2048
         v.cpus = 2
+        if (params['fix_console'] || 0) == 1
+          v.customize ["modifyvm", :id, "--uart1", "0x3F8", "4"]
+          v.customize ["modifyvm", :id, "--uartmode1", "file", "./#{name}_ttyS0.log"]
+        end
       end
       box.vm.provider :libvirt do |v|
         v.memory = 2048


### PR DESCRIPTION
EOL release get removed by ubuntu which causes 404 with vagrant. Instead
of trying to keep EOL releases working we should just stick to the
supported ones.

The ubuntu boxes have 2 issues:

- VM boot takes minutes due to missing serial port. The `fix_console`
  flag fixes that
- The driver for the virtualbox shared fs is missing. The `vbguest`
  Vagrant plugin fixes that.

Related:

- https://bugs.launchpad.net/cloud-images/+bug/1851186
- https://bugs.launchpad.net/cloud-images/+bug/1573095
- https://bugs.launchpad.net/cloud-images/+bug/1829625

Fixes #1114