### PR TITLE
Cache symbol resolvers by PID

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -91,10 +91,10 @@ int format(char * s, size_t n, const char * fmt, std::vector<std::unique_ptr<IPr
 
 BPFtrace::~BPFtrace()
 {
-  for (const auto& pair : exe_sym_)
+  for (const auto &pair : pid_sym_)
   {
     if (pair.second.second)
-      bcc_free_symcache(pair.second.second, pair.second.first);
+      bcc_free_symcache(pair.second.second, pair.first);
   }
 
   if (ksyms_)
@@ -1756,27 +1756,36 @@ std::string BPFtrace::resolve_usym(uintptr_t addr, int pid, bool show_offset, bo
   symopts.use_debug_file = 1;
   symopts.check_debug_file_crc = 1;
   symopts.use_symbol_type = BCC_SYM_ALL_TYPES;
-
   if (resolve_user_symbols_)
   {
     if (cache_user_symbols_)
     {
-      std::string pid_exe = get_pid_exe(pid);
-      auto itr = exe_sym_.find(pid_exe);
-
-      if (itr != exe_sym_.end() && itr->second.first == pid) {
-        // FIXME check if that's the same process, e.g. ctime on /proc/pid/exe link
-        psyms = exe_sym_[pid_exe].second;
-      }
-
-      if (!psyms) {
-        if (itr != exe_sym_.end()) {
-          bcc_free_symcache(itr->second.second, itr->second.first);
-          exe_sym_.erase(itr);
+      auto itr = pid_sym_.find(pid);
+      if (itr != pid_sym_.end())
+      {
+        // Check if same process (based on creation time)
+        struct timespec ts;
+        if (!get_pid_create_time(pid, &ts) &&
+            !memcmp(&ts, &itr->second.first, sizeof(ts)))
+        {
+          psyms = itr->second.second;
         }
-        // not cached, create new ProcSyms cache
-        psyms = bcc_symcache_new(pid, &symopts);
-        exe_sym_[pid_exe] = std::make_pair(pid, psyms);
+        else
+        {
+          // Time don't match, proc is dead, drop cache
+          bcc_free_symcache(itr->second.second, pid);
+          pid_sym_.erase(itr);
+        }
+      }
+      if (!psyms)
+      {
+        struct timespec ts;
+        if (!get_pid_create_time(pid, &ts))
+        {
+          // not cached, create new ProcSyms cache
+          psyms = bcc_symcache_new(pid, &symopts);
+          pid_sym_[pid] = std::make_pair(ts, psyms);
+        }
       }
     }
     else
@@ -1807,6 +1816,21 @@ std::string BPFtrace::resolve_usym(uintptr_t addr, int pid, bool show_offset, bo
     bcc_free_symcache(psyms, pid);
 
   return symbol.str();
+}
+
+int BPFtrace::get_pid_create_time(int pid, struct timespec *ts)
+{
+  char path[128];
+  int err = snprintf(path, 128, "/proc/%d", pid);
+  struct stat st;
+
+  if (err < 0)
+    return err;
+  path[std::min(err, 128)] = '\0';
+
+  err = lstat(path, &st);
+  *ts = st.st_ctim;
+  return err;
 }
 
 std::string BPFtrace::resolve_probe(uint64_t probe_id) const

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -201,7 +201,8 @@ private:
                         void (*trigger)(void));
   std::vector<std::unique_ptr<AttachedProbe>> attached_probes_;
   void* ksyms_{nullptr};
-  std::map<std::string, std::pair<int, void *>> exe_sym_; // exe -> (pid, cache)
+  std::map<int, std::pair<struct timespec, void *>> pid_sym_; // pid -> (ctime,
+                                                              // cache)
   int ncpus_;
   int online_cpus_;
   std::vector<std::string> params_;
@@ -223,6 +224,8 @@ private:
   static uint64_t read_address_from_output(std::string output);
   std::vector<uint8_t> find_empty_key(IMap &map, size_t size) const;
   static bool is_pid_alive(int pid);
+
+  static int get_pid_create_time(int pid, struct timespec *ts);
 };
 
 } // namespace bpftrace


### PR DESCRIPTION
Symbol resolver cache is currently using executable paths as key, this leads to bad results when enabled with ASLR and bad performance when disabled.
This patch changes the cache a bit to store resolvers by PID.