### PR TITLE
Add support for listing struct/union/enum definitions using BTF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to
   - [#1259](https://github.com/iovisor/bpftrace/pull/1259)
 - Allow positional parameters in probe attachpoint definitions
   - [#1328](https://github.com/iovisor/bpftrace/pull/1328)
+- Only list uprobe and usdt probes when `-p` is given
+  - [#1340](https://github.com/iovisor/bpftrace/pull/1340)
 
 #### Deprecated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to
   - [#1276](https://github.com/iovisor/bpftrace/pull/1276)
 - Add tuples to language
   - [#1326](https://github.com/iovisor/bpftrace/pull/1326)
+- Add support for listing struct/union/enum definitions using BTF
+  - [#1340](https://github.com/iovisor/bpftrace/pull/1340)
 
 #### Changed
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -293,6 +293,17 @@ tracepoint:syscalls:sys_enter_open
     umode_t mode;
 ```
 
+If BTF is available, it is also possible to list struct/union/emum definitions. For example:
+
+```
+# bpftrace -lv "struct path"
+BTF: using data from /sys/kernel/btf/vmlinux
+struct path {
+        struct vfsmount *mnt;
+        struct dentry *dentry;
+};
+```
+
 ## 5. `-d`: Debug Output
 
 The `-d` option produces debug output, and does not run the program. This is mostly useful for debugging

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -197,6 +197,9 @@ static std::string full_type_str(const struct btf *btf, const struct btf_type *t
   if (BTF_INFO_KIND(type->info) == BTF_KIND_UNION)
     return std::string("union ") + str;
 
+  if (BTF_INFO_KIND(type->info) == BTF_KIND_ENUM)
+    return std::string("enum ") + str;
+
   return str;
 }
 
@@ -248,16 +251,14 @@ std::string BTF::c_def(std::unordered_set<std::string>& set)
         }
       }
     }
-    else
-    {
-      std::string str = full_type_str(btf, t);
 
-      auto it = myset.find(str);
-      if (it != myset.end())
-      {
-        btf_dump__dump_type(dump, id);
-        myset.erase(it);
-      }
+    std::string str = full_type_str(btf, t);
+
+    auto it = myset.find(str);
+    if (it != myset.end())
+    {
+      btf_dump__dump_type(dump, id);
+      myset.erase(it);
     }
   }
 

--- a/src/btf.h
+++ b/src/btf.h
@@ -26,10 +26,11 @@ public:
   ~BTF();
 
   bool has_data(void) const;
-  std::string c_def(std::unordered_set<std::string>& set);
+  std::string c_def(const std::unordered_set<std::string>& set) const;
   std::string type_of(const std::string& name, const std::string& field);
   std::string type_of(const btf_type* type, const std::string& field);
   void display_funcs(std::regex* re) const;
+  void display_structs(std::regex* re) const;
 
   int resolve_args(const std::string &func,
                    std::map<std::string, SizedType>& args,

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -304,7 +304,8 @@ void list_probes(const BPFtrace& bpftrace, const std::string& search_input)
     return;
   }
 
-  bool list_all = has_wildcard_in_probe || probe_name.empty();
+  bool list_all = (bpftrace.pid() == 0) &&
+                  (has_wildcard_in_probe || probe_name.empty());
 
   // software
   if (list_all || probe_name == "software")
@@ -315,11 +316,11 @@ void list_probes(const BPFtrace& bpftrace, const std::string& search_input)
     list_probes_from_list(HW_PROBE_LIST, "hardware", search, re);
 
   // uprobe
-  if (list_all || probe_name == "uprobe")
+  if (bpftrace.pid() > 0 || probe_name == "uprobe")
     list_uprobes(bpftrace, probe_name, search, re);
 
   // usdt
-  if (list_all || probe_name == "usdt")
+  if (bpftrace.pid() > 0 || probe_name == "usdt")
     list_usdt(bpftrace, probe_name, search, re);
 
   // tracepoints

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -333,6 +333,11 @@ void list_probes(const BPFtrace& bpftrace, const std::string& search_input)
   // kfuncs
   if (list_all || probe_name == "kfunc")
     bpftrace.btf_.display_funcs(search.empty() ? nullptr : &re);
+
+  // struct / union / enum
+  if (probe_name.empty() &&
+      std::regex_search(search, std::regex("^(struct|union|enum) ")))
+    bpftrace.btf_.display_structs(search.empty() ? nullptr : &re);
 }
 
 } // namespace bpftrace


### PR DESCRIPTION
'-l' option now can take struct/union/enum name and dump its definition
using BTF. For example:

```
% sudo ./src/bpftrace -l "enum bpf*"
enum bpf_access_type
enum bpf_adj_room_mode
enum bpf_arg_type
enum bpf_attach_type
enum bpf_cgroup_storage_type
[...]
```

and

```
% sudo ./src/bpftrace -lv "struct path"
BTF: using data from /sys/kernel/btf/vmlinux
struct path {
        struct vfsmount *mnt;
        struct dentry *dentry;
};
```

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
