### PR TITLE
Report helper function errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to
   - [#1329](https://github.com/iovisor/bpftrace/pull/1329)
 - Add --usdt-file-activation to activate usdt semaphores by file name
   - [#1317](https://github.com/iovisor/bpftrace/pull/1317)
+- Introduce `-k` and `-kk` options. Emit a warning when a bpf helper returns an error
+  - [#1276](https://github.com/iovisor/bpftrace/pull/1276)
 
 #### Changed
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -144,6 +144,8 @@ OPTIONS:
     -p PID         enable USDT probes on PID
     -c 'CMD'       run CMD and enable USDT probes on resulting process
     -v             verbose messages
+    -k             emit a warning when a bpf helper returns an error (except read functions)
+    -kk            check all bpf helper functions
     --version      bpftrace version
 
 ENVIRONMENT:

--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -77,5 +77,21 @@ struct Buf
   }
 } __attribute__((packed));
 
+struct HelperError
+{
+  uint64_t action_id;
+  uint64_t error_id;
+  int32_t return_value;
+
+  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b)
+  {
+    return {
+      b.getInt64Ty(), // asyncid
+      b.getInt64Ty(), // error_id
+      b.getInt32Ty(), // return value
+    };
+  }
+} __attribute__((packed));
+
 } // namespace AsyncEvent
 } // namespace bpftrace

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -57,20 +57,20 @@ public:
   llvm::ConstantInt *GetIntSameSize(uint64_t C, llvm::Type *ty);
   CallInst   *CreateBpfPseudoCall(int mapfd);
   CallInst   *CreateBpfPseudoCall(Map &map);
-  Value      *CreateMapLookupElem(Map &map, AllocaInst *key);
-  Value      *CreateMapLookupElem(int mapfd, AllocaInst *key, SizedType &type);
-  void        CreateMapUpdateElem(Map &map, AllocaInst *key, Value *val);
-  void        CreateMapDeleteElem(Map &map, AllocaInst *key);
-  void        CreateProbeRead(AllocaInst *dst, size_t size, Value *src);
-  void        CreateProbeRead(AllocaInst *dst, llvm::Value *size, Value *src);
-  CallInst   *CreateProbeReadStr(AllocaInst *dst, llvm::Value *size, Value *src);
-  CallInst   *CreateProbeReadStr(AllocaInst *dst, size_t size, Value *src);
-  CallInst   *CreateProbeReadStr(Value *dst, size_t size, Value *src);
-  Value      *CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_point, int arg_name, Builtin &builtin, pid_t pid);
-  Value      *CreateStrcmp(Value* val, std::string str, bool inverse=false);
-  Value      *CreateStrcmp(Value* val1, Value* val2, bool inverse=false);
-  Value      *CreateStrncmp(Value* val, std::string str, uint64_t n, bool inverse=false);
-  Value      *CreateStrncmp(Value* val1, Value* val2, uint64_t n, bool inverse=false);
+  Value      *CreateMapLookupElem(Value* ctx, Map &map, AllocaInst *key, const location& loc);
+  Value      *CreateMapLookupElem(Value* ctx, int mapfd, AllocaInst *key, SizedType &type, const location& loc);
+  void        CreateMapUpdateElem(Value* ctx, Map &map, AllocaInst *key, Value *val, const location& loc);
+  void        CreateMapDeleteElem(Value* ctx, Map &map, AllocaInst *key, const location& loc);
+  void        CreateProbeRead(Value *ctx, AllocaInst *dst, size_t size, Value *src, const location& loc);
+  void        CreateProbeRead(Value *ctx, AllocaInst *dst, llvm::Value *size, Value *src, const location& loc);
+  CallInst   *CreateProbeReadStr(Value* ctx, AllocaInst *dst, llvm::Value *size, Value *src, const location& loc);
+  CallInst   *CreateProbeReadStr(Value* ctx, AllocaInst *dst, size_t size, Value *src, const location& loc);
+  CallInst   *CreateProbeReadStr(Value* ctx, Value *dst, size_t size, Value *src, const location& loc);
+  Value      *CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_point, int arg_name, Builtin &builtin, pid_t pid, const location& loc);
+  Value      *CreateStrcmp(Value* ctx, Value* val, std::string str, const location& loc, bool inverse=false);
+  Value      *CreateStrcmp(Value* ctx, Value* val1, Value* val2, const location& loc, bool inverse=false);
+  Value      *CreateStrncmp(Value* ctx, Value* val, std::string str, uint64_t n, const location& loc, bool inverse=false);
+  Value      *CreateStrncmp(Value* ctx, Value* val1, Value* val2, uint64_t n, const location& loc, bool inverse=false);
   CallInst   *CreateGetNs();
   CallInst   *CreateGetPidTgid();
   CallInst   *CreateGetCurrentCgroupId();
