### PR TITLE
Allow positional parameters in attachpoint definitions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to
 - Require C++17 and CMake 3.8 for building bpftrace
   - [#1200](https://github.com/iovisor/bpftrace/pull/1200)
   - [#1259](https://github.com/iovisor/bpftrace/pull/1259)
+- Allow positional parameters in probe attachpoint definitions
+  - [#1328](https://github.com/iovisor/bpftrace/pull/1328)
 
 #### Deprecated
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1796,7 +1796,8 @@ Syntax: `$1`, `$2`, ..., `$N`, `$#`
 These are the positional parameters to the bpftrace program, also referred to as command line arguments.
 If the parameter is numeric (entirely digits), it can be used as a number. If it is non-numeric, it must
 be used as a string in the `str()` call. If a parameter is used that was not provided, it will default to
-zero for numeric context, and "" for string context.
+zero for numeric context, and "" for string context. Positional parameters may also be used in probe
+argument and will be treated as a string parameter.
 
 `$#` returns the number of positional arguments supplied.
 

--- a/src/ast/attachpoint_parser.h
+++ b/src/ast/attachpoint_parser.h
@@ -19,6 +19,16 @@ public:
 
 private:
   int parse_attachpoint(AttachPoint &ap);
+  /*
+   * This method splits an attach point definition into arguments,
+   * where arguments are separated by `:`. The exception is `:`s inside
+   * of quoted strings, which we must treat as a literal.
+   *
+   * Note that this function assumes the raw string is generally well
+   * formed. More specifically, that there is no unescaped whitespace
+   * and no unmatched quotes.
+   */
+  int lex_attachpoint(const std::string &raw);
 
   int kprobe_parser(bool allow_offset = true);
   int kretprobe_parser();

--- a/src/ast/attachpoint_parser.h
+++ b/src/ast/attachpoint_parser.h
@@ -24,11 +24,14 @@ private:
    * where arguments are separated by `:`. The exception is `:`s inside
    * of quoted strings, which we must treat as a literal.
    *
+   * This method also resolves positional parameters. Positional params
+   * may be escaped with double quotes.
+   *
    * Note that this function assumes the raw string is generally well
    * formed. More specifically, that there is no unescaped whitespace
    * and no unmatched quotes.
    */
-  int lex_attachpoint(const std::string &raw);
+  int lex_attachpoint(const AttachPoint &ap);
 
   int kprobe_parser(bool allow_offset = true);
   int kretprobe_parser();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -429,20 +429,25 @@ int main(int argc, char *argv[])
       driver.source(filename, buf.str());
     }
 
-    err = driver.parse();
-    if (err)
-      return err;
-
     optind++;
   }
   else
   {
     // Script is provided as a command line argument
     driver.source("stdin", script);
-    err = driver.parse();
-    if (err)
-      return err;
   }
+
+  // Load positional parameters before driver runs so positional
+  // parameters used inside attach point definitions can be resolved.
+  while (optind < argc)
+  {
+    bpftrace.add_param(argv[optind]);
+    optind++;
+  }
+
+  err = driver.parse();
+  if (err)
+    return err;
 
   if (!is_root())
     return 1;
@@ -464,12 +469,6 @@ int main(int argc, char *argv[])
   enforce_infinite_rlimit();
 
   cap_memory_limits();
-
-  // positional parameters
-  while (optind < argc) {
-    bpftrace.add_param(argv[optind]);
-    optind++;
-  }
 
   // defaults
   bpftrace.join_argnum_ = 16;

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -190,6 +190,19 @@ attach_point_def : attach_point_def ident    { $$ = $1 + $2; }
                  | attach_point_def MUL      { $$ = $1 + "*"; }
                  | attach_point_def LBRACKET { $$ = $1 + "["; }
                  | attach_point_def RBRACKET { $$ = $1 + "]"; }
+                 | attach_point_def param    {
+                                               if ($2->ptype != PositionalParameterType::positional)
+                                               {
+                                                  error(@$, "Not a positional parameter");
+                                                  YYERROR;
+                                               }
+
+                                               // "Un-parse" the positional parameter back into text so
+                                               // we can give it to the AttachPointParser. This is kind of
+                                               // a hack but there doesn't look to be any other way.
+                                               $$ = $1 + "$" + std::to_string($2->n);
+                                               delete $2;
+                                             }
                  |                           { $$ = ""; }
                  ;
 

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -88,6 +88,16 @@ RUN bpftrace -v -e 'BEGIN { if (str($1) != str($2)) { printf("I got %s\n", str($
 EXPECT not equal
 TIMEOUT 5
 
+NAME positional attachpoint
+RUN bpftrace -e 'i:ms:$1 { printf("hello world\n"); exit(); }' 1
+EXPECT hello world
+TIMEOUT 1
+
+NAME positional attachpoint probe
+RUN bpftrace -e 'BEG$1 { printf("hello world\n"); exit(); }' IN
+EXPECT hello world
+TIMEOUT 1
+
 NAME string compare map lookup
 RUN bpftrace -v -e 't:syscalls:sys_enter_openat /comm == "cat"/ { @[comm] = 1; }' -c "/bin/cat /dev/null"
 EXPECT @\[cat\]: 1


### PR DESCRIPTION
This commit supports using positional parameters as follows:

      # bpftrace -e 'kprobe:$1 { 1 }' -- f
      Attaching 1 probe...

      # bpftrace -e 'kprobe:$1asdf { 1 }' -- f
      stdin:1:1-14: ERROR: Found trailing text 'asdf' in positional parameter index. Try quoting the trailing text.
      kprobe:$1asdf { 1 }
      ~~~~~~~~~~~~~

      # bpftrace -e 'kprobe:$1"asdf" { 1 }' -- f
      Attaching 1 probe...
      cannot attach kprobe, probe entry may not exist
      Error attaching probe: 'kprobe:fasdf'

This closes #606 .

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
