### PR TITLE
Reimplement `Type::array`

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -566,7 +566,7 @@ void SemanticAnalyser::visit(Call &call)
 
     if (call.vargs->size() == 1)
       if (arg.type.IsArrayTy())
-        buffer_size = arg.type.pointee_size * arg.type.size;
+        buffer_size = arg.type.GetNumElements() * arg.type.GetElementTy()->size;
       else
         error(call.func + "() expects a length argument for non-array type " +
                   typestr(arg.type.type),
@@ -624,7 +624,7 @@ void SemanticAnalyser::visit(Call &call)
       check_arg(call, Type::integer, 0);
     }
 
-    if (arg->type.type != Type::integer && arg->type.type != Type::array)
+    if (!arg->type.IsIntTy() & !arg->type.IsArrayTy())
       ERR(call.func << "() expects an integer or array argument, got "
                     << arg->type.type,
           call.loc);
@@ -639,9 +639,15 @@ void SemanticAnalyser::visit(Call &call)
     //   }
     // }
     int buffer_size = 24;
-    if (arg->type.IsArrayTy())
+    auto type = arg->type;
+
+    // Ensure u8 array of either 4 or 16 elements
+    if (type.IsArrayTy())
     {
-      if (arg->type.elem_type != Type::integer || arg->type.pointee_size != 1 || !(arg->type.size == 4 || arg->type.size == 16)) {
+      if (!(type.GetElementTy()->IsIntTy() &&
+            type.GetElementTy()->GetIntBitWidth() == 8 &&
+            (type.GetNumElements() == 4 || type.GetNumElements() == 16)))
+      {
         error(call.func + "() invalid array", call.loc);
       }
     }
@@ -1148,8 +1154,12 @@ void SemanticAnalyser::visit(ArrayAccess &arr)
   SizedType &indextype = arr.indexpr->type;
 
   if (is_final_pass()) {
-    if (!((type.IsArrayTy() || type.IsCtxTy()) && type.elem_type != Type::none))
+    if (!((type.IsCtxTy() || type.IsArrayTy()) &&
+          !type.GetElementTy()->IsNoneTy()))
+    {
       error("The array index operator [] can only be used on arrays.", arr.loc);
+      return;
+    }
 
     if (indextype.IsIntTy() && arr.indexpr->is_literal)
     {
@@ -1166,7 +1176,8 @@ void SemanticAnalyser::visit(ArrayAccess &arr)
     }
   }
 
-  arr.type = SizedType(type.elem_type, type.pointee_size, type.IsSigned());
+  arr.type = (type.IsCtxTy() | type.IsArrayTy()) ? *type.GetElementTy()
+                                                 : CreateNone();
 }
 
 void SemanticAnalyser::visit(Binop &binop)

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -321,7 +321,7 @@ static SizedType get_sized_type(CXType clang_type)
     case CXType_ConstantArray:
     {
       auto elem_type = clang_getArrayElementType(clang_type);
-      auto size = clang_getArraySize(clang_type);
+      auto size = clang_getNumElements(clang_type);
       if (elem_type.kind == CXType_Char_S || elem_type.kind == CXType_Char_U)
       {
         return CreateString(size);
@@ -330,8 +330,8 @@ static SizedType get_sized_type(CXType clang_type)
       // Only support one-dimensional arrays for now
       if (elem_type.kind != CXType_ConstantArray)
       {
-        auto type = get_sized_type(elem_type);
-        return CreateArray(size, type.type, type.size, type.IsSigned());
+        auto elem_stype = get_sized_type(elem_type);
+        return CreateArray(size, elem_stype);
       } else {
         return CreateNone();
       }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -24,12 +24,11 @@ std::ostream &operator<<(std::ostream &os, const SizedType &type)
   }
   else if (type.IsIntTy())
   {
-    os << (type.is_signed_ ? "" : "unsigned ") << "int" << 8*type.size;
+    os << (type.is_signed_ ? "" : "unsigned ") << "int" << 8 * type.size;
   }
   else if (type.IsArrayTy())
   {
-    os << (type.is_signed_ ? "" : "unsigned ") << "int" << 8 * type.pointee_size;
-    os << "[" << type.size << "]";
+    os << type.GetElementTy() << "[" << type.GetNumElements() << "]";
   }
   else if (type.IsStringTy() || type.IsBufferTy())
   {
@@ -257,14 +256,11 @@ SizedType CreateCTX(size_t size, std::string name)
   return SizedType(Type::ctx, size, name);
 }
 
-SizedType CreateArray(size_t num_elem,
-                      Type elem_type,
-                      size_t elem_size,
-                      bool elem_is_signed)
+SizedType CreateArray(size_t num_elements, const SizedType &element_type)
 {
-  auto ty = SizedType(Type::array, num_elem, elem_is_signed);
-  ty.elem_type = elem_type;
-  ty.pointee_size = elem_size;
+  auto ty = SizedType(Type::array, num_elements);
+  ty.num_elements_ = num_elements;
+  ty.element_type_ = new SizedType(element_type);
   return ty;
 }
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -24,11 +24,11 @@ std::ostream &operator<<(std::ostream &os, const SizedType &type)
   }
   else if (type.IsIntTy())
   {
-    os << (type.is_signed ? "" : "unsigned ") << "int" << 8*type.size;
+    os << (type.is_signed_ ? "" : "unsigned ") << "int" << 8*type.size;
   }
   else if (type.IsArrayTy())
   {
-    os << (type.is_signed ? "" : "unsigned ") << "int" << 8 * type.pointee_size;
+    os << (type.is_signed_ ? "" : "unsigned ") << "int" << 8 * type.pointee_size;
     os << "[" << type.size << "]";
   }
   else if (type.IsStringTy() || type.IsBufferTy())
