### PR TITLE
RFC: Probe read split

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -929,6 +929,11 @@ void CodegenLLVM::visit(Call &call)
     expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), arg.type.is_signed);
     b_.CreateOverrideReturn(ctx_, expr_);
   }
+  else if (call.func == "kptr" || call.func == "uptr")
+  {
+    auto &arg = *call.vargs->at(0);
+    arg.accept(*this);
+  }
   else
   {
     std::cerr << "missing codegen for function \"" << call.func << "\"" << std::endl;

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -4,6 +4,7 @@
 #include <ostream>
 
 #include "ast.h"
+#include "bpffeature.h"
 #include "bpftrace.h"
 #include "irbuilderbpf.h"
 #include "map.h"
@@ -22,13 +23,14 @@ using CallArgs = std::vector<std::tuple<std::string, std::vector<Field>>>;
 
 class CodegenLLVM : public Visitor {
 public:
-  explicit CodegenLLVM(Node *root, BPFtrace &bpftrace) :
-    root_(root),
-    module_(std::make_unique<Module>("bpftrace", context_)),
-    b_(context_, *module_.get(), bpftrace),
-    layout_(module_.get()),
-    bpftrace_(bpftrace)
-    { }
+  explicit CodegenLLVM(Node *root, BPFtrace &bpftrace, BPFfeature &feature)
+      : root_(root),
+        module_(std::make_unique<Module>("bpftrace", context_)),
+        b_(context_, *module_.get(), bpftrace, feature),
+        layout_(module_.get()),
+        bpftrace_(bpftrace)
+  {
+  }
 
   void visit(Integer &integer) override;
   void visit(PositionalParameter &param) override;

--- a/src/ast/printer.cpp
+++ b/src/ast/printer.cpp
@@ -14,7 +14,10 @@ std::string Printer::type(const SizedType &ty)
   std::stringstream buf;
   if (print_types)
   {
-    buf << " :: type[" << ty << "]";
+    buf << " :: type[" << ty;
+    if (ty.addrspace != AddrSpace::none)
+      buf << " AS(" << ty.addrspace << ")";
+    buf << "]";
   }
   return buf.str();
 }

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1354,8 +1354,11 @@ void SemanticAnalyser::visit(Binop &binop)
     binop.type.addrspace = laddr;
   else
   {
-    warning("Address space mismatch", binop.loc);
-    binop.type.addrspace = AddrSpace::user;
+    if (is_final_pass())
+    {
+      warning("Address space mismatch", binop.loc);
+      binop.type.addrspace = AddrSpace::user;
+    }
   }
 }
 

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -367,7 +367,7 @@ const struct btf_type *BTF::btf_type_skip_modifiers(const struct btf_type *t)
 
 SizedType BTF::get_stype(__u32 id)
 {
-  SizedType stype = SizedType(Type::none, 8);
+  SizedType stype = SizedType(Type::none, 8, AddrSpace::kernel);
 
   const struct btf_type *t = btf__type_by_id(btf, id);
 

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -29,7 +29,7 @@ vspace  [\n\r]
 space   {hspace}|{vspace}
 path    :(\\.|[_\-\./a-zA-Z0-9#\*])*:
 builtin arg[0-9]|args|cgroup|comm|cpid|cpu|ctx|curtask|elapsed|func|gid|nsecs|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
-call    avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|ksym|lhist|max|min|ntop|override|print|printf|reg|signal|sizeof|stats|str|strncmp|sum|system|time|uaddr|usym|zero
+call    avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|max|min|ntop|override|print|printf|reg|signal|sizeof|stats|str|strncmp|sum|system|time|uaddr|uptr|usym|zero
 
 /* Don't add to this! Use builtin OR call not both */
 call_and_builtin kstack|ustack

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -605,20 +605,8 @@ int main(int argc, char *argv[])
   if (err)
     return err;
 
-  if (!cmd_str.empty())
-  {
-    try
-    {
-      bpftrace.child_ = std::make_unique<ChildProc>(cmd_str);
-    }
-    catch (const std::runtime_error& e)
-    {
-      std::cerr << "Failed to fork child: " << e.what() << std::endl;
-      return -1;
-    }
-  }
+  ast::CodegenLLVM llvm(driver.root_, bpftrace, bpftrace.feature_);
 
-  ast::CodegenLLVM llvm(driver.root_, bpftrace);
   auto bpforc = llvm.compile(bt_debug);
 
   if (bt_debug != DebugLevel::kNone)

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -11,6 +11,12 @@ std::ostream &operator<<(std::ostream &os, Type type)
   return os;
 }
 
+std::ostream &operator<<(std::ostream &os, AddrSpace as)
+{
+  os << addrspacestr(as);
+  return os;
+}
+
 std::ostream &operator<<(std::ostream &os, ProbeType type)
 {
   os << probetypeName(type);
@@ -76,6 +82,25 @@ bool SizedType::IsArray() const
 bool SizedType::IsStack() const
 {
   return type == Type::ustack || type == Type::kstack;
+}
+
+std::string addrspacestr(AddrSpace as)
+{
+  switch (as)
+  {
+    case AddrSpace::kernel:
+      return "kernel";
+      break;
+    case AddrSpace::user:
+      return "user";
+      break;
+    case AddrSpace::none:
+      return "none";
+      break;
+    default:
+      std::cerr << "Unknown addrspace" << std::endl;
+      abort();
+  }
 }
 
 std::string typestr(Type t)

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -11,6 +11,12 @@ std::ostream &operator<<(std::ostream &os, Type type)
   return os;
 }
 
+std::ostream &operator<<(std::ostream &os, ProbeType type)
+{
+  os << probetypeName(type);
+  return os;
+}
+
 std::ostream &operator<<(std::ostream &os, const SizedType &type)
 {
   if (type.type == Type::cast)

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -200,4 +200,17 @@ uint64_t asyncactionint(AsyncAction a)
   return (uint64_t)a;
 }
 
+AddrSpace addrspace_for(ProbeType ty)
+{
+  switch (ty)
+  {
+    case ProbeType::uprobe:
+    case ProbeType::uretprobe:
+    case ProbeType::usdt:
+      return AddrSpace::user;
+    default:
+      return AddrSpace::kernel;
+  }
+}
+
 } // namespace bpftrace

--- a/src/types.h
+++ b/src/types.h
@@ -124,6 +124,8 @@ enum class ProbeType
   kretfunc,
 };
 
