### PR TITLE
Add proper bcc prefix for bcc headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -104,9 +104,9 @@ set(CMAKE_REQUIRED_LIBRARIES bcc)
 get_filename_component(LIBBCC_LIBDIR ${LIBBCC_LIBRARIES} DIRECTORY)
 set(CMAKE_REQUIRED_LINK_OPTIONS -L${LIBBCC_LIBDIR})
 
-check_symbol_exists(bcc_prog_load "${LIBBCC_INCLUDE_DIRS}/libbpf.h" HAVE_BCC_PROG_LOAD)
-check_symbol_exists(bcc_create_map "${LIBBCC_INCLUDE_DIRS}/libbpf.h" HAVE_BCC_CREATE_MAP)
-check_symbol_exists(bcc_elf_foreach_sym "${LIBBCC_INCLUDE_DIRS}/bcc_elf.h" HAVE_BCC_ELF_FOREACH_SYM)
+check_symbol_exists(bcc_prog_load "${LIBBCC_INCLUDE_DIRS}/bcc/libbpf.h" HAVE_BCC_PROG_LOAD)
+check_symbol_exists(bcc_create_map "${LIBBCC_INCLUDE_DIRS}/bcc/libbpf.h" HAVE_BCC_CREATE_MAP)
+check_symbol_exists(bcc_elf_foreach_sym "${LIBBCC_INCLUDE_DIRS}/bcc/bcc_elf.h" HAVE_BCC_ELF_FOREACH_SYM)
 set(CMAKE_REQUIRED_LIBRARIES)
 set(CMAKE_REQUIRED_LINK_OPTIONS)
 

--- a/cmake/FindLibBcc.cmake
+++ b/cmake/FindLibBcc.cmake
@@ -14,7 +14,7 @@ endif (LIBBCC_LIBRARIES AND LIBBCC_INCLUDE_DIRS)
 
 find_path (LIBBCC_INCLUDE_DIRS
   NAMES
-    libbpf.h
+    bcc/libbpf.h
   PATHS
     /usr/include
     /usr/include/bcc

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1,7 +1,6 @@
 #include <iostream>
 
 #include "irbuilderbpf.h"
-#include "bcc_usdt.h"
 #include "arch/arch.h"
 #include "utils.h"
 

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -1,9 +1,9 @@
 #pragma once
 
 #include "ast.h"
-#include "bcc_usdt.h"
 #include "bpftrace.h"
 #include "types.h"
+#include <bcc/bcc_usdt.h>
 
 #include <llvm/Config/llvm-config.h>
 #include <llvm/IR/IRBuilder.h>

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -13,7 +13,7 @@
 #include <string>
 #include <sys/stat.h>
 
-#include "libbpf.h"
+#include <bcc/libbpf.h>
 
 namespace bpftrace {
 namespace ast {

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -15,14 +15,12 @@
 
 #include "attached_probe.h"
 #include "bpftrace.h"
-#include "utils.h"
-#include "bcc_syms.h"
-#include "bcc_usdt.h"
-#include "bcc_elf.h"
-#include "libbpf.h"
-#include "utils.h"
-#include "list.h"
 #include "disasm.h"
+#include "list.h"
+#include "utils.h"
+#include <bcc/bcc_elf.h>
+#include <bcc/bcc_syms.h>
+#include <bcc/bcc_usdt.h>
 #include <linux/perf_event.h>
 #include <linux/version.h>
 

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -6,7 +6,7 @@
 
 #include "types.h"
 
-#include "libbpf.h"
+#include <bcc/libbpf.h>
 
 namespace bpftrace {
 

--- a/src/bfd-disasm.cpp
+++ b/src/bfd-disasm.cpp
@@ -8,11 +8,11 @@
 // bfd.h assumes everyone is using autotools and will error out unless
 // PACKAGE is defined. Some distros patch this check out.
 #define PACKAGE "bpftrace"
+#include "bfd-disasm.h"
+#include <bcc/bcc_elf.h>
+#include <bcc/bcc_syms.h>
 #include <bfd.h>
 #include <dis-asm.h>
-#include "bcc_syms.h"
-#include "bcc_elf.h"
-#include "bfd-disasm.h"
 
 namespace bpftrace {
 

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -20,11 +20,11 @@
 #ifdef HAVE_BCC_ELF_FOREACH_SYM
 #include <linux/elf.h>
 
-#include "bcc_elf.h"
+#include <bcc/bcc_elf.h>
 #endif
 
-#include "bcc_syms.h"
-#include "perf_reader.h"
+#include <bcc/bcc_syms.h>
+#include <bcc/perf_reader.h>
 
 #include "bpforc.h"
 #include "bpftrace.h"

--- a/src/imap.h
+++ b/src/imap.h
@@ -5,7 +5,7 @@
 #include "mapkey.h"
 #include "types.h"
 
-#include "libbpf.h"
+#include <bcc/libbpf.h>
 
 namespace bpftrace {
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -3,9 +3,9 @@
 #include <unistd.h>
 #include <linux/version.h>
 
-#include "libbpf.h"
-#include "utils.h"
 #include "bpftrace.h"
+#include "utils.h"
+#include <bcc/libbpf.h>
 
 #include "map.h"
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -13,9 +13,9 @@
 #include <tuple>
 #include <unistd.h>
 
-#include "bcc_elf.h"
-#include "bcc_usdt.h"
 #include "utils.h"
+#include <bcc/bcc_elf.h>
+#include <bcc/bcc_usdt.h>
 
 namespace {
 


### PR DESCRIPTION
It's important that we use the 'bcc' prefix for bcc includes,
so they don't get mixed up with others.

For example "libbpf.h" might get confused with libbpf's
libbpf.h header.

Changing the semantics of LIBBCC_INCLUDE_DIRS, which now
points to the include directory that contains 'bcc/*headers..'

Signed-off-by: Jiri Olsa <jolsa@kernel.org>