### PR TITLE
Remove RLIMIT_AS limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to
   - [#1328](https://github.com/iovisor/bpftrace/pull/1328)
 - Only list uprobe and usdt probes when `-p` is given
   - [#1340](https://github.com/iovisor/bpftrace/pull/1340)
+- Remove address space memory limit
+  - [#1358](https://github.com/iovisor/bpftrace/pull/1358)
 
 #### Deprecated
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -102,7 +102,6 @@ if (BUILD_ASAN)
     # target_link_options is supported in CMake 3.13 and newer
     message("Please use CMake 3.13 or newer to enable ASAN")
   endif()
-  target_compile_definitions(bpftrace PRIVATE BUILD_ASAN)
   target_compile_options(bpftrace PUBLIC "-fsanitize=address")
   target_link_options(bpftrace PUBLIC "-fsanitize=address")
 endif()


### PR DESCRIPTION
We haven't seen any OOM issues in a while so I suspect either our type
fixes in bpftrace or upstream llvm changes have resolved the issue.

This closes #1355.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
