### PR TITLE
Add --usdt-file-activation to activate USDT semaphores by filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to
   - [#1318](https://github.com/iovisor/bpftrace/pull/1318)
 - Add environment variable, BPFTRACE_PERF_RB_PAGES, to tune perf ring buffer size
   - [#1329](https://github.com/iovisor/bpftrace/pull/1329)
+- Add --usdt-file-activation to activate usdt semaphores by file name
+  - [#1317](https://github.com/iovisor/bpftrace/pull/1317)
 
 #### Changed
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1204,6 +1204,16 @@ the probe to be found, regardless of the name of the binary:
 bpftrace -e 'usdt:/root/tock:tick:loop { printf("hi\n"); }'
 ```
 
+bpftrace also supports USDT semaphores. You may activate semaphores by passing in `-p $PID` or
+`--usdt-file-activation`. `--usdt-file-activation` looks through `/proc` to find processes that
+have your probe's binary mapped with executable permissions into their address space and then tries
+to attach your probe. Note that file activation occurs only once (during attach time). In other
+words, if later during your tracing session a new process with your executable is spawned, your
+current tracing session will not activate the new process. Also note that `--usdt-file-activation`
+matches based on file path. This means that if bpftrace runs from the root host, things may not work
+as expected if there are processes `execve`d from private mount namespaces or bind mounted directories.
+One workaround is to run bpftrace inside the appropriate namespaces (ie the container).
+
 ## 8. `usdt`: Static Tracing, User-Level Arguments
 
 Examples:

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -822,7 +822,13 @@ void AttachedProbe::attach_usdt(int pid)
 #endif
 
   if (err)
-    throw std::runtime_error("Error finding or enabling probe: " + probe_.name);
+  {
+    std::string err;
+    err += "Error finding or enabling probe: " + probe_.name;
+    err += '\n';
+    err += "Try using -p or --usdt-file-activation if there's USDT semaphores";
+    throw std::runtime_error(err);
+  }
 
   auto u = USDTHelper::find(pid, probe_.path, probe_.ns, probe_.attach_point);
   probe_.path = std::get<USDT_PATH_INDEX>(u);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -167,6 +167,7 @@ public:
   bool safe_mode_ = true;
   bool force_btf_ = false;
   bool has_usdt_ = false;
+  bool usdt_file_activation_ = false;
 
   static void sort_by_key(
       std::vector<SizedType> key_args,

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -217,8 +217,9 @@ private:
   std::string src_;
   std::string filename_;
 
-  std::unique_ptr<AttachedProbe> attach_probe(Probe &probe,
-                                              const BpfOrc &bpforc);
+  std::vector<std::unique_ptr<AttachedProbe>> attach_probe(
+      Probe &probe,
+      const BpfOrc &bpforc);
   int setup_perf_events();
   void poll_perf_events(int epollfd, bool drain = false);
   int print_map_hist(IMap &map, uint32_t top, uint32_t div);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -217,6 +217,11 @@ private:
   std::string src_;
   std::string filename_;
 
+  std::vector<std::unique_ptr<AttachedProbe>> attach_usdt_probe(
+      Probe &probe,
+      std::tuple<uint8_t *, uintptr_t> func,
+      int pid,
+      bool file_activation);
   std::vector<std::unique_ptr<AttachedProbe>> attach_probe(
       Probe &probe,
       const BpfOrc &bpforc);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -57,6 +57,8 @@ void usage()
   std::cerr << "    -l [search]    list probes" << std::endl;
   std::cerr << "    -p PID         enable USDT probes on PID" << std::endl;
   std::cerr << "    -c 'CMD'       run CMD and enable USDT probes on resulting process" << std::endl;
+  std::cerr << "    --usdt-file-activation" << std::endl;
+  std::cerr << "                   activate usdt semaphores based on file path" << std::endl;
   std::cerr << "    --unsafe       allow unsafe builtin functions" << std::endl;
   std::cerr << "    -v             verbose messages" << std::endl;
   std::cerr << "    --info         Print information about kernel BPF support" << std::endl;
@@ -186,6 +188,7 @@ int main(int argc, char *argv[])
   bool listing = false;
   bool safe_mode = true;
   bool force_btf = false;
+  bool usdt_file_activation = false;
   std::string script, search, file_name, output_file, output_format;
   OutputBufferConfig obc = OutputBufferConfig::UNSET;
   int c;
@@ -194,6 +197,7 @@ int main(int argc, char *argv[])
   option long_options[] = {
     option{ "help", no_argument, nullptr, 'h' },
     option{ "version", no_argument, nullptr, 'V' },
+    option{ "usdt-file-activation", no_argument, nullptr, '$' },
     option{ "unsafe", no_argument, nullptr, 'u' },
     option{ "btf", no_argument, nullptr, 'b' },
     option{ "include", required_argument, nullptr, '#' },
@@ -257,6 +261,9 @@ int main(int argc, char *argv[])
         break;
       case 'c':
         cmd_str = optarg;
+        break;
+      case '$':
+        usdt_file_activation = true;
         break;
       case 'u':
         safe_mode = false;
@@ -339,6 +346,7 @@ int main(int argc, char *argv[])
   BPFtrace bpftrace(std::move(output));
   Driver driver(bpftrace);
 
+  bpftrace.usdt_file_activation_ = usdt_file_activation;
   bpftrace.safe_mode_ = safe_mode;
   bpftrace.force_btf_ = force_btf;
 

--- a/tests/runtime/scripts/usdt_file_activation_multiprocess.bt
+++ b/tests/runtime/scripts/usdt_file_activation_multiprocess.bt
@@ -1,0 +1,28 @@
+BEGIN
+{
+    @count = 0;
+}
+
+usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe
+{
+    // Ensure each process only increments @count once
+    if (@pids[pid] == 0)
+    {
+        @count++;
+        @pids[pid] = 1;
+    }
+
+    // Hacky, but easiest way to get script to exit quickly for tests
+    if (@count == 2)
+    {
+        exit();
+    }
+}
+
+END
+{
+    printf("found %d processes\n", @count);
+
+    clear(@pids);
+    clear(@count);
+}

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -176,6 +176,25 @@ TIMEOUT 5
 BEFORE ./testprogs/usdt_semaphore_test
 REQUIRES ./testprogs/usdt_semaphore_test should_not_skip
 
+NAME "usdt probes - file based semaphore activation"
+RUN bpftrace -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }' --usdt-file-activation
+EXPECT tracetest_testprobe_semaphore: 1
+TIMEOUT 5
+BEFORE ./testprogs/usdt_semaphore_test
+REQUIRES ./testprogs/usdt_semaphore_test should_not_skip
+
+NAME "usdt probes - file based semaphore activation no process"
+RUN bpftrace -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { exit(); }' --usdt-file-activation
+EXPECT Failed to find processes running
+TIMEOUT 5
+
+NAME "usdt probes - file based semaphore activation multi process"
+RUN bpftrace -v runtime/scripts/usdt_file_activation_multiprocess.bt --usdt-file-activation
+EXPECT found 2 processes
+TIMEOUT 5
+BEFORE ./testprogs/usdt_semaphore_test & ./testprogs/usdt_semaphore_test
+REQUIRES ./testprogs/usdt_semaphore_test should_not_skip
+
 NAME "usdt probes - list probes by pid in separate mountns"
 RUN bpftrace -l 'usdt:*' -p $(pidof usdt_test)
 EXPECT usdt:.*/tmp/bpftrace-unshare-mountns-test/usdt_test:tracetest:testprobe


### PR DESCRIPTION
This PR implements USDT semaphore probe activation. Previously, you had
to pass in `-p $PID` or `-c $CMD` to activate usdt semaphores on a process.
This has the limitation of single binaries. It's also difficult to make work in a
distributed tracing environment where you don't know the PIDs beforehand are
attaching to running processes.

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
