### PR TITLE
RFC: Add skboutput function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,7 @@ set(CMAKE_REQUIRED_DEFINITIONS)
 find_package(LibBpf)
 find_package(LibBfd)
 find_package(LibOpcodes)
+find_package(LibPcap)
 
 if(POLICY CMP0075)
   cmake_policy(SET CMP0075 NEW)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -265,6 +265,10 @@ if (LIBBPF_BTF_DUMP_FOUND)
   endif()
 endif(LIBBPF_BTF_DUMP_FOUND)
 
+if(LIBPCAP_FOUND)
+  set(BPFTRACE_FLAGS "${BPFTRACE_FLAGS}" HAVE_LIBPCAP)
+endif(LIBPCAP_FOUND)
+
 add_subdirectory(src/arch)
 add_subdirectory(src/ast)
 add_subdirectory(src/ast/bpforc)

--- a/cmake/FindLibPcap.cmake
+++ b/cmake/FindLibPcap.cmake
@@ -1,0 +1,39 @@
+# - Try to find libpcap
+# Once done this will define
+#
+#  LIBPCAP_INCLUDE_DIRS - where to find pcap/pcap.h
+#  LIBPCAP_LIBRARIES    - List of libraries when using pcap
+#  LIBPCAP_FOUND        - True if pcap found.
+
+find_path(LIBPCAP_INCLUDE_DIRS
+  NAMES
+    pcap/pcap.h
+  PATHS
+    /usr/include
+    /usr/local/include
+    /opt/local/include
+    /sw/include
+    ENV CPATH
+)
+
+find_library(LIBPCAP_LIBRARIES
+  NAMES
+    pcap
+  PATHS
+    /usr/lib
+    /usr/lib64
+    /usr/local/lib
+    /opt/local/lib
+    /sw/lib
+    ENV LIBRARY_PATH
+    ENV LD_LIBRARY_PATH
+)
+
+include (FindPackageHandleStandardArgs)
+
+# handle the QUIETLY and REQUIRED arguments and set LIBPCAP_FOUND to TRUE if all listed variables are TRUE
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibPcap "Please install the libcap development package"
+  LIBPCAP_LIBRARIES
+  LIBPCAP_INCLUDE_DIRS)
+
+mark_as_advanced(LIBPCAP_INCLUDE_DIRS LIBPCAP_LIBRARIES)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(libbpftrace
   types.cpp
   usdt.cpp
   utils.cpp
+  pcap_writer.cpp
   ${BFD_DISASM_SRC}
 )
 # So it's not "liblibbpftrace"
@@ -116,6 +117,10 @@ if (LIBBPF_BTF_DUMP_FOUND)
   target_include_directories(libbpftrace PUBLIC ${LIBBPF_INCLUDE_DIRS})
   target_link_libraries(libbpftrace ${LIBBPF_LIBRARIES})
 endif(LIBBPF_BTF_DUMP_FOUND)
+
+if(LIBPCAP_FOUND)
+  target_link_libraries(libbpftrace ${LIBPCAP_LIBRARIES})
+endif(LIBPCAP_FOUND)
 
 if(HAVE_BFD_DISASM)
   if(STATIC_LINKING)

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -202,6 +202,7 @@ private:
   int system_id_ = 0;
   int non_map_print_id_ = 0;
   uint64_t watchpoint_id_ = 0;
+  int skb_output_id_ = 0;
 
   Function *linear_func_ = nullptr;
   Function *log2_func_ = nullptr;

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -161,6 +161,7 @@ public:
   StructType *GetStructType(std::string name, const std::vector<llvm::Type *> & elements, bool packed = false);
   AllocaInst *CreateUSym(llvm::Value *val);
   Value      *CreatKFuncArg(Value *ctx, SizedType& type, std::string& name);
+  void        CreateSkboutput(Value *skb, Value *len, AllocaInst *data, size_t size, int caplen);
   void CreatePath(Value *ctx,
                   AllocaInst *buf,
                   Value *path,

--- a/src/ast/resource_analyser.cpp
+++ b/src/ast/resource_analyser.cpp
@@ -152,6 +152,13 @@ void ResourceAnalyser::visit(Call &call)
   {
     resources_.stackid_maps.insert(call.type.stack_type);
   }
+  else if (call.func == "skboutput")
+  {
+    auto &file_arg = *call.vargs->at(0);
+    String &file = static_cast<String&>(file_arg);
+
+    resources_.skboutput_args_.emplace_back(file.str, 0);
+  }
 }
 
 void ResourceAnalyser::visit(Map &map)

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1214,6 +1214,24 @@ void SemanticAnalyser::visit(Call &call)
     // Return type cannot be used
     call.type = SizedType(Type::none, 0);
   }
