### PR TITLE
btf: Allow referencing an enum value to pull in enum definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to
   - [#1269](https://github.com/iovisor/bpftrace/pull/1269)
 - C style while loop support, `while ($a < 100) { $a++ }`
   - [#1066](https://github.com/iovisor/bpftrace/pull/1066)
+- Using a BTF enum value will pull in the entire enum definition
+  - [#1274](https://github.com/iovisor/bpftrace/pull/1274)
 
 #### Changed
 

--- a/tests/runtime/btf
+++ b/tests/runtime/btf
@@ -9,3 +9,9 @@ RUN bpftrace -v --btf -e 'tracepoint:syscalls:sys_enter_nanosleep { args->rqtp->
 EXPECT Attaching 1 probe...
 TIMEOUT 5
 REQUIRES bpftrace --info 2>&1 | grep "btf: yes"
+
+NAME enum_value_reference
+RUN bpftrace -v --btf -e 'BEGIN { printf("%d\n", sizeof(BTF_VAR_STATIC)); exit(); }'
+EXPECT ^8$
+TIMEOUT 5
+REQUIRES bpftrace --info 2>&1 | grep "btf: yes"


### PR DESCRIPTION
It's useful to be able to reference an enum value to have bpftrace pull
in the enum definition from BTF. This is especially useful for anonymous
enums which cannot be correctly referenced.