### PR TITLE
Only link agains libbpf if it exists

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,7 +73,9 @@ target_link_libraries(bpftrace arch ast parser resources)
 
 if(STATIC_LINKING)
   target_link_libraries(bpftrace ${LIBBCC_LIBRARIES})
+if (LIBBPF_BTF_DUMP_FOUND)
   target_link_libraries(bpftrace ${LIBBPF_LIBRARY_STATIC})
+endif(LIBBPF_BTF_DUMP_FOUND)
   target_link_libraries(bpftrace ${LIBBCC_LOADER_LIBRARY_STATIC})
 
   add_library(LIBELF STATIC IMPORTED)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,7 +95,9 @@ if (STATIC_LINKING)
   endif()
 
   target_link_libraries(bpftrace_test ${LIBBCC_LIBRARIES})
+if (LIBBPF_BTF_DUMP_FOUND)
   target_link_libraries(bpftrace_test ${LIBBPF_LIBRARY_STATIC})
+endif(LIBBPF_BTF_DUMP_FOUND)
   target_link_libraries(bpftrace_test ${LIBBCC_LOADER_LIBRARY_STATIC})
 
   add_library(LIBELF STATIC IMPORTED)


### PR DESCRIPTION
Libbpf is optional so we must only link against it when it exists. This
optional linking is already  done for the dynamic build but not the
static:

```
if (LIBBPF_BTF_DUMP_FOUND)
  target_compile_definitions(bpftrace_test PRIVATE HAVE_LIBBPF_BTF_DUMP)
  target_include_directories(bpftrace_test PUBLIC ${LIBBPF_INCLUDE_DIRS})
  target_link_libraries(bpftrace_test ${LIBBPF_LIBRARIES})
endif(LIBBPF_BTF_DUMP_FOUND)
```