@@ -78,21 +78,24 @@ public:
   CallInst   *CreateGetCpuId();
   CallInst   *CreateGetCurrentTask();
   CallInst   *CreateGetRandom();
-  CallInst   *CreateGetStackId(Value *ctx, bool ustack, StackType stack_type);
-  CallInst   *CreateGetJoinMap(Value *ctx);
-  void        CreateGetCurrentComm(AllocaInst *buf, size_t size);
+  CallInst   *CreateGetStackId(Value *ctx, bool ustack, StackType stack_type, const location& loc);
+  CallInst   *CreateGetJoinMap(Value *ctx, const location& loc);
+  void        CreateGetCurrentComm(Value *ctx, AllocaInst *buf, size_t size, const location& loc);
   void        CreatePerfEventOutput(Value *ctx, Value *data, size_t size);
-  void        CreateSignal(Value *sig);
+  void        CreateSignal(Value *ctx, Value *sig, const location &loc);
   void        CreateOverrideReturn(Value *ctx, Value *rc);
+  void        CreateHelperError(Value *ctx, Value *return_value, libbpf::bpf_func_id func_id, const location& loc);
+  void        CreateHelperErrorCond(Value *ctx, Value *return_value, libbpf::bpf_func_id func_id, const location& loc, bool compare_zero=false);
   StructType *GetStructType(std::string name, const std::vector<llvm::Type *> & elements, bool packed = false);
   AllocaInst *CreateUSym(llvm::Value *val);
   Value      *CreatKFuncArg(Value *ctx, SizedType& type, std::string& name);
+  int helper_error_id_ = 0;
 
 private:
   Module &module_;
   BPFtrace &bpftrace_;
 
-  Value      *CreateUSDTReadArgument(Value *ctx, struct bcc_usdt_argument *argument, Builtin &builtin);
+  Value      *CreateUSDTReadArgument(Value *ctx, struct bcc_usdt_argument *argument, Builtin &builtin, const location& loc);
   CallInst   *createMapLookup(int mapfd, AllocaInst *key);
   Constant   *createProbeReadStrFn(llvm::Type * dst, llvm::Type * src);
 

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -79,6 +79,12 @@ private:
   std::string msg_;
 };
 
