### PR TITLE
Check a type of condition of if and ternary

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1219,11 +1219,17 @@ void CodegenLLVM::visit(Ternary &ternary)
     // fetch selected integer via CreateStore
     b_.SetInsertPoint(left_block);
     ternary.left->accept(*this);
+    expr_ = b_.CreateIntCast(expr_,
+                             b_.GetType(ternary.type),
+                             ternary.type.is_signed);
     b_.CreateStore(expr_, result);
     b_.CreateBr(done);
 
     b_.SetInsertPoint(right_block);
     ternary.right->accept(*this);
+    expr_ = b_.CreateIntCast(expr_,
+                             b_.GetType(ternary.type),
+                             ternary.type.is_signed);
     b_.CreateStore(expr_, result);
     b_.CreateBr(done);
 

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1352,6 +1352,13 @@ void SemanticAnalyser::visit(If &if_block)
 {
   if_block.cond->accept(*this);
 
+  if (is_final_pass())
+  {
+    Type &cond = if_block.cond->type.type;
+    if (cond != Type::integer)
+      ERR("Invalid condition in if(): " << cond, if_block.loc);
+  }
+
   for (Statement *stmt : *if_block.stmts) {
     stmt->accept(*this);
   }

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1329,6 +1329,7 @@ void SemanticAnalyser::visit(Ternary &ternary)
   ternary.cond->accept(*this);
   ternary.left->accept(*this);
   ternary.right->accept(*this);
+  Type &cond = ternary.cond->type.type;
   Type &lhs = ternary.left->type.type;
   Type &rhs = ternary.right->type.type;
   if (is_final_pass()) {
@@ -1338,6 +1339,8 @@ void SemanticAnalyser::visit(Ternary &ternary)
               << "and '" << rhs << "'",
           ternary.loc);
     }
