### PR TITLE
Positional fixes

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -93,6 +93,7 @@ void Identifier::accept(Visitor &v) {
 PositionalParameter::PositionalParameter(PositionalParameterType ptype, long n)
     : ptype(ptype), n(n)
 {
+  is_literal = true;
 }
 
 PositionalParameter::PositionalParameter(PositionalParameterType ptype,
@@ -100,6 +101,7 @@ PositionalParameter::PositionalParameter(PositionalParameterType ptype,
                                          location loc)
     : Expression(loc), ptype(ptype), n(n)
 {
+  is_literal = true;
 }
 
 void PositionalParameter::accept(Visitor &v) {

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -35,7 +35,7 @@ void CodegenLLVM::visit(PositionalParameter &param)
         std::string pstr = bpftrace_.get_param(param.n, param.is_in_str);
         if (is_numeric(pstr))
         {
-          expr_ = b_.getInt64(std::stoll(pstr));
+          expr_ = b_.getInt64(std::stoll(pstr, nullptr, 0));
         }
         else
         {

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -68,8 +68,8 @@ void SemanticAnalyser::visit(PositionalParameter &param)
         std::string pstr = bpftrace_.get_param(param.n, param.is_in_str);
         if (!is_numeric(pstr) && !param.is_in_str)
         {
-          ERR(param.loc << "$" << param.n << " used numerically << but given \""
-                        << pstr << "\". Try using str($" << param.n << ").",
+          ERR("$" << param.n << " used numerically but given \"" << pstr
+                  << "\". Try using str($" << param.n << ").",
               param.loc);
         }
         if (is_numeric(pstr) && param.is_in_str)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -175,7 +175,7 @@ static int info()
 int main(int argc, char *argv[])
 {
   int err;
-  char *pid_str = nullptr;
+  std::string pid_str;
   char *cmd_str = nullptr;
   bool listing = false;
   bool safe_mode = true;
@@ -283,7 +283,7 @@ int main(int argc, char *argv[])
     return 1;
   }
 
-  if (cmd_str && pid_str)
+  if (cmd_str && !pid_str.empty())
   {
     std::cerr << "USAGE: Cannot use both -c and -p." << std::endl;
     usage();
@@ -341,14 +341,17 @@ int main(int argc, char *argv[])
   // - make PID a filter for all probe types: pass to perf_event_open(), etc.
   // - provide PID in USDT probe specification as a way to override -p.
   bpftrace.pid_ = 0;
-  if (pid_str)
+  if (!pid_str.empty())
   {
-    if (!is_numeric(pid_str))
+    try
     {
-      std::cerr << "ERROR: pid '" << pid_str << "' is not a valid number." << std::endl;
+      bpftrace.pid_ = parse_pid(pid_str);
+    }
+    catch (const InvalidPIDException& e)
+    {
+      std::cerr << "ERROR: " << e.what() << std::endl;
       return 1;
     }
-    bpftrace.pid_ = strtol(pid_str, NULL, 10);
   }
 
   // Listing probes

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -800,4 +800,30 @@ bool symbol_has_cpp_mangled_signature(const std::string &sym_name)
     return false;
 }
 
+pid_t parse_pid(const std::string &str)
+{
+  try
+  {
+    constexpr ssize_t pid_max = 4 * 1024 * 1024;
+    std::size_t idx = 0;
+    auto pid = std::stol(str, &idx, 10);
+    // Detect cases like `13ABC`
+    if (idx < str.size())
+      throw InvalidPIDException(str, "is not a valid decimal number");
+    if (pid < 1 || pid > pid_max)
+      throw InvalidPIDException(str,
+                                "out of valid pid range [1," +
+                                    std::to_string(pid_max) + "]");
+    return pid;
+  }
+  catch (const std::out_of_range &e)
+  {
+    throw InvalidPIDException(str, "outside of integer range");
+  }
+  catch (const std::invalid_argument &e)
+  {
+    throw InvalidPIDException(str, "is not a valid decimal number");
+  }
+}
+
 } // namespace bpftrace

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -780,7 +780,16 @@ std::string str_join(const std::vector<std::string> &list, const std::string &de
 
 bool is_numeric(const std::string &s)
 {
-  return !s.empty() && std::all_of(s.begin(), s.end(), ::isdigit);
+  std::size_t idx;
+  try
+  {
+    std::stoll(s, &idx, 0);
+  }
+  catch (...)
+  {
+    return false;
+  }
+  return idx == s.size();
 }
 
 bool symbol_has_cpp_mangled_signature(const std::string &sym_name)

--- a/src/utils.h
+++ b/src/utils.h
@@ -44,6 +44,23 @@ private:
   std::string msg_;
 };
 
+class InvalidPIDException : public std::exception
+{
+public:
+  InvalidPIDException(const std::string &pid, const std::string &msg)
+  {
+    msg_ = "pid '" + pid + "' " + msg;
+  }
+
+  const char *what() const noexcept override
+  {
+    return msg_.c_str();
+  }
+
+private:
+  std::string msg_;
+};
+
 class StderrSilencer
 {
 public:
@@ -131,6 +148,7 @@ std::string str_join(const std::vector<std::string> &list,
                      const std::string &delim);
 bool is_numeric(const std::string &str);
 bool symbol_has_cpp_mangled_signature(const std::string &sym_name);
+pid_t parse_pid(const std::string &str);
 
 // trim from end of string (right)
 inline std::string &rtrim(std::string &s)

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -65,17 +65,22 @@ TIMEOUT 1
 
 NAME pid fails validation with leading non-number
 RUN bpftrace -p a1111
-EXPECT ERROR: pid 'a1111' is not a valid number.
+EXPECT ERROR: pid 'a1111' is not a valid decimal number
 TIMEOUT 1
 
 NAME pid fails validation with non-number in between
 RUN bpftrace -p 111a1
-EXPECT ERROR: pid '111a1' is not a valid number.
+EXPECT ERROR: pid '111a1' is not a valid decimal number
 TIMEOUT 1
 
 NAME pid fails validation with non-numeric argument
 RUN bpftrace -p not_a_pid
-EXPECT ERROR: pid 'not_a_pid' is not a valid number.
+EXPECT ERROR: pid 'not_a_pid' is not a valid decimal number
+TIMEOUT 1
+
+NAME pid outside of valid pid range
+RUN bpftrace -p 5000000
+EXPECT ERROR: pid '5000000' out of valid pid range \[1,4194304\]
 TIMEOUT 1
 
 NAME libraries under /usr/include are in the search path

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -103,6 +103,11 @@ RUN bpftrace -v -e 'BEGIN { printf("got %d args: %s %d\n", $#, str($1), $2); exi
 EXPECT got 2 args: one 2
 TIMEOUT 5
 
+NAME positional multiple bases
+RUN bpftrace -e 'BEGIN { printf("got: %d %d 0x%x\n", $1, $2, $3); exit() }' 123 0775 0x123
+EXPECT got: 123 509 0x123
+TIMEOUT 5
+
 NAME lhist can be cleared
 RUN bpftrace -e 'BEGIN{ @[1] = lhist(3,0,10,1); clear(@); exit() }'
 EXPECT .*

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1139,6 +1139,14 @@ TEST(semantic_analyser, positional_parameters)
 
   test(bpftrace, "kprobe:f { printf(\"%d\", $#); }", 0);
   test(bpftrace, "kprobe:f { printf(\"%s\", str($#)); }", 10);
+
+  Driver driver(bpftrace);
+  test(driver, "k:f { $1 }", 0);
+  auto stmt = static_cast<ast::ExprStatement *>(
+      driver.root_->probes->at(0)->stmts->at(0));
+  auto pp = static_cast<ast::PositionalParameter *>(stmt->expr);
+  EXPECT_EQ(SizedType(Type::integer, 8, true), pp->type);
+  EXPECT_TRUE(pp->is_literal);
 }
 
 TEST(semantic_analyser, macros)

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1123,6 +1123,7 @@ TEST(semantic_analyser, positional_parameters)
   BPFtrace bpftrace;
   bpftrace.add_param("123");
   bpftrace.add_param("hello");
+  bpftrace.add_param("0x123");
 
   test(bpftrace, "kprobe:f { printf(\"%d\", $0); }", 1);
   test(bpftrace, "kprobe:f { printf(\"%s\", str($0)); }", 1);
@@ -1133,9 +1134,11 @@ TEST(semantic_analyser, positional_parameters)
   test(bpftrace, "kprobe:f { printf(\"%s\", str($2)); }", 0);
   test(bpftrace, "kprobe:f { printf(\"%d\", $2); }", 10);
 
-  // Parameters are not required to exist to be used:
-  test(bpftrace, "kprobe:f { printf(\"%s\", str($3)); }", 0);
   test(bpftrace, "kprobe:f { printf(\"%d\", $3); }", 0);
+
+  // Parameters are not required to exist to be used:
+  test(bpftrace, "kprobe:f { printf(\"%s\", str($4)); }", 0);
+  test(bpftrace, "kprobe:f { printf(\"%d\", $4); }", 0);
 
   test(bpftrace, "kprobe:f { printf(\"%d\", $#); }", 0);
   test(bpftrace, "kprobe:f { printf(\"%s\", str($#)); }", 10);
@@ -1147,6 +1150,9 @@ TEST(semantic_analyser, positional_parameters)
   auto pp = static_cast<ast::PositionalParameter *>(stmt->expr);
   EXPECT_EQ(SizedType(Type::integer, 8, true), pp->type);
   EXPECT_TRUE(pp->is_literal);
+
+  bpftrace.add_param("0999");
+  test(bpftrace, "kprobe:f { printf(\"%d\", $4); }", 10);
 }
 
 TEST(semantic_analyser, macros)


### PR DESCRIPTION
A few fixes for integer positional parameters. With this it is now possible to use different bases (octal, hex) and support different numbers:

```
# bpftrace  -e 'BEGIN { printf("got: %d %d %d\n", $1, $2, $3); exit() }' -- -123 0775 0x123
got: -123 509 291
```

Where before it would error:

```
# bpftrace  -e 'BEGIN { printf("got: %d %d %d\n", $1, $2, $3); exit() }' -- -123 0775 0x123
stdin:1:35-37: ERROR: 1.35-36 $1 used numerically << but given "-123". Try using str($1).
BEGIN { printf("got: %d %d %d\n", $1, $2, $3); exit() }
                                  ~~
stdin:1:43-45: ERROR: 1.43-44 $3 used numerically << but given "0x123". Try using str($3).
BEGIN { printf("got: %d %d %d\n", $1, $2, $3); exit() }
                                          ~~
```