+std::ostream &operator<<(std::ostream &os, ProbeType type);
+
 struct ProbeItem
 {
   std::string name;

--- a/src/types.h
+++ b/src/types.h
@@ -81,8 +81,29 @@ struct SizedType
       : type(type), size(size_), is_signed(is_signed), cast_type(cast_type)
   {
   }
+  SizedType(Type type,
+            size_t size_,
+            bool is_signed,
+            AddrSpace as,
+            const std::string &cast_type = "")
+      : type(type),
+        size(size_),
+        is_signed(is_signed),
+        addrspace(as),
+        cast_type(cast_type)
+  {
+  }
+
   SizedType(Type type, size_t size_, const std::string &cast_type = "")
       : type(type), size(size_), cast_type(cast_type)
+  {
+  }
+
+  SizedType(Type type,
+            size_t size_,
+            AddrSpace as,
+            const std::string &cast_type = "")
+      : type(type), size(size_), addrspace(as), cast_type(cast_type)
   {
   }
 
@@ -90,18 +111,19 @@ struct SizedType
   {
     stack_type = stack_type_;
   }
+
   Type type;
   Type elem_type = Type::none; // Array element type if accessing elements of an
                                // array
   size_t size;
   StackType stack_type;
   bool is_signed = false;
+  AddrSpace addrspace = AddrSpace::none;
   std::string cast_type;
   bool is_internal = false;
   bool is_pointer = false;
   bool is_tparg = false;
   bool is_kfarg = false;
-  AddrSpace addrspace = AddrSpace::none;
   size_t pointee_size = 0;
   int kfarg_idx = -1;
 
@@ -209,6 +231,8 @@ enum class PositionalParameterType
   positional,
   count
 };
+
+AddrSpace addrspace_for(ProbeType ty);
 
 } // namespace bpftrace
 

--- a/src/types.h
+++ b/src/types.h
@@ -45,7 +45,15 @@ enum class Type
   // clang-format on
 };
 
+enum class AddrSpace
+{
+  none,
+  kernel,
+  user,
+};
+
 std::ostream &operator<<(std::ostream &os, Type type);
+std::ostream &operator<<(std::ostream &os, AddrSpace as);
 
 enum class StackMode
 {
@@ -93,6 +101,7 @@ struct SizedType
   bool is_pointer = false;
   bool is_tparg = false;
   bool is_kfarg = false;
+  AddrSpace addrspace = AddrSpace::none;
   size_t pointee_size = 0;
   int kfarg_idx = -1;
 
@@ -152,8 +161,9 @@ const std::vector<ProbeItem> PROBE_LIST =
   { "kretfunc", "fr", ProbeType::kretfunc },
 };
 
-std::string typestr(Type t);
 ProbeType probetype(const std::string &type);
+std::string addrspacestr(AddrSpace as);
+std::string typestr(Type t);
 std::string probetypeName(const std::string &type);
 std::string probetypeName(ProbeType t);
 

--- a/tests/codegen/call_kstack.cpp
+++ b/tests/codegen/call_kstack.cpp
@@ -33,7 +33,7 @@ TEST(codegen, call_kstack_mapids)
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 
-  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  ast::CodegenLLVM codegen(driver.root_, bpftrace, feature);
   codegen.compile();
 
   ASSERT_EQ(FakeMap::next_mapfd_, 7);
@@ -64,7 +64,7 @@ TEST(codegen, call_kstack_modes_mapids)
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 
-  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  ast::CodegenLLVM codegen(driver.root_, bpftrace, feature);
   codegen.compile();
 
   ASSERT_EQ(FakeMap::next_mapfd_, 7);

--- a/tests/codegen/call_ustack.cpp
+++ b/tests/codegen/call_ustack.cpp
@@ -33,7 +33,7 @@ TEST(codegen, call_ustack_mapids)
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 
-  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  ast::CodegenLLVM codegen(driver.root_, bpftrace, feature);
   codegen.compile();
 
   ASSERT_EQ(FakeMap::next_mapfd_, 7);
@@ -64,7 +64,7 @@ TEST(codegen, call_ustack_modes_mapids)
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 
-  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  ast::CodegenLLVM codegen(driver.root_, bpftrace, feature);
   codegen.compile();
 
   ASSERT_EQ(FakeMap::next_mapfd_, 7);

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -355,10 +355,6 @@ static void test(BPFtrace &bpftrace,
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 
-  ast::Printer p(std::cout, true);
-  driver.root_->accept(p);
-  std::cout << std::endl;
-
   std::stringstream out;
   ast::CodegenLLVM codegen(driver.root_, bpftrace, feature);
   codegen.compile(DebugLevel::kDebug, out);

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -16,6 +16,8 @@
 #include "semantic_analyser.h"
 #include "tracepoint_format_parser.h"
 
+#include "printer.h"
+
 namespace bpftrace {
 namespace test {
 namespace codegen {
@@ -349,11 +351,16 @@ static void test(BPFtrace &bpftrace,
 
   MockBPFfeature feature;
   ast::SemanticAnalyser semantics(driver.root_, bpftrace, feature);
+
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 
+  ast::Printer p(std::cout, true);
+  driver.root_->accept(p);
+  std::cout << std::endl;
+
   std::stringstream out;
-  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  ast::CodegenLLVM codegen(driver.root_, bpftrace, feature);
   codegen.compile(DebugLevel::kDebug, out);
 
   uint64_t update_tests = 0;

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -48,7 +48,7 @@ TEST(codegen, populate_sections)
   ast::SemanticAnalyser semantics(driver.root_, bpftrace, feature);
   ASSERT_EQ(semantics.analyse(), 0);
   std::stringstream out;
-  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  ast::CodegenLLVM codegen(driver.root_, bpftrace, feature);
   auto bpforc = codegen.compile();
 
   // Check sections are populated
@@ -77,7 +77,7 @@ TEST(codegen, printf_offsets)
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
   std::stringstream out;
-  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  ast::CodegenLLVM codegen(driver.root_, bpftrace, feature);
   auto bpforc = codegen.compile();
 
   EXPECT_EQ(bpftrace.printf_args_.size(), 1U);
@@ -118,7 +118,7 @@ TEST(codegen, probe_count)
   MockBPFfeature feature;
   ast::SemanticAnalyser semantics(driver.root_, bpftrace, feature);
   ASSERT_EQ(semantics.analyse(), 0);
-  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  ast::CodegenLLVM codegen(driver.root_, bpftrace, feature);
   codegen.compile();
 }
 } // namespace codegen

--- a/tests/codegen/llvm/builtin_ctx_field.ll
+++ b/tests/codegen/llvm/builtin_ctx_field.ll
@@ -67,7 +67,7 @@ entry:
   %19 = inttoptr i64 %18 to i64*
   %20 = load volatile i64, i64* %19, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %"struct c.c")
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i64)*)(i8* nonnull %"struct c.c", i32 1, i64 %20)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* nonnull %"struct c.c", i32 1, i64 %20)
   %21 = load i8, i8* %"struct c.c", align 1
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %"struct c.c")
   %22 = bitcast i64* %"@d_key" to i8*

--- a/tests/codegen/llvm/builtin_sarg.ll
+++ b/tests/codegen/llvm/builtin_sarg.ll
@@ -23,7 +23,7 @@ entry:
   %3 = bitcast i64* %sarg0 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   %4 = add i64 %reg_sp, 8
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* nonnull %sarg0, i32 8, i64 %4)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* nonnull %sarg0, i32 8, i64 %4)
   %5 = load i64, i64* %sarg0, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %6 = bitcast i64* %"@x_key" to i8*
@@ -40,7 +40,7 @@ entry:
   %8 = bitcast i64* %sarg2 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   %9 = add i64 %reg_sp1, 24
-  %probe_read2 = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* nonnull %sarg2, i32 8, i64 %9)
+  %probe_read_kernel2 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* nonnull %sarg2, i32 8, i64 %9)
   %10 = load i64, i64* %sarg2, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   %11 = bitcast i64* %"@y_key" to i8*

