### PR TITLE
Emit better tracepoint parser errors

### DIFF
--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -30,8 +30,7 @@ bool TracepointFormatParser::parse(ast::Program *program)
   for (ast::Probe *probe : probes_with_tracepoint)
   {
     n.analyse(probe);
-    if (!probe->need_tp_args_structs)
-      continue;
+
     for (ast::AttachPoint *ap : *probe->attach_points)
     {
       if (ap->provider == "tracepoint")
@@ -75,6 +74,9 @@ bool TracepointFormatParser::parse(ast::Program *program)
             }
           }
 
+          if (!probe->need_tp_args_structs)
+            continue;
+
           for (size_t i = 0; i < glob_result.gl_pathc; ++i) {
             std::string filename(glob_result.gl_pathv[i]);
             std::ifstream format_file(filename);
@@ -107,6 +109,9 @@ bool TracepointFormatParser::parse(ast::Program *program)
             }
             return false;
           }
+
+          if (!probe->need_tp_args_structs)
+            continue;
 
           // Check to avoid adding the same struct more than once to definitions
           std::string struct_name = get_struct_name(category, event_name);


### PR DESCRIPTION
Before, we were only doing our nice tracepoint error checks if the tp
args was used. We can make our error messages a little better if we do
all the work except actually parse the format file.

Before:

    $ sudo bpftrace -e 'tracepoint:syscall:sys_enter_nanosleepz { 1 }'
    Attaching 1 probe...
    open(/sys/kernel/debug/tracing/events/syscall/sys_enter_nanosleepz/id):
    No such file or directory
    Error attaching probe: tracepoint:syscall:sys_enter_nanosleepz

After:

    $ sudo bpftrace -e 'tracepoint:syscall:sys_enter_nanosleepz { 1 }'
    ERROR: tracepoint not found: syscall:sys_enter_nanosleepz
    Did you mean syscalls:sys_enter_nanosleepz?