### PR TITLE
Make `exit()` terminate current probe

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -658,6 +658,15 @@ void CodegenLLVM::visit(Call &call)
     b_.CreatePerfEventOutput(ctx_, perfdata, sizeof(uint64_t));
     b_.CreateLifetimeEnd(perfdata);
     expr_ = nullptr;
+    b_.CreateRet(ConstantInt::get(module_->getContext(), APInt(64, 0)));
+
+    // create an unreachable basic block for all the "dead instructions" that
+    // may come after exit(). If we don't, LLVM will emit the instructions
+    // leading to a `unreachable insn` warning from the verifier
+    BasicBlock *deadcode = BasicBlock::Create(module_->getContext(),
+                                              "deadcode",
+                                              b_.GetInsertBlock()->getParent());
+    b_.SetInsertPoint(deadcode);
   }
   else if (call.func == "print")
   {

--- a/tests/codegen/call_exit.cpp
+++ b/tests/codegen/call_exit.cpp
@@ -6,9 +6,7 @@ namespace codegen {
 
 TEST(codegen, call_exit)
 {
-  test("kprobe:f { exit() }",
-
-       NAME);
+  test("kprobe:f { exit(); @=10 }", NAME);
 }
 
 } // namespace codegen

--- a/tests/codegen/llvm/call_exit.ll
+++ b/tests/codegen/llvm/call_exit.ll
@@ -15,7 +15,7 @@ entry:
   %1 = bitcast i64* %perfdata to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   store i64 30000, i64* %perfdata, align 8
-  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, i64*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, i64* nonnull %perfdata, i64 8)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -134,3 +134,8 @@ RUN bpftrace -v -e 'struct Foo { unsigned int a:4, b:8, c:3, d:1, e:16; } uprobe
 EXPECT 1 2 5 0 65535
 TIMEOUT 5
 AFTER ./testprogs/bitfield_test
+
+NAME exit exits immediately
+RUN bpftrace -e 'i:ms:100 { @++; exit(); @++ }'
+EXPECT @: 1
+TIMEOUT 1


### PR DESCRIPTION
Currently `exit()` emits an async event but does not terminate further
probe processing. E.g. the following prints 2 which can confuse users:

```
$ bpftrace -e 'i:ms:100 { @=1; exit(); @=2 }'
@: 2
```

or a program that appears to conditionally exit but still writes to a
map:

```
$ bpftrace -e 'i:ms:100 { if(1){exit();} @=11 }'
@: 11
```

Due to it's asynchronous behaviour `exit()` is never fully reliable. A
probe might fire again before the runtime has had time to unload a
probe but this should improve the situation a bit.