### PR TITLE
Type fixes

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -181,13 +181,13 @@ void CodegenLLVM::visit(Builtin &builtin)
       offset = arch::arg_offset(arg_num);
     }
 
+    Value *ctx = b_.CreatePointerCast(ctx_, b_.getInt64Ty()->getPointerTo());
     // LLVM optimization is possible to transform `(uint64*)ctx` into
     // `(uint8*)ctx`, but sometimes this causes invalid context access.
     // Mark every context acess to supporess any LLVM optimization.
-    expr_ = b_.CreateLoad(
-        b_.getInt64Ty(),
-        b_.CreateGEP(ctx_, b_.getInt64(offset * sizeof(uintptr_t))),
-        builtin.ident);
+    expr_ = b_.CreateLoad(b_.getInt64Ty(),
+                          b_.CreateGEP(ctx, b_.getInt64(offset)),
+                          builtin.ident);
     // LLVM 7.0 <= does not have CreateLoad(*Ty, *Ptr, isVolatile, Name),
     // so call setVolatile() manually
     dyn_cast<LoadInst>(expr_)->setVolatile(true);

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -654,8 +654,7 @@ void CodegenLLVM::visit(Call &call)
      * The asyncaction_id informs user-space that this is not a printf(), but is a
      * special asynchronous action. The ID maps to exit().
      */
-    ArrayType *perfdata_type = ArrayType::get(b_.getInt8Ty(), sizeof(uint64_t));
-    AllocaInst *perfdata = b_.CreateAllocaBPF(perfdata_type, "perfdata");
+    AllocaInst *perfdata = b_.CreateAllocaBPF(b_.getInt64Ty(), "perfdata");
     b_.CreateStore(b_.getInt64(asyncactionint(AsyncAction::exit)), perfdata);
     b_.CreatePerfEventOutput(ctx_, perfdata, sizeof(uint64_t));
     b_.CreateLifetimeEnd(perfdata);

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -573,15 +573,13 @@ void CodegenLLVM::visit(Call &call)
     //   }
     // }
     //}
-    std::vector<llvm::Type *> elements = {
-      b_.getInt64Ty(), // printf ID
-      ArrayType::get(b_.getInt8Ty(), 16)
-    };
-    StructType *inet_struct = StructType::create(elements, "inet_t", false);
+    std::vector<llvm::Type *> elements = { b_.getInt64Ty(),
+                                           ArrayType::get(b_.getInt8Ty(), 16) };
+    StructType *inet_struct = b_.GetStructType("inet_t", elements, false);
 
     AllocaInst *buf = b_.CreateAllocaBPF(inet_struct, "inet");
 
-    Value *af_offset = b_.CreateGEP(buf, b_.getInt64(0));
+    Value *af_offset = b_.CreateGEP(buf, { b_.getInt64(0), b_.getInt32(0) });
     Value *af_type;
 
     auto inet = call.vargs->at(0);
