### PR TITLE
bpftrace: Fix usdt reads in various architecture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to
   - [#1241](https://github.com/iovisor/bpftrace/pull/1241)
 - Type check the `cond` of if and ternary statements
   - [#1229](https://github.com/iovisor/bpftrace/pull/1229)
+- Fix usdt reads in various architecture
+  - [#1325](https://github.com/iovisor/bpftrace/pull/1325)
 
 #### Tools
 

--- a/src/arch/ppc64.cpp
+++ b/src/arch/ppc64.cpp
@@ -2,7 +2,10 @@
 
 #include <algorithm>
 #include <array>
+#include <set>
+#include <vector>
 
+#define ARG_REGISTERS 8
 // For little endian 64 bit, sp + 32 + 8 regs save area + argX
 #define ARG0_STACK_LE 96
 // For big endian 64 bit, sp + 48 + 8 regs save area + argX
@@ -12,54 +15,54 @@ namespace bpftrace {
 namespace arch {
 
 // clang-format off
-static std::array<std::string, 44> registers = {
-  "r0",
-  "r1",
-  "r2",
-  "r3",
-  "r4",
-  "r5",
-  "r6",
-  "r7",
-  "r8",
-  "r9",
-  "r10",
-  "r11",
-  "r12",
-  "r13",
-  "r14",
-  "r15",
-  "r16",
-  "r17",
-  "r18",
-  "r19",
-  "r20",
-  "r21",
-  "r22",
-  "r23",
-  "r24",
-  "r25",
-  "r26",
-  "r27",
-  "r28",
-  "r29",
-  "r30",
-  "r31",
-  "nip",
-  "msr",
-  "orig_gpr3",
-  "ctr",
-  "link",
-  "xer",
-  "ccr",
-  "softe",
-  "trap",
-  "dar",
-  "dsisr",
-  "result",
+static std::vector<std::set<std::string>> registers = {
+  { "r0", "gpr[0]" },
+  { "r1", "gpr[1]" },
+  { "r2", "gpr[2]" },
+  { "r3", "gpr[3]" },
+  { "r4", "gpr[4]" },
+  { "r5", "gpr[5]" },
+  { "r6", "gpr[6]" },
+  { "r7", "gpr[7]" },
+  { "r8", "gpr[8]" },
+  { "r9", "gpr[9]" },
+  { "r10", "gpr[10]" },
+  { "r11", "gpr[11]" },
+  { "r12", "gpr[12]" },
+  { "r13", "gpr[13]" },
+  { "r14", "gpr[14]" },
+  { "r15", "gpr[15]" },
+  { "r16", "gpr[16]" },
+  { "r17", "gpr[17]" },
+  { "r18", "gpr[18]" },
+  { "r19", "gpr[19]" },
+  { "r20", "gpr[20]" },
+  { "r21", "gpr[21]" },
+  { "r22", "gpr[22]" },
+  { "r23", "gpr[23]" },
+  { "r24", "gpr[24]" },
+  { "r25", "gpr[25]" },
+  { "r26", "gpr[26]" },
+  { "r27", "gpr[27]" },
+  { "r28", "gpr[28]" },
+  { "r29", "gpr[29]" },
+  { "r30", "gpr[30]" },
+  { "r31", "gpr[31]" },
+  { "nip" },
+  { "msr" },
+  { "orig_gpr3" },
+  { "ctr" },
+  { "link" },
+  { "xer" },
+  { "ccr" },
+  { "softe" },
+  { "trap" },
+  { "dar" },
+  { "dsisr" },
+  { "result" },
 };
 
-static std::array<std::string, 8> arg_registers = {
+static std::array<std::string, ARG_REGISTERS> arg_registers = {
   "r3",
   "r4",
   "r5",
@@ -73,10 +76,12 @@ static std::array<std::string, 8> arg_registers = {
 
 int offset(std::string reg_name)
 {
-  auto it = find(registers.begin(), registers.end(), reg_name);
-  if (it == registers.end())
-    return -1;
-  return distance(registers.begin(), it);
+  for (unsigned int i = 0; i < registers.size(); i++)
+  {
+    if (registers[i].count(reg_name))
+      return i;
+  }
+  return -1;
 }
 
 int max_arg()

--- a/src/arch/s390.cpp
+++ b/src/arch/s390.cpp
@@ -2,8 +2,9 @@
 
 #include <algorithm>
 #include <array>
+#include <set>
+#include <vector>
 
-#define REQ_REGISTERS 19
 #define ARG_REGISTERS 5
 // For s390x, r2-r6 registers are used as function arguments, then the extra
 // arguments can be found starting at sp+160
@@ -13,28 +14,28 @@ namespace bpftrace {
 namespace arch {
 
 // clang-format off
-static std::array<std::string, REQ_REGISTERS> registers = {
+static std::vector<std::set<std::string>> registers = {
   // Breakpoint event address
-  "arg",
-  "pswmask",
+  { "arg" },
+  { "pswmask" },
   // Instruction address
-  "pswaddr",
-  "r0",
-  "r1",
-  "r2",
-  "r3",
-  "r4",
-  "r5",
-  "r6",
-  "r7",
-  "r8",
-  "r9",
-  "r10",
-  "r11",
-  "r12",
-  "r13",
-  "r14",
-  "r15",
+  { "pswaddr" },
+  { "r0", "gprs[0]" },
+  { "r1", "gprs[1]" },
+  { "r2", "gprs[2]" },
+  { "r3", "gprs[3]" },
+  { "r4", "gprs[4]" },
+  { "r5", "gprs[5]" },
+  { "r6", "gprs[6]" },
+  { "r7", "gprs[7]" },
+  { "r8", "gprs[8]" },
+  { "r9", "gprs[9]" },
+  { "r10", "gprs[10]" },
+  { "r11", "gprs[11]" },
+  { "r12", "gprs[12]" },
+  { "r13", "gprs[13]" },
+  { "r14", "gprs[14]" },
+  { "r15", "gprs[15]" }
 };
 
 static std::array<std::string, ARG_REGISTERS> arg_registers = {
@@ -48,10 +49,12 @@ static std::array<std::string, ARG_REGISTERS> arg_registers = {
 
 int offset(std::string reg_name)
 {
-  auto it = find(registers.begin(), registers.end(), reg_name);
-  if (it == registers.end())
-    return -1;
-  return distance(registers.begin(), it);
+  for (unsigned int i = 0; i < registers.size(); i++)
+  {
+    if (registers[i].count(reg_name))
+      return i;
+  }
+  return -1;
 }
 
 int max_arg()


### PR DESCRIPTION
In USDT tracing, bpftrace uses bcc library function
bcc_usdt_get_argument to retrieve the arg passed to the DTRACE_PROBE().
The value present in the arg string is "gprs[0-15]" in s390. However it
is named as "r[0-15]" in bpftrace. This leads to offset for register
"gprs[0-15]" not known error.

Fix this by creating an alias of each register for s390x/ppc64. aarch64 already does it.
x86 does have the same convention in bpftrace and bcc.

Signed-off-by: Sumanth Korikkar <sumanthk@linux.ibm.com>

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
