### PR TITLE
Update minimum required version of CMake to 3.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.8)
 project(bpftrace)
 
 # bpftrace version number components.


### PR DESCRIPTION
CMake 3.8 is required to use C++17.
cf. https://github.com/Kitware/CMake/commit/ae1a6815b6e2c0a45df51e994b75f9005e1794fe

closes #1193