### PR TITLE
Printf alignment

### DIFF
--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -88,23 +88,21 @@ TEST(codegen, printf_offsets)
 
   EXPECT_EQ(args.size(), 4U);
 
-  // Note that scalar types are promoted to 64-bits when put into
-  // a perf event buffer
   EXPECT_EQ(args[0].type.type, Type::integer);
-  EXPECT_EQ(args[0].type.size, 8U);
+  EXPECT_EQ(args[0].type.size, 1U);
   EXPECT_EQ(args[0].offset, 8);
 
   EXPECT_EQ(args[1].type.type, Type::integer);
-  EXPECT_EQ(args[1].type.size, 8U);
-  EXPECT_EQ(args[1].offset, 16);
+  EXPECT_EQ(args[1].type.size, 4U);
+  EXPECT_EQ(args[1].offset, 12);
 
   EXPECT_EQ(args[2].type.type, Type::string);
   EXPECT_EQ(args[2].type.size, 10U);
-  EXPECT_EQ(args[2].offset, 24);
+  EXPECT_EQ(args[2].offset, 16);
 
   EXPECT_EQ(args[3].type.type, Type::integer);
   EXPECT_EQ(args[3].type.size, 8U);
-  EXPECT_EQ(args[3].offset, 40);
+  EXPECT_EQ(args[3].offset, 32);
 }
 
 TEST(codegen, probe_count)

--- a/tests/codegen/llvm/call_printf.ll
+++ b/tests/codegen/llvm/call_printf.ll
@@ -3,7 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
-%printf_t = type { i64, i64, i64 }
+%printf_t = type { i64, i8, i64 }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
@@ -25,7 +25,7 @@ entry:
   %3 = load i8, i8* %"struct Foo.c", align 1
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %"struct Foo.c")
   %4 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
-  store i8 %3, i64* %4, align 8
+  store i8 %3, i8* %4, align 8
   %5 = bitcast i64* %"struct Foo.l" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   %probe_read1 = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* nonnull %"struct Foo.l", i32 8, i64 8)

--- a/tests/codegen/llvm/comparison_extend.ll
+++ b/tests/codegen/llvm/comparison_extend.ll
@@ -17,16 +17,16 @@ entry:
   %2 = bitcast i8* %1 to i64*
   %arg0 = load volatile i64, i64* %2, align 8
   %3 = icmp ugt i64 %arg0, 1
-  %4 = zext i1 %3 to i64
-  %5 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %4 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@_key", align 8
+  %5 = zext i1 %3 to i64
   %6 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
-  store i64 %4, i64* %"@_val", align 8
+  store i64 %5, i64* %"@_val", align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
 }

--- a/tests/codegen/llvm/if_nested_printf.ll
+++ b/tests/codegen/llvm/if_nested_printf.ll
@@ -20,22 +20,22 @@ entry:
 
 if_stmt:                                          ; preds = %entry
   %get_pid_tgid3 = tail call i64 inttoptr (i64 14 to i64 ()*)()
-  %.lobit = and i64 %get_pid_tgid3, 4294967296
-  %true_cond4 = icmp eq i64 %.lobit, 0
+  %2 = and i64 %get_pid_tgid3, 4294967296
+  %true_cond4 = icmp eq i64 %2, 0
   br i1 %true_cond4, label %if_stmt1, label %else_stmt
 
 else_stmt:                                        ; preds = %if_stmt, %if_stmt1, %entry
   ret i64 0
 
 if_stmt1:                                         ; preds = %if_stmt
-  %2 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
-  %3 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
-  store i64 0, i64* %3, align 8
+  %3 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %4 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
+  store i64 0, i64* %4, align 8
   %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 8)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   br label %else_stmt
 }
 

--- a/tests/codegen/llvm/logical_and_or_different_type.ll
+++ b/tests/codegen/llvm/logical_and_or_different_type.ll
@@ -3,7 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
-%printf_t = type { i64, i64, i64, i64, i64 }
+%printf_t = type { i64, i32, i32, i32, i32 }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
@@ -29,46 +29,46 @@ entry:
   %3 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   %4 = bitcast i32* %"struct Foo.m" to i8*
-  %5 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
-  store i64 0, i64* %5, align 8
+  %5 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %5, i8 0, i64 24, i1 false)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* nonnull %"struct Foo.m", i32 4, [4 x i8]* nonnull %tmpcast)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   %6 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
-  store i64 0, i64* %6, align 8
+  store i1 false, i32* %6, align 8
   %7 = bitcast i32* %"struct Foo.m6" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
   %probe_read7 = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* nonnull %"struct Foo.m6", i32 4, [4 x i8]* nonnull %tmpcast)
   %8 = load i32, i32* %"struct Foo.m6", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   %rhs_true_cond = icmp ne i32 %8, 0
-  %"&&_result5.0" = zext i1 %rhs_true_cond to i64
   %9 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2
