### PR TITLE
Gracefully handle long position param overflow

### DIFF
--- a/src/parser.yy
+++ b/src/parser.yy
@@ -195,7 +195,15 @@ pred : DIV expr ENDPRED { $$ = new ast::Predicate($2, @$); }
 ternary : expr QUES expr COLON expr { $$ = new ast::Ternary($1, $3, $5, @$); }
      ;
 
-param : PARAM      { $$ = new ast::PositionalParameter(PositionalParameterType::positional, std::stoll($1.substr(1, $1.size()-1)), @$); }
+param : PARAM      {
+                     try {
+                       $$ = new ast::PositionalParameter(PositionalParameterType::positional, std::stol($1.substr(1, $1.size()-1)), @$);
+                     } catch (std::exception const& e) {
+                       error(@1, "param " + $1 + " is out of integer range [1, " +
+                             std::to_string(std::numeric_limits<long>::max()) + "]");
+                       YYERROR;
+                     }
+                   }
       | PARAMCOUNT { $$ = new ast::PositionalParameter(PositionalParameterType::count, 0, @$); }
       ;
 

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1427,6 +1427,22 @@ TEST(Parser, invalid_increment_decrement)
   test_parse_failure("i:s:1 { @=\"a\"++}");
 }
 
+TEST(Parser, long_param_overflow)
+{
+  BPFtrace bpftrace;
+  std::stringstream out;
+  Driver driver(bpftrace, out);
+  EXPECT_NO_THROW(
+      driver.parse_str("i:s:100 { @=$111111111111111111111111111 }"));
+  std::string expected = "stdin:1:11-41: ERROR: param "
+                         "$111111111111111111111111111 is out of "
+                         "integer range [1, " +
+                         std::to_string(std::numeric_limits<long>::max()) +
+                         "]\n" +
+                         "i:s:100 { @=$111111111111111111111111111 }\n" +
+                         "          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n";
+  EXPECT_EQ(out.str(), expected);
+}
 
 } // namespace parser
 } // namespace test


### PR DESCRIPTION
Before this change the param could overflow which led to program crash:

```
$ bpftrace -e 'i:s:100 { @=$111111111111111111111111111 }'
terminate called after throwing an instance of 'std::out_of_range'
  what():  stoll
Aborted
```

Now, the event  is gracefully handled with error like:

```
$bpftrace -e 'i:s:100 { @=$111111111111111111111111111 }'
stdin:1:11-41: ERROR: param $111111111111111111111111111 is out of integer range [1, 9223372036854775807]
i:s:100 { @=$111111111111111111111111111 }
          ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Fixes: #994