### PR TITLE
Report kernel instruction limit

### DIFF
--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -24,10 +24,15 @@ public:
   {
     return has_override_return_;
   };
+  bool instruction_limit(void)
+  {
+    return insns_limit_;
+  };
   std::string report(void);
 
 protected:
   bool has_loop_;
+  int insns_limit_;
 
   /* Helpers */
   bool has_signal_;


### PR DESCRIPTION
This makes use of the verifier log to find the instruction limit of the
kernel.

The log message is the similar between all kernel versions I've tested
(centos 7, fedora 31 and ubuntu 19.10) which makes extracting the limit
quite easy, which is also why I left any error handling out.

```
$ bpftrace --info
Kernel helpers
  get_current_cgroup_id: yes
  send_signal: yes
  override_return: no

Kernel features
  Instruction limit: 1000000
  Loop support: yes
```