### PR TITLE
Fix KBUILD_MODNAME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ and this project adheres to
   - [#1325](https://github.com/iovisor/bpftrace/pull/1325)
 - Attach to duplicated USDT markers
   - [#1341](https://github.com/iovisor/bpftrace/pull/1341)
+- Fix `KBUILD_MODNAME`
+  - [#1352](https://github.com/iovisor/bpftrace/pull/1352)
 
 #### Tools
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -374,7 +374,7 @@ std::vector<std::string> get_kernel_cflags(
   cflags.push_back("-D__HAVE_BUILTIN_BSWAP16__");
   cflags.push_back("-D__HAVE_BUILTIN_BSWAP32__");
   cflags.push_back("-D__HAVE_BUILTIN_BSWAP64__");
-  cflags.push_back("-DKBUILD_MODNAME='\"bpftrace\"'");
+  cflags.push_back("-DKBUILD_MODNAME=\"bpftrace\"");
 
   // If ARCH env variable is set, pass this along.
   if (archenv)


### PR DESCRIPTION
I found that bpftrace cannot include net/sock.h on Linux 5.7-rc7.

```
% sudo ./src/bpftrace -e 'BEGIN {}' --include net/sock.h
[...]
/lib/modules/5.7.0-rc7/source/include/net/flow_offload.h:342:3: error: array initializer must be an initializer list or string literal
/lib/modules/5.7.0-rc7/source/include/net/flow_offload.h:342:3: error: expected ';' at end of declaration
```

Related parts are

https://github.com/torvalds/linux/commit/319a1d19471ec49b8a91a7f6a3fe2c4535e5c279#diff-c92be59c4d9bb3274ff03bce22e057b4R269
https://github.com/torvalds/linux/blob/444fc5cde64330661bf59944c43844e7d4c2ccd8/include/linux/netlink.h#L96

and it seems `KBUILD_MODNAME` is invalid. Use "bpftrace" instead of '"bpftrace"' as `KBUILD_MODNAME`.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
  - This is no language changes.
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
