### PR TITLE
Use BPFtrace::error for TracepointFormatParser errors

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -521,7 +521,7 @@ int main(int argc, char *argv[])
   if (cmd_str)
     bpftrace.cmd_ = cmd_str;
 
-  if (TracepointFormatParser::parse(driver.root_) == false)
+  if (TracepointFormatParser::parse(driver.root_, bpftrace) == false)
     return 1;
 
   if (bt_debug != DebugLevel::kNone)

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -43,8 +43,10 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
 
         if (has_wildcard(category))
         {
-            bpftrace.error(std::cerr, ap->loc,
-              "wildcards in tracepoint category is not supported: " + category);
+          bpftrace.error(std::cerr,
+                         ap->loc,
+                         "wildcards in tracepoint category is not supported: " +
+                             category);
           return false;
         }
 
@@ -57,11 +59,16 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
           {
             if (ret == GLOB_NOMATCH)
             {
-              bpftrace.error(std::cerr, ap->loc, "tracepoints not found: " + category + ":" + event_name);
+              bpftrace.error(std::cerr,
+                             ap->loc,
+                             "tracepoints not found: " + category + ":" +
+                                 event_name);
 
               // helper message:
               if (category == "syscall")
-                bpftrace.error(std::cerr, ap->loc, "Did you mean syscalls:" + event_name + "?");
+                bpftrace.error(std::cerr,
+                               ap->loc,
+                               "Did you mean syscalls:" + event_name + "?");
               if (bt_verbose) {
                   std::cerr << strerror(errno) << ": " << format_file_path << std::endl;
               }
@@ -98,15 +105,20 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
           std::ifstream format_file(format_file_path.c_str());
           if (format_file.fail())
           {
-            bpftrace.error(std::cerr, ap->loc,
-              "tracepoint not found: " + category + ":" + event_name);
+            bpftrace.error(std::cerr,
+                           ap->loc,
+                           "tracepoint not found: " + category + ":" +
+                               event_name);
             // helper message:
             if (category == "syscall")
-              bpftrace.warning(std::cerr, ap->loc,
-                "Did you mean syscalls:" + event_name + "?");
+              bpftrace.warning(std::cerr,
+                               ap->loc,
+                               "Did you mean syscalls:" + event_name + "?");
             if (bt_verbose) {
-                // Having the location info isn't really useful here, so no bpftrace.error
-                std::cerr << strerror(errno) << ": " << format_file_path << std::endl;
+              // Having the location info isn't really useful here, so no
+              // bpftrace.error
+              std::cerr << strerror(errno) << ": " << format_file_path
+                        << std::endl;
             }
             return false;
           }

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -105,6 +105,9 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
           std::ifstream format_file(format_file_path.c_str());
           if (format_file.fail())
           {
+            // Errno might get clobbered by bpftrace.error and bpftrace.warning.
+            int saved_errno = errno;
+
             bpftrace.error(std::cerr,
                            ap->loc,
                            "tracepoint not found: " + category + ":" +
@@ -114,6 +117,9 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
               bpftrace.warning(std::cerr,
                                ap->loc,
                                "Did you mean syscalls:" + event_name + "?");
+
+            errno = saved_errno;
+
             if (bt_verbose) {
               // Having the location info isn't really useful here, so no
               // bpftrace.error

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -12,7 +12,7 @@ namespace bpftrace {
 
 std::set<std::string> TracepointFormatParser::struct_list;
 
-bool TracepointFormatParser::parse(ast::Program *program)
+bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
 {
   std::vector<ast::Probe*> probes_with_tracepoint;
   for (ast::Probe *probe : *program->probes)

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -117,13 +117,10 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
               bpftrace.warning(std::cerr,
                                ap->loc,
                                "Did you mean syscalls:" + event_name + "?");
-
-            errno = saved_errno;
-
             if (bt_verbose) {
               // Having the location info isn't really useful here, so no
               // bpftrace.error
-              std::cerr << strerror(errno) << ": " << format_file_path
+              std::cerr << strerror(saved_errno) << ": " << format_file_path
                         << std::endl;
             }
             return false;

--- a/src/tracepoint_format_parser.h
+++ b/src/tracepoint_format_parser.h
@@ -4,6 +4,7 @@
 #include <set>
 
 #include "ast/ast.h"
+#include "bpftrace.h"
 
 namespace bpftrace {
 
@@ -119,7 +120,7 @@ private:
 class TracepointFormatParser
 {
 public:
-  static bool parse(ast::Program *program);
+  static bool parse(ast::Program *program, BPFtrace &bpftrace);
   static std::string get_struct_name(const std::string &category,
                                      const std::string &event_name);
 


### PR DESCRIPTION
Fix #1213 

I didn't change BPFtrace::error for the verbose errors because when I tested, it didn't look right.
(Those verbose errors show messages from syscalls, it doesn't make sense to also show a file location).