-  store i64 %"&&_result5.0", i64* %9, align 8
+  store i1 %rhs_true_cond, i32* %9, align 4
   %10 = bitcast i32* %"struct Foo.m8" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
   %probe_read9 = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* nonnull %"struct Foo.m8", i32 4, [4 x i8]* nonnull %tmpcast)
   %11 = load i32, i32* %"struct Foo.m8", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
   %lhs_true_cond10 = icmp ne i32 %11, 0
-  %"||_result.0" = zext i1 %lhs_true_cond10 to i64
   %12 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 3
-  store i64 %"||_result.0", i64* %12, align 8
+  store i1 %lhs_true_cond10, i32* %12, align 8
   %13 = bitcast i32* %"struct Foo.m16" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %13)
   %probe_read17 = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* nonnull %"struct Foo.m16", i32 4, [4 x i8]* nonnull %tmpcast)
   %14 = load i32, i32* %"struct Foo.m16", align 4
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %13)
   %rhs_true_cond18 = icmp ne i32 %14, 0
-  %"||_result15.0" = zext i1 %rhs_true_cond18 to i64
   %15 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 4
-  store i64 %"||_result15.0", i64* %15, align 8
+  store i1 %rhs_true_cond18, i32* %15, align 4
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 40)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 24)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   ret i64 0
 }
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1276,24 +1276,54 @@ TEST(semantic_analyser, binop_sign)
     "kprobe:f { "
     "  $t = ((struct t *)0xFF); ";
 
-  std::string operators[] = { "==", "!=", "<", "<=", ">", ">=", "+", "-", "/", "*"};
-  for(std::string op : operators)
   {
-    BPFtrace bpftrace;
-    Driver driver(bpftrace);
-    std::string prog = prog_pre +
-      "$varA = $t->l "  + op + " $t->l; "
-      "$varB = $t->ul " + op + " $t->l; "
-      "$varC = $t->ul " + op + " $t->ul;"
-      "}";
+    std::string operators[] = { "==", "!=", "<", "<=", ">", ">=" };
+    for(std::string op : operators)
+    {
+      BPFtrace bpftrace;
+      Driver driver(bpftrace);
+      std::string prog = prog_pre +
+        "$varA = $t->l "  + op + " $t->l; "
+        "$varB = $t->ul " + op + " $t->l; "
+        "$varC = $t->ul " + op + " $t->ul;"
+        "}";
 
-    test(driver, prog, 0);
-    auto varA = static_cast<ast::AssignVarStatement*>(driver.root_->probes->at(0)->stmts->at(1));
-    EXPECT_EQ(SizedType(Type::integer, 8, true), varA->var->type);
-    auto varB = static_cast<ast::AssignVarStatement*>(driver.root_->probes->at(0)->stmts->at(2));
-    EXPECT_EQ(SizedType(Type::integer, 8, false), varB->var->type);
-    auto varC = static_cast<ast::AssignVarStatement*>(driver.root_->probes->at(0)->stmts->at(3));
-    EXPECT_EQ(SizedType(Type::integer, 8, false), varC->var->type);
+      test(driver, prog, 0);
+      auto varA = static_cast<ast::AssignVarStatement *>(
+          driver.root_->probes->at(0)->stmts->at(1));
+      EXPECT_EQ(SizedType(Type::integer, 1, false), varA->var->type);
+      auto varB = static_cast<ast::AssignVarStatement *>(
+          driver.root_->probes->at(0)->stmts->at(2));
+      EXPECT_EQ(SizedType(Type::integer, 1, false), varB->var->type);
+      auto varC = static_cast<ast::AssignVarStatement *>(
+          driver.root_->probes->at(0)->stmts->at(3));
+      EXPECT_EQ(SizedType(Type::integer, 1, false), varC->var->type);
+    }
+  }
+
+  {
+    std::string operators[] = { "+", "-", "/", "*"};
+    for(std::string op : operators)
+    {
+      BPFtrace bpftrace;
+      Driver driver(bpftrace);
+      std::string prog = prog_pre +
+        "$varA = $t->l "  + op + " $t->l; "
+        "$varB = $t->ul " + op + " $t->l; "
+        "$varC = $t->ul " + op + " $t->ul;"
+        "}";
+
+      test(driver, prog, 0);
+      auto varA = static_cast<ast::AssignVarStatement *>(
+          driver.root_->probes->at(0)->stmts->at(1));
+      EXPECT_EQ(SizedType(Type::integer, 8, true), varA->var->type);
+      auto varB = static_cast<ast::AssignVarStatement *>(
+          driver.root_->probes->at(0)->stmts->at(2));
+      EXPECT_EQ(SizedType(Type::integer, 8, false), varB->var->type);
+      auto varC = static_cast<ast::AssignVarStatement *>(
+          driver.root_->probes->at(0)->stmts->at(3));
+      EXPECT_EQ(SizedType(Type::integer, 8, false), varC->var->type);
+    }
   }
 }
 


### PR DESCRIPTION
This removes the current "all ints are i64"  assumption and uses sizes appropriate for the operations instead.

Still a draft as i have to cleanup the commit messages and do more testing. But if anyone has good ways to test this it would be helpful. 

Fixes #1173 
Relates to #1091 