### PR TITLE
Install C++17 compatible compiler on xenial embedded builds

### DIFF
--- a/docker/Dockerfile.ubuntu-glibc
+++ b/docker/Dockerfile.ubuntu-glibc
@@ -63,6 +63,16 @@ RUN if [ "${DISTRO}" = "xenial" ]; then \
     apt install -y cmake \
     ; fi
 
+# Install C++17 compatible compiler if running on xenial
+RUN if [ "${DISTRO}" = "xenial" ]; then \
+    apt-get install -y software-properties-common \
+    && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+    && apt update \
+    && apt install -y g++-7 \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 \
+                           --slave /usr/bin/g++ g++ /usr/bin/g++-7 \
+    ; fi
+
 # Build BCC and install static libs
 RUN mkdir -p /src && git clone https://github.com/$bcc_org/bcc /src/bcc
 

--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -62,7 +62,11 @@ struct Time
 struct Buf
 {
   uint8_t length;
-  char content[];
+  // Seems like GCC 7.4.x can't handle `char content[]`. Work around by using
+  // 0 sized array (a GCC extension that clang also accepts:
+  // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70932). It also looks like
+  // the issue doesn't exist in GCC 7.5.x.
+  char content[0];
 
   std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b, size_t length)
   {

--- a/tests/runtime/engine/utils.py
+++ b/tests/runtime/engine/utils.py
@@ -100,7 +100,7 @@ class Utils(object):
                         shell=True,
                         stdout=dn,
                         stderr=dn,
-                        env={'PATH': f"{BPF_PATH}:{ENV_PATH}"},
+                        env={'PATH': "{}:{}".format(BPF_PATH, ENV_PATH)},
                     ) != 0:
                         print(warn("[   SKIP   ] ") + "%s.%s" % (test.suite, test.name))
                         return Utils.SKIP_REQUIREMENT_UNSATISFIED


### PR DESCRIPTION
The build is failing on missing C++17 support. Xenial is still using
GCC5 which is too old. According to:
https://gcc.gnu.org/onlinedocs/libstdc++/manual/status.html#status.iso.201z ,
std::optional was not available until gcc7-ish.