### PR TITLE
Fix semantic analysis of assignment

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1426,7 +1426,11 @@ void SemanticAnalyser::visit(AssignMapStatement &assignment)
     }
     else {
       map_val_[map_ident].cast_type = cast_type;
-      map_val_[map_ident].is_internal = true;
+      if (!assignment.expr->type.is_pointer)
+      {
+        // A pointer value is loaded to a register, not in the stack
+        map_val_[map_ident].is_internal = true;
+      }
     }
   }
   else if (type == Type::string)

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -139,3 +139,8 @@ NAME exit exits immediately
 RUN bpftrace -e 'i:ms:100 { @++; exit(); @++ }'
 EXPECT @: 1
 TIMEOUT 1
+
+NAME map_assign_map_ptr
+RUN bpftrace -e 'i:ms:100 { @ = curtask; @a = @; printf("%d\n", @a); exit(); }'
+EXPECT -?[0-9]+
+TIMEOUT 1


### PR DESCRIPTION
A pointer value is loaded to a register, not in the stack.
Make `is_internal = false` if a type is a pointer.
This fixes the following error.

```
% sudo ./src/bpftrace -e 'k:f { @ = curtask; @a = @; }'
bpftrace: /home/ubuntu/work/bpftrace/bpftrace/src/ast/irbuilderbpf.cpp:282: void bpftrace::ast::IRBuilderBPF::CreateMapUpdateElem(bpftrace::ast::Map &, llvm::AllocaInst *, llvm::Value *): Assertion `val->getType()->isPointerTy()' failed.
zsh: abort      sudo ./src/bpftrace -e 'k:f { @ = curtask; @a = @; }'
```