### PR TITLE
Add missing <string> include to btf.h

### DIFF
--- a/src/btf.h
+++ b/src/btf.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <linux/types.h>
+#include <string>
 #include <unistd.h>
 #include <unordered_set>
 


### PR DESCRIPTION
The missing include was causing building problems with gcc 10.0.1:

In file included from
/builddir/build/BUILD/bpftrace-0.9.4/src/btf.cpp:1:
/builddir/build/BUILD/bpftrace-0.9.4/src/btf.h:26:8: error: 'string' in
namespace 'std' does not name a type
   26 |   std::string c_def(std::unordered_set<std::string>& set);
      |        ^~~~~~
/builddir/build/BUILD/bpftrace-0.9.4/src/btf.h:7:1: note: 'std::string'
is defined in header '<string>'; did you forget to '#include <string>'?
    6 | #include <unordered_set>
  +++ |+#include <string>
    7 |