### PR TITLE
usdt: Fix attaching to probes in different binaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ and this project adheres to
   - [#1352](https://github.com/iovisor/bpftrace/pull/1352)
 - Fix `ntop()` not accepting tracepoint arguments
   - [#1365](https://github.com/iovisor/bpftrace/pull/1365)
+- Fix attaching to usdt probes in multiple binaries
+  - [#1356](https://github.com/iovisor/bpftrace/pull/1356)
 
 #### Tools
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(bpftrace
   struct.cpp
   tracepoint_format_parser.cpp
   types.cpp
+  usdt.cpp
   utils.cpp
   ${BFD_DISASM_SRC}
 )

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -7,6 +7,7 @@
 #include <vector>
 
 #include "types.h"
+#include "usdt.h"
 
 namespace bpftrace {
 namespace ast {

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1897,8 +1897,12 @@ void CodegenLLVM::visit(Probe &probe)
           attach_point->ns = orig_ns;
 
           // Set the probe identifier so that we can read arguments later
-          attach_point->usdt = USDTHelper::find(
+          auto usdt = USDTHelper::find(
               bpftrace_.pid(), attach_point->target, ns, func_id);
+          if (!usdt.has_value())
+            throw std::runtime_error("Failed to find usdt probe: " +
+                                     probefull_);
+          attach_point->usdt = *usdt;
 
           // A "unique" USDT probe can be present in a binary in multiple
           // locations. One case where this happens is if a function containing

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -6,7 +6,7 @@
 #include "parser.tab.hh"
 #include "tracepoint_format_parser.h"
 #include "types.h"
-#include "utils.h"
+#include "usdt.h"
 #include <algorithm>
 #include <arpa/inet.h>
 #include <csignal>

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -6,7 +6,7 @@
 #include "parser.tab.hh"
 #include "printf.h"
 #include "tracepoint_format_parser.h"
-#include "utils.h"
+#include "usdt.h"
 #include <algorithm>
 #include <cstring>
 #include <regex>

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -17,7 +17,7 @@
 #include "bpftrace.h"
 #include "disasm.h"
 #include "list.h"
-#include "utils.h"
+#include "usdt.h"
 #include <bcc/bcc_elf.h>
 #include <bcc/bcc_syms.h>
 #include <bcc/bcc_usdt.h>

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -831,7 +831,9 @@ void AttachedProbe::attach_usdt(int pid)
   }
 
   auto u = USDTHelper::find(pid, probe_.path, probe_.ns, probe_.attach_point);
-  probe_.path = u.path;
+  if (!u.has_value())
+    throw std::runtime_error("Failed to find usdt probe: " + eventname());
+  probe_.path = u->path;
 
   err = bcc_usdt_get_location(ctx, probe_.ns.c_str(), probe_.attach_point.c_str(), 0, &loc);
   if (err)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -644,7 +644,16 @@ int main(int argc, char *argv[])
   }
 
   ast::CodegenLLVM llvm(driver.root_, bpftrace);
-  auto bpforc = llvm.compile(bt_debug);
+  std::unique_ptr<BpfOrc> bpforc;
+  try
+  {
+    bpforc = llvm.compile(bt_debug);
+  }
+  catch (const std::exception& ex)
+  {
+    std::cerr << "Failed to compile: " << ex.what() << std::endl;
+    return 1;
+  }
 
   if (bt_debug != DebugLevel::kNone)
     return 0;

--- a/src/usdt.cpp
+++ b/src/usdt.cpp
@@ -26,10 +26,10 @@ static void usdt_probe_each(struct bcc_usdt *usdt_probe)
   });
 }
 
-usdt_probe_entry USDTHelper::find(int pid,
-                                  const std::string &target,
-                                  const std::string &provider,
-                                  const std::string &name)
+std::optional<usdt_probe_entry> USDTHelper::find(int pid,
+                                                 const std::string &target,
+                                                 const std::string &provider,
+                                                 const std::string &name)
 {
   if (pid > 0)
     read_probes_for_pid(pid);
@@ -49,7 +49,7 @@ usdt_probe_entry USDTHelper::find(int pid,
   }
   else
   {
-    return {};
+    return std::nullopt;
   }
 }
 

--- a/src/usdt.cpp
+++ b/src/usdt.cpp
@@ -51,22 +51,6 @@ usdt_probe_entry USDTHelper::find(int pid,
   }
 }
 
