### PR TITLE
Allow user supplied C definitions to reference BTF definitions

### DIFF
--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -545,6 +545,9 @@ std::unordered_set<std::string> ClangParser::get_incomplete_types(
           data.complete_types.emplace(get_unqualified_type_name(parent_type));
 
           auto cursor_type = clang_getCanonicalType(clang_getCursorType(c));
+          // We need layouts of pointee types because users could dereference
+          if (cursor_type.kind == CXType_Pointer)
+            cursor_type = clang_getPointeeType(cursor_type);
           if (cursor_type.kind == CXType_Record)
           {
             auto type_name = get_unqualified_type_name(cursor_type);

--- a/src/clang_parser.h
+++ b/src/clang_parser.h
@@ -22,7 +22,6 @@ public:
 
 private:
   bool visit_children(CXCursor &cursor, BPFtrace &bpftrace);
-  bool parse_btf_definitions(BPFtrace &bpftrace);
   /*
    * The user might have written some struct definitions that rely on types
    * supplied by BTF data. This method will pull out any forward-declared /

--- a/tests/runtime/btf
+++ b/tests/runtime/btf
@@ -1,0 +1,5 @@
+NAME user_supplied_c_def_using_btf
+RUN bpftrace -v --btf -e 'struct foo { struct task_struct t; } BEGIN { exit(); }'
+EXPECT Attaching 1 probe...
+TIMEOUT 5
+REQUIRES bpftrace --info 2>&1 | grep "btf: yes"

--- a/tests/runtime/btf
+++ b/tests/runtime/btf
@@ -3,3 +3,9 @@ RUN bpftrace -v --btf -e 'struct foo { struct task_struct t; } BEGIN { exit(); }
 EXPECT Attaching 1 probe...
 TIMEOUT 5
 REQUIRES bpftrace --info 2>&1 | grep "btf: yes"
+
+NAME tracepoint_pointer_type_resolution
+RUN bpftrace -v --btf -e 'tracepoint:syscalls:sys_enter_nanosleep { args->rqtp->tv_sec; exit(); }'
+EXPECT Attaching 1 probe...
+TIMEOUT 5
+REQUIRES bpftrace --info 2>&1 | grep "btf: yes"


### PR DESCRIPTION
Before, this would fail even with --btf flag:

    struct foo
    {
	  struct task_struct t;
    }

    BEGIN
    {
    }

This should be allowed since we can get everything we need from BTF
data.

This commit adds another pass on clang AST to figure out which structs
are referenced but not defined. There's also a hack that passes
`-D_LINUX_TYPES_H` to the clang front end. It's pretty bad but it's also
the cleanest way I can think of to avoid redefinition conflicts.