### PR TITLE
Revert "No need to promote scalars to 64-bit"

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -637,12 +637,13 @@ void SemanticAnalyser::visit(Call &call)
         auto &fmt_arg = *call.vargs->at(0);
         String &fmt = static_cast<String&>(fmt_arg);
         std::vector<Field> args;
-
         for (auto iter = call.vargs->begin() + 1; iter != call.vargs->end();
              iter++)
         {
           auto ty = (*iter)->type;
-
+          // Promote to 64-bit if it's not an array type
+          if (!ty.IsArray())
+            ty.size = 8;
           args.push_back(Field{
             .type =  ty,
             .offset = 0,
@@ -654,7 +655,6 @@ void SemanticAnalyser::visit(Call &call)
             },
           });
         }
-
         std::string msg = verify_format_string(fmt.str, args);
         if (msg != "")
         {

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -83,21 +83,23 @@ TEST(codegen, printf_offsets)
 
   EXPECT_EQ(args.size(), 4U);
 
+  // Note that scalar types are promoted to 64-bits when put into
+  // a perf event buffer
   EXPECT_EQ(args[0].type.type, Type::integer);
-  EXPECT_EQ(args[0].type.size, 1U);
+  EXPECT_EQ(args[0].type.size, 8U);
   EXPECT_EQ(args[0].offset, 8);
 
   EXPECT_EQ(args[1].type.type, Type::integer);
-  EXPECT_EQ(args[1].type.size, 4U);
-  EXPECT_EQ(args[1].offset, 12);
+  EXPECT_EQ(args[1].type.size, 8U);
+  EXPECT_EQ(args[1].offset, 16);
 
   EXPECT_EQ(args[2].type.type, Type::string);
   EXPECT_EQ(args[2].type.size, 10U);
-  EXPECT_EQ(args[2].offset, 16);
+  EXPECT_EQ(args[2].offset, 24);
 
   EXPECT_EQ(args[3].type.type, Type::integer);
   EXPECT_EQ(args[3].type.size, 8U);
-  EXPECT_EQ(args[3].offset, 32);
+  EXPECT_EQ(args[3].offset, 40);
 }
 
 TEST(codegen, probe_count)

--- a/tests/codegen/llvm/call_printf.ll
+++ b/tests/codegen/llvm/call_printf.ll
@@ -3,7 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
-%printf_t = type { i64, i8, i64 }
+%printf_t = type { i64, i64, i64 }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
@@ -25,7 +25,7 @@ entry:
   %3 = load i8, i8* %"struct Foo.c", align 1
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %"struct Foo.c")
   %4 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
-  store i8 %3, i8* %4, align 8
+  store i8 %3, i64* %4, align 8
   %5 = bitcast i64* %"struct Foo.l" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i64, i8*)*)(i64* nonnull %"struct Foo.l", i64 8, i64 8)


### PR DESCRIPTION
This reverts commit 8af25ae9176766839d98d8cc31e1fb499fae36a4 as per #1173 

As indicated in the issue, this commit breaks a number of the tcp tools, possibly others. We'll need to investigate why and add a regression test when this commit is re-introduced.

@fbs @ajor 