-usdt_probe_list USDTHelper::probes_for_provider(const std::string &provider)
-{
-  usdt_probe_list probes;
-
-  if (!provider_cache_loaded)
-  {
-    std::cerr << "cannot read probes by provider before providers have been "
-                 "loaded by pid or path."
-              << std::endl;
-    return probes;
-  }
-
-  read_probes_for_pid(0);
-  return usdt_provider_cache[provider];
-}
-
 usdt_probe_list USDTHelper::probes_for_pid(int pid)
 {
   read_probes_for_pid(pid);

--- a/src/usdt.cpp
+++ b/src/usdt.cpp
@@ -1,0 +1,144 @@
+#include "usdt.h"
+
+#include <signal.h>
+
+#include <algorithm>
+#include <iostream>
+#include <map>
+
+#include <bcc/bcc_elf.h>
+#include <bcc/bcc_usdt.h>
+
+static bool provider_cache_loaded = false;
+
+// Maps all providers of pid to vector of tracepoints on that provider
+static std::map<std::string, usdt_probe_list> usdt_provider_cache;
+
+static void usdt_probe_each(struct bcc_usdt *usdt_probe)
+{
+  usdt_provider_cache[usdt_probe->provider].emplace_back(usdt_probe_entry{
+      .path = usdt_probe->bin_path,
+      .provider = usdt_probe->provider,
+      .name = usdt_probe->name,
+      .num_locations = usdt_probe->num_locations,
+  });
+}
+
+usdt_probe_entry USDTHelper::find(int pid,
+                                  const std::string &target,
+                                  const std::string &provider,
+                                  const std::string &name)
+{
+  if (pid > 0)
+    read_probes_for_pid(pid);
+  else
+    read_probes_for_path(target);
+
+  usdt_probe_list probes = usdt_provider_cache[provider];
+
+  auto it = std::find_if(probes.begin(),
+                         probes.end(),
+                         [&name](const usdt_probe_entry &e) {
+                           return e.name == name;
+                         });
+  if (it != probes.end())
+  {
+    return *it;
+  }
+  else
+  {
+    return {};
+  }
+}
+
+usdt_probe_list USDTHelper::probes_for_provider(const std::string &provider)
+{
+  usdt_probe_list probes;
+
+  if (!provider_cache_loaded)
+  {
+    std::cerr << "cannot read probes by provider before providers have been "
+                 "loaded by pid or path."
+              << std::endl;
+    return probes;
+  }
+
+  read_probes_for_pid(0);
+  return usdt_provider_cache[provider];
+}
+
+usdt_probe_list USDTHelper::probes_for_pid(int pid)
+{
+  read_probes_for_pid(pid);
+
+  usdt_probe_list probes;
+  for (auto const &usdt_probes : usdt_provider_cache)
+  {
+    probes.insert(probes.end(),
+                  usdt_probes.second.begin(),
+                  usdt_probes.second.end());
+  }
+  return probes;
+}
+
+usdt_probe_list USDTHelper::probes_for_path(const std::string &path)
+{
+  read_probes_for_path(path);
+
+  usdt_probe_list probes;
+  for (auto const &usdt_probes : usdt_provider_cache)
+  {
+    probes.insert(probes.end(),
+                  usdt_probes.second.begin(),
+                  usdt_probes.second.end());
+  }
+  return probes;
+}
+
+void USDTHelper::read_probes_for_pid(int pid)
+{
+  if (provider_cache_loaded)
+    return;
+
+  if (pid > 0)
+  {
+    void *ctx = bcc_usdt_new_frompid(pid, nullptr);
+    if (ctx == nullptr)
+    {
+      std::cerr << "failed to initialize usdt context for pid: " << pid
+                << std::endl;
+      if (kill(pid, 0) == -1 && errno == ESRCH)
+      {
+        std::cerr << "hint: process not running" << std::endl;
+      }
+      return;
+    }
+    bcc_usdt_foreach(ctx, usdt_probe_each);
+    bcc_usdt_close(ctx);
+
+    provider_cache_loaded = true;
+  }
+  else
+  {
+    std::cerr << "a pid must be specified to list USDT probes by PID"
+              << std::endl;
+  }
+}
+
+void USDTHelper::read_probes_for_path(const std::string &path)
+{
+  if (provider_cache_loaded)
+    return;
+
+  void *ctx = bcc_usdt_new_frompath(path.c_str());
+  if (ctx == nullptr)
+  {
+    std::cerr << "failed to initialize usdt context for path " << path
+              << std::endl;
+    return;
+  }
+  bcc_usdt_foreach(ctx, usdt_probe_each);
+  bcc_usdt_close(ctx);
+
+  provider_cache_loaded = true;
+}

--- a/src/usdt.h
+++ b/src/usdt.h
@@ -22,9 +22,10 @@ public:
                                const std::string &target,
                                const std::string &provider,
                                const std::string &name);
