### PR TITLE
Docs: Add missing builtin functions in reference guide

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1878,7 +1878,7 @@ Supported Probe Types:
 - u(ret)probes
 - USDT
 
-**Does not work with ASLR, see issue [#75](https://github.com/iovisor/bpftrace/75)**
+**Does not work with ASLR, see issue [#75](https://github.com/iovisor/bpftrace/issues/75)**
 
 The `uaddr` function returns the address of the specified symbol. This lookup
 happens during program compilation and cannot be used dynamically.

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1688,6 +1688,9 @@ Tracing block I/O sizes > 0 bytes
 - `ustack([StackMode mode, ][int level])` - User stack trace
 - `ntop([int af, ]int|char[4|16] addr)` - Convert IP address data to text
 - `cat(char *filename)` - Print file content
+- `signal(char[] signal | u32 signal)` - Send a signal to the current task
+- `strncmp(char *s1, char *s2, int length)` - Compare first n characters of two strings
+- `override(u64 rc)` - Override return value
 
 Some of these are asynchronous: the kernel queues the event, but some time later (milliseconds) it is
 processed in user-space. The asynchronous actions are: `printf()`, `time()`, and `join()`. Both `ksym()`


### PR DESCRIPTION
A couple of minor fixes to keep things in sync.