### PR TITLE
Fix heap-buffer-overflow of JsonOutput::tuple_to_str

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -642,7 +642,7 @@ std::string JsonOutput::tuple_to_str(BPFtrace &bpftrace,
       ret += ',';
 
     std::vector<uint8_t> elem_value(value.begin() + offset,
-                                    value.begin() + offset + ty.size);
+                                    value.begin() + offset + elemtype.size);
 
     if (elemtype.type == Type::tuple)
       ret += tuple_to_str(bpftrace, elemtype, elem_value);


### PR DESCRIPTION
Similar to https://github.com/iovisor/bpftrace/pull/1326#discussion_r426317843. AddressSanitizer detects it.

I think it's a good idea to build with AddressSanitizer in CI. Memory leak detector (LeakSanitizer) does not abort when finding leaks by default, so runtime tests will pass even they have a memory leak (heap-buffer-overflow results in abort). It is also possible to disable memory leak detection using ` ASAN_OPTIONS=detect_leaks=0` if necessary. 