### PR TITLE
RFC: Store strings off-stack (rebased)

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -1,6 +1,7 @@
 #include "ast.h"
 #include "parser.tab.hh"
 #include <iostream>
+#include <cstdlib>
 
 namespace bpftrace {
 namespace ast {
@@ -108,27 +109,37 @@ void PositionalParameter::accept(Visitor &v) {
   v.visit(*this);
 }
 
-Call::Call(const std::string &func) : func(is_deprecated(func)), vargs(nullptr)
-{
-}
-
-Call::Call(const std::string &func, location loc)
-    : Expression(loc), func(is_deprecated(func)), vargs(nullptr)
-{
-}
-
-Call::Call(const std::string &func, ExpressionList *vargs)
-    : func(is_deprecated(func)), vargs(vargs)
-{
-}
-
-Call::Call(const std::string &func, ExpressionList *vargs, location loc)
+Call::Call(const std::string &func, location loc, ExpressionList *vargs)
     : Expression(loc), func(is_deprecated(func)), vargs(vargs)
 {
 }
 
 void Call::accept(Visitor &v) {
   v.visit(*this);
+}
+
+StrCall::StrCall(location loc, ExpressionList *vargs)
+    : Call("str", std::move(loc), vargs)
+{
+}
+
+void StrCall::StrMapState::ZeroesDeleter::operator()(std::byte* bytes) {
+  free(bytes);
+}
+
+StrCall::StrMapState::StrMapState(
+  std::shared_ptr<IMap> map,
+  std::unique_ptr<std::byte, ZeroesDeleter> zeroesForClearingMap
+  )
+: map(std::move(map))
+, zeroesForClearingMap(std::move(zeroesForClearingMap))
+{}
+
+Call* CallFactory::createCall(const std::string &func, location loc, ExpressionList *vargs) {
+  if (func == "str") {
+    return new StrCall(std::move(loc), vargs);
+  }
+  return new Call(func, std::move(loc), vargs);
 }
 
 Map::Map(const std::string &ident, location loc)

--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -93,5 +93,17 @@ struct HelperError
   }
 } __attribute__((packed));
 
+struct StrMap
+{
+  uint64_t mapfd;
+  uint64_t arrayIx;
+  uint64_t strLen;
+
+  llvm::StructType *asLLVMType(ast::IRBuilderBPF& b)
+  {
+    return b.GetMapStrTy();
+  }
+}; // deliberately not packed; IRBuilder specifies isPacked=false
+
 } // namespace AsyncEvent
 } // namespace bpftrace

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -2300,11 +2300,26 @@ void CodegenLLVM::createFormatStringCall(Call &call, int &id, CallArgs &call_arg
     arg.offset = struct_layout->getElementOffset(i+1); // +1 for the id field
   }
 
-  AllocaInst *fmt_args = b_.CreateAllocaBPF(fmt_struct, call_name + "_args");
-  b_.CREATE_MEMSET(fmt_args, b_.getInt8(0), struct_size, 1);
+  int asyncId = id + asyncactionint(async_action);
+  Value *fmt_args = b_.CreateGetFmtStrMap(ctx_, fmt_struct, call.loc);
+
+  Function *parent = b_.GetInsertBlock()->getParent();
+  BasicBlock *zero = BasicBlock::Create(module_->getContext(), "fmtstrzero", parent);
+  BasicBlock *notzero = BasicBlock::Create(module_->getContext(), "fmtstrnotzero", parent);
+
+  auto fmt_struct_ptr_ty = PointerType::get(fmt_struct, 0);
+  auto null_ptr = ConstantExpr::getCast(Instruction::IntToPtr, b_.getInt64(0), fmt_struct_ptr_ty);
+  b_.CreateCondBr(b_.CreateICmpNE(fmt_args, null_ptr, "fmtstrcond"), notzero, zero);
+
+  b_.SetInsertPoint(notzero);
+
+  auto zeroed_area_ptr = b_.getInt64(reinterpret_cast<uintptr_t>(bpftrace_.fmtstr_map_zero_));
+
+  b_.CreateProbeRead(ctx_, fmt_args, struct_size,
+                     ConstantExpr::getCast(Instruction::IntToPtr, zeroed_area_ptr, fmt_struct_ptr_ty), call.loc);
 
   Value *id_offset = b_.CreateGEP(fmt_args, {b_.getInt32(0), b_.getInt32(0)});