+    if (cond != Type::integer)
+      ERR("Invalid condition in ternary: " << cond, ternary.loc);
   }
   if (lhs == Type::string)
     ternary.type = SizedType(lhs, STRING_SIZE);

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -798,6 +798,7 @@ void SemanticAnalyser::visit(Call &call)
     call.type = SizedType(Type::none, 0);
   }
   else if (call.func == "exit") {
+    check_assignment(call, false, false, false);
     check_nargs(call, 0);
   }
   else if (call.func == "print") {

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -483,6 +483,7 @@ void SemanticAnalyser::visit(Call &call)
     bool sign = false;
     check_assignment(call, true, false, false);
     if (check_nargs(call, 1)) {
+      check_arg(call, Type::integer, 0);
       sign = call.vargs->at(0)->type.is_signed;
     }
     call.type = SizedType(Type::sum, 8, sign);
@@ -491,6 +492,7 @@ void SemanticAnalyser::visit(Call &call)
     bool sign = false;
     check_assignment(call, true, false, false);
     if (check_nargs(call, 1)) {
+      check_arg(call, Type::integer, 0);
       sign = call.vargs->at(0)->type.is_signed;
     }
     call.type = SizedType(Type::min, 8, sign);
@@ -499,6 +501,7 @@ void SemanticAnalyser::visit(Call &call)
     bool sign = false;
     check_assignment(call, true, false, false);
     if (check_nargs(call, 1)) {
+      check_arg(call, Type::integer, 0);
       sign = call.vargs->at(0)->type.is_signed;
     }
     call.type = SizedType(Type::max, 8, sign);
@@ -506,11 +509,13 @@ void SemanticAnalyser::visit(Call &call)
   else if (call.func == "avg") {
     check_assignment(call, true, false, false);
     check_nargs(call, 1);
+    check_arg(call, Type::integer, 0);
     call.type = SizedType(Type::avg, 8, true);
   }
   else if (call.func == "stats") {
     check_assignment(call, true, false, false);
     check_nargs(call, 1);
+    check_arg(call, Type::integer, 0);
     call.type = SizedType(Type::stats, 8, true);
   }
   else if (call.func == "delete") {

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -43,6 +43,11 @@ RUN bpftrace -v -e 'i:ms:1 { $a = !nsecs ? 0 : 1; printf("%d\n", $a); exit();}'
 EXPECT 0
 TIMEOUT 5
 
+NAME ternary_int8
+RUN bpftrace -v -e 'i:ms:1 { $a = 1 ? (int8)1 : 0; printf("%d\n", $a); exit();}'
+EXPECT 1
+TIMEOUT 5
+
 NAME unroll
 RUN bpftrace -v -e 'i:ms:1 {$a = 1; unroll (10) { $a = $a + 1; } printf("a=%d\n", $a); exit();}'
 EXPECT a=11

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -436,6 +436,7 @@ TEST(semantic_analyser, call_exit)
 {
   test("kprobe:f { exit(); }", 0);
   test("kprobe:f { exit(1); }", 1);
+  test("kprobe:f { @a = exit(); }", 1);
   test("kprobe:f { @a = exit(1); }", 1);
   test("kprobe:f { $a = exit(1); }", 1);
   test("kprobe:f { @[exit(1)] = 1; }", 1);

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -334,6 +334,7 @@ TEST(semantic_analyser, call_hist)
   test("kprobe:f { $x = hist(1); }", 1);
   test("kprobe:f { @x[hist(1)] = 1; }", 1);
   test("kprobe:f { if(hist()) { 123 } }", 1);
+  test("kprobe:f { hist() ? 0 : 1; }", 1);
 }
 
 TEST(semantic_analyser, call_lhist)
@@ -349,6 +350,7 @@ TEST(semantic_analyser, call_lhist)
   test("kprobe:f { $x = lhist(); }", 1);
   test("kprobe:f { @[lhist()] = 1; }", 1);
   test("kprobe:f { if(lhist()) { 123 } }", 1);
+  test("kprobe:f { lhist() ? 0 : 1; }", 1);
 }
 
 TEST(semantic_analyser, call_count)
@@ -359,6 +361,7 @@ TEST(semantic_analyser, call_count)
   test("kprobe:f { $x = count(); }", 1);
   test("kprobe:f { @[count()] = 1; }", 1);
   test("kprobe:f { if(count()) { 123 } }", 1);
+  test("kprobe:f { count() ? 0 : 1; }", 1);
 }
 
 TEST(semantic_analyser, call_sum)
@@ -370,6 +373,7 @@ TEST(semantic_analyser, call_sum)
   test("kprobe:f { $x = sum(123); }", 1);
   test("kprobe:f { @[sum(123)] = 1; }", 1);
   test("kprobe:f { if(sum(1)) { 123 } }", 1);
+  test("kprobe:f { sum(1) ? 0 : 1; }", 1);
 }
 
 TEST(semantic_analyser, call_min)
@@ -380,6 +384,7 @@ TEST(semantic_analyser, call_min)
   test("kprobe:f { $x = min(123); }", 1);
   test("kprobe:f { @[min(123)] = 1; }", 1);
   test("kprobe:f { if(min(1)) { 123 } }", 1);
+  test("kprobe:f { min(1) ? 0 : 1; }", 1);
 }
 
 TEST(semantic_analyser, call_max)
@@ -390,6 +395,7 @@ TEST(semantic_analyser, call_max)
   test("kprobe:f { $x = max(123); }", 1);
   test("kprobe:f { @[max(123)] = 1; }", 1);
   test("kprobe:f { if(max(1)) { 123 } }", 1);
+  test("kprobe:f { max(1) ? 0 : 1; }", 1);
 }
 
 TEST(semantic_analyser, call_avg)
@@ -400,6 +406,7 @@ TEST(semantic_analyser, call_avg)
   test("kprobe:f { $x = avg(123); }", 1);
   test("kprobe:f { @[avg(123)] = 1; }", 1);
   test("kprobe:f { if(avg(1)) { 123 } }", 1);
+  test("kprobe:f { avg(1) ? 0 : 1; }", 1);
 }
 
 TEST(semantic_analyser, call_stats)