@@ -614,7 +612,9 @@ void CodegenLLVM::visit(Call &call)
     }
     else
     {
-      b_.CreateStore(b_.CreateIntCast(expr_, b_.getInt32Ty(), false), inet_offset);
+      b_.CreateStore(b_.CreateIntCast(expr_, b_.getInt32Ty(), false),
+                     b_.CreatePointerCast(inet_offset,
+                                          b_.getInt32Ty()->getPointerTo()));
     }
 
     expr_ = buf;

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -15,6 +15,20 @@ namespace libbpf {
 namespace bpftrace {
 namespace ast {
 
+StructType *IRBuilderBPF::GetStructType(
+    std::string name,
+    const std::vector<llvm::Type *> &elements,
+    bool packed)
+{
+  auto search = structs_.find(name);
+  if (search != structs_.end())
+    return search->second;
+
+  StructType *s = StructType::create(elements, name, packed);
+  structs_.insert({ name, s });
+  return s;
+}
+
 IRBuilderBPF::IRBuilderBPF(LLVMContext &context,
                            Module &module,
                            BPFtrace &bpftrace)

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -77,6 +77,7 @@ public:
   void        CreatePerfEventOutput(Value *ctx, Value *data, size_t size);
   void        CreateSignal(Value *sig);
   void        CreateOverrideReturn(Value *ctx, Value *rc);
+  StructType *GetStructType(std::string name, const std::vector<llvm::Type *> & elements, bool packed = false);
 
 private:
   Module &module_;
@@ -84,6 +85,8 @@ private:
 
   Value      *CreateUSDTReadArgument(Value *ctx, struct bcc_usdt_argument *argument, Builtin &builtin);
   CallInst   *createMapLookup(int mapfd, AllocaInst *key);
+
+  std::map<std::string, StructType *> structs_;
   // clang-format on
 };
 

--- a/tests/codegen/llvm/builtin_arg.ll
+++ b/tests/codegen/llvm/builtin_arg.ll
@@ -16,29 +16,31 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %1 = getelementptr i8, i8* %0, i64 112
-  %arg0 = load volatile i64, i8* %1, align 8
-  %2 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  store i64 0, i64* %"@x_key", align 8
-  %3 = bitcast i64* %"@x_val" to i8*
+  %2 = bitcast i8* %1 to i64*
+  %arg0 = load volatile i64, i64* %2, align 8
+  %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 0, i64* %"@x_key", align 8
+  %4 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %arg0, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  %4 = getelementptr i8, i8* %0, i64 96
-  %arg2 = load volatile i64, i8* %4, align 8
-  %5 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  %5 = getelementptr i8, i8* %0, i64 96
+  %6 = bitcast i8* %5 to i64*
+  %arg2 = load volatile i64, i64* %6, align 8
+  %7 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 0, i64* %"@y_key", align 8
-  %6 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %8 = bitcast i64* %"@y_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 %arg2, i64* %"@y_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem2 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@y_key", i64* nonnull %"@y_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/builtin_comm.ll
+++ b/tests/codegen/llvm/builtin_comm.ll
@@ -16,7 +16,7 @@ entry:
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i8 0, i64 16, i1 false)
-  %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
+  %get_comm = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   %2 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/llvm/builtin_comm_LLVM-5.ll
+++ b/tests/codegen/llvm/builtin_comm_LLVM-5.ll
@@ -16,7 +16,7 @@ entry:
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 16, i32 1, i1 false)
-  %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
+  %get_comm = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   %2 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/llvm/builtin_func.ll
+++ b/tests/codegen/llvm/builtin_func.ll
@@ -14,17 +14,18 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %1 = getelementptr i8, i8* %0, i64 128
-  %func = load volatile i64, i8* %1, align 8
-  %2 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  store i64 0, i64* %"@x_key", align 8
-  %3 = bitcast i64* %"@x_val" to i8*
+  %2 = bitcast i8* %1 to i64*
+  %func = load volatile i64, i64* %2, align 8
+  %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 0, i64* %"@x_key", align 8
+  %4 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %func, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/builtin_func_uprobe.ll
+++ b/tests/codegen/llvm/builtin_func_uprobe.ll
@@ -15,24 +15,25 @@ entry:
   %"@x_key" = alloca i64, align 8
   %func1 = alloca [16 x i8], align 8
   %1 = getelementptr i8, i8* %0, i64 128
-  %func = load volatile i64, i8* %1, align 8
-  %2 = getelementptr inbounds [16 x i8], [16 x i8]* %func1, i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  %2 = bitcast i8* %1 to i64*
+  %func = load volatile i64, i64* %2, align 8
+  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %func1, i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   %get_pid_tgid = tail call i64 inttoptr (i64 14 to i64 ()*)()
-  %3 = lshr i64 %get_pid_tgid, 32
-  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %func1, i64 0, i64 8
+  %4 = lshr i64 %get_pid_tgid, 32
+  %5 = getelementptr inbounds [16 x i8], [16 x i8]* %func1, i64 0, i64 8
   store i64 %func, [16 x i8]* %func1, align 8
-  store i64 %3, i8* %4, align 8
-  %5 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  store i64 0, i64* %"@x_key", align 8
-  %6 = getelementptr inbounds [16 x i8], [16 x i8]* %"@x_val", i64 0, i64 0
+  store i64 %4, i8* %5, align 8
+  %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  store i64 0, i64* %"@x_key", align 8
+  %7 = getelementptr inbounds [16 x i8], [16 x i8]* %"@x_val", i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store [16 x i8]* %func1, [16 x i8]* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [16 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [16 x i8]* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/builtin_func_wild.ll
+++ b/tests/codegen/llvm/builtin_func_wild.ll
@@ -14,17 +14,18 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %1 = getelementptr i8, i8* %0, i64 128
-  %func = load volatile i64, i8* %1, align 8
-  %2 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  store i64 0, i64* %"@x_key", align 8
-  %3 = bitcast i64* %"@x_val" to i8*
+  %2 = bitcast i8* %1 to i64*
+  %func = load volatile i64, i64* %2, align 8
+  %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 0, i64* %"@x_key", align 8
+  %4 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %func, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/builtin_kstack.ll
+++ b/tests/codegen/llvm/builtin_kstack.ll
@@ -14,7 +14,7 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %get_stackid = tail call i64 inttoptr (i64 27 to i64 (i8*, i8*, i64)*)(i8* %0, i64 %pseudo, i64 0)
+  %get_stackid = tail call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 0)
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/llvm/builtin_retval.ll
+++ b/tests/codegen/llvm/builtin_retval.ll
@@ -14,17 +14,18 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %1 = getelementptr i8, i8* %0, i64 80
-  %retval = load volatile i64, i8* %1, align 8
-  %2 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  store i64 0, i64* %"@x_key", align 8
-  %3 = bitcast i64* %"@x_val" to i8*
+  %2 = bitcast i8* %1 to i64*
+  %retval = load volatile i64, i64* %2, align 8
+  %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 0, i64* %"@x_key", align 8
+  %4 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 %retval, i64* %"@x_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/builtin_ustack.ll
+++ b/tests/codegen/llvm/builtin_ustack.ll
@@ -14,7 +14,7 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %get_stackid = tail call i64 inttoptr (i64 27 to i64 (i8*, i8*, i64)*)(i8* %0, i64 %pseudo, i64 256)
+  %get_stackid = tail call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 256)
   %get_pid_tgid = tail call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = shl i64 %get_pid_tgid, 32
   %2 = or i64 %1, %get_stackid