--- a/tests/codegen/llvm/call_buf_implicit_size.ll
+++ b/tests/codegen/llvm/call_buf_implicit_size.ll
@@ -21,7 +21,7 @@ entry:
   %2 = getelementptr inbounds %buffer_16_t, %buffer_16_t* %buffer, i64 0, i32 1
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %3, i8 0, i64 16, i1 false)
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* nonnull %2, i8 16, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* nonnull %2, i8 16, i64 0)
   %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/llvm/call_buf_size_literal.ll
+++ b/tests/codegen/llvm/call_buf_size_literal.ll
@@ -22,7 +22,7 @@ entry:
   %3 = getelementptr i8, i8* %0, i64 112
   %4 = bitcast i8* %3 to i64*
   %arg0 = load volatile i64, i64* %4, align 8
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([1 x i8]*, i32, i64)*)([1 x i8]* nonnull %2, i64 1, i64 %arg0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([1 x i8]*, i32, i64)*)([1 x i8]* nonnull %2, i64 1, i64 %arg0)
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/llvm/call_buf_size_nonliteral.ll
+++ b/tests/codegen/llvm/call_buf_size_nonliteral.ll
@@ -29,7 +29,7 @@ entry:
   %7 = getelementptr i8, i8* %0, i64 112
   %8 = bitcast i8* %7 to i64*
   %arg0 = load volatile i64, i64* %8, align 8
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* nonnull %5, i64 %length.select, i64 %arg0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* nonnull %5, i64 %length.select, i64 %arg0)
   %9 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/llvm/call_ntop_char16.ll
+++ b/tests/codegen/llvm/call_ntop_char16.ll
@@ -22,7 +22,7 @@ entry:
   %3 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
   %4 = getelementptr inbounds [16 x i8], [16 x i8]* %3, i64 0, i64 0
   call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %4, i8 0, i64 16, i1 false)
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* nonnull %3, i32 16, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* nonnull %3, i32 16, i64 0)
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/llvm/call_ntop_char4.ll
+++ b/tests/codegen/llvm/call_ntop_char4.ll
@@ -22,7 +22,7 @@ entry:
   %3 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
   %4 = getelementptr inbounds [16 x i8], [16 x i8]* %3, i64 0, i64 0
   call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %4, i8 0, i64 16, i1 false)
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* nonnull %3, i32 4, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* nonnull %3, i32 4, i64 0)
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/llvm/call_printf.ll
+++ b/tests/codegen/llvm/call_printf.ll
@@ -21,14 +21,14 @@ entry:
   %2 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %2, i8 0, i64 16, i1 false)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %"struct Foo.c")
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i64)*)(i8* nonnull %"struct Foo.c", i32 1, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* nonnull %"struct Foo.c", i32 1, i64 0)
   %3 = load i8, i8* %"struct Foo.c", align 1
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %"struct Foo.c")
   %4 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
   store i8 %3, i64* %4, align 8
   %5 = bitcast i64* %"struct Foo.l" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* nonnull %"struct Foo.l", i32 8, i64 8)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* nonnull %"struct Foo.l", i32 8, i64 8)
   %6 = load i64, i64* %"struct Foo.l", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   %7 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2

--- a/tests/codegen/llvm/call_sizeof.ll
+++ b/tests/codegen/llvm/call_sizeof.ll
@@ -7,7 +7,7 @@ target triple = "bpf-pc-linux"
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 define i64 @BEGIN(i8* nocapture readnone) local_unnamed_addr section "s_BEGIN_1" {
 entry:
@@ -27,7 +27,7 @@ entry:
 }
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/call_str.ll
+++ b/tests/codegen/llvm/call_str.ll
@@ -19,7 +19,7 @@ entry:
   %2 = getelementptr i8, i8* %0, i64 112
   %3 = bitcast i8* %2 to i64*
   %arg0 = load volatile i64, i64* %3, align 8
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* nonnull %str, i32 64, i64 %arg0)
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* nonnull %str, i32 64, i64 %arg0)
   %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/llvm/call_str_2_expr.ll
+++ b/tests/codegen/llvm/call_str_2_expr.ll
@@ -26,7 +26,7 @@ entry:
   %7 = bitcast i8* %6 to i64*
   %arg0 = load volatile i64, i64* %7, align 8
   %8 = trunc i64 %str.min.select to i32
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* nonnull %str, i32 %8, i64 %arg0)
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* nonnull %str, i32 %8, i64 %arg0)
   %9 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/llvm/call_str_2_lit.ll
+++ b/tests/codegen/llvm/call_str_2_lit.ll
@@ -19,7 +19,7 @@ entry:
   %2 = getelementptr i8, i8* %0, i64 112
   %3 = bitcast i8* %2 to i64*
   %arg0 = load volatile i64, i64* %3, align 8
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* nonnull %str, i32 7, i64 %arg0)
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* nonnull %str, i32 7, i64 %arg0)
   %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/llvm/dereference.ll
+++ b/tests/codegen/llvm/dereference.ll
@@ -16,7 +16,7 @@ entry:
   %deref = alloca i64, align 8
   %1 = bitcast i64* %deref to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* nonnull %deref, i32 8, i64 1234)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* nonnull %deref, i32 8, i64 1234)
   %2 = load i64, i64* %deref, align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/intptrcast_assign_var.ll
+++ b/tests/codegen/llvm/intptrcast_assign_var.ll
@@ -19,7 +19,7 @@ entry:
   %reg_bp = load volatile i64, i64* %2, align 8
   %3 = add i64 %reg_bp, -1
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %deref)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i64)*)(i8* nonnull %deref, i32 1, i64 %3)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* nonnull %deref, i32 1, i64 %3)
   %4 = load i8, i8* %deref, align 1
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %deref)
   %5 = bitcast i64* %"@_key" to i8*

--- a/tests/codegen/llvm/intptrcast_call.ll
+++ b/tests/codegen/llvm/intptrcast_call.ll
@@ -36,7 +36,7 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   %reg_bp = load volatile i64, i64* %5, align 8
   %6 = add i64 %reg_bp, -1
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %deref)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i64)*)(i8* nonnull %deref, i32 1, i64 %6)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* nonnull %deref, i32 1, i64 %6)
   %7 = load i8, i8* %deref, align 1
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %deref)
   %8 = sext i8 %7 to i64

--- a/tests/codegen/llvm/logical_and_or_different_type.ll
+++ b/tests/codegen/llvm/logical_and_or_different_type.ll
@@ -32,13 +32,13 @@ entry:
   %5 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
   store i64 0, i64* %5, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* nonnull %"struct Foo.m", i32 4, [4 x i8]* nonnull %tmpcast)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, [4 x i8]*)*)(i32* nonnull %"struct Foo.m", i32 4, [4 x i8]* nonnull %tmpcast)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %6 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
   store i64 0, i64* %6, align 8
   %7 = bitcast i32* %"struct Foo.m6" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* nonnull %"struct Foo.m6", i32 4, [4 x i8]* nonnull %tmpcast)
+  %probe_read_kernel7 = call i64 inttoptr (i64 113 to i64 (i32*, i32, [4 x i8]*)*)(i32* nonnull %"struct Foo.m6", i32 4, [4 x i8]* nonnull %tmpcast)
   %8 = load i32, i32* %"struct Foo.m6", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   %rhs_true_cond = icmp ne i32 %8, 0
