### PR TITLE
types: Add basic type wrappers

### DIFF
--- a/docs/internals_development.md
+++ b/docs/internals_development.md
@@ -307,9 +307,9 @@ You can imagine now mapping this back, line by line, to IR. Eg:
 Becomes:
 
 ```C++
-  AllocaInst *arg_a_alloc = b_.CreateAllocaBPF(SizedType(Type::integer, 4), "arg_a");
-  AllocaInst *arg_b_alloc = b_.CreateAllocaBPF(SizedType(Type::integer, 4), "arg_b");
-  AllocaInst *sum_alloc = b_.CreateAllocaBPF(SizedType(Type::integer, 4), "sum");
+  AllocaInst *arg_a_alloc = b_.CreateAllocaBPF(CreateUInt32(), "arg_a");
+  AllocaInst *arg_b_alloc = b_.CreateAllocaBPF(CreateUInt32(), "arg_b");
+  AllocaInst *sum_alloc = b_.CreateAllocaBPF(CreateUInt32(), "sum");
 ```
 
 And then:
@@ -449,7 +449,7 @@ index 8eb5744..64c9411 100644
        builtin.ident == "cpu" ||
 +      builtin.ident == "curtask" ||
        builtin.ident == "retval") {
-     builtin.type = SizedType(Type::integer, 8);
+     builtin.type = CreateUInt64();
    }
 diff --git a/src/lexer.l b/src/lexer.l
 index c5996b6..3bec616 100644

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -102,7 +102,7 @@ void CodegenLLVM::visit(Builtin &builtin)
     b_.CreateStore(b_.getInt64(0), key);
 
     auto &map = bpftrace_.elapsed_map_;
-    auto type = SizedType(Type::integer, 8);
+    auto type = CreateUInt64();
     auto start = b_.CreateMapLookupElem(map->mapfd_, key, type);
     expr_ = b_.CreateSub(b_.CreateGetNs(), start);
     // start won't be on stack, no need to LifeTimeEnd it
@@ -1897,7 +1897,7 @@ AllocaInst *CodegenLLVM::getMapKey(Map &map)
   else
   {
     // No map key (e.g., @ = 1;). Use 0 as a key.
-    key = b_.CreateAllocaBPF(SizedType(Type::integer, 8), map.ident + "_key");
+    key = b_.CreateAllocaBPF(CreateUInt64(), map.ident + "_key");
     b_.CreateStore(b_.getInt64(0), key);
   }
   return key;
@@ -1933,7 +1933,7 @@ AllocaInst *CodegenLLVM::getHistMapKey(Map &map, Value *log2)
   }
   else
   {
-    key = b_.CreateAllocaBPF(SizedType(Type::integer, 8), map.ident + "_key");
+    key = b_.CreateAllocaBPF(CreateUInt64(), map.ident + "_key");
     b_.CreateStore(log2, key);
   }
   return key;
@@ -2049,9 +2049,9 @@ void CodegenLLVM::createLog2Function()
 
   // setup n and result registers
   Value *arg = log2_func->arg_begin();
-  Value *n_alloc = b_.CreateAllocaBPF(SizedType(Type::integer, 8));
+  Value *n_alloc = b_.CreateAllocaBPF(CreateUInt64());
   b_.CreateStore(arg, n_alloc);
-  Value *result = b_.CreateAllocaBPF(SizedType(Type::integer, 8));
+  Value *result = b_.CreateAllocaBPF(CreateUInt64());
   b_.CreateStore(b_.getInt64(0), result);
 
   // test for less than zero
@@ -2116,11 +2116,11 @@ void CodegenLLVM::createLinearFunction()
   b_.SetInsertPoint(entry);
 
   // pull in arguments