+struct HelperErrorInfo
+{
+  int func_id;
+  location loc;
+};
+
 class BPFtrace
 {
 public:
@@ -145,6 +151,7 @@ public:
   std::vector<std::string> join_args_;
   std::vector<std::string> time_args_;
   std::vector<std::tuple<std::string, std::vector<Field>>> cat_args_;
+  std::unordered_map<int64_t, struct HelperErrorInfo> helper_error_info_;
   std::unordered_map<StackType, std::unique_ptr<IMap>> stackid_maps_;
   std::unique_ptr<IMap> join_map_;
   std::unique_ptr<IMap> elapsed_map_;
@@ -168,6 +175,7 @@ public:
   bool force_btf_ = false;
   bool has_usdt_ = false;
   bool usdt_file_activation_ = false;
+  int helper_check_level_ = 0;
 
   static void sort_by_key(
       std::vector<SizedType> key_args,

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -166,7 +166,7 @@ public:
   uint64_t mapmax_ = 4096;
   size_t cat_bytes_max_ = 10240;
   uint64_t max_probes_ = 512;
-  uint64_t log_size_ = 409600;
+  uint64_t log_size_ = 1000000;
   uint64_t perf_rb_pages_ = 64;
   bool demangle_cpp_symbols_ = true;
   bool resolve_user_symbols_ = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -71,7 +71,7 @@ void usage()
   std::cerr << "    BPFTRACE_MAP_KEYS_MAX       [default: 4096] max keys in a map" << std::endl;
   std::cerr << "    BPFTRACE_CAT_BYTES_MAX      [default: 10k] maximum bytes read by cat builtin" << std::endl;
   std::cerr << "    BPFTRACE_MAX_PROBES         [default: 512] max number of probes" << std::endl;
-  std::cerr << "    BPFTRACE_LOG_SIZE           [default: 409600] log size in bytes" << std::endl;
+  std::cerr << "    BPFTRACE_LOG_SIZE           [default: 1000000] log size in bytes" << std::endl;
   std::cerr << "    BPFTRACE_PERF_RB_PAGES      [default: 64] pages per CPU to allocate for ring buffer" << std::endl;
   std::cerr << "    BPFTRACE_NO_USER_SYMBOLS    [default: 0] disable user symbol resolution" << std::endl;
   std::cerr << "    BPFTRACE_CACHE_USER_SYMBOLS [default: auto] enable user symbol cache" << std::endl;

--- a/src/types.h
+++ b/src/types.h
@@ -220,6 +220,7 @@ const int RESERVED_IDS_PER_ASYNCACTION = 10000;
 
 enum class AsyncAction
 {
+  // clang-format off
   printf  = 0,     // printf reserves 0-9999 for printf_ids
   syscall = 10000, // system reserves 10000-19999 for printf_ids
   cat     = 20000, // cat reserves 20000-29999 for printf_ids
@@ -229,6 +230,8 @@ enum class AsyncAction
   zero,
   time,
   join,
+  helper_error,
+  // clang-format on
 };
 
 uint64_t asyncactionint(AsyncAction a);

--- a/tests/codegen/llvm/runtime_error_check.ll
+++ b/tests/codegen/llvm/runtime_error_check.ll
@@ -1,0 +1,69 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%helper_error_t = type <{ i64, i64, i32 }>
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
+entry:
+  %helper_error_t = alloca %helper_error_t, align 8
+  %"@_newval" = alloca i64, align 8
+  %"@_key" = alloca i64, align 8
+  %1 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  store i64 0, i64* %"@_key", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* nonnull %"@_key")
+  %map_lookup_cond = icmp eq i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_merge, label %lookup_success
+
+lookup_success:                                   ; preds = %entry
+  %cast = bitcast i8* %lookup_elem to i64*
+  %2 = load i64, i64* %cast, align 8
+  %phitmp = add i64 %2, 1
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %entry, %lookup_success
+  %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %entry ]
+  %3 = bitcast i64* %"@_newval" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 %lookup_elem_val.0, i64* %"@_newval", align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@_key", i64* nonnull %"@_newval", i64 0)
+  %4 = trunc i64 %update_elem to i32
+  %5 = icmp sgt i32 %4, -1
+  br i1 %5, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %lookup_merge
+  %6 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
+  %7 = getelementptr inbounds %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %7, align 8
+  %8 = getelementptr inbounds %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %8, align 8
+  %9 = getelementptr inbounds %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %4, i32* %9, align 8
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo2, i64 %get_cpu_id, %helper_error_t* nonnull %helper_error_t, i64 20)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  br label %helper_merge
+
+helper_merge:                                     ; preds = %helper_failure, %lookup_merge
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/runtime_error_check_lookup.ll
+++ b/tests/codegen/llvm/runtime_error_check_lookup.ll
@@ -1,0 +1,85 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%helper_error_t = type <{ i64, i64, i32 }>
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
+entry:
+  %helper_error_t3 = alloca %helper_error_t, align 8
+  %"@_newval" = alloca i64, align 8
+  %helper_error_t = alloca %helper_error_t, align 8
+  %"@_key" = alloca i64, align 8
+  %1 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  store i64 0, i64* %"@_key", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* nonnull %"@_key")
+  %map_lookup_cond = icmp eq i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_failure, label %lookup_success
+
+lookup_success:                                   ; preds = %entry
+  %cast = bitcast i8* %lookup_elem to i64*
+  %2 = load i64, i64* %cast, align 8
+  %phitmp = add i64 %2, 1
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  %3 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %4 = getelementptr inbounds %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %4, align 8
+  %5 = getelementptr inbounds %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %5, align 8
+  %6 = getelementptr inbounds %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 0, i32* %6, align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 %get_cpu_id, %helper_error_t* nonnull %helper_error_t, i64 20)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %lookup_elem_val.0 = phi i64 [ %phitmp, %lookup_success ], [ 1, %lookup_failure ]
+  %7 = bitcast i64* %"@_newval" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
+  store i64 %lookup_elem_val.0, i64* %"@_newval", align 8
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* nonnull %"@_key", i64* nonnull %"@_newval", i64 0)
+  %8 = trunc i64 %update_elem to i32
+  %9 = icmp sgt i32 %8, -1
+  br i1 %9, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %lookup_merge
+  %10 = bitcast %helper_error_t* %helper_error_t3 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
+  %11 = getelementptr inbounds %helper_error_t, %helper_error_t* %helper_error_t3, i64 0, i32 0
+  store i64 30006, i64* %11, align 8
+  %12 = getelementptr inbounds %helper_error_t, %helper_error_t* %helper_error_t3, i64 0, i32 1
+  store i64 1, i64* %12, align 8
+  %13 = getelementptr inbounds %helper_error_t, %helper_error_t* %helper_error_t3, i64 0, i32 2
+  store i32 %8, i32* %13, align 8
+  %pseudo4 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %get_cpu_id5 = call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output6 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo4, i64 %get_cpu_id5, %helper_error_t* nonnull %helper_error_t3, i64 20)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
+  br label %helper_merge
+
+helper_merge:                                     ; preds = %helper_failure, %lookup_merge
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/runtime_error_check.cpp
+++ b/tests/codegen/runtime_error_check.cpp
@@ -1,0 +1,23 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, runtime_error_check)
+{
+  BPFtrace bpftrace;
+  bpftrace.helper_check_level_ = 1;
+  test(bpftrace, "kprobe:f { @++; }", NAME);
+}
+
+TEST(codegen, runtime_error_check_lookup)
+{
+  BPFtrace bpftrace;
+  bpftrace.helper_check_level_ = 2;
+  test(bpftrace, "kprobe:f { @++; }", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -174,3 +174,13 @@ NAME map_assign_map_ptr
 RUN bpftrace -e 'i:ms:100 { @ = curtask; @a = @; printf("%d\n", @a); exit(); }'
 EXPECT -?[0-9]+
 TIMEOUT 1
+
+NAME runtime_error_check_delete
+RUN bpftrace -k -e 'i:ms:100 { @[1] = 1; delete(@[2]); exit(); }'
+EXPECT WARNING: Failed to map_delete_elem: No such file or directory \(-2\)
+TIMEOUT 1
+
+NAME runtime_error_check_lookup
+RUN bpftrace -kk -e 'i:ms:100 { @[1] = 1; printf("%d\n", @[2]); exit(); }'
+EXPECT WARNING: Failed to map_lookup_elem: 0
+TIMEOUT 1


### PR DESCRIPTION
Some helper functions return error codes when failing, but currently,
bpftrace does not check and discards it. Several times I had to use bcc
to check error codes for debugging.

This patch adds an error checking mechanism, and helper function errors
are reported in runtime using '-k' option. For example:

```
% sudo BPFTRACE_MAP_KEYS_MAX=2 ./src/bpftrace -e \
  'BEGIN { @[0] = 0; @[1] = 1; @[2] = 2;} -k'
Attaching 1 probe...
stdin:1:35-36: WARNING: Failed to map_update_elem: Argument list too long (-7)
BEGIN { @[0] = 0; @[1] = 1; @[2] = 2;}
                                 ~

^C

@[0]: 0
@[1]: 1
```

This mechanism is implemented as an async action. By default, errors of
`bpf_probe_read()`-related functions and `bpf_map_lookup_elem()` are not
checked. This is because when these functions fail, bpftrace returns
zero as a result, and some scripts already check it, for example, by
using predicate `/ @[tid] /`. `-kk` option forces to check all errors
including these functions.

Note that the error check increases code size. All codegen tests are
performed with the error check disabled.