### PR TITLE
Add support for using demangled symbols in uretprobe names

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -140,7 +140,8 @@ int BPFtrace::add_probe(ast::Probe &p)
       }
       attach_funcs.insert(attach_funcs.end(), matches.begin(), matches.end());
     }
-    else if (probetype(attach_point->provider) == ProbeType::uprobe &&
+    else if ((probetype(attach_point->provider) == ProbeType::uprobe ||
+              probetype(attach_point->provider) == ProbeType::uretprobe) &&
              !attach_point->func.empty())
     {
       std::set<std::string> matches;


### PR DESCRIPTION
This allows using demangled symbols in uretprobe such as `ur:./a.out:"f(int)"`.
Demangled symbols in uprobe names are already supported (#1116).