### PR TITLE
Use urandom instead of random

### DIFF
--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -31,10 +31,10 @@ TIMEOUT 5
 AFTER cat /dev/null
 
 NAME 32-bit tracepoint arg
-RUN bpftrace -v -e 'tracepoint:random:random_read { $i = args->got_bits; printf("bits: %d\n", $i); if ($i == 24) { exit() } }'
+RUN bpftrace -v -e 'tracepoint:random:urandom_read { $i = args->got_bits; printf("bits: %d\n", $i); if ($i == 24) { exit() } }'
 EXPECT bits: 24
 TIMEOUT 5
-AFTER dd if=/dev/random bs=3 count=1
+AFTER dd if=/dev/urandom bs=3 count=1
 
 NAME tracepoint arg casts in predicates
 RUN bpftrace -v -e 'tracepoint:syscalls:sys_enter_wait4 /args->ru/ { @ru[tid] = args->ru; } tracepoint:syscalls:sys_exit_wait4 /@ru[tid]/ { @++; exit(); }' -c ./testprogs/wait4_ru


### PR DESCRIPTION
I found that "variable.32-bit tracepoint arg" runtime test fails on
Linux 5.6 rc5. It turns out that Linux 5.6 changes the behavior of
/dev/random and now it behaves almost like urandom, and
trace_urandom_read() is called instead of trace_random_read():

https://github.com/torvalds/linux/commit/30c08efec8884fb106b8e57094baa51bb4c44e32

Use urandom instead of random so that the test runs on a new kernel.