--- a/tests/codegen/llvm/call_delete.ll
+++ b/tests/codegen/llvm/call_delete.ll
@@ -28,7 +28,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key1", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %delete_elem = call i64 inttoptr (i64 3 to i64 (i8*, i8*)*)(i64 %pseudo2, i64* nonnull %"@x_key1")
+  %delete_elem = call i64 inttoptr (i64 3 to i64 (i64, i8*)*)(i64 %pseudo2, i64* nonnull %"@x_key1")
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_exit.ll
+++ b/tests/codegen/llvm/call_exit.ll
@@ -11,13 +11,13 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
-  %perfdata = alloca [8 x i8], align 8
-  %1 = getelementptr inbounds [8 x i8], [8 x i8]* %perfdata, i64 0, i64 0
+  %perfdata = alloca i64, align 8
+  %1 = bitcast i64* %perfdata to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 30000, [8 x i8]* %perfdata, align 8
+  store i64 30000, i64* %perfdata, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, [8 x i8]*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [8 x i8]* nonnull %perfdata, i64 8)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, i64*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, i64* nonnull %perfdata, i64 8)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_kstack.ll
+++ b/tests/codegen/llvm/call_kstack.ll
@@ -16,7 +16,7 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 4)
-  %get_stackid = tail call i64 inttoptr (i64 27 to i64 (i8*, i8*, i64)*)(i8* %0, i64 %pseudo, i64 0)
+  %get_stackid = tail call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 0)
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 0, i64* %"@x_key", align 8
@@ -28,7 +28,7 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
-  %get_stackid3 = call i64 inttoptr (i64 27 to i64 (i8*, i8*, i64)*)(i8* %0, i64 %pseudo2, i64 0)
+  %get_stackid3 = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo2, i64 0)
   %3 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@y_key", align 8

--- a/tests/codegen/llvm/call_ntop_char16.ll
+++ b/tests/codegen/llvm/call_ntop_char16.ll
@@ -17,17 +17,18 @@ entry:
   %inet = alloca %inet_t, align 8
   %1 = bitcast %inet_t* %inet to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 10, %inet_t* %inet, align 8
-  %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
-  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %3, i8 0, i64 16, i1 false)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* nonnull %2, i64 16, i64 0)
-  %4 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 0
+  store i64 10, i64* %2, align 8
+  %3 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
+  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %3, i64 0, i64 0
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %4, i8 0, i64 16, i1 false)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* nonnull %3, i64 16, i64 0)
+  %5 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %inet_t*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_ntop_char4.ll
+++ b/tests/codegen/llvm/call_ntop_char4.ll
@@ -17,17 +17,18 @@ entry:
   %inet = alloca %inet_t, align 8
   %1 = bitcast %inet_t* %inet to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 2, %inet_t* %inet, align 8
-  %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
-  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %3, i8 0, i64 16, i1 false)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* nonnull %2, i64 4, i64 0)
-  %4 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 0
+  store i64 2, i64* %2, align 8
+  %3 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
+  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %3, i64 0, i64 0
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %4, i8 0, i64 16, i1 false)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)([16 x i8]* nonnull %3, i64 4, i64 0)
+  %5 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %inet_t*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %inet_t* nonnull %inet, i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_ntop_key.ll
+++ b/tests/codegen/llvm/call_ntop_key.ll
@@ -17,11 +17,13 @@ entry:
   %inet = alloca %inet_t, align 8
   %1 = bitcast %inet_t* %inet to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 2, %inet_t* %inet, align 8