@@ -47,7 +47,7 @@ entry:
   store i64 %"&&_result5.0", i64* %9, align 8
   %10 = bitcast i32* %"struct Foo.m8" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
-  %probe_read9 = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* nonnull %"struct Foo.m8", i32 4, [4 x i8]* nonnull %tmpcast)
+  %probe_read_kernel9 = call i64 inttoptr (i64 113 to i64 (i32*, i32, [4 x i8]*)*)(i32* nonnull %"struct Foo.m8", i32 4, [4 x i8]* nonnull %tmpcast)
   %11 = load i32, i32* %"struct Foo.m8", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
   %lhs_true_cond10 = icmp ne i32 %11, 0
@@ -56,7 +56,7 @@ entry:
   store i64 %"||_result.0", i64* %12, align 8
   %13 = bitcast i32* %"struct Foo.m16" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %13)
-  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* nonnull %"struct Foo.m16", i32 4, [4 x i8]* nonnull %tmpcast)
+  %probe_read_kernel17 = call i64 inttoptr (i64 113 to i64 (i32*, i32, [4 x i8]*)*)(i32* nonnull %"struct Foo.m16", i32 4, [4 x i8]* nonnull %tmpcast)
   %14 = load i32, i32* %"struct Foo.m16", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %13)
   %rhs_true_cond18 = icmp ne i32 %14, 0

--- a/tests/codegen/llvm/optional_positional_parameter.ll
+++ b/tests/codegen/llvm/optional_positional_parameter.ll
@@ -32,7 +32,7 @@ entry:
   %4 = getelementptr inbounds [1 x i8], [1 x i8]* %str1, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i8 0, i8* %4, align 1
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, [1 x i8]*)*)([64 x i8]* nonnull %str, i32 64, [1 x i8]* nonnull %str1)
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, [1 x i8]*)*)([64 x i8]* nonnull %str, i32 64, [1 x i8]* nonnull %str1)
   %5 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@y_key", align 8

--- a/tests/codegen/llvm/string_equal_comparison.ll
+++ b/tests/codegen/llvm/string_equal_comparison.ll
@@ -12,7 +12,7 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kretprobe:vfs_read"(i8* nocapture readnone) local_unnamed_addr section "s_kretprobe:vfs_read_1" {
 entry:
   %"@_val" = alloca i64, align 8
-  %comm9 = alloca [16 x i8], align 1
+  %comm7 = alloca [16 x i8], align 1
   %comm = alloca [16 x i8], align 1
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
@@ -22,16 +22,16 @@ entry:
   %strcmp.cmp = icmp eq i8 %2, 115
   br i1 %strcmp.cmp, label %strcmp.loop, label %pred_false
 
-pred_false:                                       ; preds = %strcmp.loop5, %strcmp.loop3, %strcmp.loop1, %strcmp.loop, %entry
+pred_false:                                       ; preds = %strcmp.loop3, %strcmp.loop1, %strcmp.loop, %entry
   ret i64 0
 
-pred_true:                                        ; preds = %strcmp.loop5
-  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %comm9, i64 0, i64 0
+pred_true:                                        ; preds = %strcmp.loop3
+  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %comm7, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %3, i8 0, i64 16, i1 false)
-  %get_comm10 = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* nonnull %comm9, i64 16)
+  %get_comm8 = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* nonnull %comm7, i64 16)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [16 x i8]*)*)(i64 %pseudo, [16 x i8]* nonnull %comm9)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [16 x i8]*)*)(i64 %pseudo, [16 x i8]* nonnull %comm7)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -51,29 +51,23 @@ strcmp.loop3:                                     ; preds = %strcmp.loop1
   %8 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 3
   %9 = load i8, i8* %8, align 1
   %strcmp.cmp6 = icmp eq i8 %9, 100
-  br i1 %strcmp.cmp6, label %strcmp.loop5, label %pred_false
-
-strcmp.loop5:                                     ; preds = %strcmp.loop3
-  %10 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 4
-  %11 = load i8, i8* %10, align 1
-  %strcmp.cmp8 = icmp eq i8 %11, 0
-  br i1 %strcmp.cmp8, label %pred_true, label %pred_false
+  br i1 %strcmp.cmp6, label %pred_true, label %pred_false
 
 lookup_success:                                   ; preds = %pred_true
   %cast = bitcast i8* %lookup_elem to i64*
-  %12 = load i64, i64* %cast, align 8
-  %phitmp = add i64 %12, 1
+  %10 = load i64, i64* %cast, align 8
+  %phitmp = add i64 %10, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %pred_true, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %pred_true ]
-  %13 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %13)
+  %11 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %11)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
-  %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo11, [16 x i8]* nonnull %comm9, i64* nonnull %"@_val", i64 0)
+  %pseudo9 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo9, [16 x i8]* nonnull %comm7, i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %13)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %11)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/string_not_equal_comparison.ll
+++ b/tests/codegen/llvm/string_not_equal_comparison.ll
@@ -12,7 +12,7 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kretprobe:vfs_read"(i8* nocapture readnone) local_unnamed_addr section "s_kretprobe:vfs_read_1" {
 entry:
   %"@_val" = alloca i64, align 8
-  %comm9 = alloca [16 x i8], align 1
+  %comm7 = alloca [16 x i8], align 1
   %comm = alloca [16 x i8], align 1
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
@@ -22,16 +22,16 @@ entry:
   %strcmp.cmp = icmp eq i8 %2, 115
   br i1 %strcmp.cmp, label %strcmp.loop, label %pred_true
 
-pred_false:                                       ; preds = %strcmp.loop5
+pred_false:                                       ; preds = %strcmp.loop3
   ret i64 0
 
-pred_true:                                        ; preds = %strcmp.loop5, %strcmp.loop3, %strcmp.loop1, %strcmp.loop, %entry
-  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %comm9, i64 0, i64 0
+pred_true:                                        ; preds = %strcmp.loop3, %strcmp.loop1, %strcmp.loop, %entry
+  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %comm7, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %3, i8 0, i64 16, i1 false)
-  %get_comm10 = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* nonnull %comm9, i64 16)
+  %get_comm8 = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* nonnull %comm7, i64 16)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [16 x i8]*)*)(i64 %pseudo, [16 x i8]* nonnull %comm9)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [16 x i8]*)*)(i64 %pseudo, [16 x i8]* nonnull %comm7)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
@@ -51,29 +51,23 @@ strcmp.loop3:                                     ; preds = %strcmp.loop1
   %8 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 3
   %9 = load i8, i8* %8, align 1
   %strcmp.cmp6 = icmp eq i8 %9, 100
-  br i1 %strcmp.cmp6, label %strcmp.loop5, label %pred_true
-
-strcmp.loop5:                                     ; preds = %strcmp.loop3
-  %10 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 4
-  %11 = load i8, i8* %10, align 1
-  %strcmp.cmp8 = icmp eq i8 %11, 0
-  br i1 %strcmp.cmp8, label %pred_false, label %pred_true
+  br i1 %strcmp.cmp6, label %pred_false, label %pred_true
 
 lookup_success:                                   ; preds = %pred_true
   %cast = bitcast i8* %lookup_elem to i64*