@@ -410,6 +417,7 @@ TEST(semantic_analyser, call_stats)
   test("kprobe:f { $x = stats(123); }", 1);
   test("kprobe:f { @[stats(123)] = 1; }", 1);
   test("kprobe:f { if(stats(1)) { 123 } }", 1);
+  test("kprobe:f { stats(1) ? 0 : 1; }", 1);
 }
 
 TEST(semantic_analyser, call_delete)
@@ -421,6 +429,7 @@ TEST(semantic_analyser, call_delete)
   test("kprobe:f { $y = delete(@x); }", 1);
   test("kprobe:f { @[delete(@x)] = 1; }", 1);
   test("kprobe:f { @x = 1; if(delete(@x)) { 123 } }", 10);
+  test("kprobe:f { @x = 1; delete(@x) ? 0 : 1; }", 10);
 }
 
 TEST(semantic_analyser, call_exit)
@@ -431,6 +440,7 @@ TEST(semantic_analyser, call_exit)
   test("kprobe:f { $a = exit(1); }", 1);
   test("kprobe:f { @[exit(1)] = 1; }", 1);
   test("kprobe:f { if(exit()) { 123 } }", 10);
+  test("kprobe:f { exit() ? 0 : 1; }", 10);
 }
 
 TEST(semantic_analyser, call_print)
@@ -449,6 +459,7 @@ TEST(semantic_analyser, call_print)
   test("kprobe:f { @x = count(); $y = print(@x); }", 1);
   test("kprobe:f { @x = count(); @[print(@x)] = 1; }", 1);
   test("kprobe:f { @x = count(); if(print(@x)) { 123 } }", 10);
+  test("kprobe:f { @x = count(); print(@x) ? 0 : 1; }", 10);
 }
 
 TEST(semantic_analyser, call_clear)
@@ -465,6 +476,7 @@ TEST(semantic_analyser, call_clear)
   test("kprobe:f { @x = count(); $y = clear(@x); }", 1);
   test("kprobe:f { @x = count(); @[clear(@x)] = 1; }", 1);
   test("kprobe:f { @x = count(); if(clear(@x)) { 123 } }", 10);
+  test("kprobe:f { @x = count(); clear(@x) ? 0 : 1; }", 10);
 }
 
 TEST(semantic_analyser, call_zero)
@@ -481,6 +493,7 @@ TEST(semantic_analyser, call_zero)
   test("kprobe:f { @x = count(); $y = zero(@x); }", 1);
   test("kprobe:f { @x = count(); @[zero(@x)] = 1; }", 1);
   test("kprobe:f { @x = count(); if(zero(@x)) { 123 } }", 10);
+  test("kprobe:f { @x = count(); zero(@x) ? 0 : 1; }", 10);
 }
 
 TEST(semantic_analyser, call_time)
@@ -494,6 +507,7 @@ TEST(semantic_analyser, call_time)
   test("kprobe:f { time(1); }", 10);
   test("kprobe:f { $x = \"str\"; time($x); }", 10);
   test("kprobe:f { if(time()) { 123 } }", 10);
+  test("kprobe:f { time() ? 0 : 1; }", 10);
 }
 
 TEST(semantic_analyser, call_str)
@@ -674,6 +688,7 @@ TEST(semantic_analyser, call_cat)
   test("kprobe:f { $x = cat(\"/proc/loadavg\"); }", 1);
   test("kprobe:f { @[cat(\"/proc/loadavg\")] = 1; }", 1);
   test("kprobe:f { if(cat(\"/proc/loadavg\")) { 123 } }", 10);
+  test("kprobe:f { cat(\"/proc/loadavg\") ? 0 : 1; }", 10);
 }
 
 TEST(semantic_analyser, call_stack)

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -333,6 +333,7 @@ TEST(semantic_analyser, call_hist)
   test("kprobe:f { hist(1); }", 1);
   test("kprobe:f { $x = hist(1); }", 1);
   test("kprobe:f { @x[hist(1)] = 1; }", 1);
+  test("kprobe:f { if(hist()) { 123 } }", 1);
 }
 
 TEST(semantic_analyser, call_lhist)
