### PR TITLE
Child process management

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(bpftrace
   bpffeature.cpp
   bpftrace.cpp
   btf.cpp
+  child.cpp
   clang_parser.cpp
   disasm.cpp
   driver.cpp

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -248,7 +248,7 @@ void CodegenLLVM::visit(Builtin &builtin)
   }
   else if (builtin.ident == "cpid")
   {
-    pid_t cpid = bpftrace_.child_pid();
+    pid_t cpid = bpftrace_.child_->pid();
     if (cpid < 1) {
       std::cerr << "BUG: Invalid cpid: " << cpid << std::endl;
       abort();

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1652,6 +1652,7 @@ void SemanticAnalyser::visit(AttachPoint &ap)
     }
   }
   else if (ap.provider == "usdt") {
+    bpftrace_.has_usdt_ = true;
     if (ap.func == "")
       error("usdt probe must have a target function or wildcard", ap.loc);
 

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -334,7 +334,8 @@ void SemanticAnalyser::visit(Builtin &builtin)
     builtin.type = SizedType(Type::username, 8);
   }
   else if (builtin.ident == "cpid") {
-    if (! bpftrace_.has_child_cmd()) {
+    if (!has_child_)
+    {
       error("cpid cannot be used without child command", builtin.loc);
     }
     builtin.type = SizedType(Type::integer, 4);

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -18,8 +18,21 @@ public:
   explicit SemanticAnalyser(Node *root,
                             BPFtrace &bpftrace,
                             BPFfeature &feature,
-                            std::ostream &out = std::cerr)
-      : root_(root), bpftrace_(bpftrace), feature_(feature), out_(out)
+                            std::ostream &out = std::cerr,
+                            bool has_child = true)
+      : root_(root),
+        bpftrace_(bpftrace),
+        feature_(feature),
+        out_(out),
+        has_child_(has_child)
+  {
+  }
+
+  explicit SemanticAnalyser(Node *root,
+                            BPFtrace &bpftrace,
+                            BPFfeature &feature,
+                            bool has_child)
+      : SemanticAnalyser(root, bpftrace, feature, std::cerr, has_child)
   {
   }
 
@@ -89,6 +102,7 @@ private:
   bool needs_elapsed_map_ = false;
   bool has_begin_probe_ = false;
   bool has_end_probe_ = false;
+  bool has_child_ = false;
 };
 
 } // namespace ast

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -35,15 +35,11 @@
 #include "triggers.h"
 #include "utils.h"
 