-  %12 = load i64, i64* %cast, align 8
-  %phitmp = add i64 %12, 1
+  %10 = load i64, i64* %cast, align 8
+  %phitmp = add i64 %10, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %pred_true, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %pred_true ]
-  %13 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %13)
+  %11 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %11)
   store i64 %lookup_elem_val.0, i64* %"@_val", align 8
-  %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo11, [16 x i8]* nonnull %comm9, i64* nonnull %"@_val", i64 0)
+  %pseudo9 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo9, [16 x i8]* nonnull %comm7, i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %13)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %11)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/strncmp.ll
+++ b/tests/codegen/llvm/strncmp.ll
@@ -28,12 +28,12 @@ entry:
   %4 = add i64 %3, 8
   %5 = inttoptr i64 %4 to i64*
   %6 = load volatile i64, i64* %5, align 8
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* nonnull %str, i32 64, i64 %6)
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* nonnull %str, i32 64, i64 %6)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char_l)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %strcmp.char_r)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %2)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %2)
   %7 = load i8, i8* %strcmp.char_l, align 1
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %1)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %1)
   %8 = load i8, i8* %strcmp.char_r, align 1
   %strcmp.cmp = icmp eq i8 %7, %8
   br i1 %strcmp.cmp, label %strcmp.loop_null_cmp, label %pred_false.critedge
@@ -68,10 +68,10 @@ strcmp.false:                                     ; preds = %strcmp.loop86, %str
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
   %11 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 1
-  %probe_read4 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %11)
+  %probe_read_kernel4 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %11)
   %12 = load i8, i8* %strcmp.char_l, align 1
   %13 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 1
-  %probe_read5 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %13)
+  %probe_read_kernel5 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %13)
   %14 = load i8, i8* %strcmp.char_r, align 1
   %strcmp.cmp6 = icmp eq i8 %12, %14
   br i1 %strcmp.cmp6, label %strcmp.loop_null_cmp3, label %strcmp.false
@@ -82,10 +82,10 @@ strcmp.loop_null_cmp:                             ; preds = %entry
 
 strcmp.loop2:                                     ; preds = %strcmp.loop_null_cmp3
   %15 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 2
-  %probe_read10 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %15)
+  %probe_read_kernel10 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %15)
   %16 = load i8, i8* %strcmp.char_l, align 1
   %17 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 2
-  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %17)
+  %probe_read_kernel11 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %17)
   %18 = load i8, i8* %strcmp.char_r, align 1
   %strcmp.cmp12 = icmp eq i8 %16, %18
   br i1 %strcmp.cmp12, label %strcmp.loop_null_cmp9, label %strcmp.false
@@ -96,10 +96,10 @@ strcmp.loop_null_cmp3:                            ; preds = %strcmp.loop
 
 strcmp.loop8:                                     ; preds = %strcmp.loop_null_cmp9
   %19 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 3
-  %probe_read16 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %19)
+  %probe_read_kernel16 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %19)
   %20 = load i8, i8* %strcmp.char_l, align 1
   %21 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 3
-  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %21)
+  %probe_read_kernel17 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %21)
   %22 = load i8, i8* %strcmp.char_r, align 1
   %strcmp.cmp18 = icmp eq i8 %20, %22
   br i1 %strcmp.cmp18, label %strcmp.loop_null_cmp15, label %strcmp.false
@@ -110,10 +110,10 @@ strcmp.loop_null_cmp9:                            ; preds = %strcmp.loop2
 
 strcmp.loop14:                                    ; preds = %strcmp.loop_null_cmp15
   %23 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 4
-  %probe_read22 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %23)
+  %probe_read_kernel22 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %23)
   %24 = load i8, i8* %strcmp.char_l, align 1
   %25 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 4
-  %probe_read23 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %25)
+  %probe_read_kernel23 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %25)
   %26 = load i8, i8* %strcmp.char_r, align 1
   %strcmp.cmp24 = icmp eq i8 %24, %26
   br i1 %strcmp.cmp24, label %strcmp.loop_null_cmp21, label %strcmp.false
@@ -124,10 +124,10 @@ strcmp.loop_null_cmp15:                           ; preds = %strcmp.loop8
 
 strcmp.loop20:                                    ; preds = %strcmp.loop_null_cmp21
   %27 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 5
-  %probe_read28 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %27)
+  %probe_read_kernel28 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %27)
   %28 = load i8, i8* %strcmp.char_l, align 1
   %29 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 5
-  %probe_read29 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %29)
+  %probe_read_kernel29 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %29)
   %30 = load i8, i8* %strcmp.char_r, align 1
   %strcmp.cmp30 = icmp eq i8 %28, %30
   br i1 %strcmp.cmp30, label %strcmp.loop_null_cmp27, label %strcmp.false
@@ -138,10 +138,10 @@ strcmp.loop_null_cmp21:                           ; preds = %strcmp.loop14
 
 strcmp.loop26:                                    ; preds = %strcmp.loop_null_cmp27
   %31 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 6
-  %probe_read34 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %31)
+  %probe_read_kernel34 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %31)
   %32 = load i8, i8* %strcmp.char_l, align 1
   %33 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 6
-  %probe_read35 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %33)
+  %probe_read_kernel35 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %33)
   %34 = load i8, i8* %strcmp.char_r, align 1
   %strcmp.cmp36 = icmp eq i8 %32, %34
   br i1 %strcmp.cmp36, label %strcmp.loop_null_cmp33, label %strcmp.false
@@ -152,10 +152,10 @@ strcmp.loop_null_cmp27:                           ; preds = %strcmp.loop20
 
 strcmp.loop32:                                    ; preds = %strcmp.loop_null_cmp33
   %35 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 7
-  %probe_read40 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %35)
+  %probe_read_kernel40 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %35)
   %36 = load i8, i8* %strcmp.char_l, align 1
   %37 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 7
-  %probe_read41 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %37)
+  %probe_read_kernel41 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %37)
   %38 = load i8, i8* %strcmp.char_r, align 1
   %strcmp.cmp42 = icmp eq i8 %36, %38
   br i1 %strcmp.cmp42, label %strcmp.loop_null_cmp39, label %strcmp.false
@@ -166,10 +166,10 @@ strcmp.loop_null_cmp33:                           ; preds = %strcmp.loop26
 
 strcmp.loop38:                                    ; preds = %strcmp.loop_null_cmp39
   %39 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 8
-  %probe_read46 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %39)
+  %probe_read_kernel46 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %39)
   %40 = load i8, i8* %strcmp.char_l, align 1
   %41 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 8
-  %probe_read47 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %41)
+  %probe_read_kernel47 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %41)
   %42 = load i8, i8* %strcmp.char_r, align 1
   %strcmp.cmp48 = icmp eq i8 %40, %42
   br i1 %strcmp.cmp48, label %strcmp.loop_null_cmp45, label %strcmp.false
@@ -180,10 +180,10 @@ strcmp.loop_null_cmp39:                           ; preds = %strcmp.loop32
 
 strcmp.loop44:                                    ; preds = %strcmp.loop_null_cmp45
   %43 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 9
-  %probe_read52 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %43)
+  %probe_read_kernel52 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %43)
   %44 = load i8, i8* %strcmp.char_l, align 1
   %45 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 9
