### PR TITLE
Support piping scripts through stdin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to
   - [#1274](https://github.com/iovisor/bpftrace/pull/1274)
 - Add support of using positional params in unroll and increase the unroll limit to 100
   - [#1286](https://github.com/iovisor/bpftrace/pull/1286)
+- Support for piping scripts in via stdin
+  - [#1310](https://github.com/iovisor/bpftrace/pull/1310)
 
 #### Changed
 

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -18,6 +18,11 @@ RUN bpftrace non_existent_file.bt
 EXPECT Error opening file 'non_existent_file.bt': No such file or directory
 TIMEOUT 1
 
+NAME piped script
+RUN bpftrace - < runtime/scripts/hello_world.bt
+EXPECT hello world!
+TIMEOUT 1
+
 NAME it lists kprobes
 RUN bpftrace -l | grep kprobes
 EXPECT kprobe

--- a/tests/runtime/scripts/hello_world.bt
+++ b/tests/runtime/scripts/hello_world.bt
@@ -1,0 +1,5 @@
+BEGIN
+{
+    printf("hello world!\n");
+    exit();
+}


### PR DESCRIPTION
For example, you can now do:

    echo 'BEGIN { printf("hello world!\\n") }' | sudo bpftrace -

In other words, you can pipe input to bpftrace now. It's always good to
let people script tools better.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
