### PR TITLE
Slowfix

### DIFF
--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -206,10 +206,9 @@ static std::string remove_qualifiers(std::string &&typestr)
 {
   // libclang prints "const" keyword first
   // https://github.com/llvm-mirror/clang/blob/65acf43270ea2894dffa0d0b292b92402f80c8cb/lib/AST/TypePrinter.cpp#L137-L157
-  return std::regex_replace(typestr,
-                            std::regex("^(const volatile\\s+)|^(const\\s+)|"
-                                       "^(volatile\\s+)|\\*(\\s*restrict)$"),
-                            "");
+  static std::regex re("^(const volatile\\s+)|^(const\\s+)|"
+                       "^(volatile\\s+)|\\*(\\s*restrict)$");
+  return std::regex_replace(typestr, re, "");
 }
 
 static std::string get_unqualified_type_name(CXType clang_type)


### PR DESCRIPTION
Avoid calling "slow" regex constructor

On my ubuntu VM it took ~17 seconds before `tcpconnect.bt` was compiled,
most of the time spent in the newly added `remove)qualifiers`:

```
Time spent in remove_qualifiers: 17502 ms
Time spent in remove_qualifiers: 16662 ms
```

Which is mostly caused by the regex constructor being called 27k times.

With this patch the average of 10 runs is down to: 575ms

This fixes a regression introduced by #1177

----

The second commit optimizes the regex a bit, shaving off ~70ms

---

@mmisono  can you take a look at this one? I tested it by adding:

```
std::string x = std::regex_replace(typestr, re, "");
std::cout << x << std::endl;
return x;
```

The output for the original and mine are equal for tcpconnect.bt
