### PR TITLE
Don't rely on <linux/types.h> being present

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to
   - [#1286](https://github.com/iovisor/bpftrace/pull/1286)
 - Support for piping scripts in via stdin
   - [#1310](https://github.com/iovisor/bpftrace/pull/1310)
+- Don't require <linux/types.h> if --btf is specified
+  - [#1315](https://github.com/iovisor/bpftrace/pull/1315)
 
 #### Changed
 


### PR DESCRIPTION
Especially inside containers where kernel headers are not installed,
<linux/types.h> may not be present.

We actually don't need this header at all if the system has BTF support.
We can just get everything from BTF.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
