### PR TITLE
Bpftrace fixes for s390x

### DIFF
--- a/src/arch/CMakeLists.txt
+++ b/src/arch/CMakeLists.txt
@@ -3,6 +3,9 @@ if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
 elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64" OR
        CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64le")
     add_library(arch ppc64.cpp)
+elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "s390" OR
+       CMAKE_SYSTEM_PROCESSOR STREQUAL "s390x")
+    add_library(arch s390.cpp)
 elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
     add_library(arch x86_64.cpp)
 else()

--- a/src/arch/aarch64.cpp
+++ b/src/arch/aarch64.cpp
@@ -3,6 +3,9 @@
 #include <algorithm>
 #include <array>
 
+// SP points to the first argument that is passed on the stack
+#define ARG0_STACK 0
+
 namespace bpftrace {
 namespace arch {
 
@@ -132,6 +135,11 @@ int pc_offset()
 int sp_offset()
 {
   return offset("sp");
+}
+
+int arg_stack_offset()
+{
+  return ARG0_STACK / 8;
 }
 
 std::string name()

--- a/src/arch/arch.h
+++ b/src/arch/arch.h
@@ -11,6 +11,7 @@ int arg_offset(int arg_num);
 int ret_offset();
 int pc_offset();
 int sp_offset();
+int arg_stack_offset();
 std::string name();
 
 } // namespace arch

--- a/src/arch/ppc64.cpp
+++ b/src/arch/ppc64.cpp
@@ -3,6 +3,11 @@
 #include <algorithm>
 #include <array>
 
+// For little endian 64 bit, sp + 32 + 8 regs save area + argX
+#define ARG0_STACK_LE 96
+// For big endian 64 bit, sp + 48 + 8 regs save area + argX
+#define ARG0_STACK_BE 112
+
 namespace bpftrace {
 namespace arch {
 
@@ -97,6 +102,15 @@ int pc_offset()
 int sp_offset()
 {
   return offset("r1");
+}
+
+int arg_stack_offset()
+{
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  return ARG0_STACK_LE / 8;
+#else
+  return ARG0_STACK_BE / 8;
+#endif
 }
 
 std::string name()

--- a/src/arch/s390.cpp
+++ b/src/arch/s390.cpp
@@ -5,6 +5,9 @@
 
 #define REQ_REGISTERS 19
 #define ARG_REGISTERS 5
+// For s390x, r2-r6 registers are used as function arguments, then the extra
+// arguments can be found starting at sp+160
+#define ARG0_STACK 160
 
 namespace bpftrace {
 namespace arch {
@@ -74,6 +77,11 @@ int pc_offset()
 int sp_offset()
 {
   return offset("r15");
+}
+
+int arg_stack_offset()
+{
+  return ARG0_STACK / 8;
 }
 
 std::string name()

--- a/src/arch/s390.cpp
+++ b/src/arch/s390.cpp
@@ -1,0 +1,85 @@
+#include "arch.h"
+
+#include <algorithm>
+#include <array>
+
+#define REQ_REGISTERS 19
+#define ARG_REGISTERS 5
+
+namespace bpftrace {
+namespace arch {
+
+// clang-format off
+static std::array<std::string, REQ_REGISTERS> registers = {
+  // Breakpoint event address
+  "arg",
+  "pswmask",
+  // Instruction address
+  "pswaddr",
+  "r0",
+  "r1",
+  "r2",
+  "r3",
+  "r4",
+  "r5",
+  "r6",
+  "r7",
+  "r8",
+  "r9",
+  "r10",
+  "r11",
+  "r12",
+  "r13",
+  "r14",
+  "r15",
+};
+
+static std::array<std::string, ARG_REGISTERS> arg_registers = {
+  "r2",
+  "r3",
+  "r4",
+  "r5",
+  "r6",
+};
+// clang-format on
+
+int offset(std::string reg_name)
+{
+  auto it = find(registers.begin(), registers.end(), reg_name);
+  if (it == registers.end())
+    return -1;
+  return distance(registers.begin(), it);
+}
+
+int max_arg()
+{
+  return arg_registers.size() - 1;
+}
+
+int arg_offset(int arg_num)
+{
+  return offset(arg_registers.at(arg_num));
+}
+
+int ret_offset()
+{
+  return offset("r2");
+}
+
+int pc_offset()
+{
+  return offset("pswaddr");
+}
+
+int sp_offset()
+{
+  return offset("r15");
+}
+
+std::string name()
+{
+  return std::string("s390x");
+}
+
+} // namespace arch
+} // namespace bpftrace

--- a/src/arch/x86_64.cpp
+++ b/src/arch/x86_64.cpp
@@ -3,6 +3,9 @@
 #include <algorithm>
 #include <array>
 
+// SP + 8 points to the first argument that is passed on the stack
+#define ARG0_STACK 8
+
 namespace bpftrace {
 namespace arch {
 
@@ -78,6 +81,11 @@ int pc_offset()
 int sp_offset()
 {
   return offset("sp");
+}
+
+int arg_stack_offset()
+{
+  return ARG0_STACK / 8;
 }
 
 std::string name()

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -219,7 +219,9 @@ void CodegenLLVM::visit(Builtin &builtin)
                               "reg_sp");
     dyn_cast<LoadInst>(sp)->setVolatile(true);
     AllocaInst *dst = b_.CreateAllocaBPF(builtin.type, builtin.ident);
-    Value *src = b_.CreateAdd(sp, b_.getInt64((arg_num + 1) * sizeof(uintptr_t)));
+    Value *src = b_.CreateAdd(sp,
+                              b_.getInt64((arg_num + arch::arg_stack_offset()) *
+                                          sizeof(uintptr_t)));
     b_.CreateProbeRead(dst, 8, src);
     expr_ = b_.CreateLoad(dst);
     b_.CreateLifetimeEnd(dst);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1230,7 +1230,7 @@ int BPFtrace::print_map_hist(IMap &map, uint32_t top, uint32_t div)
   while (bpf_get_next_key(map.mapfd_, old_key.data(), key.data()) == 0)
   {
     auto key_prefix = std::vector<uint8_t>(map.key_.size());
-    int bucket = key.at(map.key_.size());
+    uint64_t bucket = read_data<uint64_t>(key.data() + map.key_.size());
 
     for (size_t i=0; i<map.key_.size(); i++)
       key_prefix.at(i) = key.at(i);
@@ -1267,7 +1267,7 @@ int BPFtrace::print_map_hist(IMap &map, uint32_t top, uint32_t div)
   std::vector<std::pair<std::vector<uint8_t>, uint64_t>> total_counts_by_key;
   for (auto &map_elem : values_by_key)
   {
-    int sum = 0;
+    int64_t sum = 0;
     for (size_t i=0; i<map_elem.second.size(); i++)
     {
       sum += map_elem.second.at(i);
@@ -1309,7 +1309,7 @@ int BPFtrace::print_map_stats(IMap &map)
   while (bpf_get_next_key(map.mapfd_, old_key.data(), key.data()) == 0)
   {
     auto key_prefix = std::vector<uint8_t>(map.key_.size());
-    int bucket = key.at(map.key_.size());
+    uint64_t bucket = read_data<uint64_t>(key.data() + map.key_.size());
 
     for (size_t i=0; i<map.key_.size(); i++)
       key_prefix.at(i) = key.at(i);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -609,31 +609,36 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(const std::vec
     switch (arg.type.type)
     {
       case Type::integer:
-        switch (arg.type.size)
+        // If no casting is performed, we have already promoted the ty.size to 8
+        if (arg.type.cast_type == "" || arg.type.cast_type == "uint64" ||
+            arg.type.cast_type == "int64")
         {
-          case 8:
-            arg_values.push_back(
-              std::make_unique<PrintableInt>(
-                *reinterpret_cast<uint64_t*>(arg_data+arg.offset)));
-            break;
-          case 4:
-            arg_values.push_back(
-              std::make_unique<PrintableInt>(
-                *reinterpret_cast<uint32_t*>(arg_data+arg.offset)));
-            break;
-          case 2:
-            arg_values.push_back(
-              std::make_unique<PrintableInt>(
-                *reinterpret_cast<uint16_t*>(arg_data+arg.offset)));
-            break;
-          case 1:
-            arg_values.push_back(
-              std::make_unique<PrintableInt>(
-                *reinterpret_cast<uint8_t*>(arg_data+arg.offset)));
-            break;
-          default:
-            std::cerr << "get_arg_values: invalid integer size. 8, 4, 2 and byte supported. " << arg.type.size << "provided" << std::endl;
-            abort();
+          arg_values.push_back(std::make_unique<PrintableInt>(
+              *reinterpret_cast<uint64_t *>(arg_data + arg.offset)));
+        }
+        else if (arg.type.cast_type == "uint32" ||
+                 arg.type.cast_type == "int32")
+        {
+          arg_values.push_back(std::make_unique<PrintableInt>(
+              *reinterpret_cast<uint32_t *>(arg_data + arg.offset)));
+        }
+        else if (arg.type.cast_type == "uint16" ||
+                 arg.type.cast_type == "int16")
+        {
+          arg_values.push_back(std::make_unique<PrintableInt>(
+              *reinterpret_cast<uint16_t *>(arg_data + arg.offset)));
+        }
+        else if (arg.type.cast_type == "uint8" || arg.type.cast_type == "int8")
+        {
+          arg_values.push_back(std::make_unique<PrintableInt>(
+              *reinterpret_cast<uint8_t *>(arg_data + arg.offset)));
+        }
+        else
+        {
+          std::cerr << "get_arg_values: invalid integer size. 8, 4, 2 and byte "
+                       "supported. "
+                    << arg.type.size << "provided" << std::endl;
+          abort();
         }
         break;
       case Type::string:

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -61,6 +61,21 @@ TIMEOUT 5
 NAME sarg
 RUN bpftrace -v -e 'uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS '$test' %d %d\n", sarg0, sarg1); exit(); }'
 EXPECT SUCCESS sarg 32 64
+ARCH x86_64
+TIMEOUT 5
+AFTER ./testprogs/stack_args
+
+NAME sarg
+RUN bpftrace -v -e 'uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS '$test' %d %d\n", sarg0, sarg1); exit(); }'
+EXPECT SUCCESS sarg 128 256
+ARCH aarch64|ppc64|ppc64le
+TIMEOUT 5
+AFTER ./testprogs/stack_args
+
+NAME sarg
+RUN bpftrace -v -e 'uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS '$test' %d %d\n", sarg0, sarg1); exit(); }'
+EXPECT SUCCESS sarg 16 32
+ARCH s390x
 TIMEOUT 5
 AFTER ./testprogs/stack_args
 

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -43,6 +43,28 @@ NAME ksym
 RUN bpftrace -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("ip"))); exit();}'
 EXPECT do_nanosleep
 TIMEOUT 5
+ARCH x86_64
+AFTER sleep 0.1
+
+NAME ksym
+RUN bpftrace -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("pswaddr"))); exit();}'
+EXPECT do_nanosleep
+TIMEOUT 5
+ARCH s390x
+AFTER sleep 0.1
+
+NAME ksym
+RUN bpftrace -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("pc"))); exit();}'
+EXPECT do_nanosleep
+TIMEOUT 5
+ARCH aarch64
+AFTER sleep 0.1
+
+NAME ksym
+RUN bpftrace -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("nip"))); exit();}'
+EXPECT do_nanosleep
+TIMEOUT 5
+ARCH ppc64|ppc64le
 AFTER sleep 0.1
 
 NAME system

