### PR TITLE
Use direct increase instead of map update for count function

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -270,14 +270,7 @@ void CodegenLLVM::visit(Call &call)
   {
     Map &map = *call.map;
     AllocaInst *key = getMapKey(map);
-    Value *oldval = b_.CreateMapLookupElem(map, key);
-    AllocaInst *newval = b_.CreateAllocaBPF(map.type, map.ident + "_val");
-    b_.CreateStore(b_.CreateAdd(oldval, b_.getInt64(1)), newval);
-    b_.CreateMapUpdateElem(map, key, newval);
-
-    // oldval can only be an integer so won't be in memory and doesn't need lifetime end
-    b_.CreateLifetimeEnd(key);
-    b_.CreateLifetimeEnd(newval);
+    b_.CreateMapCount(map, key);
     expr_ = nullptr;
   }
   else if (call.func == "sum")

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -59,6 +59,7 @@ public:
   CallInst   *CreateBpfPseudoCall(Map &map);
   Value      *CreateMapLookupElem(Map &map, AllocaInst *key);
   Value      *CreateMapLookupElem(int mapfd, AllocaInst *key, SizedType &type);
+  Value      *CreateMapCount(Map &map, AllocaInst *key);
   void        CreateMapUpdateElem(Map &map, AllocaInst *key, Value *val);
   void        CreateMapDeleteElem(Map &map, AllocaInst *key);
   void        CreateProbeRead(AllocaInst *dst, size_t size, Value *src);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -36,7 +36,12 @@ Map::Map(const std::string &name, const SizedType &type, const MapKey &key, int 
   if (key_size == 0)
     key_size = 8;
 
-  if ((type.type == Type::hist || type.type == Type::lhist || type.type == Type::count ||
+  if (type.type == Type::count && !key.args_.size())
+  {
+    map_type_ = BPF_MAP_TYPE_PERCPU_ARRAY;
+    max_entries = 1;
+    key_size = 4;
+  } else if ((type.type == Type::hist || type.type == Type::lhist || type.type == Type::count ||
       type.type == Type::sum || type.type == Type::min || type.type == Type::max ||
       type.type == Type::avg || type.type == Type::stats) &&
       (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)))


### PR DESCRIPTION
So the code generated for count follows this logic:

```
  val = map_lookup(key)
  if (!val)
    val = 0;
  val += 1
  map_update(key, val)
```
The idea of the change is to skip map_update call and do the 
increase directly in the memory, like:

```
  ptr = map_lookup(key)
  if (!ptr)
    map_update(key, 1)
  else
   *ptr += 1
```

I couldn't find interface to add `inc ptr` or `add ptr` op, 
I only found locked locked increase, which is not necessary for this case, but works ;-)

Any idea if there's interface for non locked add directly in memory?

The newly generated code looks like:
```
0: (b7) r1 = 0 
1: (7b) *(u64 *)(r10 -16) = r1
2: (18) r1 = 0xffff8898052cc800
4: (bf) r2 = r10 
5: (07) r2 += -16 
6: (85) call bpf_map_lookup_elem#1
7: (15) if r0 == 0x0 goto pc+3
```
new in memory increase:
```
8: (b7) r1 = 1 
9: (db) lock *(u64 *)(r0 +0) += r1
10: (05) goto pc+10
```
slow path for first item:
```
11: (b7) r1 = 1 
12: (7b) *(u64 *)(r10 -8) = r1
13: (18) r1 = 0xffff8898052cc800
15: (bf) r2 = r10 
16: (07) r2 += -16 
17: (bf) r3 = r10 
18: (07) r3 += -8
19: (b7) r4 = 0 
20: (85) call bpf_map_update_elem#2
21: (b7) r0 = 0 
22: (95) exit
```