-  Value *value_alloc = b_.CreateAllocaBPF(SizedType(Type::integer, 8));
-  Value *min_alloc = b_.CreateAllocaBPF(SizedType(Type::integer, 8));
-  Value *max_alloc = b_.CreateAllocaBPF(SizedType(Type::integer, 8));
-  Value *step_alloc = b_.CreateAllocaBPF(SizedType(Type::integer, 8));
-  Value *result_alloc = b_.CreateAllocaBPF(SizedType(Type::integer, 8));
+  Value *value_alloc = b_.CreateAllocaBPF(CreateUInt64());
+  Value *min_alloc = b_.CreateAllocaBPF(CreateUInt64());
+  Value *max_alloc = b_.CreateAllocaBPF(CreateUInt64());
+  Value *step_alloc = b_.CreateAllocaBPF(CreateUInt64());
+  Value *result_alloc = b_.CreateAllocaBPF(CreateUInt64());
   Value *value = linear_func->arg_begin()+0;
   Value *min = linear_func->arg_begin()+1;
   Value *max = linear_func->arg_begin()+2;

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -83,7 +83,7 @@ private:
   bool check_arg(const Call &call, Type type, int arg_num, bool want_literal=false);
   bool check_symbol(const Call &call, int arg_num);
 
-  void check_stack_call(Call &call, Type type);
+  void check_stack_call(Call &call, bool kernel);
   void error(const std::string &msg, const location &loc);
   void warning(const std::string &msg, const location &loc);
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -1,5 +1,6 @@
-#include <iostream>
 #include <algorithm>
+#include <cassert>
+#include <iostream>
 
 #include "types.h"
 
@@ -169,4 +170,181 @@ uint64_t asyncactionint(AsyncAction a)
   return (uint64_t)a;
 }
 
+// Type wrappers
+SizedType CreateInteger(size_t bits, bool is_signed)
+{
+  assert(bits == 8 || bits == 16 || bits == 32 || bits == 64);
+  return SizedType(Type::integer, bits / 8, is_signed);
+}
+
+SizedType CreateInt(size_t bits)
+{
+  return CreateInteger(bits, true);
+};
+
+SizedType CreateUInt(size_t bits)
+{
+  return CreateInteger(bits, false);
+}
+
+SizedType CreateInt8()
+{
+  return CreateInt(8);
+}
+
+SizedType CreateInt16()
+{
+  return CreateInt(16);
+}
+
+SizedType CreateInt32()
+{
+  return CreateInt(32);
+}
+
+SizedType CreateInt64()
+{
+  return CreateInt(64);
+}
+
+SizedType CreateUInt8()
+{
+  return CreateUInt(8);
+}
+
+SizedType CreateUInt16()
+{
+  return CreateUInt(16);
+}
+
+SizedType CreateUInt32()
+{
+  return CreateUInt(32);
+}
+
+SizedType CreateUInt64()
+{
+  return CreateUInt(64);
+}
+
+SizedType CreateString(size_t size)
+{
+  return SizedType(Type::string, size);
+}
+
+SizedType CreateNone()
+{
+  return SizedType(Type::none, 0);
+}
+
+SizedType CreateStackMode()
+{
+  return SizedType(Type::stack_mode, 0);
+}
+
+SizedType CreateCast(size_t size, std::string name)
+{
+  assert(size % 8 == 0);
+  return SizedType(Type::cast, size / 8, name);
+}
+
+SizedType CreateCTX(size_t size, std::string name)
+{
+  return SizedType(Type::ctx, size, name);
+}
+
+SizedType CreateArray(size_t num_elem,
+                      Type elem_type,
+                      size_t elem_size,
+                      bool elem_is_signed)
+{
+  auto ty = SizedType(Type::array, num_elem, elem_is_signed);
+  ty.elem_type = elem_type;
+  ty.pointee_size = elem_size;
+  return ty;
+}
+
+SizedType CreateStack(bool kernel, StackType stack)
+{
+  auto st = SizedType(kernel ? Type::kstack : Type::ustack, 8);
+  st.stack_type = stack;
+  return st;
+}
+
+SizedType CreateMin(bool is_signed)
+{
+  return SizedType(Type::min, 8, is_signed);
+}
+
+SizedType CreateMax(bool is_signed)
+{
+  return SizedType(Type::max, 8, is_signed);
+}
+
+SizedType CreateSum(bool is_signed)
+{
+  return SizedType(Type::sum, 8, is_signed);
+}
+
+SizedType CreateCount(bool is_signed)
+{
+  return SizedType(Type::count, 8, is_signed);
+}
+
+SizedType CreateAvg(bool is_signed)
+{
+  return SizedType(Type::avg, 8, is_signed);
+}
+
+SizedType CreateStats(bool is_signed)
+{
+  return SizedType(Type::stats, 8, is_signed);
+}
+
+SizedType CreateProbe()
+{
+  return SizedType(Type::probe, 8);
+}
+
+SizedType CreateUsername()
+{
+  return SizedType(Type::username, 8);
+}
+
+SizedType CreateInet(size_t size)
+{
+  auto st = SizedType(Type::inet, size);
+  st.is_internal = true;
+  return st;
+}
+
+SizedType CreateLhist()
+{
+  return SizedType(Type::lhist, 8);
+}
+
+SizedType CreateHist()
+{
+  return SizedType(Type::hist, 8);
+}
+
+SizedType CreateUSym()
+{
+  return SizedType(Type::usym, 16);
+}
+
+SizedType CreateKSym()
+{
+  return SizedType(Type::ksym, 8);
+}
+
+SizedType CreateJoin(size_t argnum, size_t argsize)
+{
+  return SizedType(Type::join, 8 + 8 + argnum * argsize);
+}
+
+SizedType CreateBuffer(size_t size)
+{
+  return SizedType(Type::buffer, size);
+}
 } // namespace bpftrace