-  %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
-  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %3, i8 0, i64 16, i1 false)
-  store i32 -1, [16 x i8]* %2, align 8
+  %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 0
+  store i64 2, i64* %2, align 8
+  %3 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
+  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %3, i64 0, i64 0
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %4, i8 0, i64 16, i1 false)
+  %5 = bitcast [16 x i8]* %3 to i32*
+  store i32 -1, i32* %5, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, %inet_t*)*)(i64 %pseudo, %inet_t* nonnull %inet)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
@@ -29,19 +31,19 @@ entry:
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %4 = load i64, i64* %cast, align 8
-  %phitmp = add i64 %4, 1
+  %6 = load i64, i64* %cast, align 8
+  %phitmp = add i64 %6, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %5 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %7 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, %inet_t*, i64*, i64)*)(i64 %pseudo1, %inet_t* nonnull %inet, i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_ntop_key_LLVM-5.ll
+++ b/tests/codegen/llvm/call_ntop_key_LLVM-5.ll
@@ -17,11 +17,13 @@ entry:
   %inet = alloca %inet_t, align 8
   %1 = bitcast %inet_t* %inet to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 2, %inet_t* %inet, align 8
-  %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
-  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %2, i64 0, i64 0
-  call void @llvm.memset.p0i8.i64(i8* %3, i8 0, i64 16, i32 8, i1 false)
-  store i32 -1, [16 x i8]* %2, align 8
+  %2 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 0
+  store i64 2, i64* %2, align 8
+  %3 = getelementptr inbounds %inet_t, %inet_t* %inet, i64 0, i32 1
+  %4 = getelementptr inbounds [16 x i8], [16 x i8]* %3, i64 0, i64 0
+  call void @llvm.memset.p0i8.i64(i8* %4, i8 0, i64 16, i32 8, i1 false)
+  %5 = bitcast [16 x i8]* %3 to i32*
+  store i32 -1, i32* %5, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, %inet_t*)*)(i64 %pseudo, %inet_t* nonnull %inet)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
@@ -29,19 +31,19 @@ entry:
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %4 = load i64, i64* %cast, align 8
-  %phitmp = add i64 %4, 1
+  %6 = load i64, i64* %cast, align 8
+  %phitmp = add i64 %6, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %5 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %7 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, %inet_t*, i64*, i64)*)(i64 %pseudo1, %inet_t* nonnull %inet, i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_override.ll
+++ b/tests/codegen/llvm/call_override.ll
@@ -6,7 +6,8 @@ target triple = "bpf-pc-linux"
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %1 = getelementptr i8, i8* %0, i64 112
-  %arg0 = load volatile i64, i8* %1, align 8
+  %2 = bitcast i8* %1 to i64*
+  %arg0 = load volatile i64, i64* %2, align 8
   %override = tail call i64 inttoptr (i64 58 to i64 (i8*, i64)*)(i8* %0, i64 %arg0)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_signal.ll
+++ b/tests/codegen/llvm/call_signal.ll
@@ -6,8 +6,9 @@ target triple = "bpf-pc-linux"
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %1 = getelementptr i8, i8* %0, i64 112
-  %arg0 = load volatile i64, i8* %1, align 8
-  %2 = trunc i64 %arg0 to i32
-  %signal = tail call i64 inttoptr (i64 109 to i64 (i32)*)(i32 %2)
+  %2 = bitcast i8* %1 to i64*
+  %arg0 = load volatile i64, i64* %2, align 8
+  %3 = trunc i64 %arg0 to i32
+  %signal = tail call i64 inttoptr (i64 109 to i64 (i32)*)(i32 %3)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_str.ll
+++ b/tests/codegen/llvm/call_str.ll
@@ -17,14 +17,15 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i8 0, i64 64, i1 false)
   %2 = getelementptr i8, i8* %0, i64 112
-  %arg0 = load volatile i64, i8* %2, align 8
+  %3 = bitcast i8* %2 to i64*
+  %arg0 = load volatile i64, i64* %3, align 8
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %arg0)
-  %3 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_str_2_expr.ll
+++ b/tests/codegen/llvm/call_str_2_expr.ll
@@ -14,23 +14,25 @@ entry:
   %"@x_key" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %1 = getelementptr i8, i8* %0, i64 104
