### PR TITLE
Unroll improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to
   - [#1066](https://github.com/iovisor/bpftrace/pull/1066)
 - Using a BTF enum value will pull in the entire enum definition
   - [#1274](https://github.com/iovisor/bpftrace/pull/1274)
+- Add support of using positional params in unroll
+  - [#1286](https://github.com/iovisor/bpftrace/pull/1286)
 
 #### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to
   - [#1066](https://github.com/iovisor/bpftrace/pull/1066)
 - Using a BTF enum value will pull in the entire enum definition
   - [#1274](https://github.com/iovisor/bpftrace/pull/1274)
-- Add support of using positional params in unroll
+- Add support of using positional params in unroll and increase the unroll limit to 100
   - [#1286](https://github.com/iovisor/bpftrace/pull/1286)
 
 #### Changed

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -338,7 +338,8 @@ void If::accept(Visitor &v) {
   v.visit(*this);
 }
 
-Unroll::Unroll(long int var, StatementList *stmts) : var(var), stmts(stmts)
+Unroll::Unroll(Expression *expr, StatementList *stmts, location loc)
+    : Statement(loc), expr(expr), stmts(stmts)
 {
 }
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -235,8 +235,9 @@ public:
 
 class Unroll : public Statement {
 public:
-  Unroll(long int var, StatementList *stmts);
+  Unroll(Expression *expr, StatementList *stmts, location loc);
   long int var = 0;
+  Expression *expr;
   StatementList *stmts;
 
   void accept(Visitor &v) override;

--- a/src/ast/field_analyser.cpp
+++ b/src/ast/field_analyser.cpp
@@ -140,10 +140,10 @@ void FieldAnalyser::visit(If &if_block)
 
 void FieldAnalyser::visit(Unroll &unroll)
 {
-  for (int i=0; i < unroll.var; i++) {
-    for (Statement *stmt : *unroll.stmts) {
-      stmt->accept(*this);
-    }
+  // visit statements in unroll once
+  for (Statement *stmt : *unroll.stmts)
+  {
+    stmt->accept(*this);
   }
 }
 

--- a/src/ast/printer.cpp
+++ b/src/ast/printer.cpp
@@ -265,13 +265,17 @@ void Printer::visit(If &if_block)
 void Printer::visit(Unroll &unroll)
 {
   std::string indent(depth_, ' ');
-  out_ << indent << "unroll " << unroll.var << std::endl;
-  ++depth_;
+  out_ << indent << "unroll" << std::endl;
 
+  ++depth_;
+  unroll.expr->accept(*this);
+  out_ << indent << " block" << std::endl;
+
+  ++depth_;
   for (Statement *stmt : *unroll.stmts) {
     stmt->accept(*this);
   }
-  --depth_;
+  depth_ -= 2;
 }
 
 void Printer::visit(While &while_block)

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1437,9 +1437,9 @@ void SemanticAnalyser::visit(Unroll &unroll)
     abort();
   }
 
-  if (unroll.var > 20)
+  if (unroll.var > 100)
   {
-    error("unroll maximum value is 20", unroll.loc);
+    error("unroll maximum value is 100", unroll.loc);
   }
   else if (unroll.var < 1)
   {

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -234,7 +234,8 @@ jump_stmt  : BREAK    { $$ = new ast::Jump(token::BREAK, @$); }
            | RETURN   { $$ = new ast::Jump(token::RETURN, @$); }
            ;
 
-loop_stmt  : UNROLL "(" INT ")" block             { $$ = new ast::Unroll($3, $5); }
+loop_stmt  : UNROLL "(" int ")" block             { $$ = new ast::Unroll($3, $5, @1 + @4); }
+           | UNROLL "(" param ")" block           { $$ = new ast::Unroll($3, $5, @1 + @4); }
            | WHILE  "(" expr ")" block            { $$ = new ast::While($3, $5, @1); }
            ;
 

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -741,21 +741,24 @@ TEST(Parser, if_elseif_elseif_else)
 
 TEST(Parser, unroll)
 {
-  test("kprobe:sys_open { $i = 0; unroll(5) { printf(\"i: %d\\n\", $i); $i = $i + 1; } }",
+  test("kprobe:sys_open { $i = 0; unroll(5) { printf(\"i: %d\\n\", $i); $i = "
+       "$i + 1; } }",
        "Program\n"
        " kprobe:sys_open\n"
        "  =\n"
        "   variable: $i\n"
        "   int: 0\n"
-       "  unroll 5\n"
-       "   call: printf\n"
-       "    string: i: %d\\n\n"
-       "    variable: $i\n"
-       "   =\n"
-       "    variable: $i\n"
-       "    +\n"
+       "  unroll\n"
+       "   int: 5\n"
+       "   block\n"
+       "    call: printf\n"
+       "     string: i: %d\\n\n"
        "     variable: $i\n"
-       "     int: 1\n");
+       "    =\n"
+       "     variable: $i\n"
+       "     +\n"
+       "      variable: $i\n"
+       "      int: 1\n");
 }
 
 TEST(Parser, ternary_str)

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -63,6 +63,11 @@ RUN bpftrace -v -e 'i:ms:1 {$a = 1; unroll (0) { $a = $a + 2; } printf("a=%d\n",
 EXPECT unroll minimum value is 1
 TIMEOUT 5
 
+NAME unroll_param
+RUN bpftrace -v -e 'i:ms:1 {$a = 1; unroll ($1) { $a = $a + 1; } printf("a=%d\n", $a); exit();}' 10
+EXPECT a=11
+TIMEOUT 5
+
 NAME if_compare_and_print_string
 RUN bpftrace -v -e 'BEGIN { if (comm == "bpftrace") { printf("comm: %s\n", comm);} exit();}'
 EXPECT comm: bpftrace

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -54,8 +54,8 @@ EXPECT a=11
 TIMEOUT 5
 
 NAME unroll_max_value
-RUN bpftrace -v -e 'i:ms:1 {$a = 1; unroll (30) { $a = $a + 2; } printf("a=%d\n", $a); exit();}'
-EXPECT unroll maximum value is 20
+RUN bpftrace -v -e 'i:ms:1 {$a = 1; unroll (101) { $a = $a + 2; } printf("a=%d\n", $a); exit();}'
+EXPECT unroll maximum value is 100
 TIMEOUT 5
 
 NAME unroll_min_value

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -803,15 +803,19 @@ TEST(semantic_analyser, variable_type)
 TEST(semantic_analyser, unroll)
 {
   test("kprobe:f { $i = 0; unroll(5) { printf(\"i: %d\\n\", $i); $i = $i + 1; } }", 0);
-  test("kprobe:f { $i = 0; unroll(21) { printf(\"i: %d\\n\", $i); $i = $i + 1; } }", 1);
+  test("kprobe:f { $i = 0; unroll(101) { printf(\"i: %d\\n\", $i); $i = $i + "
+       "1; } }",
+       1);
   test("kprobe:f { $i = 0; unroll(0) { printf(\"i: %d\\n\", $i); $i = $i + 1; } }", 1);
 
   BPFtrace bpftrace;
   bpftrace.add_param("10");
   bpftrace.add_param("hello");
+  bpftrace.add_param("101");
   test(bpftrace, "kprobe:f { unroll($#) { printf(\"hi\\n\"); } }", 0);
   test(bpftrace, "kprobe:f { unroll($1) { printf(\"hi\\n\"); } }", 0);
   test(bpftrace, "kprobe:f { unroll($2) { printf(\"hi\\n\"); } }", 1);
+  test(bpftrace, "kprobe:f { unroll($3) { printf(\"hi\\n\"); } }", 1);
 }
 
 TEST(semantic_analyser, map_integer_sizes)

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -805,6 +805,13 @@ TEST(semantic_analyser, unroll)
   test("kprobe:f { $i = 0; unroll(5) { printf(\"i: %d\\n\", $i); $i = $i + 1; } }", 0);
   test("kprobe:f { $i = 0; unroll(21) { printf(\"i: %d\\n\", $i); $i = $i + 1; } }", 1);
   test("kprobe:f { $i = 0; unroll(0) { printf(\"i: %d\\n\", $i); $i = $i + 1; } }", 1);
+
+  BPFtrace bpftrace;
+  bpftrace.add_param("10");
+  bpftrace.add_param("hello");
+  test(bpftrace, "kprobe:f { unroll($#) { printf(\"hi\\n\"); } }", 0);
+  test(bpftrace, "kprobe:f { unroll($1) { printf(\"hi\\n\"); } }", 0);
+  test(bpftrace, "kprobe:f { unroll($2) { printf(\"hi\\n\"); } }", 1);
 }
 
 TEST(semantic_analyser, map_integer_sizes)


### PR DESCRIPTION
Add support of using positional params in unroll and increase the unroll limit to 100.

Example:

```
% sudo ./src/bpftrace -e 'BEGIN { unroll($1) { printf("hi\n"); } }' 5
Attaching 1 probe...
hi
hi
hi
hi
hi
^C
```