### PR TITLE
Remove codegen tests warning

### DIFF
--- a/tests/codegen/builtin_cpid.cpp
+++ b/tests/codegen/builtin_cpid.cpp
@@ -6,15 +6,16 @@ namespace codegen {
 
 class MockBPFtraceCpid : public BPFtrace
 {
-public:
-  MOCK_METHOD0(child_pid, int(void));
+  pid_t child_pid()
+  {
+    return 1337;
+  };
 };
 
 TEST(codegen, builtin_cpid)
 {
   MockBPFtraceCpid bpftrace;
   bpftrace.cmd_ = "sleep 1";
-  ON_CALL(bpftrace, child_pid()).WillByDefault(Return(1337));
 
   test(bpftrace,
        "kprobe:f { @ = cpid }",


### PR DESCRIPTION
```
[ RUN      ] codegen.builtin_cpid

GMOCK WARNING:
Uninteresting mock function call - taking default action specified at:
/vagrant/tests/codegen/builtin_cpid.cpp:17:
    Function call: child_pid()
          Returns: 1337
NOTE: You can safely ignore the above warning unless this call should not happen.  Do not suppress it by blindly adding an EXPECT_CALL() if you don't mean to enforce the call.  See https://github.com/google/googletest/blob/master/googlemock/docs/CookBook.md#knowing-when-to-expect for details.
```