-  %arg1 = load volatile i64, i8* %1, align 8
-  %2 = add i64 %arg1, 1
-  %3 = icmp ult i64 %2, 64
-  %str.min.select = select i1 %3, i64 %2, i64 64
-  %4 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %4, i8 0, i64 64, i1 false)
-  %5 = getelementptr i8, i8* %0, i64 112
-  %arg0 = load volatile i64, i8* %5, align 8
+  %2 = bitcast i8* %1 to i64*
+  %arg1 = load volatile i64, i64* %2, align 8
+  %3 = add i64 %arg1, 1
+  %4 = icmp ult i64 %3, 64
+  %str.min.select = select i1 %4, i64 %3, i64 64
+  %5 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %5, i8 0, i64 64, i1 false)
+  %6 = getelementptr i8, i8* %0, i64 112
+  %7 = bitcast i8* %6 to i64*
+  %arg0 = load volatile i64, i64* %7, align 8
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 %str.min.select, i64 %arg0)
-  %6 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_str_2_expr_LLVM-5.ll
+++ b/tests/codegen/llvm/call_str_2_expr_LLVM-5.ll
@@ -14,23 +14,25 @@ entry:
   %"@x_key" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %1 = getelementptr i8, i8* %0, i64 104
-  %arg1 = load volatile i64, i8* %1, align 8
-  %2 = add i64 %arg1, 1
-  %3 = icmp ult i64 %2, 64
-  %str.min.select = select i1 %3, i64 %2, i64 64
-  %4 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  call void @llvm.memset.p0i8.i64(i8* nonnull %4, i8 0, i64 64, i32 1, i1 false)
-  %5 = getelementptr i8, i8* %0, i64 112
-  %arg0 = load volatile i64, i8* %5, align 8
+  %2 = bitcast i8* %1 to i64*
+  %arg1 = load volatile i64, i64* %2, align 8
+  %3 = add i64 %arg1, 1
+  %4 = icmp ult i64 %3, 64
+  %str.min.select = select i1 %4, i64 %3, i64 64
+  %5 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.memset.p0i8.i64(i8* nonnull %5, i8 0, i64 64, i32 1, i1 false)
+  %6 = getelementptr i8, i8* %0, i64 112
+  %7 = bitcast i8* %6 to i64*
+  %arg0 = load volatile i64, i64* %7, align 8
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 %str.min.select, i64 %arg0)
-  %6 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_str_2_lit.ll
+++ b/tests/codegen/llvm/call_str_2_lit.ll
@@ -17,14 +17,15 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i8 0, i64 64, i1 false)
   %2 = getelementptr i8, i8* %0, i64 112
-  %arg0 = load volatile i64, i8* %2, align 8
+  %3 = bitcast i8* %2 to i64*
+  %arg0 = load volatile i64, i64* %3, align 8
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 7, i64 %arg0)
-  %3 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_str_2_lit_LLVM-5.ll
+++ b/tests/codegen/llvm/call_str_2_lit_LLVM-5.ll
@@ -17,14 +17,15 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 64, i32 1, i1 false)
   %2 = getelementptr i8, i8* %0, i64 112
-  %arg0 = load volatile i64, i8* %2, align 8
+  %3 = bitcast i8* %2 to i64*
+  %arg0 = load volatile i64, i64* %3, align 8
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 7, i64 %arg0)
-  %3 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_str_LLVM-5.ll
+++ b/tests/codegen/llvm/call_str_LLVM-5.ll
@@ -17,14 +17,15 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 64, i32 1, i1 false)
   %2 = getelementptr i8, i8* %0, i64 112
-  %arg0 = load volatile i64, i8* %2, align 8
+  %3 = bitcast i8* %2 to i64*
+  %arg0 = load volatile i64, i64* %3, align 8
   %probe_read_str = call i64 inttoptr (i64 45 to i64 (i8*, i64, i8*)*)([64 x i8]* nonnull %str, i64 64, i64 %arg0)
-  %3 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", [64 x i8]* nonnull %str, i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_ustack.ll
+++ b/tests/codegen/llvm/call_ustack.ll
@@ -16,7 +16,7 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 4)
-  %get_stackid = tail call i64 inttoptr (i64 27 to i64 (i8*, i8*, i64)*)(i8* %0, i64 %pseudo, i64 256)
+  %get_stackid = tail call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 256)
   %get_pid_tgid = tail call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = shl i64 %get_pid_tgid, 32
   %2 = or i64 %1, %get_stackid
@@ -31,7 +31,7 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
-  %get_stackid3 = call i64 inttoptr (i64 27 to i64 (i8*, i8*, i64)*)(i8* %0, i64 %pseudo2, i64 256)
+  %get_stackid3 = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo2, i64 256)
   %get_pid_tgid4 = call i64 inttoptr (i64 14 to i64 ()*)()
   %5 = shl i64 %get_pid_tgid4, 32
   %6 = or i64 %5, %get_stackid3

--- a/tests/codegen/llvm/call_usym_key.ll
+++ b/tests/codegen/llvm/call_usym_key.ll
@@ -3,6 +3,8 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%usym_t = type { i64, i64 }
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
@@ -12,34 +14,35 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
-  %usym = alloca [16 x i8], align 8
-  %1 = getelementptr inbounds [16 x i8], [16 x i8]* %usym, i64 0, i64 0
+  %usym = alloca %usym_t, align 8
+  %1 = bitcast %usym_t* %usym to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %get_pid_tgid = tail call i64 inttoptr (i64 14 to i64 ()*)()
   %2 = lshr i64 %get_pid_tgid, 32
