### PR TITLE
cmake: Add a path /usr/lib64 for LIBBPF_LIBRARIES

### DIFF
--- a/cmake/FindLibBpf.cmake
+++ b/cmake/FindLibBpf.cmake
@@ -27,6 +27,7 @@ find_library (LIBBPF_LIBRARIES
     bpf
   PATHS
     /usr/lib
+    /usr/lib64
     /usr/local/lib
     /opt/local/lib
     /sw/lib


### PR DESCRIPTION
The installed libbpf path can be /usr/lib64/
if $(uname -m) is x86_64 so add the path.