### PR TITLE
Cast LNOT result

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -994,8 +994,13 @@ void CodegenLLVM::visit(Unop &unop)
     {
       case bpftrace::Parser::token::LNOT:
       {
-        Value *zero_value = Constant::getNullValue(expr_->getType());
+        auto ty = expr_->getType();
+        Value *zero_value = Constant::getNullValue(ty);
         expr_ = b_.CreateICmpEQ(expr_, zero_value);
+        // CreateICmpEQ() returns 1-bit integer
+        // Cast it to the same type of the operand
+        // Use unsigned extention, otherwise !0 becomes -1
+        expr_ = b_.CreateIntCast(expr_, ty, false);
         break;
       }
       case bpftrace::Parser::token::BNOT: expr_ = b_.CreateNot(expr_); break;


### PR DESCRIPTION
CreateICmpEQ() returns 1-bit integer and this can causes typing issues.
Promote a result to the same type of the operand.

Fixes #1223