-  %3 = getelementptr inbounds [16 x i8], [16 x i8]* %usym, i64 0, i64 8
-  store i64 0, [16 x i8]* %usym, align 8
-  store i64 %2, i8* %3, align 8
+  %3 = getelementptr inbounds %usym_t, %usym_t* %usym, i64 0, i32 0
+  %4 = getelementptr inbounds %usym_t, %usym_t* %usym, i64 0, i32 1
+  store i64 0, i64* %3, align 8
+  store i64 %2, i64* %4, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [16 x i8]*)*)(i64 %pseudo, [16 x i8]* nonnull %usym)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, %usym_t*)*)(i64 %pseudo, %usym_t* nonnull %usym)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %4 = load i64, i64* %cast, align 8
-  %phitmp = add i64 %4, 1
+  %5 = load i64, i64* %cast, align 8
+  %phitmp = add i64 %5, 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %entry, %lookup_success
   %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
-  %5 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %6 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 %lookup_elem_val.0, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo1, [16 x i8]* nonnull %usym, i64* nonnull %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, %usym_t*, i64*, i64)*)(i64 %pseudo1, %usym_t* nonnull %usym, i64* nonnull %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/comparison_extend.ll
+++ b/tests/codegen/llvm/comparison_extend.ll
@@ -14,19 +14,20 @@ entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
   %1 = getelementptr i8, i8* %0, i64 112
-  %arg0 = load volatile i64, i8* %1, align 8
-  %2 = icmp ugt i64 %arg0, 1
-  %3 = zext i1 %2 to i64
-  %4 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  store i64 0, i64* %"@_key", align 8
-  %5 = bitcast i64* %"@_val" to i8*
+  %2 = bitcast i8* %1 to i64*
+  %arg0 = load volatile i64, i64* %2, align 8
+  %3 = icmp ugt i64 %arg0, 1
+  %4 = zext i1 %3 to i64
+  %5 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  store i64 %3, i64* %"@_val", align 8
+  store i64 0, i64* %"@_key", align 8
+  %6 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  store i64 %4, i64* %"@_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/intcast_call.ll
+++ b/tests/codegen/llvm/intcast_call.ll
@@ -31,11 +31,12 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   %3 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   %4 = getelementptr i8, i8* %0, i64 80
-  %retval = load volatile i64, i8* %4, align 8
+  %5 = bitcast i8* %4 to i64*
+  %retval = load volatile i64, i64* %5, align 8
   %sext = shl i64 %retval, 32
-  %5 = ashr exact i64 %sext, 32
-  %6 = add i64 %5, %lookup_elem_val.0
-  store i64 %6, i64* %"@_val", align 8
+  %6 = ashr exact i64 %sext, 32
+  %7 = add i64 %6, %lookup_elem_val.0
+  store i64 %7, i64* %"@_val", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)

--- a/tests/codegen/llvm/intcast_retval.ll
+++ b/tests/codegen/llvm/intcast_retval.ll
@@ -14,19 +14,20 @@ entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
   %1 = getelementptr i8, i8* %0, i64 80
-  %retval = load volatile i64, i8* %1, align 8
-  %2 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  %2 = bitcast i8* %1 to i64*
+  %retval = load volatile i64, i64* %2, align 8
+  %3 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@_key", align 8
   %sext = shl i64 %retval, 32
-  %3 = ashr exact i64 %sext, 32
-  %4 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  store i64 %3, i64* %"@_val", align 8
+  %4 = ashr exact i64 %sext, 32
+  %5 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  store i64 %4, i64* %"@_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/literal_strncmp.ll
+++ b/tests/codegen/llvm/literal_strncmp.ll
@@ -17,7 +17,7 @@ entry:
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i8 0, i64 16, i1 false)
-  %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
+  %get_comm = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   %2 = load i8, [16 x i8]* %comm, align 1
   %strcmp.cmp = icmp eq i8 %2, 115
   br i1 %strcmp.cmp, label %strcmp.loop, label %pred_true.critedge
@@ -33,7 +33,7 @@ pred_true:                                        ; preds = %strcmp.loop, %pred_
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %comm3, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %3, i8 0, i64 16, i1 false)
-  %get_comm4 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm3, i64 16)
+  %get_comm4 = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* nonnull %comm3, i64 16)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [16 x i8]*)*)(i64 %pseudo, [16 x i8]* nonnull %comm3)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null