--- a/src/types.h
+++ b/src/types.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <memory>
 #include <ostream>
 #include <sstream>
 #include <string>
@@ -41,6 +42,7 @@ enum class Type
   array,
   // BPF program context; needing a different access method to satisfy the verifier
   ctx,
+  record, // struct or union
   buffer,
   // clang-format on
 };
@@ -78,14 +80,10 @@ struct SizedType
   {
   }
 
-  SizedType(Type type, StackType stack_type_) : SizedType(type, 8)
-  {
-    stack_type = stack_type_;
-  }
   Type type;
   Type elem_type = Type::none; // Array element type if accessing elements of an
                                // array
-  size_t size;
+  size_t size;                 // in bytes
   StackType stack_type;
   bool is_signed = false;
   std::string cast_type;
@@ -103,6 +101,49 @@ struct SizedType
   bool operator==(const SizedType &t) const;
   bool operator!=(const SizedType &t) const;
 };
+// Type helpers
+
+SizedType CreateNone();
+SizedType CreateInteger(size_t bits, bool is_signed);
+SizedType CreateInt(size_t bits);
+SizedType CreateUInt(size_t bits);
+SizedType CreateInt8();
+SizedType CreateInt16();
+SizedType CreateInt32();
+SizedType CreateInt64();
+SizedType CreateUInt8();
+SizedType CreateUInt16();
+SizedType CreateUInt32();
+SizedType CreateUInt64();
+
+SizedType CreateString(size_t size);
+SizedType CreateArray(size_t num_elem,
+                      Type elem_type,
+                      size_t elem_size,
+                      bool elem_is_signed);
+
+SizedType CreateStackMode();
+SizedType CreateStack(bool kernel, StackType st = StackType());
+
+// Size in bits
+SizedType CreateCast(size_t size, std::string name = "");
+SizedType CreateCTX(size_t size, std::string name);
+
+SizedType CreateMin(bool is_signed);
+SizedType CreateMax(bool is_signed);
+SizedType CreateSum(bool is_signed);
+SizedType CreateCount(bool is_signed);
+SizedType CreateAvg(bool is_signed);
+SizedType CreateStats(bool is_signed);
+SizedType CreateProbe();
+SizedType CreateUsername();
+SizedType CreateInet(size_t size);
+SizedType CreateLhist();
+SizedType CreateHist();
+SizedType CreateUSym();
+SizedType CreateKSym();
+SizedType CreateJoin(size_t argnum, size_t argsize);
+SizedType CreateBuffer(size_t size);
 
 std::ostream &operator<<(std::ostream &os, const SizedType &type);
 
@@ -218,4 +259,5 @@ struct hash<bpftrace::StackType>
     }
   }
 };