+  else if (call.func == "skboutput")
+  {
+    check_assignment(call, false, false, false);
+    if (check_varargs(call, 2, 3))
+    {
+      if (is_final_pass())
+      {
+        check_arg(call, Type::string,  0, true);
+        check_arg(call, Type::pointer, 1, false);
+        check_arg(call, Type::integer, 2, false);
+
+        auto &file_arg = *call.vargs->at(0);
+        String &file = static_cast<String&>(file_arg);
+
+        bpftrace_.resources.skboutput_args_.emplace_back(file.str, 0);
+      }
+    }
+  }
   else
   {
     LOG(ERROR, call.loc, err_) << "Unknown function: '" << call.func << "'";

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -77,6 +77,7 @@ public:
   bool has_map_batch();
   bool has_d_path();
   bool has_uprobe_refcnt();
+  bool has_skb_output();
 
   std::string report(void);
 
@@ -113,6 +114,7 @@ protected:
   std::optional<int> insns_limit_;
   std::optional<bool> has_map_batch_;
   std::optional<bool> has_uprobe_refcnt_;
+  std::optional<bool> has_skb_output_;
 
 private:
   bool detect_map(enum libbpf::bpf_map_type map_type);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -24,6 +24,7 @@
 #include "struct.h"
 #include "types.h"
 #include "utils.h"
+#include "pcap_writer.h"
 
 namespace bpftrace {
 
@@ -136,6 +137,9 @@ public:
   std::string get_string_literal(const ast::Expression *expr) const;
   std::optional<std::string> get_watchpoint_binary_path() const;
   virtual bool is_traceable_func(const std::string &func_name) const;
+  int create_pcaps(void);
+  void close_pcaps(void);
+  bool write_pcaps(uint64_t id, uint64_t ns, uint8_t *pkt, unsigned int size);
 
   std::vector<std::unique_ptr<AttachedProbe>> attached_probes_;
   std::string cmd_;
@@ -150,6 +154,8 @@ public:
   std::map<std::string, std::string> macros_;
   std::map<std::string, uint64_t> enums_;
   std::unordered_set<std::string> traceable_funcs_;
+
+  std::vector<std::unique_ptr<PCAPwriter>> pcaps;
 
   unsigned int join_argnum_ = 16;
   unsigned int join_argsize_ = 1024;

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -37,7 +37,7 @@ vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#\*])+
 builtin  arg[0-9]|args|cgroup|comm|cpid|cpu|ctx|curtask|elapsed|func|gid|nsecs|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
-call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|reg|signal|sizeof|stats|str|strftime|strncmp|sum|system|time|uaddr|uptr|usym|zero|path|unwatch
+call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|reg|signal|sizeof|stats|str|strftime|strncmp|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|skboutput
 
 /* Don't add to this! Use builtin OR call not both */
 call_and_builtin kstack|ustack

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -820,6 +820,10 @@ int main(int argc, char* argv[])
     }
   }
 
+  err = bpftrace.create_pcaps();
+  if (err)
+    return err;
+
   ast::CodegenLLVM llvm(&*ast_root, bpftrace);
   BpfBytecode bytecode;
   try
@@ -927,5 +931,6 @@ int main(int argc, char* argv[])
   if (err)
     return err;
 
+  bpftrace.close_pcaps();
   return 0;
 }

--- a/src/pcap_writer.cpp
+++ b/src/pcap_writer.cpp
@@ -1,0 +1,72 @@
+#include "pcap_writer.h"
+
+#ifdef HAVE_LIBPCAP
+#include <pcap/pcap.h>
+
+namespace bpftrace {
+
+bool PCAPwriter::open(std::string file)
+{
+  pd_ = pcap_open_dead(DLT_RAW, 65535);
+  if (!pd_)
+    return false;
+
+  pdumper_ = pcap_dump_open(pd_, file.c_str());
+  return true;
+}
+
+void PCAPwriter::close(void)
+{
+  pcap_close(pd_);
+  pcap_dump_close(pdumper_);
+}
+
+#define NSEC_PER_SEC    1000000000L
+#define NSEC_PER_USEC   1000L
+
+bool PCAPwriter::write(uint64_t ns, void *pkt, unsigned int size)
+{
+  time_t secs, usecs, nsecs = ns;
+
+  secs   = nsecs / NSEC_PER_SEC;
+  nsecs -= secs  * NSEC_PER_SEC;
+  usecs  = nsecs / NSEC_PER_USEC;
+
+  struct pcap_pkthdr hdr = {
+    .ts     = {
+      .tv_sec  = secs,
+      .tv_usec = usecs,
+    },
+    .caplen = size,
+    .len    = size,
+  };
+
+  pcap_dump((u_char*) pdumper_, &hdr, (const u_char*) pkt);
+  return true;
+}
+
+}; // namespace bpftrace
+
+#else
+
+namespace bpftrace {
+
+bool PCAPwriter::open(std::string file __attribute__((__unused__)),
+                      unsigned int caplen __attribute__((__unused__)))
+{
+  return false;
+}
+
+void PCAPwriter::close(void)
+{
+}
+
+bool PCAPwriter::write(uint64_t ns __attribute__((__unused__)),
+                       void *pkt __attribute__((__unused__)))
+{
+  return false;
+}
+
+}; // namespace bpftrace
+
+#endif // HAVE_LIBPCAP

