### PR TITLE
Fix if comparison

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1420,7 +1420,10 @@ void CodegenLLVM::visit(If &if_block)
   if_block.cond->accept(*this);
   Value *cond = expr_;
 
-  b_.CreateCondBr(b_.CreateICmpNE(cond, b_.getInt64(0), "true_cond"), if_true, if_false);
+  Value *zero_value = Constant::getNullValue(cond->getType());
+  b_.CreateCondBr(b_.CreateICmpNE(cond, zero_value, "true_cond"),
+                  if_true,
+                  if_false);
 
   b_.SetInsertPoint(if_true);
   for (Statement *stmt : *if_block.stmts)

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -33,6 +33,16 @@ RUN bpftrace -v -e 'i:ms:1 { if ((int32)pid) {} printf("done\n"); exit();}'
 EXPECT done
 TIMEOUT 5
 
+NAME ternary
+RUN bpftrace -v -e 'i:ms:1 { $a = 1 ? "yes" : "no"; printf("%s\n", $a); exit();}'
+EXPECT yes
+TIMEOUT 5
+
+NAME ternary_lnot
+RUN bpftrace -v -e 'i:ms:1 { $a = !nsecs ? 0 : 1; printf("%d\n", $a); exit();}'
+EXPECT 0
+TIMEOUT 5
+
 NAME unroll
 RUN bpftrace -v -e 'i:ms:1 {$a = 1; unroll (10) { $a = $a + 1; } printf("a=%d\n", $a); exit();}'
 EXPECT a=11

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -28,6 +28,11 @@ RUN bpftrace -v -e 'i:ms:1 {$a = ""; if (1 > 2) { $a = "hi" } else if (5 < 3) { 
 EXPECT a=asdf
 TIMEOUT 5
 
+NAME if_cast
+RUN bpftrace -v -e 'i:ms:1 { if ((int32)pid) {} printf("done\n"); exit();}'
+EXPECT done
+TIMEOUT 5
+
 NAME unroll
 RUN bpftrace -v -e 'i:ms:1 {$a = 1; unroll (10) { $a = $a + 1; } printf("a=%d\n", $a); exit();}'
 EXPECT a=11

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -215,6 +215,14 @@ TEST(semantic_analyser, consistent_map_keys)
   test("kprobe:f { @x[1,\"a\",kstack] = 0; @x[\"b\", 2, kstack]; }", 10);
 }
 
+TEST(semantic_analyser, if_statements)
+{
+  test("kprobe:f { if(1) { 123 } }", 0);
+  test("kprobe:f { if(1) { 123 } else { 456 } }", 0);
+  test("kprobe:f { if(0) { 123 } else if(1) { 456 } else { 789 } }", 0);
+  test("kprobe:f { if((int32)pid) { 123 } }", 0);
+}
+
 TEST(semantic_analyser, predicate_expressions)
 {
   test("kprobe:f / 999 / { 123 }", 0);


### PR DESCRIPTION
if_block compares condition with a value of int64ty and it cannot be
used with other types. Fix this by using the same type of the cond.

Error example:

```
% sudo ./src/bpftrace -e 'k:f { if ( (int32)pid ) { 1 } }'
bpftrace: /usr/lib/llvm-10/include/llvm/IR/Instructions.h:1163: void llvm::ICmpInst::AssertOK(): Assertion `getOperand(0)->getType() == getOperand(1)->getType() && "Both operands to ICmp instruction are not of the same type!"' failed.
zsh: abort      sudo ./src/bpftrace -e 'k:f { if ( (int32)pid ) { 1 } }'
```