### PR TITLE
Add support to list C++ mangled symbols for uprobes

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -892,18 +892,21 @@ uretprobe:library_name:function_name
 These use uprobes (a Linux kernel capability). `uprobe` instruments the beginning of a user-level
 function's execution, and `uretprobe` instruments the end (its return).
 
-To list available uprobes, you can use any program to list the text segment symbols from a binary, such
-as `objdump` and `nm`. For example:
+To list available uprobes, you can use bpftrace (or any other program to list the text segment symbols
+from a binary, such as `objdump` and `nm`). For example:
 
 ```
-# objdump -tT /bin/bash | grep readline
-00000000007003f8 g    DO .bss	0000000000000004  Base        rl_readline_state
-0000000000499e00 g    DF .text	00000000000001c5  Base        readline_internal_char
-00000000004993d0 g    DF .text	0000000000000126  Base        readline_internal_setup
-000000000046d400 g    DF .text	000000000000004b  Base        posix_readline_initialize
-000000000049a520 g    DF .text	0000000000000081  Base        readline
+# bpftrace -l 'uprobe:/bin/bash:*readline*'
+uprobe:/bin/bash:initialize_readline
+uprobe:/bin/bash:pcomp_set_readline_variables
+uprobe:/bin/bash:posix_readline_initialize
+uprobe:/bin/bash:readline
+uprobe:/bin/bash:readline_internal_char
 [...]
 ```
+
+Note: When listing uprobes, bpftrace automatically demangles C++ symbols. It's also possible to list them
+in the mangled format using the '-lv' flag.
 
 This has listed various functions containing "readline" from /bin/bash. These can be instrumented using
 `uprobe` and `uretprobe`.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -151,7 +151,7 @@ add_test(NAME bpftrace_test COMMAND bpftrace_test)
 
 # Compile all testprograms, one per .c file for runtime testing
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testprogs/)
-file(GLOB testprogs testprogs/*.c)
+file(GLOB testprogs testprogs/*.c testprogs/*.cpp)
 set(compiled_testprogs "")
 foreach(testprog ${testprogs})
   get_filename_component(bin_name ${testprog} NAME_WE)

--- a/tests/runtime/uprobe
+++ b/tests/runtime/uprobe
@@ -56,3 +56,13 @@ NAME "uprobes - probe function in non-executable library"
 RUN bpftrace -e 'uprobe:./testlibs/libsimple.so:fun {}'
 EXPECT Attaching 1 probe...
 TIMEOUT 5
+
+NAME "uprobes - list probes by file with C++ mangled names - full function signature"
+RUN bpftrace -l 'uprobe:./testprogs/cpp_uprobe_test:function1(int)'
+EXPECT uprobe:./testprogs/cpp_uprobe_test:function1\(int\)
+TIMEOUT 5
+
+NAME "uprobes - list probes by file with C++ mangled names - function name only"
+RUN bpftrace -l 'uprobe:./testprogs/cpp_uprobe_test:function1'
+EXPECT uprobe:./testprogs/cpp_uprobe_test:function1\(int\)\nuprobe:./testprogs/cpp_uprobe_test:function1()
+TIMEOUT 5

--- a/tests/testprogs/cpp_uprobe_test.cpp
+++ b/tests/testprogs/cpp_uprobe_test.cpp
@@ -1,0 +1,14 @@
+int function1()
+{
+  return 0;
+}
+
+int function1(int x)
+{
+  return x;
+}
+
+int main(int argc __attribute__((unused)), char **argv __attribute__((unused)))
+{
+  return 0;
+}


### PR DESCRIPTION
Before:

> bpftrace -l 'uprobe:/bin/bpftrace:*cpus*'
uprobe:/bin/bpftrace:_ZN8bpftrace15get_online_cpusEv
uprobe:/bin/bpftrace:_ZN8bpftrace17get_possible_cpusEv

After:

> bpftrace -l 'uprobe:/bin/bpftrace:*cpus*'
uprobe:/bin/bpftrace:bpftrace::get_online_cpus()
uprobe:/bin/bpftrace:bpftrace::get_possible_cpus()

Note: It's still possible to list uprobe symbols in the mangled format
using '-lv' flag.