### PR TITLE
Fix 'signed operands for /' warning in naptime.bt

### DIFF
--- a/tools/naptime.bt
+++ b/tools/naptime.bt
@@ -30,5 +30,5 @@ tracepoint:syscalls:sys_enter_nanosleep
 	time("%H:%M:%S ");
 	printf("%-6d %-16s %-6d %-16s %d.%03d\n", $task->real_parent->pid,
 	    $task->real_parent->comm, pid, comm,
-	    args->rqtp->tv_sec, args->rqtp->tv_nsec / 1000000);
+	    args->rqtp->tv_sec, (uint64)args->rqtp->tv_nsec / 1000000);
 }


### PR DESCRIPTION
Fix the following warning in naptime.bt:

> bpftrace naptime.bt
naptime.bt:33:46-47: WARNING: signed operands for '/' can lead to
undefined behavior (cast to unsigned to silence warning)
        args->rqtp->tv_sec, args->rqtp->tv_nsec / 1000000);
                                                ~
Attaching 2 probes...
Tracing sleeps. Hit Ctrl-C to end.
^C