### PR TITLE
Move BTF line in --info to kernel features

### DIFF
--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -5,6 +5,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
+#include "btf.h"
 #include "utils.h"
 
 namespace bpftrace {
@@ -143,6 +144,12 @@ bool BPFfeature::has_loop(void)
   return has_loop();
 }
 
+bool BPFfeature::has_btf(void)
+{
+  BTF btf;
+  return btf.has_data();
+}
+
 int BPFfeature::instruction_limit(void)
 {
   if (insns_limit_.has_value())
@@ -209,7 +216,8 @@ std::string BPFfeature::report(void)
 
   buf << "Kernel features" << std::endl
       << "  Instruction limit: " << instruction_limit() << std::endl
-      << "  Loop support: " << to_str(has_loop()) << std::endl;
+      << "  Loop support: " << to_str(has_loop())
+      << "  btf: " << to_str(has_btf()) << std::endl;
 
   buf << "Map types" << std::endl
       << "  hash: " << to_str(has_map_hash())

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -67,6 +67,7 @@ public:
 
   int instruction_limit();
   bool has_loop();
+  bool has_btf();
 
   std::string report(void);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -132,7 +132,6 @@ static int info()
 {
   struct utsname utsname;
   uname(&utsname);
-  BTF btf;
 
   std::cerr << "System" << std::endl
             << "  OS: " << utsname.sysname << " " << utsname.release << " "
@@ -155,12 +154,6 @@ static int info()
 #else
             << "no" << std::endl;
 #endif
-  std::cerr << "  btf: ";
-  if (btf.has_data())
-    std::cerr << "yes" << std::endl;
-  else
-    std::cerr << "no" << std::endl;
-
   std::cerr << "  bfd: "
 #ifdef HAVE_BFD_DISASM
             << "yes" << std::endl;


### PR DESCRIPTION
Previously it was in the "Build" section. This used to be correct when
"btf" meant something build related but now it's a runtime feature
check.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
