### PR TITLE
Fix reading USDT probe arguments on AArch64

### DIFF
--- a/src/arch/aarch64.cpp
+++ b/src/arch/aarch64.cpp
@@ -7,7 +7,7 @@ namespace bpftrace {
 namespace arch {
 
 // clang-format off
-static std::array<std::string, 35> registers = {
+static std::array<std::string, 34> registers = {
   "r0",
   "r1",
   "r2",
@@ -39,7 +39,44 @@ static std::array<std::string, 35> registers = {
   "r28",
   "r29",
   "r30",
-  "r31",
+  "sp",
+  "pc",
+  "pstate",
+};
+
+// Alternative register names that match struct pt_regs
+static std::array<std::string, 34> ptrace_registers = {
+  "regs[0]",
+  "regs[1]",
+  "regs[2]",
+  "regs[3]",
+  "regs[4]",
+  "regs[5]",
+  "regs[6]",
+  "regs[7]",
+  "regs[8]",
+  "regs[9]",
+  "regs[10]",
+  "regs[11]",
+  "regs[12]",
+  "regs[13]",
+  "regs[14]",
+  "regs[15]",
+  "regs[16]",
+  "regs[17]",
+  "regs[18]",
+  "regs[19]",
+  "regs[20]",
+  "regs[21]",
+  "regs[22]",
+  "regs[23]",
+  "regs[24]",
+  "regs[25]",
+  "regs[26]",
+  "regs[27]",
+  "regs[28]",
+  "regs[29]",
+  "regs[30]",
   "sp",
   "pc",
   "pstate",
@@ -61,7 +98,14 @@ int offset(std::string reg_name)
 {
   auto it = find(registers.begin(), registers.end(), reg_name);
   if (it == registers.end())
-    return -1;
+  {
+    // Also allow register names that match the fields in struct pt_regs.
+    // These appear in USDT probe arguments.
+    it = find(ptrace_registers.begin(), ptrace_registers.end(), reg_name);
+    if (it == ptrace_registers.end())
+      return -1;
+    return distance(ptrace_registers.begin(), it);
+  }
   return distance(registers.begin(), it);
 }
 

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -348,6 +348,13 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx, struct bcc_usdt_argument
   if (argument->valid & BCC_USDT_ARGUMENT_BASE_REGISTER_NAME) {
     int offset = 0;
     offset = arch::offset(argument->base_register_name);
+    if (offset < 0)
+    {
+      std::cerr << "offset for register " << argument->base_register_name
+                << " not known" << std::endl;
+      abort();
+    }
+
     Value* reg = CreateGEP(ctx, getInt64(offset * sizeof(uintptr_t)), "load_register");
     AllocaInst *dst = CreateAllocaBPF(builtin.type, builtin.ident);
     CreateProbeRead(dst, builtin.type.size, reg);


### PR DESCRIPTION
On AArch64 the register names in USDT probe arguments from libbcc are names of fields in `struct pt_regs` like "regs[0]", "regs[1]", etc. rather than the "r0", "r1", names currently used by bpftrace.

Modified `arch::offset()` to accept the pt_regs style names in addition to the existing names so we can generate the correct structure offsets.

Also fixed a small bug with the existing AArch64 register definitions where it defines registers r0..r31 but the `regs` array in `struct pt_regs` only has 31 elements. So the offsets of the registers after r31 are incorrect and e.g. `reg("sp")` actually reads "pc".