### PR TITLE
codegen: Send map id instead of ident string for async events

### DIFF
--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -1,0 +1,63 @@
+#pragma once
+
+#include "irbuilderbpf.h"
+#include <cstdint>
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Type.h>
+
+/*
+  The main goal here is to keep the struct definitions close to each other,
+  making it easier to spot type mismatches.
+*/
+
+namespace bpftrace {
+namespace AsyncEvent {
+
+struct Print
+{
+  uint64_t action_id;
+  uint32_t mapid;
+  uint32_t top;
+  uint32_t div;
+
+  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b)
+  {
+    return {
+      b.getInt64Ty(), // asyncid
+      b.getInt32Ty(), // map id
+      b.getInt32Ty(), // top
+      b.getInt32Ty(), // div
+    };
+  }
+} __attribute__((packed));
+
+struct MapEvent
+{
+  uint64_t action_id;
+  uint32_t mapid;
+
+  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b)
+  {
+    return {
+      b.getInt64Ty(), // asyncid
+      b.getInt32Ty(), // map id
+    };
+  }
+} __attribute__((packed));
+
+struct Time
+{
+  uint64_t action_id;
+  uint32_t time_id;
+
+  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b)
+  {
+    return {
+      b.getInt64Ty(), // asyncid
+      b.getInt32Ty(), // time id
+    };
+  }
+} __attribute__((packed));
+
+} // namespace AsyncEvent
+} // namespace bpftrace

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -91,6 +91,11 @@ private:
   int cat_id_ = 0;
   uint64_t join_id_ = 0;
   int system_id_ = 0;
+
+  size_t getStructSize(StructType *s)
+  {
+    return layout_.getTypeAllocSize(s);
+  }
 };
 
 } // namespace ast

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -136,6 +136,13 @@ AllocaInst *IRBuilderBPF::CreateAllocaBPF(int bytes, const std::string &name)
   return CreateAllocaBPF(ty, name);
 }
 
+llvm::ConstantInt *IRBuilderBPF::GetIntSameSize(uint64_t C, llvm::Type *ty)
+{
+  assert(ty->isIntegerTy());
+  unsigned size = ty->getIntegerBitWidth();
+  return getIntN(size, C);
+}
+
 llvm::ConstantInt *IRBuilderBPF::GetIntSameSize(uint64_t C, llvm::Value *expr)
 {
   unsigned size = expr->getType()->getIntegerBitWidth();

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -54,6 +54,7 @@ public:
   AllocaInst *CreateAllocaBPF(int bytes, const std::string &name="");
   llvm::Type *GetType(const SizedType &stype);
   llvm::ConstantInt *GetIntSameSize(uint64_t C, llvm::Value *expr);
+  llvm::ConstantInt *GetIntSameSize(uint64_t C, llvm::Type *ty);
   CallInst   *CreateBpfPseudoCall(int mapfd);
   CallInst   *CreateBpfPseudoCall(Map &map);
   Value      *CreateMapLookupElem(Map &map, AllocaInst *key);

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1790,7 +1790,11 @@ int SemanticAnalyser::create_maps(bool debug)
     auto &key = search_args->second;
 
     if (debug)
+    {
       bpftrace_.maps_[map_name] = std::make_unique<bpftrace::FakeMap>(map_name, type, key);
+      bpftrace_.maps_[map_name]->id = bpftrace_.map_ids_.size();
+      bpftrace_.map_ids_.push_back(map_name);
+    }
     else
     {
       if (type.type == Type::lhist)
@@ -1809,11 +1813,20 @@ int SemanticAnalyser::create_maps(bool debug)
         Integer &min = static_cast<Integer&>(min_arg);
         Integer &max = static_cast<Integer&>(max_arg);
         Integer &step = static_cast<Integer&>(step_arg);
-        bpftrace_.maps_[map_name] = std::make_unique<bpftrace::Map>(map_name, type, key, min.n, max.n, step.n, bpftrace_.mapmax_);
+        bpftrace_.maps_[map_name] = std::make_unique<bpftrace::Map>(
+            map_name, type, key, min.n, max.n, step.n, bpftrace_.mapmax_);
+        bpftrace_.maps_[map_name]->id = bpftrace_.map_ids_.size();
+        bpftrace_.map_ids_.push_back(map_name);
         failed_maps += is_invalid_map(bpftrace_.maps_[map_name]->mapfd_);
       }
       else
-        bpftrace_.maps_[map_name] = std::make_unique<bpftrace::Map>(map_name, type, key, bpftrace_.mapmax_);
+      {
+        bpftrace_.maps_[map_name] = std::make_unique<bpftrace::Map>(
+            map_name, type, key, bpftrace_.mapmax_);
+        bpftrace_.maps_[map_name]->id = bpftrace_.map_ids_.size();
+        bpftrace_.map_ids_.push_back(map_name);
+        failed_maps += is_invalid_map(bpftrace_.maps_[map_name]->mapfd_);
+      }
     }
   }
 

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -85,9 +85,9 @@ public:
   int num_probes() const;
   int run(std::unique_ptr<BpfOrc> bpforc);
   int print_maps();
