### PR TITLE
Extend info flag with system/build info

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -126,6 +126,51 @@ bool is_root()
     return true;
 }
 
+static int info()
+{
+  struct utsname utsname;
+  uname(&utsname);
+
+  std::cerr << "System" << std::endl
+            << "  OS: " << utsname.sysname << " " << utsname.release << " "
+            << utsname.version << std::endl
+            << "  Arch: " << utsname.machine << std::endl;
+
+  std::cerr << std::endl
+            << "Build" << std::endl
+            << "  version: " << BPFTRACE_VERSION << std::endl
+            << "  LLVM: " << LLVM_VERSION_MAJOR << std::endl
+            << "  foreach_sym: "
+#ifdef HAVE_BCC_ELF_FOREACH_SYM
+            << "yes" << std::endl
+#else
+            << "no" << std::endl
+#endif
+            << "  unsafe uprobe: "
+#ifdef HAVE_UNSAFE_UPROBE
+            << "yes" << std::endl
+#else
+            << "no" << std::endl
+#endif
+            << "  btf: "
+#ifdef HAVE_LIBBPF_BTF_DUMP
+            << "yes" << std::endl
+#else
+            << "no" << std::endl
+#endif
+            << "  bfd: "
+#ifdef HAVE_BFD_DISASM
+            << "yes" << std::endl
+#else
+            << "no" << std::endl
+#endif
+
+  std::cerr << std::endl;
+  std::cerr << BPFfeature().report();
+
+  return 0;
+}
+
 int main(int argc, char *argv[])
 {
   int err;
@@ -155,13 +200,11 @@ int main(int argc, char *argv[])
   {
     switch (c)
     {
-      case 2000:
+      case 2000: // --info
         if (is_root())
-        {
-          std::cerr << BPFfeature().report();
-          return 0;
-        }
+          return info();
         return 1;
+        break;
       case 'o':
         output_file = optarg;
         break;


### PR DESCRIPTION
This makes it easier for users to gather system/build info when opening
a bug report.

```
$ bpftrace  --info
System
  OS: Linux 5.3.0-40-generic #32-Ubuntu SMP Fri Jan 31 20:24:34 UTC 2020
  Arch: x86_64

Build
  version: v0.9.4-38-gd079-dirty
  LLVM: 7
  foreach_sym: yes
  unsafe uprobe: no
  btf: no
  bfd: yes

Kernel helpers
  get_current_cgroup_id: yes
  send_signal: yes
  override_return: yes

Kernel features
  Instruction limit: 1000000
  Loop support: yes
```

The ifdefs are a bit verbose but I don't see a better way to do it.