### PR TITLE
Fix "Unsupported architecture" error message

### DIFF
--- a/src/arch/CMakeLists.txt
+++ b/src/arch/CMakeLists.txt
@@ -9,5 +9,5 @@ elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "s390" OR
 elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
     add_library(arch x86_64.cpp)
 else()
-  message(FATAL_ERROR "Unsupported architecture: {CMAKE_SYSTEM_PROCESSOR}")
+  message(FATAL_ERROR "Unsupported architecture: ${CMAKE_SYSTEM_PROCESSOR}")
 endif()


### PR DESCRIPTION
To show a CMAKE variable value, a '$' prefix should be used.