@@ -347,6 +348,7 @@ TEST(semantic_analyser, call_lhist)
   test("kprobe:f { @ = lhist(-10, -10, 10, 1); }", 10); // must be positive
   test("kprobe:f { $x = lhist(); }", 1);
   test("kprobe:f { @[lhist()] = 1; }", 1);
+  test("kprobe:f { if(lhist()) { 123 } }", 1);
 }
 
 TEST(semantic_analyser, call_count)
@@ -356,6 +358,7 @@ TEST(semantic_analyser, call_count)
   test("kprobe:f { count(); }", 1);
   test("kprobe:f { $x = count(); }", 1);
   test("kprobe:f { @[count()] = 1; }", 1);
+  test("kprobe:f { if(count()) { 123 } }", 1);
 }
 
 TEST(semantic_analyser, call_sum)
@@ -366,6 +369,7 @@ TEST(semantic_analyser, call_sum)
   test("kprobe:f { sum(123); }", 1);
   test("kprobe:f { $x = sum(123); }", 1);
   test("kprobe:f { @[sum(123)] = 1; }", 1);
+  test("kprobe:f { if(sum(1)) { 123 } }", 1);
 }
 
 TEST(semantic_analyser, call_min)
@@ -375,6 +379,7 @@ TEST(semantic_analyser, call_min)
   test("kprobe:f { min(123); }", 1);
   test("kprobe:f { $x = min(123); }", 1);
   test("kprobe:f { @[min(123)] = 1; }", 1);
+  test("kprobe:f { if(min(1)) { 123 } }", 1);
 }
 
 TEST(semantic_analyser, call_max)
@@ -384,6 +389,7 @@ TEST(semantic_analyser, call_max)
   test("kprobe:f { max(123); }", 1);
   test("kprobe:f { $x = max(123); }", 1);
   test("kprobe:f { @[max(123)] = 1; }", 1);
+  test("kprobe:f { if(max(1)) { 123 } }", 1);
 }
 
 TEST(semantic_analyser, call_avg)
@@ -393,6 +399,7 @@ TEST(semantic_analyser, call_avg)
   test("kprobe:f { avg(123); }", 1);
   test("kprobe:f { $x = avg(123); }", 1);
   test("kprobe:f { @[avg(123)] = 1; }", 1);
+  test("kprobe:f { if(avg(1)) { 123 } }", 1);
 }
 
 TEST(semantic_analyser, call_stats)
@@ -402,6 +409,7 @@ TEST(semantic_analyser, call_stats)
   test("kprobe:f { stats(123); }", 1);
   test("kprobe:f { $x = stats(123); }", 1);
   test("kprobe:f { @[stats(123)] = 1; }", 1);
+  test("kprobe:f { if(stats(1)) { 123 } }", 1);
 }
 
 TEST(semantic_analyser, call_delete)
@@ -412,6 +420,7 @@ TEST(semantic_analyser, call_delete)
   test("kprobe:f { @y = delete(@x); }", 1);
   test("kprobe:f { $y = delete(@x); }", 1);
   test("kprobe:f { @[delete(@x)] = 1; }", 1);
+  test("kprobe:f { @x = 1; if(delete(@x)) { 123 } }", 10);
 }
 
 TEST(semantic_analyser, call_exit)
@@ -421,6 +430,7 @@ TEST(semantic_analyser, call_exit)
   test("kprobe:f { @a = exit(1); }", 1);
   test("kprobe:f { $a = exit(1); }", 1);
   test("kprobe:f { @[exit(1)] = 1; }", 1);
+  test("kprobe:f { if(exit()) { 123 } }", 10);
 }
 
 TEST(semantic_analyser, call_print)
@@ -438,6 +448,7 @@ TEST(semantic_analyser, call_print)
   test("kprobe:f { @x = count(); @ = print(@x); }", 1);
   test("kprobe:f { @x = count(); $y = print(@x); }", 1);
   test("kprobe:f { @x = count(); @[print(@x)] = 1; }", 1);
