### PR TITLE
Implement sizeof() function

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -84,6 +84,7 @@ discussion to other files in /docs, the /tools/\*\_examples.txt files, or blog p
     - [19. `strncmp()`: Compare first n characters of two strings](#19-strncmp-compare-first-n-characters-of-two-strings)
     - [20. `override()`: Override return value](#20-override-override-return-value)
     - [21. `buf()`: Buffers](#21-buf-buffers)
+    - [22. `sizeof()`: Size of type or expression](#22-sizeof-size-of-type-or-expression)
 - [Map Functions](#map-functions)
     - [1. Builtins](#1-builtins-2)
     - [2. `count()`: Count](#2-count-count)
@@ -2536,6 +2537,39 @@ Datagram bytes: \x08\x00+\xb9\x06b\x00\x01Aen^\x00\x00\x00\x00KM\x0c\x00\x00\x00
 --- 8.8.8.8 ping statistics ---
 1 packets transmitted, 1 received, 0% packet loss, time 0ms
 rtt min/avg/max/mdev = 19.426/19.426/19.426/0.000 ms
+```
+
+## 22. `sizeof()`: Size of type or expression
+
+Syntax:
+- `sizeof(TYPE)`
+- `sizeof(EXPRESSION)`
+
+Returns size of the argument in bytes. Similar to C/C++ `sizeof` operator. Note
+that the expression does not get evaluated.
+
+Examples:
+
+```
+# bpftrace -e 'struct Foo { int x; char c; } BEGIN { printf("%d\n", sizeof(struct Foo)); }'
+Attaching 1 probe...
+8
+
+# bpftrace -e 'struct Foo { int x; char c; } BEGIN { printf("%d\n", sizeof(((struct Foo)0).c)); }'
+Attaching 1 probe...
+1
+
+# bpftrace -e 'BEGIN { printf("%d\n", sizeof(1 == 1)); }'
+Attaching 1 probe...
+8
+
+# bpftrace --btf -e 'BEGIN { printf("%d\n", sizeof(struct task_struct)); }'
+Attaching 1 probe...
+13120
+
+# bpftrace -e 'BEGIN { $x = 3; printf("%d\n", sizeof($x)); }'
+Attaching 1 probe...
+8
 ```
 
 # Map Functions

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -67,6 +67,8 @@ void CodegenLLVM::visit(String &string)
   expr_ = buf;
 }
 
+// NB: we do not resolve identifiers that are structs. That is because in
+// bpftrace you cannot really instantiate a struct.
 void CodegenLLVM::visit(Identifier &identifier)
 {
   if (bpftrace_.enums_.count(identifier.ident) != 0)
@@ -858,6 +860,10 @@ void CodegenLLVM::visit(Call &call)
     arg.accept(*this);
     expr_ = b_.CreateIntCast(expr_, b_.getInt32Ty(), arg.type.is_signed);
     b_.CreateSignal(expr_);
+  }
+  else if (call.func == "sizeof")
+  {
+    expr_ = b_.getInt64(call.vargs->at(0)->type.size);
   }
   else if (call.func == "strncmp") {
     uint64_t size = static_cast<Integer *>(call.vargs->at(2))->n;

--- a/src/ast/field_analyser.cpp
+++ b/src/ast/field_analyser.cpp
@@ -21,8 +21,9 @@ void FieldAnalyser::visit(StackMode &mode __attribute__((unused)))
 {
 }
 
-void FieldAnalyser::visit(Identifier &identifier __attribute__((unused)))
+void FieldAnalyser::visit(Identifier &identifier)
 {
+  bpftrace_.btf_set_.insert(identifier.ident);
 }
 
 void FieldAnalyser::visit(Builtin &builtin)

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -29,7 +29,7 @@ vspace  [\n\r]
 space   {hspace}|{vspace}
 path    :(\\.|[_\-\./a-zA-Z0-9#\*])*:
 builtin arg[0-9]|args|cgroup|comm|cpid|cpu|ctx|curtask|elapsed|func|gid|nsecs|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
-call    avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|ksym|lhist|max|min|ntop|override|print|printf|reg|signal|stats|str|strncmp|sum|system|time|uaddr|usym|zero
+call    avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|ksym|lhist|max|min|ntop|override|print|printf|reg|signal|sizeof|stats|str|strncmp|sum|system|time|uaddr|usym|zero
 
 /* Don't add to this! Use builtin OR call not both */
 call_and_builtin kstack|ustack

--- a/tests/codegen/call_sizeof.cpp
+++ b/tests/codegen/call_sizeof.cpp
@@ -1,0 +1,16 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, call_sizeof)
+{
+  test("struct Foo { int x; char c; } BEGIN { @x = sizeof(struct Foo) }",
+
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -192,7 +192,8 @@ static std::string rewrite_lifetime_end_decl(const std::string &line)
   return std::string(
       "declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1");
 #else
-  return line;
+  return std::string(
+      "declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1");
 #endif
 }
 
@@ -206,7 +207,8 @@ static std::string rewrite_lifetime_start_decl(const std::string &line)
   return std::string(
       "declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1");
 #else
-  return line;
+  return std::string(
+      "declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1");
 #endif
 }
 

--- a/tests/codegen/llvm/call_sizeof.ll
+++ b/tests/codegen/llvm/call_sizeof.ll
@@ -1,0 +1,33 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
+
+define i64 @BEGIN(i8* nocapture readnone) local_unnamed_addr section "s_BEGIN_1" {
+entry:
+  %"@x_val" = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  %1 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  store i64 0, i64* %"@x_key", align 8
+  %2 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  store i64 8, i64* %"@x_val", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -169,3 +169,19 @@ NAME cat "no such file"
 RUN bpftrace -e 'i:ms:1 { cat("/does/not/exist/file"); exit(); }'
 EXPECT ^Error opening file '/does/not/exist/file': No such file or directory$
 TIMEOUT 5
+
+NAME sizeof
+RUN bpftrace -e 'struct Foo { int x; char c; } BEGIN { $x = 1; printf("%d %d %d %d %d\n", sizeof(struct Foo), sizeof(((struct Foo)0).x), sizeof(((struct Foo)0).c), sizeof(1 == 1), sizeof($x)); exit(); }'
+EXPECT ^8 4 1 8 8$
+TIMEOUT 5
+
+NAME sizeof_ints
+RUN bpftrace -e 'BEGIN { printf("%d %d %d %d %d %d\n", sizeof(uint8), sizeof(int8), sizeof(uint16), sizeof(int16), sizeof(uint32), sizeof(int32)); exit(); }'
+EXPECT ^1 1 2 2 4 4$
+TIMEOUT 5
+
+# printf only takes 7 args
+NAME sizeof_ints_pt2
+RUN bpftrace -e 'BEGIN { printf("%d %d\n", sizeof(uint64), sizeof(int64)); exit(); }'
+EXPECT ^8 8$
+TIMEOUT 5

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -185,3 +185,9 @@ NAME sizeof_ints_pt2
 RUN bpftrace -e 'BEGIN { printf("%d %d\n", sizeof(uint64), sizeof(int64)); exit(); }'
 EXPECT ^8 8$
 TIMEOUT 5
+
+NAME sizeof_btf
+RUN bpftrace --btf -e 'BEGIN { printf("size=%d\n", sizeof(struct task_struct)); exit(); }'
+EXPECT ^size=
+TIMEOUT 5
+REQUIRES bpftrace --info 2>&1 | grep "btf: yes"

--- a/tests/runtime/engine/utils.py
+++ b/tests/runtime/engine/utils.py
@@ -9,6 +9,7 @@ from distutils.version import LooseVersion
 import re
 
 BPF_PATH = environ["BPFTRACE_RUNTIME_TEST_EXECUTABLE"]
+ENV_PATH = environ["PATH"]
 ATTACH_TIMEOUT = 5
 DEFAULT_TIMEOUT = 5
 
@@ -94,7 +95,13 @@ class Utils(object):
             print(ok("[ RUN      ] ") + "%s.%s" % (test.suite, test.name))
             if test.requirement:
                 with open(devnull, 'w') as dn:
-                    if subprocess.call(test.requirement, shell=True, stdout=dn, stderr=dn) != 0:
+                    if subprocess.call(
+                        test.requirement,
+                        shell=True,
+                        stdout=dn,
+                        stderr=dn,
+                        env={'PATH': f"{BPF_PATH}:{ENV_PATH}"},
+                    ) != 0:
                         print(warn("[   SKIP   ] ") + "%s.%s" % (test.suite, test.name))
                         return Utils.SKIP_REQUIREMENT_UNSATISFIED
 


### PR DESCRIPTION
It's often useful to know the size of a struct. As a bonus, this
implementation also works with all other known types and
expressions. eg:

    struct Foo
    {
        int x;
    }

    BEGIN
    {
        printf("%d\n", sizeof(struct Foo));
        printf("%d\n", sizeof(1 == 1));
        printf("%d\n", sizeof(((struct Foo)0).x));
    }

This closes #73 .