### PR TITLE
btf: Do not use <linux/types.h> for resolving tracepoint defs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to
   - [#1315](https://github.com/iovisor/bpftrace/pull/1315)
 - Silence errors about `modprobe` not being found
   - [#1314](https://github.com/iovisor/bpftrace/pull/1314)
+- With --btf, do not use <linux/types.h> for resolving tracepoint defs
+  - [#1318](https://github.com/iovisor/bpftrace/pull/1318)
 
 #### Changed
 

--- a/src/tracepoint_format_parser.h
+++ b/src/tracepoint_format_parser.h
@@ -135,7 +135,9 @@ public:
                                      const std::string &event_name);
 
 private:
-  static std::string parse_field(const std::string &line, int *last_offset);
+  static std::string parse_field(const std::string &line,
+                                 int *last_offset,
+                                 BPFtrace &bpftrace);
   static std::string adjust_integer_types(const std::string &field_type,
                                           int size);
   static std::set<std::string> struct_list;
@@ -143,7 +145,8 @@ private:
 protected:
   static std::string get_tracepoint_struct(std::istream &format_file,
                                            const std::string &category,
-                                           const std::string &event_name);
+                                           const std::string &event_name,
+                                           BPFtrace &bpftrace);
 };
 
 } // namespace bpftrace

--- a/tests/tracepoint_format_parser.cpp
+++ b/tests/tracepoint_format_parser.cpp
@@ -1,5 +1,8 @@
-#include "gtest/gtest.h"
 #include "tracepoint_format_parser.h"
+#include "mocks.h"
+#include "gtest/gtest.h"
+
+using namespace testing;
 
 namespace bpftrace {
 namespace test {
@@ -8,9 +11,12 @@ namespace tracepoint_format_parser {
 class MockTracepointFormatParser : public TracepointFormatParser
 {
 public:
-  static std::string get_tracepoint_struct_public(std::istream &format_file, const std::string &category, const std::string &event_name)
+  static std::string get_tracepoint_struct_public(std::istream &format_file,
+                                                  const std::string &category,
+                                                  const std::string &event_name,
+                                                  BPFtrace &bpftrace)
   {
-    return get_tracepoint_struct(format_file, category, event_name);
+    return get_tracepoint_struct(format_file, category, event_name, bpftrace);
   }
 };
 
@@ -50,7 +56,9 @@ TEST(tracepoint_format_parser, tracepoint_struct)
 
   std::istringstream format_file(input);
 
-  std::string result = MockTracepointFormatParser::get_tracepoint_struct_public(format_file, "syscalls", "sys_enter_read");
+  MockBPFtrace bpftrace;
+  std::string result = MockTracepointFormatParser::get_tracepoint_struct_public(
+      format_file, "syscalls", "sys_enter_read", bpftrace);
 
   EXPECT_EQ(expected, result);
 }
@@ -70,7 +78,9 @@ TEST(tracepoint_format_parser, array)
 
   std::istringstream format_file(input);
 
-  std::string result = MockTracepointFormatParser::get_tracepoint_struct_public(format_file, "syscalls", "sys_enter_read");
+  MockBPFtrace bpftrace;
+  std::string result = MockTracepointFormatParser::get_tracepoint_struct_public(
+      format_file, "syscalls", "sys_enter_read", bpftrace);
 
   EXPECT_EQ(expected, result);
 }
@@ -87,7 +97,9 @@ TEST(tracepoint_format_parser, data_loc)
 
   std::istringstream format_file(input);
 
-  std::string result = MockTracepointFormatParser::get_tracepoint_struct_public(format_file, "syscalls", "sys_enter_read");
+  MockBPFtrace bpftrace;
+  std::string result = MockTracepointFormatParser::get_tracepoint_struct_public(
+      format_file, "syscalls", "sys_enter_read", bpftrace);
 
   EXPECT_EQ(expected, result);
 }
@@ -147,7 +159,9 @@ TEST(tracepoint_format_parser, adjust_integer_types)
 
   std::istringstream format_file(input);
 
-  std::string result = MockTracepointFormatParser::get_tracepoint_struct_public(format_file, "syscalls", "sys_enter_read");
+  MockBPFtrace bpftrace;
+  std::string result = MockTracepointFormatParser::get_tracepoint_struct_public(
+      format_file, "syscalls", "sys_enter_read", bpftrace);
 
   EXPECT_EQ(expected, result);
 }
@@ -192,10 +206,49 @@ TEST(tracepoint_format_parser, padding)
 
   std::istringstream format_file(input);
 
+  MockBPFtrace bpftrace;
   std::string result = MockTracepointFormatParser::get_tracepoint_struct_public(
-      format_file, "sched", "sched_wakeup");
+      format_file, "sched", "sched_wakeup", bpftrace);
 
   EXPECT_EQ(expected, result);
+}
+
+TEST(tracepoint_format_parser, tracepoint_struct_btf)
+{
+  std::string input =
+      "name: sys_enter_read\n"
+      "ID: 650\n"
+      "format:\n"
+      "	field:unsigned short common_type;	offset:0;	size:2;	"
+      "signed:0;\n"
+      "	field:unsigned char common_flags;	offset:2;	size:1;	"
+      "signed:0;\n"
+      "	field:unsigned char common_preempt_count;	offset:3;	"
+      "size:1;	signed:0;\n"
+      "	field:int common_pid;	offset:4;	size:4;	signed:1;\n"
+      "\n"
+      "	field:int __syscall_nr;	offset:8;	size:4;	signed:1;\n"
+      "	field:unsigned int fd;	offset:16;	size:8;	signed:0;\n"
+      "	field:char * buf;	offset:24;	size:8;	signed:0;\n"
+      "	field:size_t count;	offset:32;	size:8;	signed:0;\n"
+      "\n"
+      "print fmt: \"fd: 0x%08lx, buf: 0x%08lx, count: 0x%08lx\", ((unsigned "
+      "long)(REC->fd)), ((unsigned long)(REC->buf)), ((unsigned "
+      "long)(REC->count))\n";
+
+  std::istringstream format_file(input);
+
+  MockBPFtrace bpftrace;
+  std::string result = MockTracepointFormatParser::get_tracepoint_struct_public(
+      format_file, "syscalls", "sys_enter_read", bpftrace);
+
+  // Check that BTF types are populated
+  EXPECT_THAT(bpftrace.btf_set_, Contains("unsigned short"));
+  EXPECT_THAT(bpftrace.btf_set_, Contains("unsigned char"));
+  EXPECT_THAT(bpftrace.btf_set_, Contains("int"));
+  EXPECT_THAT(bpftrace.btf_set_, Contains("u64"));
+  EXPECT_THAT(bpftrace.btf_set_, Contains("char *"));
+  EXPECT_THAT(bpftrace.btf_set_, Contains("size_t"));
 }
 
 } // namespace tracepoint_format_parser


### PR DESCRIPTION
Passing --btf should mean bpftrace does not use system headers at all.
The only exception should be if the user manually does an `#include`.

To that end, this patch has TracepointFormatParser use the existing
BTF infrastructure to resolve basic types we used to get from
<linux/types.h> instead of doing header inclusions.

This is particularly important in container environments where kernel
headers may not be installed.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