@@ -48,7 +48,7 @@ std::ostream &operator<<(std::ostream &os, const SizedType &type)
 
 bool SizedType::IsEqual(const SizedType &t) const
 {
-  return type == t.type && size == t.size && is_signed == t.is_signed;
+  return type == t.type && size == t.size && is_signed_ == t.is_signed_;
 }
 
 bool SizedType::operator!=(const SizedType &t) const
@@ -354,7 +354,7 @@ SizedType CreateBuffer(size_t size)
 
 bool SizedType::IsSigned(void) const
 {
-  return is_signed;
+  return is_signed_;
 }
 
 } // namespace bpftrace

--- a/src/types.h
+++ b/src/types.h
@@ -74,7 +74,7 @@ public:
             size_t size_,
             bool is_signed,
             const std::string &cast_type = "")
-      : type(type), size(size_), cast_type(cast_type), is_signed(is_signed)
+      : type(type), size(size_), cast_type(cast_type), is_signed_(is_signed)
   {
   }
   SizedType(Type type, size_t size_, const std::string &cast_type = "")
@@ -96,7 +96,7 @@ public:
   int kfarg_idx = -1;
 
 private:
-  bool is_signed = false;
+  bool is_signed_ = false;
 
 public:
   bool IsArray() const;

--- a/src/types.h
+++ b/src/types.h
@@ -85,6 +85,7 @@ public:
   Type type;
   Type elem_type = Type::none; // Array element type if accessing elements of an
                                // array
+
   size_t size;                 // in bytes
   StackType stack_type;
   std::string cast_type;
@@ -97,6 +98,9 @@ public:
 
 private:
   bool is_signed_ = false;
+  SizedType *element_type_ = nullptr; // for "container" and pointer
+                                      // (like) types
+  size_t num_elements_;               // for array like types
 
 public:
   bool IsArray() const;
@@ -107,6 +111,29 @@ public:
   bool operator!=(const SizedType &t) const;
 
   bool IsSigned(void) const;
+
+  size_t GetIntBitWidth() const
+  {
+    assert(IsIntTy());
+    return 8 * size;
+  };
+
+  size_t GetNumElements() const
+  {
+    assert(IsArrayTy() || IsStringTy());
+    return size;
+  };
+
+  const SizedType *GetElementTy() const
+  {
+    assert(IsArrayTy() || IsCtxTy());
+    return element_type_;
+  }
+
+  bool IsPtrTy() const
+  {
+    return IsIntTy() && is_pointer;
+  };
 
   bool IsIntTy() const
   {
@@ -216,6 +243,11 @@ public:
 
   friend std::ostream &operator<<(std::ostream &, const SizedType &);
   friend std::ostream &operator<<(std::ostream &, Type);
+
+  // Factories
+
+  friend SizedType CreateArray(size_t num_elements,
+                               const SizedType &element_type);
 };
 // Type helpers
 
@@ -233,10 +265,7 @@ SizedType CreateUInt32();
 SizedType CreateUInt64();
 
 SizedType CreateString(size_t size);
-SizedType CreateArray(size_t num_elem,
-                      Type elem_type,
-                      size_t elem_size,
-                      bool elem_is_signed);
+SizedType CreateArray(size_t num_elements, const SizedType &element_type);
 
 SizedType CreateStackMode();
 SizedType CreateStack(bool kernel, StackType st = StackType());

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1598,7 +1598,7 @@ TEST(semantic_analyser, type_ctx)
   auto arrayaccess = static_cast<ast::ArrayAccess *>(assignment->expr);
   EXPECT_EQ(CreateInt16(), arrayaccess->type);
   fieldaccess = static_cast<ast::FieldAccess *>(arrayaccess->expr);
-  EXPECT_EQ(SizedType(Type::ctx, 4, true), fieldaccess->type);
+  EXPECT_EQ(SizedType(Type::ctx, 4, false), fieldaccess->type);
   unop = static_cast<ast::Unop *>(fieldaccess->expr);
   EXPECT_EQ(SizedType(Type::ctx, 32, false), unop->type);
   var = static_cast<ast::Variable *>(unop->expr);


### PR DESCRIPTION
This is the first in the series, so if we want to change function name style or something this is probably the best time.

Related to #878 

---

Arrays used the `size`, `elem_type` and `pointee_size` fields to store
array type information. This is confusing as `pointee_size` indicates a
pointer and also incomplete as an array of pointers cannot be stored
without losing pointee size information.

This fixes that by storing the complete type (`SizedType *`) instead of
just a few fields.
