### PR TITLE
Use host network when building docker image

### DIFF
--- a/build-debug.sh
+++ b/build-debug.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-docker run --rm -it -u $(id -u):$(id -g) -v $(pwd):$(pwd) -e STATIC_LINKING=ON -e STATIC_LIBC=ON -e RUN_TESTS=0 bpftrace-builder-alpine "$(pwd)/build-debug" Debug "$@"
+docker run --network host --rm -it -u $(id -u):$(id -g) -v $(pwd):$(pwd) -e STATIC_LINKING=ON -e STATIC_LIBC=ON -e RUN_TESTS=0 bpftrace-builder-alpine "$(pwd)/build-debug" Debug "$@"

--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 set -e
 pushd docker
-docker build -t bpftrace-builder-alpine -f Dockerfile.alpine .
+docker build --network host -t bpftrace-builder-alpine -f Dockerfile.alpine .
 popd

--- a/build-release.sh
+++ b/build-release.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 set -e
-docker run --rm -it -u $(id -u):$(id -g) -v $(pwd):$(pwd) -e STATIC_LINKING=ON -e STATIC_LIBC=ON -e RUN_TESTS=0 bpftrace-builder-alpine "$(pwd)/build-release" Release "$@"
+docker run --network host --rm -it -u $(id -u):$(id -g) -v $(pwd):$(pwd) -e STATIC_LINKING=ON -e STATIC_LIBC=ON -e RUN_TESTS=0 bpftrace-builder-alpine "$(pwd)/build-release" Release "$@"


### PR DESCRIPTION
I was getting these errors before:
```
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/main/x86_64/APKINDEX.tar.gz
ERROR: http://dl-cdn.alpinelinux.org/alpine/v3.8/main: temporary error (try again later)
WARNING: Ignoring APKINDEX.adfa7ceb.tar.gz: No such file or directory
fetch http://dl-cdn.alpinelinux.org/alpine/v3.8/community/x86_64/APKINDEX.tar.gz
ERROR: http://dl-cdn.alpinelinux.org/alpine/v3.8/community: temporary error (try again later)
WARNING: Ignoring APKINDEX.efaa1f73.tar.gz: No such file or directory
ERROR: unsatisfiable constraints:
```

Adding this flag seemed to fix the issue.