--- a/src/pcap_writer.h
+++ b/src/pcap_writer.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <string>
+
+struct pcap;
+typedef struct pcap pcap_t;
+
+struct pcap_dumper;
+typedef struct pcap_dumper pcap_dumper_t;
+
+namespace bpftrace {
+
+class PCAPwriter {
+public:
+  PCAPwriter() { }
+  ~PCAPwriter() { }
+
+  bool open(std::string file);
+  void close(void);
+
+  bool write(uint64_t ns, void *pkt, unsigned int size);
+
+private:
+  pcap_t          *pd_;
+  pcap_dumper_t   *pdumper_;
+};
+
+}; // namespace bpftrace

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -81,6 +81,7 @@ public:
   std::vector<std::string> strftime_args;
   std::vector<std::tuple<std::string, std::vector<Field>>> cat_args;
   std::vector<SizedType> non_map_print_args;
+  std::vector<std::tuple<std::string, int>> skboutput_args_;
 
   // Async argument metadata that codegen creates. Ideally ResourceAnalyser
   // pass should be collecting this, but it's complex to move the logic.

--- a/src/types.h
+++ b/src/types.h
@@ -546,6 +546,7 @@ enum class AsyncAction
   strftime,
   watchpoint_attach,
   watchpoint_detach,
+  skboutput,
   // clang-format on
 };
 


### PR DESCRIPTION
heya,
please take as RFC, it's by no means final code ;-)
I just need to hear some feedback on wether you guys think this is useful

I tried to put together something we discussed with Arnaldo and Jiri Benc
on LPC - storing skb_buff via bpf helper from any probe with 'skb' argument

the new bpftrace function has following syntax:

`  skboutput(file, skb, caplen)`

it will store packet from 'skb' object to tcpdump 'file' and limit the size by 'caplen', for example:

```
# bpftrace -e 'kfunc:napi_gro_receive { skboutput("krava.pcap", args->skb, 1500);  }'
Attaching 1 probe...
...

# tcpdump -n -r ./krava.pcap
reading from file ./krava.pcap, link-type RAW (Raw IP)
dropped privs to tcpdump
02:43:07.069621 unknown ip 0
02:43:07.069640 unknown ip 0
02:43:07.084865 IP 10.40.192.62.40032 > 10.37.152.221.ssh: Flags [.], ack 3619840828, win 1867, options [nop,nop,TS val 862106286 ecr 226183539], length 0
02:43:07.097883 IP 10.40.192.62.40032 > 10.37.152.221.ssh: Flags [.], ack 53, win 1867, options [nop,nop,TS val 862106298 ecr 226183554], length 0
02:43:07.110942 IP 10.40.192.62.40032 > 10.37.152.221.ssh: Flags [.], ack 105, win 1867, options [nop,nop,TS val 862106311 ecr 226183567], length 0
02:43:07.125958 IP 10.40.192.62.40032 > 10.37.152.221.ssh: Flags [.], ack 157, win 1867, options [nop,nop,TS val 862106326 ecr 226183581], length 0
02:43:07.126282 unknown ip 0
02:43:07.138008 IP 10.40.192.62.40032 > 10.37.152.221.ssh: Flags [.], ack 209, win 1867, options [nop,nop,TS val 862106339 ecr 226183596], length 0
02:43:07.138969 IP 10.40.192.62.40032 > 10.37.152.221.ssh: Flags [.], ack 261, win 1867, options [nop,nop,TS val 862106339 ecr 226183596], length 0
02:43:07.151006 IP 10.40.192.62.40032 > 10.37.152.221.ssh: Flags [.], ack 313, win 1867, options [nop,nop,TS val 862106351 ecr 226183608], length 0
02:43:07.152040 IP 10.40.192.62.40032 > 10.37.152.221.ssh: Flags [.], ack 365, win 1867, options [nop,nop,TS val 862106352 ecr 226183609], length 0
02:43:07.153369 unknown ip 0
02:43:07.164084 IP 10.40.192.62.40032 > 10.37.152.221.ssh: Flags [.], ack 417, win 1867, options [nop,nop,TS val 862106364 ecr 226183621], length 0
02:43:07.165010 IP 10.40.192.62.40032 > 10.37.152.221.ssh: Flags [.], ack 469, win 1867, options [nop,nop,TS val 862106365 ecr 226183622], length 0
02:43:07.165020 IP 10.40.192.62.40032 > 10.37.152.221.ssh: Flags [.], ack 521, win 1867, options [nop,nop,TS val 862106366 ecr 226183623], length 0
...
```

you can use skboutput function from multiple places/probes with different files

it seems useful for debuging network stuff, but what do I know..? ;-)
I haven't got too much positive feedback yet to continue on with this

thanks for any thoughts on this