### PR TITLE
tests: cmake: Fix build with ninja

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -8,12 +8,13 @@ endif()
 
 # Regenerate codegen_includes.cpp whenever anything in the tests/codegen
 # directory changes
+file(GLOB_RECURSE CODEGEN_SOURCES codegen/*.cpp codegen/*.h)
 add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/tests/codegen_includes.cpp
   COMMAND
     ${CMAKE_COMMAND}
     -DTEST_SRC_DIR="${CMAKE_SOURCE_DIR}/tests/codegen"
     -P ${CMAKE_SOURCE_DIR}/tests/codegen/generate_codegen_includes.cmake
-  DEPENDS codegen/*.cpp codegen/*.h)
+  DEPENDS ${CODEGEN_SOURCES})
 
 add_executable(bpftrace_test
   ast.cpp


### PR DESCRIPTION
Fix the following error when trying to build with ninja:
$ mkdir build
$ cd build
$ cmake .. -GNinja
$ ninja
ninja: error: '../tests/codegen/*.cpp', needed by 'tests/codegen_includes.cpp', missing and no known rule to make it

Signed-off-by: Ovidiu Panait <ovpanait@gmail.com>