### PR TITLE
cmake: Link against libz when searching for btf_dump__new

### DIFF
--- a/cmake/FindLibBpf.cmake
+++ b/cmake/FindLibBpf.cmake
@@ -47,7 +47,7 @@ mark_as_advanced(LIBBPF_INCLUDE_DIRS LIBBPF_LIBRARIES)
 if (LIBBPF_FOUND)
   include(CheckSymbolExists)
   # adding also elf for static build check
-  SET(CMAKE_REQUIRED_LIBRARIES ${LIBBPF_LIBRARIES} elf)
+  SET(CMAKE_REQUIRED_LIBRARIES ${LIBBPF_LIBRARIES} elf z)
   # libbpf quirk, needs upstream fix
   SET(CMAKE_REQUIRED_DEFINITIONS -include stdbool.h)
   check_symbol_exists(btf_dump__new "${LIBBPF_INCLUDE_DIRS}/bpf/btf.h" HAVE_BTF_DUMP)


### PR DESCRIPTION
Kernel commit 166750bc1dd256 ("libbpf: Support libbpf-provided extern variables")
placed an explicit dependency from libbpf to libz. This caused symbol
checks in static builds to fail linking (because static library
dependencies are not automatically pulled in like dynamic libraries).

The end result was that BTF support was silently failing because the
BTF::BTF() constructor was using the stubbed out implementation, leaving
the BTF instance in bpftrace in NODATA state. This caused the
FieldAnalyser to bail early and not analyze fields b/c it thought the
system did not have BTF data.