### PR TITLE
Docs: Fix broken link in reference guide intro

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1,7 +1,7 @@
 # bpftrace Reference Guide
 
 For a reference summary, see the [README.md](../README.md) for the sections on
-[Probe types](../README.md#probe-types) as well as the [probes](#probes), [variable builtins](#1-builtins), and [function builtins](#1-builtins-1) sections in this guide.
+[Probe types](../README.md#probe-types) as well as the [Probes](#probes), [Variable builtins](#1-builtins), and [Function builtins](#1-builtins-1) sections in this guide.
 
 This is a work in progress. If something is missing, check the bpftrace source to see if these docs are
 just out of date. And if you find something, please file an issue or pull request to update these docs.

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1,7 +1,7 @@
 # bpftrace Reference Guide
 
 For a reference summary, see the [README.md](../README.md) for the sections on
-[Probe types](../README.md#probe-types) and [Builtins](../README.md#builtins).
+[Probe types](../README.md#probe-types) as well as the [probes](#probes), [variable builtins](#1-builtins), and [function builtins](#1-builtins-1) sections in this guide.
 
 This is a work in progress. If something is missing, check the bpftrace source to see if these docs are
 just out of date. And if you find something, please file an issue or pull request to update these docs.


### PR DESCRIPTION
The "Builtins" list was removed from the readme a while ago, but we can link to the helpful lists in the ref guide.

### Checklist

- [X] Language changes are updated in docs/reference_guide.md
- [X] User-visible and non-trivial changes updated in CHANGELOG.md