### PR TITLE
Add links to examples for probes in reference_guide

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1247,6 +1247,9 @@ Attaching 2 probes...
 
 This prints the rate of syscalls per second.
 
+Examples in situ:
+[search /tools](https://github.com/search?q=interval%3A+path%3Atools+extension%3Abt&type=Code)
+
 ## 11. `software`: Pre-defined Software Events
 
 Syntax:
@@ -1347,6 +1350,10 @@ END
 
 These are special built-in events provided by the bpftrace runtime. `BEGIN` is triggered before all other
 probes are attached. `END` is triggered after all other probes are detached.
+
+Examples in situ:
+[(BEGIN) search /tools](https://github.com/search?q=BEGIN+path%3A%2Ftools+extension%3Abt&type=Code)
+[(END) search /tools](https://github.com/search?q=END+path%3A%2Ftools+extension%3Abt&type=Code)
 
 ## 14. `watchpoint`: Memory watchpoints
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1215,8 +1215,6 @@ Attaching 1 probe...
 @[32586]: 98
 @[0]: 579
 ```
-Examples in situ:
-[tool: profile_order.bt](https://github.com/iovisor/bpftrace/blob/master/tests/runtime/scripts/profile_order.bt)
 
 ## 10. `interval`: Timed Output
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -999,6 +999,10 @@ Attaching 1 probe...
 Unsafe uprobe in the middle of the instruction: /bin/bash:main+1
 ```
 
+Examples in situ:
+[(uprobe) search /tools](https://github.com/iovisor/bpftrace/search?q=uprobe%3A+path%3Atools&type=Code)
+[(uretprobe) /tools](https://github.com/iovisor/bpftrace/search?q=uretprobe%3A+path%3Atools&type=Code)
+
 ## 4. `uprobe`/`uretprobe`: Dynamic Tracing, User-Level Arguments
 
 Syntax:
@@ -1052,6 +1056,10 @@ readline: "uname -r"
 
 Back to the bash `readline()` example: after checking the source code, I saw that the return value was
 the string read. So I can use a `uretprobe` and the `retval` variable to see the read string.
+
+Examples in situ:
+[(uprobe) search /tools](https://github.com/iovisor/bpftrace/search?q=uprobe%3A+path%3Atools&type=Code)
+[(uretprobe) /tools](https://github.com/iovisor/bpftrace/search?q=uretprobe%3A+path%3Atools&type=Code)
 
 ## 5. `tracepoint`: Static Tracing, Kernel-Level
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1215,6 +1215,8 @@ Attaching 1 probe...
 @[32586]: 98
 @[0]: 579
 ```
+Examples in situ:
+[tool: profile_order.bt](https://github.com/iovisor/bpftrace/blob/master/tests/runtime/scripts/profile_order.bt)
 
 ## 10. `interval`: Timed Output
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1079,6 +1079,9 @@ block I/O created by 28941
 [...]
 ```
 
+Examples in situ:
+[search /tools](https://github.com/iovisor/bpftrace/search?q=tracepoint%3A+path%3Atools&type=Code)
+
 ## 6. `tracepoint`: Static Tracing, Kernel-Level Arguments
 
 Example:
@@ -1118,6 +1121,9 @@ print fmt: "dfd: 0x%08lx, filename: 0x%08lx, flags: 0x%08lx, mode: 0x%08lx", ((u
 
 Apart from the `filename` member, we can also print `flags`, `mode`, and more. After the "common" members
 listed first, the members are specific to the tracepoint.
+
+Examples in situ:
+[search /tools](https://github.com/iovisor/bpftrace/search?q=tracepoint%3A+path%3Atools&type=Code)
 
 ## 7. `usdt`: Static Tracing, User-Level
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1246,7 +1246,7 @@ Attaching 2 probes...
 This prints the rate of syscalls per second.
 
 Examples in situ:
-[search /tools](https://github.com/search?q=interval%3A+path%3Atools+extension%3Abt&type=Code)
+[search /tools](https://github.com/iovisor/bpftrace/search?q=interval+extension%3Abt+path%3Atools&type=Code)
 
 ## 11. `software`: Pre-defined Software Events
 
@@ -1350,8 +1350,8 @@ These are special built-in events provided by the bpftrace runtime. `BEGIN` is t
 probes are attached. `END` is triggered after all other probes are detached.
 
 Examples in situ:
-[(BEGIN) search /tools](https://github.com/search?q=BEGIN+path%3A%2Ftools+extension%3Abt&type=Code)
-[(END) search /tools](https://github.com/search?q=END+path%3A%2Ftools+extension%3Abt&type=Code)
+[(BEGIN) search /tools](https://github.com/iovisor/bpftrace/search?q=BEGIN+extension%3Abt+path%3Atools&type=Code)
+[(END) search /tools](https://github.com/iovisor/bpftrace/search?q=END+extension%3Abt+path%3Atools&type=Code)
 
 ## 14. `watchpoint`: Memory watchpoints
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -815,6 +815,10 @@ In this case, linux kernel still checks instruction alignment.
 
 The default vmlinux path can be overridden using the environment variable `BPFTRACE_VMLINUX`.
 
+Examples in situ:
+[(kprobe) search /tools](https://github.com/iovisor/bpftrace/search?q=kprobe%3A+path%3Atools&type=Code)
+[(kretprobe) /tools](https://github.com/iovisor/bpftrace/search?q=kretprobe%3A+path%3Atools&type=Code)
+
 ## 2. `kprobe`/`kretprobe`: Dynamic Tracing, Kernel-Level Arguments
 
 Syntax:
@@ -904,6 +908,10 @@ Requirements for using BTF:
 - bpftrace v0.9.3+ with BTF support (built with libbpf v0.0.4+)
 
 See [kernel documentation](https://www.kernel.org/doc/html/latest/bpf/btf.html) for more information on BTF.
+
+Examples in situ:
+[(kprobe) search /tools](https://github.com/iovisor/bpftrace/search?q=kprobe%3A+path%3Atools&type=Code)
+[(kretprobe) /tools](https://github.com/iovisor/bpftrace/search?q=kretprobe%3A+path%3Atools&type=Code)
 
 ## 3. `uprobe`/`uretprobe`: Dynamic Tracing, User-Level
 


### PR DESCRIPTION
During my discovery of bpftrace I missed the fact there were no links to examples for the probe. So I added links the same way BCC has.

Some probes don't have any links to examples because there are no tools which use them in the bpftrace repo.