### PR TITLE
parser: Do not remove empty probe arguments

### DIFF
--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -20,8 +20,7 @@ namespace {
  * formed. More specifically, that there is no unescaped whitespace
  * and no unmatched quotes.
  */
-std::vector<std::string> split_attachpoint(const std::string &raw,
-                                           bool remove_empty = false)
+std::vector<std::string> split_attachpoint(const std::string &raw)
 {
   std::vector<std::string> ret;
   bool in_quotes = false;
@@ -31,9 +30,6 @@ std::vector<std::string> split_attachpoint(const std::string &raw,
   {
     if (raw[idx] == ':' && !in_quotes)
     {
-      if (argument.empty() && remove_empty)
-        continue;
-
       ret.emplace_back(std::move(argument));
       // The standard says an std::string in moved-from state is in
       // valid but unspecified state, so clear() to be safe
@@ -51,9 +47,11 @@ std::vector<std::string> split_attachpoint(const std::string &raw,
       argument += raw[idx];
   }
 
-  // Always drop final element if it's empty
-  if (argument.size())
-    ret.emplace_back(std::move(argument));
+  // Add final argument
+  //
+  // There will always be text in `argument` unless the AP definition
+  // ended in a ':' which we will treat as an empty argument.
+  ret.emplace_back(std::move(argument));
 
   return ret;
 }
@@ -96,7 +94,7 @@ int AttachPointParser::parse_attachpoint(AttachPoint &ap)
 {
   ap_ = &ap;
 
-  parts_ = split_attachpoint(ap_->raw_input, true);
+  parts_ = split_attachpoint(ap_->raw_input);
   if (parts_.empty())
   {
     errs_ << "Invalid attachpoint definition" << std::endl;
@@ -315,9 +313,6 @@ int AttachPointParser::uretprobe_parser()
 
 int AttachPointParser::usdt_parser()
 {
-  // Allow empty fields
-  parts_ = split_attachpoint(ap_->raw_input, false);
-
   if (parts_.size() != 3 && parts_.size() != 4)
   {
     errs_ << ap_->provider << " probe type requires 2 or 3 arguments"
@@ -501,9 +496,6 @@ int AttachPointParser::hardware_parser()
 
 int AttachPointParser::watchpoint_parser()
 {
-  // Allow empty fields
-  parts_ = split_attachpoint(ap_->raw_input, false);
-
   if (parts_.size() != 5)
   {
     errs_ << ap_->provider << " probe type requires 4 arguments" << std::endl;

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1536,6 +1536,13 @@ TEST(Parser, long_param_overflow)
   EXPECT_EQ(out.str(), expected);
 }
 
+TEST(Parser, empty_arguments)
+{
+  test_parse_failure("::k::vfs_open:: { 1 }");
+  test_parse_failure("k:vfs_open: { 1 }");
+  test_parse_failure(":w:0x10000000:8:rw { 1 }");
+}
+
 } // namespace parser
 } // namespace test
 } // namespace bpftrace


### PR DESCRIPTION
There was no reason to remove empty probe arguments. There wasn't a
single probe that needed this behavior.

Also add a regression test.