### PR TITLE
snapcraft: limit version string to 32 characters

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -94,7 +94,8 @@ parts:
             version=${description%$sha}
             commits=$(git log --oneline | wc -l)
             date=$(date +'%Y%m%d')
-            snapcraftctl set-version "$version$date-$commits-$sha"
+            version=$(echo $version$date-$commits-$sha | cut -c1-32)
+            snapcraftctl set-version "$version"
         build-packages:
           - bison
           - cmake


### PR DESCRIPTION
Snaps are limited to a 32 character version string, so truncate
overly long version strings.

Signed-off-by: Colin Ian King <colin.king@canonical.com>