### PR TITLE
Switch count type on map with no arguments to BPF_MAP_TYPE_PERCPU_ARRAY

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -36,10 +36,17 @@ Map::Map(const std::string &name, const SizedType &type, const MapKey &key, int 
   if (key_size == 0)
     key_size = 8;
 
-  if ((type.type == Type::hist || type.type == Type::lhist || type.type == Type::count ||
-      type.type == Type::sum || type.type == Type::min || type.type == Type::max ||
-      type.type == Type::avg || type.type == Type::stats) &&
-      (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)))
+  if (type.type == Type::count && !key.args_.size())
+  {
+    map_type_ = BPF_MAP_TYPE_PERCPU_ARRAY;
+    max_entries = 1;
+    key_size = 4;
+  }
+  else if ((type.type == Type::hist || type.type == Type::lhist ||
+            type.type == Type::count || type.type == Type::sum ||
+            type.type == Type::min || type.type == Type::max ||
+            type.type == Type::avg || type.type == Type::stats) &&
+           (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)))
   {
       map_type_ = BPF_MAP_TYPE_PERCPU_HASH;
   }


### PR DESCRIPTION
We use `BPF_MAP_TYPE_PERCPU_HASH` for count() maps, which works fine until you don't use any arguments with map, like:

`  @[pid] = count();`

is much faster under benchmark below then:

`  @ = count();`

The reason for that is that kernel is taking lock for the bucket first and only after it goes for the per cpu area of the bucket data.

So with having just one element in the hash (which is the case for @ = count()) any update on the map needs to get that lock, which gets bad:

Before:
```
  # perf stat -e cycles:k bpftrace -e 'kfunc:ksys_write { @ = count(); }' -c "/home/jolsa/bin/perf bench sched messaging -l 100000"
  Attaching kfunc:ksys_write
  Running...
  ...

  18,300,472,136,962      cycles:k

       189.125188715 seconds time elapsed

       502.697921000 seconds user
      6971.654744000 seconds sys
```
After:
```
  # perf stat -e cycles:k bpftrace -e 'kfunc:ksys_write { @ = count(); }' -c "/home/jolsa/bin/perf bench sched messaging -l 100000"
  Attaching kfunc:ksys_write
  Running...

   3,324,209,184,058      cycles:k

        37.343001587 seconds time elapsed

       131.090993000 seconds user
      1238.403323000 seconds sys
```
The benchmark time for @[pid] = count(); case for reference:
```
  # perf stat -e cycles:k ./src/bpftrace -e 'kfunc:ksys_write { @[pid] = count(); }' -c "/home/jolsa/bin/perf bench sched messaging -l 100000" -v >out
  Attaching kfunc:ksys_write
  Running...

   3,438,836,168,758      cycles:k

        38.765892305 seconds time elapsed

       132.819241000 seconds user
      1285.974003000 seconds sys
```
The fix is to change map type to `BPF_MAP_TYPE_PERCPU_ARRAY` for @ = count() case, which does no locking on update and is fully sufficient for this case.