### PR TITLE
Attach to duplicated USDT markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ and this project adheres to
   - [#1229](https://github.com/iovisor/bpftrace/pull/1229)
 - Fix usdt reads in various architecture
   - [#1325](https://github.com/iovisor/bpftrace/pull/1325)
+- Attach to duplicated USDT markers
+  - [#1341](https://github.com/iovisor/bpftrace/pull/1341)
 
 #### Tools
 

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1803,7 +1803,8 @@ void CodegenLLVM::visit(Probe &probe)
       }
 
       tracepoint_struct_ = "";
-      for (auto &match_ : matches) {
+      for (const auto &match : matches)
+      {
         printf_id_ = starting_printf_id;
         cat_id_ = starting_cat_id;
         system_id_ = starting_system_id;
@@ -1811,12 +1812,10 @@ void CodegenLLVM::visit(Probe &probe)
         join_id_ = starting_join_id;
         b_.helper_error_id_ = starting_helper_error_id;
 
-        std::string full_func_id = match_;
-
         // USDT probes must specify both a provider and a function name
         // So we will extract out the provider namespace to get just the function name
         if (probetype(attach_point->provider) == ProbeType::usdt) {
-          std::string func_id = match_;
+          std::string func_id = match;
           std::string orig_ns = attach_point->ns;
           std::string ns = func_id.substr(0, func_id.find(":"));
 
@@ -1835,10 +1834,10 @@ void CodegenLLVM::visit(Probe &probe)
         } else if (attach_point->provider == "BEGIN" || attach_point->provider == "END") {
           probefull_ = attach_point->provider;
         } else {
-          probefull_ = attach_point->name(full_func_id);
+          probefull_ = attach_point->name(match);
         }
 
-        generateProbe(probe, full_func_id, func_type, true);
+        generateProbe(probe, match, func_type, true);
       }
     }
   }

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1717,6 +1717,41 @@ void CodegenLLVM::visit(AttachPoint &)
   // Empty
 }
 
