### PR TITLE
Fix ternary comparison

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1105,8 +1105,10 @@ void CodegenLLVM::visit(Ternary &ternary)
   Value *cond;
   ternary.cond->accept(*this);
   cond = expr_;
-  b_.CreateCondBr(b_.CreateICmpNE(cond, b_.getInt64(0), "true_cond"),
-                  left_block, right_block);
+  Value *zero_value = Constant::getNullValue(cond->getType());
+  b_.CreateCondBr(b_.CreateICmpNE(cond, zero_value, "true_cond"),
+                  left_block,
+                  right_block);
 
   if (ternary.type.type == Type::integer) {
     // fetch selected integer via CreateStore


### PR DESCRIPTION
`CreateICmpNE()` in a ternary unconditionally uses Int64Ty and cannot
use with other types. For example:

```
% sudo ./src/bpftrace -e 'k:f {!nsecs ? 0: 1;}'
bpftrace: /usr/lib/llvm-9/include/llvm/IR/Instructions.h:1151: void llvm::ICmpInst::AssertOK(): Assertion `getOperand(0)->getType() == getOperand(1)->getType() && "Both operands to ICmp instruction are not of the same type!"' failed.
```

The type of `!nsecs` is Integer whose bit width is 1.
Fix this by using the same type of the operand.