### PR TITLE
Support pushing docker images to quay.io from github actions

### DIFF
--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -82,6 +82,7 @@ jobs:
       if: matrix.env['TYPE'] == 'Release'
       run: |
         docker run --privileged -v $(pwd):$(pwd) -w $(pwd) -v /sys/kernel/debug:/sys/kernel/debug:rw -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -e STATIC_LINKING=${STATIC_LINKING} -e STATIC_LIBC=${STATIC_LIBC} -e EMBED_LLVM=${EMBED_LLVM} -e EMBED_CLANG=${EMBED_CLANG} -e EMBED_BCC=${EMBED_BCC} -e EMBED_LIBELF=${EMBED_LIBELF} -e EMBED_LIBCLANG_ONLY=${EMBED_LIBCLANG_ONLY} -e EMBED_BINUTILS=${EMBED_BINUTILS} --entrypoint /bin/bash bpftrace-embedded-${{ matrix.env['DISTRO'] }} -c "strip --keep-symbol BEGIN_trigger $(pwd)/build-embedded/src/bpftrace"
+
     - uses: actions/upload-artifact@v1
       with:
         name: bpftrace-${{ matrix.env['TYPE'] }}-${{ matrix.env['NAME'] }}
@@ -90,3 +91,13 @@ jobs:
       with:
         name: bpftrace_test-${{ matrix.env['TYPE'] }}-${{ matrix.env['NAME'] }}
         path: build-embedded/tests/bpftrace_test
+
+    - name: Authenticate with docker registry
+      if: matrix.env['TYPE'] == 'Release'
+      env:
+        QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+      run: ./docker/scripts/auth.sh ${{ github.repository }}
+
+    - name: Package docker image and push to quay.io
+      if: matrix.env['TYPE'] == 'Release'
+      run: ./docker/scripts/push.sh ${{ github.repository }} ${{ github.ref }} ${{ github.sha }} $(echo ${{ matrix.env['NAME'] }} | sed 's/+/_/g')

--- a/docker/Dockerfile.minimal
+++ b/docker/Dockerfile.minimal
@@ -1,0 +1,10 @@
+ARG DISTRO=bionic
+FROM ubuntu:$DISTRO
+
+ARG build_dir=build-embedded
+
+# Run security updates
+RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+
+COPY /$build_dir/src/bpftrace /usr/bin/bpftrace
+COPY /tools/*.bt /usr/local/bin/

--- a/docker/scripts/auth.sh
+++ b/docker/scripts/auth.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -e
+
+# For now only quay.io is supported, but this could be portable to dockerhub
+# and other image repositories.
+
+# Forks can push using this approach if they create a quay.io bot user
+# with name matching of ORGNAME+bpftrace_buildbot, or by setting QUAY_BOT_NAME
+
+git_repo=$1 # github.repository format: ORGNAME/REPONAME
+
+# Set this value as QUAY_TOKEN in the github repository settings "Secrets" tab
+[[ -z "${QUAY_TOKEN}" ]] && echo "QUAY_TOKEN not set" && exit 0
+
+# Set this to match the name of the bot user on quay.io
+[[ -z "${QUAY_BOT_NAME}" ]] && QUAY_BOT_NAME="bpftrace_buildbot"
+
+quay_user="$(dirname ${git_repo})+${QUAY_BOT_NAME}"
+echo "${QUAY_TOKEN}" | docker login -u="${quay_user}" --password-stdin quay.io

--- a/docker/scripts/push.sh
+++ b/docker/scripts/push.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -e
+
+# Push docker tags to a configured docker repo, defaulting to quay.io
+# You must run login.sh before running this script.
+
+DEFAULT_DOCKER_REPO="quay.io"
+DEFAULT_RELEASE_TARGET="vanilla_llvm+clang+glibc2.27"
+
+# Currently only support pushing to quay.io
+DOCKER_REPO=${DEFAULT_DOCKER_REPO}
+
+git_repo=$1  # github.repository format: ORGNAME/REPONAME
+git_ref=$2   # github.ref        format: refs/REMOTE/REF
+             #                       eg, refs/heads/BRANCH
+             #                           refs/tags/v0.9.6-pre
+git_sha=$3   # github.sha                GIT_SHA
+type_name=$4 # build name, s/+/_/g   eg, vanilla_llvm_clang_glibc2.27
+
+# refname will be either a branch like "master" or "some-branch",
+# or a tag, like "v0.9.6-pre".
+# When a tag is pushed, a build is done for both the branch and the tag, as
+# separate builds.
+# This is a feature specific #to github actions based on the `github.ref` object
+refname=$(basename ${git_ref})
+
+# The main docker image build, copying the bpftrace artifact on top of a vanilla OS image
+echo "Building minimal release docker image"
+docker build -t ${DOCKER_REPO}/${git_repo}:${git_sha}-${type_name} -f docker/Dockerfile.minimal .
+
+echo "Upload image for git sha ${git_sha} to ${DOCKER_REPO}/${git_repo}"
+docker push ${DOCKER_REPO}/${git_repo}:${git_sha}-${type_name}
+
+echo "Push tags to branch or git tag HEAD refs"
+docker tag ${DOCKER_REPO}/${git_repo}:${git_sha}-${type_name} ${DOCKER_REPO}/${git_repo}:${refname}-${type_name}
+docker push ${DOCKER_REPO}/${git_repo}:${refname}-${type_name}
+
+# Only push to un-suffixed tags for the default release target build type
+if [[ "${NAME}" == "${DEFAULT_RELEASE_TARGET}" ]];then
+  # Update branch / git tag ref
+  echo "Pushing tags for ${DOCKER_REPO}/${git_repo}:${refname}"
+  docker tag ${DOCKER_REPO}/${git_repo}:${git_sha}-${type_name} ${DOCKER_REPO}/${git_repo}:${refname}
+  docker push ${DOCKER_REPO}/${git_repo}:${refname}
+
+  if [[ "${refname}" != "master" ]];then
+    echo "This is a build on master, pushing ${DOCKER_REPO}/${git_repo}:latest and for SHA as well"
+    docker tag ${DOCKER_REPO}/${git_repo}:${git_sha}-${type_name} ${DOCKER_REPO}/${git_repo}:latest
+    docker push ${DOCKER_REPO}/${git_repo}:latest
+    docker push ${DOCKER_REPO}/${git_repo}:${git_sha}
+  fi
+fi


### PR DESCRIPTION
If this works we can revert #1139 as this approach is better i think.

We can push whatever tags we want using this approach, and we're already building the CI artifacts.

I've tested on my personal fork of bpftrace, and tried to make it work seamlessly for iovisor/bpftrace. We won't know for sure until we see something merged to master (including this PR).

The result of this should be the following artifacts:

- An image tagged with SHA-NAME for all Release builds. This will let us very surgically reference specific builds, even if another build has been pushed to a given tag/branch.
- An image tagged with BRANCHNAME-NAME for all Release builds. This will let us keep a floating reference of the latest build of a given type for a branch name
- An image tagged with BRANCHNAME for the vanilla+glibc2.7 image type. This will let us keep a floating reference to the default release image for a given branch name, as well as have tagged releases
- An image tagged with :latest if the branch is master. 

Note that for tags, it will do one build each for the branch and the tag.

Since tagging is just a book-keeping thing, this only actually builds one image (even though it may push multiple tags).