+  test("kprobe:f { @x = count(); if(print(@x)) { 123 } }", 10);
 }
 
 TEST(semantic_analyser, call_clear)
@@ -453,6 +464,7 @@ TEST(semantic_analyser, call_clear)
   test("kprobe:f { @x = count(); @ = clear(@x); }", 1);
   test("kprobe:f { @x = count(); $y = clear(@x); }", 1);
   test("kprobe:f { @x = count(); @[clear(@x)] = 1; }", 1);
+  test("kprobe:f { @x = count(); if(clear(@x)) { 123 } }", 10);
 }
 
 TEST(semantic_analyser, call_zero)
@@ -468,6 +480,7 @@ TEST(semantic_analyser, call_zero)
   test("kprobe:f { @x = count(); @ = zero(@x); }", 1);
   test("kprobe:f { @x = count(); $y = zero(@x); }", 1);
   test("kprobe:f { @x = count(); @[zero(@x)] = 1; }", 1);
+  test("kprobe:f { @x = count(); if(zero(@x)) { 123 } }", 10);
 }
 
 TEST(semantic_analyser, call_time)
@@ -480,6 +493,7 @@ TEST(semantic_analyser, call_time)
   test("kprobe:f { @[time()] = 1; }", 1);
   test("kprobe:f { time(1); }", 10);
   test("kprobe:f { $x = \"str\"; time($x); }", 10);
+  test("kprobe:f { if(time()) { 123 } }", 10);
 }
 
 TEST(semantic_analyser, call_str)
@@ -659,6 +673,7 @@ TEST(semantic_analyser, call_cat)
   test("kprobe:f { @x = cat(\"/proc/loadavg\"); }", 1);
   test("kprobe:f { $x = cat(\"/proc/loadavg\"); }", 1);
   test("kprobe:f { @[cat(\"/proc/loadavg\")] = 1; }", 1);
+  test("kprobe:f { if(cat(\"/proc/loadavg\")) { 123 } }", 10);
 }
 
 TEST(semantic_analyser, call_stack)


### PR DESCRIPTION
Some functions (e.g., `exit()`) return Type::none but if and ternary does not check it and that results in a NULL pointer dereference.

```
% sudo ./src/bpftrace -e 'k:f { exit() ? 0 : 0 }'
AddressSanitizer:DEADLYSIGNAL
=================================================================
==14010==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x000000850854 bp 0x7fffffffa450 sp 0x7fffffffa180 T0)
==14010==The signal is caused by a READ memory access.
==14010==Hint: address points to the zero page.
    #0 0x850853 in bpftrace::ast::CodegenLLVM::visit(bpftrace::ast::Ternary&) /home/ubuntu/work/bpftrace/src/ast/codegen_llvm.cpp
    #1 0x861f29 in bpftrace::ast::CodegenLLVM::visit(bpftrace::ast::Probe&) /home/ubuntu/work/bpftrace/src/ast/codegen_llvm.cpp:1506:13
    #2 0x865256 in bpftrace::ast::CodegenLLVM::visit(bpftrace::ast::Program&) /home/ubuntu/work/bpftrace/src/ast/codegen_llvm.cpp:1597:12
    #3 0x86e34b in bpftrace::ast::CodegenLLVM::compile(bpftrace::DebugLevel, std::ostream&) /home/ubuntu/work/bpftrace/src/ast/codegen_llvm.cpp:2013:10
    #4 0x77623f in main /home/ubuntu/work/bpftrace/src/main.cpp:605:22
    #5 0x7fffee1451e2 in __libc_start_main /build/glibc-t7JzpG/glibc-2.30/csu/../csu/libc-start.c:308:16
    #6 0x4d1bcd in _start (/disk/work/bpftrace/build_san3/src/bpftrace+0x4d1bcd)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV /home/ubuntu/work/bpftrace/src/ast/codegen_llvm.cpp in bpftrace::ast::CodegenLLVM::visit(bpftrace::ast::Ternary&)
==1401
```

Fix this by checking a type of cond in the semantic analysis.