-  int print_map_ident(const std::string &ident, uint32_t top, uint32_t div);
-  int clear_map_ident(const std::string &ident);
-  int zero_map_ident(const std::string &ident);
+  int clear_map(IMap &map);
+  int zero_map(IMap &map);
+  int print_map(IMap &map, uint32_t top, uint32_t div);
   inline int next_probe_id() {
     return next_probe_id_++;
   };
@@ -96,6 +96,10 @@ public:
     filename_ = filename;
   }
   inline const std::string &source() { return src_; }
+  inline IMap &get_map_by_id(uint32_t id)
+  {
+    return *maps_[map_ids_[id]].get();
+  };
   std::string get_stack(uint64_t stackidpid, bool ustack, StackType stack_type, int indent=0);
   std::string resolve_ksym(uintptr_t addr, bool show_offset=false);
   std::string resolve_usym(uintptr_t addr, int pid, bool show_offset=false, bool show_module=false);
@@ -130,6 +134,10 @@ public:
   static volatile sig_atomic_t exitsig_recv;
 
   std::map<std::string, std::unique_ptr<IMap>> maps_;
+
+  // Maps a map id back to the map identifier. See get_map_by_id()
+  std::vector<std::string> map_ids_;
+
   std::map<std::string, Struct> structs_;
   std::map<std::string, std::string> macros_;
   std::map<std::string, uint64_t> enums_;
@@ -208,9 +216,6 @@ private:
                                               const BpfOrc &bpforc);
   int setup_perf_events();
   void poll_perf_events(int epollfd, bool drain = false);
-  int clear_map(IMap &map);
-  int zero_map(IMap &map);
-  int print_map(IMap &map, uint32_t top, uint32_t div);
   int print_map_hist(IMap &map, uint32_t top, uint32_t div);
   int print_map_stats(IMap &map);
   template <typename T>

--- a/src/imap.h
+++ b/src/imap.h
@@ -28,6 +28,9 @@ public:
            map_type_ == BPF_MAP_TYPE_PERCPU_ARRAY;
   }
 
+  // unique id of this map. Used by (bpf) runtime to reference
+  // this map
+  uint32_t id;
   // used by lhist(). TODO: move to separate Map object.
   int lqmin;
   int lqmax;