--- a/tests/codegen/llvm/literal_strncmp_LLVM-5.ll
+++ b/tests/codegen/llvm/literal_strncmp_LLVM-5.ll
@@ -17,7 +17,7 @@ entry:
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 16, i32 1, i1 false)
-  %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
+  %get_comm = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   %2 = load i8, [16 x i8]* %comm, align 1
   %strcmp.cmp = icmp eq i8 %2, 115
   br i1 %strcmp.cmp, label %strcmp.loop, label %pred_true.critedge
@@ -33,7 +33,7 @@ pred_true:                                        ; preds = %strcmp.loop, %pred_
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %comm3, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.memset.p0i8.i64(i8* nonnull %3, i8 0, i64 16, i32 1, i1 false)
-  %get_comm4 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm3, i64 16)
+  %get_comm4 = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* nonnull %comm3, i64 16)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [16 x i8]*)*)(i64 %pseudo, [16 x i8]* nonnull %comm3)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null

--- a/tests/codegen/llvm/string_equal_comparison.ll
+++ b/tests/codegen/llvm/string_equal_comparison.ll
@@ -17,7 +17,7 @@ entry:
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i8 0, i64 16, i1 false)
-  %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
+  %get_comm = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   %2 = load i8, [16 x i8]* %comm, align 1
   %strcmp.cmp = icmp eq i8 %2, 115
   br i1 %strcmp.cmp, label %strcmp.loop, label %pred_false
@@ -29,7 +29,7 @@ pred_true:                                        ; preds = %strcmp.loop5
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %comm9, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %3, i8 0, i64 16, i1 false)
-  %get_comm10 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm9, i64 16)
+  %get_comm10 = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* nonnull %comm9, i64 16)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [16 x i8]*)*)(i64 %pseudo, [16 x i8]* nonnull %comm9)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null

--- a/tests/codegen/llvm/string_equal_comparison_LLVM-5.ll
+++ b/tests/codegen/llvm/string_equal_comparison_LLVM-5.ll
@@ -17,7 +17,7 @@ entry:
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 16, i32 1, i1 false)
-  %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
+  %get_comm = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   %2 = load i8, [16 x i8]* %comm, align 1
   %strcmp.cmp = icmp eq i8 %2, 115
   br i1 %strcmp.cmp, label %strcmp.loop, label %pred_false
@@ -29,7 +29,7 @@ pred_true:                                        ; preds = %strcmp.loop5
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %comm9, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.memset.p0i8.i64(i8* nonnull %3, i8 0, i64 16, i32 1, i1 false)
-  %get_comm10 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm9, i64 16)
+  %get_comm10 = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* nonnull %comm9, i64 16)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [16 x i8]*)*)(i64 %pseudo, [16 x i8]* nonnull %comm9)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null

--- a/tests/codegen/llvm/string_not_equal_comparison.ll
+++ b/tests/codegen/llvm/string_not_equal_comparison.ll
@@ -17,7 +17,7 @@ entry:
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i8 0, i64 16, i1 false)
-  %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
+  %get_comm = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   %2 = load i8, [16 x i8]* %comm, align 1
   %strcmp.cmp = icmp eq i8 %2, 115
   br i1 %strcmp.cmp, label %strcmp.loop, label %pred_true
@@ -29,7 +29,7 @@ pred_true:                                        ; preds = %strcmp.loop5, %strc
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %comm9, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %3, i8 0, i64 16, i1 false)
-  %get_comm10 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm9, i64 16)
+  %get_comm10 = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* nonnull %comm9, i64 16)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [16 x i8]*)*)(i64 %pseudo, [16 x i8]* nonnull %comm9)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null

--- a/tests/codegen/llvm/string_not_equal_comparison_LLVM-5.ll
+++ b/tests/codegen/llvm/string_not_equal_comparison_LLVM-5.ll
@@ -17,7 +17,7 @@ entry:
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 16, i32 1, i1 false)
-  %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
+  %get_comm = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   %2 = load i8, [16 x i8]* %comm, align 1
   %strcmp.cmp = icmp eq i8 %2, 115
   br i1 %strcmp.cmp, label %strcmp.loop, label %pred_true
@@ -29,7 +29,7 @@ pred_true:                                        ; preds = %strcmp.loop5, %strc
   %3 = getelementptr inbounds [16 x i8], [16 x i8]* %comm9, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.memset.p0i8.i64(i8* nonnull %3, i8 0, i64 16, i32 1, i1 false)
-  %get_comm10 = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm9, i64 16)
+  %get_comm10 = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* nonnull %comm9, i64 16)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [16 x i8]*)*)(i64 %pseudo, [16 x i8]* nonnull %comm9)
   %map_lookup_cond = icmp eq i8* %lookup_elem, null