-extern char** environ;
-
 namespace bpftrace {
 
 DebugLevel bt_debug = DebugLevel::kNone;
 bool bt_verbose = false;
 volatile sig_atomic_t BPFtrace::exitsig_recv = false;
-constexpr char CHILD_EXIT_QUIETLY = '\0';
-constexpr char CHILD_GO = 'g';
 
 int format(char * s, size_t n, const char * fmt, std::vector<std::unique_ptr<IPrintable>> &args) {
   int ret = -1;
@@ -84,16 +80,6 @@ int format(char * s, size_t n, const char * fmt, std::vector<std::unique_ptr<IPr
 
 BPFtrace::~BPFtrace()
 {
-  kill_child();
-  if (child_pid() != 0)
-  {
-    // We don't care if waitpid returns any errors. We're just trying
-    // to make a best effort here. It's not like we could recover from
-    // an error.
-    int status;
-    waitpid(child_pid(), &status, 0);
-  }
-
   for (const auto& pair : exe_sym_)
   {
     if (pair.second.second)
@@ -412,30 +398,12 @@ int BPFtrace::num_probes() const
   return special_probes_.size() + probes_.size();
 }
 
-void BPFtrace::kill_child()
-{
-  if (child_pid() == 0)
-    return;
-
-  if (child_running_) {
-    kill(child_pid(), SIGTERM);
-  } else {
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wunused-result"
-    // We need to disable this warning for some GCC/libc combinations despite
-    // using the void cast: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66425
-    (void)write(child_start_pipe_, &CHILD_EXIT_QUIETLY, 1);
-#pragma GCC diagnostic pop
-    close(child_start_pipe_);
-  }
-}
-
 void BPFtrace::request_finalize()
 {
   finalize_ = true;
   attached_probes_.clear();
-  kill_child();
-
+  if (child_)
+    child_->terminate();
 }
 
 void perf_event_printer(void *cb_cookie, void *data, int size __attribute__((unused)))
@@ -757,7 +725,10 @@ std::unique_ptr<AttachedProbe> BPFtrace::attach_probe(Probe &probe, const BpfOrc
   try
   {
     if (probe.type == ProbeType::usdt || probe.type == ProbeType::watchpoint)
-      return std::make_unique<AttachedProbe>(probe, func->second, pid_);
+    {
+      pid_t pid = child_ ? child_->pid() : pid_;
+      return std::make_unique<AttachedProbe>(probe, func->second, pid);
+    }
     else
       return std::make_unique<AttachedProbe>(probe, func->second, safe_mode_);
   }
@@ -846,7 +817,6 @@ int BPFtrace::run(std::unique_ptr<BpfOrc> bpforc)
       auto attached_probe = attach_probe(*probes, *bpforc.get());
       if (attached_probe == nullptr)
       {
-        kill_child();
         return -1;
       }
       attached_probes_.push_back(std::move(attached_probe));
@@ -859,7 +829,6 @@ int BPFtrace::run(std::unique_ptr<BpfOrc> bpforc)
       auto attached_probe = attach_probe(*r_probes, *bpforc.get());
       if (attached_probe == nullptr)
       {
-        kill_child();
         return -1;
       }
       attached_probes_.push_back(std::move(attached_probe));
@@ -867,17 +836,9 @@ int BPFtrace::run(std::unique_ptr<BpfOrc> bpforc)
   }
 
   // Kick the child to execute the command.
-  if (has_child_cmd())
+  if (child_)
   {
-    int ret = write(child_start_pipe_, &CHILD_GO, 1);
-    if (ret < 0)
-    {
-      perror("unable to write to 'go' pipe");
-      return ret;
-    }
-
-    child_running_ = true;
-    close(child_start_pipe_);
+    child_->run();
   }
 
   if (bt_verbose)
@@ -965,7 +926,7 @@ void BPFtrace::poll_perf_events(int epollfd, bool drain)
     // Note that there technically is a race with a new process using the
     // same pid, but we're polling at 100ms and it would be unlikely that
     // the pids wrap around that fast.
-    if (pid_ > 0 && !is_pid_alive(pid_))
+    if ((pid_ > 0 && !is_pid_alive(pid_)) || (child_ && !child_->is_alive()))
     {
       return;
     }
@@ -1360,106 +1321,6 @@ int BPFtrace::print_map_stats(IMap &map)
 
   out_->map_stats(*this, map, values_by_key, total_counts_by_key);
   return 0;
-}
-
-pid_t BPFtrace::spawn_child()
-{
-  static const int maxargs = 256;
-  char* argv[maxargs];
-  int wait_for_tracing_pipe[2];
-
-  auto args = split_string(cmd_, ' ');
-  auto paths = resolve_binary_path(args[0]); // does path lookup on executable
-  switch (paths.size())
-  {
-  case 0:
-    std::cerr << "path '" << args[0] << "' does not exist or is not executable" << std::endl;
-    return -1;
-  case 1:
-    args[0] = paths.front().c_str();
-    break;
-  default:
-    std::cerr << "path '" << args[0] << "' must refer to a unique binary but matched "
-              << paths.size() << " binaries" << std::endl;
-    return -1;
-  }
-
-
-  if (args.size() >= (maxargs - 1))
-  {
-    std::cerr << "Too many args passed into spawn_child (" << args.size()
-              << " > " << maxargs - 1 << ")" << std::endl;
-    return -1;
-  }
-
-  // Convert vector of strings into raw array of C-strings for execve(2)
-  int idx = 0;
-  for (const auto& arg : args)
-  {
-    argv[idx] = const_cast<char*>(arg.c_str());
-    ++idx;
-  }
-  argv[idx] = nullptr;  // must be null terminated
-
-  if (pipe(wait_for_tracing_pipe) < 0)
-  {
-    perror("failed to create 'go' pipe");
-    return -1;
-  }
-
-  // Fork and exec
-  pid_t pid = fork();
-  if (pid == 0)
-  {
-    // Receive SIGTERM if parent dies
-    //
-    // Useful if user doesn't kill the bpftrace process group
-    if (prctl(PR_SET_PDEATHSIG, SIGTERM))
-      perror("prctl(PR_SET_PDEATHSIG)");
-
-    // Closing the parent's end and wait until the
-    // parent tells us to go. Set the child's end
-    // to be closed on exec.
-    close(wait_for_tracing_pipe[1]);
-    fcntl(wait_for_tracing_pipe[0], F_SETFD, FD_CLOEXEC);
-
-    char bf;
-
-    int ret = read(wait_for_tracing_pipe[0], &bf, 1);
-    if (ret != 1)
-    {
-      perror("failed to read 'go' pipe");
-      return -1;
-    }
-
-    if (bf == CHILD_EXIT_QUIETLY)
-    {
-      close(wait_for_tracing_pipe[0]);
-      exit(0);
-    }
-
-    if (execve(argv[0], argv, environ))
-    {
-      auto err = "Failed to execve: " + std::string(argv[0]);
-      perror(err.c_str());
-      return -1;
-    }
-  }
-  else if (pid > 0)
-  {
-    close(wait_for_tracing_pipe[0]);
-    child_start_pipe_ = wait_for_tracing_pipe[1];
-    child_pid_ = pid;
-    pid_ = pid;
-    return pid;
-  }
-  else
-  {
-    perror("Failed to fork");
-    return -1;
-  }
-
-  return -1;  // silence end of control compiler warning
 }
 
 template <typename T>
@@ -1961,12 +1822,6 @@ bool BPFtrace::is_pid_alive(int pid)
   {
     throw std::runtime_error("failed to snprintf");
   }
-
-  // Do a nonblocking wait on the pid just in case it's our child and it
-  // has exited. We don't really care about any errors, we're just trying
-  // to make a best effort.
-  int status;
-  waitpid(pid, &status, WNOHANG);
 
   int fd = open(buf, 0, O_RDONLY);
   if (fd < 0 && errno == ENOENT)

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -805,6 +805,19 @@ int BPFtrace::run(std::unique_ptr<BpfOrc> bpforc)
   if (run_special_probe("BEGIN_trigger", *bpforc.get(), BEGIN_trigger))
     return -1;
 
+  if (child_ && has_usdt_)
+  {
+    try
+    {
+      child_->run(true);
+    }
+    catch (std::runtime_error &e)
+    {
+      std::cerr << "Failed to setup child: " << e.what() << std::endl;
+      return -1;
+    }
+  }
+
   // The kernel appears to fire some probes in the order that they were
   // attached and others in reverse order. In order to make sure that blocks
   // are executed in the same order they were declared, iterate over the probes
@@ -838,7 +851,18 @@ int BPFtrace::run(std::unique_ptr<BpfOrc> bpforc)
   // Kick the child to execute the command.
   if (child_)
   {
-    child_->run();
+    try
+    {
+      if (has_usdt_)
+        child_->resume();
+      else
+        child_->run();
+    }
+    catch (std::runtime_error &e)
+    {
+      std::cerr << "Failed to run child: " << e.what() << std::endl;
+      return -1;
+    }
   }
 
   if (bt_verbose)

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -162,6 +162,7 @@ public:
   bool cache_user_symbols_ = true;
   bool safe_mode_ = true;
   bool force_btf_ = false;
+  bool has_usdt_ = false;
 
   static void sort_by_key(
       std::vector<SizedType> key_args,

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -11,6 +11,7 @@
 #include "ast.h"
 #include "attached_probe.h"
 #include "btf.h"
+#include "child.h"
 #include "imap.h"
 #include "output.h"
 #include "printf.h"
@@ -121,10 +122,6 @@ public:
   void error(std::ostream &out, const location &l, const std::string &m);
   void warning(std::ostream &out, const location &l, const std::string &m);
   void log_with_location(std::string, std::ostream &, const location &, const std::string &);
-  bool has_child_cmd() { return cmd_.size() != 0; }
-  virtual pid_t child_pid() { return child_pid_; };
-  int spawn_child();
-  void kill_child();
   bool is_aslr_enabled(int pid);
 
   std::string cmd_;
@@ -188,6 +185,7 @@ public:
   BTF btf_;
   std::unordered_set<std::string> btf_set_;
   std::map<std::string, std::map<std::string, SizedType>> btf_ap_args_;
+  std::unique_ptr<ChildProcBase> child_;
 
 protected:
   std::vector<Probe> probes_;
@@ -204,11 +202,6 @@ private:
   int online_cpus_;
   std::vector<std::string> params_;
   int next_probe_id_ = 0;
-
-  pid_t child_pid_ = 0;
-  bool child_running_ = false; // true when `CHILD_GO` has been sent (child
-                               // execve)
-  int child_start_pipe_ = -1;
 
   std::string src_;
   std::string filename_;

--- a/src/child.cpp
+++ b/src/child.cpp
@@ -1,0 +1,221 @@
+#include <cerrno>
+#include <fcntl.h>
+#include <cassert>
+
+#include <stdexcept>
+#include <string>
+#include <sys/prctl.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <system_error>
+#include <unistd.h>
+
+#include "child.h"
+#include "utils.h"
+
+extern char** environ;
+
+namespace bpftrace {
+
+constexpr unsigned int maxargs = 256;
+constexpr char CHILD_GO = 'g';
+constexpr unsigned int STACK_SIZE = (64 * 1024UL);
+
+std::system_error SYS_ERROR(std::string msg)
+{
+  return std::system_error(errno, std::generic_category(), msg);
+}
+
+static int childfn(void* arg)
+{
+  struct child_args* args = static_cast<struct child_args*>(arg);
+
+  // Receive SIGTERM if parent dies
+  if (prctl(PR_SET_PDEATHSIG, SIGTERM))
+  {
+    perror("child: prctl(PR_SET_PDEATHSIG)");
+    return 10;
+  }
+
+  // Convert vector of strings into raw array of C-strings for execve(2)
+  char* argv[maxargs];
+  int idx = 0;
+  for (const auto& arg : args->cmd)
+  {
+    argv[idx++] = const_cast<char*>(arg.c_str());
+  }
+  argv[idx] = nullptr; // must be null terminated
+
+  char bf;
+  int ret = read(args->pipe_fd, &bf, 1);
+  if (ret != 1)
+  {
+    perror("child: failed to read 'go' pipe");
+    return 11;
+  }
+
+  close(args->pipe_fd);
+
+  execve(argv[0], argv, environ);
+
+  auto err = "child: failed to execve: " + std::string(argv[0]);
+  perror(err.c_str());
+  return 12;
+}
+
+static void validate_cmd(std::vector<std::string>& cmd)
+{
+  auto paths = resolve_binary_path(cmd[0]);
+  switch (paths.size())
+  {
+    case 0:
+      throw std::runtime_error("path '" + cmd[0] +
+                               "' does not exist or is not executable");
+    case 1:
+      cmd[0] = paths.front().c_str();
+      break;
+    default:
+      throw std::runtime_error("path '" + cmd[0] +
+                               "' must refer to a unique binary but matched " +
+                               std::to_string(paths.size()) + " binaries");
+      return;
+  }
+
+  if (cmd.size() >= (maxargs - 1))
+  {
+    throw std::runtime_error("Too many arguments for command (" +
+                             std::to_string(cmd.size()) + " > " +
+                             std::to_string(maxargs - 1) + ")");
+  }
+}
+
+ChildProc::ChildProc(std::string cmd)
+{
+  auto child_args = std::make_unique<struct child_args>();
+  auto child_stack = std::make_unique<char[]>(STACK_SIZE);
+
+  child_args->cmd = split_string(cmd, ' ');
+  validate_cmd(child_args->cmd);
+
+  int pipefd[2];
+  int ret = pipe2(pipefd, O_CLOEXEC);
+  if (ret < 0)
+  {
+    SYS_ERROR("Failed to create pipe");
+  }
+
+  child_args->pipe_fd = pipefd[0];
+  child_pipe_ = pipefd[1];
+
+  pid_t cpid = clone(
+      childfn, child_stack.get() + STACK_SIZE, SIGCHLD, child_args.get());
+
+  if (cpid <= 0)
+  {
+    close(pipefd[0]);
+    close(pipefd[1]);
+    throw SYS_ERROR("Failed to clone child");
+  }
+
+  child_pid_ = cpid;
+  close(pipefd[0]);
+  state_ = State::FORKED;
+}
+
+ChildProc::~ChildProc()
+{
+  close(child_pipe_);
+
+  if (is_alive())
+    terminate(true);
+}
+
+bool ChildProc::is_alive()
+{
+  if (!died())
+    check_child();
+  return !died();
+}
+
+void ChildProc::terminate(bool force)
+{
+  // Make sure child didn't terminate in mean time
+  check_child();
+  if (died())
+    return;
+
+  if (child_pid_ <= 1)
+    throw std::runtime_error("BUG: child_pid <= 1");
+
+  int sig = force ? SIGKILL : SIGTERM;
+
+  kill(child_pid_, sig);
+  check_child(force);
+}
+
+void ChildProc::run(bool pause __attribute__((unused)))
+{
+  if (!is_alive())
+  {
+    throw std::runtime_error("Child died unexpectedly");
+  }
+
+  assert(state_ == State::FORKED);
+
+  int ret = write(child_pipe_, &CHILD_GO, 1);
+  if (ret < 0)
+  {
+    terminate(true);
+    throw SYS_ERROR("Failed to write 'go' pipe");
+  }
+  state_ = State::RUNNING;
+  close(child_pipe_);
+}
+
+// private
+void ChildProc::check_wstatus(int wstatus)
+{
+  if (WIFEXITED(wstatus))
+    exit_code_ = WEXITSTATUS(wstatus);
+  else if (WIFSIGNALED(wstatus))
+    term_signal_ = WTERMSIG(wstatus);
+  // Ignore STOP and CONT
+  else
+    return;
+
+  state_ = State::DIED;
+}
+
+void ChildProc::check_child(bool block)
+{
+  int status = 0;
+
+  int flags = WNOHANG;
+  if (block)
+    flags &= ~WNOHANG;
+
+  pid_t ret;
+  while ((ret = waitpid(child_pid_, &status, flags)) < 0 && errno == EINTR)
+    ;
+
+  if (ret < 0)
+  {
+    if (errno == EINVAL)
+      throw std::runtime_error("BUG: waitpid() EINVAL");
+    else
+    {
+      std::cerr << "waitpid(" << child_pid_
+                << ") returned unexpected error: " << errno
+                << ". Marking the child as dead" << std::endl;
+      state_ = State::DIED;
+      return;
+    }
+  }
+
+  if (ret == 0)
+    return;
+
+  check_wstatus(status);
+}
+
+} // namespace bpftrace

--- a/src/child.h
+++ b/src/child.h
@@ -1,0 +1,141 @@
+#pragma once
+
+#include <csignal>
+#include <memory>
+#include <string>
+#include <vector>
+
+namespace bpftrace {
+
+struct child_args
+{
+  std::vector<std::string> cmd;
+  int pipe_fd;
+};
+
+class ChildProcBase
+{
+public:
+  /**
+     Parse command and fork a child process.
+
+     \param cmd Command to run
+   */
+  ChildProcBase() = default;
+  virtual ~ChildProcBase() = default;
+
+  /**
+     let child run (execve).
+
+     \param pause If set the child will be paused(stopped) just
+     after `execve`. To resume the child `resume` will have to
+     be called.
+  */
+  virtual void run(bool pause = false) = 0;
+
+  /**
+     Ask child to terminate
+
+     \param force Forcefully kill the child (SIGKILL)
+  */
+  virtual void terminate(bool force = false) = 0;
+
+  /**
+     Whether the child process is still alive or not
+  */
+  virtual bool is_alive() = 0;
+
+  /**
+     return the child pid
+  */
+  pid_t pid()
+  {
+    return child_pid_;
+  };
+
+  /**
+     Get child exit code, if any. This should only be called when the child has
+     finished (i.e. when is_alive() returns false)
+
+     \return The exit code of the child or -1 if the child hasn't been
+  terminated (by a signal)
+
+  */
+  int exit_code()
+  {
+    return exit_code_;
+  };
+
+  /**
+     Get termination signal, if any. This should only be called when the child
+     has finished (i.e. when is_alive() returns false)
+
+     \return A signal ID or -1 if the child hasn't been terminated (by a signal)
+  */
+  int term_signal()
+  {
+    return term_signal_;
+  };
+
+  /**
+     Resume a paused child. Only valid when run() has been called with
+     pause=true
+   */
+  virtual void resume(void) = 0;
+
+protected:
+  pid_t child_pid_ = -1;
+  int exit_code_ = -1;
+  int term_signal_ = -1;
+};
+
+class ChildProc : public ChildProcBase
+{
+public:
+  /**
+    Parse command and fork a child process. The child is run with the same
+    permissions and environment variables as bpftrace.
+
+    \param the command to run, with up to 255 optional arguments. If the
+  executables path isn't fully specified it the current PATH will be searched.
+  If more than one binary with the same name is found in the PATH an exception
+  is raised.
+
+  */
+  ChildProc(std::string cmd);
+  ~ChildProc();
+
+  // Disallow copying as the internal state will get out of sync which will
+  // cause issues.
+  ChildProc(const ChildProc&) = delete;
+  ChildProc& operator=(const ChildProc&) = delete;
+  ChildProc(ChildProc&&) = delete;
+  ChildProc& operator=(ChildProc&&) = delete;
+
+  void run(bool pause = false) override;
+  void terminate(bool force = false) override;
+  bool is_alive() override;
+  void resume(void) override {};
+
+private:
+  enum class State
+  {
+    INIT,
+    FORKED,
+    RUNNING,
+    DIED,
+  };
+
+  State state_ = State::INIT;
+
+  void check_child(bool block = false);
+  void check_wstatus(int wstatus);
+  bool died()
+  {
+    return state_ == State::DIED;
+  };
+
+  int child_pipe_ = -1;
+};
+
+} // namespace bpftrace

--- a/src/child.h
+++ b/src/child.h
@@ -115,7 +115,7 @@ public:
   void run(bool pause = false) override;
   void terminate(bool force = false) override;
   bool is_alive() override;
-  void resume(void) override {};
+  void resume(void) override;
 
 private:
   enum class State
@@ -124,6 +124,7 @@ private:
     FORKED,
     RUNNING,
     DIED,
+    PTRACE_PAUSE,
   };
 
   State state_ = State::INIT;
@@ -136,6 +137,8 @@ private:
   };
 
   int child_pipe_ = -1;
+  bool with_ptrace_ = false;
+  bool did_run_ = false;
 };
 
 } // namespace bpftrace

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -102,23 +102,25 @@ static void usdt_probe_each(struct bcc_usdt *usdt_probe)
   usdt_provider_cache[usdt_probe->provider].push_back(std::make_tuple(usdt_probe->bin_path, usdt_probe->provider, usdt_probe->name));
 }
 
