### PR TITLE
Don't print errors to stderr if modprobe isn't found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to
   - [#1310](https://github.com/iovisor/bpftrace/pull/1310)
 - Don't require <linux/types.h> if --btf is specified
   - [#1315](https://github.com/iovisor/bpftrace/pull/1315)
+- Silence errors about `modprobe` not being found
+  - [#1314](https://github.com/iovisor/bpftrace/pull/1314)
 
 #### Changed
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -429,6 +429,9 @@ namespace {
     }
 
     if (::stat("/sys/kernel/kheaders.tar.xz", &stat_buf) != 0) {
+      StderrSilencer silencer;
+      silencer.silence();
+
       FILE* modprobe = ::popen("modprobe kheaders", "w");
       if (modprobe == nullptr || pclose(modprobe) != 0) {
         return "";


### PR DESCRIPTION
This feature was always designed to work opportunistically. So it
follows that it's ok to fail silently.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