-  %probe_read53 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %45)
+  %probe_read_kernel53 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %45)
   %46 = load i8, i8* %strcmp.char_r, align 1
   %strcmp.cmp54 = icmp eq i8 %44, %46
   br i1 %strcmp.cmp54, label %strcmp.loop_null_cmp51, label %strcmp.false
@@ -194,10 +194,10 @@ strcmp.loop_null_cmp45:                           ; preds = %strcmp.loop38
 
 strcmp.loop50:                                    ; preds = %strcmp.loop_null_cmp51
   %47 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 10
-  %probe_read58 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %47)
+  %probe_read_kernel58 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %47)
   %48 = load i8, i8* %strcmp.char_l, align 1
   %49 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 10
-  %probe_read59 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %49)
+  %probe_read_kernel59 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %49)
   %50 = load i8, i8* %strcmp.char_r, align 1
   %strcmp.cmp60 = icmp eq i8 %48, %50
   br i1 %strcmp.cmp60, label %strcmp.loop_null_cmp57, label %strcmp.false
@@ -208,10 +208,10 @@ strcmp.loop_null_cmp51:                           ; preds = %strcmp.loop44
 
 strcmp.loop56:                                    ; preds = %strcmp.loop_null_cmp57
   %51 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 11
-  %probe_read64 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %51)
+  %probe_read_kernel64 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %51)
   %52 = load i8, i8* %strcmp.char_l, align 1
   %53 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 11
-  %probe_read65 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %53)
+  %probe_read_kernel65 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %53)
   %54 = load i8, i8* %strcmp.char_r, align 1
   %strcmp.cmp66 = icmp eq i8 %52, %54
   br i1 %strcmp.cmp66, label %strcmp.loop_null_cmp63, label %strcmp.false
@@ -222,10 +222,10 @@ strcmp.loop_null_cmp57:                           ; preds = %strcmp.loop50
 
 strcmp.loop62:                                    ; preds = %strcmp.loop_null_cmp63
   %55 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 12
-  %probe_read70 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %55)
+  %probe_read_kernel70 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %55)
   %56 = load i8, i8* %strcmp.char_l, align 1
   %57 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 12
-  %probe_read71 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %57)
+  %probe_read_kernel71 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %57)
   %58 = load i8, i8* %strcmp.char_r, align 1
   %strcmp.cmp72 = icmp eq i8 %56, %58
   br i1 %strcmp.cmp72, label %strcmp.loop_null_cmp69, label %strcmp.false
@@ -236,10 +236,10 @@ strcmp.loop_null_cmp63:                           ; preds = %strcmp.loop56
 
 strcmp.loop68:                                    ; preds = %strcmp.loop_null_cmp69
   %59 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 13
-  %probe_read76 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %59)
+  %probe_read_kernel76 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %59)
   %60 = load i8, i8* %strcmp.char_l, align 1
   %61 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 13
-  %probe_read77 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %61)
+  %probe_read_kernel77 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %61)
   %62 = load i8, i8* %strcmp.char_r, align 1
   %strcmp.cmp78 = icmp eq i8 %60, %62
   br i1 %strcmp.cmp78, label %strcmp.loop_null_cmp75, label %strcmp.false
@@ -250,10 +250,10 @@ strcmp.loop_null_cmp69:                           ; preds = %strcmp.loop62
 
 strcmp.loop74:                                    ; preds = %strcmp.loop_null_cmp75
   %63 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 14
-  %probe_read82 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %63)
+  %probe_read_kernel82 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %63)
   %64 = load i8, i8* %strcmp.char_l, align 1
   %65 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 14
-  %probe_read83 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %65)
+  %probe_read_kernel83 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %65)
   %66 = load i8, i8* %strcmp.char_r, align 1
   %strcmp.cmp84 = icmp eq i8 %64, %66
   br i1 %strcmp.cmp84, label %strcmp.loop_null_cmp81, label %strcmp.false
@@ -264,10 +264,10 @@ strcmp.loop_null_cmp75:                           ; preds = %strcmp.loop68
 
 strcmp.loop80:                                    ; preds = %strcmp.loop_null_cmp81
   %67 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 15
-  %probe_read88 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %67)
+  %probe_read_kernel88 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %67)
   %68 = load i8, i8* %strcmp.char_l, align 1
   %69 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 15
-  %probe_read89 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %69)
+  %probe_read_kernel89 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %69)
   %70 = load i8, i8* %strcmp.char_r, align 1
   %strcmp.cmp90 = icmp eq i8 %68, %70
   br i1 %strcmp.cmp90, label %strcmp.loop_null_cmp87, label %strcmp.false
@@ -278,10 +278,10 @@ strcmp.loop_null_cmp81:                           ; preds = %strcmp.loop74
 
 strcmp.loop86:                                    ; preds = %strcmp.loop_null_cmp87
   %71 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 16
-  %probe_read94 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %71)
+  %probe_read_kernel94 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_l, i32 1, i8* nonnull %71)
   %72 = load i8, i8* %strcmp.char_l, align 1
   %73 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 16
-  %probe_read95 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %73)
+  %probe_read_kernel95 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* nonnull %strcmp.char_r, i32 1, i8* nonnull %73)
   %74 = load i8, i8* %strcmp.char_r, align 1
   %strcmp.cmp96 = icmp eq i8 %72, %74
   br i1 %strcmp.cmp96, label %pred_true.critedge, label %strcmp.false

--- a/tests/codegen/llvm/struct_char_1.ll
+++ b/tests/codegen/llvm/struct_char_1.ll
@@ -22,7 +22,7 @@ entry:
   %2 = load i8, i8 addrspace(64)* null, align 536870912
   store i8 %2, i8* %1, align 1
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %"struct Foo.x")
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, [1 x i8]*)*)(i8* nonnull %"struct Foo.x", i32 1, [1 x i8]* nonnull %"$foo")
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, [1 x i8]*)*)(i8* nonnull %"struct Foo.x", i32 1, [1 x i8]* nonnull %"$foo")
   %3 = load i8, i8* %"struct Foo.x", align 1
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %"struct Foo.x")
   %4 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/struct_char_2.ll
+++ b/tests/codegen/llvm/struct_char_2.ll
@@ -15,7 +15,7 @@ entry:
   %"@x_key" = alloca i64, align 8
   %"struct Foo.x" = alloca i8, align 1
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %"struct Foo.x")
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i64)*)(i8* nonnull %"struct Foo.x", i32 1, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* nonnull %"struct Foo.x", i32 1, i64 0)
   %1 = load i8, i8* %"struct Foo.x", align 1
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %"struct Foo.x")
   %2 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/struct_integer_ptr_1.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_1.ll
@@ -25,12 +25,12 @@ entry:
   store i64 %2, i64* %"$foo", align 8
   %3 = bitcast i64* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, [8 x i8]*)*)(i64* nonnull %"struct Foo.x", i32 8, [8 x i8]* nonnull %tmpcast)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, [8 x i8]*)*)(i64* nonnull %"struct Foo.x", i32 8, [8 x i8]* nonnull %tmpcast)
   %4 = load i64, i64* %"struct Foo.x", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i32* %deref to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* nonnull %deref, i32 4, i64 %4)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* nonnull %deref, i32 4, i64 %4)
   %6 = load i32, i32* %deref, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   %7 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/struct_integer_ptr_2.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_2.ll