-  static usdt_probe_list probes_for_provider(const std::string &provider);
   static usdt_probe_list probes_for_pid(int pid);
   static usdt_probe_list probes_for_path(const std::string &path);
+
+private:
   static void read_probes_for_pid(int pid);
   static void read_probes_for_path(const std::string &path);
 };

--- a/src/usdt.h
+++ b/src/usdt.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -18,10 +19,10 @@ typedef std::vector<usdt_probe_entry> usdt_probe_list;
 class USDTHelper
 {
 public:
-  static usdt_probe_entry find(int pid,
-                               const std::string &target,
-                               const std::string &provider,
-                               const std::string &name);
+  static std::optional<usdt_probe_entry> find(int pid,
+                                              const std::string &target,
+                                              const std::string &provider,
+                                              const std::string &name);
   static usdt_probe_list probes_for_pid(int pid);
   static usdt_probe_list probes_for_path(const std::string &path);
 

--- a/src/usdt.h
+++ b/src/usdt.h
@@ -13,6 +13,8 @@ struct usdt_probe_entry
 
 typedef std::vector<usdt_probe_entry> usdt_probe_list;
 
+// Note this class is fully static because bcc_usdt_foreach takes a function
+// pointer callback without a context variable. So we must keep global state.
 class USDTHelper
 {
 public:

--- a/src/usdt.h
+++ b/src/usdt.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+struct usdt_probe_entry
+{
+  std::string path;
+  std::string provider;
+  std::string name;
+  int num_locations;
+};
+
+typedef std::vector<usdt_probe_entry> usdt_probe_list;
+
+class USDTHelper
+{
+public:
+  static usdt_probe_entry find(int pid,
+                               const std::string &target,
+                               const std::string &provider,
+                               const std::string &name);
+  static usdt_probe_list probes_for_provider(const std::string &provider);
+  static usdt_probe_list probes_for_pid(int pid);
+  static usdt_probe_list probes_for_path(const std::string &path);
+  static void read_probes_for_pid(int pid);
+  static void read_probes_for_path(const std::string &path);
+};

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -15,7 +15,6 @@
 
 #include "utils.h"
 #include <bcc/bcc_elf.h>
-#include <bcc/bcc_usdt.h>
 
 namespace {
 
@@ -88,24 +87,9 @@ const struct vmlinux_location vmlinux_locs[] = {
   { nullptr, false },
 };
 
-static bool provider_cache_loaded = false;
-
-// Maps all providers of pid to vector of tracepoints on that provider
-static std::map<std::string, usdt_probe_list> usdt_provider_cache;
-
 static bool pid_in_different_mountns(int pid);
 static std::vector<std::string>
 resolve_binary_path(const std::string &cmd, const char *env_paths, int pid);
-
-static void usdt_probe_each(struct bcc_usdt *usdt_probe)
-{
-  usdt_provider_cache[usdt_probe->provider].emplace_back(usdt_probe_entry{
-      .path = usdt_probe->bin_path,
-      .provider = usdt_probe->provider,
-      .name = usdt_probe->name,
-      .num_locations = usdt_probe->num_locations,
-  });
-}
 
 void StdioSilencer::silence()
 {
@@ -127,108 +111,6 @@ StdioSilencer::~StdioSilencer()
     close(old_stdio_);
     old_stdio_ = -1;
   }
-}
-
-usdt_probe_entry USDTHelper::find(
-    int pid,
-    const std::string &target,
-    const std::string &provider,
-    const std::string &name)
-{
-
-  if (pid > 0)
-    read_probes_for_pid(pid);
-  else
-    read_probes_for_path(target);
-
-  usdt_probe_list probes = usdt_provider_cache[provider];
-
-  auto it = std::find_if(probes.begin(),
-                         probes.end(),
-                         [&name](const usdt_probe_entry &e) {
-                           return e.name == name;
-                         });
-  if (it != probes.end()) {
-    return *it;
-  } else {
-    return {};
-  }
-}
-
-usdt_probe_list USDTHelper::probes_for_provider(const std::string &provider)
-{
-  usdt_probe_list probes;
-
-  if(!provider_cache_loaded) {
-    std::cerr << "cannot read probes by provider before providers have been loaded by pid or path." << std::endl;
-    return probes;
-  }
-
-  read_probes_for_pid(0);
-  return usdt_provider_cache[provider];
-}
-
-usdt_probe_list USDTHelper::probes_for_pid(int pid)
-{
-  read_probes_for_pid(pid);
-
-  usdt_probe_list probes;
-  for (auto const& usdt_probes : usdt_provider_cache)
-  {
-    probes.insert( probes.end(), usdt_probes.second.begin(), usdt_probes.second.end() );
-  }
-  return probes;
-}
-
-usdt_probe_list USDTHelper::probes_for_path(const std::string &path)
-{
-  read_probes_for_path(path);
-
-  usdt_probe_list probes;
-  for (auto const& usdt_probes : usdt_provider_cache)
-  {
-    probes.insert( probes.end(), usdt_probes.second.begin(), usdt_probes.second.end() );
-  }
-  return probes;
-}
-
-void USDTHelper::read_probes_for_pid(int pid)
-{
-  if(provider_cache_loaded)
-    return;
-
-  if (pid > 0) {
-    void *ctx = bcc_usdt_new_frompid(pid, nullptr);
-    if (ctx == nullptr) {
-      std::cerr << "failed to initialize usdt context for pid: " << pid << std::endl;
-      if (kill(pid, 0) == -1 && errno == ESRCH) {
-        std::cerr << "hint: process not running" << std::endl;
-      }
-      return;
-    }
-    bcc_usdt_foreach(ctx, usdt_probe_each);
-    bcc_usdt_close(ctx);
-
-    provider_cache_loaded = true;
-  } else {
-    std::cerr << "a pid must be specified to list USDT probes by PID" << std::endl;
-  }
-}
-
-void USDTHelper::read_probes_for_path(const std::string &path)
-{
-  if(provider_cache_loaded)
-    return;
-
-  void *ctx = bcc_usdt_new_frompath(path.c_str());
-  if (ctx == nullptr) {
-    std::cerr << "failed to initialize usdt context for path " << path << std::endl;
-    return;
-  }
-  bcc_usdt_foreach(ctx, usdt_probe_each);
-  bcc_usdt_close(ctx);
-
-  provider_cache_loaded = true;
 }
 
 bool get_uint64_env_var(const std::string &str, uint64_t &dest)

--- a/src/utils.h
+++ b/src/utils.h
@@ -18,16 +18,6 @@ struct vmlinux_location
   bool raw;         // file is either as ELF (false) or raw BTF data (true)
 };
 extern const struct vmlinux_location vmlinux_locs[];
-
-struct usdt_probe_entry
-{
-  std::string path;
-  std::string provider;
-  std::string name;
-  int num_locations;
-};
-typedef std::vector<usdt_probe_entry> usdt_probe_list;
-
 class MountNSException : public std::exception
 {
 public:
@@ -91,20 +81,6 @@ public:
   {
     ofile = stdout;
   }
-};
-
-class USDTHelper
-{
-public:
-  static usdt_probe_entry find(int pid,
-                               const std::string &target,
-                               const std::string &provider,
-                               const std::string &name);
-  static usdt_probe_list probes_for_provider(const std::string &provider);
-  static usdt_probe_list probes_for_pid(int pid);
-  static usdt_probe_list probes_for_path(const std::string &path);
-  static void read_probes_for_pid(int pid);
-  static void read_probes_for_path(const std::string &path);
 };
 
 // Hack used to suppress build warning related to #474

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -51,6 +51,7 @@ add_executable(bpftrace_test
   ${CMAKE_SOURCE_DIR}/src/struct.cpp
   ${CMAKE_SOURCE_DIR}/src/tracepoint_format_parser.cpp
   ${CMAKE_SOURCE_DIR}/src/types.cpp
+  ${CMAKE_SOURCE_DIR}/src/usdt.cpp
   ${CMAKE_SOURCE_DIR}/src/utils.cpp
   ${BFD_DISASM_SRC}
 )

--- a/tests/runtime/scripts/usdt_multi_modules.bt
+++ b/tests/runtime/scripts/usdt_multi_modules.bt
@@ -1,0 +1,9 @@
+usdt:./testprogs/usdt_test:tracetest:testprobe
+{
+    exit();
+}
+
+usdt:./testprogs/usdt_sized_args:test:probe1
+{
+    exit();
+}

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -232,3 +232,9 @@ RUN bpftrace -e 'usdt:./testprogs/usdt_inlined:tracetest:testprobe { exit(); }' 
 EXPECT Attaching 2 probes
 TIMEOUT 1
 REQUIRES ./testprogs/usdt_inlined should_not_skip
+
+NAME "usdt probes in multiple modules"
+RUN bpftrace runtime/scripts/usdt_multi_modules.bt -c ./testprogs/usdt_test
+EXPECT Attaching 2 probes
+TIMEOUT 1
+REQUIRES ./testprogs/usdt_test should_not_skip


### PR DESCRIPTION
USDTHelper caching logic was previously incorrect. It would mark the
cache as loaded if any pid or path was processed. This would cause
scripts that place usdt probes on different binaries to silently fail
(because a default usdt_probe_entry would be returned).

See the runtime test for an example of how this can occur.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