--- a/tests/codegen/llvm/call_clear.ll
+++ b/tests/codegen/llvm/call_clear.ll
@@ -3,6 +3,8 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%clear_t = type <{ i64, i32 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
@@ -31,19 +33,16 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
-  %perfdata = alloca [11 x i8], align 8
-  %1 = getelementptr inbounds [11 x i8], [11 x i8]* %perfdata, i64 0, i64 0
+  %"clear_@x" = alloca %clear_t, align 8
+  %1 = bitcast %clear_t* %"clear_@x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 30002, [11 x i8]* %perfdata, align 8
-  %str.sroa.0.0..sroa_idx = getelementptr inbounds [11 x i8], [11 x i8]* %perfdata, i64 0, i64 8
-  store i8 64, i8* %str.sroa.0.0..sroa_idx, align 8
-  %str.sroa.4.0..sroa_idx = getelementptr inbounds [11 x i8], [11 x i8]* %perfdata, i64 0, i64 9
-  store i8 120, i8* %str.sroa.4.0..sroa_idx, align 1
-  %str.sroa.5.0..sroa_idx = getelementptr inbounds [11 x i8], [11 x i8]* %perfdata, i64 0, i64 10
-  store i8 0, i8* %str.sroa.5.0..sroa_idx, align 2
+  %2 = getelementptr inbounds %clear_t, %clear_t* %"clear_@x", i64 0, i32 0
+  store i64 30002, i64* %2, align 8
+  %3 = getelementptr inbounds %clear_t, %clear_t* %"clear_@x", i64 0, i32 1
+  store i32 0, i32* %3, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, [11 x i8]*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [11 x i8]* nonnull %perfdata, i64 11)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %clear_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %clear_t* nonnull %"clear_@x", i64 12)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_print.ll
+++ b/tests/codegen/llvm/call_print.ll
@@ -3,6 +3,8 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%print_t = type <{ i64, i32, i32, i32 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
@@ -31,27 +33,23 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
-  %perfdata = alloca [27 x i8], align 8
-  %1 = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 0
+  %"print_@x" = alloca %print_t, align 8
+  %1 = bitcast %print_t* %"print_@x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 30001, [27 x i8]* %perfdata, align 8
-  %2 = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 8
-  %str.sroa.0.0..sroa_idx = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 24
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %2, i8 0, i64 16, i1 false)
-  store i8 64, i8* %str.sroa.0.0..sroa_idx, align 8
-  %str.sroa.4.0..sroa_idx = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 25
-  store i8 120, i8* %str.sroa.4.0..sroa_idx, align 1
-  %str.sroa.5.0..sroa_idx = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 26
-  store i8 0, i8* %str.sroa.5.0..sroa_idx, align 2
+  %2 = getelementptr inbounds %print_t, %print_t* %"print_@x", i64 0, i32 0
+  store i64 30001, i64* %2, align 8
+  %3 = getelementptr inbounds %print_t, %print_t* %"print_@x", i64 0, i32 1
+  store i32 0, i32* %3, align 8
+  %4 = getelementptr inbounds %print_t, %print_t* %"print_@x", i64 0, i32 2
+  store i32 0, i32* %4, align 4
+  %5 = getelementptr inbounds %print_t, %print_t* %"print_@x", i64 0, i32 3
+  store i32 0, i32* %5, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, [27 x i8]*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [27 x i8]* nonnull %perfdata, i64 27)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %print_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %print_t* nonnull %"print_@x", i64 20)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/call_print_LLVM-5.ll
+++ b/tests/codegen/llvm/call_print_LLVM-5.ll
@@ -3,6 +3,8 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%print_t = type <{ i64, i32, i32, i32 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
@@ -31,27 +33,23 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
-  %perfdata = alloca [27 x i8], align 8
-  %1 = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 0
+  %"print_@x" = alloca %print_t, align 8
+  %1 = bitcast %print_t* %"print_@x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 30001, [27 x i8]* %perfdata, align 8
-  %2 = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 8
-  %str.sroa.0.0..sroa_idx = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 24
-  call void @llvm.memset.p0i8.i64(i8* %2, i8 0, i64 16, i32 8, i1 false)
-  store i8 64, i8* %str.sroa.0.0..sroa_idx, align 8
-  %str.sroa.4.0..sroa_idx = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 25
-  store i8 120, i8* %str.sroa.4.0..sroa_idx, align 1
-  %str.sroa.5.0..sroa_idx = getelementptr inbounds [27 x i8], [27 x i8]* %perfdata, i64 0, i64 26
-  store i8 0, i8* %str.sroa.5.0..sroa_idx, align 2
+  %2 = getelementptr inbounds %print_t, %print_t* %"print_@x", i64 0, i32 0
+  store i64 30001, i64* %2, align 8
+  %3 = getelementptr inbounds %print_t, %print_t* %"print_@x", i64 0, i32 1
+  store i32 0, i32* %3, align 8
+  %4 = getelementptr inbounds %print_t, %print_t* %"print_@x", i64 0, i32 2
+  store i32 0, i32* %4, align 4
+  %5 = getelementptr inbounds %print_t, %print_t* %"print_@x", i64 0, i32 3
+  store i32 0, i32* %5, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, [27 x i8]*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [27 x i8]* nonnull %perfdata, i64 27)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %print_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %print_t* nonnull %"print_@x", i64 20)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i32, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/call_time.ll
+++ b/tests/codegen/llvm/call_time.ll
@@ -3,6 +3,8 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%time_t = type <{ i64, i32 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
@@ -11,15 +13,16 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
-  %perfdata = alloca [16 x i8], align 8
-  %1 = getelementptr inbounds [16 x i8], [16 x i8]* %perfdata, i64 0, i64 0
+  %time_t = alloca %time_t, align 8
+  %1 = bitcast %time_t* %time_t to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 30004, [16 x i8]* %perfdata, align 8
-  %2 = getelementptr inbounds [16 x i8], [16 x i8]* %perfdata, i64 0, i64 8
-  store i64 0, i8* %2, align 8
+  %2 = getelementptr inbounds %time_t, %time_t* %time_t, i64 0, i32 0
+  store i64 30004, i64* %2, align 8
+  %3 = getelementptr inbounds %time_t, %time_t* %time_t, i64 0, i32 1
+  store i32 0, i32* %3, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, [16 x i8]*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [16 x i8]* nonnull %perfdata, i64 16)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %time_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %time_t* nonnull %time_t, i64 12)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_zero.ll
+++ b/tests/codegen/llvm/call_zero.ll
@@ -3,6 +3,8 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%zero_t = type <{ i64, i32 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
@@ -31,19 +33,16 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
 entry:
-  %perfdata = alloca [11 x i8], align 8
-  %1 = getelementptr inbounds [11 x i8], [11 x i8]* %perfdata, i64 0, i64 0
+  %"zero_@x" = alloca %zero_t, align 8
+  %1 = bitcast %zero_t* %"zero_@x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 30003, [11 x i8]* %perfdata, align 8
-  %str.sroa.0.0..sroa_idx = getelementptr inbounds [11 x i8], [11 x i8]* %perfdata, i64 0, i64 8
-  store i8 64, i8* %str.sroa.0.0..sroa_idx, align 8
-  %str.sroa.4.0..sroa_idx = getelementptr inbounds [11 x i8], [11 x i8]* %perfdata, i64 0, i64 9
-  store i8 120, i8* %str.sroa.4.0..sroa_idx, align 1
-  %str.sroa.5.0..sroa_idx = getelementptr inbounds [11 x i8], [11 x i8]* %perfdata, i64 0, i64 10
-  store i8 0, i8* %str.sroa.5.0..sroa_idx, align 2
+  %2 = getelementptr inbounds %zero_t, %zero_t* %"zero_@x", i64 0, i32 0
+  store i64 30003, i64* %2, align 8
+  %3 = getelementptr inbounds %zero_t, %zero_t* %"zero_@x", i64 0, i32 1
+  store i32 0, i32* %3, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, [11 x i8]*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, [11 x i8]* nonnull %perfdata, i64 11)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %zero_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %zero_t* nonnull %"zero_@x", i64 12)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }


### PR DESCRIPTION
We're currently sending the full map identifier as string to userspace.
This has a lot of overhead as we're sending a lot of potentially very
long strings around.

The approach taking here is to assign each map a unique uint32_t id
during creation. Which can then be used to send events from bpf to user
space.
To make the whole thing llvm-type-safe and remove the confusing pointer
math it now uses structs instead of arrays on both the bpf and the
user space side.

To avoid having to keep track of the "LLVM struct" and the "C struct"
in multiple files and accidentally introduce type issues they've been
defined in a single place. While there is no checking on them, having
them close together makes spotting errors easier.

Fixes #1188 