### PR TITLE
Move process monitoring out of `BPFtrace`

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(bpftrace
   map.cpp
   mapkey.cpp
   output.cpp
+  procmon.cpp
   printf.cpp
   resolve_cgroupid.cpp
   signal.cpp

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -183,8 +183,8 @@ void CodegenLLVM::visit(Builtin &builtin)
     {
       int arg_num = atoi(builtin.ident.substr(3).c_str());
       if (probetype(current_attach_point_->provider) == ProbeType::usdt) {
-        expr_ = b_.CreateUSDTReadArgument(ctx_, current_attach_point_,
-                                          arg_num, builtin, bpftrace_.pid_);
+        expr_ = b_.CreateUSDTReadArgument(
+            ctx_, current_attach_point_, arg_num, builtin, bpftrace_.pid());
         return;
       }
       offset = arch::arg_offset(arg_num);
@@ -1687,7 +1687,8 @@ void CodegenLLVM::visit(Probe &probe)
           attach_point->ns = orig_ns;
 
           // Set the probe identifier so that we can read arguments later
-          attach_point->usdt = USDTHelper::find(bpftrace_.pid_, attach_point->target, ns, func_id);
+          attach_point->usdt = USDTHelper::find(
+              bpftrace_.pid(), attach_point->target, ns, func_id);
         } else if (attach_point->provider == "BEGIN" || attach_point->provider == "END") {
           probefull_ = attach_point->provider;
         } else {

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -429,7 +429,11 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx, struct bcc_usdt_argument
   return result;
 }
 
-Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_point, int arg_num, Builtin &builtin, int pid)
+Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
+                                            AttachPoint *attach_point,
+                                            int arg_num,
+                                            Builtin &builtin,
+                                            pid_t pid)
 {
   struct bcc_usdt_argument argument;
 

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -66,7 +66,7 @@ public:
   CallInst   *CreateProbeReadStr(AllocaInst *dst, llvm::Value *size, Value *src);
   CallInst   *CreateProbeReadStr(AllocaInst *dst, size_t size, Value *src);
   CallInst   *CreateProbeReadStr(Value *dst, size_t size, Value *src);
-  Value      *CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_point, int arg_name, Builtin &builtin, int pid);
+  Value      *CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_point, int arg_name, Builtin &builtin, pid_t pid);
   Value      *CreateStrcmp(Value* val, std::string str, bool inverse=false);
   Value      *CreateStrcmp(Value* val1, Value* val2, bool inverse=false);
   Value      *CreateStrncmp(Value* val, std::string str, uint64_t n, bool inverse=false);

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1771,7 +1771,7 @@ void SemanticAnalyser::visit(AttachPoint &ap)
     if (ap.provider == "uretprobe" && ap.func_offset != 0)
       error("uretprobes can not be attached to a function offset", ap.loc);
 
-    auto paths = resolve_binary_path(ap.target, bpftrace_.pid_);
+    auto paths = resolve_binary_path(ap.target, bpftrace_.pid());
     switch (paths.size())
     {
     case 0:
@@ -1806,7 +1806,7 @@ void SemanticAnalyser::visit(AttachPoint &ap)
       error("usdt probe must have a target function or wildcard", ap.loc);
 
     if (ap.target != "") {
-      auto paths = resolve_binary_path(ap.target, bpftrace_.pid_);
+      auto paths = resolve_binary_path(ap.target, bpftrace_.pid());
       switch (paths.size())
       {
       case 0:
@@ -1836,11 +1836,16 @@ void SemanticAnalyser::visit(AttachPoint &ap)
       }
     }
 
-    if (bpftrace_.pid_ > 0) {
-       USDTHelper::probes_for_pid(bpftrace_.pid_);
-    } else if (ap.target != "") {
-       USDTHelper::probes_for_path(ap.target);
-    } else {
+    if (bpftrace_.pid() > 0)
+    {
+      USDTHelper::probes_for_pid(bpftrace_.pid());
+    }
+    else if (ap.target != "")
+    {
+      USDTHelper::probes_for_path(ap.target);
+    }
+    else
+    {
       error("usdt probe must specify at least path or pid to probe", ap.loc);
     }
   }

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -16,6 +16,7 @@
 #include "imap.h"
 #include "output.h"
 #include "printf.h"
+#include "procmon.h"
 #include "struct.h"
 #include "types.h"
 #include "utils.h"
@@ -127,7 +128,6 @@ public:
   bool is_aslr_enabled(int pid);
 
   std::string cmd_;
-  int pid_{0};
   bool finalize_ = false;
   // Global variable checking if an exit signal was received
   static volatile sig_atomic_t exitsig_recv;
@@ -190,6 +190,11 @@ public:
   std::unordered_set<std::string> btf_set_;
   std::map<std::string, std::map<std::string, SizedType>> btf_ap_args_;
   std::unique_ptr<ChildProcBase> child_;
+  std::unique_ptr<ProcMonBase> procmon_;
+  pid_t pid(void) const
+  {
+    return procmon_ ? procmon_->pid() : 0;
+  }
 
 protected:
   std::vector<Probe> probes_;
@@ -222,7 +227,6 @@ private:
   static uint64_t max_value(const std::vector<uint8_t> &value, int nvalues);
   static uint64_t read_address_from_output(std::string output);
   std::vector<uint8_t> find_empty_key(IMap &map, size_t size) const;
-  static bool is_pid_alive(int pid);
 };
 
 } // namespace bpftrace

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -150,10 +150,10 @@ void list_probes(const BPFtrace &bpftrace, const std::string &search_input)
     std::string absolute_exe;
     bool show_all = false;
 
