### PR TITLE
Error if wildcards are used in "category" of tracepoint

### DIFF
--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -41,6 +41,14 @@ bool TracepointFormatParser::parse(ast::Program *program)
         std::string format_file_path = "/sys/kernel/debug/tracing/events/" + category + "/" + event_name + "/format";
         glob_t glob_result;
 
+        if (has_wildcard(category))
+        {
+          std::cerr
+              << "ERROR: wildcards in tracepoint category is not supported: "
+              << category << std::endl;
+          return false;
+        }
+
         if (has_wildcard(event_name))
         {
           // tracepoint wildcard expansion, part 1 of 3. struct definitions.


### PR DESCRIPTION
Currently, TracepointFormatParser::parse() does not expand wildcards in "category". This leads to an incorrect event name.
https://github.com/iovisor/bpftrace/blob/24f97308895078fe0130a58e0cf5703f4de975a9/src/tracepoint_format_parser.cpp#L73-L75

Check if wildcards are used in "category" and return an error in that case.
For example:

```
% sudo ./src/bpftrace -e 'tracepoint:sys*:*{args;}'
ERROR: wildcard in tracepoint category is not supported: sys*
```