### PR TITLE
types: Fix abort in semantic analysis

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -173,7 +173,11 @@ uint64_t asyncactionint(AsyncAction a)
 // Type wrappers
 SizedType CreateInteger(size_t bits, bool is_signed)
 {
-  assert(bits == 8 || bits == 16 || bits == 32 || bits == 64);
+  // Zero sized integers are not usually valid. However, during semantic
+  // analysis when we're inferring types, the first pass may not have
+  // enough information to figure out the exact size of the integer. Later
+  // passes infer the exact size.
+  assert(bits == 0 || bits == 8 || bits == 16 || bits == 32 || bits == 64);
   return SizedType(Type::integer, bits / 8, is_signed);
 }
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1635,6 +1635,16 @@ TEST(semantic_analyser, type_ctx)
   test(driver, "t:sched:sched_one { @ = (uint64)ctx; }", 1);
 }
 
+TEST(semantic_analyser, multi_pass_type_inference_zero_size_int)
+{
+  auto bpftrace = get_mock_bpftrace();
+  // The first pass on processing the Unop does not have enough information
+  // to figure out size of `@i` yet. The analyzer figures out the size
+  // after seeing the `@i++`. On the second pass the correct size is
+  // determined.
+  test(*bpftrace, "BEGIN { if (!@i) { @i++; } }", 0);
+}
+
 #ifdef HAVE_LIBBPF_BTF_DUMP
 
 #include "btf_common.h"


### PR DESCRIPTION
Commit f68ef85005c ("types: Add basic type wrappers") added an assert
for integer sizes. However, it's possible during the first pass of
semantic analysis that integer size is unknown. On later passes the
correct size is determined.

The easy fix is to allow 0 sized integers and rely on the fact that
another error check later will catch the invalid integer if a zero sized
integer actually manages to get through semantic analysis.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