+void CodegenLLVM::generateProbe(Probe &probe,
+                                const std::string &full_func_id,
+                                FunctionType *func_type,
+                                bool expansion)
+{
+  // tracepoint wildcard expansion, part 3 of 3. Set tracepoint_struct_ for use
+  // by args builtin.
+  if (probetype(current_attach_point_->provider) == ProbeType::tracepoint)
+    tracepoint_struct_ = TracepointFormatParser::get_struct_name(
+        current_attach_point_->target, full_func_id);
+  int index = getNextIndexForProbe(probe.name());
+  if (expansion)
+    current_attach_point_->set_index(full_func_id, index);
+  else
+    probe.set_index(index);
+  Function *func = Function::Create(
+      func_type, Function::ExternalLinkage, probefull_, module_.get());
+  func->setSection(getSectionNameForProbe(probefull_, index));
+  BasicBlock *entry = BasicBlock::Create(module_->getContext(), "entry", func);
+  b_.SetInsertPoint(entry);
+
+  // check: do the following 8 lines need to be in the wildcard loop?
+  ctx_ = func->arg_begin();
+  if (probe.pred)
+  {
+    probe.pred->accept(*this);
+  }
+  variables_.clear();
+  for (Statement *stmt : *probe.stmts)
+  {
+    stmt->accept(*this);
+  }
+  b_.CreateRet(ConstantInt::get(module_->getContext(), APInt(64, 0)));
+}
+
 void CodegenLLVM::visit(Probe &probe)
 {
   FunctionType *func_type = FunctionType::get(
@@ -1742,24 +1777,8 @@ void CodegenLLVM::visit(Probe &probe)
    */
   if (probe.need_expansion == false) {
     // build a single BPF program pre-wildcards
-    Function *func = Function::Create(func_type, Function::ExternalLinkage, probe.name(), module_.get());
-    probe.set_index(getNextIndexForProbe(probe.name()));
-    func->setSection(getSectionNameForProbe(probe.name(), probe.index()));
-    BasicBlock *entry = BasicBlock::Create(module_->getContext(), "entry", func);
-    b_.SetInsertPoint(entry);
-
-    ctx_ = func->arg_begin();
-
-    if (probe.pred) {
-      probe.pred->accept(*this);
-    }
-    variables_.clear();
-    for (Statement *stmt : *probe.stmts) {
-      stmt->accept(*this);
-    }
-
-    b_.CreateRet(ConstantInt::get(module_->getContext(), APInt(64, 0)));
-
+    probefull_ = probe.name();
+    generateProbe(probe, probefull_, func_type, false);
   } else {
     /*
      * Build a separate BPF program for each wildcard match.
@@ -1819,26 +1838,7 @@ void CodegenLLVM::visit(Probe &probe)
           probefull_ = attach_point->name(full_func_id);
         }
 
-        // tracepoint wildcard expansion, part 3 of 3. Set tracepoint_struct_ for use by args builtin.
-        if (probetype(attach_point->provider) == ProbeType::tracepoint)
-          tracepoint_struct_ = TracepointFormatParser::get_struct_name(attach_point->target, full_func_id);
-        int index = getNextIndexForProbe(probe.name());
-        attach_point->set_index(full_func_id, index);
-        Function *func = Function::Create(func_type, Function::ExternalLinkage, probefull_, module_.get());
-        func->setSection(getSectionNameForProbe(probefull_, index));
-        BasicBlock *entry = BasicBlock::Create(module_->getContext(), "entry", func);
-        b_.SetInsertPoint(entry);
-
-        // check: do the following 8 lines need to be in the wildcard loop?
-        ctx_ = func->arg_begin();
-        if (probe.pred) {
-          probe.pred->accept(*this);
-        }
-        variables_.clear();
-        for (Statement *stmt : *probe.stmts) {
-          stmt->accept(*this);
-        }
-        b_.CreateRet(ConstantInt::get(module_->getContext(), APInt(64, 0)));
+        generateProbe(probe, full_func_id, func_type, true);
       }
     }
   }

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -72,6 +72,11 @@ public:
   std::unique_ptr<BpfOrc> compile(DebugLevel debug=DebugLevel::kNone, std::ostream &out=std::cout);
 
 private:
+  void generateProbe(Probe &probe,
+                     const std::string &full_func_id,
+                     FunctionType *func_type,
+                     bool expansion);
+
   Node *root_;
   LLVMContext context_;
   std::unique_ptr<Module> module_;

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -74,6 +74,7 @@ public:
 private:
   void generateProbe(Probe &probe,
                      const std::string &full_func_id,
+                     const std::string &section_name,
                      FunctionType *func_type,
                      bool expansion);
 
@@ -91,6 +92,8 @@ private:
   std::string probefull_;
   std::string tracepoint_struct_;
   std::map<std::string, int> next_probe_index_;
+  // Used if there are duplicate USDT entries
+  int current_usdt_location_index_{ 0 };
 
   std::map<std::string, AllocaInst *> variables_;
   int printf_id_ = 0;

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -511,8 +511,8 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
     exit(-1);
   }
 
-  std::string ns = std::get<USDT_PROVIDER_INDEX>(attach_point->usdt);
-  std::string func = std::get<USDT_FNAME_INDEX>(attach_point->usdt);
+  std::string ns = attach_point->usdt.provider;
+  std::string func = attach_point->usdt.name;
 
   if (bcc_usdt_get_argument(usdt, ns.c_str(), func.c_str(), 0, arg_num, &argument) != 0) {
     std::cerr << "couldn't get argument " << arg_num << " for " << attach_point->target << ":"

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -489,6 +489,7 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
 
 Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
                                             AttachPoint *attach_point,
+                                            int usdt_location_index,
                                             int arg_num,
                                             Builtin &builtin,
                                             pid_t pid,
@@ -514,7 +515,13 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
   std::string ns = attach_point->usdt.provider;
   std::string func = attach_point->usdt.name;
 
-  if (bcc_usdt_get_argument(usdt, ns.c_str(), func.c_str(), 0, arg_num, &argument) != 0) {
+  if (bcc_usdt_get_argument(usdt,
+                            ns.c_str(),
+                            func.c_str(),
+                            usdt_location_index,
+                            arg_num,
+                            &argument) != 0)
+  {
     std::cerr << "couldn't get argument " << arg_num << " for " << attach_point->target << ":"
               << attach_point->ns << ":" << attach_point->func << std::endl;
     exit(-2);

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -66,7 +66,7 @@ public:
   CallInst   *CreateProbeReadStr(Value* ctx, AllocaInst *dst, llvm::Value *size, Value *src, const location& loc);
   CallInst   *CreateProbeReadStr(Value* ctx, AllocaInst *dst, size_t size, Value *src, const location& loc);
   CallInst   *CreateProbeReadStr(Value* ctx, Value *dst, size_t size, Value *src, const location& loc);
-  Value      *CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_point, int arg_name, Builtin &builtin, pid_t pid, const location& loc);
+  Value      *CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_point, int usdt_location_index, int arg_name, Builtin &builtin, pid_t pid, const location& loc);
   Value      *CreateStrcmp(Value* ctx, Value* val, std::string str, const location& loc, bool inverse=false);
   Value      *CreateStrcmp(Value* ctx, Value* val1, Value* val2, const location& loc, bool inverse=false);
   Value      *CreateStrncmp(Value* ctx, Value* val, std::string str, uint64_t n, const location& loc, bool inverse=false);

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -831,7 +831,7 @@ void AttachedProbe::attach_usdt(int pid)
   }
 
   auto u = USDTHelper::find(pid, probe_.path, probe_.ns, probe_.attach_point);
-  probe_.path = std::get<USDT_PATH_INDEX>(u);
+  probe_.path = u.path;
 
   err = bcc_usdt_get_location(ctx, probe_.ns.c_str(), probe_.attach_point.c_str(), 0, &loc);
   if (err)

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -403,9 +403,8 @@ std::unique_ptr<std::istream> BPFtrace::get_symbols_from_usdt(
 
   for (auto const& usdt_probe : usdt_probes)
   {
-    std::string path     = std::get<USDT_PATH_INDEX>(usdt_probe);
-    std::string provider = std::get<USDT_PROVIDER_INDEX>(usdt_probe);
-    std::string fname    = std::get<USDT_FNAME_INDEX>(usdt_probe);
+    std::string provider = usdt_probe.provider;
+    std::string fname = usdt_probe.name;
     probes += provider + ":" + fname + "\n";
   }
 

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -175,10 +175,9 @@ int BPFtrace::add_probe(ast::Probe &p)
         attach_funcs.push_back(attach_point->func);
     }
 
-    for (auto func_ : attach_funcs)
+    for (const auto &func : attach_funcs)
     {
-      std::string full_func_id = func_;
-      std::string func_id = func_;
+      std::string func_id = func;
 
       // USDT probes must specify both a provider and a function name for full id
       // So we will extract out the provider namespace to get just the function name
@@ -204,8 +203,8 @@ int BPFtrace::add_probe(ast::Probe &p)
       probe.address = attach_point->address;
       probe.func_offset = attach_point->func_offset;
       probe.loc = 0;
-      probe.index = attach_point->index(full_func_id) > 0 ?
-          attach_point->index(full_func_id) : p.index();
+      probe.index = attach_point->index(func) > 0 ? attach_point->index(func)
+                                                  : p.index();
       probe.len = attach_point->len;
       probe.mode = attach_point->mode;
       probes_.push_back(probe);

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -219,9 +219,9 @@ void list_probes(const BPFtrace &bpftrace, const std::string &search_input)
 
   for (auto const& usdt_probe : usdt_probes)
   {
-    std::string path     = std::get<USDT_PATH_INDEX>(usdt_probe);
-    std::string provider = std::get<USDT_PROVIDER_INDEX>(usdt_probe);
-    std::string fname    = std::get<USDT_FNAME_INDEX>(usdt_probe);
+    std::string path = usdt_probe.path;
+    std::string provider = usdt_probe.provider;
+    std::string fname = usdt_probe.name;
     std::string probe    = "usdt:" + path + ":" + provider + ":" + fname;
     if (usdt_path_list || search.empty() || !search_probe(probe, re))
       std::cout << probe << std::endl;

--- a/src/types.h
+++ b/src/types.h
@@ -206,6 +206,7 @@ struct Probe
   std::string name;             // full probe name
   std::string ns;               // for USDT probes, if provider namespace not from path
   uint64_t loc;                 // for USDT probes
+  int usdt_location_idx = 0;    // to disambiguate duplicate USDT markers
   uint64_t log_size;
   int index = 0;
   int freq;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -99,7 +99,11 @@ resolve_binary_path(const std::string &cmd, const char *env_paths, int pid);
 
 static void usdt_probe_each(struct bcc_usdt *usdt_probe)
 {
-  usdt_provider_cache[usdt_probe->provider].push_back(std::make_tuple(usdt_probe->bin_path, usdt_probe->provider, usdt_probe->name));
+  usdt_provider_cache[usdt_probe->provider].emplace_back(usdt_probe_entry{
+      .path = usdt_probe->bin_path,
+      .provider = usdt_probe->provider,
+      .name = usdt_probe->name,
+  });
 }
 
 void StdioSilencer::silence()
@@ -138,11 +142,15 @@ usdt_probe_entry USDTHelper::find(
 
   usdt_probe_list probes = usdt_provider_cache[provider];
 
-  auto it = std::find_if(probes.begin(), probes.end(), [&name](const usdt_probe_entry& e) {return std::get<USDT_FNAME_INDEX>(e) == name;});
+  auto it = std::find_if(probes.begin(),
+                         probes.end(),
+                         [&name](const usdt_probe_entry &e) {
+                           return e.name == name;
+                         });
   if (it != probes.end()) {
     return *it;
   } else {
-    return std::make_tuple("", "", "");
+    return {};
   }
 }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -103,6 +103,7 @@ static void usdt_probe_each(struct bcc_usdt *usdt_probe)
       .path = usdt_probe->bin_path,
       .provider = usdt_probe->provider,
       .name = usdt_probe->name,
+      .num_locations = usdt_probe->num_locations,
   });
 }
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -19,13 +19,12 @@ struct vmlinux_location
 };
 extern const struct vmlinux_location vmlinux_locs[];
 
-typedef enum _USDT_TUPLE_ORDER_
+struct usdt_probe_entry
 {
-  USDT_PATH_INDEX,
-  USDT_PROVIDER_INDEX,
-  USDT_FNAME_INDEX
-} usdt_probe_entry_enum;
-typedef std::tuple<std::string, std::string, std::string> usdt_probe_entry;
+  std::string path;
+  std::string provider;
+  std::string name;
+};
 typedef std::vector<usdt_probe_entry> usdt_probe_list;
 
 class MountNSException : public std::exception

--- a/src/utils.h
+++ b/src/utils.h
@@ -24,6 +24,7 @@ struct usdt_probe_entry
   std::string path;
   std::string provider;
   std::string name;
+  int num_locations;
 };
 typedef std::vector<usdt_probe_entry> usdt_probe_list;
 

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -222,3 +222,11 @@ RUN bpftrace -e 'usdt:./testprogs/usdt_sized_args:test:probe2 { printf("%ld\n", 
 EXPECT ^1$
 TIMEOUT 5
 BEFORE ./testprogs/usdt_sized_args
+
+# USDT probes can be inlined which creates duplicate identical probes. We must
+# attach to all of them
+NAME "usdt duplicated markers"
+RUN bpftrace -e 'usdt:./testprogs/usdt_inlined:tracetest:testprobe { exit(); }' -c ./testprogs/usdt_inlined
+EXPECT Attaching 2 probes
+TIMEOUT 1
+BEFORE ./testprogs/usdt_sized_args

--- a/tests/testprogs/usdt_inlined.c
+++ b/tests/testprogs/usdt_inlined.c
@@ -1,0 +1,46 @@
+#ifdef HAVE_SYSTEMTAP_SYS_SDT_H
+#include <sys/sdt.h>
+#else
+#define DTRACE_PROBE2(a, b, c, d) (void)0
+#endif
+#include <stdio.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+__attribute__((always_inline)) inline static void myclock()
+{
+  struct timeval tv;
+  gettimeofday(&tv, NULL);
+  DTRACE_PROBE2(tracetest, testprobe, tv.tv_sec, "Hello world");
+}
+
+static void mywrapper()
+{
+  myclock();
+}
+
+static void loop()
+{
+  while (1)
+  {
+    myclock();
+    mywrapper();
+    sleep(1);
+  }
+}
+
+int main(int argc, char **argv __attribute__((unused)))
+{
+  if (argc > 1)
+  // If we don't have Systemtap headers, we should skip USDT tests. Returning 1
+  // can be used as validation in the REQUIRE
+#ifndef HAVE_SYSTEMTAP_SYS_SDT_H
+    return 1;
+#else
+    return 0;
+#endif
+
+  loop();
+
+  return 0;
+}


### PR DESCRIPTION
This PR adds support for duplicated USDT markers. Duplication in
this context means identical provider and name. See the runtime
test for an example of how this can occur.

With this change, bpftrace will generate separate programs for each
duplicated marker. We need to generate separate programs because the
location of the usdt arguments may not be the same in each call site.
The later runtime test does not reproduce this behavior but I've
observed this happening in production before.

Note that a good portion of this PR is light refactoring work. Someone
(probably me) should really refactor the probe generation code. It's
excruciatingly difficult to reason about and extremely easy to make
mistakes. Maybe it could be made better by passing a metadata struct
around instead of trying to guess section names.

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
