### PR TITLE
Allow overriding whether usym module is shown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to
   - [#1286](https://github.com/iovisor/bpftrace/pull/1286)
 - Support for piping scripts in via stdin
   - [#1310](https://github.com/iovisor/bpftrace/pull/1310)
+- Add new environment variable `BPFTRACE_SHOW_USER_MODULE`
+  - [#1313] (https://github.com/iovisor/bpftrace/pull/1313)
 
 #### Changed
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -154,6 +154,7 @@ ENVIRONMENT:
     BPFTRACE_CACHE_USER_SYMBOLS [default: auto] enable user symbol cache
     BPFTRACE_VMLINUX            [default: none] vmlinux path used for kernel symbol resolution
     BPFTRACE_BTF                [default: none] BTF file
+    BPFTRACE_SHOW_USER_MODULE [default:0] enables module for userspace symbols
 
 EXAMPLES:
 bpftrace -l '*sleep*'
@@ -495,6 +496,12 @@ Default: None
 
 The path to a BTF file. By default, bpftrace searches several locations to find a BTF file.
 See src/btf.cpp for the details.
+
+### 9.8 `BPFTRACE_SHOW_USER_MODULE`
+
+Default: 0
+
+This controls whether each printed user-space symbol will contain the module it is from.
 
 ## 10. Clang Environment Variables
 

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1787,13 +1787,13 @@ std::string BPFtrace::resolve_usym(uintptr_t addr, int pid, bool show_offset, bo
       symbol << usym.name;
     if (show_offset)
       symbol << "+" << usym.offset;
-    if (show_module)
+    if (show_module || show_user_module_)
       symbol << " (" << usym.module << ")";
   }
   else
   {
     symbol << (void*)addr;
-    if (show_module)
+    if (show_module || show_user_module_)
       symbol << " ([unknown])";
   }
 

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -166,6 +166,7 @@ public:
   bool safe_mode_ = true;
   bool force_btf_ = false;
   bool has_usdt_ = false;
+  bool show_user_module_ = false;
 
   static void sort_by_key(
       std::vector<SizedType> key_args,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -550,6 +550,21 @@ int main(int argc, char *argv[])
                                    !bpftrace.is_aslr_enabled(-1);
   }
 
+  if (const char* env_p = std::getenv("BPFTRACE_SHOW_USER_MODULE"))
+  {
+    if (std::string(env_p) == "1")
+      bpftrace.show_user_module_ = true;
+    else if (std::string(env_p) == "0")
+      bpftrace.show_user_module_ = false;
+    else
+    {
+      std::cerr << "Env var 'BPFTRACE_SHOW_USER_MODULE' did not contain a "
+                   "valid value (0 or 1)."
+                << std::endl;
+      return 1;
+    }
+  }
+
   if (!cmd_str.empty())
     bpftrace.cmd_ = cmd_str;
 


### PR DESCRIPTION
I found it useful to on several occasions to display explicitly where the specific symbol is coming from. This patch allows overriding whether usym module is shown by setting an env variable.