### PR TITLE
Remove unused members from BPFtrace

### DIFF
--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -211,7 +211,6 @@ private:
   int zero_map(IMap &map);
   int print_map(IMap &map, uint32_t top, uint32_t div);
   int print_map_hist(IMap &map, uint32_t top, uint32_t div);
-  int print_map_lhist(IMap &map);
   int print_map_stats(IMap &map);
   template <typename T>
   static T reduce_value(const std::vector<uint8_t> &value, int nvalues);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -201,7 +201,6 @@ private:
 
   std::string src_;
   std::string filename_;
-  std::vector<std::string> srclines_;
 
   std::unique_ptr<AttachedProbe> attach_probe(Probe &probe,
                                               const BpfOrc &bpforc);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -214,10 +214,6 @@ private:
   int print_map_lhist(IMap &map);
   int print_map_stats(IMap &map);
   int print_hist(const std::vector<uint64_t> &values, uint32_t div) const;
-  int print_lhist(const std::vector<uint64_t> &values,
-                  int min,
-                  int max,
-                  int step) const;
   template <typename T>
   static T reduce_value(const std::vector<uint8_t> &value, int nvalues);
   static int64_t min_value(const std::vector<uint8_t> &value, int nvalues);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -213,7 +213,6 @@ private:
   int print_map_hist(IMap &map, uint32_t top, uint32_t div);
   int print_map_lhist(IMap &map);
   int print_map_stats(IMap &map);
-  int print_hist(const std::vector<uint64_t> &values, uint32_t div) const;
   template <typename T>
   static T reduce_value(const std::vector<uint8_t> &value, int nvalues);
   static int64_t min_value(const std::vector<uint8_t> &value, int nvalues);


### PR DESCRIPTION
A few functions didn't have implementations and one member variable was unused. The individual commits have details.

Related to #1080.