### PR TITLE
Don't over-read usdt arguments

### DIFF
--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -172,3 +172,9 @@ RUN bpftrace -e 'usdt:./testprogs/usdt_quoted_probe:test:"\"probe1\"" { printf("
 EXPECT 1
 TIMEOUT 5
 BEFORE ./testprogs/usdt_quoted_probe
+
+NAME "usdt sized arguments"
+RUN bpftrace -e 'usdt:./testprogs/usdt_sized_args:test:probe2 { printf("%ld\n", arg0); exit(); }' -p $(pidof usdt_sized_args)
+EXPECT ^1$
+TIMEOUT 5
+BEFORE ./testprogs/usdt_sized_args

--- a/tests/testprogs/usdt_sized_args.c
+++ b/tests/testprogs/usdt_sized_args.c
@@ -1,0 +1,25 @@
+#ifdef HAVE_SYSTEMTAP_SYS_SDT_H
+#include <sys/sdt.h>
+#else
+#define DTRACE_PROBE1(a, b, c) (void)0
+#endif
+#include <stdint.h>
+
+int main()
+{
+  uint32_t a = 0xdeadbeef;
+  uint32_t b = 1;
+  uint64_t c = UINT64_MAX;
+  (void)a;
+  (void)b;
+  (void)c;
+
+  while (1)
+  {
+    DTRACE_PROBE1(test, probe1, a);
+    DTRACE_PROBE1(test, probe2, b);
+    DTRACE_PROBE1(test, probe3, c);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
bpftrace internally represents USDT arguments as 64 bit types. However,
actual USDT arguments can be less than that. This commit ensures we only
read the actual size while zero-ing out unused bits.

See runtime test for where the previous behavior can go wrong.