### PR TITLE
Add environment variable to tune perf ring buffer size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to
   - [#1314](https://github.com/iovisor/bpftrace/pull/1314)
 - With --btf, do not use <linux/types.h> for resolving tracepoint defs
   - [#1318](https://github.com/iovisor/bpftrace/pull/1318)
+- Add environment variable, BPFTRACE_PERF_RB_PAGES, to tune perf ring buffer size
+  - [#1329](https://github.com/iovisor/bpftrace/pull/1329)
 
 #### Changed
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -496,6 +496,16 @@ Default: None
 The path to a BTF file. By default, bpftrace searches several locations to find a BTF file.
 See src/btf.cpp for the details.
 
+### 9.8 `BPFTRACE_PERF_RB_PAGES`
+
+Default: 64
+
+Number of pages to allocate per CPU for perf ring buffer. The value must be a power of 2.
+
+If you're getting a lot of dropped events bpftrace may not be processing events in the ring buffer
+fast enough. It may be useful to bump the value higher so more events can be queued up. The tradeoff
+is that bpftrace will use more memory.
+
 ## 10. Clang Environment Variables
 
 bpftrace parses header files using libclang, the C interface to Clang. Thus environment variables

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -916,8 +916,8 @@ int BPFtrace::setup_perf_events()
   online_cpus_ = cpus.size();
   for (int cpu : cpus)
   {
-    int page_cnt = 64;
-    void *reader = bpf_open_perf_buffer(&perf_event_printer, &perf_event_lost, this, -1, cpu, page_cnt);
+    void *reader = bpf_open_perf_buffer(
+        &perf_event_printer, &perf_event_lost, this, -1, cpu, perf_rb_pages_);
     if (reader == nullptr)
     {
       std::cerr << "Failed to open perf buffer" << std::endl;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -160,6 +160,7 @@ public:
   size_t cat_bytes_max_ = 10240;
   uint64_t max_probes_ = 512;
   uint64_t log_size_ = 409600;
+  uint64_t perf_rb_pages_ = 64;
   bool demangle_cpp_symbols_ = true;
   bool resolve_user_symbols_ = true;
   bool cache_user_symbols_ = true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,6 +68,7 @@ void usage()
   std::cerr << "    BPFTRACE_CAT_BYTES_MAX      [default: 10k] maximum bytes read by cat builtin" << std::endl;
   std::cerr << "    BPFTRACE_MAX_PROBES         [default: 512] max number of probes" << std::endl;
   std::cerr << "    BPFTRACE_LOG_SIZE           [default: 409600] log size in bytes" << std::endl;
+  std::cerr << "    BPFTRACE_PERF_RB_PAGES      [default: 64] pages per CPU to allocate for ring buffer" << std::endl;
   std::cerr << "    BPFTRACE_NO_USER_SYMBOLS    [default: 0] disable user symbol resolution" << std::endl;
   std::cerr << "    BPFTRACE_CACHE_USER_SYMBOLS [default: auto] enable user symbol cache" << std::endl;
   std::cerr << "    BPFTRACE_VMLINUX            [default: none] vmlinux path used for kernel symbol resolution" << std::endl;
@@ -490,6 +491,9 @@ int main(int argc, char *argv[])
     return 1;
 
   if (!get_uint64_env_var("BPFTRACE_LOG_SIZE", bpftrace.log_size_))
+    return 1;
+
+  if (!get_uint64_env_var("BPFTRACE_PERF_RB_PAGES", bpftrace.perf_rb_pages_))
     return 1;
 
   if (const char* env_p = std::getenv("BPFTRACE_CAT_BYTES_MAX"))


### PR DESCRIPTION
Some scripts sample high frequency events and can overflow the ring
buffer. We should let the user be able to tune the ring buffer size as
it's a pretty classical throughput / space tradeoff.

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
