### PR TITLE
Revert "Only link agains libbpf if it exists (#1247)"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -73,9 +73,7 @@ target_link_libraries(bpftrace arch ast parser resources)
 
 if(STATIC_LINKING)
   target_link_libraries(bpftrace ${LIBBCC_LIBRARIES})
-if (LIBBPF_BTF_DUMP_FOUND)
   target_link_libraries(bpftrace ${LIBBPF_LIBRARY_STATIC})
-endif(LIBBPF_BTF_DUMP_FOUND)
   target_link_libraries(bpftrace ${LIBBCC_LOADER_LIBRARY_STATIC})
 
   add_library(LIBELF STATIC IMPORTED)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -95,9 +95,7 @@ if (STATIC_LINKING)
   endif()
 
   target_link_libraries(bpftrace_test ${LIBBCC_LIBRARIES})
-if (LIBBPF_BTF_DUMP_FOUND)
   target_link_libraries(bpftrace_test ${LIBBPF_LIBRARY_STATIC})
-endif(LIBBPF_BTF_DUMP_FOUND)
   target_link_libraries(bpftrace_test ${LIBBCC_LOADER_LIBRARY_STATIC})
 
   add_library(LIBELF STATIC IMPORTED)


### PR DESCRIPTION
This reverts commit a3febcb89ad8b031f950f2284200544ce05c7afb.

The shared library (libbcc.so) includes libbpf while the static object
doesn't[1]. So this link is actually required, regardless of whether
we use libbpf for btf later.

[1]:

```
for x in libbcc.so libbcc.a libbcc_bpf.so libbcc_bpf.a; do echo $x; nm --defined-only $x | grep bpf_object__priv; do
libbcc.so
0000000002ca33f0 T bpf_object__priv
libbcc.a
libbcc_bpf.so
0000000000019d80 T bpf_object__priv
libbcc_bpf.a
0000000000004030 T bpf_object__priv
```