### PR TITLE
Check the length of ap.mode

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1675,13 +1675,16 @@ void SemanticAnalyser::visit(AttachPoint &ap)
       error("watchpoint must be attached to a non-zero address", ap.loc);
     if (ap.len != 1 && ap.len != 2 && ap.len != 4 && ap.len != 8)
       error("watchpoint length must be one of (1,2,4,8)", ap.loc);
+    if (ap.mode.empty())
+      error("watchpoint mode must be combination of (r,w,x)", ap.loc);
     std::sort(ap.mode.begin(), ap.mode.end());
     for (const char c : ap.mode) {
       if (c != 'r' && c != 'w' && c != 'x')
         error("watchpoint mode must be combination of (r,w,x)", ap.loc);
     }
-    for (size_t i = 0; i < ap.mode.size() - 1; ++i) {
-      if (ap.mode[i] == ap.mode[i+1])
+    for (size_t i = 1; i < ap.mode.size(); ++i)
+    {
+      if (ap.mode[i - 1] == ap.mode[i])
         error("watchpoint modes may not be duplicated", ap.loc);
     }
     if (ap.mode == "rx" || ap.mode == "wx" || ap.mode == "rwx")


### PR DESCRIPTION
This fixes the following error.

```
% sudo ./src/bpftrace -e 'w::0x10000000:8:: {}'
AddressSanitizer:DEADLYSIGNAL
=================================================================
==26761==ERROR: AddressSanitizer: SEGV on unknown address 0x614000010000 (pc 0x0000008dc6b6 bp 0x7ffe172080c0 sp 0x7ffe17207540 T0)
==26761==The signal is caused by a READ memory access.
    #0 0x8dc6b6 in bpftrace::ast::SemanticAnalyser::visit(bpftrace::ast::AttachPoint&) /home/ubuntu/work/bpftrace/bpftrace/build_asan/../src/ast/semantic_analyser.cpp:1684:25
    #1 0x87c3e3 in bpftrace::ast::AttachPoint::accept(bpftrace::ast::Visitor&) /home/ubuntu/work/bpftrace/bpftrace/build_asan/../src/ast/ast.cpp:323:5
    #2 0x8dd1bc in bpftrace::ast::SemanticAnalyser::visit(bpftrace::ast::Probe&) /home/ubuntu/work/bpftrace/bpftrace/build_asan/../src/ast/semantic_analyser.cpp:1737:9
    #3 0x87c603 in bpftrace::ast::Probe::accept(bpftrace::ast::Visitor&) /home/ubuntu/work/bpftrace/bpftrace/build_asan/../src/ast/ast.cpp:355:5
    #4 0x8dd2eb in bpftrace::ast::SemanticAnalyser::visit(bpftrace::ast::Program&) /home/ubuntu/work/bpftrace/bpftrace/build_asan/../src/ast/semantic_analyser.cpp:1751:12
    #5 0x87c6b3 in bpftrace::ast::Program::accept(bpftrace::ast::Visitor&) /home/ubuntu/work/bpftrace/bpftrace/build_asan/../src/ast/ast.cpp:364:5
    #6 0x8dd35a in bpftrace::ast::SemanticAnalyser::analyse() /home/ubuntu/work/bpftrace/bpftrace/build_asan/../src/ast/semantic_analyser.cpp:1760:12
    #7 0x80f63f in main /home/ubuntu/work/bpftrace/bpftrace/build_asan/../src/main.cpp:577:19
    #8 0x7fec4efa5b96 in __libc_start_main /build/glibc-OTsEL5/glibc-2.27/csu/../csu/libc-start.c:310
    #9 0x5c1e39 in _start (/home/ubuntu/work/bpftrace/bpftrace/build_asan/src/bpftrace+0x5c1e39)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /home/ubuntu/work/bpftrace/bpftrace/build_asan/../src/ast/semantic_analyser.cpp:1684:25 in bpftrace::ast::SemanticAnalyser::visit(bpftrace::ast::AttachPoint&)
==26761==ABORTING
```

This is because `ap.mode.size()` is zero (`ap.mode` is a empty string)
and `ap.mode.size() - 1` causes underflow (`size_t` is unsigned).

https://github.com/iovisor/bpftrace/blob/96b6eb83c93668fd1e54147c8e1929fedd571dac/src/ast/semantic_analyser.cpp#L1683-L1684

With this patch,

```
% sudo ./src/bpftrace -e 'w::0x10000000:8:: {}'
stdin:1:1-18: ERROR: watchpoint mode must be combination of (r,w,x)
w::0x10000000:8:: {}
~~~~~~~~~~~~~~~~
```