### PR TITLE
Improve an error message when trying to use 'args' other than tracepoint

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1282,7 +1282,13 @@ void SemanticAnalyser::visit(FieldAccess &acc)
 
   if (type.is_tparg) {
     for (AttachPoint *attach_point : *probe_->attach_points) {
-      assert(probetype(attach_point->provider) == ProbeType::tracepoint);
+      if (probetype(attach_point->provider) != ProbeType::tracepoint)
+      {
+        // The args builtin can only be used with tracepoint
+        // an error message is already generated in visit(Builtin)
+        // just continue semantic analysis
+        continue;
+      }
 
       auto symbol_stream = bpftrace_.get_symbols_from_file(
           "/sys/kernel/debug/tracing/available_events");


### PR DESCRIPTION
This cahnges an error message

```
% sudo ./src/bpftrace -e 'k:f,t:syscalls:sys_enter_open {@=str(args->filename);}'
bpftrace: ../src/ast/semantic_analyser.cpp:1285: virtual void bpftrace::ast::SemanticAnalyser::visit(bpftrace::ast::FieldAccess &): Assertion `probetype(attach_point->provider) == ProbeType::tracepoint' failed.
zsh: abort      sudo ./src/bpftrace -e
```

to

```
% sudo ./src/bpftrace -e 'k:f,t:syscalls:sys_enter_open {@=str(args->filename);}'
stdin:1:1-41: ERROR: The args builtin can only be used with tracepoint probes (kprobe used here)
k:f,t:syscalls:sys_enter_open{@=str(args->filename);}
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```