### PR TITLE
Detect lockdown

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -15,6 +15,7 @@
   - (*please add sections for other OSes)*
   - [Using Docker](#using-docker)
   - [Generic build](#generic-build-process)
+- [Disable Lockdown](#disable-lockdown)
 
 # Linux Kernel Requirements
 
@@ -250,3 +251,41 @@ To test that the build works, you can try running the test suite, and a one-line
 ./tests/bpftrace_test
 ./src/bpftrace -e 'kprobe:do_nanosleep { printf("sleep by %s\n", comm); }'
 ```
+
+# Disable Lockdown
+
+From the original patch set description:
+
+> This patchset introduces an optional kernel lockdown feature, intended
+> to strengthen the boundary between UID 0 and the kernel. When enabled,
+> various pieces of kernel functionality are restricted. Applications that
+> rely on low-level access to either hardware or the kernel may cease
+> working as a result - therefore this should not be enabled without
+> appropriate evaluation beforehand.
+>
+> The majority of mainstream distributions have been carrying variants of
+> this patchset for many years now, so there's value in providing a
+> doesn't meet every distribution requirement, but gets us much closer to
+> not requiring external patches.
+>
+>   - https://patchwork.kernel.org/patch/11140085/
+
+When lockdown is enabled and set to 'confidentiality' all methods that can
+extract confidential data from the kernel are blocked. This means that:
+
+- kprobes are blocked
+- tracefs access is blocked
+- probe_read and probe_read_str are blocked
+
+which makes it impossible for bpftrace to function.
+
+There are a few ways to disable lockdown.
+
+1. Disable secure boot in UEFI.
+2. Disable validation using mokutil, run the following command, reboot and
+   follow the prompt.
+```
+$ sudo mokutil --disable-validation
+```
+3. Use the `SysRQ+x` key combination to temporarily lift lockdown (until next
+   boot)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,6 +12,7 @@ add_executable(bpftrace
   driver.cpp
   fake_map.cpp
   list.cpp
+  lockdown.cpp
   main.cpp
   map.cpp
   mapkey.cpp

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -12,7 +12,6 @@ namespace libbpf {
 #include "libbpf/bpf.h"
 } // namespace libbpf
 
-
 namespace bpftrace {
 
 #define ARRAY_SIZE(x) (sizeof(x) / sizeof((x)[0]))
@@ -157,6 +156,8 @@ bool BPFfeature::has_loop(void)
 EMIT_HELPER_TEST(send_signal, BPF_PROG_TYPE_KPROBE);
 EMIT_HELPER_TEST(override_return, BPF_PROG_TYPE_KPROBE);
 EMIT_HELPER_TEST(get_current_cgroup_id, BPF_PROG_TYPE_KPROBE);
+EMIT_HELPER_TEST(probe_read, BPF_PROG_TYPE_KPROBE);
+EMIT_HELPER_TEST(probe_read_str, BPF_PROG_TYPE_KPROBE);
 EMIT_MAP_TEST(array, BPF_MAP_TYPE_ARRAY);
 EMIT_MAP_TEST(hash, BPF_MAP_TYPE_HASH);
 EMIT_MAP_TEST(percpu_array, BPF_MAP_TYPE_PERCPU_ARRAY);
@@ -215,6 +216,7 @@ std::string BPFfeature::report(void)
   auto to_str = [](bool f) -> std::string { return f ? "yes\n" : "no\n"; };
 
   buf << "Kernel helpers" << std::endl
+      << "  probe_read: " << to_str(has_helper_probe_read())
       << "  get_current_cgroup_id: "
       << to_str(has_helper_get_current_cgroup_id())
       << "  send_signal: " << to_str(has_helper_send_signal())

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -212,34 +212,32 @@ int BPFfeature::instruction_limit(void)
 std::string BPFfeature::report(void)
 {
   std::stringstream buf;
-  auto to_str = [](bool f) -> std::string { return f ? "yes" : "no"; };
+  auto to_str = [](bool f) -> std::string { return f ? "yes\n" : "no\n"; };
+
   buf << "Kernel helpers" << std::endl
       << "  get_current_cgroup_id: "
-      << to_str(has_helper_get_current_cgroup_id()) << std::endl
-      << "  send_signal: " << to_str(has_helper_send_signal()) << std::endl
+      << to_str(has_helper_get_current_cgroup_id())
+      << "  send_signal: " << to_str(has_helper_send_signal())
       << "  override_return: " << to_str(has_helper_override_return())
-      << std::endl
-      << std::endl
-      << "Kernel features" << std::endl
-      << "  Instruction limit: " << std::to_string(instruction_limit())
-      << std::endl
-      << "  Loop support: " << to_str(has_loop()) << std::endl
-      << std::endl
-      << "Map types" << std::endl
-      << "  hash: " << to_str(has_map_hash()) << std::endl
-      << "  percpu hash: " << to_str(has_map_percpu_hash()) << std::endl
-      << "  array: " << to_str(has_map_array()) << std::endl
-      << "  percpu array: " << to_str(has_map_percpu_array()) << std::endl
-      << "  stack_trace: " << to_str(has_map_stack_trace()) << std::endl
-      << "  perf_event_array: " << to_str(has_map_perf_event_array())
-      << std::endl
-      << std::endl
-      << "Probe types" << std::endl
-      << "  kprobe: " << to_str(has_prog_kprobe()) << std::endl
-      << "  tracepoint: " << to_str(has_prog_tracepoint()) << std::endl
-      << "  perf_event: " << to_str(has_prog_perf_event()) << std::endl
-      << std::endl
       << std::endl;
+
+  buf << "Kernel features" << std::endl
+      << "  Instruction limit: " << instruction_limit() << std::endl
+      << "  Loop support: " << to_str(has_loop()) << std::endl;
+
+  buf << "Map types" << std::endl
+      << "  hash: " << to_str(has_map_hash())
+      << "  percpu hash: " << to_str(has_map_percpu_hash())
+      << "  array: " << to_str(has_map_array())
+      << "  percpu array: " << to_str(has_map_percpu_array())
+      << "  stack_trace: " << to_str(has_map_stack_trace())
+      << "  perf_event_array: " << to_str(has_map_perf_event_array())
+      << std::endl;
+
+  buf << "Probe types" << std::endl
+      << "  kprobe: " << to_str(has_prog_kprobe())
+      << "  tracepoint: " << to_str(has_prog_tracepoint())
+      << "  perf_event: " << to_str(has_prog_perf_event()) << std::endl;
 
   return buf.str();
 }

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <string>
 
 namespace bpftrace {
@@ -7,37 +8,25 @@ namespace bpftrace {
 class BPFfeature
 {
 public:
-  BPFfeature();
-  bool has_loop(void)
-  {
-    return has_loop_;
-  };
-  bool has_helper_send_signal(void)
-  {
-    return has_signal_;
-  };
-  bool has_helper_get_current_cgroup_id(void)
-  {
-    return has_get_current_cgroup_id_;
-  };
-  bool has_helper_override_return(void)
-  {
-    return has_override_return_;
-  };
-  bool instruction_limit(void)
-  {
-    return insns_limit_;
-  };
+  BPFfeature(){};
+
+  int instruction_limit();
+  bool has_loop();
+
+  bool has_helper_override_return();
+  bool has_helper_get_current_cgroup_id();
+  bool has_helper_send_signal();
+
   std::string report(void);
 
 protected:
-  bool has_loop_;
-  int insns_limit_;
+  std::unique_ptr<bool> has_loop_;
+  std::unique_ptr<int> insns_limit_;
 
   /* Helpers */
-  bool has_signal_;
-  bool has_get_current_cgroup_id_;
-  bool has_override_return_;
+  std::unique_ptr<bool> has_send_signal_;
+  std::unique_ptr<bool> has_get_current_cgroup_id_;
+  std::unique_ptr<bool> has_override_return_;
 };
 
 } // namespace bpftrace

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -16,6 +16,8 @@ public:
   bool has_helper_override_return();
   bool has_helper_get_current_cgroup_id();
   bool has_helper_send_signal();
+  bool has_helper_probe_read();
+  bool has_helper_probe_read_str();
 
   bool has_map_array();
   bool has_map_hash();
@@ -48,6 +50,8 @@ protected:
   std::unique_ptr<bool> prog_perf_event_;
 
   /* Helpers */
+  std::unique_ptr<bool> has_probe_read_;
+  std::unique_ptr<bool> has_probe_read_str_;
   std::unique_ptr<bool> has_send_signal_;
   std::unique_ptr<bool> has_get_current_cgroup_id_;
   std::unique_ptr<bool> has_override_return_;

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -24,6 +24,10 @@ public:
   bool has_map_stack_trace();
   bool has_map_perf_event_array();
 
+  bool has_prog_kprobe();
+  bool has_prog_tracepoint();
+  bool has_prog_perf_event();
+
   std::string report(void);
 
 protected:
@@ -37,6 +41,11 @@ protected:
   std::unique_ptr<bool> map_percpu_array_;
   std::unique_ptr<bool> map_stack_trace_;
   std::unique_ptr<bool> map_perf_event_array_;
+
+  /* Prog type */
+  std::unique_ptr<bool> prog_kprobe_;
+  std::unique_ptr<bool> prog_tracepoint_;
+  std::unique_ptr<bool> prog_perf_event_;
 
   /* Helpers */
   std::unique_ptr<bool> has_send_signal_;

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -8,7 +8,18 @@ namespace bpftrace {
 class BPFfeature
 {
 public:
-  BPFfeature(){};
+  BPFfeature() = default;
+  virtual ~BPFfeature() = default;
+
+  // Due to the unique_ptr usage the generated copy constructor & assignment
+  // don't work. Move works but doesn't make sense as the `has_*` functions
+  // will just reassign the unique_ptr.
+  // A single bpffeature should be constructed in main() and passed around,
+  // making these as deleted to avoid accidentally copying/moving it.
+  BPFfeature(const BPFfeature&) = delete;
+  BPFfeature& operator=(const BPFfeature&) = delete;
+  BPFfeature(BPFfeature&&) = delete;
+  BPFfeature& operator=(BPFfeature&&) = delete;
 
   int instruction_limit();
   bool has_loop();

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -17,11 +17,26 @@ public:
   bool has_helper_get_current_cgroup_id();
   bool has_helper_send_signal();
 
+  bool has_map_array();
+  bool has_map_hash();
+  bool has_map_percpu_array();
+  bool has_map_percpu_hash();
+  bool has_map_stack_trace();
+  bool has_map_perf_event_array();
+
   std::string report(void);
 
 protected:
   std::unique_ptr<bool> has_loop_;
   std::unique_ptr<int> insns_limit_;
+
+  /* Map types */
+  std::unique_ptr<bool> map_hash_;
+  std::unique_ptr<bool> map_percpu_hash_;
+  std::unique_ptr<bool> map_array_;
+  std::unique_ptr<bool> map_percpu_array_;
+  std::unique_ptr<bool> map_stack_trace_;
+  std::unique_ptr<bool> map_perf_event_array_;
 
   /* Helpers */
   std::unique_ptr<bool> has_send_signal_;

--- a/src/lockdown.cpp
+++ b/src/lockdown.cpp
@@ -1,0 +1,88 @@
+#include <algorithm>
+#include <fstream>
+
+#include <cerrno>
+
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/utsname.h>
+#include <unistd.h>
+
+#include "lockdown.h"
+
+namespace bpftrace {
+namespace lockdown {
+
+static LockdownState from_string(const std::string &s)
+{
+  if (s == "none")
+    return LockdownState::None;
+  else if (s == "integrity")
+    return LockdownState::Integrity;
+  else if (s == "confidentiality")
+    return LockdownState::Confidentiality;
+
+  return LockdownState::Unknown;
+}
+
+static bool is_ubuntu(void)
+{
+  // If ubuntu is somewhere in uname it is probably ubuntu
+  struct utsname name = {};
+  uname(&name);
+
+  std::string version(name.version);
+
+  std::transform(version.begin(),
+                 version.end(),
+                 version.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+
+  return (version.find("ubuntu") != std::string::npos);
+}
+
+static LockdownState read_security_lockdown(void)
+{
+  std::ifstream file("/sys/kernel/security/lockdown");
+  if (file.fail())
+    return LockdownState::Unknown;
+
+  // Format: none [integrity] confidentiality
+  // read one field at a time, if it starts with [ it's the one we want
+  while (!file.fail())
+  {
+    std::string field;
+    file >> field;
+    if (field[0] == '[')
+      return from_string(field.substr(1, field.length() - 2));
+  }
+  return LockdownState::Unknown;
+}
+
+void emit_warning(std::ostream &out)
+{
+  // clang-format off
+  // these lines are ~80 chars wide in terminal
+  out << "Kernel lockdown is enabled and set to 'confidentiality'. Lockdown mode blocks" << std::endl
+      << "parts of BPF which makes it impossible for bpftrace to function. Please see " << std::endl
+      << "https://github.com/iovisor/bpftrace/blob/master/INSTALL.md#disable-lockdown" << std::endl
+      << "for more details on lockdown and how to disable it." << std::endl;
+  // clang-format on
+}
+
+LockdownState detect(BPFfeature &feature)
+{
+  // Ubuntu (19.10 at least) ships a lockdown version that fully blocks the bpf
+  // syscall
+  if (is_ubuntu() && !feature.has_map_array() &&
+      !feature.has_helper_probe_read())
+  {
+    return LockdownState::Confidentiality;
+  }
+
+  return read_security_lockdown();
+}
+
+} //  namespace lockdown
+} //  namespace bpftrace

--- a/src/lockdown.h
+++ b/src/lockdown.h
@@ -1,0 +1,20 @@
+#include <iostream>
+
+#include "bpffeature.h"
+
+namespace bpftrace {
+namespace lockdown {
+
+enum class LockdownState
+{
+  None,
+  Integrity,
+  Confidentiality,
+  Unknown, // Could not determine whether lockdown is enabled or not
+};
+
+LockdownState detect(BPFfeature &feature);
+void emit_warning(std::ostream &out);
+
+} //  namespace lockdown
+} //  namespace bpftrace

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -164,8 +164,8 @@ static int info()
 #else
             << "no" << std::endl
 #endif
+            << std::endl;
 
-  std::cerr << std::endl;
   std::cerr << BPFfeature().report();
 
   return 0;

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -62,8 +62,9 @@ class MockBPFfeature : public BPFfeature
 public:
   MockBPFfeature(bool has_features = true)
   {
-    has_loop_ = has_signal_ = has_get_current_cgroup_id_ =
-        has_override_return_ = has_features;
+    has_send_signal_ = std::make_unique<bool>(has_features);
+    has_get_current_cgroup_id_ = std::make_unique<bool>(has_features);
+    has_override_return_ = std::make_unique<bool>(has_features);
   };
 };
 

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -28,7 +28,7 @@ void gen_bytecode(const std::string &input, std::stringstream &out)
   ClangParser clang;
   clang.parse(driver.root_, *bpftrace);
 
-  MockBPFfeature feature = MockBPFfeature();
+  MockBPFfeature feature;
   ast::SemanticAnalyser semantics(driver.root_, *bpftrace, feature);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -76,7 +76,7 @@ void test(BPFtrace &bpftrace,
     bool safe_mode = true)
 {
   Driver driver(bpftrace);
-  MockBPFfeature feature = MockBPFfeature();
+  MockBPFfeature feature;
   test(bpftrace, feature, driver, input, expected_result, safe_mode);
 }
 
@@ -86,7 +86,7 @@ void test(Driver &driver,
     bool safe_mode = true)
 {
   auto bpftrace = get_mock_bpftrace();
-  MockBPFfeature feature = MockBPFfeature();
+  MockBPFfeature feature;
   test(*bpftrace, feature, driver, input, expected_result, safe_mode);
 }
 
@@ -104,7 +104,7 @@ void test(const std::string &input,
     int expected_result=0,
     bool safe_mode = true)
 {
-  MockBPFfeature feature = MockBPFfeature();
+  MockBPFfeature feature;
   test(feature, input, expected_result, safe_mode);
 }
 


### PR DESCRIPTION
The first 4 commits of this PR add map and probe type detection to `BPFfeature` and remove some of the boiler plate. To detect a helper adding ` EMIT_HELPER_TEST(override_return, BPF_PROG_TYPE_KPROBE);` should now be enough (after update bpffeature.h).

The last commit adds lock down detection. The detection is based on these two commits:

- https://github.com/torvalds/linux/commit/a94549dd87f5ea4ca50fee493df08a2dc6256b53
- https://github.com/torvalds/linux/commit/9d1f8be5cf42b497a3bddf1d523f2bb142e9318c

If both kprobes and probe_read support is it is likely that lockdown is in effect. It could still be a false positive but in any case the system is not suitable to run bpftrace.

My only test system is an ubuntu 19.10 workstation. For some reason bpf appears to be fully blocked on it, even map creation fails. This doesn't appear to be part of the original patches, but it only happens when secure boot is enabled. It would be good to have more people test this.

```
sudo strace -e bpf -c  bpftrace  --info
The system appears to be in lockdown mode (kprobes and probe_reads are blocked).
Lockdown mode blocks parts of BPF which makes it impossible for bpftrace to function.
Please see https://github.com/iovisor/bpftrace/blob/master/INSTALL.md#disable-lockdown
for more details on lockdown and how to disable it.
Keep in mind that detection is not entirely accurate, there are other
security mechanisms that can cause this too

Kernel helpers
  get_current_cgroup_id: no
  send_signal: no
  override_return: no

Kernel features
  Instruction limit: -1
  Loop support: no

Map types
  hash: no
  percpu hash: no
  array: no
  percpu array: no
  stack_trace: no
  perf_event_array: no

Probe types
  kprobe: no
  tracepoint: no
  perf_event: no

% time     seconds  usecs/call     calls    errors syscall
------ ----------- ----------- --------- --------- ----------------
100,00    0,000135           3        40        40 bpf
------ ----------- ----------- --------- --------- ----------------
100.00    0,000135                    40        40 total
```

Relates to: #925