@@ -17,12 +17,12 @@ entry:
   %"struct Foo.x" = alloca i64, align 8
   %1 = bitcast i64* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* nonnull %"struct Foo.x", i32 8, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* nonnull %"struct Foo.x", i32 8, i64 0)
   %2 = load i64, i64* %"struct Foo.x", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i32* %deref to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* nonnull %deref, i32 4, i64 %2)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* nonnull %deref, i32 4, i64 %2)
   %4 = load i32, i32* %deref, align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/struct_integers_1.ll
+++ b/tests/codegen/llvm/struct_integers_1.ll
@@ -24,7 +24,7 @@ entry:
   store i32 %2, i32* %"$foo", align 4
   %3 = bitcast i32* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* nonnull %"struct Foo.x", i32 4, [4 x i8]* nonnull %tmpcast)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, [4 x i8]*)*)(i32* nonnull %"struct Foo.x", i32 4, [4 x i8]* nonnull %tmpcast)
   %4 = load i32, i32* %"struct Foo.x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/struct_integers_2.ll
+++ b/tests/codegen/llvm/struct_integers_2.ll
@@ -16,7 +16,7 @@ entry:
   %"struct Foo.x" = alloca i32, align 4
   %1 = bitcast i32* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* nonnull %"struct Foo.x", i32 4, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* nonnull %"struct Foo.x", i32 4, i64 0)
   %2 = load i32, i32* %"struct Foo.x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/struct_long_1.ll
+++ b/tests/codegen/llvm/struct_long_1.ll
@@ -24,7 +24,7 @@ entry:
   store i64 %2, i64* %"$foo", align 8
   %3 = bitcast i64* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, [8 x i8]*)*)(i64* nonnull %"struct Foo.x", i32 8, [8 x i8]* nonnull %tmpcast)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, [8 x i8]*)*)(i64* nonnull %"struct Foo.x", i32 8, [8 x i8]* nonnull %tmpcast)
   %4 = load i64, i64* %"struct Foo.x", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/struct_long_2.ll
+++ b/tests/codegen/llvm/struct_long_2.ll
@@ -16,7 +16,7 @@ entry:
   %"struct Foo.x" = alloca i64, align 8
   %1 = bitcast i64* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* nonnull %"struct Foo.x", i32 8, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* nonnull %"struct Foo.x", i32 8, i64 0)
   %2 = load i64, i64* %"struct Foo.x", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/struct_nested_struct_anon_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_1.ll
@@ -24,7 +24,7 @@ entry:
   store i32 %2, i32* %"$foo", align 4
   %3 = bitcast i32* %"struct Foo::(anonymous at definitions.h:1:14).x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* nonnull %"struct Foo::(anonymous at definitions.h:1:14).x", i32 4, [4 x i8]* nonnull %tmpcast)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, [4 x i8]*)*)(i32* nonnull %"struct Foo::(anonymous at definitions.h:1:14).x", i32 4, [4 x i8]* nonnull %tmpcast)
   %4 = load i32, i32* %"struct Foo::(anonymous at definitions.h:1:14).x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/struct_nested_struct_anon_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_2.ll
@@ -16,7 +16,7 @@ entry:
   %"struct Foo::(anonymous at definitions.h:1:14).x" = alloca i32, align 4
   %1 = bitcast i32* %"struct Foo::(anonymous at definitions.h:1:14).x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* nonnull %"struct Foo::(anonymous at definitions.h:1:14).x", i32 4, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* nonnull %"struct Foo::(anonymous at definitions.h:1:14).x", i32 4, i64 0)
   %2 = load i32, i32* %"struct Foo::(anonymous at definitions.h:1:14).x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/struct_nested_struct_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_1.ll
@@ -24,7 +24,7 @@ entry:
   store i32 %2, i32* %"$foo", align 4
   %3 = bitcast i32* %"struct Bar.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* nonnull %"struct Bar.x", i32 4, [4 x i8]* nonnull %tmpcast)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, [4 x i8]*)*)(i32* nonnull %"struct Bar.x", i32 4, [4 x i8]* nonnull %tmpcast)
   %4 = load i32, i32* %"struct Bar.x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/struct_nested_struct_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_2.ll
@@ -16,7 +16,7 @@ entry:
   %"struct Bar.x" = alloca i32, align 4
   %1 = bitcast i32* %"struct Bar.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* nonnull %"struct Bar.x", i32 4, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* nonnull %"struct Bar.x", i32 4, i64 0)
   %2 = load i32, i32* %"struct Bar.x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
@@ -25,12 +25,12 @@ entry:
   store i64 %2, i64* %"$foo", align 8
   %3 = bitcast i64* %"struct Foo.bar" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, [8 x i8]*)*)(i64* nonnull %"struct Foo.bar", i32 8, [8 x i8]* nonnull %tmpcast)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, [8 x i8]*)*)(i64* nonnull %"struct Foo.bar", i32 8, [8 x i8]* nonnull %tmpcast)
   %4 = load i64, i64* %"struct Foo.bar", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i32* %"struct Bar.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* nonnull %"struct Bar.x", i32 4, i64 %4)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* nonnull %"struct Bar.x", i32 4, i64 %4)
   %6 = load i32, i32* %"struct Bar.x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   %7 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
@@ -17,12 +17,12 @@ entry:
   %"struct Foo.bar" = alloca i64, align 8
   %1 = bitcast i64* %"struct Foo.bar" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* nonnull %"struct Foo.bar", i32 8, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* nonnull %"struct Foo.bar", i32 8, i64 0)
   %2 = load i64, i64* %"struct Foo.bar", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i32* %"struct Bar.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* nonnull %"struct Bar.x", i32 4, i64 %2)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* nonnull %"struct Bar.x", i32 4, i64 %2)
   %4 = load i32, i32* %"struct Bar.x", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/struct_save_1.ll
+++ b/tests/codegen/llvm/struct_save_1.ll
@@ -18,7 +18,7 @@ entry:
   store i64 0, i64* %"@foo_key", align 8
   %2 = getelementptr inbounds [12 x i8], [12 x i8]* %"@foo_val", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([12 x i8]*, i32, i64)*)([12 x i8]* nonnull %"@foo_val", i32 12, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([12 x i8]*, i32, i64)*)([12 x i8]* nonnull %"@foo_val", i32 12, i64 0)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [12 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@foo_key", [12 x i8]* nonnull %"@foo_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)

--- a/tests/codegen/llvm/struct_save_2.ll
+++ b/tests/codegen/llvm/struct_save_2.ll
@@ -18,7 +18,7 @@ entry:
   store i64 0, i64* %"@foo_key", align 8
   %2 = getelementptr inbounds [12 x i8], [12 x i8]* %"@foo_val", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([12 x i8]*, i32, i64)*)([12 x i8]* nonnull %"@foo_val", i32 12, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([12 x i8]*, i32, i64)*)([12 x i8]* nonnull %"@foo_val", i32 12, i64 0)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [12 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@foo_key", [12 x i8]* nonnull %"@foo_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)