-void StderrSilencer::silence()
+void StdioSilencer::silence()
 {
-  fflush(stderr);
-  old_stderr_ = dup(STDERR_FILENO);
-  int new_stderr_ = open("/dev/null", O_WRONLY);
-  dup2(new_stderr_, STDERR_FILENO);
-  close(new_stderr_);
+  fflush(ofile);
+  int fd = fileno(ofile);
+  old_stdio_ = dup(fd);
+  int new_stdio_ = open("/dev/null", O_WRONLY);
+  dup2(new_stdio_, fd);
+  close(new_stdio_);
 }
 
-StderrSilencer::~StderrSilencer()
+StdioSilencer::~StdioSilencer()
 {
-  if (old_stderr_ != -1)
+  if (old_stdio_ != -1)
   {
-    fflush(stderr);
-    dup2(old_stderr_, STDERR_FILENO);
-    close(old_stderr_);
-    old_stderr_ = -1;
+    fflush(ofile);
+    int fd = fileno(ofile);
+    dup2(old_stdio_, fd);
+    close(old_stdio_);
+    old_stdio_ = -1;
   }
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -61,15 +61,36 @@ private:
   std::string msg_;
 };
 
-class StderrSilencer
+class StdioSilencer
 {
 public:
-  StderrSilencer() = default;
-  ~StderrSilencer();
+  StdioSilencer() = default;
+  ~StdioSilencer();
   void silence();
 
+protected:
+  FILE *ofile;
+
 private:
-  int old_stderr_ = -1;
+  int old_stdio_ = -1;
+};
+
+class StderrSilencer : public StdioSilencer
+{
+public:
+  StderrSilencer()
+  {
+    ofile = stderr;
+  }
+};
+
+class StdoutSilencer : public StdioSilencer
+{
+public:
+  StdoutSilencer()
+  {
+    ofile = stdout;
+  }
 };
 
 class USDTHelper

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/tests/codegen_includes.cpp
 add_executable(bpftrace_test
   ast.cpp
   bpftrace.cpp
+  child.cpp
   clang_parser.cpp
   main.cpp
   mocks.cpp
@@ -34,6 +35,7 @@ add_executable(bpftrace_test
   ${CMAKE_SOURCE_DIR}/src/bpftrace.cpp
   ${CMAKE_SOURCE_DIR}/src/bpffeature.cpp
   ${CMAKE_SOURCE_DIR}/src/btf.cpp
+  ${CMAKE_SOURCE_DIR}/src/child.cpp
   ${CMAKE_SOURCE_DIR}/src/clang_parser.cpp
   ${CMAKE_SOURCE_DIR}/src/disasm.cpp
   ${CMAKE_SOURCE_DIR}/src/driver.cpp

--- a/tests/child.cpp
+++ b/tests/child.cpp
@@ -1,0 +1,190 @@
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include <sstream>
+#include <string>
+
+#include <fcntl.h>
+#include <signal.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+
+#include <time.h>
+
+#include "child.h"
+#include "utils.h"
+
+namespace bpftrace {
+namespace test {
+namespace child {
+
+using ::testing::HasSubstr;
+
+#define TEST_BIN "/bin/ls"
+#define TEST_BIN_LONG "/bin/sleep 10"
+
+int msleep(int msec)
+{
+  struct timespec sleep = { .tv_sec = 0, .tv_nsec = msec * 1000000L };
+  struct timespec rem = {};
+  if (nanosleep(&sleep, &rem) < 0)
+    return 1000L * rem.tv_sec + 1000000L * rem.tv_nsec;
+  return 0;
+}
+
+void wait_for(ChildProcBase *child, int msec_timeout)
+{
+  constexpr int wait = 10;
+  while (child->is_alive() && msec_timeout > 0)
+    msec_timeout -= wait - msleep(wait);
+}
+
+std::unique_ptr<ChildProc> getChild(std::string cmd)
+{
+  std::unique_ptr<ChildProc> child;
+  {
+    StderrSilencer es;
+    StdoutSilencer os;
+    os.silence();
+    es.silence();
+    child = std::make_unique<ChildProc>(cmd);
+  }
+  EXPECT_NE(child->pid(), -1);
+  EXPECT_TRUE(child->is_alive());
+  return child;
+}
+
+TEST(childproc, exe_does_not_exist)
+{
+  try
+  {
+    ChildProc child("/does/not/exist/abc/fed");
+    FAIL();
+  }
+  catch (const std::runtime_error &e)
+  {
+    EXPECT_THAT(e.what(), HasSubstr("does not exist or is not executable"));
+  }
+}
+
+TEST(childproc, too_many_arguments)
+{
+  std::stringstream cmd;
+  cmd << "/bin/ls";
+  for (int i = 0; i < 280; i++)
+    cmd << " a";
+
+  try
+  {
+    ChildProc child(cmd.str());
+    FAIL();
+  }
+  catch (const std::runtime_error &e)
+  {
+    EXPECT_THAT(e.what(), HasSubstr("Too many arguments"));
+  }
+}
+
+TEST(childproc, child_exit_success)
+{
+  // Spawn a child that exits  success
+  auto child = getChild(TEST_BIN);
+
+  child->run();
+  wait_for(child.get(), 1000);
+  EXPECT_FALSE(child->is_alive());
+  EXPECT_EQ(child->exit_code(), 0);
+  EXPECT_EQ(child->term_signal(), -1);
+}
+
+TEST(childproc, child_exit_err)
+{
+  // Spawn a child that exits  success
+  auto child = getChild("/bin/ls /does/not/exist/abc/fed");
+
+  child->run();
+  wait_for(child.get(), 1000);
+  EXPECT_FALSE(child->is_alive());
+  EXPECT_EQ(child->exit_code(), 2);
+  EXPECT_EQ(child->term_signal(), -1);
+}
+
+TEST(childproc, terminate)
+{
+  auto child = getChild(TEST_BIN_LONG);
+
+  child->run();
+  child->terminate();
+  wait_for(child.get(), 100);
+  EXPECT_FALSE(child->is_alive());
+  EXPECT_EQ(child->term_signal(), SIGTERM);
+}
+
+TEST(childproc, destructor_destroy_child)
+{
+  pid_t child_pid = 0;
+  {
+    std::unique_ptr<ChildProc> child = getChild(TEST_BIN_LONG);
+    child->run();
+    child_pid = child->pid();
+    msleep(25);
+  }
+
+  int status = 0;
+  pid_t ret = waitpid(child_pid, &status, WNOHANG);
+  if (ret == -1 && errno == ECHILD)
+    return;
+
+  FAIL() << "Child should've been killed but appears to be alive: ret: " << ret
+         << ", errno: " << errno << ", status: " << status << std::endl;
+}
+
+TEST(childproc, died_before_exec)
+{
+  auto child = getChild(TEST_BIN_LONG);
+
+  EXPECT_EQ(kill(child->pid(), SIGHUP), 0);
+  wait_for(child.get(), 100);
+
+  EXPECT_FALSE(child->is_alive());
+  EXPECT_EQ(child->exit_code(), -1);
+  EXPECT_EQ(child->term_signal(), SIGHUP);
+}
+
+TEST(childproc, stop_cont)
+{
+  // STOP/CONT should not incorrectly mark the child
+  // as dead
+  auto child = getChild(TEST_BIN_LONG);
+  int status = 0;
+
+  child->run();
+  msleep(25);
+  EXPECT_TRUE(child->is_alive());
+
+  if (kill(child->pid(), SIGSTOP))
+    FAIL() << "kill(SIGSTOP)";
+
+  waitpid(child->pid(), &status, WUNTRACED);
+  if (!(WIFSTOPPED(status) && WSTOPSIG(status) == SIGSTOP))
+    FAIL() << "! WIFSTOPPED";
+
+  EXPECT_TRUE(child->is_alive());
+
+  if (kill(child->pid(), SIGCONT))
+    FAIL() << "kill(SIGCONT)";
+
+  waitpid(child->pid(), &status, WCONTINUED);
+  if (!WIFCONTINUED(status))
+    FAIL() << "! WIFCONTINUED";
+
+  EXPECT_TRUE(child->is_alive());
+
+  child->terminate();
+  wait_for(child.get(), 100);
+  EXPECT_EQ(child->exit_code(), -1);
+  EXPECT_EQ(child->term_signal(), SIGTERM);
+}
+
+} // namespace child
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/builtin_cpid.cpp
+++ b/tests/codegen/builtin_cpid.cpp
@@ -4,23 +4,11 @@ namespace bpftrace {
 namespace test {
 namespace codegen {
 
-class MockBPFtraceCpid : public BPFtrace
-{
-  pid_t child_pid()
-  {
-    return 1337;
-  };
-};
-
 TEST(codegen, builtin_cpid)
 {
-  MockBPFtraceCpid bpftrace;
-  bpftrace.cmd_ = "sleep 1";
-
-  test(bpftrace,
-       "kprobe:f { @ = cpid }",
-
-       NAME);
+  MockBPFtrace bpftrace;
+  bpftrace.child_ = std::make_unique<MockChildProc>("");
+  test(bpftrace, "kprobe:f { @ = cpid }", NAME);
 }
 
 } // namespace codegen

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -2,6 +2,7 @@
 
 #include "bpffeature.h"
 #include "bpftrace.h"
+#include "child.h"
 #include "gmock/gmock.h"
 
 namespace bpftrace {
@@ -65,6 +66,28 @@ public:
     has_send_signal_ = std::make_unique<bool>(has_features);
     has_get_current_cgroup_id_ = std::make_unique<bool>(has_features);
     has_override_return_ = std::make_unique<bool>(has_features);
+  };
+};
+
+class MockChildProc : public ChildProcBase
+{
+public:
+  MockChildProc(std::string cmd __attribute__((unused)))
+  {
+    child_pid_ = 1337;
+  };
+  ~MockChildProc(){};
+
+  void terminate(bool force __attribute__((unused)) = false) override{};
+  bool is_alive() override
+  {
+    return true;
+  };
+  void resume(void) override{};
+
+  void run(bool pause = false) override
+  {
+    (void)pause;
   };
 };
 

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -46,16 +46,21 @@ REQUIRES ./testprogs/usdt_test should_not_skip
 NAME "usdt probes - attach to fully specified probe by file"
 RUN bpftrace -e 'usdt:./testprogs/usdt_test:tracetest:testprobe { printf("here\n" ); exit(); }'
 EXPECT here
-TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
+TIMEOUT 5
+
+NAME "usdt probes - attach to fully specified probe of child"
+RUN bpftrace -e 'usdt:./testprogs/usdt_test:tracetest:testprobe { printf("here\n" ); exit(); }' -c ./testprogs/usdt_test
+EXPECT here
+TIMEOUT 5
 
 NAME "usdt probes - attach to fully specified probe by pid"
 RUN bpftrace -e 'usdt::tracetest:testprobe { printf("here\n" ); exit(); }' -p $(pidof usdt_test)
 EXPECT here
-TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
+TIMEOUT 5
 
 NAME "usdt probes - all probes by wildcard and file"
 RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("here\n" ); exit(); }'
@@ -63,6 +68,11 @@ EXPECT Attaching 3 probes...
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
+
+NAME "usdt probes - all probes by wildcard and file with child"
+RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("here\n" ); exit(); }' -c ./testprogs/usdt_test
+EXPECT Attaching 3 probes...
+TIMEOUT 5
 
 # TODO(mmarchini): re-enable this test
 # This test has two problems: it relies on the latest version of bcc and it
@@ -87,12 +97,22 @@ TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 
+NAME "usdt probes - attach to probe by wildcard and file with child"
+RUN bpftrace -e 'usdt:./testprogs/usdt_test::*probe2 { printf("here\n" ); exit(); }' -c ./testprogs/usdt_test
+EXPECT Attaching 2 probes...
+TIMEOUT 5
+
 NAME "usdt probes - attach to probes by wildcard file"
 RUN bpftrace -e 'usdt:./testprogs/usdt_test*::* { printf("here\n" ); exit(); }'
 EXPECT Attaching 3 probes...
-TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
+TIMEOUT 5
+
+NAME "usdt probes - attach to probes by wildcard file with child"
+RUN bpftrace -e 'usdt:./testprogs/usdt_test*::* { printf("here\n" ); exit(); }' -c ./testprogs/usdt_test
+EXPECT Attaching 3 probes...
+TIMEOUT 5
 
 NAME "usdt probes - attach to probe with ambiguous wildcard file fails"
 RUN bpftrace -e 'usdt:./testprogs/u*::* { printf("here\n" ); exit(); }'
@@ -136,6 +156,11 @@ EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
+
+NAME "usdt probes - attach to probe with probe builtin and args by file with child"
+RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }' -c ./testprogs/usdt_test
+EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe
+TIMEOUT 5
 
 NAME "usdt probes - attach to probe with probe builtin and args by pid"
 RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }' -p $(pidof usdt_test)


### PR DESCRIPTION
This re-implements the child process management bpftrace has, it:

- Moves the code to a new module, cleaning up the bpftrace class (#1080)
- Optionally uses ptrace to allow USDTs on child processes (#990)
- Uses `waitpid` to monitor the child process, avoiding polling `/proc`

I've considered using pidfds for this but I don't think it adds anything. It would allows us to `poll` the fd, but we would still need to `wait` to reap the child.