### PR TITLE
Add tuples to language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to
   - [#1317](https://github.com/iovisor/bpftrace/pull/1317)
 - Introduce `-k` and `-kk` options. Emit a warning when a bpf helper returns an error
   - [#1276](https://github.com/iovisor/bpftrace/pull/1276)
+- Add tuples to language
+  - [#1326](https://github.com/iovisor/bpftrace/pull/1326)
 
 #### Changed
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -37,6 +37,7 @@ discussion to other files in /docs, the /tools/\*\_examples.txt files, or blog p
     - [11. Integer casts](#11-integer-casts)
     - [12. Looping constructs](#12-looping-constructs)
     - [13. `return`: Terminate Early](#13-return-terminate-early)
+    - [14. `( , )`: Tuples](#14----tuples)
 - [Probes](#probes)
     - [1. `kprobe`/`kretprobe`: Dynamic Tracing, Kernel-Level](#1-kprobekretprobe-dynamic-tracing-kernel-level)
     - [2. `kprobe`/`kretprobe`: Dynamic Tracing, Kernel-Level Arguments](#2-kprobekretprobe-dynamic-tracing-kernel-level-arguments)
@@ -780,6 +781,21 @@ Loops can be short circuited by using the `continue` and `break` keywords.
 
 The `return` keyword is used to exit the current probe. This differs from
 `exit()` in that it doesn't exit bpftrace.
+
+## 14. `( , )`: Tuples
+
+N-tuples are supported, where N is any integer greater than 1.
+
+Indexing is supported using the `.` operator.
+
+Example:
+
+```
+# bpftrace -e 'BEGIN { $t = (1, 2, "string"); printf("%d %s\n", $t.1, $t.2); }'
+Attaching 1 probe...
+2 string
+^C
+```
 
 # Probes
 

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -224,6 +224,11 @@ FieldAccess::FieldAccess(Expression *expr,
 {
 }
 
+FieldAccess::FieldAccess(Expression *expr, ssize_t index, location loc)
+    : Expression(loc), expr(expr), index(index)
+{
+}
+
 void FieldAccess::accept(Visitor &v) {
   v.visit(*this);
 }

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -259,6 +259,16 @@ void Cast::accept(Visitor &v) {
   v.visit(*this);
 }
 
+Tuple::Tuple(ExpressionList *elems, location loc)
+    : Expression(loc), elems(elems)
+{
+}
+
+void Tuple::accept(Visitor &v)
+{
+  v.visit(*this);
+}
+
 Statement::Statement(location loc) : Node(loc)
 {
 }

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -187,6 +187,15 @@ public:
   void accept(Visitor &v) override;
 };
 
+class Tuple : public Expression
+{
+public:
+  Tuple(ExpressionList *elems, location loc);
+  ExpressionList *elems;
+
+  void accept(Visitor &v) override;
+};
+
 class Statement : public Node {
 public:
   Statement() = default;
@@ -364,6 +373,7 @@ public:
   virtual void visit(FieldAccess &acc) = 0;
   virtual void visit(ArrayAccess &arr) = 0;
   virtual void visit(Cast &cast) = 0;
+  virtual void visit(Tuple &tuple) = 0;
   virtual void visit(ExprStatement &expr) = 0;
   virtual void visit(AssignMapStatement &assignment) = 0;
   virtual void visit(AssignVarStatement &assignment) = 0;

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -157,8 +157,10 @@ class FieldAccess : public Expression {
 public:
   FieldAccess(Expression *expr, const std::string &field);
   FieldAccess(Expression *expr, const std::string &field, location loc);
+  FieldAccess(Expression *expr, ssize_t index, location loc);
   Expression *expr;
   std::string field;
+  ssize_t index = -1;
 
   void accept(Visitor &v) override;
 };

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1477,6 +1477,11 @@ void CodegenLLVM::visit(Cast &cast)
   }
 }
 
+void CodegenLLVM::visit(Tuple &tuple __attribute__((unused)))
+{
+  // XXX implement
+}
+
 void CodegenLLVM::visit(ExprStatement &expr)
 {
   expr.expr->accept(*this);

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -964,7 +964,7 @@ void CodegenLLVM::visit(Map &map)
 
 void CodegenLLVM::visit(Variable &var)
 {
-  if (!var.type.IsArray())
+  if (!var.type.IsAggregate())
   {
     expr_ = b_.CreateLoad(variables_[var.ident]);
   }
@@ -1554,7 +1554,7 @@ void CodegenLLVM::visit(AssignVarStatement &assignment)
     variables_[var.ident] = val;
   }
 
-  if (!var.type.IsArray())
+  if (!var.type.IsAggregate())
   {
     b_.CreateStore(expr_, variables_[var.ident]);
   }
@@ -2244,7 +2244,7 @@ void CodegenLLVM::createFormatStringCall(Call &call, int &id, CallArgs &call_arg
     expr_deleter_ = nullptr;
     arg.accept(*this);
     Value *offset = b_.CreateGEP(fmt_args, {b_.getInt32(0), b_.getInt32(i)});
-    if (arg.type.IsArray())
+    if (arg.type.IsAggregate())
     {
       b_.CREATE_MEMCPY(offset, expr_, arg.type.size, 1);
       if (!arg.is_variable && dyn_cast<AllocaInst>(expr_))

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -45,6 +45,7 @@ public:
   void visit(FieldAccess &acc) override;
   void visit(ArrayAccess &arr) override;
   void visit(Cast &cast) override;
+  void visit(Tuple &tuple) override;
   void visit(ExprStatement &expr) override;
   void visit(AssignMapStatement &assignment) override;
   void visit(AssignVarStatement &assignment) override;

--- a/src/ast/field_analyser.cpp
+++ b/src/ast/field_analyser.cpp
@@ -179,6 +179,12 @@ void FieldAnalyser::visit(Cast &cast)
   bpftrace_.btf_set_.insert(type_);
 }
 
+void FieldAnalyser::visit(Tuple &tuple)
+{
+  for (Expression *expr : *tuple.elems)
+    expr->accept(*this);
+}
+
 void FieldAnalyser::visit(ExprStatement &expr)
 {
   expr.expr->accept(*this);

--- a/src/ast/field_analyser.h
+++ b/src/ast/field_analyser.h
@@ -32,6 +32,7 @@ public:
   void visit(FieldAccess &acc) override;
   void visit(ArrayAccess &arr) override;
   void visit(Cast &cast) override;
+  void visit(Tuple &tuple) override;
   void visit(ExprStatement &expr) override;
   void visit(AssignMapStatement &assignment) override;
   void visit(AssignVarStatement &assignment) override;

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <sstream>
 
 #include "arch/arch.h"
 #include "ast/async_event_types.h"
@@ -158,6 +159,20 @@ llvm::Type *IRBuilderBPF::GetType(const SizedType &stype)
   if (stype.IsArray())
   {
     ty = ArrayType::get(getInt8Ty(), stype.size);
+  }
+  else if (stype.IsTupleTy())
+  {
+    std::vector<llvm::Type *> llvm_elems;
+    std::ostringstream ty_name;
+
+    for (const auto &elemtype : stype.tuple_elems)
+    {
+      llvm_elems.emplace_back(GetType(elemtype));
+      ty_name << elemtype << "_";
+    }
+    ty_name << "_tuple_t";
+
+    ty = GetStructType(ty_name.str(), llvm_elems, true);
   }
   else
   {

--- a/src/ast/printer.cpp
+++ b/src/ast/printer.cpp
@@ -210,6 +210,17 @@ void Printer::visit(Cast &cast)
   --depth_;
 }
 
+void Printer::visit(Tuple &tuple)
+{
+  std::string indent(depth_, ' ');
+  out_ << indent << "tuple:" << std::endl;
+
+  ++depth_;
+  for (Expression *expr : *tuple.elems)
+    expr->accept(*this);
+  --depth_;
+}
+
 void Printer::visit(ExprStatement &expr)
 {
   expr.expr->accept(*this);

--- a/src/ast/printer.cpp
+++ b/src/ast/printer.cpp
@@ -183,7 +183,10 @@ void Printer::visit(FieldAccess &acc)
   acc.expr->accept(*this);
   --depth_;
 
-  out_ << indent << " " << acc.field << std::endl;
+  if (acc.field.size())
+    out_ << indent << " " << acc.field << std::endl;
+  else
+    out_ << indent << " " << acc.index << std::endl;
 }
 
 void Printer::visit(ArrayAccess &arr)

--- a/src/ast/printer.h
+++ b/src/ast/printer.h
@@ -28,6 +28,7 @@ public:
   void visit(FieldAccess &acc) override;
   void visit(ArrayAccess &arr) override;
   void visit(Cast &cast) override;
+  void visit(Tuple &tuple) override;
   void visit(ExprStatement &expr) override;
   void visit(AssignMapStatement &assignment) override;
   void visit(AssignVarStatement &assignment) override;

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -2369,7 +2369,7 @@ bool SemanticAnalyser::check_assignment(const Call &call, bool want_map, bool wa
   {
     if (!call.map)
     {
-      error(call.func + "() should be assigned to a map", call.loc);
+      error(call.func + "() should be directly assigned to a map", call.loc);
       return false;
     }
   }

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -779,8 +779,8 @@ void SemanticAnalyser::visit(Call &call)
              iter++)
         {
           auto ty = (*iter)->type;
-          // Promote to 64-bit if it's not an array type
-          if (!ty.IsArray())
+          // Promote to 64-bit if it's not an aggregate type
+          if (!ty.IsAggregate())
             ty.size = 8;
           args.push_back(Field{
             .type =  ty,

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1505,9 +1505,16 @@ void SemanticAnalyser::visit(FieldAccess &acc)
   if (type.type != Type::cast && type.type != Type::ctx &&
       type.type != Type::tuple)
   {
-    if (is_final_pass()) {
-      ERR("Can not access field '" << acc.field << "' on expression of type '"
-                                   << type << "'",
+    if (is_final_pass())
+    {
+      std::string field;
+      if (acc.field.size())
+        field += "field '" + acc.field + "'";
+      else
+        field += "index " + std::to_string(acc.index);
+
+      ERR("Can not access " << field << " on expression of type '" << type
+                            << "'",
           acc.loc);
     }
     return;

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1625,6 +1625,11 @@ void SemanticAnalyser::visit(Cast &cast)
   cast.type.is_pointer = cast.is_pointer;
 }
 
+void SemanticAnalyser::visit(Tuple &tuple __attribute__((unused)))
+{
+  // XXX implement
+}
+
 void SemanticAnalyser::visit(ExprStatement &expr)
 {
   expr.expr->accept(*this);

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -53,6 +53,7 @@ public:
   void visit(FieldAccess &acc) override;
   void visit(ArrayAccess &arr) override;
   void visit(Cast &cast) override;
+  void visit(Tuple &tuple) override;
   void visit(ExprStatement &expr) override;
   void visit(AssignMapStatement &assignment) override;
   void visit(AssignVarStatement &assignment) override;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1205,47 +1205,50 @@ int BPFtrace::zero_map(IMap &map)
   return 0;
 }
 
-std::string BPFtrace::map_value_to_str(IMap &map, std::vector<uint8_t> value, uint32_t div)
+std::string BPFtrace::map_value_to_str(const SizedType &stype,
+                                       std::vector<uint8_t> value,
+                                       bool is_per_cpu,
+                                       uint32_t div)
 {
-  uint32_t nvalues = map.is_per_cpu_type() ? ncpus_ : 1;
-  if (map.type_.IsKstackTy())
+  uint32_t nvalues = is_per_cpu ? ncpus_ : 1;
+  if (stype.IsKstackTy())
     return get_stack(
-        read_data<uint64_t>(value.data()), false, map.type_.stack_type, 8);
-  else if (map.type_.IsUstackTy())
+        read_data<uint64_t>(value.data()), false, stype.stack_type, 8);
+  else if (stype.IsUstackTy())
     return get_stack(
-        read_data<uint64_t>(value.data()), true, map.type_.stack_type, 8);
-  else if (map.type_.IsKsymTy())
+        read_data<uint64_t>(value.data()), true, stype.stack_type, 8);
+  else if (stype.IsKsymTy())
     return resolve_ksym(read_data<uintptr_t>(value.data()));
-  else if (map.type_.IsUsymTy())
+  else if (stype.IsUsymTy())
     return resolve_usym(read_data<uintptr_t>(value.data()),
                         read_data<uintptr_t>(value.data() + 8));
-  else if (map.type_.IsInetTy())
+  else if (stype.IsInetTy())
     return resolve_inet(read_data<uint32_t>(value.data()),
                         (uint8_t *)(value.data() + 8));
-  else if (map.type_.IsUsernameTy())
+  else if (stype.IsUsernameTy())
     return resolve_uid(read_data<uint64_t>(value.data()));
-  else if (map.type_.IsBufferTy())
+  else if (stype.IsBufferTy())
     return resolve_buf(reinterpret_cast<char *>(value.data() + 1),
                        *reinterpret_cast<uint8_t *>(value.data()));
-  else if (map.type_.IsStringTy())
+  else if (stype.IsStringTy())
   {
     auto p = reinterpret_cast<const char *>(value.data());
-    return std::string(p, strnlen(p, map.type_.size));
+    return std::string(p, strnlen(p, stype.size));
   }
-  else if (map.type_.IsCountTy())
+  else if (stype.IsCountTy())
     return std::to_string(reduce_value<uint64_t>(value, nvalues) / div);
-  else if (map.type_.IsSumTy() || map.type_.IsIntTy())
+  else if (stype.IsSumTy() || stype.IsIntTy())
   {
-    if (map.type_.IsSigned())
+    if (stype.IsSigned())
       return std::to_string(reduce_value<int64_t>(value, nvalues) / div);
 
     return std::to_string(reduce_value<uint64_t>(value, nvalues) / div);
   }
-  else if (map.type_.IsMinTy())
+  else if (stype.IsMinTy())
     return std::to_string(min_value(value, nvalues) / div);
-  else if (map.type_.IsMaxTy())
+  else if (stype.IsMaxTy())
     return std::to_string(max_value(value, nvalues) / div);
-  else if (map.type_.IsProbeTy())
+  else if (stype.IsProbeTy())
     return resolve_probe(read_data<uint64_t>(value.data()));
   else
     return std::to_string(read_data<int64_t>(value.data()) / div);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -119,7 +119,10 @@ public:
   virtual int resolve_uname(const std::string &name,
                             struct symbol *sym,
                             const std::string &path) const;
-  std::string map_value_to_str(IMap &map, std::vector<uint8_t> value, uint32_t div);
+  std::string map_value_to_str(const SizedType &stype,
+                               std::vector<uint8_t> value,
+                               bool is_per_cpu,
+                               uint32_t div);
   virtual std::string extract_func_symbols_from_path(const std::string &path) const;
   std::string resolve_probe(uint64_t probe_id) const;
   uint64_t resolve_cgroupid(const std::string &path) const;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -152,7 +152,8 @@ void TextOutput::map(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t div,
     }
 
     out_ << map.name_ << map.key_.argument_value_list_str(bpftrace, key) << ": ";
-    out_ << bpftrace.map_value_to_str(map, value, div);
+    out_ << bpftrace.map_value_to_str(
+        map.type_, value, map.is_per_cpu_type(), div);
 
     if (map.type_.type != Type::kstack && map.type_.type != Type::ustack &&
         map.type_.type != Type::ksym && map.type_.type != Type::usym &&
@@ -380,11 +381,14 @@ void JsonOutput::map(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t div,
         map.type_.IsUsernameTy() || map.type_.IsStringTy() ||
         map.type_.IsBufferTy() || map.type_.IsProbeTy())
     {
-      out_ << "\"" << json_escape(bpftrace.map_value_to_str(map, value, div))
+      out_ << "\""
+           << json_escape(bpftrace.map_value_to_str(
+                  map.type_, value, map.is_per_cpu_type(), div))
            << "\"";
     }
     else {
-      out_ << bpftrace.map_value_to_str(map, value, div);
+      out_ << bpftrace.map_value_to_str(
+          map.type_, value, map.is_per_cpu_type(), div);
     }
 
     i++;

--- a/src/output.h
+++ b/src/output.h
@@ -78,6 +78,9 @@ private:
   static std::string lhist_index_label(int number);
   void hist(const std::vector<uint64_t> &values, uint32_t div) const;
   void lhist(const std::vector<uint64_t> &values, int min, int max, int step) const;
+  std::string tuple_to_str(BPFtrace &bpftrace,
+                           const SizedType &ty,
+                           const std::vector<uint8_t> &value) const;
 };
 
 class JsonOutput : public Output {
@@ -106,6 +109,9 @@ private:
              int min,
              int max,
              int step) const;
+  std::string tuple_to_str(BPFtrace &bpftrace,
+                           const SizedType &ty,
+                           const std::vector<uint8_t> &value) const;
 };
 
 } // namespace bpftrace

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -327,6 +327,7 @@ expr : int                                      { $$ = $1; }
      | MINUS expr                               { $$ = new ast::Unop(token::MINUS, $2, @1); }
      | MUL  expr %prec DEREF                    { $$ = new ast::Unop(token::MUL,  $2, @1); }
      | expr DOT ident                           { $$ = new ast::FieldAccess($1, $3, @2); }
+     | expr DOT INT                             { $$ = new ast::FieldAccess($1, $3, @3); }
      | expr PTR ident                           { $$ = new ast::FieldAccess(new ast::Unop(token::MUL, $1, @2), $3, @$); }
      | expr "[" expr "]"                        { $$ = new ast::ArrayAccess($1, $3, @2 + @4); }
      | "(" IDENT ")" expr %prec CAST            { $$ = new ast::Cast($2, false, $4, @1 + @3); }

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -331,6 +331,12 @@ expr : int                                      { $$ = $1; }
      | expr "[" expr "]"                        { $$ = new ast::ArrayAccess($1, $3, @2 + @4); }
      | "(" IDENT ")" expr %prec CAST            { $$ = new ast::Cast($2, false, $4, @1 + @3); }
      | "(" IDENT MUL ")" expr %prec CAST        { $$ = new ast::Cast($2, true, $5, @1 + @4); }
+     | "(" expr "," vargs ")"                   {
+                                                  auto args = new ast::ExpressionList;
+                                                  args->emplace_back($2);
+                                                  args->insert(args->end(), $4->begin(), $4->end());
+                                                  $$ = new ast::Tuple(args, @$);
+                                                }
      | pre_post_op                              { $$ = $1; }
      ;
 

--- a/src/tracepoint_format_parser.h
+++ b/src/tracepoint_format_parser.h
@@ -60,6 +60,11 @@ public:
   void visit(Cast &cast) override {
     cast.expr->accept(*this);
   };
+  void visit(Tuple &tuple) override
+  {
+    for (Expression *expr : *tuple.elems)
+      expr->accept(*this);
+  };
   void visit(ExprStatement &expr) override {
     expr.expr->accept(*this);
   };

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -80,6 +80,11 @@ bool SizedType::IsArray() const
          ((type == Type::cast || type == Type::ctx) && !is_pointer);
 }
 
+bool SizedType::IsAggregate() const
+{
+  return IsArray() || IsTupleTy();
+}
+
 bool SizedType::IsStack() const
 {
   return type == Type::ustack || type == Type::kstack;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -35,6 +35,18 @@ std::ostream &operator<<(std::ostream &os, const SizedType &type)
   {
     os << type.type << "[" << type.size << "]";
   }
+  else if (type.type == Type::tuple)
+  {
+    os << "(";
+    size_t n = type.tuple_elems.size();
+    for (size_t i = 0; i < n; ++i)
+    {
+      os << type.tuple_elems[i];
+      if (i != n - 1)
+        os << ",";
+    }
+    os << ")";
+  }
   else
   {
     os << type.type;
@@ -102,6 +114,7 @@ std::string typestr(Type t)
     case Type::array:    return "array";    break;
     case Type::ctx:      return "ctx";      break;
     case Type::buffer:   return "buffer";   break;
+    case Type::tuple:    return "tuple";    break;
     // clang-format on
     default:
       std::cerr << "call or probe type not found" << std::endl;

--- a/src/types.h
+++ b/src/types.h
@@ -45,6 +45,7 @@ enum class Type
   ctx,
   record, // struct or union
   buffer,
+  tuple,
   // clang-format on
 };
 
@@ -94,6 +95,8 @@ public:
   bool is_kfarg = false;
   size_t pointee_size = 0;
   int kfarg_idx = -1;
+  // Only valid if `type == Type::tuple`
+  std::vector<SizedType> tuple_elems;
 
 private:
   bool is_signed = false;
@@ -212,6 +215,10 @@ public:
   bool IsBufferTy(void) const
   {
     return type == Type::buffer;
+  };
+  bool IsTupleTy(void) const
+  {
+    return type == Type::tuple;
   };
 
   friend std::ostream &operator<<(std::ostream &, const SizedType &);

--- a/src/types.h
+++ b/src/types.h
@@ -103,6 +103,7 @@ private:
 
 public:
   bool IsArray() const;
+  bool IsAggregate() const;
   bool IsStack() const;
 
   bool IsEqual(const SizedType &t) const;

--- a/tests/codegen/llvm/tuple.ll
+++ b/tests/codegen/llvm/tuple.ll
@@ -1,0 +1,49 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"int64_int64_string[64]__tuple_t" = type <{ i64, i64, [64 x i8] }>
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kprobe:f"(i8* nocapture readnone) local_unnamed_addr section "s_kprobe:f_1" {
+entry:
+  %"@t_key" = alloca i64, align 8
+  %tuple = alloca %"int64_int64_string[64]__tuple_t", align 8
+  %1 = bitcast %"int64_int64_string[64]__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  %2 = getelementptr inbounds %"int64_int64_string[64]__tuple_t", %"int64_int64_string[64]__tuple_t"* %tuple, i64 0, i32 0
+  store i64 1, i64* %2, align 8
+  %3 = getelementptr inbounds %"int64_int64_string[64]__tuple_t", %"int64_int64_string[64]__tuple_t"* %tuple, i64 0, i32 1
+  store i64 2, i64* %3, align 8
+  %str.sroa.0.0..sroa_idx = getelementptr inbounds %"int64_int64_string[64]__tuple_t", %"int64_int64_string[64]__tuple_t"* %tuple, i64 0, i32 2, i64 0
+  store i8 115, i8* %str.sroa.0.0..sroa_idx, align 8
+  %str.sroa.4.0..sroa_idx = getelementptr inbounds %"int64_int64_string[64]__tuple_t", %"int64_int64_string[64]__tuple_t"* %tuple, i64 0, i32 2, i64 1
+  store i8 116, i8* %str.sroa.4.0..sroa_idx, align 1
+  %str.sroa.5.0..sroa_idx = getelementptr inbounds %"int64_int64_string[64]__tuple_t", %"int64_int64_string[64]__tuple_t"* %tuple, i64 0, i32 2, i64 2
+  store i8 114, i8* %str.sroa.5.0..sroa_idx, align 2
+  %str.sroa.6.0..sroa_idx = getelementptr inbounds %"int64_int64_string[64]__tuple_t", %"int64_int64_string[64]__tuple_t"* %tuple, i64 0, i32 2, i64 3
+  %4 = bitcast i64* %"@t_key" to i8*
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %str.sroa.6.0..sroa_idx, i8 0, i64 61, i1 false)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 0, i64* %"@t_key", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %"int64_int64_string[64]__tuple_t"*, i64)*)(i64 %pseudo, i64* nonnull %"@t_key", %"int64_int64_string[64]__tuple_t"* nonnull %tuple, i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/tuple.cpp
+++ b/tests/codegen/tuple.cpp
@@ -1,0 +1,16 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, tuple)
+{
+  test(R"_(k:f { @t = (1, 2, "str"); })_",
+
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -138,3 +138,10 @@ NAME basic tuple map
 RUN bpftrace -e 'BEGIN { $v = 99; @t = (0, 1, "str"); printf("%d %d %s\n", @t.0, @t.1, @t.2); exit(); }'
 EXPECT 0 1 str
 TIMEOUT 5
+
+# Careful with '(' and ')', they are read by the test engine as a regex group,
+# so make sure to escape them.
+NAME tuple print
+RUN bpftrace -e 'BEGIN { @ = (1, 2, "string", (4, 5)); exit(); }'
+EXPECT ^@: \(1, 2, string, \(4, 5\)\)$
+TIMEOUT 5

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -128,3 +128,13 @@ RUN bpftrace -e 'BEGIN { $a = 0; while ($a <= 100) { @=avg($a++) } exit(); }'
 EXPECT @: 50
 TIMEOUT 5
 REQUIRES bpftrace --info 2>&1 | grep "Loop support: yes"
+
+NAME basic tuple
+RUN bpftrace -e 'BEGIN { $v = 99; $t = (0, 1, "str", (5, 6), $v); printf("%d %d %s %d %d %d\n", $t.0, $t.1, $t.2, $t.3.0, $t.3.1, $t.4); exit(); }'
+EXPECT 0 1 str 5 6 99
+TIMEOUT 5
+
+NAME basic tuple map
+RUN bpftrace -e 'BEGIN { $v = 99; @t = (0, 1, "str"); printf("%d %d %s\n", @t.0, @t.1, @t.2); exit(); }'
+EXPECT 0 1 str
+TIMEOUT 5

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -82,3 +82,10 @@ NAME cat
 RUN bpftrace -v -f json -e 'BEGIN { cat("/proc/uptime"); exit(); }'
 EXPECT ^{"type": "cat", "data": "[0-9]*.[0-9]* [0-9]*.[0-9]*\\n"}$
 TIMEOUT 5
+
+# Careful with '[' and ']', they are read by the test engine as a regex
+# character class, so make sure to escape them.
+NAME tuple
+RUN bpftrace -f json -e 'BEGIN { @ = (1, 2, "string", (4, 5)); exit(); }'
+EXPECT ^{"type": "map", "data": {"@": \[1,2,"string",\[4,5\]\]}}$
+TIMEOUT 5

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1661,6 +1661,18 @@ TEST(semantic_analyser, tuple)
   test(R"_(BEGIN { @t = (1, count()) })_", 1);
 }
 
+TEST(semantic_analyser, tuple_indexing)
+{
+  test(R"_(BEGIN { (1,2).0 })_", 0);
+  test(R"_(BEGIN { (1,2).1 })_", 0);
+  test(R"_(BEGIN { (1,2,3).2 })_", 0);
+  test(R"_(BEGIN { $t = (1,2,3).0 })_", 0);
+  test(R"_(BEGIN { $t = (1,2,3); $v = $t.0; })_", 0);
+
+  test(R"_(BEGIN { (1,2,3).3 })_", 10);
+  test(R"_(BEGIN { (1,2,3).9999999999999 })_", 10);
+}
+
 // More in depth inspection of AST
 TEST(semantic_analyser, tuple_assign_var)
 {


### PR DESCRIPTION
This PR adds tuple support to the bpftrace language.

Tuples are useful for a couple of reasons:
* There is already a way to associate multiple values to a map key
(`@[1,2] = 3`) which is useful. Likewise, it would be very useful to
associate multiple values with a map value (ie `@[1] = (2,3)`).
Scripts currently work around this by using multiple maps. That's
fine but it'd be nicer to have the language support common use
cases.
* Tuples provide a way to structure data together in output.
Especially for distributed tracing, one common feature request is
to have multiple pieces of data appear as one "row" in wherever
the data is collected. You could work around this by using `printf`
and requiring a certain format (like CSV), but that's not very
reliable and can be easily broken by typos.

This PR allows stuff like the following:
```
$t = (1, 2, "string");
printf("%d %d %s\n", $t.0, $t.1, $t.2);

@m = ("str", (1, 2));
printf("%s %d %d\n", @m.0, @m.1.0, @m.1.1);
print(@m);
```

I'd rather get this proof of concept out to get feedback first, so
still on the todo list:
- [x] `print()`ing tuples
  * so stuff like `@ = (1,2); print(@);` comes out correctly
- [ ] modifying a tuple after creation (probably for another PR)
  * is this even desired? for example python tuples are immutable
  * would look something like: `$t = (0,1); $t.0 = 5;`


##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