--- a/tests/codegen/llvm/struct_save_nested.ll
+++ b/tests/codegen/llvm/struct_save_nested.ll
@@ -25,7 +25,7 @@ entry:
   store i64 0, i64* %"@foo_key", align 8
   %2 = getelementptr inbounds [16 x i8], [16 x i8]* %"@foo_val", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* nonnull %"@foo_val", i32 16, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* nonnull %"@foo_val", i32 16, i64 0)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [16 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@foo_key", [16 x i8]* nonnull %"@foo_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)

--- a/tests/codegen/llvm/struct_save_string.ll
+++ b/tests/codegen/llvm/struct_save_string.ll
@@ -21,7 +21,7 @@ entry:
   store i64 0, i64* %"@foo_key", align 8
   %2 = getelementptr inbounds [32 x i8], [32 x i8]* %"@foo_val", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([32 x i8]*, i32, i64)*)([32 x i8]* nonnull %"@foo_val", i32 32, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([32 x i8]*, i32, i64)*)([32 x i8]* nonnull %"@foo_val", i32 32, i64 0)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [32 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@foo_key", [32 x i8]* nonnull %"@foo_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)

--- a/tests/codegen/llvm/struct_short_1.ll
+++ b/tests/codegen/llvm/struct_short_1.ll
@@ -24,7 +24,7 @@ entry:
   store i16 %2, i16* %"$foo", align 2
   %3 = bitcast i16* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i16*, i32, [2 x i8]*)*)(i16* nonnull %"struct Foo.x", i32 2, [2 x i8]* nonnull %tmpcast)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i16*, i32, [2 x i8]*)*)(i16* nonnull %"struct Foo.x", i32 2, [2 x i8]* nonnull %tmpcast)
   %4 = load i16, i16* %"struct Foo.x", align 2
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   %5 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/struct_short_2.ll
+++ b/tests/codegen/llvm/struct_short_2.ll
@@ -16,7 +16,7 @@ entry:
   %"struct Foo.x" = alloca i16, align 2
   %1 = bitcast i16* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i16*, i32, i64)*)(i16* nonnull %"struct Foo.x", i32 2, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i16*, i32, i64)*)(i16* nonnull %"struct Foo.x", i32 2, i64 0)
   %2 = load i16, i16* %"struct Foo.x", align 2
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   %3 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/struct_string_array_1.ll
+++ b/tests/codegen/llvm/struct_string_array_1.ll
@@ -21,7 +21,7 @@ entry:
   call void @llvm.memcpy.p0i8.p64i8.i64(i8* nonnull align 1 %1, i8 addrspace(64)* align 536870912 null, i64 32, i1 false)
   %2 = getelementptr inbounds [32 x i8], [32 x i8]* %"struct Foo.str", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([32 x i8]*, i32, [32 x i8]*)*)([32 x i8]* nonnull %"struct Foo.str", i32 32, [32 x i8]* nonnull %"$foo")
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([32 x i8]*, i32, [32 x i8]*)*)([32 x i8]* nonnull %"struct Foo.str", i32 32, [32 x i8]* nonnull %"$foo")
   %3 = bitcast i64* %"@mystr_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@mystr_key", align 8

--- a/tests/codegen/llvm/struct_string_array_2.ll
+++ b/tests/codegen/llvm/struct_string_array_2.ll
@@ -15,7 +15,7 @@ entry:
   %"struct Foo.str" = alloca [32 x i8], align 1
   %1 = getelementptr inbounds [32 x i8], [32 x i8]* %"struct Foo.str", i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([32 x i8]*, i32, i64)*)([32 x i8]* nonnull %"struct Foo.str", i32 32, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([32 x i8]*, i32, i64)*)([32 x i8]* nonnull %"struct Foo.str", i32 32, i64 0)
   %2 = bitcast i64* %"@mystr_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@mystr_key", align 8

--- a/tests/codegen/llvm/struct_string_ptr.ll
+++ b/tests/codegen/llvm/struct_string_ptr.ll
@@ -19,10 +19,10 @@ entry:
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i8 0, i64 64, i1 false)
   %2 = bitcast i64* %"struct Foo.str" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* nonnull %"struct Foo.str", i32 8, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* nonnull %"struct Foo.str", i32 8, i64 0)
   %3 = load i64, i64* %"struct Foo.str", align 8
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* nonnull %str, i32 64, i64 %3)
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* nonnull %str, i32 64, i64 %3)
   %4 = bitcast i64* %"@mystr_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@mystr_key", align 8

--- a/tests/codegen/optional_positional_parameter.cpp
+++ b/tests/codegen/optional_positional_parameter.cpp
@@ -6,9 +6,7 @@ namespace codegen {
 
 TEST(codegen, optional_positional_parameter)
 {
-  test("BEGIN { @x = $1; @y = str($2) }",
-
-       NAME);
+  test("BEGIN { @x = $1; @y = str($2) }", NAME);
 }
 
 } // namespace codegen

--- a/tests/codegen/regression.cpp
+++ b/tests/codegen/regression.cpp
@@ -26,7 +26,7 @@ TEST(codegen, regression_957)
   ast::SemanticAnalyser semantics(driver.root_, *bpftrace, feature);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
-  ast::CodegenLLVM codegen(driver.root_, *bpftrace);
+  ast::CodegenLLVM codegen(driver.root_, *bpftrace, feature);
   codegen.compile();
 }
 

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -67,8 +67,11 @@ public:
     has_get_current_cgroup_id_ = std::make_optional<bool>(has_features);
     has_override_return_ = std::make_optional<bool>(has_features);
     prog_kfunc_ = std::make_optional<bool>(has_features);
-    has_loop_ = std::make_optional<bool>(has_features);
-  };
+    has_probe_read_kernel_ = std::make_optional<bool>(has_features);
+    has_probe_read_kernel_str_ = std::make_optional<bool>(has_features);
+    has_probe_read_user_ = std::make_optional<bool>(has_features);
+    has_probe_read_user_str_ = std::make_optional<bool>(has_features);
+  }
 };
 
 class MockChildProc : public ChildProcBase

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -37,7 +37,7 @@ void gen_bytecode(const std::string &input, std::stringstream &out)
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 
-  ast::CodegenLLVM codegen(driver.root_, *bpftrace);
+  ast::CodegenLLVM codegen(driver.root_, *bpftrace, feature);
   codegen.compile(DebugLevel::kDebug, out);
 }
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1624,6 +1624,12 @@ TEST(semantic_analyser, type_ctx)
   test(driver, "t:sched:sched_one { @ = (uint64)ctx; }", 1);
 }
 
+TEST(semantic_analyser, address_space)
+{
+  test("k:f { $a = uptr(pid); $a = kptr($a); }", 10);
+  test_for_warning("k:f { $a = uptr(arg0) + kptr(arg0); }", "Adress space mismatch");
+}
+
 #ifdef HAVE_LIBBPF_BTF_DUMP
 
 #include "btf_common.h"


### PR DESCRIPTION
This mostly works. We should get #1104 in first as it removes the probe_read from `args->`.

Opening it as RFC as I'm not entirely happy with it but not sure what the best way is to improve it either. 

- Manually keeping track of address space feels a bit fragile to me. But once we get it right it might not need that much updating, so it could be ok.
- `args` expansion is a bit weird as it happens during both the semantic and the codegen phase. 