-    if (bpftrace.pid_ > 0)
+    if (bpftrace.pid() > 0)
     {
-      executable = get_pid_exe(bpftrace.pid_);
-      absolute_exe = path_for_pid_mountns(bpftrace.pid_, executable);
+      executable = get_pid_exe(bpftrace.pid());
+      absolute_exe = path_for_pid_mountns(bpftrace.pid(), executable);
     } else if (probe_name == "uprobe")
     {
       executable = search.substr(search.find(":") + 1, search.size());
@@ -193,16 +193,16 @@ void list_probes(const BPFtrace &bpftrace, const std::string &search_input)
   // usdt
   usdt_probe_list usdt_probes;
   bool usdt_path_list = false;
-  if (bpftrace.pid_ > 0)
+  if (bpftrace.pid() > 0)
   {
     // PID takes precedence over path, so path from search expression will be ignored if pid specified
-    usdt_probes = USDTHelper::probes_for_pid(bpftrace.pid_);
+    usdt_probes = USDTHelper::probes_for_pid(bpftrace.pid());
   } else if (probe_name == "usdt") {
     // If the *full* path is provided as part of the search expression parse it out and use it
     std::string usdt_path = search.substr(search.find(":")+1, search.size());
     usdt_path_list = usdt_path.find(":") == std::string::npos;
     usdt_path = usdt_path.substr(0, usdt_path.find(":"));
-    auto paths = resolve_binary_path(usdt_path, bpftrace.pid_);
+    auto paths = resolve_binary_path(usdt_path, bpftrace.pid());
     switch (paths.size())
     {
     case 0:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -20,6 +20,7 @@
 #include "lockdown.h"
 #include "output.h"
 #include "printer.h"
+#include "procmon.h"
 #include "semantic_analyser.h"
 #include "tracepoint_format_parser.h"
 
@@ -345,17 +346,13 @@ int main(int argc, char *argv[])
   bpftrace.safe_mode_ = safe_mode;
   bpftrace.force_btf_ = force_btf;
 
-  // PID is currently only used for USDT probes that need enabling. Future work:
-  // - make PID a filter for all probe types: pass to perf_event_open(), etc.
-  // - provide PID in USDT probe specification as a way to override -p.
-  bpftrace.pid_ = 0;
   if (!pid_str.empty())
   {
     try
     {
-      bpftrace.pid_ = parse_pid(pid_str);
+      bpftrace.procmon_ = std::make_unique<ProcMon>(pid_str);
     }
-    catch (const InvalidPIDException& e)
+    catch (const std::exception& e)
     {
       std::cerr << "ERROR: " << e.what() << std::endl;
       return 1;

--- a/src/procmon.cpp
+++ b/src/procmon.cpp
@@ -1,0 +1,116 @@
+#include <cerrno>
+#include <fcntl.h>
+#include <poll.h>
+#include <stdexcept>
+#include <sys/syscall.h>
+#include <system_error>
+#include <unistd.h>
+
+#include "procmon.h"
+#include "utils.h"
+
+namespace bpftrace {
+
+#ifndef __NR_pidfd_open
+#define __NR_pidfd_open 434
+#endif
+
+static std::system_error SYS_ERROR(std::string msg)
+{
+  return std::system_error(errno, std::generic_category(), msg);
+}
+
+static inline int pidfd_open(int pid, unsigned int flags)
+{
+  return syscall(__NR_pidfd_open, pid, flags);
+}
+
+ProcMon::ProcMon(const std::string& pid)
+{
+  setup(parse_pid(pid));
+}
+
+ProcMon::ProcMon(pid_t pid)
+{
+  setup(pid);
+}
+
+void ProcMon::setup(pid_t pid)
+{
+  pid_ = pid;
+
+  int pidfd = pidfd_open(pid, 0);
+  // Fall back to polling if pidfds or anon inodes are not supported
+  if (pidfd >= 0)
+  {
+    pidfd_ = pidfd;
+    return;
+  }
+  else if (errno != ENOSYS)
+  {
+    if (errno == ESRCH)
+      throw SYS_ERROR(""); /* use default error message for ESRCH */
+    throw SYS_ERROR("Failed to pidfd_open pid");
+  }
+
+  int ret = snprintf(proc_path_,
+                     sizeof(proc_path_) / sizeof(proc_path_[0]),
+                     "/proc/%d/status",
+                     pid);
+  if (ret < 0)
+  {
+    throw std::runtime_error("failed to snprintf");
+  }
+
+  if (!is_alive())
+    throw std::runtime_error("No such process: " + std::to_string(pid));
+}
+
+ProcMon::~ProcMon()
+{
+  if (pidfd_ >= 0)
+    close(pidfd_);
+}
+
+bool ProcMon::is_alive(void)
+{
+  // store death to avoid pid reuse issues on polling /proc
+  if (died_)
+    return false;
+
+  if (pidfd_ > -1)
+  {
+    struct pollfd pollfd;
+    pollfd.fd = pidfd_;
+    pollfd.events = POLLIN;
+
+    int ret;
+    while ((ret = poll(&pollfd, 1, 0)) < 0 && errno == EINTR)
+      ;
+
+    if (ret < 0)
+      throw SYS_ERROR("poll pidfd");
+    else if (ret == 0) // no change, so must be alive
+      return true;
+
+    died_ = true;
+    return false;
+  }
+
+  int fd = open(proc_path_, 0, O_RDONLY);
+  if (fd < 0)
+  {
+    if (errno == ENOENT)
+    {
+      died_ = true;
+      return false;
+    }
+    std::string msg = "Failed to open " + std::string(proc_path_);
+    throw SYS_ERROR(msg);
+  }
+
+  close(fd);
+  return true;
+}
+
+} // namespace bpftrace

--- a/src/procmon.h
+++ b/src/procmon.h
@@ -1,0 +1,53 @@
+#pragma once
+#include <string>
+#include <unistd.h>
+
+namespace bpftrace {
+
+class ProcMonBase
+{
+public:
+  ProcMonBase() = default;
+  virtual ~ProcMonBase() = default;
+
+  /**
+     Whether the process is still alive
+  */
+  virtual bool is_alive(void) = 0;
+
+  /**
+     pid of the process being monitored
+  */
+  pid_t pid(void)
+  {
+    return pid_;
+  };
+
+protected:
+  int pid_ = -1;
+};
+
+class ProcMon : public ProcMonBase
+{
+public:
+  ProcMon(pid_t pid);
+  ProcMon(const std::string& pid);
+  ~ProcMon() override;
+
+  // Disallow copying as the internal state will get out of sync which will
+  // cause issues.
+  ProcMon(const ProcMon&) = delete;
+  ProcMon& operator=(const ProcMon&) = delete;
+  ProcMon(ProcMon&&) = delete;
+  ProcMon& operator=(ProcMon&&) = delete;
+
+  bool is_alive(void) override;
+
+private:
+  int pidfd_ = -1;
+  char proc_path_[32];
+  bool died_ = false;
+  void setup(pid_t pid);
+};
+
+} // namespace bpftrace

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ add_executable(bpftrace_test
   main.cpp
   mocks.cpp
   parser.cpp
+  procmon.cpp
   probe.cpp
   semantic_analyser.cpp
   tracepoint_format_parser.cpp
@@ -44,6 +45,7 @@ add_executable(bpftrace_test
   ${CMAKE_SOURCE_DIR}/src/mapkey.cpp
   ${CMAKE_SOURCE_DIR}/src/output.cpp
   ${CMAKE_SOURCE_DIR}/src/printf.cpp
+  ${CMAKE_SOURCE_DIR}/src/procmon.cpp
   ${CMAKE_SOURCE_DIR}/src/resolve_cgroupid.cpp
   ${CMAKE_SOURCE_DIR}/src/signal.cpp
   ${CMAKE_SOURCE_DIR}/src/struct.cpp

--- a/tests/child.cpp
+++ b/tests/child.cpp
@@ -8,9 +8,8 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 
-#include <time.h>
-
 #include "child.h"
+#include "childhelper.h"
 #include "utils.h"
 
 namespace bpftrace {
@@ -22,37 +21,6 @@ using ::testing::HasSubstr;
 #define TEST_BIN "/bin/ls"
 #define TEST_BIN_ERR "/bin/ls /does/not/exist/abc"
 #define TEST_BIN_SLOW "/bin/sleep 10"
-
-int msleep(int msec)
-{
-  struct timespec sleep = { .tv_sec = 0, .tv_nsec = msec * 1000000L };
-  struct timespec rem = {};
-  if (nanosleep(&sleep, &rem) < 0)
-    return 1000L * rem.tv_sec + 1000000L * rem.tv_nsec;
-  return 0;
-}
-
-void wait_for(ChildProcBase *child, int msec_timeout)
-{
-  constexpr int wait = 10;
-  while (child->is_alive() && msec_timeout > 0)
-    msec_timeout -= wait - msleep(wait);
-}
-
-std::unique_ptr<ChildProc> getChild(std::string cmd)
-{
-  std::unique_ptr<ChildProc> child;
-  {
-    StderrSilencer es;
-    StdoutSilencer os;
-    os.silence();
-    es.silence();
-    child = std::make_unique<ChildProc>(cmd);
-  }
-  EXPECT_NE(child->pid(), -1);
-  EXPECT_TRUE(child->is_alive());
-  return child;
-}
 
 TEST(childproc, exe_does_not_exist)
 {

--- a/tests/childhelper.h
+++ b/tests/childhelper.h
@@ -1,0 +1,41 @@
+#include <time.h>
+
+#include "child.h"
+#include "utils.h"
+
+namespace bpftrace {
+namespace test {
+
+static int msleep(int msec)
+{
+  struct timespec sleep = { .tv_sec = 0, .tv_nsec = msec * 1000000L };
+  struct timespec rem = {};
+  if (nanosleep(&sleep, &rem) < 0)
+    return 1000L * rem.tv_sec + 1000000L * rem.tv_nsec;
+  return 0;
+}
+
+static void wait_for(ChildProcBase *child, int msec_timeout)
+{
+  constexpr int wait = 10;
+  while (child->is_alive() && msec_timeout > 0)
+    msec_timeout -= wait - msleep(wait);
+}
+
+static std::unique_ptr<ChildProc> getChild(std::string cmd)
+{
+  std::unique_ptr<ChildProc> child;
+  {
+    StderrSilencer es;
+    StdoutSilencer os;
+    os.silence();
+    es.silence();
+    child = std::make_unique<ChildProc>(cmd);
+  }
+  EXPECT_NE(child->pid(), -1);
+  EXPECT_TRUE(child->is_alive());
+  return child;
+}
+
+} // namespace test
+} // namespace bpftrace

--- a/tests/procmon.cpp
+++ b/tests/procmon.cpp
@@ -1,0 +1,51 @@
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include <time.h>
+
+#include "child.h"
+#include "procmon.h"
+
+#include "childhelper.h"
+
+namespace bpftrace {
+namespace test {
+namespace procmon {
+
+using ::testing::HasSubstr;
+
+TEST(procmon, no_such_proc)
+{
+  try
+  {
+    ProcMon(1 << 21);
+    FAIL();
+  }
+  catch (const std::runtime_error &e)
+  {
+    EXPECT_THAT(e.what(), HasSubstr("No such process"));
+  }
+}
+
+TEST(procmon, child_terminates)
+{
+  auto child = getChild("/bin/ls");
+  auto procmon = std::make_unique<ProcMon>(child->pid());
+  EXPECT_TRUE(procmon->is_alive());
+  child->run();
+  wait_for(child.get(), 1000);
+  EXPECT_FALSE(child->is_alive());
+  EXPECT_FALSE(procmon->is_alive());
+  EXPECT_FALSE(procmon->is_alive());
+}
+
+TEST(procmon, pid_string)
+{
+  auto child = getChild("/bin/ls");
+  auto procmon = std::make_unique<ProcMon>(std::to_string(child->pid()));
+  EXPECT_TRUE(procmon->is_alive());
+}
+
+} // namespace procmon
+} // namespace test
+} // namespace bpftrace


### PR DESCRIPTION
This moves the process monitoring logic out of bpftrace itself and
instead provide a simple interface bpftrace can use.

If pidfds are supported by the system they're used, else it falls back
to polling. Detection is done at runtime.

The way the 'pid to trace' and 'child pid' are accessed through the
bpftrace class is still a bit messy and confusing. But that's for later.