--- a/tests/runtime/intptrcast
+++ b/tests/runtime/intptrcast
@@ -2,10 +2,68 @@ NAME Sum casted value
 RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("sp")+8)); exit();}'
 EXPECT ^@: 3258
 TIMEOUT 5
+ARCH x86_64
+AFTER ./testprogs/intptrcast
+
+NAME Sum casted value
+RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("sp")+0)); exit();}'
+EXPECT ^@: 3258
+TIMEOUT 5
+ARCH aarch64
+AFTER ./testprogs/intptrcast
+
+NAME Sum casted value
+RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r1")+96)); exit();}'
+EXPECT ^@: 3258
+TIMEOUT 5
+ARCH ppc64le
+AFTER ./testprogs/intptrcast
+
+NAME Sum casted value
+RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r1")+112)); exit();}'
+EXPECT ^@: 3258
+TIMEOUT 5
+ARCH ppc64
+AFTER ./testprogs/intptrcast
+
+NAME Sum casted value
+RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r15")+160)); exit();}'
+EXPECT ^@: 3258
+TIMEOUT 5
+ARCH s390x
 AFTER ./testprogs/intptrcast
 
 NAME Casting ints
 RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("sp")+8); printf("%d\n", $a); exit();}'
 EXPECT 3258
 TIMEOUT 5
