### PR TITLE
Don't check cgroupid string argument length

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -96,7 +96,8 @@ void SemanticAnalyser::visit(PositionalParameter &param)
 
 void SemanticAnalyser::visit(String &string)
 {
-  if (string.str.size() > STRING_SIZE-1) {
+  if (!is_compile_time_func(func_) && string.str.size() > STRING_SIZE - 1)
+  {
     ERR("String is too long (over " << STRING_SIZE << " bytes): " << string.str,
         string.loc);
   }

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -332,6 +332,26 @@ void SemanticAnalyser::visit(Call &call)
           call.loc);
   }
 
+  struct func_setter
+  {
+    func_setter(SemanticAnalyser &analyser, const std::string &s)
+        : analyser_(analyser), old_func_(analyser_.func_)
+    {
+      analyser_.func_ = s;
+    }
+
+    ~func_setter()
+    {
+      analyser_.func_ = old_func_;
+    }
+
+  private:
+    SemanticAnalyser &analyser_;
+    std::string old_func_;
+  };
+
+  func_setter scope_bound_func_setter{ *this, call.func };
+
   if (call.vargs) {
     for (Expression *expr : *call.vargs) {
       expr->accept(*this);

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -75,6 +75,7 @@ private:
   void assign_map_type(const Map &map, const SizedType &type);
 
   Probe *probe_;
+  std::string func_;
   std::map<std::string, SizedType> variable_val_;
   std::map<std::string, SizedType> map_val_;
   std::map<std::string, MapKey> map_key_;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -541,6 +541,13 @@ bool is_unsafe_func(const std::string &func_name)
       });
 }
 
+bool is_compile_time_func(const std::string &func_name)
+{
+  return std::any_of(COMPILE_TIME_FUNCS.begin(),
+                     COMPILE_TIME_FUNCS.end(),
+                     [&](const auto &cand) { return func_name == cand; });
+}
+
 std::string exec_system(const char* cmd)
 {
   std::array<char, 128> buffer;

--- a/src/utils.h
+++ b/src/utils.h
@@ -99,6 +99,8 @@ static std::vector<std::string> UNSAFE_BUILTIN_FUNCS = {
   "override",
 };
 
+static std::vector<std::string> COMPILE_TIME_FUNCS = { "cgroupid" };
+
 bool get_uint64_env_var(const ::std::string &str, uint64_t &dest);
 std::string get_pid_exe(pid_t pid);
 bool has_wildcard(const std::string &str);
@@ -119,6 +121,7 @@ std::vector<std::string> get_kernel_cflags(const char *uname_machine,
                                            const std::string &kobj);
 const std::string &is_deprecated(const std::string &str);
 bool is_unsafe_func(const std::string &func_name);
+bool is_compile_time_func(const std::string &func_name);
 std::string exec_system(const char *cmd);
 std::vector<std::string> resolve_binary_path(const std::string &cmd);
 std::vector<std::string> resolve_binary_path(const std::string &cmd, int pid);

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -183,6 +183,7 @@ TEST(semantic_analyser, builtin_functions)
   test("kprobe:f { ustack(1) }", 0);
   test("kprobe:f { cat(\"/proc/uptime\") }", 0);
   test("uprobe:/bin/bash:main { uaddr(\"glob_asciirange\") }", 0);
+  test("kprobe:f { cgroupid(\"/sys/fs/cgroup/unified/mycg\"); }", 0);
 }
 
 TEST(semantic_analyser, undefined_map)
@@ -572,6 +573,16 @@ TEST(semantic_analyser, call_uaddr)
     EXPECT_EQ(true, v->var->type.is_pointer);
     EXPECT_EQ((unsigned long int)sizes.at(i), v->var->type.pointee_size);
   }
+}
+
+TEST(semantic_analyser, call_cgroupid)
+{
+  // Handle args above STRING_SIZE
+  test("kprobe:f { cgroupid("
+       //          1         2         3         4         5         6
+       "\"123456789/123456789/123456789/123456789/123456789/123456789/12345\""
+       "); }",
+       0);
 }
 
 TEST(semantic_analyser, call_reg)


### PR DESCRIPTION
Since `cgroupid` is evaluated at compile-time, we don't need to check its arguments length.

Now when analyzing function calls, we keep track of the inner-most function and use it to decide whether to check the string argument length, skipping the check for compile-time functions. This just applies to `cgroupid` for now.

We can extend this to `kaddr` and `uaddr` with a few more lines. If this approach looks OK I can add them here or in another PR.

Fixes #1207.