-  b_.CreateStore(b_.getInt64(id + asyncactionint(async_action)), id_offset);
+  b_.CreateStore(b_.getInt64(asyncId), id_offset);
   for (size_t i=1; i<call.vargs->size(); i++)
   {
     Expression &arg = *call.vargs->at(i);
@@ -2327,6 +2342,11 @@ void CodegenLLVM::createFormatStringCall(Call &call, int &id, CallArgs &call_arg
   id++;
   b_.CreatePerfEventOutput(ctx_, fmt_args, struct_size);
   b_.CreateLifetimeEnd(fmt_args);
+
+  b_.CreateBr(zero);
+
+  // done
+  b_.SetInsertPoint(zero);
   expr_ = nullptr;
 }
 

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -66,6 +66,7 @@ public:
   CallInst   *CreateProbeReadStr(Value* ctx, AllocaInst *dst, llvm::Value *size, Value *src, const location& loc);
   CallInst   *CreateProbeReadStr(Value* ctx, AllocaInst *dst, size_t size, Value *src, const location& loc);
   CallInst   *CreateProbeReadStr(Value* ctx, Value *dst, size_t size, Value *src, const location& loc);
+  CallInst   *CreateProbeReadStr(Value* ctx, Value *dst, Value *size, Value *src, const location& loc);
   Value      *CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_point, int usdt_location_index, int arg_name, Builtin &builtin, pid_t pid, const location& loc);
   Value      *CreateStrcmp(Value* ctx, Value* val, std::string str, const location& loc, bool inverse=false);
   Value      *CreateStrcmp(Value* ctx, Value* val1, Value* val2, const location& loc, bool inverse=false);
@@ -80,6 +81,7 @@ public:
   CallInst   *CreateGetRandom();
   CallInst   *CreateGetStackId(Value *ctx, bool ustack, StackType stack_type, const location& loc);
   CallInst   *CreateGetJoinMap(Value *ctx, const location& loc);
+  CallInst   *CreateGetStrMap(Value *ctx, int mapfd, int elem, const location& loc);
   CallInst   *CreateGetFmtStrMap(Value *ctx, StructType *printf_struct, const location& loc);
   void        CreateGetCurrentComm(Value *ctx, AllocaInst *buf, size_t size, const location& loc);
   void        CreatePerfEventOutput(Value *ctx, Value *data, size_t size);
@@ -90,6 +92,7 @@ public:
   StructType *GetStructType(std::string name, const std::vector<llvm::Type *> & elements, bool packed = false);
   AllocaInst *CreateUSym(llvm::Value *val);
   Value      *CreatKFuncArg(Value *ctx, SizedType& type, std::string& name);
+  StructType *GetMapStrTy();
   int helper_error_id_ = 0;
 
 private:

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -61,8 +61,8 @@ public:
   Value      *CreateMapLookupElem(Value* ctx, int mapfd, AllocaInst *key, SizedType &type, const location& loc);
   void        CreateMapUpdateElem(Value* ctx, Map &map, AllocaInst *key, Value *val, const location& loc);
   void        CreateMapDeleteElem(Value* ctx, Map &map, AllocaInst *key, const location& loc);
-  void        CreateProbeRead(Value *ctx, AllocaInst *dst, size_t size, Value *src, const location& loc);
-  void        CreateProbeRead(Value *ctx, AllocaInst *dst, llvm::Value *size, Value *src, const location& loc);
+  void        CreateProbeRead(Value *ctx, Value *dst, size_t size, Value *src, const location& loc);
+  void        CreateProbeRead(Value *ctx, Value *dst, llvm::Value *size, Value *src, const location& loc);
   CallInst   *CreateProbeReadStr(Value* ctx, AllocaInst *dst, llvm::Value *size, Value *src, const location& loc);
   CallInst   *CreateProbeReadStr(Value* ctx, AllocaInst *dst, size_t size, Value *src, const location& loc);
   CallInst   *CreateProbeReadStr(Value* ctx, Value *dst, size_t size, Value *src, const location& loc);
@@ -80,6 +80,7 @@ public:
   CallInst   *CreateGetRandom();
   CallInst   *CreateGetStackId(Value *ctx, bool ustack, StackType stack_type, const location& loc);
   CallInst   *CreateGetJoinMap(Value *ctx, const location& loc);
