### PR TITLE
Do not keep open BEGIN/END probes

### DIFF
--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -185,8 +185,10 @@ protected:
   std::vector<Probe> special_probes_;
 
 private:
+  int run_special_probe(std::string name,
+                        const BpfOrc &bpforc,
+                        void (*trigger)(void));
   std::vector<std::unique_ptr<AttachedProbe>> attached_probes_;
-  std::vector<std::unique_ptr<AttachedProbe>> special_attached_probes_;
   void* ksyms_{nullptr};
   std::map<std::string, std::pair<int, void *>> exe_sym_; // exe -> (pid, cache)
   int ncpus_;

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -92,7 +92,7 @@ TIMEOUT 5
 AFTER sleep 0.1
 
 NAME begin probe
-RUN bpftrace -v -e 'BEGIN { printf("%s", probe);exit(); } END{printf("-%s\n", probe); }'
+RUN bpftrace -e 'BEGIN { printf("%s", probe);exit(); } END{printf("-%s\n", probe); }'
 EXPECT ^BEGIN-END$
 TIMEOUT 5
 AFTER sleep 0.1


### PR DESCRIPTION
We currently create special BEGIN/END probes at start,
so they are up the whole time of bpftrace execution.

The problem is that BEGIN and END are implemented via
uprobes and on x86_64 there's uprobe related mmap handler
code in kernel executed if there's a uprobe defined in
the system.

So we are actualy 'slowing' down the system just by
using BEGIN and END ;-) It's not bad, but it's actualy
visible in perf profiles.

Creating the BEGIN and END probes only for the brief
time of their execution.