### PR TITLE
sizedtype accessors

### DIFF
--- a/src/ast/field_analyser.cpp
+++ b/src/ast/field_analyser.cpp
@@ -59,7 +59,7 @@ void FieldAnalyser::visit(Builtin &builtin)
   {
     auto it = ap_args_.find("$retval");
 
-    if (it != ap_args_.end() && it->second.type == Type::cast)
+    if (it != ap_args_.end() && it->second.IsCastTy())
       type_ = it->second.cast_type;
     else
       type_ = "";
@@ -157,7 +157,7 @@ void FieldAnalyser::visit(FieldAccess &acc)
   {
     auto it = ap_args_.find(acc.field);
 
-    if (it != ap_args_.end() && it->second.type == Type::cast)
+    if (it != ap_args_.end() && it->second.IsCastTy())
       type_ = it->second.cast_type;
     else
       type_ = "";
@@ -222,7 +222,7 @@ void FieldAnalyser::visit(AttachPoint &ap __attribute__((unused)))
       {
         auto stype = arg.second;
 
-        if (stype.type == Type::cast)
+        if (stype.IsCastTy())
           bpftrace_.btf_set_.insert(stype.cast_type);
       }
     }

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -257,9 +257,9 @@ Value *IRBuilderBPF::CreateMapLookupElem(Value *ctx,
       "map_lookup_cond");
   CreateCondBr(condition, lookup_success_block, lookup_failure_block);
 
-  bool is_array = (type.type == Type::string || type.type == Type::buffer ||
-                   (type.type == Type::cast && !type.is_pointer) ||
-                   type.type == Type::inet || type.type == Type::usym);
+  bool is_array = (type.IsStringTy() || type.IsBufferTy() ||
+                   (type.IsCastTy() && !type.is_pointer) || type.IsInetTy() ||
+                   type.IsUsymTy());
 
   SetInsertPoint(lookup_success_block);
   if (is_array)

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1235,7 +1235,7 @@ std::string BPFtrace::map_value_to_str(IMap &map, std::vector<uint8_t> value, ui
   else if (map.type_.type == Type::count)
     return std::to_string(reduce_value<uint64_t>(value, nvalues) / div);
   else if (map.type_.type == Type::sum || map.type_.type == Type::integer) {
-    if (map.type_.is_signed)
+    if (map.type_.IsSigned())
       return std::to_string(reduce_value<int64_t>(value, nvalues) / div);
 
     return std::to_string(reduce_value<uint64_t>(value, nvalues) / div);
@@ -1298,7 +1298,7 @@ int BPFtrace::print_map(IMap &map, uint32_t top, uint32_t div)
 
   if (map.type_.type == Type::count || map.type_.type == Type::sum || map.type_.type == Type::integer)
   {
-    bool is_signed = map.type_.is_signed;
+    bool is_signed = map.type_.IsSigned();
     std::sort(values_by_key.begin(), values_by_key.end(), [&](auto &a, auto &b)
     {
       if (is_signed)

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -331,7 +331,7 @@ static SizedType get_sized_type(CXType clang_type)
       if (elem_type.kind != CXType_ConstantArray)
       {
         auto type = get_sized_type(elem_type);
-        return CreateArray(size, type.type, type.size, type.is_signed);
+        return CreateArray(size, type.type, type.size, type.IsSigned());
       } else {
         return CreateNone();
       }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -30,27 +30,25 @@ Map::Map(const std::string &name, const SizedType &type, const MapKey &key, int 
   lqstep = step;
 
   int key_size = key.size();
-  if (type.type == Type::hist || type.type == Type::lhist ||
-      type.type == Type::avg || type.type == Type::stats)
+  if (type.IsHistTy() || type.IsLhistTy() || type.IsAvgTy() || type.IsStatsTy())
     key_size += 8;
   if (key_size == 0)
     key_size = 8;
 
-  if (type.type == Type::count && !key.args_.size())
+  if (type.IsCountTy() && !key.args_.size())
   {
     map_type_ = BPF_MAP_TYPE_PERCPU_ARRAY;
     max_entries = 1;
     key_size = 4;
   }
-  else if ((type.type == Type::hist || type.type == Type::lhist ||
-            type.type == Type::count || type.type == Type::sum ||
-            type.type == Type::min || type.type == Type::max ||
-            type.type == Type::avg || type.type == Type::stats) &&
+  else if ((type.IsHistTy() || type.IsLhistTy() || type.IsCountTy() ||
+            type.IsSumTy() || type.IsMinTy() || type.IsMaxTy() ||
+            type.IsAvgTy() || type.IsStatsTy()) &&
            (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)))
   {
       map_type_ = BPF_MAP_TYPE_PERCPU_HASH;
   }
-  else if (type.type == Type::join)
+  else if (type.IsJoinTy())
   {
     map_type_ = BPF_MAP_TYPE_PERCPU_ARRAY;
     max_entries = 1;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -250,7 +250,7 @@ void TextOutput::map_hist(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t 
 
     out_ << map.name_ << map.key_.argument_value_list_str(bpftrace, key) << ": " << std::endl;
 
-    if (map.type_.type == Type::hist)
+    if (map.type_.IsHistTy())
       hist(value, div);
     else
       lhist(value, map.lqmin, map.lqmax, map.lqstep);
@@ -276,7 +276,7 @@ void TextOutput::map_stats(BPFtrace &bpftrace, IMap &map,
     if (count != 0)
       average = total / count;
 
-    if (map.type_.type == Type::stats)
+    if (map.type_.IsStatsTy())
       out_ << "count " << count << ", average " <<  average << ", total " << total << std::endl;
     else
       out_ << average << std::endl;
@@ -375,11 +375,10 @@ void JsonOutput::map(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t div,
       out_ << "\"" << json_escape(str_join(args, ",")) << "\": ";
     }
 
-    if (map.type_.type == Type::kstack || map.type_.type == Type::ustack ||
-        map.type_.type == Type::ksym || map.type_.type == Type::usym ||
-        map.type_.type == Type::inet || map.type_.type == Type::username ||
-        map.type_.type == Type::string || map.type_.type == Type::buffer ||
-        map.type_.type == Type::probe)
+    if (map.type_.IsKstackTy() || map.type_.IsUstackTy() ||
+        map.type_.IsKsymTy() || map.type_.IsUsymTy() || map.type_.IsInetTy() ||
+        map.type_.IsUsernameTy() || map.type_.IsStringTy() ||
+        map.type_.IsBufferTy() || map.type_.IsProbeTy())
     {
       out_ << "\"" << json_escape(bpftrace.map_value_to_str(map, value, div))
            << "\"";
@@ -496,7 +495,7 @@ void JsonOutput::map_hist(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t 
       out_ << "\"" << json_escape(str_join(args, ",")) << "\": ";
     }
 
-    if (map.type_.type == Type::hist)
+    if (map.type_.IsHistTy())
       hist(value, div);
     else
       lhist(value, map.lqmin, map.lqmax, map.lqstep);
@@ -541,7 +540,7 @@ void JsonOutput::map_stats(BPFtrace &bpftrace, IMap &map,
     if (count != 0)
       average = total / count;
 
-    if (map.type_.type == Type::stats)
+    if (map.type_.IsStatsTy())
       out_ << "{\"count\": " << count << ", \"average\": " <<  average << ", \"total\": " << total << "}";
     else
       out_ << average;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -351,4 +351,10 @@ SizedType CreateBuffer(size_t size)
 {
   return SizedType(Type::buffer, size);
 }
+
+bool SizedType::IsSigned(void) const
+{
+  return is_signed;
+}
+
 } // namespace bpftrace

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -14,24 +14,24 @@ std::ostream &operator<<(std::ostream &os, Type type)
 
 std::ostream &operator<<(std::ostream &os, const SizedType &type)
 {
-  if (type.type == Type::cast)
+  if (type.IsCastTy())
   {
     os << type.cast_type;
   }
-  else if (type.type == Type::ctx)
+  else if (type.IsCtxTy())
   {
     os << "(ctx) " << type.cast_type;
   }
-  else if (type.type == Type::integer)
+  else if (type.IsIntTy())
   {
     os << (type.is_signed ? "" : "unsigned ") << "int" << 8*type.size;
   }
-  else if (type.type == Type::array)
+  else if (type.IsArrayTy())
   {
     os << (type.is_signed ? "" : "unsigned ") << "int" << 8 * type.pointee_size;
     os << "[" << type.size << "]";
   }
-  else if (type.type == Type::string || type.type == Type::buffer)
+  else if (type.IsStringTy() || type.IsBufferTy())
   {
     os << type.type << "[" << type.size << "]";
   }

--- a/src/types.h
+++ b/src/types.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cassert>
 #include <memory>
 #include <ostream>
 #include <sstream>
@@ -102,6 +103,111 @@ public:
   bool operator!=(const SizedType &t) const;
 
   bool IsSigned(void) const;
+  bool IsIntTy() const
+  {
+    return type == Type::integer;
+  };
+
+  bool IsNoneTy(void) const
+  {
+    return type == Type::none;
+  };
+  bool IsIntegerTy(void) const
+  {
+    return type == Type::integer;
+  };
+  bool IsHistTy(void) const
+  {
+    return type == Type::hist;
+  };
+  bool IsLhistTy(void) const
+  {
+    return type == Type::lhist;
+  };
+  bool IsCountTy(void) const
+  {
+    return type == Type::count;
+  };
+  bool IsSumTy(void) const
+  {
+    return type == Type::sum;
+  };
+  bool IsMinTy(void) const
+  {
+    return type == Type::min;
+  };
+  bool IsMaxTy(void) const
+  {
+    return type == Type::max;
+  };
+  bool IsAvgTy(void) const
+  {
+    return type == Type::avg;
+  };
+  bool IsStatsTy(void) const
+  {
+    return type == Type::stats;
+  };
+  bool IsKstackTy(void) const
+  {
+    return type == Type::kstack;
+  };
+  bool IsUstackTy(void) const
+  {
+    return type == Type::ustack;
+  };
+  bool IsStringTy(void) const
+  {
+    return type == Type::string;
+  };
+  bool IsKsymTy(void) const
+  {
+    return type == Type::ksym;
+  };
+  bool IsUsymTy(void) const
+  {
+    return type == Type::usym;
+  };
+  bool IsCastTy(void) const
+  {
+    return type == Type::cast;
+  };
+  bool IsJoinTy(void) const
+  {
+    return type == Type::join;
+  };
+  bool IsProbeTy(void) const
+  {
+    return type == Type::probe;
+  };
+  bool IsUsernameTy(void) const
+  {
+    return type == Type::username;
+  };
+  bool IsInetTy(void) const
+  {
+    return type == Type::inet;
+  };
+  bool IsStack_modeTy(void) const
+  {
+    return type == Type::stack_mode;
+  };
+  bool IsArrayTy(void) const
+  {
+    return type == Type::array;
+  };
+  bool IsCtxTy(void) const
+  {
+    return type == Type::ctx;
+  };
+  bool IsRecordTy(void) const
+  {
+    return type == Type::record;
+  };
+  bool IsBufferTy(void) const
+  {
+    return type == Type::buffer;
+  };
 
   friend std::ostream &operator<<(std::ostream &, const SizedType &);
   friend std::ostream &operator<<(std::ostream &, Type);

--- a/src/types.h
+++ b/src/types.h
@@ -65,8 +65,10 @@ struct StackType
   }
 };
 
-struct SizedType
+class SizedType
 {
+public:
+
   SizedType() : type(Type::none), size(0) { }
   SizedType(Type type,
             size_t size_,

--- a/src/types.h
+++ b/src/types.h
@@ -95,6 +95,10 @@ public:
   size_t pointee_size = 0;
   int kfarg_idx = -1;
 
+private:
+  bool is_signed = false;
+
+public:
   bool IsArray() const;
   bool IsStack() const;
 
@@ -103,6 +107,7 @@ public:
   bool operator!=(const SizedType &t) const;
 
   bool IsSigned(void) const;
+
   bool IsIntTy() const
   {
     return type == Type::integer;
@@ -188,7 +193,7 @@ public:
   {
     return type == Type::inet;
   };
-  bool IsStack_modeTy(void) const
+  bool IsStackModeTy(void) const
   {
     return type == Type::stack_mode;
   };
@@ -211,9 +216,6 @@ public:
 
   friend std::ostream &operator<<(std::ostream &, const SizedType &);
   friend std::ostream &operator<<(std::ostream &, Type);
-
-private:
-  bool is_signed = false;
 };
 // Type helpers
 

--- a/src/types.h
+++ b/src/types.h
@@ -68,13 +68,12 @@ struct StackType
 class SizedType
 {
 public:
-
   SizedType() : type(Type::none), size(0) { }
   SizedType(Type type,
             size_t size_,
             bool is_signed,
             const std::string &cast_type = "")
-      : type(type), size(size_), is_signed(is_signed), cast_type(cast_type)
+      : type(type), size(size_), cast_type(cast_type), is_signed(is_signed)
   {
   }
   SizedType(Type type, size_t size_, const std::string &cast_type = "")
@@ -87,7 +86,6 @@ public:
                                // array
   size_t size;                 // in bytes
   StackType stack_type;
-  bool is_signed = false;
   std::string cast_type;
   bool is_internal = false;
   bool is_pointer = false;
@@ -102,6 +100,14 @@ public:
   bool IsEqual(const SizedType &t) const;
   bool operator==(const SizedType &t) const;
   bool operator!=(const SizedType &t) const;
+
+  bool IsSigned(void) const;
+
+  friend std::ostream &operator<<(std::ostream &, const SizedType &);
+  friend std::ostream &operator<<(std::ostream &, Type);
+
+private:
+  bool is_signed = false;
 };
 // Type helpers
 


### PR DESCRIPTION
This adds and uses accessors for the `is_signed` and `type` fields of `sizedtype` as part of the type system improvement.

These make it easier to improve the type system, e.g. we could add `assert(IsIntTy()` to the `IsSigned` method to ensure that sign checking is only done on integers, without having to modify the code in 1000 places (like happens now)

This is largely an automatic refactor.
