### PR TITLE
snapcraft: add arm64 to build architectures

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -25,7 +25,7 @@ description: BPFtrace is a high-level tracing language for
 confinement: strict
 grade: stable
 base: core18
-architectures: [amd64]
+architectures: [amd64, arm64]
 assumes: [snapd2.37]
 adopt-info: bpftrace
 


### PR DESCRIPTION
This builds also for arm64, so add that to the allowed list.

Signed-off-by: Colin Ian King <colin.king@canonical.com>