### PR TITLE
Printer print ast after semantic analysis

### DIFF
--- a/src/ast/printer.h
+++ b/src/ast/printer.h
@@ -8,7 +8,10 @@ namespace ast {
 
 class Printer : public Visitor {
 public:
-  explicit Printer(std::ostream &out) : out_(out) { }
+  explicit Printer(std::ostream &out, bool print_types = false)
+      : out_(out), print_types(print_types)
+  {
+  }
 
   void visit(Integer &integer) override;
   void visit(PositionalParameter &param) override;
@@ -41,6 +44,8 @@ public:
 
 private:
   std::ostream &out_;
+  bool print_types = false;
+  std::string type(const SizedType &ty);
 };
 
 } // namespace ast

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -538,6 +538,8 @@ int main(int argc, char *argv[])
 
   if (bt_debug != DebugLevel::kNone)
   {
+    std::cout << "\nAST\n";
+    std::cout << "-------------------\n";
     ast::Printer p(std::cout);
     driver.root_->accept(p);
     std::cout << std::endl;
@@ -589,6 +591,15 @@ int main(int argc, char *argv[])
   err = semantics.analyse();
   if (err)
     return err;
+
+  if (bt_debug != DebugLevel::kNone)
+  {
+    std::cout << "\nAST after semantic analysis\n";
+    std::cout << "-------------------\n";
+    ast::Printer p(std::cout, true);
+    driver.root_->accept(p);
+    std::cout << std::endl;
+  }
 
   err = semantics.create_maps(bt_debug != DebugLevel::kNone);
   if (err)


### PR DESCRIPTION
Extracting all the relevant type information while debugging can be
quite tedious. Walking the AST manually in GDB is a pain and putting
break points in the right places to be able to inspect it isn't much
easier either.

This extends the AST printer to include the type information added by
the semantic analyser:

```
AST after semantic analysis
-------------------
struct A { int a };

Program
 kprobe:f
  =
   variable: $a :: type[struct A*]
   (struct A*)
    int: 0 :: type[int64]
  =
   map: @ :: type[int64]
   .
    dereference
     variable: $a :: type[struct A*]
    a
  =
   map: @a :: type[string[16]]
   builtin: comm :: type[string[16]]
```