+ARCH x86_64
+AFTER ./testprogs/intptrcast
+
+NAME Casting ints
+RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("sp")+0); printf("%d\n", $a); exit();}'
+EXPECT 3258
+TIMEOUT 5
+ARCH aarch64
+AFTER ./testprogs/intptrcast
+
+NAME Casting ints
+RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("r1")+96); printf("%d\n", $a); exit();}'
+EXPECT 3258
+TIMEOUT 5
+ARCH ppc64le
+AFTER ./testprogs/intptrcast
+
+NAME Casting ints
+RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("r1")+112); printf("%d\n", $a); exit();}'
+EXPECT 3258
+TIMEOUT 5
+ARCH ppc64
+AFTER ./testprogs/intptrcast
+
+NAME Casting ints
+RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("r15")+160); printf("%d\n", $a); exit();}'
+EXPECT 3258
+TIMEOUT 5
+ARCH s390x
 AFTER ./testprogs/intptrcast

--- a/tests/testprogs/intptrcast.c
+++ b/tests/testprogs/intptrcast.c
@@ -1,9 +1,17 @@
-// a is on the stack
-int fn(short rdi, short rsi, short rdx, short rcx, short r8, short r9, short a) {
-    return rdi + rsi + rdx + rcx + r8 + r9 + a;
+int fn(short p1,
+       short p2,
+       short p3,
+       short p4,
+       short p5,
+       short p6,
+       short p7,
+       short p8,
+       short p9)
+{
+  return p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9;
 }
 
 int main() {
-  fn(0x123, 0x456, 0x789, 0xabc, 0xdef, 0xfed, 0xcba);
+  fn(0x123, 0x456, 0x789, 0xabc, 0xdef, 0xfed, 0xcba, 0xcba, 0xcba);
   return 0;
 }

--- a/tests/testprogs/stack_args.c
+++ b/tests/testprogs/stack_args.c
@@ -1,10 +1,21 @@
 #define ARG(x) int (x) __attribute((unused))
 
 // Declare enough args that some are placed on the stack
-void too_many_args(ARG(a), ARG(b), ARG(c), ARG(d), ARG(e), ARG(f), ARG(g), ARG(h)) {}
+void too_many_args(ARG(a),
+                   ARG(b),
+                   ARG(c),
+                   ARG(d),
+                   ARG(e),
+                   ARG(f),
+                   ARG(g),
+                   ARG(h),
+                   ARG(i),
+                   ARG(j))
+{
+}
 
 int main(void)
 {
-  too_many_args(0, 1, 2, 4, 8, 16, 32, 64);
+  too_many_args(0, 1, 2, 4, 8, 16, 32, 64, 128, 256);
   return 0;
 }


### PR DESCRIPTION
The patch series provides register support for s390x. This also solves various issues that can occur in big-endian architectures.
1. bpftrace: Add s390x register support
2. bpftrace: Fix sarg support for s390x and other architectures
3. bpftrace: Fix type conversion in printf() builtin
4. bpftrace: Fix histogram output & stat output for big-endian systems
5. bpftrace: Add architecture specific testcase support
6. bpftrace: Introduce htonl, htons, ntohl, ntohs functions
7. bpftrace: Fix ntop builtin function
8. bpftrace: Fix variable assignment of 32 bit integers