+  CallInst   *CreateGetFmtStrMap(Value *ctx, StructType *printf_struct, const location& loc);
   void        CreateGetCurrentComm(Value *ctx, AllocaInst *buf, size_t size, const location& loc);
   void        CreatePerfEventOutput(Value *ctx, Value *data, size_t size);
   void        CreateSignal(Value *ctx, Value *sig, const location &loc);

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -772,6 +772,7 @@ void SemanticAnalyser::visit(Call &call)
   }
   else if (call.func == "printf" || call.func == "system" || call.func == "cat")
   {
+    needs_fmtstr_map_ = true;
     check_assignment(call, false, false, false);
     if (check_varargs(call, 1, 7))
     {
@@ -781,6 +782,7 @@ void SemanticAnalyser::visit(Call &call)
         auto &fmt_arg = *call.vargs->at(0);
         String &fmt = static_cast<String&>(fmt_arg);
         std::vector<Field> args;
+        size_t args_size = 0;
         for (auto iter = call.vargs->begin() + 1; iter != call.vargs->end();
              iter++)
         {
@@ -798,7 +800,9 @@ void SemanticAnalyser::visit(Call &call)
               .mask = 0,
             },
           });
+          args_size += ty.size;
         }
+        max_fmtstr_args_size_ = std::max(max_fmtstr_args_size_, args_size);
         std::string msg = verify_format_string(fmt.str, args);
         if (msg != "")
         {
@@ -2316,6 +2320,21 @@ int SemanticAnalyser::create_maps(bool debug)
     }
     bpftrace_.perf_event_map_ = std::make_unique<bpftrace::Map>(BPF_MAP_TYPE_PERF_EVENT_ARRAY);
     failed_maps += is_invalid_map(bpftrace_.perf_event_map_->mapfd_);
+  }
+
+  if (needs_fmtstr_map_)
+  {
+    std::string map_ident = "fmtstr";
+
+    SizedType type = SizedType(Type::fmtstr, sizeof(size_t) + max_fmtstr_args_size_);
+    MapKey key;
+    if (debug)
+      bpftrace_.fmtstr_map_ = std::make_unique<bpftrace::FakeMap>(map_ident, type, key);
+    else {
+      bpftrace_.fmtstr_map_ = std::make_unique<bpftrace::Map>(map_ident, type, key, 1);
+      bpftrace_.fmtstr_map_zero_ = calloc(1, max_fmtstr_args_size_ + sizeof(size_t));
+    }
+    failed_maps += is_invalid_map(bpftrace_.fmtstr_map_->mapfd_);
   }
 
   if (failed_maps > 0)

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <sstream>
 #include <unordered_set>
+#include <vector>
 
 #include "ast.h"
 #include "bpffeature.h"
@@ -107,6 +108,7 @@ private:
   std::map<std::string, ExpressionList> map_args_;
   std::map<std::string, SizedType> ap_args_;
   std::unordered_set<StackType> needs_stackid_maps_;
+  std::vector<StrCall*> str_calls_;
   uint32_t loop_depth_ = 0;
   bool needs_join_map_ = false;
   bool needs_fmtstr_map_ = false;

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -109,10 +109,12 @@ private:
   std::unordered_set<StackType> needs_stackid_maps_;
   uint32_t loop_depth_ = 0;
   bool needs_join_map_ = false;
+  bool needs_fmtstr_map_ = false;
   bool needs_elapsed_map_ = false;
   bool has_begin_probe_ = false;
   bool has_end_probe_ = false;
   bool has_child_ = false;
+  size_t max_fmtstr_args_size_ = 0;
 };
 
 } // namespace ast

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -157,6 +157,8 @@ public:
   std::unordered_map<int64_t, struct HelperErrorInfo> helper_error_info_;
   std::unordered_map<StackType, std::unique_ptr<IMap>> stackid_maps_;
   std::unique_ptr<IMap> join_map_;
+  std::unique_ptr<IMap> fmtstr_map_;
+  void *fmtstr_map_zero_ = nullptr;
   std::unique_ptr<IMap> elapsed_map_;
   std::unique_ptr<IMap> perf_event_map_;
   std::vector<std::string> probe_ids_;