--- a/tests/codegen/llvm/strncmp.ll
+++ b/tests/codegen/llvm/strncmp.ll
@@ -20,7 +20,7 @@ entry:
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i8 0, i64 16, i1 false)
-  %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
+  %get_comm = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   %2 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %2, i8 0, i64 64, i1 false)

--- a/tests/codegen/llvm/strncmp_LLVM-5.ll
+++ b/tests/codegen/llvm/strncmp_LLVM-5.ll
@@ -20,7 +20,7 @@ entry:
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull %1, i8 0, i64 16, i32 1, i1 false)
-  %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
+  %get_comm = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   %2 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.memset.p0i8.i64(i8* nonnull %2, i8 0, i64 64, i32 1, i1 false)

--- a/tests/codegen/llvm/strncmp_LLVM-9.ll
+++ b/tests/codegen/llvm/strncmp_LLVM-9.ll
@@ -20,7 +20,7 @@ entry:
   %1 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %1, i8 0, i64 16, i1 false)
-  %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
+  %get_comm = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   %2 = getelementptr inbounds [64 x i8], [64 x i8]* %str, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %2, i8 0, i64 64, i1 false)

--- a/tests/codegen/llvm/struct_semicolon_1.ll
+++ b/tests/codegen/llvm/struct_semicolon_1.ll
@@ -19,7 +19,7 @@ entry:
   %2 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
   store i64 0, i64* %2, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_stackid = tail call i64 inttoptr (i64 27 to i64 (i8*, i8*, i64)*)(i8* %0, i64 %pseudo, i64 256)
+  %get_stackid = tail call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 256)
   %get_pid_tgid = tail call i64 inttoptr (i64 14 to i64 ()*)()
   %3 = shl i64 %get_pid_tgid, 32
   %4 = or i64 %3, %get_stackid

--- a/tests/codegen/llvm/struct_semicolon_2.ll
+++ b/tests/codegen/llvm/struct_semicolon_2.ll
@@ -19,7 +19,7 @@ entry:
   %2 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
   store i64 0, i64* %2, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_stackid = tail call i64 inttoptr (i64 27 to i64 (i8*, i8*, i64)*)(i8* %0, i64 %pseudo, i64 256)
+  %get_stackid = tail call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 256)
   %get_pid_tgid = tail call i64 inttoptr (i64 14 to i64 ()*)()
   %3 = shl i64 %get_pid_tgid, 32
   %4 = or i64 %3, %get_stackid

--- a/tests/codegen/llvm/variable.ll
+++ b/tests/codegen/llvm/variable.ll
@@ -21,7 +21,7 @@ entry:
   %2 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %2, i8 0, i64 16, i1 false)
-  %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
+  %get_comm = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull align 1 %1, i8* nonnull align 1 %2, i64 16, i1 false)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)

--- a/tests/codegen/llvm/variable_LLVM-5.ll
+++ b/tests/codegen/llvm/variable_LLVM-5.ll
@@ -21,7 +21,7 @@ entry:
   %2 = getelementptr inbounds [16 x i8], [16 x i8]* %comm, i64 0, i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
   call void @llvm.memset.p0i8.i64(i8* nonnull %2, i8 0, i64 16, i32 1, i1 false)
-  %get_comm = call i64 inttoptr (i64 16 to i64 (i8*, i64)*)([16 x i8]* nonnull %comm, i64 16)
+  %get_comm = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* nonnull %comm, i64 16)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* nonnull %1, i8* nonnull %2, i64 16, i32 1, i1 false)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -118,3 +118,8 @@ NAME uaddr
 RUN bpftrace -v -e 'uprobe:testprogs/uprobe_test:function1 { printf("0x%lx -- 0x%lx\n", *uaddr("GLOBAL_A"), *uaddr("GLOBAL_C")); exit(); }' -c ./testprogs/uprobe_test
 EXPECT 0x55555555 -- 0x33333333
 TIMEOUT 5
+
+NAME ntop static ip
+RUN bpftrace -v -e 'i:ms:100 { printf("IP: %s, %s, %s, %s\n", ntop(1), ntop(0x0100007f), ntop(0xffff0000), ntop(0x0000ffff)); exit() }'
+EXPECT IP: 1.0.0.0, 127.0.0.1, 0.0.255.255, 255.255.0.0
+TIMEOUT 5


### PR DESCRIPTION
With #1108 merged these are now a lot less tedious to do. This is the first PR of a series to get rid of the IR typing issues we have. 

Once all of them are in we can use llvm-as to validate the IR and avoid these kinds of issues in the future.

My plan is to switch all builtin types from arrays to structs as LLVM will handle the typing in that case and we won't have to update all indices if we switch from a i64 to an i32. usym is the first example of this.