+
 } // namespace std

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -734,7 +734,7 @@ TEST(bpftrace, sort_by_key_int)
 {
   StrictMock<MockBPFtrace> bpftrace;
 
-  std::vector<SizedType> key_args = { SizedType(Type::integer, 8) };
+  std::vector<SizedType> key_args = { CreateUInt64() };
   std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> values_by_key =
   {
     key_value_pair_int({2}, 12),
@@ -758,9 +758,9 @@ TEST(bpftrace, sort_by_key_int_int)
   StrictMock<MockBPFtrace> bpftrace;
 
   std::vector<SizedType> key_args = {
-    SizedType(Type::integer, 8),
-    SizedType(Type::integer, 8),
-    SizedType(Type::integer, 8),
+    CreateUInt64(),
+    CreateUInt64(),
+    CreateUInt64(),
   };
   std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> values_by_key =
   {
@@ -791,7 +791,7 @@ TEST(bpftrace, sort_by_key_str)
   StrictMock<MockBPFtrace> bpftrace;
 
   std::vector<SizedType> key_args = {
-    SizedType(Type::string, STRING_SIZE),
+    CreateString(STRING_SIZE),
   };
   std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> values_by_key =
   {
@@ -818,9 +818,9 @@ TEST(bpftrace, sort_by_key_str_str)
   StrictMock<MockBPFtrace> bpftrace;
 
   std::vector<SizedType> key_args = {
-    SizedType(Type::string, STRING_SIZE),
-    SizedType(Type::string, STRING_SIZE),
-    SizedType(Type::string, STRING_SIZE),
+    CreateString(STRING_SIZE),
+    CreateString(STRING_SIZE),
+    CreateString(STRING_SIZE),
   };
   std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> values_by_key =
   {
@@ -851,8 +851,8 @@ TEST(bpftrace, sort_by_key_int_str)
   StrictMock<MockBPFtrace> bpftrace;
 
   std::vector<SizedType> key_args = {
-    SizedType(Type::integer, 8),
-    SizedType(Type::string, STRING_SIZE),
+    CreateUInt64(),
+    CreateString(STRING_SIZE),
   };
   std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> values_by_key =
   {

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -55,30 +55,29 @@ void setup_mock_bpftrace(MockBPFtrace &bpftrace)
       });
 
   // Fill in some default tracepoint struct definitions
-  bpftrace.structs_["struct _tracepoint_sched_sched_one"] = Struct
-  {
+  bpftrace.structs_["struct _tracepoint_sched_sched_one"] = Struct{
     .size = 8,
-    .fields = {{"common_field", Field
-      {
-        .type = SizedType(Type::integer, 8, false),
-        .offset = 8,
-        .is_bitfield = false,
-        .bitfield = {},
-      }}},
+    .fields = { { "common_field",
+                  Field{
+                      .type = CreateUInt64(),
+                      .offset = 8,
+                      .is_bitfield = false,
+                      .bitfield = {},
+                  } } },
   };
-  bpftrace.structs_["struct _tracepoint_sched_sched_two"] = Struct
-  {
+  bpftrace.structs_["struct _tracepoint_sched_sched_two"] = Struct{
     .size = 8,
-    .fields = {{"common_field", Field
-      {
-        .type = SizedType(Type::integer, 8, false),
-        .offset = 16, // different offset than sched_one.common_field
-        .is_bitfield = false,
-        .bitfield = {},
-      }}},
+    .fields = { { "common_field",
+                  Field{
+                      .type = CreateUInt64(),
+                      .offset = 16, // different offset than
+                                    // sched_one.common_field
+                      .is_bitfield = false,
+                      .bitfield = {},
+                  } } },
   };
 
-  auto ptr_type = SizedType(Type::integer, 8, false);
+  auto ptr_type = CreateUInt64();
   ptr_type.is_pointer = true;
   ptr_type.pointee_size = 1;
   bpftrace.structs_["struct _tracepoint_file_filename"] = Struct{


### PR DESCRIPTION
`SizedType` is getting a bit unwieldy. It has a lot of fields that are only relevant for a single type and which one is used where isn't clear. This leads to confusion and (not so)subtle bugs.

This creates a set of `SizedType` "factories" which make creating types easier. Instead of manually creating a sizedtype and setting it's fields this provides an interface, removing the confusion about which field to set.

This is just the "easy" part with the simple types, doing these first will remove a lot of noise from the follow up PRs which deal with the complexer types (cast/pointers, ctx etc).

#878 


##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