--- a/src/imap.h
+++ b/src/imap.h
@@ -22,6 +22,8 @@ public:
   SizedType type_;
   MapKey key_;
   enum bpf_map_type map_type_;
+  int max_entries_;
+  int value_size_;
   bool is_per_cpu_type()
   {
     return map_type_ == BPF_MAP_TYPE_PERCPU_HASH ||

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -66,7 +66,8 @@ void usage()
   std::cerr << "    -kk            check all bpf helper functions" << std::endl;
   std::cerr << "    -V, --version  bpftrace version" << std::endl << std::endl;
   std::cerr << "ENVIRONMENT:" << std::endl;
-  std::cerr << "    BPFTRACE_STRLEN             [default: 64] bytes on BPF stack per str()" << std::endl;
+  std::cerr << "    BPFTRACE_STRLEN             [default: 64] max str() size" << std::endl;
+  std::cerr << "    BPFTRACE_EVENTS_BUFFER_SIZE [default: 4] max str()s waiting to be printed" << std::endl;
   std::cerr << "    BPFTRACE_NO_CPP_DEMANGLE    [default: 0] disable C++ symbol demangling" << std::endl;
   std::cerr << "    BPFTRACE_MAP_KEYS_MAX       [default: 4096] max keys in a map" << std::endl;
   std::cerr << "    BPFTRACE_CAT_BYTES_MAX      [default: 10k] maximum bytes read by cat builtin" << std::endl;
@@ -477,18 +478,8 @@ int main(int argc, char *argv[])
   if (!get_uint64_env_var("BPFTRACE_STRLEN", bpftrace.strlen_))
     return 1;
 
-  // in practice, the largest buffer I've seen fit into the BPF stack was 240 bytes.
-  // I've set the bar lower, in case your program has a deeper stack than the one from my tests,
-  // in the hope that you'll get this instructive error instead of getting the BPF verifier's error.
-  if (bpftrace.strlen_ > 200) {
-    // the verifier errors you would encounter when attempting larger allocations would be:
-    // >240=  <Looks like the BPF stack limit of 512 bytes is exceeded. Please move large on stack variables into BPF per-cpu array map.>
-    // ~1024= <A call to built-in function 'memset' is not supported.>
-    std::cerr << "'BPFTRACE_STRLEN' " << bpftrace.strlen_ << " exceeds the current maximum of 200 bytes." << std::endl
-    << "This limitation is because strings are currently stored on the 512 byte BPF stack." << std::endl
-    << "Long strings will be pursued in: https://github.com/iovisor/bpftrace/issues/305" << std::endl;
+  if (!get_uint64_env_var("BPFTRACE_EVENTS_BUFFER_SIZE", bpftrace.events_buffer_size_))
     return 1;
-  }
 
   if (const char* env_p = std::getenv("BPFTRACE_NO_CPP_DEMANGLE"))
   {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -19,7 +19,7 @@ int Map::create_map(enum bpf_map_type map_type, const char *name, int key_size, 
 #endif
 }
 
-Map::Map(const std::string &name, const SizedType &type, const MapKey &key, int min, int max, int step, int max_entries)
+Map::Map(const std::string &name, const SizedType &type, const MapKey &key, int min, int max, int step, int max_entries, int value_size)
 {
   name_ = name;
   type_ = type;
@@ -48,17 +48,17 @@ Map::Map(const std::string &name, const SizedType &type, const MapKey &key, int 
   {
       map_type_ = BPF_MAP_TYPE_PERCPU_HASH;
   }
-  else if (type.IsJoinTy() || type.IsFmtStrTy())
+  else if (type.IsJoinTy() || type.IsFmtStrTy() || type.IsMapStrTy())
   {
     map_type_ = BPF_MAP_TYPE_PERCPU_ARRAY;
-    max_entries = 1;
     key_size = 4;
   }
   else
     map_type_ = BPF_MAP_TYPE_HASH;
 
-  int value_size = type.size;
   int flags = 0;
+  max_entries_ = max_entries;
+  value_size_ = value_size;
   mapfd_ = create_map(map_type_, name.c_str(), key_size, value_size, max_entries, flags);
   if (mapfd_ < 0)
   {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -48,7 +48,7 @@ Map::Map(const std::string &name, const SizedType &type, const MapKey &key, int 
   {
       map_type_ = BPF_MAP_TYPE_PERCPU_HASH;
   }
-  else if (type.IsJoinTy())
+  else if (type.IsJoinTy() || type.IsFmtStrTy())
   {
     map_type_ = BPF_MAP_TYPE_PERCPU_ARRAY;
     max_entries = 1;

--- a/src/map.h
+++ b/src/map.h
@@ -10,15 +10,17 @@ public:
   Map(const std::string &name,
       const SizedType &type,
       const MapKey &key,
-      int max_entries)
-      : Map(name, type, key, 0, 0, 0, max_entries){};
+      int max_entries,
+      int value_size)
+      : Map(name, type, key, 0, 0, 0, max_entries, value_size){};
   Map(const std::string &name,
       const SizedType &type,
       const MapKey &key,
       int min,
       int max,
       int step,
-      int max_entries);
+      int max_entries,
+      int value_size);
   Map(const SizedType &type);
   Map(enum bpf_map_type map_type);
   virtual ~Map() override;

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -358,10 +358,10 @@ ident : IDENT         { $$ = $1; }
       | STACK_MODE    { $$ = $1; }
       ;
 
-call : CALL "(" ")"                 { $$ = new ast::Call($1, @$); }
-     | CALL "(" vargs ")"           { $$ = new ast::Call($1, $3, @$); }
-     | CALL_BUILTIN  "(" ")"        { $$ = new ast::Call($1, @$); }
-     | CALL_BUILTIN "(" vargs ")"   { $$ = new ast::Call($1, $3, @$); }
+call : CALL "(" ")"                 { $$ = ast::CallFactory::createCall($1, @$); }
+     | CALL "(" vargs ")"           { $$ = ast::CallFactory::createCall($1, @$, $3); }
+     | CALL_BUILTIN  "(" ")"        { $$ = ast::CallFactory::createCall($1, @$); }
+     | CALL_BUILTIN "(" vargs ")"   { $$ = ast::CallFactory::createCall($1, @$, $3); }
      | IDENT "(" ")"                { error(@1, "Unknown function: " + $1); YYERROR;  }
      | IDENT "(" vargs ")"          { error(@1, "Unknown function: " + $1); YYERROR;  }
      | BUILTIN "(" ")"              { error(@1, "Unknown function: " + $1); YYERROR;  }

--- a/src/printf_format_types.h
+++ b/src/printf_format_types.h
@@ -17,7 +17,7 @@ namespace bpftrace {
 // print("{\"r\", Type::buffer},")
 // print(",\n".join([f"{{\"{l+s}\", Type::integer}}" for l in lengths for s in specifiers]))
 const std::unordered_map<std::string, Type> printf_format_types = {
-  {"s", Type::string},
+  {"s", Type::mapstr},
   {"r", Type::buffer},
   {"c", Type::integer},
   {"d", Type::integer},

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -75,7 +75,7 @@ bool SizedType::operator==(const SizedType &t) const
 bool SizedType::IsArray() const
 {
   return type == Type::array || type == Type::string || type == Type::usym ||
-         type == Type::inet || type == Type::buffer ||
+         type == Type::inet || type == Type::buffer || type == Type::mapstr ||
          ((type == Type::cast || type == Type::ctx) && !is_pointer);
 }
 
@@ -107,6 +107,7 @@ std::string typestr(Type t)
     case Type::kstack:   return "kstack";   break;
     case Type::ustack:   return "ustack";   break;
     case Type::string:   return "string";   break;
+    case Type::mapstr:   return "mapstr";   break;
     case Type::ksym:     return "ksym";     break;
     case Type::usym:     return "usym";     break;
     case Type::cast:     return "cast";     break;
@@ -251,6 +252,13 @@ SizedType CreateUInt64()
 SizedType CreateString(size_t size)
 {
   return SizedType(Type::string, size);
+}
+
+SizedType CreateMapString()
+{
+  // struct (int mapfd, int array_key, int strlen)
+  // TODO: consider whether we can go down to 32-bit ints
+  return SizedType(Type::mapstr, 24);
 }
 
 SizedType CreateNone()

--- a/src/types.h
+++ b/src/types.h
@@ -36,6 +36,7 @@ enum class Type
   usym,
   cast,
   join,
+  fmtstr,
   probe,
   username,
   inet,
@@ -211,6 +212,10 @@ public:
   bool IsJoinTy(void) const
   {
     return type == Type::join;
+  };
+  bool IsFmtStrTy(void) const
+  {
+    return type == Type::fmtstr;
   };
   bool IsProbeTy(void) const
   {

--- a/src/types.h
+++ b/src/types.h
@@ -37,6 +37,7 @@ enum class Type
   cast,
   join,
   fmtstr,
+  mapstr,
   probe,
   username,
   inet,
@@ -217,6 +218,10 @@ public:
   {
     return type == Type::fmtstr;
   };
+  bool IsMapStrTy(void) const
+  {
+    return type == Type::mapstr;
+  };
   bool IsProbeTy(void) const
   {
     return type == Type::probe;
@@ -278,6 +283,7 @@ SizedType CreateUInt32();
 SizedType CreateUInt64();
 
 SizedType CreateString(size_t size);
+SizedType CreateMapString();
 SizedType CreateArray(size_t num_elements, const SizedType &element_type);
 
 SizedType CreateStackMode();


### PR DESCRIPTION
**This is just a rebase/squash of https://github.com/iovisor/bpftrace/pull/1346, intended to make it easier to branch off and try suggestions from the review.**

Resolves https://github.com/iovisor/bpftrace/issues/305.

Incorporates @mmarchini's RFC https://github.com/iovisor/bpftrace/pull/750.

We can now set BPFTRACE_STRLEN as high as we like. str() reads strings into a map, and gives printf() a descriptor of how to locate the string (map_fd, map_key, str_len, cpu_id).

=====

I suspect a data race is possible (similar to what @mmarchini theorised in https://github.com/iovisor/bpftrace/pull/750) since reading perf events is async.

Happy path:  
1. write string into map key 0
2. output perf event "you should read map key 0"
3. read perf event "you should read map key 0"

Data race:  
1. write string into map key 0
2. output perf event "you should read map key 0"
3. write string into map key 0
4. output perf event "you should read map key 0"
5. read perf event "you should read map key 0"
6. read perf event "you should read map key 0"

Proposed solution:  
1. write string into map key 0
2. output perf event "you should read map key 0"
3. write string into map key 1
4. output perf event "you should read map key 1"
5. read perf event "you should read map key 0"
6. indicate "map key 0 is now free to re-use"
7. read perf event "you should read map key 1"

In other words, a ring buffer. I haven't implemented this yet, but you'll see the idea referenced in the code so far.

We could determine "how likely is this data race to happen" by outputting a numeric sequence via frequent events, and check whether we encounter gaps in that sequence when printed.

Such a data race is already presumed to affect join(), but nobody's reported its happening in the wild.

=====

I think I would want each str() call to have an additional per-CPU array to encode 2 values: "start_used_map_ix" and "end_used_map_ix". This should be enough for the BPF program and userspace to coordinate "where's a free slot for me to write my strings".

This would solve the data race on str(). We'd need to do something similar for printf() too. And both would need error-handling to communicate when there's no free slots left.

=====

We could also avoid the data race on str() entirely (and be left with just the data race on printf() to worry about).

I chose to give printf "a descriptor of where to lookup the string", but it would've also been possible to put the string itself straight into printf's perf event. This would eliminate the need to coordinate userspace to read our strings out of maps.

You'd have to "always allocate space for max strlen" or "compose a struct of dynamic size". I don't know whether it's problematic for perf events to be big. I do know that it's hard to create structs of dynamic sizes.

Visitor pattern makes it hard for the str() call to probe read bytes directly into printf()'s buffer; the obvious implementation involves str() probe-reading into one map, and then printf() probe-reading the same bytes into its perf event buffer.

=====

Whilst thrashing around, I made a ring indexer in user-space, but I think the logic will need to move to BPF-space instead. Could be a useful reference though:

https://github.com/iovisor/bpftrace/blob/4dc04e781050036f08ab5493edfa4e4e3a457d9a/src/ring_indexer.h  
https://github.com/iovisor/bpftrace/blob/4dc04e781050036f08ab5493edfa4e4e3a457d9a/src/ring_indexer.cpp

=====

We'll also need to decide "should all strings be off-stack?" (e.g. string literals). In this prototype, printf() only supports printing strings produced by str().

I also expect that if we have anything like a "concatenate strings" operator, or a "compare string" function: those will now be incompatible with the output of str().