### PR TITLE
RFC: Store strings off-stack (in per-CPU scratch buffer)

### DIFF
--- a/src/ast/allocation_helper.h
+++ b/src/ast/allocation_helper.h
@@ -1,0 +1,16 @@
+#pragma once
+#include "bpftrace.h"
+
+// this file is for storage concerns shared between semantic_analyser and
+// codegen_llvm
+namespace bpftrace {
+namespace ast {
+
+inline bool needMapStorage(const SizedType &stype)
+{
+  // TODO: consider a threshold size
+  return stype.IsAggregate();
+}
+
+} // namespace ast
+} // namespace bpftrace

--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "irbuilderbpf.h"
+#include <cstddef>
 #include <cstdint>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Type.h>
@@ -92,7 +93,7 @@ struct Strftime
 
 struct Buf
 {
-  uint8_t length;
+  uint32_t length;
   // Seems like GCC 7.4.x can't handle `char content[]`. Work around by using
   // 0 sized array (a GCC extension that clang also accepts:
   // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=70932). It also looks like
@@ -102,7 +103,7 @@ struct Buf
   std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b, size_t length)
   {
     return {
-      b.getInt8Ty(),                               // buffer length
+      b.getInt32Ty(),                              // buffer length
       llvm::ArrayType::get(b.getInt8Ty(), length), // buffer content
     };
   }
@@ -113,6 +114,7 @@ struct HelperError
   uint64_t action_id;
   uint64_t error_id;
   int32_t return_value;
+  int8_t is_fatal;
 
   std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b)
   {
@@ -120,6 +122,7 @@ struct HelperError
       b.getInt64Ty(), // asyncid
       b.getInt64Ty(), // error_id
       b.getInt32Ty(), // return value
+      b.getInt8Ty(),  // is_fatal
     };
   }
 } __attribute__((packed));

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1,4 +1,5 @@
 #include "codegen_llvm.h"
+#include "allocation_helper.h"
 #include "arch/arch.h"
 #include "ast.h"
 #include "ast/async_event_types.h"
@@ -978,6 +979,9 @@ void CodegenLLVM::visit(Variable &var)
 {
   if (needMemcpy(var.type))
   {
+    // TODO: where needMapStorage(var.type) is true, we could use
+    // CreateMapLookupElem here instead. would there be any advantage
+    // to doing so?
     expr_ = variables_[var.ident];
   }
   else
@@ -1687,7 +1691,8 @@ void CodegenLLVM::visit(AssignVarStatement &assignment)
 
   // any map-backed variable will have already had storage allocated in entry
   // block
-  if (variables_.find(var.ident) == variables_.end() && !needMemcpy(var.type))
+  if (variables_.find(var.ident) == variables_.end() &&
+      !needMapStorage(var.type))
   {
     // alloca is hoisted to start of program, so doesn't matter which block
     // we're in
@@ -1697,7 +1702,9 @@ void CodegenLLVM::visit(AssignVarStatement &assignment)
 
   if (needMemcpy(var.type))
   {
-    // consider a CreateMapUpdateElem here
+    // TODO: where needMapStorage(var.type) is true, we could use
+    // CreateMapUpdateElem here instead. would there be any advantage
+    // to doing so?
     b_.CreateCopy(
         ctx_, variables_[var.ident], expr_, var.type.size, assignment.loc);
   }

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -4,6 +4,7 @@
 #include "bpftrace.h"
 #include "types.h"
 #include <bcc/bcc_usdt.h>
+#include <string_view>
 
 #include <llvm/Config/llvm-config.h>
 #include <llvm/IR/IRBuilder.h>
@@ -58,30 +59,30 @@ public:
   CallInst   *CreateBpfPseudoCall(Map &map);
   Value *CreateMapLookupElem(Value *ctx,
                              Map &map,
-                             AllocaInst *key,
+                             Value *key,
                              const location &loc);
   Value *CreateMapLookupElem(Value *ctx,
                              int mapfd,
-                             AllocaInst *key,
+                             Value *key,
                              SizedType &type,
                              const location &loc);
   void CreateMapUpdateElem(Value *ctx,
                            Map &map,
-                           AllocaInst *key,
+                           Value *key,
                            Value *val,
                            const location &loc);
   void CreateMapDeleteElem(Value *ctx,
                            Map &map,
-                           AllocaInst *key,
+                           Value *key,
                            const location &loc);
   void CreateProbeRead(Value *ctx,
-                       AllocaInst *dst,
+                       Value *dst,
                        size_t size,
                        Value *src,
                        AddrSpace as,
                        const location &loc);
   void CreateProbeRead(Value *ctx,
-                       AllocaInst *dst,
+                       Value *dst,
                        llvm::Value *size,
                        Value *src,
                        AddrSpace as,
@@ -101,6 +102,12 @@ public:
   CallInst *CreateProbeReadStr(Value *ctx,
                                Value *dst,
                                size_t size,
+                               Value *src,
+                               AddrSpace as,
+                               const location &loc);
+  CallInst *CreateProbeReadStr(Value *ctx,
+                               Value *dst,
+                               Value *size,
                                Value *src,
                                AddrSpace as,
                                const location &loc);
@@ -149,16 +156,50 @@ public:
   CallInst   *CreateGetRandom();
   CallInst   *CreateGetStackId(Value *ctx, bool ustack, StackType stack_type, const location& loc);
   CallInst   *CreateGetJoinMap(Value *ctx, const location& loc);
+  CallInst *CreateGetVarMap(Value *ctx,
+                            const std::string &var_name,
+                            const MapBackedVariable &var);
+  CallInst *CreateGetStrMap(Value *ctx, int key, const location &loc);
+  CallInst *CreateGetKeyMap(Value *ctx,
+                            int key,
+                            PointerType *key_struct_ptr_ty,
+                            const location &loc);
+  CallInst *CreateGetBufMap(Value *ctx,
+                            int key,
+                            PointerType *buf_struct_ptr_ty,
+                            const location &loc);
+  CallInst *CreateGetFmtStrMap(Value *ctx,
+                               PointerType *printf_struct_ptr_ty,
+                               const location &loc);
   CallInst   *createCall(Value *callee, ArrayRef<Value *> args, const Twine &Name);
   void        CreateGetCurrentComm(Value *ctx, AllocaInst *buf, size_t size, const location& loc);
   void        CreatePerfEventOutput(Value *ctx, Value *data, size_t size);
   void        CreateSignal(Value *ctx, Value *sig, const location &loc);
   void        CreateOverrideReturn(Value *ctx, Value *rc);
-  void        CreateHelperError(Value *ctx, Value *return_value, libbpf::bpf_func_id func_id, const location& loc);
-  void        CreateHelperErrorCond(Value *ctx, Value *return_value, libbpf::bpf_func_id func_id, const location& loc, bool compare_zero=false);
+  void CreateHelperError(Value *ctx,
+                         Value *return_value,
+                         libbpf::bpf_func_id func_id,
+                         const location &loc,
+                         bool is_fatal = false);
+  void CreateHelperErrorCond(Value *ctx,
+                             Value *return_value,
+                             libbpf::bpf_func_id func_id,
+                             const location &loc,
+                             bool compare_zero = false,
+                             bool require_success = false);
   StructType *GetStructType(std::string name, const std::vector<llvm::Type *> & elements, bool packed = false);
   AllocaInst *CreateUSym(llvm::Value *val);
   Value      *CreatKFuncArg(Value *ctx, SizedType& type, std::string& name);
+  void CreateStoreConstStr(Value *ctx,
+                           std::string_view string,
+                           Value *buf,
+                           const location &loc);
+  void CreateCopy(Value *ctx,
+                  Value *dst,
+                  Value *src,
+                  size_t size,
+                  const location &loc);
+  void CreateZeroInit(Value *ctx, Value *dst, size_t size, const location &loc);
   int helper_error_id_ = 0;
 
 private:
@@ -170,10 +211,27 @@ private:
                                 Builtin &builtin,
                                 AddrSpace as,
                                 const location &loc);
-  CallInst   *createMapLookup(int mapfd, AllocaInst *key);
+  CallInst *createMapLookup(int mapfd,
+                            Value *key,
+                            const std::string &name = "lookup_elem");
+  CallInst *createMapLookup(int mapfd,
+                            Value *key,
+                            PointerType *ptr_ty,
+                            const std::string &name = "lookup_elem");
   Constant *createProbeReadStrFn(llvm::Type *dst,
                                  llvm::Type *src,
                                  AddrSpace as);
+  CallInst *CreateGetScratchMap(Value *ctx,
+                                int mapfd,
+                                const std::string &name,
+                                const location &loc,
+                                int key = 0);
+  CallInst *CreateGetScratchMap(Value *ctx,
+                                int mapfd,
+                                const std::string &name,
+                                PointerType *ptr_ty,
+                                const location &loc,
+                                int key = 0);
   libbpf::bpf_func_id selectProbeReadHelper(AddrSpace as, bool str);
 
   std::map<std::string, StructType *> structs_;

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1,7 +1,7 @@
 #include "semantic_analyser.h"
+#include "allocation_helper.h"
 #include "arch/arch.h"
 #include "ast.h"
-#include "codegen_helper.h"
 #include "fake_map.h"
 #include "list.h"
 #include "log.h"
@@ -2367,7 +2367,7 @@ int SemanticAnalyser::create_maps(bool debug)
     bpftrace_.vars_.try_emplace(probe);
     for (const auto &[var_name, var_semantic] : probe_vars)
     {
-      if (!needMemcpy(var_semantic.sized_type))
+      if (!needMapStorage(var_semantic.sized_type))
         continue;
 
       std::unique_ptr<IMap> map;

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -99,7 +99,10 @@ private:
 
   Probe *probe_;
   std::string func_;
-  std::map<std::string, SizedType> variable_val_;
+  std::unordered_map<
+      Probe *,
+      std::unordered_map<std::string, struct MapBackedVariable::Semantic>>
+      variable_val_;
   std::map<std::string, SizedType> map_val_;
   std::map<std::string, MapKey> map_key_;
   std::map<std::string, ExpressionList> map_args_;
@@ -107,10 +110,14 @@ private:
   std::unordered_set<StackType> needs_stackid_maps_;
   uint32_t loop_depth_ = 0;
   bool needs_join_map_ = false;
+  bool needs_fmtstr_map_ = false;
   bool needs_elapsed_map_ = false;
   bool has_begin_probe_ = false;
   bool has_end_probe_ = false;
   bool has_child_ = false;
+  size_t max_fmtstr_args_size_ = 0;
+  size_t max_key_size_ = 0;
+  size_t max_buf_size_ = 0;
 };
 
 } // namespace ast

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -20,8 +20,12 @@ class AttachedProbe
 public:
   AttachedProbe(Probe &probe,
                 std::tuple<uint8_t *, uintptr_t> func,
+                size_t max_name_length,
                 bool safe_mode);
-  AttachedProbe(Probe &probe, std::tuple<uint8_t *, uintptr_t> func, int pid);
+  AttachedProbe(Probe &probe,
+                std::tuple<uint8_t *, uintptr_t> func,
+                size_t max_name_length,
+                int pid);
   ~AttachedProbe();
   AttachedProbe(const AttachedProbe &) = delete;
   AttachedProbe &operator=(const AttachedProbe &) = delete;
@@ -32,7 +36,7 @@ private:
   static std::string sanitise(const std::string &str);
   void resolve_offset_kprobe(bool safe_mode);
   void resolve_offset_uprobe(bool safe_mode);
-  void load_prog();
+  void load_prog(size_t max_name_length);
   void attach_kprobe(bool safe_mode);
   void attach_uprobe(bool safe_mode);
   void attach_usdt(int pid);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -20,7 +20,14 @@ int Map::create_map(enum bpf_map_type map_type, const char *name, int key_size, 
 #endif
 }
 
-Map::Map(const std::string &name, const SizedType &type, const MapKey &key, int min, int max, int step, int max_entries)
+Map::Map(const std::string &name,
+         const SizedType &type,
+         const MapKey &key,
+         int min,
+         int max,
+         int step,
+         int max_entries,
+         bool is_scratch_map)
 {
   name_ = name;
   type_ = type;
@@ -49,10 +56,9 @@ Map::Map(const std::string &name, const SizedType &type, const MapKey &key, int 
   {
       map_type_ = BPF_MAP_TYPE_PERCPU_HASH;
   }
-  else if (type.IsJoinTy())
+  else if (is_scratch_map)
   {
     map_type_ = BPF_MAP_TYPE_PERCPU_ARRAY;
-    max_entries = 1;
     key_size = 4;
   }
   else

--- a/src/map.h
+++ b/src/map.h
@@ -10,15 +10,17 @@ public:
   Map(const std::string &name,
       const SizedType &type,
       const MapKey &key,
-      int max_entries)
-      : Map(name, type, key, 0, 0, 0, max_entries){};
+      int max_entries,
+      bool is_scratch_map = false)
+      : Map(name, type, key, 0, 0, 0, max_entries, is_scratch_map){};
   Map(const std::string &name,
       const SizedType &type,
       const MapKey &key,
       int min,
       int max,
       int step,
-      int max_entries);
+      int max_entries,
+      bool is_scratch_map = false);
   Map(const SizedType &type);
   Map(enum bpf_map_type map_type);
   virtual ~Map() override;

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -109,8 +109,8 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
     }
     case Type::buffer:
     {
-      auto p = static_cast<const char *>(data) + 1;
-      return hex_format_buffer(p, arg.size - 1);
+      auto buf = reinterpret_cast<const AsyncEvent::Buf *>(data);
+      return hex_format_buffer(buf->content, buf->length);
     }
     case Type::pointer:
     {

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -4,6 +4,7 @@
 
 #include "log.h"
 #include "types.h"
+#include "utils.h"
 
 namespace bpftrace {
 
@@ -164,7 +165,6 @@ std::string typestr(Type t)
     case Type::string:   return "string";   break;
     case Type::ksym:     return "ksym";     break;
     case Type::usym:     return "usym";     break;
-    case Type::join:     return "join";     break;
     case Type::probe:    return "probe";    break;
     case Type::username: return "username"; break;
     case Type::inet:     return "inet";     break;
@@ -417,12 +417,16 @@ SizedType CreateKSym()
 
 SizedType CreateJoin(size_t argnum, size_t argsize)
 {
-  return SizedType(Type::join, 8 + 8 + argnum * argsize);
+  return SizedType(Type::string, 8 + 8 + argnum * argsize);
 }
 
 SizedType CreateBuffer(size_t size)
 {
-  return SizedType(Type::buffer, size);
+  /*
+   * codegen allocates a non-packed struct, so we need to align to word size.
+   * TODO: get access to llvm::DataLayout and actually measure a AsyncEvent::Buf
+   */
+  return SizedType(Type::buffer, 4 + align_to(size, 4));
 }
 
 SizedType CreateTimestamp()

--- a/src/types.h
+++ b/src/types.h
@@ -13,7 +13,6 @@ namespace bpftrace {
 
 const int MAX_STACK_SIZE = 1024;
 const int DEFAULT_STACK_SIZE = 127;
-const int STRING_SIZE = 64;
 const int COMM_SIZE = 16;
 
 enum class Type
@@ -36,7 +35,6 @@ enum class Type
   string,
   ksym,
   usym,
-  join,
   probe,
   username,
   inet,
@@ -241,11 +239,6 @@ public:
   bool IsUsymTy(void) const
   {
     return type == Type::usym;
-  };
-
-  bool IsJoinTy(void) const
-  {
-    return type == Type::join;
   };
   bool IsProbeTy(void) const
   {

--- a/src/utils.h
+++ b/src/utils.h
@@ -171,6 +171,12 @@ inline std::string &trim(std::string &s)
   return ltrim(rtrim(s));
 }
 
+// rounds up to nearest factor of `alignment`
+inline size_t align_to(size_t proposed, size_t alignment)
+{
+  return (proposed + alignment - 1) / alignment * alignment;
+};
+
 int signal_name_to_num(std::string &signal);
 
 template <typename T>

--- a/tests/codegen/llvm/args_multiple_tracepoints.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints.ll
@@ -46,9 +46,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %12, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  %13 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@_val" to i8*
+  %14 = bitcast [8 x i8]* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
@@ -99,9 +99,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %12, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  %13 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@_val" to i8*
+  %14 = bitcast [8 x i8]* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }

--- a/tests/codegen/llvm/args_multiple_tracepoints_category_wild.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints_category_wild.ll
@@ -46,9 +46,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %12, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  %13 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@_val" to i8*
+  %14 = bitcast [8 x i8]* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
@@ -99,9 +99,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %12, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  %13 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@_val" to i8*
+  %14 = bitcast [8 x i8]* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
@@ -146,9 +146,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %12, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  %13 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@_val" to i8*
+  %14 = bitcast [8 x i8]* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }

--- a/tests/codegen/llvm/args_multiple_tracepoints_wild.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints_wild.ll
@@ -46,9 +46,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %12, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  %13 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@_val" to i8*
+  %14 = bitcast [8 x i8]* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
@@ -99,9 +99,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %12, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  %13 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@_val" to i8*
+  %14 = bitcast [8 x i8]* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }

--- a/tests/codegen/llvm/basic_while_loop.ll
+++ b/tests/codegen/llvm/basic_while_loop.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"interval:s:1"(i8*) section "s_interval:s:1_1" {
 entry:
-  %"@_val" = alloca i64
   %"@_key" = alloca i64
+  %"@_val" = alloca i64
   %"$a" = alloca i64
   %1 = bitcast i64* %"$a" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -30,17 +30,17 @@ while_body:                                       ; preds = %while_cond
   %6 = load i64, i64* %"$a"
   %7 = add i64 %6, 1
   store i64 %7, i64* %"$a"
-  %8 = bitcast i64* %"@_key" to i8*
+  %8 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  store i64 0, i64* %"@_key"
-  %9 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 %6, i64* %"@_val"
+  %9 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i64 0, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
-  %10 = bitcast i64* %"@_key" to i8*
+  %10 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@_val" to i8*
+  %11 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   br label %while_cond
 

--- a/tests/codegen/llvm/bitshift_left.ll
+++ b/tests/codegen/llvm/bitshift_left.ll
@@ -8,19 +8,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 1024, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/bitshift_right.ll
+++ b/tests/codegen/llvm/bitshift_right.ll
@@ -8,19 +8,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 2, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/bitwise_not.ll
+++ b/tests/codegen/llvm/bitwise_not.ll
@@ -8,19 +8,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @BEGIN(i8*) section "s_BEGIN_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 -11, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_arg.ll
+++ b/tests/codegen/llvm/builtin_arg.ll
@@ -8,39 +8,39 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@y_val" = alloca i64
   %"@y_key" = alloca i64
-  %"@x_val" = alloca i64
+  %"@y_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 14
   %arg0 = load volatile i64, i64* %2
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@x_key"
-  %4 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"@x_val"
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %5 = bitcast i64* %"@x_key" to i8*
+  %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@x_val" to i8*
+  %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   %7 = bitcast i8* %0 to i64*
   %8 = getelementptr i64, i64* %7, i64 12
   %arg2 = load volatile i64, i64* %8
-  %9 = bitcast i64* %"@y_key" to i8*
+  %9 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store i64 0, i64* %"@y_key"
-  %10 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 %arg2, i64* %"@y_val"
+  %10 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i64 0, i64* %"@y_key"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem2 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@y_key", i64* %"@y_val", i64 0)
-  %11 = bitcast i64* %"@y_key" to i8*
+  %11 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@y_val" to i8*
+  %12 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_cpid.ll
+++ b/tests/codegen/llvm/builtin_cpid.ll
@@ -8,19 +8,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@_val" = alloca i64
   %"@_key" = alloca i64
-  %1 = bitcast i64* %"@_key" to i8*
+  %"@_val" = alloca i64
+  %1 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@_key"
-  %2 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 1337, i64* %"@_val"
+  %2 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
-  %3 = bitcast i64* %"@_key" to i8*
+  %3 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@_val" to i8*
+  %4 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_cpu.ll
+++ b/tests/codegen/llvm/builtin_cpu.ll
@@ -8,21 +8,22 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %1 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
+  %"@x_val" = alloca i64
+  %get_cpu_id = call i32 inttoptr (i64 8 to i32 ()*)()
+  %1 = zext i32 %get_cpu_id to i64
   %2 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 %get_cpu_id, i64* %"@x_val"
+  store i64 %1, i64* %"@x_val"
+  %3 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
   %4 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  %5 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/builtin_ctx.ll
+++ b/tests/codegen/llvm/builtin_ctx.ll
@@ -8,20 +8,20 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %1 = ptrtoint i8* %0 to i64
-  %2 = bitcast i64* %"@x_key" to i8*
+  %2 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 0, i64* %"@x_key"
-  %3 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   store i64 %1, i64* %"@x_val"
+  %3 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %4 = bitcast i64* %"@x_key" to i8*
+  %4 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
-  %5 = bitcast i64* %"@x_val" to i8*
+  %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_ctx_field.ll
+++ b/tests/codegen/llvm/builtin_ctx_field.ll
@@ -10,15 +10,15 @@ define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %"@e_key" = alloca i64
   %"struct x.e" = alloca [4 x i8]
-  %"@d_val" = alloca i64
   %"@d_key" = alloca i64
+  %"@d_val" = alloca i64
   %"struct c.c" = alloca i8
-  %"@c_val" = alloca i64
   %"@c_key" = alloca i64
-  %"@b_val" = alloca i64
+  %"@c_val" = alloca i64
   %"@b_key" = alloca i64
-  %"@a_val" = alloca i64
+  %"@b_val" = alloca i64
   %"@a_key" = alloca i64
+  %"@a_val" = alloca i64
   %"$x" = alloca i64
   %1 = bitcast i64* %"$x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -31,35 +31,35 @@ entry:
   %5 = add i64 %4, 0
   %6 = inttoptr i64 %5 to i64*
   %7 = load volatile i64, i64* %6
-  %8 = bitcast i64* %"@a_key" to i8*
+  %8 = bitcast i64* %"@a_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  store i64 0, i64* %"@a_key"
-  %9 = bitcast i64* %"@a_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 %7, i64* %"@a_val"
+  %9 = bitcast i64* %"@a_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i64 0, i64* %"@a_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@a_key", i64* %"@a_val", i64 0)
-  %10 = bitcast i64* %"@a_key" to i8*
+  %10 = bitcast i64* %"@a_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@a_val" to i8*
+  %11 = bitcast i64* %"@a_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   %12 = load i64, i64* %"$x"
   %13 = add i64 %12, 8
   %14 = add i64 %13, 0
   %15 = inttoptr i64 %14 to i16*
   %16 = load volatile i16, i16* %15
-  %17 = bitcast i64* %"@b_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
-  store i64 0, i64* %"@b_key"
-  %18 = sext i16 %16 to i64
-  %19 = bitcast i64* %"@b_val" to i8*
+  %17 = sext i16 %16 to i64
+  %18 = bitcast i64* %"@b_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
+  store i64 %17, i64* %"@b_val"
+  %19 = bitcast i64* %"@b_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
-  store i64 %18, i64* %"@b_val"
+  store i64 0, i64* %"@b_key"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem2 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@b_key", i64* %"@b_val", i64 0)
-  %20 = bitcast i64* %"@b_key" to i8*
+  %20 = bitcast i64* %"@b_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  %21 = bitcast i64* %"@b_val" to i8*
+  %21 = bitcast i64* %"@b_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
   %22 = load i64, i64* %"$x"
   %23 = add i64 %22, 16
@@ -67,17 +67,17 @@ entry:
   %25 = inttoptr i64 %24 to i8*
   %26 = load volatile i8, i8* %25
   %27 = sext i8 %26 to i64
-  %28 = bitcast i64* %"@c_key" to i8*
+  %28 = bitcast i64* %"@c_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %28)
-  store i64 0, i64* %"@c_key"
-  %29 = bitcast i64* %"@c_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %29)
   store i64 %27, i64* %"@c_val"
+  %29 = bitcast i64* %"@c_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %29)
+  store i64 0, i64* %"@c_key"
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
   %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo3, i64* %"@c_key", i64* %"@c_val", i64 0)
-  %30 = bitcast i64* %"@c_key" to i8*
+  %30 = bitcast i64* %"@c_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %30)
-  %31 = bitcast i64* %"@c_val" to i8*
+  %31 = bitcast i64* %"@c_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %31)
   %32 = load i64, i64* %"$x"
   %33 = add i64 %32, 24
@@ -89,17 +89,17 @@ entry:
   %37 = load i8, i8* %"struct c.c"
   %38 = sext i8 %37 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct c.c")
-  %39 = bitcast i64* %"@d_key" to i8*
+  %39 = bitcast i64* %"@d_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %39)
-  store i64 0, i64* %"@d_key"
-  %40 = bitcast i64* %"@d_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %40)
   store i64 %38, i64* %"@d_val"
+  %40 = bitcast i64* %"@d_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %40)
+  store i64 0, i64* %"@d_key"
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 4)
   %update_elem6 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo5, i64* %"@d_key", i64* %"@d_val", i64 0)
-  %41 = bitcast i64* %"@d_key" to i8*
+  %41 = bitcast i64* %"@d_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %41)
-  %42 = bitcast i64* %"@d_val" to i8*
+  %42 = bitcast i64* %"@d_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %42)
   %43 = load i64, i64* %"$x"
   %44 = add i64 %43, 32

--- a/tests/codegen/llvm/builtin_curtask.ll
+++ b/tests/codegen/llvm/builtin_curtask.ll
@@ -8,20 +8,20 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_ptr" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_ptr" = alloca i64
   %get_cur_task = call i64 inttoptr (i64 35 to i64 ()*)()
-  %1 = bitcast i64* %"@x_key" to i8*
+  %1 = bitcast i64* %"@x_ptr" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_ptr" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 %get_cur_task, i64* %"@x_ptr"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_ptr", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_ptr" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_ptr" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_elapsed.ll
+++ b/tests/codegen/llvm/builtin_elapsed.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"interval:s:1"(i8*) section "s_interval:s:1_1" {
 entry:
-  %"@_val" = alloca i64
   %"@_key" = alloca i64
+  %"@_val" = alloca i64
   %lookup_elem_val = alloca i64
   %elapsed_key = alloca i64
   %1 = bitcast i64* %elapsed_key to i8*
@@ -40,17 +40,17 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   %6 = sub i64 %get_ns, %4
   %7 = bitcast i64* %elapsed_key to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@_key" to i8*
+  %8 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  store i64 0, i64* %"@_key"
-  %9 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 %6, i64* %"@_val"
+  %9 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i64 0, i64* %"@_key"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %"@_val", i64 0)
-  %10 = bitcast i64* %"@_key" to i8*
+  %10 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@_val" to i8*
+  %11 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_func.ll
+++ b/tests/codegen/llvm/builtin_func.ll
@@ -8,22 +8,22 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 16
   %func = load volatile i64, i64* %2
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@x_key"
-  %4 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %func, i64* %"@x_val"
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %5 = bitcast i64* %"@x_key" to i8*
+  %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@x_val" to i8*
+  %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_func_wild.ll
+++ b/tests/codegen/llvm/builtin_func_wild.ll
@@ -8,22 +8,22 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:do_execve*"(i8*) section "s_kprobe:do_execve*_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 16
   %func = load volatile i64, i64* %2
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@x_key"
-  %4 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %func, i64* %"@x_val"
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %5 = bitcast i64* %"@x_key" to i8*
+  %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@x_val" to i8*
+  %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_kstack.ll
+++ b/tests/codegen/llvm/builtin_kstack.ll
@@ -8,21 +8,21 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 0)
-  %1 = bitcast i64* %"@x_key" to i8*
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 %get_stackid, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_nsecs.ll
+++ b/tests/codegen/llvm/builtin_nsecs.ll
@@ -8,20 +8,20 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %get_ns = call i64 inttoptr (i64 5 to i64 ()*)()
-  %1 = bitcast i64* %"@x_key" to i8*
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 %get_ns, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_pid_tid.ll
+++ b/tests/codegen/llvm/builtin_pid_tid.ll
@@ -8,37 +8,37 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@y_val" = alloca i64
   %"@y_key" = alloca i64
-  %"@x_val" = alloca i64
+  %"@y_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = lshr i64 %get_pid_tgid, 32
-  %2 = bitcast i64* %"@x_key" to i8*
+  %2 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 0, i64* %"@x_key"
-  %3 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   store i64 %1, i64* %"@x_val"
+  %3 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %4 = bitcast i64* %"@x_key" to i8*
+  %4 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
-  %5 = bitcast i64* %"@x_val" to i8*
+  %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to i64 ()*)()
   %6 = and i64 %get_pid_tgid1, 4294967295
-  %7 = bitcast i64* %"@y_key" to i8*
+  %7 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  store i64 0, i64* %"@y_key"
-  %8 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 %6, i64* %"@y_val"
+  %8 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 0, i64* %"@y_key"
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem3 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@y_key", i64* %"@y_val", i64 0)
-  %9 = bitcast i64* %"@y_key" to i8*
+  %9 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@y_val" to i8*
+  %10 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_probe.ll
+++ b/tests/codegen/llvm/builtin_probe.ll
@@ -8,19 +8,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"tracepoint:sched:sched_one"(i8*) section "s_tracepoint:sched:sched_one_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 0, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_probe_wild.ll
+++ b/tests/codegen/llvm/builtin_probe_wild.ll
@@ -8,19 +8,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"tracepoint:sched:sched_one"(i8*) section "s_tracepoint:sched:sched_one_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 0, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_rand.ll
+++ b/tests/codegen/llvm/builtin_rand.ll
@@ -8,20 +8,20 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %get_random = call i64 inttoptr (i64 7 to i64 ()*)()
-  %1 = bitcast i64* %"@x_key" to i8*
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 %get_random, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_retval.ll
+++ b/tests/codegen/llvm/builtin_retval.ll
@@ -8,22 +8,22 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kretprobe:f"(i8*) section "s_kretprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 10
   %retval = load volatile i64, i64* %2
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@x_key"
-  %4 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %retval, i64* %"@x_val"
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %5 = bitcast i64* %"@x_key" to i8*
+  %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@x_val" to i8*
+  %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_sarg.ll
+++ b/tests/codegen/llvm/builtin_sarg.ll
@@ -8,11 +8,11 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@y_val" = alloca i64
   %"@y_key" = alloca i64
+  %"@y_val" = alloca i64
   %sarg2 = alloca i64
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %sarg0 = alloca i64
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 19
@@ -24,17 +24,17 @@ entry:
   %5 = load i64, i64* %sarg0
   %6 = bitcast i64* %sarg0 to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast i64* %"@x_key" to i8*
+  %7 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  store i64 0, i64* %"@x_key"
-  %8 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 %5, i64* %"@x_val"
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %9 = bitcast i64* %"@x_key" to i8*
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_val" to i8*
+  %10 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   %11 = bitcast i8* %0 to i64*
   %12 = getelementptr i64, i64* %11, i64 19
@@ -46,17 +46,17 @@ entry:
   %15 = load i64, i64* %sarg2
   %16 = bitcast i64* %sarg2 to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = bitcast i64* %"@y_key" to i8*
+  %17 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
-  store i64 0, i64* %"@y_key"
-  %18 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
   store i64 %15, i64* %"@y_val"
+  %18 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
+  store i64 0, i64* %"@y_key"
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo3, i64* %"@y_key", i64* %"@y_val", i64 0)
-  %19 = bitcast i64* %"@y_key" to i8*
+  %19 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
-  %20 = bitcast i64* %"@y_val" to i8*
+  %20 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_uid_gid.ll
+++ b/tests/codegen/llvm/builtin_uid_gid.ll
@@ -8,37 +8,37 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@y_val" = alloca i64
   %"@y_key" = alloca i64
-  %"@x_val" = alloca i64
+  %"@y_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %get_uid_gid = call i64 inttoptr (i64 15 to i64 ()*)()
   %1 = and i64 %get_uid_gid, 4294967295
-  %2 = bitcast i64* %"@x_key" to i8*
+  %2 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 0, i64* %"@x_key"
-  %3 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   store i64 %1, i64* %"@x_val"
+  %3 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %4 = bitcast i64* %"@x_key" to i8*
+  %4 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
-  %5 = bitcast i64* %"@x_val" to i8*
+  %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
   %get_uid_gid1 = call i64 inttoptr (i64 15 to i64 ()*)()
   %6 = lshr i64 %get_uid_gid1, 32
-  %7 = bitcast i64* %"@y_key" to i8*
+  %7 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  store i64 0, i64* %"@y_key"
-  %8 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 %6, i64* %"@y_val"
+  %8 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 0, i64* %"@y_key"
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem3 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@y_key", i64* %"@y_val", i64 0)
-  %9 = bitcast i64* %"@y_key" to i8*
+  %9 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@y_val" to i8*
+  %10 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_username.ll
+++ b/tests/codegen/llvm/builtin_username.ll
@@ -8,37 +8,37 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@y_val" = alloca i64
   %"@y_key" = alloca i64
-  %"@x_val" = alloca i64
+  %"@y_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %get_uid_gid = call i64 inttoptr (i64 15 to i64 ()*)()
   %1 = and i64 %get_uid_gid, 4294967295
-  %2 = bitcast i64* %"@x_key" to i8*
+  %2 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 0, i64* %"@x_key"
-  %3 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   store i64 %1, i64* %"@x_val"
+  %3 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %4 = bitcast i64* %"@x_key" to i8*
+  %4 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
-  %5 = bitcast i64* %"@x_val" to i8*
+  %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
   %get_uid_gid1 = call i64 inttoptr (i64 15 to i64 ()*)()
   %6 = lshr i64 %get_uid_gid1, 32
-  %7 = bitcast i64* %"@y_key" to i8*
+  %7 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  store i64 0, i64* %"@y_key"
-  %8 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 %6, i64* %"@y_val"
+  %8 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 0, i64* %"@y_key"
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem3 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@y_key", i64* %"@y_val", i64 0)
-  %9 = bitcast i64* %"@y_key" to i8*
+  %9 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@y_val" to i8*
+  %10 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_ustack.ll
+++ b/tests/codegen/llvm/builtin_ustack.ll
@@ -8,24 +8,24 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 256)
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = shl i64 %get_pid_tgid, 32
   %2 = or i64 %get_stackid, %1
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@x_key"
-  %4 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %2, i64* %"@x_val"
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 0, i64* %"@x_key"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %5 = bitcast i64* %"@x_key" to i8*
+  %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@x_val" to i8*
+  %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_buf_implicit_size.ll
+++ b/tests/codegen/llvm/call_buf_implicit_size.ll
@@ -3,7 +3,8 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
-%buffer_16_t = type { i8, [16 x i8] }
+%helper_error_t = type <{ i64, i64, i32, i8 }>
+%buffer_16_t = type { i32, [16 x i8] }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
@@ -11,7 +12,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64
-  %buffer = alloca %buffer_16_t
+  %helper_error_t = alloca %helper_error_t
+  %lookup_buf_key = alloca i32
   %"$foo" = alloca i64
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -19,25 +21,50 @@ entry:
   %2 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 0, i64* %"$foo"
-  %3 = bitcast %buffer_16_t* %buffer to i8*
+  %3 = bitcast i32* %lookup_buf_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = getelementptr %buffer_16_t, %buffer_16_t* %buffer, i32 0, i32 0
-  store i8 16, i8* %4
-  %5 = getelementptr %buffer_16_t, %buffer_16_t* %buffer, i32 0, i32 1
-  %6 = bitcast [16 x i8]* %5 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 16, i1 false)
-  %7 = load i64, i64* %"$foo"
-  %8 = add i64 %7, 0
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* %5, i32 16, i64 %8)
-  %9 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i32 0, i32* %lookup_buf_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %lookup_buf_map = call %buffer_16_t* inttoptr (i64 1 to %buffer_16_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_buf_key)
+  %4 = bitcast i32* %lookup_buf_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  %5 = sext %buffer_16_t* %lookup_buf_map to i32
+  %6 = icmp ne i32 %5, 0
+  br i1 %6, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %7 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %9
+  %10 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %5, i32* %10
+  %11 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %11
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %12 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %13 = bitcast %buffer_16_t* %lookup_buf_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %13, i8 0, i64 20, i1 false)
+  %14 = getelementptr %buffer_16_t, %buffer_16_t* %lookup_buf_map, i32 0, i32 0
+  store i32 16, i32* %14
+  %15 = getelementptr %buffer_16_t, %buffer_16_t* %lookup_buf_map, i32 0, i32 1
+  %16 = load i64, i64* %"$foo"
+  %17 = add i64 %16, 0
+  %probe_read = call i64 inttoptr (i64 4 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* %15, i32 16, i64 %17)
+  %18 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
   store i64 0, i64* %"@x_key"
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %buffer_16_t*, i64)*)(i64 %pseudo, i64* %"@x_key", %buffer_16_t* %buffer, i64 0)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast %buffer_16_t* %buffer to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %buffer_16_t*, i64)*)(i64 %pseudo2, i64* %"@x_key", %buffer_16_t* %lookup_buf_map, i64 0)
+  %19 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
   ret i64 0
 }
 
@@ -45,10 +72,10 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/call_buf_size_literal.ll
+++ b/tests/codegen/llvm/call_buf_size_literal.ll
@@ -3,7 +3,8 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
-%buffer_1_t = type { i8, [1 x i8] }
+%helper_error_t = type <{ i64, i64, i32, i8 }>
+%buffer_1_t = type { i32, [1 x i8] }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
@@ -11,27 +12,53 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64
-  %buffer = alloca %buffer_1_t
-  %1 = bitcast %buffer_1_t* %buffer to i8*
+  %helper_error_t = alloca %helper_error_t
+  %lookup_buf_key = alloca i32
+  %1 = bitcast i32* %lookup_buf_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = getelementptr %buffer_1_t, %buffer_1_t* %buffer, i32 0, i32 0
-  store i8 1, i8* %2
-  %3 = getelementptr %buffer_1_t, %buffer_1_t* %buffer, i32 0, i32 1
-  %4 = bitcast [1 x i8]* %3 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 1, i1 false)
-  %5 = bitcast i8* %0 to i64*
-  %6 = getelementptr i64, i64* %5, i64 14
-  %arg0 = load volatile i64, i64* %6
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([1 x i8]*, i32, i64)*)([1 x i8]* %3, i32 1, i64 %arg0)
-  %7 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i32 0, i32* %lookup_buf_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %lookup_buf_map = call %buffer_1_t* inttoptr (i64 1 to %buffer_1_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_buf_key)
+  %2 = bitcast i32* %lookup_buf_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext %buffer_1_t* %lookup_buf_map to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %5 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %6
+  %7 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %7
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %9
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %11 = bitcast %buffer_1_t* %lookup_buf_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 8, i1 false)
+  %12 = getelementptr %buffer_1_t, %buffer_1_t* %lookup_buf_map, i32 0, i32 0
+  store i32 1, i32* %12
+  %13 = getelementptr %buffer_1_t, %buffer_1_t* %lookup_buf_map, i32 0, i32 1
+  %14 = bitcast i8* %0 to i64*
+  %15 = getelementptr i64, i64* %14, i64 14
+  %arg0 = load volatile i64, i64* %15
+  %probe_read = call i64 inttoptr (i64 4 to i64 ([1 x i8]*, i32, i64)*)([1 x i8]* %13, i32 1, i64 %arg0)
+  %16 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
   store i64 0, i64* %"@x_key"
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %buffer_1_t*, i64)*)(i64 %pseudo, i64* %"@x_key", %buffer_1_t* %buffer, i64 0)
-  %8 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast %buffer_1_t* %buffer to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %buffer_1_t*, i64)*)(i64 %pseudo2, i64* %"@x_key", %buffer_1_t* %lookup_buf_map, i64 0)
+  %17 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
   ret i64 0
 }
 
@@ -39,10 +66,10 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/call_buf_size_nonliteral.ll
+++ b/tests/codegen/llvm/call_buf_size_nonliteral.ll
@@ -3,7 +3,8 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
-%buffer_64_t = type { i8, [64 x i8] }
+%helper_error_t = type <{ i64, i64, i32, i8 }>
+%buffer_64_t = type { i32, [64 x i8] }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
@@ -11,34 +12,59 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64
-  %buffer = alloca %buffer_64_t
+  %helper_error_t = alloca %helper_error_t
+  %lookup_buf_key = alloca i32
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 13
   %arg1 = load volatile i64, i64* %2
   %length.cmp = icmp ule i64 %arg1, 64
   %length.select = select i1 %length.cmp, i64 %arg1, i64 64
-  %3 = bitcast %buffer_64_t* %buffer to i8*
+  %3 = bitcast i32* %lookup_buf_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = getelementptr %buffer_64_t, %buffer_64_t* %buffer, i32 0, i32 0
-  %5 = trunc i64 %length.select to i8
-  store i8 %5, i8* %4
-  %6 = getelementptr %buffer_64_t, %buffer_64_t* %buffer, i32 0, i32 1
-  %7 = bitcast [64 x i8]* %6 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %7, i8 0, i64 64, i1 false)
-  %8 = bitcast i8* %0 to i64*
-  %9 = getelementptr i64, i64* %8, i64 14
-  %arg0 = load volatile i64, i64* %9
-  %10 = zext i8 %5 to i32
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %6, i32 %10, i64 %arg0)
-  %11 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  store i64 0, i64* %"@x_key"
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %buffer_64_t*, i64)*)(i64 %pseudo, i64* %"@x_key", %buffer_64_t* %buffer, i64 0)
-  %12 = bitcast i64* %"@x_key" to i8*
+  store i32 0, i32* %lookup_buf_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %lookup_buf_map = call %buffer_64_t* inttoptr (i64 1 to %buffer_64_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_buf_key)
+  %4 = bitcast i32* %lookup_buf_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  %5 = sext %buffer_64_t* %lookup_buf_map to i32
+  %6 = icmp ne i32 %5, 0
+  br i1 %6, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %7 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %9
+  %10 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %5, i32* %10
+  %11 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %11
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %12 = bitcast %helper_error_t* %helper_error_t to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast %buffer_64_t* %buffer to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %13 = bitcast %buffer_64_t* %lookup_buf_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %13, i8 0, i64 68, i1 false)
+  %14 = getelementptr %buffer_64_t, %buffer_64_t* %lookup_buf_map, i32 0, i32 0
+  %15 = trunc i64 %length.select to i32
+  store i32 %15, i32* %14
+  %16 = getelementptr %buffer_64_t, %buffer_64_t* %lookup_buf_map, i32 0, i32 1
+  %17 = bitcast i8* %0 to i64*
+  %18 = getelementptr i64, i64* %17, i64 14
+  %arg0 = load volatile i64, i64* %18
+  %probe_read = call i64 inttoptr (i64 4 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %16, i32 %15, i64 %arg0)
+  %19 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
+  store i64 0, i64* %"@x_key"
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %buffer_64_t*, i64)*)(i64 %pseudo2, i64* %"@x_key", %buffer_64_t* %lookup_buf_map, i64 0)
+  %20 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
   ret i64 0
 }
 
@@ -46,10 +72,10 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/call_cat.ll
+++ b/tests/codegen/llvm/call_cat.ll
@@ -3,6 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %cat_t = type { i64 }
 
 ; Function Attrs: nounwind
@@ -10,18 +11,43 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %cat_args = alloca %cat_t
-  %1 = bitcast %cat_t* %cat_args to i8*
+  %helper_error_t = alloca %helper_error_t
+  %lookup_fmtstr_key = alloca i32
+  %1 = bitcast i32* %lookup_fmtstr_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast %cat_t* %cat_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 8, i1 false)
-  %3 = getelementptr %cat_t, %cat_t* %cat_args, i32 0, i32 0
-  store i64 20000, i64* %3
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %cat_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %cat_t* %cat_args, i64 8)
-  %4 = bitcast %cat_t* %cat_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  store i32 0, i32* %lookup_fmtstr_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_fmtstr_map = call %cat_t* inttoptr (i64 1 to %cat_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %2 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext %cat_t* %lookup_fmtstr_map to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %5 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %6
+  %7 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %7
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %9
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %11 = bitcast %cat_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 8, i1 false)
+  %12 = getelementptr %cat_t, %cat_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 20000, i64* %12
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output3 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %cat_t*, i64)*)(i8* %0, i64 %pseudo2, i64 4294967295, %cat_t* %lookup_fmtstr_map, i64 8)
   ret i64 0
 }
 
@@ -29,10 +55,10 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/call_cgroup.ll
+++ b/tests/codegen/llvm/call_cgroup.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"tracepoint:syscalls:sys_enter_openat"(i8*) section "s_tracepoint:syscalls:sys_enter_openat_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %get_cgroup_id = call i64 inttoptr (i64 80 to i64 ()*)()
   %1 = icmp eq i64 %get_cgroup_id, 4294967297
   %2 = zext i1 %1 to i64
@@ -21,17 +21,17 @@ pred_false:                                       ; preds = %entry
 
 pred_true:                                        ; preds = %entry
   %get_cgroup_id1 = call i64 inttoptr (i64 80 to i64 ()*)()
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@x_key"
-  %4 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %get_cgroup_id1, i64* %"@x_val"
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %5 = bitcast i64* %"@x_key" to i8*
+  %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@x_val" to i8*
+  %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_clear.ll
+++ b/tests/codegen/llvm/call_clear.ll
@@ -10,19 +10,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @BEGIN(i8*) section "s_BEGIN_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 1, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }
@@ -43,8 +43,7 @@ entry:
   %3 = getelementptr %clear_t, %clear_t* %"clear_@x", i64 0, i32 1
   store i32 0, i32* %3
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %clear_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %clear_t* %"clear_@x", i64 12)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %clear_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %clear_t* %"clear_@x", i64 12)
   %4 = bitcast %clear_t* %"clear_@x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0

--- a/tests/codegen/llvm/call_count.ll
+++ b/tests/codegen/llvm/call_count.ll
@@ -41,9 +41,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %7, i64* %"@x_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %8 = bitcast i64* %"@x_key" to i8*
+  %8 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@x_val" to i8*
+  %9 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_delete.ll
+++ b/tests/codegen/llvm/call_delete.ll
@@ -9,19 +9,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %"@x_key1" = alloca i64
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 1, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   %5 = bitcast i64* %"@x_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)

--- a/tests/codegen/llvm/call_exit.ll
+++ b/tests/codegen/llvm/call_exit.ll
@@ -8,31 +8,30 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@_val" = alloca i64
   %"@_key" = alloca i64
+  %"@_val" = alloca i64
   %perfdata = alloca i64
   %1 = bitcast i64* %perfdata to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 30000, i64* %perfdata
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, i64*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, i64* %perfdata, i64 8)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, i64*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, i64* %perfdata, i64 8)
   %2 = bitcast i64* %perfdata to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
   ret i64 0
 
 deadcode:                                         ; No predecessors!
-  %3 = bitcast i64* %"@_key" to i8*
+  %3 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@_key"
-  %4 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 10, i64* %"@_val"
+  %4 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 0, i64* %"@_key"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %"@_val", i64 0)
-  %5 = bitcast i64* %"@_key" to i8*
+  %5 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@_val" to i8*
+  %6 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_kstack.ll
+++ b/tests/codegen/llvm/call_kstack.ll
@@ -8,37 +8,37 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@y_val" = alloca i64
   %"@y_key" = alloca i64
-  %"@x_val" = alloca i64
+  %"@y_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 4)
   %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 0)
-  %1 = bitcast i64* %"@x_key" to i8*
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 %get_stackid, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
   %get_stackid3 = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo2, i64 0)
-  %5 = bitcast i64* %"@y_key" to i8*
+  %5 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  store i64 0, i64* %"@y_key"
-  %6 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   store i64 %get_stackid3, i64* %"@y_val"
+  %6 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  store i64 0, i64* %"@y_key"
   %pseudo4 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem5 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo4, i64* %"@y_key", i64* %"@y_val", i64 0)
-  %7 = bitcast i64* %"@y_key" to i8*
+  %7 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@y_val" to i8*
+  %8 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_max.ll
+++ b/tests/codegen/llvm/call_max.ll
@@ -43,9 +43,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   br i1 %8, label %min.ge, label %min.lt
 
 min.lt:                                           ; preds = %min.ge, %lookup_merge
-  %9 = bitcast i64* %"@x_key" to i8*
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_val" to i8*
+  %10 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 

--- a/tests/codegen/llvm/call_min.ll
+++ b/tests/codegen/llvm/call_min.ll
@@ -44,9 +44,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   br i1 %9, label %min.ge, label %min.lt
 
 min.lt:                                           ; preds = %min.ge, %lookup_merge
-  %10 = bitcast i64* %"@x_key" to i8*
+  %10 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_val" to i8*
+  %11 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   ret i64 0
 

--- a/tests/codegen/llvm/call_ntop_key.ll
+++ b/tests/codegen/llvm/call_ntop_key.ll
@@ -49,9 +49,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %11, i64* %"@x_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, %inet_t*, i64*, i64)*)(i64 %pseudo1, %inet_t* %inet, i64* %"@x_val", i64 0)
-  %12 = bitcast %inet_t* %inet to i8*
+  %12 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_val" to i8*
+  %13 = bitcast %inet_t* %inet to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_print.ll
+++ b/tests/codegen/llvm/call_print.ll
@@ -10,19 +10,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @BEGIN(i8*) section "s_BEGIN_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 1, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }
@@ -47,8 +47,7 @@ entry:
   %5 = getelementptr %print_t, %print_t* %"print_@x", i64 0, i32 3
   store i32 0, i32* %5
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %print_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %print_t* %"print_@x", i64 20)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %print_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %print_t* %"print_@x", i64 20)
   %6 = bitcast %print_t* %"print_@x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   ret i64 0

--- a/tests/codegen/llvm/call_print_composit.ll
+++ b/tests/codegen/llvm/call_print_composit.ll
@@ -4,6 +4,7 @@ target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
 %print_tuple_72_t = type <{ i64, i64, [72 x i8] }>
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %"int64_string[64]__tuple_t" = type <{ i64, [64 x i8] }>
 
 ; Function Attrs: nounwind
@@ -12,40 +13,67 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %print_tuple_72_t = alloca %print_tuple_72_t
-  %str = alloca [64 x i8]
+  %helper_error_t = alloca %helper_error_t
+  %lookup_str_key = alloca i32
   %tuple = alloca %"int64_string[64]__tuple_t"
   %1 = bitcast %"int64_string[64]__tuple_t"* %tuple to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = getelementptr %"int64_string[64]__tuple_t", %"int64_string[64]__tuple_t"* %tuple, i32 0, i32 0
   store i64 1, i64* %2
-  %3 = bitcast [64 x i8]* %str to i8*
+  %3 = bitcast i32* %lookup_str_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store [64 x i8] c"abc\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str
-  %4 = getelementptr %"int64_string[64]__tuple_t", %"int64_string[64]__tuple_t"* %tuple, i32 0, i32 1
-  %5 = bitcast [64 x i8]* %4 to i8*
-  %6 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %5, i8* align 1 %6, i64 64, i1 false)
-  %7 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast %print_tuple_72_t* %print_tuple_72_t to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %9 = getelementptr %print_tuple_72_t, %print_tuple_72_t* %print_tuple_72_t, i64 0, i32 0
-  store i64 30007, i64* %9
-  %10 = getelementptr %print_tuple_72_t, %print_tuple_72_t* %print_tuple_72_t, i64 0, i32 1
-  store i64 0, i64* %10
-  %11 = getelementptr %print_tuple_72_t, %print_tuple_72_t* %print_tuple_72_t, i32 0, i32 2
-  %12 = bitcast [72 x i8]* %11 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %12, i8 0, i64 72, i1 false)
-  %13 = bitcast [72 x i8]* %11 to i8*
-  %14 = bitcast %"int64_string[64]__tuple_t"* %tuple to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %13, i8* align 1 %14, i64 72, i1 false)
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %print_tuple_72_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %print_tuple_72_t* %print_tuple_72_t, i64 88)
-  %15 = bitcast %print_tuple_72_t* %print_tuple_72_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
-  %16 = bitcast %"int64_string[64]__tuple_t"* %tuple to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  store i32 0, i32* %lookup_str_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_str_map = call [64 x i8]* inttoptr (i64 1 to [64 x i8]* (i64, i32*)*)(i64 %pseudo, i32* %lookup_str_key)
+  %4 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  %5 = sext [64 x i8]* %lookup_str_map to i32
+  %6 = icmp ne i32 %5, 0
+  br i1 %6, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %7 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %9
+  %10 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %5, i32* %10
+  %11 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %11
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %12 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %13 = bitcast [64 x i8]* %lookup_str_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %13, i8 0, i64 64, i1 false)
+  store [4 x i8] c"abc\00", [64 x i8]* %lookup_str_map
+  %14 = getelementptr %"int64_string[64]__tuple_t", %"int64_string[64]__tuple_t"* %tuple, i32 0, i32 1
+  %15 = bitcast [64 x i8]* %14 to i8*
+  %16 = bitcast [64 x i8]* %lookup_str_map to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %15, i8* align 1 %16, i64 64, i1 false)
+  %17 = bitcast %print_tuple_72_t* %print_tuple_72_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
+  %18 = getelementptr %print_tuple_72_t, %print_tuple_72_t* %print_tuple_72_t, i64 0, i32 0
+  store i64 30007, i64* %18
+  %19 = getelementptr %print_tuple_72_t, %print_tuple_72_t* %print_tuple_72_t, i64 0, i32 1
+  store i64 0, i64* %19
+  %20 = getelementptr %print_tuple_72_t, %print_tuple_72_t* %print_tuple_72_t, i32 0, i32 2
+  %21 = bitcast [72 x i8]* %20 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %21, i8 0, i64 72, i1 false)
+  %22 = bitcast [72 x i8]* %20 to i8*
+  %23 = bitcast %"int64_string[64]__tuple_t"* %tuple to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %22, i8* align 1 %23, i64 72, i1 false)
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output3 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %print_tuple_72_t*, i64)*)(i8* %0, i64 %pseudo2, i64 4294967295, %print_tuple_72_t* %print_tuple_72_t, i64 88)
+  %24 = bitcast %print_tuple_72_t* %print_tuple_72_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
+  %25 = bitcast %"int64_string[64]__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %25)
   ret i64 0
 }
 
@@ -53,13 +81,13 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #1
-
-; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/call_print_int.ll
+++ b/tests/codegen/llvm/call_print_int.ll
@@ -23,8 +23,7 @@ entry:
   %6 = bitcast [8 x i8]* %4 to i64*
   store i64 3, i64* %6
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %print_integer_8_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %print_integer_8_t* %print_integer_8_t, i64 24)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %print_integer_8_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %print_integer_8_t* %print_integer_8_t, i64 24)
   %7 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   ret i64 0

--- a/tests/codegen/llvm/call_printf.ll
+++ b/tests/codegen/llvm/call_printf.ll
@@ -3,6 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %printf_t = type { i64, i64, i64 }
 
 ; Function Attrs: nounwind
@@ -12,7 +13,8 @@ define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %"struct Foo.l" = alloca i64
   %"struct Foo.c" = alloca i8
-  %printf_args = alloca %printf_t
+  %helper_error_t = alloca %helper_error_t
+  %lookup_fmtstr_key = alloca i32
   %"$foo" = alloca i64
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -20,36 +22,60 @@ entry:
   %2 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 0, i64* %"$foo"
-  %3 = bitcast %printf_t* %printf_args to i8*
+  %3 = bitcast i32* %lookup_fmtstr_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 24, i1 false)
-  %5 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %5
-  %6 = load i64, i64* %"$foo"
-  %7 = add i64 %6, 0
+  store i32 0, i32* %lookup_fmtstr_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %4 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  %5 = sext %printf_t* %lookup_fmtstr_map to i32
+  %6 = icmp ne i32 %5, 0
+  br i1 %6, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %7 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %9
+  %10 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %5, i32* %10
+  %11 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %11
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %12 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %13 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %13, i8 0, i64 24, i1 false)
+  %14 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, i64* %14
+  %15 = load i64, i64* %"$foo"
+  %16 = add i64 %15, 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"struct Foo.c")
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.c", i32 1, i64 %7)
-  %8 = load i8, i8* %"struct Foo.c"
-  %9 = sext i8 %8 to i64
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.c", i32 1, i64 %16)
+  %17 = load i8, i8* %"struct Foo.c"
+  %18 = sext i8 %17 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct Foo.c")
-  %10 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %9, i64* %10
-  %11 = load i64, i64* %"$foo"
-  %12 = add i64 %11, 8
-  %13 = bitcast i64* %"struct Foo.l" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.l", i32 8, i64 %12)
-  %14 = load i64, i64* %"struct Foo.l"
-  %15 = bitcast i64* %"struct Foo.l" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
-  %16 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 2
-  store i64 %14, i64* %16
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* %printf_args, i64 24)
-  %17 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %19 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 1
+  store i64 %18, i64* %19
+  %20 = load i64, i64* %"$foo"
+  %21 = add i64 %20, 8
+  %22 = bitcast i64* %"struct Foo.l" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %22)
+  %probe_read2 = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.l", i32 8, i64 %21)
+  %23 = load i64, i64* %"struct Foo.l"
+  %24 = bitcast i64* %"struct Foo.l" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
+  %25 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 2
+  store i64 %23, i64* %25
+  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output4 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo3, i64 4294967295, %printf_t* %lookup_fmtstr_map, i64 24)
   ret i64 0
 }
 
@@ -57,10 +83,10 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/call_reg.ll
+++ b/tests/codegen/llvm/call_reg.ll
@@ -8,22 +8,22 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 16
   %reg_ip = load volatile i64, i64* %2
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@x_key"
-  %4 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %reg_ip, i64* %"@x_val"
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %5 = bitcast i64* %"@x_key" to i8*
+  %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@x_val" to i8*
+  %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_sizeof.ll
+++ b/tests/codegen/llvm/call_sizeof.ll
@@ -8,19 +8,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @BEGIN(i8*) section "s_BEGIN_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 8, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_str.ll
+++ b/tests/codegen/llvm/call_str.ll
@@ -3,40 +3,65 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64
-  %str = alloca [64 x i8]
+  %helper_error_t = alloca %helper_error_t
+  %lookup_str_key = alloca i32
   %strlen = alloca i64
   %1 = bitcast i64* %strlen to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast i64* %strlen to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 8, i1 false)
   store i64 64, i64* %strlen
-  %3 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 64, i1 false)
-  %5 = bitcast i8* %0 to i64*
-  %6 = getelementptr i64, i64* %5, i64 14
-  %arg0 = load volatile i64, i64* %6
-  %7 = load i64, i64* %strlen
-  %8 = trunc i64 %7 to i32
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %8, i64 %arg0)
-  %9 = bitcast i64* %strlen to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  store i64 0, i64* %"@x_key"
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* %"@x_key", [64 x i8]* %str, i64 0)
-  %11 = bitcast i64* %"@x_key" to i8*
+  %2 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i32 0, i32* %lookup_str_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %lookup_str_map = call [64 x i8]* inttoptr (i64 1 to [64 x i8]* (i64, i32*)*)(i64 %pseudo, i32* %lookup_str_key)
+  %3 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
+  %4 = sext [64 x i8]* %lookup_str_map to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %6 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %7 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %7
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %4, i32* %9
+  %10 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %10
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %11 = bitcast %helper_error_t* %helper_error_t to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %12 = bitcast [64 x i8]* %lookup_str_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %12, i8 0, i64 64, i1 false)
+  %13 = bitcast i8* %0 to i64*
+  %14 = getelementptr i64, i64* %13, i64 14
+  %arg0 = load volatile i64, i64* %14
+  %15 = load i64, i64* %strlen
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %lookup_str_map, i64 %15, i64 %arg0)
+  %16 = bitcast i64* %strlen to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
+  store i64 0, i64* %"@x_key"
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo2, i64* %"@x_key", [64 x i8]* %lookup_str_map, i64 0)
+  %18 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
   ret i64 0
 }
 
@@ -44,10 +69,10 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/call_str_2_expr.ll
+++ b/tests/codegen/llvm/call_str_2_expr.ll
@@ -3,46 +3,72 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64
-  %str = alloca [64 x i8]
+  %helper_error_t = alloca %helper_error_t
+  %lookup_str_key = alloca i32
   %strlen = alloca i64
   %1 = bitcast i64* %strlen to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast i64* %strlen to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 8, i1 false)
-  %3 = bitcast i8* %0 to i64*
-  %4 = getelementptr i64, i64* %3, i64 13
-  %arg1 = load volatile i64, i64* %4
-  %5 = add i64 %arg1, 1
-  %str.min.cmp = icmp ule i64 %5, 64
-  %str.min.select = select i1 %str.min.cmp, i64 %5, i64 64
+  store i64 0, i64* %strlen
+  %2 = bitcast i8* %0 to i64*
+  %3 = getelementptr i64, i64* %2, i64 13
+  %arg1 = load volatile i64, i64* %3
+  %4 = add i64 %arg1, 1
+  %str.min.cmp = icmp ule i64 %4, 64
+  %str.min.select = select i1 %str.min.cmp, i64 %4, i64 64
   store i64 %str.min.select, i64* %strlen
-  %6 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %7 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %7, i8 0, i64 64, i1 false)
-  %8 = bitcast i8* %0 to i64*
-  %9 = getelementptr i64, i64* %8, i64 14
-  %arg0 = load volatile i64, i64* %9
-  %10 = load i64, i64* %strlen
-  %11 = trunc i64 %10 to i32
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %11, i64 %arg0)
-  %12 = bitcast i64* %strlen to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  store i64 0, i64* %"@x_key"
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* %"@x_key", [64 x i8]* %str, i64 0)
-  %14 = bitcast i64* %"@x_key" to i8*
+  %5 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i32 0, i32* %lookup_str_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %lookup_str_map = call [64 x i8]* inttoptr (i64 1 to [64 x i8]* (i64, i32*)*)(i64 %pseudo, i32* %lookup_str_key)
+  %6 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = sext [64 x i8]* %lookup_str_map to i32
+  %8 = icmp ne i32 %7, 0
+  br i1 %8, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %9 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %10 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %10
+  %11 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %11
+  %12 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %7, i32* %12
+  %13 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %13
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %14 = bitcast %helper_error_t* %helper_error_t to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %15 = bitcast [64 x i8]* %lookup_str_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %15, i8 0, i64 64, i1 false)
+  %16 = bitcast i8* %0 to i64*
+  %17 = getelementptr i64, i64* %16, i64 14
+  %arg0 = load volatile i64, i64* %17
+  %18 = load i64, i64* %strlen
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %lookup_str_map, i64 %18, i64 %arg0)
+  %19 = bitcast i64* %strlen to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  %20 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %20)
+  store i64 0, i64* %"@x_key"
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo2, i64* %"@x_key", [64 x i8]* %lookup_str_map, i64 0)
+  %21 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
   ret i64 0
 }
 
@@ -50,10 +76,10 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/call_str_2_lit.ll
+++ b/tests/codegen/llvm/call_str_2_lit.ll
@@ -3,40 +3,66 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64
-  %str = alloca [64 x i8]
+  %helper_error_t = alloca %helper_error_t
+  %lookup_str_key = alloca i32
   %strlen = alloca i64
   %1 = bitcast i64* %strlen to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast i64* %strlen to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 8, i1 false)
+  store i64 0, i64* %strlen
   store i64 7, i64* %strlen
-  %3 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 64, i1 false)
-  %5 = bitcast i8* %0 to i64*
-  %6 = getelementptr i64, i64* %5, i64 14
-  %arg0 = load volatile i64, i64* %6
-  %7 = load i64, i64* %strlen
-  %8 = trunc i64 %7 to i32
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %8, i64 %arg0)
-  %9 = bitcast i64* %strlen to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  store i64 0, i64* %"@x_key"
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* %"@x_key", [64 x i8]* %str, i64 0)
-  %11 = bitcast i64* %"@x_key" to i8*
+  %2 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i32 0, i32* %lookup_str_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %lookup_str_map = call [64 x i8]* inttoptr (i64 1 to [64 x i8]* (i64, i32*)*)(i64 %pseudo, i32* %lookup_str_key)
+  %3 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
+  %4 = sext [64 x i8]* %lookup_str_map to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %6 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %7 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %7
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %4, i32* %9
+  %10 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %10
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %11 = bitcast %helper_error_t* %helper_error_t to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %12 = bitcast [64 x i8]* %lookup_str_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %12, i8 0, i64 64, i1 false)
+  %13 = bitcast i8* %0 to i64*
+  %14 = getelementptr i64, i64* %13, i64 14
+  %arg0 = load volatile i64, i64* %14
+  %15 = load i64, i64* %strlen
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %lookup_str_map, i64 %15, i64 %arg0)
+  %16 = bitcast i64* %strlen to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
+  store i64 0, i64* %"@x_key"
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo2, i64* %"@x_key", [64 x i8]* %lookup_str_map, i64 0)
+  %18 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
   ret i64 0
 }
 
@@ -44,10 +70,10 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/call_strftime.ll
+++ b/tests/codegen/llvm/call_strftime.ll
@@ -4,6 +4,7 @@ target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
 %strftime_t = type <{ i64, i64 }>
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %printf_t = type { i64, i128 }
 
 ; Function Attrs: nounwind
@@ -12,29 +13,54 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %strftime_args = alloca %strftime_t
-  %printf_args = alloca %printf_t
-  %1 = bitcast %printf_t* %printf_args to i8*
+  %helper_error_t = alloca %helper_error_t
+  %lookup_fmtstr_key = alloca i32
+  %1 = bitcast i32* %lookup_fmtstr_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 24, i1 false)
-  %3 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %3
-  %4 = bitcast %strftime_t* %strftime_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  %5 = getelementptr %strftime_t, %strftime_t* %strftime_args, i64 0, i32 0
-  store i64 0, i64* %5
-  %get_ns = call i64 inttoptr (i64 5 to i64 ()*)()
-  %6 = getelementptr %strftime_t, %strftime_t* %strftime_args, i64 0, i32 1
-  store i64 %get_ns, i64* %6
-  %7 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  %8 = bitcast i128* %7 to i8*
-  %9 = bitcast %strftime_t* %strftime_args to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %8, i8* align 1 %9, i64 16, i1 false)
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* %printf_args, i64 24)
-  %10 = bitcast %printf_t* %printf_args to i8*
+  store i32 0, i32* %lookup_fmtstr_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %2 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext %printf_t* %lookup_fmtstr_map to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %5 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %6
+  %7 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %7
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %9
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %11 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 24, i1 false)
+  %12 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, i64* %12
+  %13 = bitcast %strftime_t* %strftime_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %14 = getelementptr %strftime_t, %strftime_t* %strftime_args, i64 0, i32 0
+  store i64 0, i64* %14
+  %get_ns = call i64 inttoptr (i64 5 to i64 ()*)()
+  %15 = getelementptr %strftime_t, %strftime_t* %strftime_args, i64 0, i32 1
+  store i64 %get_ns, i64* %15
+  %16 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 1
+  %17 = bitcast i128* %16 to i8*
+  %18 = bitcast %strftime_t* %strftime_args to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %17, i8* align 1 %18, i64 16, i1 false)
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output3 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo2, i64 4294967295, %printf_t* %lookup_fmtstr_map, i64 24)
   ret i64 0
 }
 
@@ -42,13 +68,13 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #1
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/call_sum.ll
+++ b/tests/codegen/llvm/call_sum.ll
@@ -43,9 +43,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %8, i64* %"@x_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %9 = bitcast i64* %"@x_key" to i8*
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_val" to i8*
+  %10 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_system.ll
+++ b/tests/codegen/llvm/call_system.ll
@@ -3,6 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %system_t = type { i64, i64 }
 
 ; Function Attrs: nounwind
@@ -10,20 +11,45 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %system_args = alloca %system_t
-  %1 = bitcast %system_t* %system_args to i8*
+  %helper_error_t = alloca %helper_error_t
+  %lookup_fmtstr_key = alloca i32
+  %1 = bitcast i32* %lookup_fmtstr_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast %system_t* %system_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 16, i1 false)
-  %3 = getelementptr %system_t, %system_t* %system_args, i32 0, i32 0
-  store i64 10000, i64* %3
-  %4 = getelementptr %system_t, %system_t* %system_args, i32 0, i32 1
-  store i64 100, i64* %4
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %system_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %system_t* %system_args, i64 16)
-  %5 = bitcast %system_t* %system_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  store i32 0, i32* %lookup_fmtstr_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_fmtstr_map = call %system_t* inttoptr (i64 1 to %system_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %2 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext %system_t* %lookup_fmtstr_map to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %5 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %6
+  %7 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %7
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %9
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %11 = bitcast %system_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 16, i1 false)
+  %12 = getelementptr %system_t, %system_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 10000, i64* %12
+  %13 = getelementptr %system_t, %system_t* %lookup_fmtstr_map, i32 0, i32 1
+  store i64 100, i64* %13
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output3 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %system_t*, i64)*)(i8* %0, i64 %pseudo2, i64 4294967295, %system_t* %lookup_fmtstr_map, i64 16)
   ret i64 0
 }
 
@@ -31,10 +57,10 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/call_time.ll
+++ b/tests/codegen/llvm/call_time.ll
@@ -18,8 +18,7 @@ entry:
   %3 = getelementptr %time_t, %time_t* %time_t, i64 0, i32 1
   store i32 0, i32* %3
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %time_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %time_t* %time_t, i64 12)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %time_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %time_t* %time_t, i64 12)
   %4 = bitcast %time_t* %time_t to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0

--- a/tests/codegen/llvm/call_uptr_1.ll
+++ b/tests/codegen/llvm/call_uptr_1.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@_val" = alloca i64
   %"@_key" = alloca i64
+  %"@_val" = alloca i64
   %deref = alloca i16
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 14
@@ -21,17 +21,17 @@ entry:
   %5 = sext i16 %4 to i64
   %6 = bitcast i16* %deref to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast i64* %"@_key" to i8*
+  %7 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  store i64 0, i64* %"@_key"
-  %8 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 %5, i64* %"@_val"
+  %8 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 0, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
-  %9 = bitcast i64* %"@_key" to i8*
+  %9 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@_val" to i8*
+  %10 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_uptr_2.ll
+++ b/tests/codegen/llvm/call_uptr_2.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@_val" = alloca i64
   %"@_key" = alloca i64
+  %"@_val" = alloca i64
   %deref = alloca i32
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 14
@@ -21,17 +21,17 @@ entry:
   %5 = sext i32 %4 to i64
   %6 = bitcast i32* %deref to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast i64* %"@_key" to i8*
+  %7 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  store i64 0, i64* %"@_key"
-  %8 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 %5, i64* %"@_val"
+  %8 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 0, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
-  %9 = bitcast i64* %"@_key" to i8*
+  %9 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@_val" to i8*
+  %10 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_ustack.ll
+++ b/tests/codegen/llvm/call_ustack.ll
@@ -8,43 +8,43 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@y_val" = alloca i64
   %"@y_key" = alloca i64
-  %"@x_val" = alloca i64
+  %"@y_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 4)
   %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 256)
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = shl i64 %get_pid_tgid, 32
   %2 = or i64 %get_stackid, %1
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@x_key"
-  %4 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %2, i64* %"@x_val"
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 0, i64* %"@x_key"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %5 = bitcast i64* %"@x_key" to i8*
+  %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@x_val" to i8*
+  %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
   %get_stackid3 = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo2, i64 256)
   %get_pid_tgid4 = call i64 inttoptr (i64 14 to i64 ()*)()
   %7 = shl i64 %get_pid_tgid4, 32
   %8 = or i64 %get_stackid3, %7
-  %9 = bitcast i64* %"@y_key" to i8*
+  %9 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store i64 0, i64* %"@y_key"
-  %10 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 %8, i64* %"@y_val"
+  %10 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i64 0, i64* %"@y_key"
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem6 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo5, i64* %"@y_key", i64* %"@y_val", i64 0)
-  %11 = bitcast i64* %"@y_key" to i8*
+  %11 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@y_val" to i8*
+  %12 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_usym_key.ll
+++ b/tests/codegen/llvm/call_usym_key.ll
@@ -48,9 +48,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %10, i64* %"@x_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, %usym_t*, i64*, i64)*)(i64 %pseudo1, %usym_t* %usym, i64* %"@x_val", i64 0)
-  %11 = bitcast %usym_t* %usym to i8*
+  %11 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_val" to i8*
+  %12 = bitcast %usym_t* %usym to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_zero.ll
+++ b/tests/codegen/llvm/call_zero.ll
@@ -10,19 +10,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @BEGIN(i8*) section "s_BEGIN_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 1, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }
@@ -43,8 +43,7 @@ entry:
   %3 = getelementptr %zero_t, %zero_t* %"zero_@x", i64 0, i32 1
   store i32 0, i32* %3
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %zero_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %zero_t* %"zero_@x", i64 12)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %zero_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %zero_t* %"zero_@x", i64 12)
   %4 = bitcast %zero_t* %"zero_@x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0

--- a/tests/codegen/llvm/comparison_extend.ll
+++ b/tests/codegen/llvm/comparison_extend.ll
@@ -8,24 +8,24 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@_val" = alloca i64
   %"@_key" = alloca i64
+  %"@_val" = alloca i64
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 14
   %arg0 = load volatile i64, i64* %2
   %3 = icmp ult i64 1, %arg0
   %4 = zext i1 %3 to i64
-  %5 = bitcast i64* %"@_key" to i8*
+  %5 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  store i64 0, i64* %"@_key"
-  %6 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   store i64 %4, i64* %"@_val"
+  %6 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  store i64 0, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
-  %7 = bitcast i64* %"@_key" to i8*
+  %7 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@_val" to i8*
+  %8 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
   ret i64 0
 }

--- a/tests/codegen/llvm/dereference.ll
+++ b/tests/codegen/llvm/dereference.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %deref = alloca i64
   %1 = bitcast i64* %deref to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -17,17 +17,17 @@ entry:
   %2 = load i64, i64* %deref
   %3 = bitcast i64* %deref to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_key" to i8*
+  %4 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  store i64 0, i64* %"@x_key"
-  %5 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
   store i64 %2, i64* %"@x_val"
+  %5 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %6 = bitcast i64* %"@x_key" to i8*
+  %6 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast i64* %"@x_val" to i8*
+  %7 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   ret i64 0
 }

--- a/tests/codegen/llvm/enum_declaration.ll
+++ b/tests/codegen/llvm/enum_declaration.ll
@@ -8,33 +8,33 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@b_val" = alloca i64
   %"@b_key" = alloca i64
-  %"@a_val" = alloca i64
+  %"@b_val" = alloca i64
   %"@a_key" = alloca i64
-  %1 = bitcast i64* %"@a_key" to i8*
+  %"@a_val" = alloca i64
+  %1 = bitcast i64* %"@a_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@a_key"
-  %2 = bitcast i64* %"@a_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 42, i64* %"@a_val"
+  %2 = bitcast i64* %"@a_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@a_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@a_key", i64* %"@a_val", i64 0)
-  %3 = bitcast i64* %"@a_key" to i8*
+  %3 = bitcast i64* %"@a_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@a_val" to i8*
+  %4 = bitcast i64* %"@a_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
-  %5 = bitcast i64* %"@b_key" to i8*
+  %5 = bitcast i64* %"@b_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  store i64 0, i64* %"@b_key"
-  %6 = bitcast i64* %"@b_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   store i64 43, i64* %"@b_val"
+  %6 = bitcast i64* %"@b_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  store i64 0, i64* %"@b_key"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem2 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@b_key", i64* %"@b_val", i64 0)
-  %7 = bitcast i64* %"@b_key" to i8*
+  %7 = bitcast i64* %"@b_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@b_val" to i8*
+  %8 = bitcast i64* %"@b_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
   ret i64 0
 }

--- a/tests/codegen/llvm/if_else_printf.ll
+++ b/tests/codegen/llvm/if_else_printf.ll
@@ -3,16 +3,19 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
-%printf_t.0 = type { i64 }
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %printf_t = type { i64 }
+%printf_t.0 = type { i64 }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %printf_args1 = alloca %printf_t.0
-  %printf_args = alloca %printf_t
+  %helper_error_t9 = alloca %helper_error_t
+  %lookup_fmtstr_key4 = alloca i32
+  %helper_error_t = alloca %helper_error_t
+  %lookup_fmtstr_key = alloca i32
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = lshr i64 %get_pid_tgid, 32
   %2 = icmp ugt i64 %1, 10
@@ -21,34 +24,82 @@ entry:
   br i1 %true_cond, label %if_body, label %else_body
 
 if_body:                                          ; preds = %entry
-  %4 = bitcast %printf_t* %printf_args to i8*
+  %4 = bitcast i32* %lookup_fmtstr_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  %5 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %5, i8 0, i64 8, i1 false)
-  %6 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %6
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* %printf_args, i64 8)
-  %7 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  br label %if_end
+  store i32 0, i32* %lookup_fmtstr_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %5 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = sext %printf_t* %lookup_fmtstr_map to i32
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %helper_merge, label %helper_failure
 
-if_end:                                           ; preds = %else_body, %if_body
+if_end:                                           ; preds = %helper_merge8, %helper_merge
   ret i64 0
 
 else_body:                                        ; preds = %entry
-  %8 = bitcast %printf_t.0* %printf_args1 to i8*
+  %8 = bitcast i32* %lookup_fmtstr_key4 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %9 = bitcast %printf_t.0* %printf_args1 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %9, i8 0, i64 8, i1 false)
-  %10 = getelementptr %printf_t.0, %printf_t.0* %printf_args1, i32 0, i32 0
-  store i64 1, i64* %10
+  store i32 0, i32* %lookup_fmtstr_key4
+  %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_fmtstr_map6 = call %printf_t.0* inttoptr (i64 1 to %printf_t.0* (i64, i32*)*)(i64 %pseudo5, i32* %lookup_fmtstr_key4)
+  %9 = bitcast i32* %lookup_fmtstr_key4 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = sext %printf_t.0* %lookup_fmtstr_map6 to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %helper_merge8, label %helper_failure7
+
+helper_failure:                                   ; preds = %if_body
+  %12 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %13 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %13
+  %14 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %14
+  %15 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %6, i32* %15
+  %16 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %16
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %17 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  ret i64 0
+
+helper_merge:                                     ; preds = %if_body
+  %18 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %18, i8 0, i64 8, i1 false)
+  %19 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, i64* %19
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id3 = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output4 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.0*, i64)*)(i8* %0, i64 %pseudo2, i64 %get_cpu_id3, %printf_t.0* %printf_args1, i64 8)
-  %11 = bitcast %printf_t.0* %printf_args1 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %perf_event_output3 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo2, i64 4294967295, %printf_t* %lookup_fmtstr_map, i64 8)
+  br label %if_end
+
+helper_failure7:                                  ; preds = %else_body
+  %20 = bitcast %helper_error_t* %helper_error_t9 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %20)
+  %21 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t9, i64 0, i32 0
+  store i64 30006, i64* %21
+  %22 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t9, i64 0, i32 1
+  store i64 1, i64* %22
+  %23 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t9, i64 0, i32 2
+  store i32 %10, i32* %23
+  %24 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t9, i64 0, i32 3
+  store i8 1, i8* %24
+  %pseudo10 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output11 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo10, i64 4294967295, %helper_error_t* %helper_error_t9, i64 21)
+  %25 = bitcast %helper_error_t* %helper_error_t9 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %25)
+  ret i64 0
+
+helper_merge8:                                    ; preds = %else_body
+  %26 = bitcast %printf_t.0* %lookup_fmtstr_map6 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %26, i8 0, i64 8, i1 false)
+  %27 = getelementptr %printf_t.0, %printf_t.0* %lookup_fmtstr_map6, i32 0, i32 0
+  store i64 1, i64* %27
+  %pseudo12 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output13 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.0*, i64)*)(i8* %0, i64 %pseudo12, i64 4294967295, %printf_t.0* %lookup_fmtstr_map6, i64 8)
   br label %if_end
 }
 
@@ -56,10 +107,10 @@ else_body:                                        ; preds = %entry
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/if_else_variable.ll
+++ b/tests/codegen/llvm/if_else_variable.ll
@@ -3,6 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %printf_t = type { i64, i64 }
 
 ; Function Attrs: nounwind
@@ -10,7 +11,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %printf_args = alloca %printf_t
+  %helper_error_t = alloca %helper_error_t
+  %lookup_fmtstr_key = alloca i32
   %"$s" = alloca i64
   %1 = bitcast i64* %"$s" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -29,35 +31,59 @@ if_body:                                          ; preds = %entry
   br label %if_end
 
 if_end:                                           ; preds = %else_body, %if_body
-  %6 = bitcast %printf_t* %printf_args to i8*
+  %6 = bitcast i32* %lookup_fmtstr_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %7 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %7, i8 0, i64 16, i1 false)
-  %8 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %8
-  %9 = load i64, i64* %"$s"
-  %10 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %9, i64* %10
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* %printf_args, i64 16)
-  %11 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  ret i64 0
+  store i32 0, i32* %lookup_fmtstr_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %7 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %8 = sext %printf_t* %lookup_fmtstr_map to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %helper_merge, label %helper_failure
 
 else_body:                                        ; preds = %entry
   store i64 20, i64* %"$s"
   br label %if_end
+
+helper_failure:                                   ; preds = %if_end
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %11
+  %12 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %12
+  %13 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %8, i32* %13
+  %14 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %14
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %15 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  ret i64 0
+
+helper_merge:                                     ; preds = %if_end
+  %16 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %16, i8 0, i64 16, i1 false)
+  %17 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, i64* %17
+  %18 = load i64, i64* %"$s"
+  %19 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 1
+  store i64 %18, i64* %19
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output3 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo2, i64 4294967295, %printf_t* %lookup_fmtstr_map, i64 16)
+  ret i64 0
 }
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/if_nested_printf.ll
+++ b/tests/codegen/llvm/if_nested_printf.ll
@@ -3,6 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %printf_t = type { i64 }
 
 ; Function Attrs: nounwind
@@ -10,7 +11,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %printf_args = alloca %printf_t
+  %helper_error_t = alloca %helper_error_t
+  %lookup_fmtstr_key = alloca i32
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = lshr i64 %get_pid_tgid, 32
   %2 = icmp ugt i64 %1, 10000
@@ -31,31 +33,55 @@ if_end:                                           ; preds = %if_end2, %entry
   ret i64 0
 
 if_body1:                                         ; preds = %if_body
-  %8 = bitcast %printf_t* %printf_args to i8*
+  %8 = bitcast i32* %lookup_fmtstr_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %9 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %9, i8 0, i64 8, i1 false)
-  %10 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %10
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* %printf_args, i64 8)
-  %11 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  br label %if_end2
+  store i32 0, i32* %lookup_fmtstr_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %9 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = sext %printf_t* %lookup_fmtstr_map to i32
+  %11 = icmp ne i32 %10, 0
+  br i1 %11, label %helper_merge, label %helper_failure
 
-if_end2:                                          ; preds = %if_body1, %if_body
+if_end2:                                          ; preds = %helper_merge, %if_body
   br label %if_end
+
+helper_failure:                                   ; preds = %if_body1
+  %12 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %13 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %13
+  %14 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %14
+  %15 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %10, i32* %15
+  %16 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %16
+  %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo5, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %17 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  ret i64 0
+
+helper_merge:                                     ; preds = %if_body1
+  %18 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %18, i8 0, i64 8, i1 false)
+  %19 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, i64* %19
+  %pseudo6 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output7 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo6, i64 4294967295, %printf_t* %lookup_fmtstr_map, i64 8)
+  br label %if_end2
 }
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/if_printf.ll
+++ b/tests/codegen/llvm/if_printf.ll
@@ -3,6 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %printf_t = type { i64, i64 }
 
 ; Function Attrs: nounwind
@@ -10,7 +11,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %printf_args = alloca %printf_t
+  %helper_error_t = alloca %helper_error_t
+  %lookup_fmtstr_key = alloca i32
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = lshr i64 %get_pid_tgid, 32
   %2 = icmp ugt i64 %1, 10000
@@ -19,35 +21,59 @@ entry:
   br i1 %true_cond, label %if_body, label %if_end
 
 if_body:                                          ; preds = %entry
-  %4 = bitcast %printf_t* %printf_args to i8*
+  %4 = bitcast i32* %lookup_fmtstr_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  %5 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %5, i8 0, i64 16, i1 false)
-  %6 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %6
-  %get_pid_tgid1 = call i64 inttoptr (i64 14 to i64 ()*)()
-  %7 = lshr i64 %get_pid_tgid1, 32
-  %8 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %7, i64* %8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* %printf_args, i64 16)
-  %9 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  br label %if_end
+  store i32 0, i32* %lookup_fmtstr_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %5 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = sext %printf_t* %lookup_fmtstr_map to i32
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %helper_merge, label %helper_failure
 
-if_end:                                           ; preds = %if_body, %entry
+if_end:                                           ; preds = %helper_merge, %entry
   ret i64 0
+
+helper_failure:                                   ; preds = %if_body
+  %8 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %9
+  %10 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %10
+  %11 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %6, i32* %11
+  %12 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %12
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %13 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  ret i64 0
+
+helper_merge:                                     ; preds = %if_body
+  %14 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %14, i8 0, i64 16, i1 false)
+  %15 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, i64* %15
+  %get_pid_tgid2 = call i64 inttoptr (i64 14 to i64 ()*)()
+  %16 = lshr i64 %get_pid_tgid2, 32
+  %17 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 1
+  store i64 %16, i64* %17
+  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output4 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo3, i64 4294967295, %printf_t* %lookup_fmtstr_map, i64 16)
+  br label %if_end
 }
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/if_variable.ll
+++ b/tests/codegen/llvm/if_variable.ll
@@ -3,6 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %printf_t = type { i64, i64 }
 
 ; Function Attrs: nounwind
@@ -10,7 +11,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %printf_args = alloca %printf_t
+  %helper_error_t = alloca %helper_error_t
+  %lookup_fmtstr_key = alloca i32
   %"$s" = alloca i64
   %1 = bitcast i64* %"$s" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -29,20 +31,44 @@ if_body:                                          ; preds = %entry
   br label %if_end
 
 if_end:                                           ; preds = %if_body, %entry
-  %6 = bitcast %printf_t* %printf_args to i8*
+  %6 = bitcast i32* %lookup_fmtstr_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %7 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %7, i8 0, i64 16, i1 false)
-  %8 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %8
-  %9 = load i64, i64* %"$s"
-  %10 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %9, i64* %10
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* %printf_args, i64 16)
-  %11 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  store i32 0, i32* %lookup_fmtstr_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %7 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %8 = sext %printf_t* %lookup_fmtstr_map to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %if_end
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %11
+  %12 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %12
+  %13 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %8, i32* %13
+  %14 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %14
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %15 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  ret i64 0
+
+helper_merge:                                     ; preds = %if_end
+  %16 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %16, i8 0, i64 16, i1 false)
+  %17 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, i64* %17
+  %18 = load i64, i64* %"$s"
+  %19 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 1
+  store i64 %18, i64* %19
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output3 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo2, i64 4294967295, %printf_t* %lookup_fmtstr_map, i64 16)
   ret i64 0
 }
 
@@ -50,10 +76,10 @@ if_end:                                           ; preds = %if_body, %entry
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/int_propagation.ll
+++ b/tests/codegen/llvm/int_propagation.ll
@@ -8,23 +8,23 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@y_val" = alloca i64
   %"@y_key" = alloca i64
+  %"@y_val" = alloca i64
   %lookup_elem_val = alloca i64
   %"@x_key1" = alloca i64
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 1234, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   %5 = bitcast i64* %"@x_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
@@ -52,17 +52,17 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   %10 = bitcast i64* %"@x_key1" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@y_key" to i8*
+  %11 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  store i64 0, i64* %"@y_key"
-  %12 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
   store i64 %8, i64* %"@y_val"
+  %12 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  store i64 0, i64* %"@y_key"
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo3, i64* %"@y_key", i64* %"@y_val", i64 0)
-  %13 = bitcast i64* %"@y_key" to i8*
+  %13 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@y_val" to i8*
+  %14 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }

--- a/tests/codegen/llvm/intcast_call.ll
+++ b/tests/codegen/llvm/intcast_call.ll
@@ -46,9 +46,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %10, i64* %"@_val"
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@_key", i64* %"@_val", i64 0)
-  %11 = bitcast i64* %"@_key" to i8*
+  %11 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@_val" to i8*
+  %12 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }

--- a/tests/codegen/llvm/intcast_retval.ll
+++ b/tests/codegen/llvm/intcast_retval.ll
@@ -8,24 +8,24 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kretprobe:f"(i8*) section "s_kretprobe:f_1" {
 entry:
-  %"@_val" = alloca i64
   %"@_key" = alloca i64
+  %"@_val" = alloca i64
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 10
   %retval = load volatile i64, i64* %2
   %cast = trunc i64 %retval to i32
-  %3 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@_key"
-  %4 = sext i32 %cast to i64
-  %5 = bitcast i64* %"@_val" to i8*
+  %3 = sext i32 %cast to i64
+  %4 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 %3, i64* %"@_val"
+  %5 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  store i64 %4, i64* %"@_val"
+  store i64 0, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
-  %6 = bitcast i64* %"@_key" to i8*
+  %6 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast i64* %"@_val" to i8*
+  %7 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   ret i64 0
 }

--- a/tests/codegen/llvm/intptrcast_assign_var.ll
+++ b/tests/codegen/llvm/intptrcast_assign_var.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kretprobe:f"(i8*) section "s_kretprobe:f_1" {
 entry:
-  %"@_val" = alloca i64
   %"@_key" = alloca i64
+  %"@_val" = alloca i64
   %deref = alloca i8
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 4
@@ -20,17 +20,17 @@ entry:
   %4 = load i8, i8* %deref
   %5 = sext i8 %4 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %deref)
-  %6 = bitcast i64* %"@_key" to i8*
+  %6 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  store i64 0, i64* %"@_key"
-  %7 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   store i64 %5, i64* %"@_val"
+  %7 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i64 0, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
-  %8 = bitcast i64* %"@_key" to i8*
+  %8 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@_val" to i8*
+  %9 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   ret i64 0
 }

--- a/tests/codegen/llvm/intptrcast_call.ll
+++ b/tests/codegen/llvm/intptrcast_call.ll
@@ -51,9 +51,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %12, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %"@_val", i64 0)
-  %13 = bitcast i64* %"@_key" to i8*
+  %13 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@_val" to i8*
+  %14 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }

--- a/tests/codegen/llvm/literal_strncmp.ll
+++ b/tests/codegen/llvm/literal_strncmp.ll
@@ -82,9 +82,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %19, i64* %"@_val"
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo5, [16 x i8]* %comm3, i64* %"@_val", i64 0)
-  %20 = bitcast [16 x i8]* %comm3 to i8*
+  %20 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  %21 = bitcast i64* %"@_val" to i8*
+  %21 = bitcast [16 x i8]* %comm3 to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
   ret i64 0
 }

--- a/tests/codegen/llvm/logical_and.ll
+++ b/tests/codegen/llvm/logical_and.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"&&_result" = alloca i64
   %1 = bitcast i64* %"&&_result" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -38,17 +38,17 @@ entry:
 
 "&&_merge":                                       ; preds = %"&&_false", %"&&_true"
   %8 = load i64, i64* %"&&_result"
-  %9 = bitcast i64* %"@x_key" to i8*
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store i64 0, i64* %"@x_key"
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 %8, i64* %"@x_val"
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %11 = bitcast i64* %"@x_key" to i8*
+  %11 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_val" to i8*
+  %12 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }

--- a/tests/codegen/llvm/logical_and_or_different_type.ll
+++ b/tests/codegen/llvm/logical_and_or_different_type.ll
@@ -3,6 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %printf_t = type { i64, i64, i64, i64, i64 }
 
 ; Function Attrs: nounwind
@@ -10,148 +11,199 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @BEGIN(i8*) section "s_BEGIN_1" {
 entry:
-  %"struct Foo.m16" = alloca i32
-  %"||_result15" = alloca i64
-  %"struct Foo.m8" = alloca i32
+  %"struct Foo.m23" = alloca i32
+  %"||_result22" = alloca i64
+  %"struct Foo.m15" = alloca i32
   %"||_result" = alloca i64
-  %"struct Foo.m6" = alloca i32
-  %"&&_result5" = alloca i64
+  %"struct Foo.m13" = alloca i32
+  %"&&_result12" = alloca i64
   %"struct Foo.m" = alloca i32
   %"&&_result" = alloca i64
-  %printf_args = alloca %printf_t
-  %"$foo" = alloca [4 x i8]
-  %1 = bitcast [4 x i8]* %"$foo" to i8*
+  %helper_error_t5 = alloca %helper_error_t
+  %lookup_fmtstr_key = alloca i32
+  %helper_error_t = alloca %helper_error_t
+  %"lookup_$foo_key" = alloca i32
+  %1 = bitcast i32* %"lookup_$foo_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast [4 x i8]* %"$foo" to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 4, i1 false)
-  %3 = bitcast [4 x i8]* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [4 x i8]* %"$foo" to i8*
-  %5 = bitcast i64 0 to i8 addrspace(64)*
-  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %4, i8 addrspace(64)* align 1 %5, i64 4, i1 false)
-  %6 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %7 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %7, i8 0, i64 40, i1 false)
-  %8 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %8
-  %9 = bitcast i64* %"&&_result" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %10 = add [4 x i8]* %"$foo", i64 0
-  %11 = bitcast i32* %"struct Foo.m" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m", i32 4, [4 x i8]* %10)
-  %12 = load i32, i32* %"struct Foo.m"
-  %13 = sext i32 %12 to i64
-  %14 = bitcast i32* %"struct Foo.m" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %lhs_true_cond = icmp ne i64 %13, 0
+  store i32 0, i32* %"lookup_$foo_key"
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %"lookup_$foo_map" = call [4 x i8]* inttoptr (i64 1 to [4 x i8]* (i64, i32*)*)(i64 %pseudo, i32* %"lookup_$foo_key")
+  %2 = bitcast i32* %"lookup_$foo_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext [4 x i8]* %"lookup_$foo_map" to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %5 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %6
+  %7 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %7
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %9
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %11 = bitcast [4 x i8]* %"lookup_$foo_map" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 4, i1 false)
+  %12 = bitcast [4 x i8]* %"lookup_$foo_map" to i8*
+  %13 = bitcast i64 0 to i8 addrspace(64)*
+  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %12, i8 addrspace(64)* align 1 %13, i64 4, i1 false)
+  %14 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  store i32 0, i32* %lookup_fmtstr_key
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i64, i32*)*)(i64 %pseudo2, i32* %lookup_fmtstr_key)
+  %15 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %16 = sext %printf_t* %lookup_fmtstr_map to i32
+  %17 = icmp ne i32 %16, 0
+  br i1 %17, label %helper_merge4, label %helper_failure3
+
+helper_failure3:                                  ; preds = %helper_merge
+  %18 = bitcast %helper_error_t* %helper_error_t5 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
+  %19 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t5, i64 0, i32 0
+  store i64 30006, i64* %19
+  %20 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t5, i64 0, i32 1
+  store i64 1, i64* %20
+  %21 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t5, i64 0, i32 2
+  store i32 %16, i32* %21
+  %22 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t5, i64 0, i32 3
+  store i8 1, i8* %22
+  %pseudo6 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %perf_event_output7 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo6, i64 4294967295, %helper_error_t* %helper_error_t5, i64 21)
+  %23 = bitcast %helper_error_t* %helper_error_t5 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
+  ret i64 0
+
+helper_merge4:                                    ; preds = %helper_merge
+  %24 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %24, i8 0, i64 40, i1 false)
+  %25 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, i64* %25
+  %26 = bitcast i64* %"&&_result" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %26)
+  %27 = add [4 x i8]* %"lookup_$foo_map", i64 0
+  %28 = bitcast i32* %"struct Foo.m" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %28)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m", i32 4, [4 x i8]* %27)
+  %29 = load i32, i32* %"struct Foo.m"
+  %30 = sext i32 %29 to i64
+  %31 = bitcast i32* %"struct Foo.m" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %31)
+  %lhs_true_cond = icmp ne i64 %30, 0
   br i1 %lhs_true_cond, label %"&&_lhs_true", label %"&&_false"
 
-"&&_lhs_true":                                    ; preds = %entry
+"&&_lhs_true":                                    ; preds = %helper_merge4
   br i1 false, label %"&&_true", label %"&&_false"
 
 "&&_true":                                        ; preds = %"&&_lhs_true"
   store i64 1, i64* %"&&_result"
   br label %"&&_merge"
 
-"&&_false":                                       ; preds = %"&&_lhs_true", %entry
+"&&_false":                                       ; preds = %"&&_lhs_true", %helper_merge4
   store i64 0, i64* %"&&_result"
   br label %"&&_merge"
 
 "&&_merge":                                       ; preds = %"&&_false", %"&&_true"
-  %15 = load i64, i64* %"&&_result"
-  %16 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %15, i64* %16
-  %17 = bitcast i64* %"&&_result5" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
-  br i1 true, label %"&&_lhs_true1", label %"&&_false3"
+  %32 = load i64, i64* %"&&_result"
+  %33 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 1
+  store i64 %32, i64* %33
+  %34 = bitcast i64* %"&&_result12" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %34)
+  br i1 true, label %"&&_lhs_true8", label %"&&_false10"
 
-"&&_lhs_true1":                                   ; preds = %"&&_merge"
-  %18 = add [4 x i8]* %"$foo", i64 0
-  %19 = bitcast i32* %"struct Foo.m6" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
-  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m6", i32 4, [4 x i8]* %18)
-  %20 = load i32, i32* %"struct Foo.m6"
-  %21 = sext i32 %20 to i64
-  %22 = bitcast i32* %"struct Foo.m6" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
-  %rhs_true_cond = icmp ne i64 %21, 0
-  br i1 %rhs_true_cond, label %"&&_true2", label %"&&_false3"
+"&&_lhs_true8":                                   ; preds = %"&&_merge"
+  %35 = add [4 x i8]* %"lookup_$foo_map", i64 0
+  %36 = bitcast i32* %"struct Foo.m13" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %36)
+  %probe_read14 = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m13", i32 4, [4 x i8]* %35)
+  %37 = load i32, i32* %"struct Foo.m13"
+  %38 = sext i32 %37 to i64
+  %39 = bitcast i32* %"struct Foo.m13" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %39)
+  %rhs_true_cond = icmp ne i64 %38, 0
+  br i1 %rhs_true_cond, label %"&&_true9", label %"&&_false10"
 
-"&&_true2":                                       ; preds = %"&&_lhs_true1"
-  store i64 1, i64* %"&&_result5"
-  br label %"&&_merge4"
+"&&_true9":                                       ; preds = %"&&_lhs_true8"
+  store i64 1, i64* %"&&_result12"
+  br label %"&&_merge11"
 
-"&&_false3":                                      ; preds = %"&&_lhs_true1", %"&&_merge"
-  store i64 0, i64* %"&&_result5"
-  br label %"&&_merge4"
+"&&_false10":                                     ; preds = %"&&_lhs_true8", %"&&_merge"
+  store i64 0, i64* %"&&_result12"
+  br label %"&&_merge11"
 
-"&&_merge4":                                      ; preds = %"&&_false3", %"&&_true2"
-  %23 = load i64, i64* %"&&_result5"
-  %24 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 2
-  store i64 %23, i64* %24
-  %25 = bitcast i64* %"||_result" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %25)
-  %26 = add [4 x i8]* %"$foo", i64 0
-  %27 = bitcast i32* %"struct Foo.m8" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %27)
-  %probe_read9 = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m8", i32 4, [4 x i8]* %26)
-  %28 = load i32, i32* %"struct Foo.m8"
-  %29 = sext i32 %28 to i64
-  %30 = bitcast i32* %"struct Foo.m8" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %30)
-  %lhs_true_cond10 = icmp ne i64 %29, 0
-  br i1 %lhs_true_cond10, label %"||_true", label %"||_lhs_false"
+"&&_merge11":                                     ; preds = %"&&_false10", %"&&_true9"
+  %40 = load i64, i64* %"&&_result12"
+  %41 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 2
+  store i64 %40, i64* %41
+  %42 = bitcast i64* %"||_result" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %42)
+  %43 = add [4 x i8]* %"lookup_$foo_map", i64 0
+  %44 = bitcast i32* %"struct Foo.m15" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %44)
+  %probe_read16 = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m15", i32 4, [4 x i8]* %43)
+  %45 = load i32, i32* %"struct Foo.m15"
+  %46 = sext i32 %45 to i64
+  %47 = bitcast i32* %"struct Foo.m15" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %47)
+  %lhs_true_cond17 = icmp ne i64 %46, 0
+  br i1 %lhs_true_cond17, label %"||_true", label %"||_lhs_false"
 
-"||_lhs_false":                                   ; preds = %"&&_merge4"
+"||_lhs_false":                                   ; preds = %"&&_merge11"
   br i1 false, label %"||_true", label %"||_false"
 
 "||_false":                                       ; preds = %"||_lhs_false"
   store i64 0, i64* %"||_result"
   br label %"||_merge"
 
-"||_true":                                        ; preds = %"||_lhs_false", %"&&_merge4"
+"||_true":                                        ; preds = %"||_lhs_false", %"&&_merge11"
   store i64 1, i64* %"||_result"
   br label %"||_merge"
 
 "||_merge":                                       ; preds = %"||_true", %"||_false"
-  %31 = load i64, i64* %"||_result"
-  %32 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 3
-  store i64 %31, i64* %32
-  %33 = bitcast i64* %"||_result15" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %33)
-  br i1 false, label %"||_true13", label %"||_lhs_false11"
+  %48 = load i64, i64* %"||_result"
+  %49 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 3
+  store i64 %48, i64* %49
+  %50 = bitcast i64* %"||_result22" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %50)
+  br i1 false, label %"||_true20", label %"||_lhs_false18"
 
-"||_lhs_false11":                                 ; preds = %"||_merge"
-  %34 = add [4 x i8]* %"$foo", i64 0
-  %35 = bitcast i32* %"struct Foo.m16" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %35)
-  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m16", i32 4, [4 x i8]* %34)
-  %36 = load i32, i32* %"struct Foo.m16"
-  %37 = sext i32 %36 to i64
-  %38 = bitcast i32* %"struct Foo.m16" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %38)
-  %rhs_true_cond18 = icmp ne i64 %37, 0
-  br i1 %rhs_true_cond18, label %"||_true13", label %"||_false12"
+"||_lhs_false18":                                 ; preds = %"||_merge"
+  %51 = add [4 x i8]* %"lookup_$foo_map", i64 0
+  %52 = bitcast i32* %"struct Foo.m23" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %52)
+  %probe_read24 = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m23", i32 4, [4 x i8]* %51)
+  %53 = load i32, i32* %"struct Foo.m23"
+  %54 = sext i32 %53 to i64
+  %55 = bitcast i32* %"struct Foo.m23" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %55)
+  %rhs_true_cond25 = icmp ne i64 %54, 0
+  br i1 %rhs_true_cond25, label %"||_true20", label %"||_false19"
 
-"||_false12":                                     ; preds = %"||_lhs_false11"
-  store i64 0, i64* %"||_result15"
-  br label %"||_merge14"
+"||_false19":                                     ; preds = %"||_lhs_false18"
+  store i64 0, i64* %"||_result22"
+  br label %"||_merge21"
 
-"||_true13":                                      ; preds = %"||_lhs_false11", %"||_merge"
-  store i64 1, i64* %"||_result15"
-  br label %"||_merge14"
+"||_true20":                                      ; preds = %"||_lhs_false18", %"||_merge"
+  store i64 1, i64* %"||_result22"
+  br label %"||_merge21"
 
-"||_merge14":                                     ; preds = %"||_true13", %"||_false12"
-  %39 = load i64, i64* %"||_result15"
-  %40 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 4
-  store i64 %39, i64* %40
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* %printf_args, i64 40)
-  %41 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %41)
+"||_merge21":                                     ; preds = %"||_true20", %"||_false19"
+  %56 = load i64, i64* %"||_result22"
+  %57 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 4
+  store i64 %56, i64* %57
+  %pseudo26 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %perf_event_output27 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo26, i64 4294967295, %printf_t* %lookup_fmtstr_map, i64 40)
   ret i64 0
 }
 
@@ -159,13 +211,13 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.memcpy.p0i8.p64i8.i64(i8* nocapture writeonly, i8 addrspace(64)* nocapture readonly, i64, i1) #1
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/logical_not.ll
+++ b/tests/codegen/llvm/logical_not.ll
@@ -8,33 +8,33 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @BEGIN(i8*) section "s_BEGIN_1" {
 entry:
-  %"@y_val" = alloca i64
   %"@y_key" = alloca i64
-  %"@x_val" = alloca i64
+  %"@y_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 0, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
-  %5 = bitcast i64* %"@y_key" to i8*
+  %5 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  store i64 0, i64* %"@y_key"
-  %6 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   store i64 1, i64* %"@y_val"
+  %6 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  store i64 0, i64* %"@y_key"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem2 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@y_key", i64* %"@y_val", i64 0)
-  %7 = bitcast i64* %"@y_key" to i8*
+  %7 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@y_val" to i8*
+  %8 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
   ret i64 0
 }

--- a/tests/codegen/llvm/logical_or.ll
+++ b/tests/codegen/llvm/logical_or.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"||_result" = alloca i64
   %1 = bitcast i64* %"||_result" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -38,17 +38,17 @@ entry:
 
 "||_merge":                                       ; preds = %"||_true", %"||_false"
   %8 = load i64, i64* %"||_result"
-  %9 = bitcast i64* %"@x_key" to i8*
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store i64 0, i64* %"@x_key"
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 %8, i64* %"@x_val"
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %11 = bitcast i64* %"@x_key" to i8*
+  %11 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_val" to i8*
+  %12 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }

--- a/tests/codegen/llvm/macro_definition.ll
+++ b/tests/codegen/llvm/macro_definition.ll
@@ -8,19 +8,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@_val" = alloca i64
   %"@_key" = alloca i64
-  %1 = bitcast i64* %"@_key" to i8*
+  %"@_val" = alloca i64
+  %1 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@_key"
-  %2 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 100, i64* %"@_val"
+  %2 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
-  %3 = bitcast i64* %"@_key" to i8*
+  %3 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@_val" to i8*
+  %4 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/map_assign_int.ll
+++ b/tests/codegen/llvm/map_assign_int.ll
@@ -8,19 +8,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 1, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/map_assign_string.ll
+++ b/tests/codegen/llvm/map_assign_string.ll
@@ -3,25 +3,55 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64
-  %str = alloca [64 x i8]
-  %1 = bitcast [64 x i8]* %str to i8*
+  %helper_error_t = alloca %helper_error_t
+  %lookup_str_key = alloca i32
+  %1 = bitcast i32* %lookup_str_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store [64 x i8] c"blah\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str
-  %2 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i32 0, i32* %lookup_str_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %lookup_str_map = call [64 x i8]* inttoptr (i64 1 to [64 x i8]* (i64, i32*)*)(i64 %pseudo, i32* %lookup_str_key)
+  %2 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext [64 x i8]* %lookup_str_map to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %5 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %6
+  %7 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %7
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %9
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %11 = bitcast [64 x i8]* %lookup_str_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 64, i1 false)
+  store [5 x i8] c"blah\00", [64 x i8]* %lookup_str_map
+  %12 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
   store i64 0, i64* %"@x_key"
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* %"@x_key", [64 x i8]* %str, i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo2, i64* %"@x_key", [64 x i8]* %lookup_str_map, i64 0)
+  %13 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }
 
@@ -30,6 +60,9 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/map_increment_decrement.ll
+++ b/tests/codegen/llvm/map_increment_decrement.ll
@@ -20,19 +20,19 @@ entry:
   %"@x_newval" = alloca i64
   %lookup_elem_val = alloca i64
   %"@x_key1" = alloca i64
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 10, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   %5 = bitcast i64* %"@x_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
@@ -64,9 +64,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %11, i64* %"@x_newval"
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo3, i64* %"@x_key1", i64* %"@x_newval", i64 0)
-  %12 = bitcast i64* %"@x_key1" to i8*
+  %12 = bitcast i64* %"@x_newval" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_newval" to i8*
+  %13 = bitcast i64* %"@x_key1" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   %14 = bitcast i64* %"@x_key5" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
@@ -98,10 +98,10 @@ lookup_merge10:                                   ; preds = %lookup_failure9, %l
   store i64 %20, i64* %"@x_newval14"
   %pseudo15 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem16 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo15, i64* %"@x_key5", i64* %"@x_newval14", i64 0)
-  %21 = bitcast i64* %"@x_key5" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
-  %22 = load i64, i64* %"@x_newval14"
-  %23 = bitcast i64* %"@x_newval14" to i8*
+  %21 = load i64, i64* %"@x_newval14"
+  %22 = bitcast i64* %"@x_newval14" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
+  %23 = bitcast i64* %"@x_key5" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
   %24 = bitcast i64* %"@x_key17" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %24)
@@ -133,9 +133,9 @@ lookup_merge22:                                   ; preds = %lookup_failure21, %
   store i64 %30, i64* %"@x_newval26"
   %pseudo27 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem28 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo27, i64* %"@x_key17", i64* %"@x_newval26", i64 0)
-  %31 = bitcast i64* %"@x_key17" to i8*
+  %31 = bitcast i64* %"@x_newval26" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %31)
-  %32 = bitcast i64* %"@x_newval26" to i8*
+  %32 = bitcast i64* %"@x_key17" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %32)
   %33 = bitcast i64* %"@x_key29" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %33)
@@ -167,10 +167,10 @@ lookup_merge34:                                   ; preds = %lookup_failure33, %
   store i64 %39, i64* %"@x_newval38"
   %pseudo39 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem40 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo39, i64* %"@x_key29", i64* %"@x_newval38", i64 0)
-  %40 = bitcast i64* %"@x_key29" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %40)
-  %41 = load i64, i64* %"@x_newval38"
-  %42 = bitcast i64* %"@x_newval38" to i8*
+  %40 = load i64, i64* %"@x_newval38"
+  %41 = bitcast i64* %"@x_newval38" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %41)
+  %42 = bitcast i64* %"@x_key29" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %42)
   ret i64 0
 }

--- a/tests/codegen/llvm/map_key_int.ll
+++ b/tests/codegen/llvm/map_key_int.ll
@@ -3,38 +3,42 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%key_t = type { i64, i64, i64 }
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
+  %"@x_key" = alloca %key_t
   %"@x_val" = alloca i64
-  %"@x_key" = alloca [24 x i8]
-  %1 = bitcast [24 x i8]* %"@x_key" to i8*
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = getelementptr [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 0
-  %3 = bitcast i8* %2 to i64*
-  store i64 11, i64* %3
-  %4 = getelementptr [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 8
-  %5 = bitcast i8* %4 to i64*
-  store i64 22, i64* %5
-  %6 = getelementptr [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 16
-  %7 = bitcast i8* %6 to i64*
-  store i64 33, i64* %7
-  %8 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 44, i64* %"@x_val"
+  %2 = bitcast %key_t* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  %3 = bitcast %key_t* %"@x_key" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %3, i8 0, i64 24, i1 false)
+  %4 = getelementptr %key_t, %key_t* %"@x_key", i32 0, i32 0
+  store i64 11, i64* %4
+  %5 = getelementptr %key_t, %key_t* %"@x_key", i32 0, i32 1
+  store i64 22, i64* %5
+  %6 = getelementptr %key_t, %key_t* %"@x_key", i32 0, i32 2
+  store i64 33, i64* %6
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [24 x i8]*, i64*, i64)*)(i64 %pseudo, [24 x i8]* %"@x_key", i64* %"@x_val", i64 0)
-  %9 = bitcast [24 x i8]* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, %key_t*, i64*, i64)*)(i64 %pseudo, %key_t* %"@x_key", i64* %"@x_val", i64 0)
+  %7 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %8 = bitcast %key_t* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
   ret i64 0
 }
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/llvm/map_key_probe.ll
+++ b/tests/codegen/llvm/map_key_probe.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"tracepoint:sched:sched_one"(i8*) section "s_tracepoint:sched:sched_one_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key1" = alloca [8 x i8]
+  %"@x_val" = alloca i64
   %lookup_elem_val = alloca i64
   %"@x_key" = alloca [8 x i8]
   %1 = bitcast [8 x i8]* %"@x_key" to i8*
@@ -40,18 +40,18 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   %7 = bitcast [8 x i8]* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   %8 = add i64 %5, 1
-  %9 = bitcast [8 x i8]* %"@x_key1" to i8*
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %10 = bitcast [8 x i8]* %"@x_key1" to i64*
-  store i64 0, i64* %10
-  %11 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   store i64 %8, i64* %"@x_val"
+  %10 = bitcast [8 x i8]* %"@x_key1" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = bitcast [8 x i8]* %"@x_key1" to i64*
+  store i64 0, i64* %11
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo2, [8 x i8]* %"@x_key1", i64* %"@x_val", i64 0)
-  %12 = bitcast [8 x i8]* %"@x_key1" to i8*
+  %12 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_val" to i8*
+  %13 = bitcast [8 x i8]* %"@x_key1" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }
@@ -64,8 +64,8 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 define i64 @"tracepoint:sched:sched_two"(i8*) section "s_tracepoint:sched:sched_two_2" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key1" = alloca [8 x i8]
+  %"@x_val" = alloca i64
   %lookup_elem_val = alloca i64
   %"@x_key" = alloca [8 x i8]
   %1 = bitcast [8 x i8]* %"@x_key" to i8*
@@ -96,18 +96,18 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   %7 = bitcast [8 x i8]* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   %8 = add i64 %5, 1
-  %9 = bitcast [8 x i8]* %"@x_key1" to i8*
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %10 = bitcast [8 x i8]* %"@x_key1" to i64*
-  store i64 1, i64* %10
-  %11 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   store i64 %8, i64* %"@x_val"
+  %10 = bitcast [8 x i8]* %"@x_key1" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = bitcast [8 x i8]* %"@x_key1" to i64*
+  store i64 1, i64* %11
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo2, [8 x i8]* %"@x_key1", i64* %"@x_val", i64 0)
-  %12 = bitcast [8 x i8]* %"@x_key1" to i8*
+  %12 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_val" to i8*
+  %13 = bitcast [8 x i8]* %"@x_key1" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }

--- a/tests/codegen/llvm/map_key_string.ll
+++ b/tests/codegen/llvm/map_key_string.ll
@@ -3,42 +3,131 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
+%key_t = type { [64 x i8], [64 x i8] }
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
+  %helper_error_t13 = alloca %helper_error_t
+  %lookup_str_key8 = alloca i32
+  %helper_error_t5 = alloca %helper_error_t
+  %lookup_str_key = alloca i32
+  %helper_error_t = alloca %helper_error_t
+  %lookup_key_key = alloca i32
   %"@x_val" = alloca i64
-  %str1 = alloca [64 x i8]
-  %str = alloca [64 x i8]
-  %"@x_key" = alloca [128 x i8]
-  %1 = bitcast [128 x i8]* %"@x_key" to i8*
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store [64 x i8] c"a\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str
-  %3 = getelementptr [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 0
-  %4 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %3, i8* align 1 %4, i64 64, i1 false)
-  %5 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast [64 x i8]* %str1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  store [64 x i8] c"b\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str1
-  %7 = getelementptr [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 64
-  %8 = bitcast [64 x i8]* %str1 to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %7, i8* align 1 %8, i64 64, i1 false)
-  %9 = bitcast [64 x i8]* %str1 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 44, i64* %"@x_val"
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [128 x i8]*, i64*, i64)*)(i64 %pseudo, [128 x i8]* %"@x_key", i64* %"@x_val", i64 0)
-  %11 = bitcast [128 x i8]* %"@x_key" to i8*
+  %2 = bitcast i32* %lookup_key_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i32 0, i32* %lookup_key_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 4)
+  %lookup_key_map = call %key_t* inttoptr (i64 1 to %key_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_key_key)
+  %3 = bitcast i32* %lookup_key_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
+  %4 = sext %key_t* %lookup_key_map to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %6 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %7 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %7
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %4, i32* %9
+  %10 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %10
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %11 = bitcast %helper_error_t* %helper_error_t to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %12 = bitcast %key_t* %lookup_key_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %12, i8 0, i64 128, i1 false)
+  %13 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  store i32 0, i32* %lookup_str_key
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %lookup_str_map = call [64 x i8]* inttoptr (i64 1 to [64 x i8]* (i64, i32*)*)(i64 %pseudo2, i32* %lookup_str_key)
+  %14 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = sext [64 x i8]* %lookup_str_map to i32
+  %16 = icmp ne i32 %15, 0
+  br i1 %16, label %helper_merge4, label %helper_failure3
+
+helper_failure3:                                  ; preds = %helper_merge
+  %17 = bitcast %helper_error_t* %helper_error_t5 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
+  %18 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t5, i64 0, i32 0
+  store i64 30006, i64* %18
+  %19 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t5, i64 0, i32 1
+  store i64 1, i64* %19
+  %20 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t5, i64 0, i32 2
+  store i32 %15, i32* %20
+  %21 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t5, i64 0, i32 3
+  store i8 1, i8* %21
+  %pseudo6 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %perf_event_output7 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo6, i64 4294967295, %helper_error_t* %helper_error_t5, i64 21)
+  %22 = bitcast %helper_error_t* %helper_error_t5 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
+  ret i64 0
+
+helper_merge4:                                    ; preds = %helper_merge
+  %23 = bitcast [64 x i8]* %lookup_str_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %23, i8 0, i64 64, i1 false)
+  store [2 x i8] c"a\00", [64 x i8]* %lookup_str_map
+  %24 = getelementptr %key_t, %key_t* %lookup_key_map, i32 0, i32 0
+  %25 = bitcast [64 x i8]* %24 to i8*
+  %26 = bitcast [64 x i8]* %lookup_str_map to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %25, i8* align 1 %26, i64 64, i1 false)
+  %27 = bitcast i32* %lookup_str_key8 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %27)
+  store i32 1, i32* %lookup_str_key8
+  %pseudo9 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %lookup_str_map10 = call [64 x i8]* inttoptr (i64 1 to [64 x i8]* (i64, i32*)*)(i64 %pseudo9, i32* %lookup_str_key8)
+  %28 = bitcast i32* %lookup_str_key8 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %28)
+  %29 = sext [64 x i8]* %lookup_str_map10 to i32
+  %30 = icmp ne i32 %29, 0
+  br i1 %30, label %helper_merge12, label %helper_failure11
+
+helper_failure11:                                 ; preds = %helper_merge4
+  %31 = bitcast %helper_error_t* %helper_error_t13 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %31)
+  %32 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t13, i64 0, i32 0
+  store i64 30006, i64* %32
+  %33 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t13, i64 0, i32 1
+  store i64 2, i64* %33
+  %34 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t13, i64 0, i32 2
+  store i32 %29, i32* %34
+  %35 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t13, i64 0, i32 3
+  store i8 1, i8* %35
+  %pseudo14 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %perf_event_output15 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo14, i64 4294967295, %helper_error_t* %helper_error_t13, i64 21)
+  %36 = bitcast %helper_error_t* %helper_error_t13 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %36)
+  ret i64 0
+
+helper_merge12:                                   ; preds = %helper_merge4
+  %37 = bitcast [64 x i8]* %lookup_str_map10 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %37, i8 0, i64 64, i1 false)
+  store [2 x i8] c"b\00", [64 x i8]* %lookup_str_map10
+  %38 = getelementptr %key_t, %key_t* %lookup_key_map, i32 0, i32 1
+  %39 = bitcast [64 x i8]* %38 to i8*
+  %40 = bitcast [64 x i8]* %lookup_str_map10 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %39, i8* align 1 %40, i64 64, i1 false)
+  %pseudo16 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, %key_t*, i64*, i64)*)(i64 %pseudo16, %key_t* %lookup_key_map, i64* %"@x_val", i64 0)
+  %41 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %41)
   ret i64 0
 }
 
@@ -46,10 +135,13 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #1
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/nested_while_loop.ll
+++ b/tests/codegen/llvm/nested_while_loop.ll
@@ -84,9 +84,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %19, i64* %"@_newval"
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo5, i64* %"@_key", i64* %"@_newval", i64 0)
-  %20 = bitcast i64* %"@_key" to i8*
+  %20 = bitcast i64* %"@_newval" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  %21 = bitcast i64* %"@_newval" to i8*
+  %21 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
   %22 = load i64, i64* %"$j"
   %23 = add i64 %22, 1

--- a/tests/codegen/llvm/optional_positional_parameter.ll
+++ b/tests/codegen/llvm/optional_positional_parameter.ll
@@ -3,59 +3,84 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @BEGIN(i8*) section "s_BEGIN_1" {
 entry:
   %"@y_key" = alloca i64
-  %str1 = alloca [1 x i8]
-  %str = alloca [64 x i8]
+  %str = alloca [1 x i8]
+  %helper_error_t = alloca %helper_error_t
+  %lookup_str_key = alloca i32
   %strlen = alloca i64
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 0, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   %5 = bitcast i64* %strlen to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %strlen to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 8, i1 false)
   store i64 64, i64* %strlen
-  %7 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %8 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %8, i8 0, i64 64, i1 false)
-  %9 = bitcast [1 x i8]* %str1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %10 = bitcast [1 x i8]* %str1 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %10, i8 0, i64 1, i1 false)
-  store [1 x i8] zeroinitializer, [1 x i8]* %str1
-  %11 = load i64, i64* %strlen
-  %12 = trunc i64 %11 to i32
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, [1 x i8]*)*)([64 x i8]* %str, i32 %12, [1 x i8]* %str1)
-  %13 = bitcast i64* %strlen to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast [1 x i8]* %str1 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  %6 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  store i32 0, i32* %lookup_str_key
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 4)
+  %lookup_str_map = call [64 x i8]* inttoptr (i64 1 to [64 x i8]* (i64, i32*)*)(i64 %pseudo1, i32* %lookup_str_key)
+  %7 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %8 = sext [64 x i8]* %lookup_str_map to i32
+  %9 = icmp ne i32 %8, 0
+  br i1 %9, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %11
+  %12 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %12
+  %13 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %8, i32* %13
+  %14 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %14
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo2, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %15 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %16 = bitcast [64 x i8]* %lookup_str_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %16, i8 0, i64 64, i1 false)
+  %17 = bitcast [1 x i8]* %str to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
+  %18 = bitcast [1 x i8]* %str to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %18, i8 0, i64 1, i1 false)
+  store [1 x i8] zeroinitializer, [1 x i8]* %str
+  %19 = load i64, i64* %strlen
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, [1 x i8]*)*)([64 x i8]* %lookup_str_map, i64 %19, [1 x i8]* %str)
+  %20 = bitcast i64* %strlen to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
+  %21 = bitcast [1 x i8]* %str to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  %22 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %22)
   store i64 0, i64* %"@y_key"
-  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem3 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo2, i64* %"@y_key", [64 x i8]* %str, i64 0)
-  %16 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo3, i64* %"@y_key", [64 x i8]* %lookup_str_map, i64 0)
+  %23 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/pred_binop.ll
+++ b/tests/codegen/llvm/pred_binop.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = lshr i64 %get_pid_tgid, 32
   %2 = icmp eq i64 %1, 1234
@@ -21,17 +21,17 @@ pred_false:                                       ; preds = %entry
   ret i64 0
 
 pred_true:                                        ; preds = %entry
-  %4 = bitcast i64* %"@x_key" to i8*
+  %4 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  store i64 0, i64* %"@x_key"
-  %5 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
   store i64 1, i64* %"@x_val"
+  %5 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %6 = bitcast i64* %"@x_key" to i8*
+  %6 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast i64* %"@x_val" to i8*
+  %7 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   ret i64 0
 }

--- a/tests/codegen/llvm/runtime_error_check.ll
+++ b/tests/codegen/llvm/runtime_error_check.ll
@@ -3,7 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
-%helper_error_t = type <{ i64, i64, i32 }>
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
@@ -57,18 +57,19 @@ helper_failure:                                   ; preds = %lookup_merge
   store i64 0, i64* %12
   %13 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
   store i32 %8, i32* %13
+  %14 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 0, i8* %14
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo2, i64 %get_cpu_id, %helper_error_t* %helper_error_t, i64 20)
-  %14 = bitcast %helper_error_t* %helper_error_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo2, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %15 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
   br label %helper_merge
 
 helper_merge:                                     ; preds = %helper_failure, %lookup_merge
-  %15 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
   %16 = bitcast i64* %"@_newval" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/runtime_error_check_lookup.ll
+++ b/tests/codegen/llvm/runtime_error_check_lookup.ll
@@ -3,7 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
-%helper_error_t = type <{ i64, i64, i32 }>
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
@@ -41,48 +41,50 @@ lookup_failure:                                   ; preds = %entry
   store i64 0, i64* %6
   %7 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
   store i32 0, i32* %7
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 0, i8* %8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 %get_cpu_id, %helper_error_t* %helper_error_t, i64 20)
-  %8 = bitcast %helper_error_t* %helper_error_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %9 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %9 = load i64, i64* %lookup_elem_val
-  %10 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@_newval" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  %12 = add i64 %9, 1
-  store i64 %12, i64* %"@_newval"
+  %10 = load i64, i64* %lookup_elem_val
+  %11 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i64* %"@_newval" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %13 = add i64 %10, 1
+  store i64 %13, i64* %"@_newval"
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@_key", i64* %"@_newval", i64 0)
-  %13 = trunc i64 %update_elem to i32
-  %14 = icmp sge i32 %13, 0
-  br i1 %14, label %helper_merge, label %helper_failure
+  %14 = trunc i64 %update_elem to i32
+  %15 = icmp sge i32 %14, 0
+  br i1 %15, label %helper_merge, label %helper_failure
 
 helper_failure:                                   ; preds = %lookup_merge
-  %15 = bitcast %helper_error_t* %helper_error_t3 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
-  %16 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t3, i64 0, i32 0
-  store i64 30006, i64* %16
-  %17 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t3, i64 0, i32 1
-  store i64 1, i64* %17
-  %18 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t3, i64 0, i32 2
-  store i32 %13, i32* %18
+  %16 = bitcast %helper_error_t* %helper_error_t3 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
+  %17 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t3, i64 0, i32 0
+  store i64 30006, i64* %17
+  %18 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t3, i64 0, i32 1
+  store i64 1, i64* %18
+  %19 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t3, i64 0, i32 2
+  store i32 %14, i32* %19
+  %20 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t3, i64 0, i32 3
+  store i8 0, i8* %20
   %pseudo4 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %get_cpu_id5 = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output6 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo4, i64 %get_cpu_id5, %helper_error_t* %helper_error_t3, i64 20)
-  %19 = bitcast %helper_error_t* %helper_error_t3 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  %perf_event_output5 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo4, i64 4294967295, %helper_error_t* %helper_error_t3, i64 21)
+  %21 = bitcast %helper_error_t* %helper_error_t3 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
   br label %helper_merge
 
 helper_merge:                                     ; preds = %helper_failure, %lookup_merge
-  %20 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  %21 = bitcast i64* %"@_newval" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  %22 = bitcast i64* %"@_newval" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
+  %23 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/string_equal_comparison.ll
+++ b/tests/codegen/llvm/string_equal_comparison.ll
@@ -100,9 +100,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %25, i64* %"@_val"
   %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo11, [16 x i8]* %comm9, i64* %"@_val", i64 0)
-  %26 = bitcast [16 x i8]* %comm9 to i8*
+  %26 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %26)
-  %27 = bitcast i64* %"@_val" to i8*
+  %27 = bitcast [16 x i8]* %comm9 to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %27)
   ret i64 0
 }

--- a/tests/codegen/llvm/string_not_equal_comparison.ll
+++ b/tests/codegen/llvm/string_not_equal_comparison.ll
@@ -100,9 +100,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %25, i64* %"@_val"
   %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo11, [16 x i8]* %comm9, i64* %"@_val", i64 0)
-  %26 = bitcast [16 x i8]* %comm9 to i8*
+  %26 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %26)
-  %27 = bitcast i64* %"@_val" to i8*
+  %27 = bitcast [16 x i8]* %comm9 to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %27)
   ret i64 0
 }

--- a/tests/codegen/llvm/string_propagation.ll
+++ b/tests/codegen/llvm/string_propagation.ll
@@ -3,6 +3,8 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
@@ -10,53 +12,79 @@ define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %"@y_key" = alloca i64
   %lookup_elem_val = alloca [64 x i8]
-  %"@x_key1" = alloca i64
+  %"@x_key3" = alloca i64
   %"@x_key" = alloca i64
-  %str = alloca [64 x i8]
-  %1 = bitcast [64 x i8]* %str to i8*
+  %helper_error_t = alloca %helper_error_t
+  %lookup_str_key = alloca i32
+  %1 = bitcast i32* %lookup_str_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store [64 x i8] c"asdf\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str
-  %2 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 0, i64* %"@x_key"
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* %"@x_key", [64 x i8]* %str, i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
-  %5 = bitcast i64* %"@x_key1" to i8*
+  store i32 0, i32* %lookup_str_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 4)
+  %lookup_str_map = call [64 x i8]* inttoptr (i64 1 to [64 x i8]* (i64, i32*)*)(i64 %pseudo, i32* %lookup_str_key)
+  %2 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext [64 x i8]* %lookup_str_map to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %5 = bitcast %helper_error_t* %helper_error_t to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  store i64 0, i64* %"@x_key1"
+  %6 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %6
+  %7 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %7
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %9
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %11 = bitcast [64 x i8]* %lookup_str_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 64, i1 false)
+  store [5 x i8] c"asdf\00", [64 x i8]* %lookup_str_map
+  %12 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  store i64 0, i64* %"@x_key"
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo2, i64* %"@x_key1")
-  %6 = bitcast [64 x i8]* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo2, i64* %"@x_key", [64 x i8]* %lookup_str_map, i64 0)
+  %13 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@x_key3" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  store i64 0, i64* %"@x_key3"
+  %pseudo4 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo4, i64* %"@x_key3")
+  %15 = bitcast [64 x i8]* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
-  %7 = bitcast [64 x i8]* %lookup_elem_val to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %7, i8* align 1 %lookup_elem, i64 64, i1 false)
+lookup_success:                                   ; preds = %helper_merge
+  %16 = bitcast [64 x i8]* %lookup_elem_val to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %16, i8* align 1 %lookup_elem, i64 64, i1 false)
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
-  %8 = bitcast [64 x i8]* %lookup_elem_val to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %8, i8 0, i64 64, i1 false)
+lookup_failure:                                   ; preds = %helper_merge
+  %17 = bitcast [64 x i8]* %lookup_elem_val to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %17, i8 0, i64 64, i1 false)
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %9 = bitcast i64* %"@x_key1" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %18 = bitcast i64* %"@x_key3" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  %19 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
   store i64 0, i64* %"@y_key"
-  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo3, i64* %"@y_key", [64 x i8]* %lookup_elem_val, i64 0)
-  %11 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast [64 x i8]* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %update_elem6 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo5, i64* %"@y_key", [64 x i8]* %lookup_elem_val, i64 0)
+  %20 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
   ret i64 0
 }
 
@@ -67,10 +95,10 @@ declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #1
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/strncmp.ll
+++ b/tests/codegen/llvm/strncmp.ll
@@ -3,17 +3,20 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"tracepoint:file:filename"(i8*) section "s_tracepoint:file:filename_1" {
 entry:
-  %"@_val" = alloca i64
   %"@_key" = alloca i64
+  %"@_val" = alloca i64
   %strcmp.char_r = alloca i8
   %strcmp.char_l = alloca i8
   %strcmp.result = alloca i1
-  %str = alloca [64 x i8]
+  %helper_error_t = alloca %helper_error_t
+  %lookup_str_key = alloca i32
   %strlen = alloca i64
   %comm = alloca [16 x i8]
   %1 = bitcast [16 x i8]* %comm to i8*
@@ -23,302 +26,310 @@ entry:
   %get_comm = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* %comm, i64 16)
   %3 = bitcast i64* %strlen to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %strlen to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 8, i1 false)
   store i64 64, i64* %strlen
-  %5 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 64, i1 false)
-  %7 = ptrtoint i8* %0 to i64
-  %8 = add i64 %7, 8
-  %9 = inttoptr i64 %8 to i64*
-  %10 = load volatile i64, i64* %9
-  %11 = load i64, i64* %strlen
-  %12 = trunc i64 %11 to i32
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %12, i64 %10)
-  %13 = bitcast i64* %strlen to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i1* %strcmp.result to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
-  store i1 false, i1* %strcmp.result
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %strcmp.char_l)
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %strcmp.char_r)
-  %15 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 0
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %15)
-  %16 = load i8, i8* %strcmp.char_l
-  %17 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 0
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %17)
-  %18 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp = icmp ne i8 %16, %18
-  br i1 %strcmp.cmp, label %strcmp.false, label %strcmp.loop_null_cmp
+  %4 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i32 0, i32* %lookup_str_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %lookup_str_map = call [64 x i8]* inttoptr (i64 1 to [64 x i8]* (i64, i32*)*)(i64 %pseudo, i32* %lookup_str_key)
+  %5 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = sext [64 x i8]* %lookup_str_map to i32
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %helper_merge, label %helper_failure
 
 pred_false:                                       ; preds = %strcmp.false
   ret i64 0
 
 pred_true:                                        ; preds = %strcmp.false
-  %19 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
-  store i64 0, i64* %"@_key"
-  %20 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %20)
+  %8 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 1, i64* %"@_val"
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
-  %21 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
-  %22 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
+  %9 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i64 0, i64* %"@_key"
+  %pseudo93 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo93, i64* %"@_key", i64* %"@_val", i64 0)
+  %10 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   ret i64 0
 
-strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop86, %strcmp.loop80, %strcmp.loop74, %strcmp.loop68, %strcmp.loop62, %strcmp.loop56, %strcmp.loop50, %strcmp.loop44, %strcmp.loop38, %strcmp.loop32, %strcmp.loop26, %strcmp.loop20, %strcmp.loop14, %strcmp.loop8, %strcmp.loop2, %strcmp.loop, %entry
-  %23 = load i1, i1* %strcmp.result
-  %24 = bitcast i1* %strcmp.result to i8*
+helper_failure:                                   ; preds = %entry
+  %12 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %13 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %13
+  %14 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %14
+  %15 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %6, i32* %15
+  %16 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %16
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %17 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %18 = bitcast [64 x i8]* %lookup_str_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %18, i8 0, i64 64, i1 false)
+  %19 = ptrtoint i8* %0 to i64
+  %20 = add i64 %19, 8
+  %21 = inttoptr i64 %20 to i64*
+  %22 = load volatile i64, i64* %21
+  %23 = load i64, i64* %strlen
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %lookup_str_map, i64 %23, i64 %22)
+  %24 = bitcast i64* %strlen to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
+  %25 = bitcast i1* %strcmp.result to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %25)
+  store i1 false, i1* %strcmp.result
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %strcmp.char_l)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %strcmp.char_r)
+  %26 = getelementptr [64 x i8], [64 x i8]* %lookup_str_map, i32 0, i32 0
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %26)
+  %27 = load i8, i8* %strcmp.char_l
+  %28 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 0
+  %probe_read2 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %28)
+  %29 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp = icmp ne i8 %27, %29
+  br i1 %strcmp.cmp, label %strcmp.false, label %strcmp.loop_null_cmp
+
+strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop81, %strcmp.loop75, %strcmp.loop69, %strcmp.loop63, %strcmp.loop57, %strcmp.loop51, %strcmp.loop45, %strcmp.loop39, %strcmp.loop33, %strcmp.loop27, %strcmp.loop21, %strcmp.loop15, %strcmp.loop9, %strcmp.loop3, %strcmp.loop, %helper_merge
+  %30 = load i1, i1* %strcmp.result
+  %31 = bitcast i1* %strcmp.result to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %31)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %strcmp.char_l)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %strcmp.char_r)
-  %25 = zext i1 %23 to i64
-  %26 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %26)
-  %27 = bitcast [16 x i8]* %comm to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %27)
-  %predcond = icmp eq i64 %25, 0
+  %32 = zext i1 %30 to i64
+  %33 = bitcast [16 x i8]* %comm to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %33)
+  %predcond = icmp eq i64 %32, 0
   br i1 %predcond, label %pred_false, label %pred_true
 
-strcmp.done:                                      ; preds = %strcmp.loop92, %strcmp.loop_null_cmp93, %strcmp.loop_null_cmp87, %strcmp.loop_null_cmp81, %strcmp.loop_null_cmp75, %strcmp.loop_null_cmp69, %strcmp.loop_null_cmp63, %strcmp.loop_null_cmp57, %strcmp.loop_null_cmp51, %strcmp.loop_null_cmp45, %strcmp.loop_null_cmp39, %strcmp.loop_null_cmp33, %strcmp.loop_null_cmp27, %strcmp.loop_null_cmp21, %strcmp.loop_null_cmp15, %strcmp.loop_null_cmp9, %strcmp.loop_null_cmp3, %strcmp.loop_null_cmp
+strcmp.done:                                      ; preds = %strcmp.loop87, %strcmp.loop_null_cmp88, %strcmp.loop_null_cmp82, %strcmp.loop_null_cmp76, %strcmp.loop_null_cmp70, %strcmp.loop_null_cmp64, %strcmp.loop_null_cmp58, %strcmp.loop_null_cmp52, %strcmp.loop_null_cmp46, %strcmp.loop_null_cmp40, %strcmp.loop_null_cmp34, %strcmp.loop_null_cmp28, %strcmp.loop_null_cmp22, %strcmp.loop_null_cmp16, %strcmp.loop_null_cmp10, %strcmp.loop_null_cmp4, %strcmp.loop_null_cmp
   store i1 true, i1* %strcmp.result
   br label %strcmp.false
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
-  %28 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 1
-  %probe_read4 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %28)
-  %29 = load i8, i8* %strcmp.char_l
-  %30 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 1
-  %probe_read5 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %30)
-  %31 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp6 = icmp ne i8 %29, %31
-  br i1 %strcmp.cmp6, label %strcmp.false, label %strcmp.loop_null_cmp3
+  %34 = getelementptr [64 x i8], [64 x i8]* %lookup_str_map, i32 0, i32 1
+  %probe_read5 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %34)
+  %35 = load i8, i8* %strcmp.char_l
+  %36 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 1
+  %probe_read6 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %36)
+  %37 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp7 = icmp ne i8 %35, %37
+  br i1 %strcmp.cmp7, label %strcmp.false, label %strcmp.loop_null_cmp4
 
-strcmp.loop_null_cmp:                             ; preds = %entry
-  %strcmp.cmp_null = icmp eq i8 %16, 0
+strcmp.loop_null_cmp:                             ; preds = %helper_merge
+  %strcmp.cmp_null = icmp eq i8 %27, 0
   br i1 %strcmp.cmp_null, label %strcmp.done, label %strcmp.loop
 
-strcmp.loop2:                                     ; preds = %strcmp.loop_null_cmp3
-  %32 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 2
-  %probe_read10 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %32)
-  %33 = load i8, i8* %strcmp.char_l
-  %34 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 2
-  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %34)
-  %35 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp12 = icmp ne i8 %33, %35
-  br i1 %strcmp.cmp12, label %strcmp.false, label %strcmp.loop_null_cmp9
+strcmp.loop3:                                     ; preds = %strcmp.loop_null_cmp4
+  %38 = getelementptr [64 x i8], [64 x i8]* %lookup_str_map, i32 0, i32 2
+  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %38)
+  %39 = load i8, i8* %strcmp.char_l
+  %40 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 2
+  %probe_read12 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %40)
+  %41 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp13 = icmp ne i8 %39, %41
+  br i1 %strcmp.cmp13, label %strcmp.false, label %strcmp.loop_null_cmp10
 
-strcmp.loop_null_cmp3:                            ; preds = %strcmp.loop
-  %strcmp.cmp_null7 = icmp eq i8 %29, 0
-  br i1 %strcmp.cmp_null7, label %strcmp.done, label %strcmp.loop2
+strcmp.loop_null_cmp4:                            ; preds = %strcmp.loop
+  %strcmp.cmp_null8 = icmp eq i8 %35, 0
+  br i1 %strcmp.cmp_null8, label %strcmp.done, label %strcmp.loop3
 
-strcmp.loop8:                                     ; preds = %strcmp.loop_null_cmp9
-  %36 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 3
-  %probe_read16 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %36)
-  %37 = load i8, i8* %strcmp.char_l
-  %38 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 3
-  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %38)
-  %39 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp18 = icmp ne i8 %37, %39
-  br i1 %strcmp.cmp18, label %strcmp.false, label %strcmp.loop_null_cmp15
+strcmp.loop9:                                     ; preds = %strcmp.loop_null_cmp10
+  %42 = getelementptr [64 x i8], [64 x i8]* %lookup_str_map, i32 0, i32 3
+  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %42)
+  %43 = load i8, i8* %strcmp.char_l
+  %44 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 3
+  %probe_read18 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %44)
+  %45 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp19 = icmp ne i8 %43, %45
+  br i1 %strcmp.cmp19, label %strcmp.false, label %strcmp.loop_null_cmp16
 
-strcmp.loop_null_cmp9:                            ; preds = %strcmp.loop2
-  %strcmp.cmp_null13 = icmp eq i8 %33, 0
-  br i1 %strcmp.cmp_null13, label %strcmp.done, label %strcmp.loop8
+strcmp.loop_null_cmp10:                           ; preds = %strcmp.loop3
+  %strcmp.cmp_null14 = icmp eq i8 %39, 0
+  br i1 %strcmp.cmp_null14, label %strcmp.done, label %strcmp.loop9
 
-strcmp.loop14:                                    ; preds = %strcmp.loop_null_cmp15
-  %40 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 4
-  %probe_read22 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %40)
-  %41 = load i8, i8* %strcmp.char_l
-  %42 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 4
-  %probe_read23 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %42)
-  %43 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp24 = icmp ne i8 %41, %43
-  br i1 %strcmp.cmp24, label %strcmp.false, label %strcmp.loop_null_cmp21
+strcmp.loop15:                                    ; preds = %strcmp.loop_null_cmp16
+  %46 = getelementptr [64 x i8], [64 x i8]* %lookup_str_map, i32 0, i32 4
+  %probe_read23 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %46)
+  %47 = load i8, i8* %strcmp.char_l
+  %48 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 4
+  %probe_read24 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %48)
+  %49 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp25 = icmp ne i8 %47, %49
+  br i1 %strcmp.cmp25, label %strcmp.false, label %strcmp.loop_null_cmp22
 
-strcmp.loop_null_cmp15:                           ; preds = %strcmp.loop8
-  %strcmp.cmp_null19 = icmp eq i8 %37, 0
-  br i1 %strcmp.cmp_null19, label %strcmp.done, label %strcmp.loop14
+strcmp.loop_null_cmp16:                           ; preds = %strcmp.loop9
+  %strcmp.cmp_null20 = icmp eq i8 %43, 0
+  br i1 %strcmp.cmp_null20, label %strcmp.done, label %strcmp.loop15
 
-strcmp.loop20:                                    ; preds = %strcmp.loop_null_cmp21
-  %44 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 5
-  %probe_read28 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %44)
-  %45 = load i8, i8* %strcmp.char_l
-  %46 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 5
-  %probe_read29 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %46)
-  %47 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp30 = icmp ne i8 %45, %47
-  br i1 %strcmp.cmp30, label %strcmp.false, label %strcmp.loop_null_cmp27
+strcmp.loop21:                                    ; preds = %strcmp.loop_null_cmp22
+  %50 = getelementptr [64 x i8], [64 x i8]* %lookup_str_map, i32 0, i32 5
+  %probe_read29 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %50)
+  %51 = load i8, i8* %strcmp.char_l
+  %52 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 5
+  %probe_read30 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %52)
+  %53 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp31 = icmp ne i8 %51, %53
+  br i1 %strcmp.cmp31, label %strcmp.false, label %strcmp.loop_null_cmp28
 
-strcmp.loop_null_cmp21:                           ; preds = %strcmp.loop14
-  %strcmp.cmp_null25 = icmp eq i8 %41, 0
-  br i1 %strcmp.cmp_null25, label %strcmp.done, label %strcmp.loop20
+strcmp.loop_null_cmp22:                           ; preds = %strcmp.loop15
+  %strcmp.cmp_null26 = icmp eq i8 %47, 0
+  br i1 %strcmp.cmp_null26, label %strcmp.done, label %strcmp.loop21
 
-strcmp.loop26:                                    ; preds = %strcmp.loop_null_cmp27
-  %48 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 6
-  %probe_read34 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %48)
-  %49 = load i8, i8* %strcmp.char_l
-  %50 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 6
-  %probe_read35 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %50)
-  %51 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp36 = icmp ne i8 %49, %51
-  br i1 %strcmp.cmp36, label %strcmp.false, label %strcmp.loop_null_cmp33
+strcmp.loop27:                                    ; preds = %strcmp.loop_null_cmp28
+  %54 = getelementptr [64 x i8], [64 x i8]* %lookup_str_map, i32 0, i32 6
+  %probe_read35 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %54)
+  %55 = load i8, i8* %strcmp.char_l
+  %56 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 6
+  %probe_read36 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %56)
+  %57 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp37 = icmp ne i8 %55, %57
+  br i1 %strcmp.cmp37, label %strcmp.false, label %strcmp.loop_null_cmp34
 
-strcmp.loop_null_cmp27:                           ; preds = %strcmp.loop20
-  %strcmp.cmp_null31 = icmp eq i8 %45, 0
-  br i1 %strcmp.cmp_null31, label %strcmp.done, label %strcmp.loop26
+strcmp.loop_null_cmp28:                           ; preds = %strcmp.loop21
+  %strcmp.cmp_null32 = icmp eq i8 %51, 0
+  br i1 %strcmp.cmp_null32, label %strcmp.done, label %strcmp.loop27
 
-strcmp.loop32:                                    ; preds = %strcmp.loop_null_cmp33
-  %52 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 7
-  %probe_read40 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %52)
-  %53 = load i8, i8* %strcmp.char_l
-  %54 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 7
-  %probe_read41 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %54)
-  %55 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp42 = icmp ne i8 %53, %55
-  br i1 %strcmp.cmp42, label %strcmp.false, label %strcmp.loop_null_cmp39
+strcmp.loop33:                                    ; preds = %strcmp.loop_null_cmp34
+  %58 = getelementptr [64 x i8], [64 x i8]* %lookup_str_map, i32 0, i32 7
+  %probe_read41 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %58)
+  %59 = load i8, i8* %strcmp.char_l
+  %60 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 7
+  %probe_read42 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %60)
+  %61 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp43 = icmp ne i8 %59, %61
+  br i1 %strcmp.cmp43, label %strcmp.false, label %strcmp.loop_null_cmp40
 
-strcmp.loop_null_cmp33:                           ; preds = %strcmp.loop26
-  %strcmp.cmp_null37 = icmp eq i8 %49, 0
-  br i1 %strcmp.cmp_null37, label %strcmp.done, label %strcmp.loop32
+strcmp.loop_null_cmp34:                           ; preds = %strcmp.loop27
+  %strcmp.cmp_null38 = icmp eq i8 %55, 0
+  br i1 %strcmp.cmp_null38, label %strcmp.done, label %strcmp.loop33
 
-strcmp.loop38:                                    ; preds = %strcmp.loop_null_cmp39
-  %56 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 8
-  %probe_read46 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %56)
-  %57 = load i8, i8* %strcmp.char_l
-  %58 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 8
-  %probe_read47 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %58)
-  %59 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp48 = icmp ne i8 %57, %59
-  br i1 %strcmp.cmp48, label %strcmp.false, label %strcmp.loop_null_cmp45
+strcmp.loop39:                                    ; preds = %strcmp.loop_null_cmp40
+  %62 = getelementptr [64 x i8], [64 x i8]* %lookup_str_map, i32 0, i32 8
+  %probe_read47 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %62)
+  %63 = load i8, i8* %strcmp.char_l
+  %64 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 8
+  %probe_read48 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %64)
+  %65 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp49 = icmp ne i8 %63, %65
+  br i1 %strcmp.cmp49, label %strcmp.false, label %strcmp.loop_null_cmp46
 
-strcmp.loop_null_cmp39:                           ; preds = %strcmp.loop32
-  %strcmp.cmp_null43 = icmp eq i8 %53, 0
-  br i1 %strcmp.cmp_null43, label %strcmp.done, label %strcmp.loop38
+strcmp.loop_null_cmp40:                           ; preds = %strcmp.loop33
+  %strcmp.cmp_null44 = icmp eq i8 %59, 0
+  br i1 %strcmp.cmp_null44, label %strcmp.done, label %strcmp.loop39
 
-strcmp.loop44:                                    ; preds = %strcmp.loop_null_cmp45
-  %60 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 9
-  %probe_read52 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %60)
-  %61 = load i8, i8* %strcmp.char_l
-  %62 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 9
-  %probe_read53 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %62)
-  %63 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp54 = icmp ne i8 %61, %63
-  br i1 %strcmp.cmp54, label %strcmp.false, label %strcmp.loop_null_cmp51
+strcmp.loop45:                                    ; preds = %strcmp.loop_null_cmp46
+  %66 = getelementptr [64 x i8], [64 x i8]* %lookup_str_map, i32 0, i32 9
+  %probe_read53 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %66)
+  %67 = load i8, i8* %strcmp.char_l
+  %68 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 9
+  %probe_read54 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %68)
+  %69 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp55 = icmp ne i8 %67, %69
+  br i1 %strcmp.cmp55, label %strcmp.false, label %strcmp.loop_null_cmp52
 
-strcmp.loop_null_cmp45:                           ; preds = %strcmp.loop38
-  %strcmp.cmp_null49 = icmp eq i8 %57, 0
-  br i1 %strcmp.cmp_null49, label %strcmp.done, label %strcmp.loop44
+strcmp.loop_null_cmp46:                           ; preds = %strcmp.loop39
+  %strcmp.cmp_null50 = icmp eq i8 %63, 0
+  br i1 %strcmp.cmp_null50, label %strcmp.done, label %strcmp.loop45
 
-strcmp.loop50:                                    ; preds = %strcmp.loop_null_cmp51
-  %64 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 10
-  %probe_read58 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %64)
-  %65 = load i8, i8* %strcmp.char_l
-  %66 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 10
-  %probe_read59 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %66)
-  %67 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp60 = icmp ne i8 %65, %67
-  br i1 %strcmp.cmp60, label %strcmp.false, label %strcmp.loop_null_cmp57
+strcmp.loop51:                                    ; preds = %strcmp.loop_null_cmp52
+  %70 = getelementptr [64 x i8], [64 x i8]* %lookup_str_map, i32 0, i32 10
+  %probe_read59 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %70)
+  %71 = load i8, i8* %strcmp.char_l
+  %72 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 10
+  %probe_read60 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %72)
+  %73 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp61 = icmp ne i8 %71, %73
+  br i1 %strcmp.cmp61, label %strcmp.false, label %strcmp.loop_null_cmp58
 
-strcmp.loop_null_cmp51:                           ; preds = %strcmp.loop44
-  %strcmp.cmp_null55 = icmp eq i8 %61, 0
-  br i1 %strcmp.cmp_null55, label %strcmp.done, label %strcmp.loop50
+strcmp.loop_null_cmp52:                           ; preds = %strcmp.loop45
+  %strcmp.cmp_null56 = icmp eq i8 %67, 0
+  br i1 %strcmp.cmp_null56, label %strcmp.done, label %strcmp.loop51
 
-strcmp.loop56:                                    ; preds = %strcmp.loop_null_cmp57
-  %68 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 11
-  %probe_read64 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %68)
-  %69 = load i8, i8* %strcmp.char_l
-  %70 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 11
-  %probe_read65 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %70)
-  %71 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp66 = icmp ne i8 %69, %71
-  br i1 %strcmp.cmp66, label %strcmp.false, label %strcmp.loop_null_cmp63
+strcmp.loop57:                                    ; preds = %strcmp.loop_null_cmp58
+  %74 = getelementptr [64 x i8], [64 x i8]* %lookup_str_map, i32 0, i32 11
+  %probe_read65 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %74)
+  %75 = load i8, i8* %strcmp.char_l
+  %76 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 11
+  %probe_read66 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %76)
+  %77 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp67 = icmp ne i8 %75, %77
+  br i1 %strcmp.cmp67, label %strcmp.false, label %strcmp.loop_null_cmp64
 
-strcmp.loop_null_cmp57:                           ; preds = %strcmp.loop50
-  %strcmp.cmp_null61 = icmp eq i8 %65, 0
-  br i1 %strcmp.cmp_null61, label %strcmp.done, label %strcmp.loop56
+strcmp.loop_null_cmp58:                           ; preds = %strcmp.loop51
+  %strcmp.cmp_null62 = icmp eq i8 %71, 0
+  br i1 %strcmp.cmp_null62, label %strcmp.done, label %strcmp.loop57
 
-strcmp.loop62:                                    ; preds = %strcmp.loop_null_cmp63
-  %72 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 12
-  %probe_read70 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %72)
-  %73 = load i8, i8* %strcmp.char_l
-  %74 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 12
-  %probe_read71 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %74)
-  %75 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp72 = icmp ne i8 %73, %75
-  br i1 %strcmp.cmp72, label %strcmp.false, label %strcmp.loop_null_cmp69
+strcmp.loop63:                                    ; preds = %strcmp.loop_null_cmp64
+  %78 = getelementptr [64 x i8], [64 x i8]* %lookup_str_map, i32 0, i32 12
+  %probe_read71 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %78)
+  %79 = load i8, i8* %strcmp.char_l
+  %80 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 12
+  %probe_read72 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %80)
+  %81 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp73 = icmp ne i8 %79, %81
+  br i1 %strcmp.cmp73, label %strcmp.false, label %strcmp.loop_null_cmp70
 
-strcmp.loop_null_cmp63:                           ; preds = %strcmp.loop56
-  %strcmp.cmp_null67 = icmp eq i8 %69, 0
-  br i1 %strcmp.cmp_null67, label %strcmp.done, label %strcmp.loop62
+strcmp.loop_null_cmp64:                           ; preds = %strcmp.loop57
+  %strcmp.cmp_null68 = icmp eq i8 %75, 0
+  br i1 %strcmp.cmp_null68, label %strcmp.done, label %strcmp.loop63
 
-strcmp.loop68:                                    ; preds = %strcmp.loop_null_cmp69
-  %76 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 13
-  %probe_read76 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %76)
-  %77 = load i8, i8* %strcmp.char_l
-  %78 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 13
-  %probe_read77 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %78)
-  %79 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp78 = icmp ne i8 %77, %79
-  br i1 %strcmp.cmp78, label %strcmp.false, label %strcmp.loop_null_cmp75
+strcmp.loop69:                                    ; preds = %strcmp.loop_null_cmp70
+  %82 = getelementptr [64 x i8], [64 x i8]* %lookup_str_map, i32 0, i32 13
+  %probe_read77 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %82)
+  %83 = load i8, i8* %strcmp.char_l
+  %84 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 13
+  %probe_read78 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %84)
+  %85 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp79 = icmp ne i8 %83, %85
+  br i1 %strcmp.cmp79, label %strcmp.false, label %strcmp.loop_null_cmp76
 
-strcmp.loop_null_cmp69:                           ; preds = %strcmp.loop62
-  %strcmp.cmp_null73 = icmp eq i8 %73, 0
-  br i1 %strcmp.cmp_null73, label %strcmp.done, label %strcmp.loop68
+strcmp.loop_null_cmp70:                           ; preds = %strcmp.loop63
+  %strcmp.cmp_null74 = icmp eq i8 %79, 0
+  br i1 %strcmp.cmp_null74, label %strcmp.done, label %strcmp.loop69
 
-strcmp.loop74:                                    ; preds = %strcmp.loop_null_cmp75
-  %80 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 14
-  %probe_read82 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %80)
-  %81 = load i8, i8* %strcmp.char_l
-  %82 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 14
-  %probe_read83 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %82)
-  %83 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp84 = icmp ne i8 %81, %83
-  br i1 %strcmp.cmp84, label %strcmp.false, label %strcmp.loop_null_cmp81
+strcmp.loop75:                                    ; preds = %strcmp.loop_null_cmp76
+  %86 = getelementptr [64 x i8], [64 x i8]* %lookup_str_map, i32 0, i32 14
+  %probe_read83 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %86)
+  %87 = load i8, i8* %strcmp.char_l
+  %88 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 14
+  %probe_read84 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %88)
+  %89 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp85 = icmp ne i8 %87, %89
+  br i1 %strcmp.cmp85, label %strcmp.false, label %strcmp.loop_null_cmp82
 
-strcmp.loop_null_cmp75:                           ; preds = %strcmp.loop68
-  %strcmp.cmp_null79 = icmp eq i8 %77, 0
-  br i1 %strcmp.cmp_null79, label %strcmp.done, label %strcmp.loop74
+strcmp.loop_null_cmp76:                           ; preds = %strcmp.loop69
+  %strcmp.cmp_null80 = icmp eq i8 %83, 0
+  br i1 %strcmp.cmp_null80, label %strcmp.done, label %strcmp.loop75
 
-strcmp.loop80:                                    ; preds = %strcmp.loop_null_cmp81
-  %84 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 15
-  %probe_read88 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %84)
-  %85 = load i8, i8* %strcmp.char_l
-  %86 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 15
-  %probe_read89 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %86)
-  %87 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp90 = icmp ne i8 %85, %87
-  br i1 %strcmp.cmp90, label %strcmp.false, label %strcmp.loop_null_cmp87
+strcmp.loop81:                                    ; preds = %strcmp.loop_null_cmp82
+  %90 = getelementptr [64 x i8], [64 x i8]* %lookup_str_map, i32 0, i32 15
+  %probe_read89 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %90)
+  %91 = load i8, i8* %strcmp.char_l
+  %92 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 15
+  %probe_read90 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %92)
+  %93 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp91 = icmp ne i8 %91, %93
+  br i1 %strcmp.cmp91, label %strcmp.false, label %strcmp.loop_null_cmp88
 
-strcmp.loop_null_cmp81:                           ; preds = %strcmp.loop74
-  %strcmp.cmp_null85 = icmp eq i8 %81, 0
-  br i1 %strcmp.cmp_null85, label %strcmp.done, label %strcmp.loop80
+strcmp.loop_null_cmp82:                           ; preds = %strcmp.loop75
+  %strcmp.cmp_null86 = icmp eq i8 %87, 0
+  br i1 %strcmp.cmp_null86, label %strcmp.done, label %strcmp.loop81
 
-strcmp.loop86:                                    ; preds = %strcmp.loop_null_cmp87
-  %88 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 16
-  %probe_read94 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %88)
-  %89 = load i8, i8* %strcmp.char_l
-  %90 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 16
-  %probe_read95 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %90)
-  %91 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp96 = icmp ne i8 %89, %91
-  br i1 %strcmp.cmp96, label %strcmp.false, label %strcmp.loop_null_cmp93
-
-strcmp.loop_null_cmp87:                           ; preds = %strcmp.loop80
-  %strcmp.cmp_null91 = icmp eq i8 %85, 0
-  br i1 %strcmp.cmp_null91, label %strcmp.done, label %strcmp.loop86
-
-strcmp.loop92:                                    ; preds = %strcmp.loop_null_cmp93
+strcmp.loop87:                                    ; preds = %strcmp.loop_null_cmp88
   br label %strcmp.done
 
-strcmp.loop_null_cmp93:                           ; preds = %strcmp.loop86
-  %strcmp.cmp_null97 = icmp eq i8 %89, 0
-  br i1 %strcmp.cmp_null97, label %strcmp.done, label %strcmp.loop92
+strcmp.loop_null_cmp88:                           ; preds = %strcmp.loop81
+  %strcmp.cmp_null92 = icmp eq i8 %91, 0
+  br i1 %strcmp.cmp_null92, label %strcmp.done, label %strcmp.loop87
 }
 
 ; Function Attrs: argmemonly nounwind

--- a/tests/codegen/llvm/struct_char_1.ll
+++ b/tests/codegen/llvm/struct_char_1.ll
@@ -3,42 +3,70 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Foo.x" = alloca i8
-  %"$foo" = alloca [1 x i8]
-  %1 = bitcast [1 x i8]* %"$foo" to i8*
+  %helper_error_t = alloca %helper_error_t
+  %"lookup_$foo_key" = alloca i32
+  %1 = bitcast i32* %"lookup_$foo_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast [1 x i8]* %"$foo" to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 1, i1 false)
-  %3 = bitcast [1 x i8]* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [1 x i8]* %"$foo" to i8*
-  %5 = bitcast i64 0 to i8 addrspace(64)*
-  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %4, i8 addrspace(64)* align 1 %5, i64 1, i1 false)
-  %6 = add [1 x i8]* %"$foo", i64 0
+  store i32 0, i32* %"lookup_$foo_key"
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %"lookup_$foo_map" = call [1 x i8]* inttoptr (i64 1 to [1 x i8]* (i64, i32*)*)(i64 %pseudo, i32* %"lookup_$foo_key")
+  %2 = bitcast i32* %"lookup_$foo_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext [1 x i8]* %"lookup_$foo_map" to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %5 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %6
+  %7 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %7
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %9
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %11 = bitcast [1 x i8]* %"lookup_$foo_map" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 1, i1 false)
+  %12 = bitcast [1 x i8]* %"lookup_$foo_map" to i8*
+  %13 = bitcast i64 0 to i8 addrspace(64)*
+  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %12, i8 addrspace(64)* align 1 %13, i64 1, i1 false)
+  %14 = add [1 x i8]* %"lookup_$foo_map", i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"struct Foo.x")
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, [1 x i8]*)*)(i8* %"struct Foo.x", i32 1, [1 x i8]* %6)
-  %7 = load i8, i8* %"struct Foo.x"
-  %8 = sext i8 %7 to i64
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, [1 x i8]*)*)(i8* %"struct Foo.x", i32 1, [1 x i8]* %14)
+  %15 = load i8, i8* %"struct Foo.x"
+  %16 = sext i8 %15 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct Foo.x")
-  %9 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %17 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
+  store i64 %16, i64* %"@x_val"
+  %18 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
   store i64 0, i64* %"@x_key"
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  store i64 %8, i64* %"@x_val"
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %11 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@x_key", i64* %"@x_val", i64 0)
+  %19 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  %20 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
   ret i64 0
 }
 
@@ -46,13 +74,13 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.memcpy.p0i8.p64i8.i64(i8* nocapture writeonly, i8 addrspace(64)* nocapture readonly, i64, i1) #1
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/struct_char_2.ll
+++ b/tests/codegen/llvm/struct_char_2.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Foo.x" = alloca i8
   %"$foo" = alloca i64
   %1 = bitcast i64* %"$foo" to i8*
@@ -25,17 +25,17 @@ entry:
   %5 = load i8, i8* %"struct Foo.x"
   %6 = sext i8 %5 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct Foo.x")
-  %7 = bitcast i64* %"@x_key" to i8*
+  %7 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  store i64 0, i64* %"@x_key"
-  %8 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 %6, i64* %"@x_val"
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %9 = bitcast i64* %"@x_key" to i8*
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_val" to i8*
+  %10 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_integer_ptr_1.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_1.ll
@@ -3,51 +3,79 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %deref = alloca i32
   %"struct Foo.x" = alloca i64
-  %"$foo" = alloca [8 x i8]
-  %1 = bitcast [8 x i8]* %"$foo" to i8*
+  %helper_error_t = alloca %helper_error_t
+  %"lookup_$foo_key" = alloca i32
+  %1 = bitcast i32* %"lookup_$foo_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast [8 x i8]* %"$foo" to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 8, i1 false)
-  %3 = bitcast [8 x i8]* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [8 x i8]* %"$foo" to i8*
-  %5 = bitcast i64 0 to i8 addrspace(64)*
-  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %4, i8 addrspace(64)* align 1 %5, i64 8, i1 false)
-  %6 = add [8 x i8]* %"$foo", i64 0
-  %7 = bitcast i64* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, [8 x i8]*)*)(i64* %"struct Foo.x", i32 8, [8 x i8]* %6)
-  %8 = load i64, i64* %"struct Foo.x"
-  %9 = bitcast i64* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i32* %deref to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %8)
-  %11 = load i32, i32* %deref
-  %12 = sext i32 %11 to i64
-  %13 = bitcast i32* %deref to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
-  store i64 0, i64* %"@x_key"
-  %15 = bitcast i64* %"@x_val" to i8*
+  store i32 0, i32* %"lookup_$foo_key"
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %"lookup_$foo_map" = call [8 x i8]* inttoptr (i64 1 to [8 x i8]* (i64, i32*)*)(i64 %pseudo, i32* %"lookup_$foo_key")
+  %2 = bitcast i32* %"lookup_$foo_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext [8 x i8]* %"lookup_$foo_map" to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %5 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %6
+  %7 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %7
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %9
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %11 = bitcast [8 x i8]* %"lookup_$foo_map" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 8, i1 false)
+  %12 = bitcast [8 x i8]* %"lookup_$foo_map" to i8*
+  %13 = bitcast i64 0 to i8 addrspace(64)*
+  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %12, i8 addrspace(64)* align 1 %13, i64 8, i1 false)
+  %14 = add [8 x i8]* %"lookup_$foo_map", i64 0
+  %15 = bitcast i64* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
-  store i64 %12, i64* %"@x_val"
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %16 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = bitcast i64* %"@x_val" to i8*
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, [8 x i8]*)*)(i64* %"struct Foo.x", i32 8, [8 x i8]* %14)
+  %16 = load i64, i64* %"struct Foo.x"
+  %17 = bitcast i64* %"struct Foo.x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %18 = bitcast i32* %deref to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
+  %probe_read2 = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %16)
+  %19 = load i32, i32* %deref
+  %20 = sext i32 %19 to i64
+  %21 = bitcast i32* %deref to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  %22 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %22)
+  store i64 %20, i64* %"@x_val"
+  %23 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
+  store i64 0, i64* %"@x_key"
+  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo3, i64* %"@x_key", i64* %"@x_val", i64 0)
+  %24 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
+  %25 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %25)
   ret i64 0
 }
 
@@ -55,13 +83,13 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.memcpy.p0i8.p64i8.i64(i8* nocapture writeonly, i8 addrspace(64)* nocapture readonly, i64, i1) #1
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/struct_integer_ptr_2.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_2.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %deref = alloca i32
   %"struct Foo.x" = alloca i64
   %"$foo" = alloca i64
@@ -34,17 +34,17 @@ entry:
   %10 = sext i32 %9 to i64
   %11 = bitcast i32* %deref to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_key" to i8*
+  %12 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  store i64 0, i64* %"@x_key"
-  %13 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
   store i64 %10, i64* %"@x_val"
+  %13 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %14 = bitcast i64* %"@x_key" to i8*
+  %14 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@x_val" to i8*
+  %15 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_integers_1.ll
+++ b/tests/codegen/llvm/struct_integers_1.ll
@@ -3,44 +3,72 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Foo.x" = alloca i32
-  %"$foo" = alloca [4 x i8]
-  %1 = bitcast [4 x i8]* %"$foo" to i8*
+  %helper_error_t = alloca %helper_error_t
+  %"lookup_$foo_key" = alloca i32
+  %1 = bitcast i32* %"lookup_$foo_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast [4 x i8]* %"$foo" to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 4, i1 false)
-  %3 = bitcast [4 x i8]* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [4 x i8]* %"$foo" to i8*
-  %5 = bitcast i64 0 to i8 addrspace(64)*
-  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %4, i8 addrspace(64)* align 1 %5, i64 4, i1 false)
-  %6 = add [4 x i8]* %"$foo", i64 0
-  %7 = bitcast i32* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.x", i32 4, [4 x i8]* %6)
-  %8 = load i32, i32* %"struct Foo.x"
-  %9 = sext i32 %8 to i64
-  %10 = bitcast i32* %"struct Foo.x" to i8*
+  store i32 0, i32* %"lookup_$foo_key"
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %"lookup_$foo_map" = call [4 x i8]* inttoptr (i64 1 to [4 x i8]* (i64, i32*)*)(i64 %pseudo, i32* %"lookup_$foo_key")
+  %2 = bitcast i32* %"lookup_$foo_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext [4 x i8]* %"lookup_$foo_map" to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %5 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %6
+  %7 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %7
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %9
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %11 = bitcast [4 x i8]* %"lookup_$foo_map" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 4, i1 false)
+  %12 = bitcast [4 x i8]* %"lookup_$foo_map" to i8*
+  %13 = bitcast i64 0 to i8 addrspace(64)*
+  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %12, i8 addrspace(64)* align 1 %13, i64 4, i1 false)
+  %14 = add [4 x i8]* %"lookup_$foo_map", i64 0
+  %15 = bitcast i32* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.x", i32 4, [4 x i8]* %14)
+  %16 = load i32, i32* %"struct Foo.x"
+  %17 = sext i32 %16 to i64
+  %18 = bitcast i32* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  %19 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
+  store i64 %17, i64* %"@x_val"
+  %20 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %20)
   store i64 0, i64* %"@x_key"
-  %12 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  store i64 %9, i64* %"@x_val"
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %13 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@x_key", i64* %"@x_val", i64 0)
+  %21 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  %22 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
   ret i64 0
 }
 
@@ -48,13 +76,13 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.memcpy.p0i8.p64i8.i64(i8* nocapture writeonly, i8 addrspace(64)* nocapture readonly, i64, i1) #1
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/struct_integers_2.ll
+++ b/tests/codegen/llvm/struct_integers_2.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Foo.x" = alloca i32
   %"$foo" = alloca i64
   %1 = bitcast i64* %"$foo" to i8*
@@ -27,17 +27,17 @@ entry:
   %7 = sext i32 %6 to i64
   %8 = bitcast i32* %"struct Foo.x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@x_key" to i8*
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store i64 0, i64* %"@x_key"
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 %7, i64* %"@x_val"
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %11 = bitcast i64* %"@x_key" to i8*
+  %11 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_val" to i8*
+  %12 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_long_1.ll
+++ b/tests/codegen/llvm/struct_long_1.ll
@@ -3,43 +3,71 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Foo.x" = alloca i64
-  %"$foo" = alloca [8 x i8]
-  %1 = bitcast [8 x i8]* %"$foo" to i8*
+  %helper_error_t = alloca %helper_error_t
+  %"lookup_$foo_key" = alloca i32
+  %1 = bitcast i32* %"lookup_$foo_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast [8 x i8]* %"$foo" to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 8, i1 false)
-  %3 = bitcast [8 x i8]* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [8 x i8]* %"$foo" to i8*
-  %5 = bitcast i64 0 to i8 addrspace(64)*
-  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %4, i8 addrspace(64)* align 1 %5, i64 8, i1 false)
-  %6 = add [8 x i8]* %"$foo", i64 0
-  %7 = bitcast i64* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, [8 x i8]*)*)(i64* %"struct Foo.x", i32 8, [8 x i8]* %6)
-  %8 = load i64, i64* %"struct Foo.x"
-  %9 = bitcast i64* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i32 0, i32* %"lookup_$foo_key"
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %"lookup_$foo_map" = call [8 x i8]* inttoptr (i64 1 to [8 x i8]* (i64, i32*)*)(i64 %pseudo, i32* %"lookup_$foo_key")
+  %2 = bitcast i32* %"lookup_$foo_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext [8 x i8]* %"lookup_$foo_map" to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %5 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %6
+  %7 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %7
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %9
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %11 = bitcast [8 x i8]* %"lookup_$foo_map" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 8, i1 false)
+  %12 = bitcast [8 x i8]* %"lookup_$foo_map" to i8*
+  %13 = bitcast i64 0 to i8 addrspace(64)*
+  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %12, i8 addrspace(64)* align 1 %13, i64 8, i1 false)
+  %14 = add [8 x i8]* %"lookup_$foo_map", i64 0
+  %15 = bitcast i64* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, [8 x i8]*)*)(i64* %"struct Foo.x", i32 8, [8 x i8]* %14)
+  %16 = load i64, i64* %"struct Foo.x"
+  %17 = bitcast i64* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %18 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
+  store i64 %16, i64* %"@x_val"
+  %19 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
   store i64 0, i64* %"@x_key"
-  %11 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  store i64 %8, i64* %"@x_val"
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %12 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@x_key", i64* %"@x_val", i64 0)
+  %20 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
+  %21 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
   ret i64 0
 }
 
@@ -47,13 +75,13 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.memcpy.p0i8.p64i8.i64(i8* nocapture writeonly, i8 addrspace(64)* nocapture readonly, i64, i1) #1
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/struct_long_2.ll
+++ b/tests/codegen/llvm/struct_long_2.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Foo.x" = alloca i64
   %"$foo" = alloca i64
   %1 = bitcast i64* %"$foo" to i8*
@@ -26,17 +26,17 @@ entry:
   %6 = load i64, i64* %"struct Foo.x"
   %7 = bitcast i64* %"struct Foo.x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@x_key" to i8*
+  %8 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  store i64 0, i64* %"@x_key"
-  %9 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 %6, i64* %"@x_val"
+  %9 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %10 = bitcast i64* %"@x_key" to i8*
+  %10 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_val" to i8*
+  %11 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_nested_struct_anon_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_1.ll
@@ -3,45 +3,73 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Foo::(anonymous at definitions.h:1:14).x" = alloca i32
-  %"$foo" = alloca [4 x i8]
-  %1 = bitcast [4 x i8]* %"$foo" to i8*
+  %helper_error_t = alloca %helper_error_t
+  %"lookup_$foo_key" = alloca i32
+  %1 = bitcast i32* %"lookup_$foo_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast [4 x i8]* %"$foo" to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 4, i1 false)
-  %3 = bitcast [4 x i8]* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [4 x i8]* %"$foo" to i8*
-  %5 = bitcast i64 0 to i8 addrspace(64)*
-  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %4, i8 addrspace(64)* align 1 %5, i64 4, i1 false)
-  %6 = add [4 x i8]* %"$foo", i64 0
-  %7 = add [4 x i8]* %6, i64 0
-  %8 = bitcast i32* %"struct Foo::(anonymous at definitions.h:1:14).x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo::(anonymous at definitions.h:1:14).x", i32 4, [4 x i8]* %7)
-  %9 = load i32, i32* %"struct Foo::(anonymous at definitions.h:1:14).x"
-  %10 = sext i32 %9 to i64
-  %11 = bitcast i32* %"struct Foo::(anonymous at definitions.h:1:14).x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  store i32 0, i32* %"lookup_$foo_key"
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %"lookup_$foo_map" = call [4 x i8]* inttoptr (i64 1 to [4 x i8]* (i64, i32*)*)(i64 %pseudo, i32* %"lookup_$foo_key")
+  %2 = bitcast i32* %"lookup_$foo_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext [4 x i8]* %"lookup_$foo_map" to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %5 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %6
+  %7 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %7
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %9
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %11 = bitcast [4 x i8]* %"lookup_$foo_map" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 4, i1 false)
+  %12 = bitcast [4 x i8]* %"lookup_$foo_map" to i8*
+  %13 = bitcast i64 0 to i8 addrspace(64)*
+  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %12, i8 addrspace(64)* align 1 %13, i64 4, i1 false)
+  %14 = add [4 x i8]* %"lookup_$foo_map", i64 0
+  %15 = add [4 x i8]* %14, i64 0
+  %16 = bitcast i32* %"struct Foo::(anonymous at definitions.h:1:14).x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo::(anonymous at definitions.h:1:14).x", i32 4, [4 x i8]* %15)
+  %17 = load i32, i32* %"struct Foo::(anonymous at definitions.h:1:14).x"
+  %18 = sext i32 %17 to i64
+  %19 = bitcast i32* %"struct Foo::(anonymous at definitions.h:1:14).x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  %20 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %20)
+  store i64 %18, i64* %"@x_val"
+  %21 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21)
   store i64 0, i64* %"@x_key"
-  %13 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  store i64 %10, i64* %"@x_val"
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %14 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@x_key", i64* %"@x_val", i64 0)
+  %22 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
+  %23 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
   ret i64 0
 }
 
@@ -49,13 +77,13 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.memcpy.p0i8.p64i8.i64(i8* nocapture writeonly, i8 addrspace(64)* nocapture readonly, i64, i1) #1
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/struct_nested_struct_anon_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_2.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Foo::(anonymous at definitions.h:1:14).x" = alloca i32
   %"$foo" = alloca i64
   %1 = bitcast i64* %"$foo" to i8*
@@ -28,17 +28,17 @@ entry:
   %8 = sext i32 %7 to i64
   %9 = bitcast i32* %"struct Foo::(anonymous at definitions.h:1:14).x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key" to i8*
+  %10 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  store i64 0, i64* %"@x_key"
-  %11 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   store i64 %8, i64* %"@x_val"
+  %11 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %12 = bitcast i64* %"@x_key" to i8*
+  %12 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_val" to i8*
+  %13 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_nested_struct_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_1.ll
@@ -3,45 +3,73 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Bar.x" = alloca i32
-  %"$foo" = alloca [4 x i8]
-  %1 = bitcast [4 x i8]* %"$foo" to i8*
+  %helper_error_t = alloca %helper_error_t
+  %"lookup_$foo_key" = alloca i32
+  %1 = bitcast i32* %"lookup_$foo_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast [4 x i8]* %"$foo" to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 4, i1 false)
-  %3 = bitcast [4 x i8]* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [4 x i8]* %"$foo" to i8*
-  %5 = bitcast i64 0 to i8 addrspace(64)*
-  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %4, i8 addrspace(64)* align 1 %5, i64 4, i1 false)
-  %6 = add [4 x i8]* %"$foo", i64 0
-  %7 = add [4 x i8]* %6, i64 0
-  %8 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Bar.x", i32 4, [4 x i8]* %7)
-  %9 = load i32, i32* %"struct Bar.x"
-  %10 = sext i32 %9 to i64
-  %11 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  store i32 0, i32* %"lookup_$foo_key"
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %"lookup_$foo_map" = call [4 x i8]* inttoptr (i64 1 to [4 x i8]* (i64, i32*)*)(i64 %pseudo, i32* %"lookup_$foo_key")
+  %2 = bitcast i32* %"lookup_$foo_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext [4 x i8]* %"lookup_$foo_map" to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %5 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %6
+  %7 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %7
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %9
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %11 = bitcast [4 x i8]* %"lookup_$foo_map" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 4, i1 false)
+  %12 = bitcast [4 x i8]* %"lookup_$foo_map" to i8*
+  %13 = bitcast i64 0 to i8 addrspace(64)*
+  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %12, i8 addrspace(64)* align 1 %13, i64 4, i1 false)
+  %14 = add [4 x i8]* %"lookup_$foo_map", i64 0
+  %15 = add [4 x i8]* %14, i64 0
+  %16 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Bar.x", i32 4, [4 x i8]* %15)
+  %17 = load i32, i32* %"struct Bar.x"
+  %18 = sext i32 %17 to i64
+  %19 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  %20 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %20)
+  store i64 %18, i64* %"@x_val"
+  %21 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21)
   store i64 0, i64* %"@x_key"
-  %13 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  store i64 %10, i64* %"@x_val"
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %14 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@x_key", i64* %"@x_val", i64 0)
+  %22 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
+  %23 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
   ret i64 0
 }
 
@@ -49,13 +77,13 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.memcpy.p0i8.p64i8.i64(i8* nocapture writeonly, i8 addrspace(64)* nocapture readonly, i64, i1) #1
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/struct_nested_struct_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_2.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Bar.x" = alloca i32
   %"$foo" = alloca i64
   %1 = bitcast i64* %"$foo" to i8*
@@ -28,17 +28,17 @@ entry:
   %8 = sext i32 %7 to i64
   %9 = bitcast i32* %"struct Bar.x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key" to i8*
+  %10 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  store i64 0, i64* %"@x_key"
-  %11 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   store i64 %8, i64* %"@x_val"
+  %11 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %12 = bitcast i64* %"@x_key" to i8*
+  %12 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_val" to i8*
+  %13 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
@@ -3,52 +3,80 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Bar.x" = alloca i32
   %"struct Foo.bar" = alloca i64
-  %"$foo" = alloca [8 x i8]
-  %1 = bitcast [8 x i8]* %"$foo" to i8*
+  %helper_error_t = alloca %helper_error_t
+  %"lookup_$foo_key" = alloca i32
+  %1 = bitcast i32* %"lookup_$foo_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast [8 x i8]* %"$foo" to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 8, i1 false)
-  %3 = bitcast [8 x i8]* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [8 x i8]* %"$foo" to i8*
-  %5 = bitcast i64 0 to i8 addrspace(64)*
-  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %4, i8 addrspace(64)* align 1 %5, i64 8, i1 false)
-  %6 = add [8 x i8]* %"$foo", i64 0
-  %7 = bitcast i64* %"struct Foo.bar" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, [8 x i8]*)*)(i64* %"struct Foo.bar", i32 8, [8 x i8]* %6)
-  %8 = load i64, i64* %"struct Foo.bar"
-  %9 = bitcast i64* %"struct Foo.bar" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = add i64 %8, 0
-  %11 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %10)
-  %12 = load i32, i32* %"struct Bar.x"
-  %13 = sext i32 %12 to i64
-  %14 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@x_key" to i8*
+  store i32 0, i32* %"lookup_$foo_key"
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %"lookup_$foo_map" = call [8 x i8]* inttoptr (i64 1 to [8 x i8]* (i64, i32*)*)(i64 %pseudo, i32* %"lookup_$foo_key")
+  %2 = bitcast i32* %"lookup_$foo_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext [8 x i8]* %"lookup_$foo_map" to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %5 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %6
+  %7 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %7
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %9
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %11 = bitcast [8 x i8]* %"lookup_$foo_map" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 8, i1 false)
+  %12 = bitcast [8 x i8]* %"lookup_$foo_map" to i8*
+  %13 = bitcast i64 0 to i8 addrspace(64)*
+  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %12, i8 addrspace(64)* align 1 %13, i64 8, i1 false)
+  %14 = add [8 x i8]* %"lookup_$foo_map", i64 0
+  %15 = bitcast i64* %"struct Foo.bar" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
-  store i64 0, i64* %"@x_key"
-  %16 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
-  store i64 %13, i64* %"@x_val"
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %17 = bitcast i64* %"@x_key" to i8*
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, [8 x i8]*)*)(i64* %"struct Foo.bar", i32 8, [8 x i8]* %14)
+  %16 = load i64, i64* %"struct Foo.bar"
+  %17 = bitcast i64* %"struct Foo.bar" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
-  %18 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  %18 = add i64 %16, 0
+  %19 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
+  %probe_read2 = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %18)
+  %20 = load i32, i32* %"struct Bar.x"
+  %21 = sext i32 %20 to i64
+  %22 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
+  %23 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
+  store i64 %21, i64* %"@x_val"
+  %24 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %24)
+  store i64 0, i64* %"@x_key"
+  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo3, i64* %"@x_key", i64* %"@x_val", i64 0)
+  %25 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %25)
+  %26 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %26)
   ret i64 0
 }
 
@@ -56,13 +84,13 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.memcpy.p0i8.p64i8.i64(i8* nocapture writeonly, i8 addrspace(64)* nocapture readonly, i64, i1) #1
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Bar.x" = alloca i32
   %"struct Foo.bar" = alloca i64
   %"$foo" = alloca i64
@@ -35,17 +35,17 @@ entry:
   %11 = sext i32 %10 to i64
   %12 = bitcast i32* %"struct Bar.x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_key" to i8*
+  %13 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  store i64 0, i64* %"@x_key"
-  %14 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
   store i64 %11, i64* %"@x_val"
+  %14 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %15 = bitcast i64* %"@x_key" to i8*
+  %15 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
-  %16 = bitcast i64* %"@x_val" to i8*
+  %16 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_save_1.ll
+++ b/tests/codegen/llvm/struct_save_1.ll
@@ -8,19 +8,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@foo_val" = alloca [12 x i8]
   %"@foo_key" = alloca i64
-  %1 = bitcast i64* %"@foo_key" to i8*
+  %"@foo_val" = alloca [12 x i8]
+  %1 = bitcast [12 x i8]* %"@foo_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@foo_key"
-  %2 = bitcast [12 x i8]* %"@foo_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   %probe_read = call i64 inttoptr (i64 4 to i64 ([12 x i8]*, i32, i64)*)([12 x i8]* %"@foo_val", i32 12, i64 0)
+  %2 = bitcast i64* %"@foo_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@foo_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [12 x i8]*, i64)*)(i64 %pseudo, i64* %"@foo_key", [12 x i8]* %"@foo_val", i64 0)
-  %3 = bitcast i64* %"@foo_key" to i8*
+  %3 = bitcast [12 x i8]* %"@foo_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [12 x i8]* %"@foo_val" to i8*
+  %4 = bitcast i64* %"@foo_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_save_2.ll
+++ b/tests/codegen/llvm/struct_save_2.ll
@@ -8,19 +8,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@foo_val" = alloca [12 x i8]
   %"@foo_key" = alloca i64
-  %1 = bitcast i64* %"@foo_key" to i8*
+  %"@foo_val" = alloca [12 x i8]
+  %1 = bitcast [12 x i8]* %"@foo_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@foo_key"
-  %2 = bitcast [12 x i8]* %"@foo_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   %probe_read = call i64 inttoptr (i64 4 to i64 ([12 x i8]*, i32, i64)*)([12 x i8]* %"@foo_val", i32 12, i64 0)
+  %2 = bitcast i64* %"@foo_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@foo_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [12 x i8]*, i64)*)(i64 %pseudo, i64* %"@foo_key", [12 x i8]* %"@foo_val", i64 0)
-  %3 = bitcast i64* %"@foo_key" to i8*
+  %3 = bitcast [12 x i8]* %"@foo_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [12 x i8]* %"@foo_val" to i8*
+  %4 = bitcast i64* %"@foo_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_save_nested.ll
+++ b/tests/codegen/llvm/struct_save_nested.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"internal_struct Foo.bar13" = alloca [8 x i8]
   %lookup_elem_val11 = alloca [16 x i8]
   %"@foo_key5" = alloca i64
@@ -17,19 +17,19 @@ entry:
   %"internal_struct Foo.bar" = alloca [8 x i8]
   %lookup_elem_val = alloca [16 x i8]
   %"@foo_key1" = alloca i64
-  %"@foo_val" = alloca [16 x i8]
   %"@foo_key" = alloca i64
-  %1 = bitcast i64* %"@foo_key" to i8*
+  %"@foo_val" = alloca [16 x i8]
+  %1 = bitcast [16 x i8]* %"@foo_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@foo_key"
-  %2 = bitcast [16 x i8]* %"@foo_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   %probe_read = call i64 inttoptr (i64 4 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* %"@foo_val", i32 16, i64 0)
+  %2 = bitcast i64* %"@foo_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@foo_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [16 x i8]*, i64)*)(i64 %pseudo, i64* %"@foo_key", [16 x i8]* %"@foo_val", i64 0)
-  %3 = bitcast i64* %"@foo_key" to i8*
+  %3 = bitcast [16 x i8]* %"@foo_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [16 x i8]* %"@foo_val" to i8*
+  %4 = bitcast i64* %"@foo_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   %5 = bitcast i64* %"@foo_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
@@ -59,64 +59,60 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   %12 = bitcast [8 x i8]* %"internal_struct Foo.bar" to i8*
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %12, i8* align 1 %10, i64 8, i1 false)
-  %13 = bitcast [16 x i8]* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@bar_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  %13 = bitcast i64* %"@bar_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
   store i64 0, i64* %"@bar_key"
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [8 x i8]*, i64)*)(i64 %pseudo3, i64* %"@bar_key", [8 x i8]* %"internal_struct Foo.bar", i64 0)
-  %15 = bitcast i64* %"@bar_key" to i8*
+  %14 = bitcast i64* %"@bar_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = bitcast [8 x i8]* %"internal_struct Foo.bar" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
-  %16 = bitcast [8 x i8]* %"internal_struct Foo.bar" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = bitcast i64* %"@foo_key5" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
+  %16 = bitcast i64* %"@foo_key5" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
   store i64 0, i64* %"@foo_key5"
   %pseudo6 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %lookup_elem7 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo6, i64* %"@foo_key5")
-  %18 = bitcast [16 x i8]* %lookup_elem_val11 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
+  %17 = bitcast [16 x i8]* %lookup_elem_val11 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
   %map_lookup_cond12 = icmp ne i8* %lookup_elem7, null
   br i1 %map_lookup_cond12, label %lookup_success8, label %lookup_failure9
 
 lookup_success8:                                  ; preds = %lookup_merge
-  %19 = bitcast [16 x i8]* %lookup_elem_val11 to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %19, i8* align 1 %lookup_elem7, i64 16, i1 false)
+  %18 = bitcast [16 x i8]* %lookup_elem_val11 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %18, i8* align 1 %lookup_elem7, i64 16, i1 false)
   br label %lookup_merge10
 
 lookup_failure9:                                  ; preds = %lookup_merge
-  %20 = bitcast [16 x i8]* %lookup_elem_val11 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %20, i8 0, i64 16, i1 false)
+  %19 = bitcast [16 x i8]* %lookup_elem_val11 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %19, i8 0, i64 16, i1 false)
   br label %lookup_merge10
 
 lookup_merge10:                                   ; preds = %lookup_failure9, %lookup_success8
-  %21 = bitcast i64* %"@foo_key5" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
-  %22 = getelementptr [16 x i8], [16 x i8]* %lookup_elem_val11, i64 0, i64 4
+  %20 = bitcast i64* %"@foo_key5" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
+  %21 = getelementptr [16 x i8], [16 x i8]* %lookup_elem_val11, i64 0, i64 4
+  %22 = bitcast [8 x i8]* %"internal_struct Foo.bar13" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %22)
   %23 = bitcast [8 x i8]* %"internal_struct Foo.bar13" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
-  %24 = bitcast [8 x i8]* %"internal_struct Foo.bar13" to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %24, i8* align 1 %22, i64 8, i1 false)
-  %25 = bitcast [16 x i8]* %lookup_elem_val11 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %25)
-  %26 = getelementptr [8 x i8], [8 x i8]* %"internal_struct Foo.bar13", i64 0, i64 0
-  %27 = load i32, i8* %26
-  %28 = bitcast [8 x i8]* %"internal_struct Foo.bar13" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %28)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %23, i8* align 1 %21, i64 8, i1 false)
+  %24 = getelementptr [8 x i8], [8 x i8]* %"internal_struct Foo.bar13", i64 0, i64 0
+  %25 = load i32, i8* %24
+  %26 = bitcast [8 x i8]* %"internal_struct Foo.bar13" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %26)
+  %27 = sext i32 %25 to i64
+  %28 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %28)
+  store i64 %27, i64* %"@x_val"
   %29 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %29)
   store i64 0, i64* %"@x_key"
-  %30 = sext i32 %27 to i64
-  %31 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %31)
-  store i64 %30, i64* %"@x_val"
   %pseudo14 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
   %update_elem15 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo14, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %32 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %32)
-  %33 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %33)
+  %30 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %30)
+  %31 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %31)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_save_string.ll
+++ b/tests/codegen/llvm/struct_save_string.ll
@@ -11,19 +11,19 @@ entry:
   %"@str_key" = alloca i64
   %lookup_elem_val = alloca [32 x i8]
   %"@foo_key1" = alloca i64
-  %"@foo_val" = alloca [32 x i8]
   %"@foo_key" = alloca i64
-  %1 = bitcast i64* %"@foo_key" to i8*
+  %"@foo_val" = alloca [32 x i8]
+  %1 = bitcast [32 x i8]* %"@foo_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@foo_key"
-  %2 = bitcast [32 x i8]* %"@foo_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   %probe_read = call i64 inttoptr (i64 4 to i64 ([32 x i8]*, i32, i64)*)([32 x i8]* %"@foo_val", i32 32, i64 0)
+  %2 = bitcast i64* %"@foo_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@foo_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [32 x i8]*, i64)*)(i64 %pseudo, i64* %"@foo_key", [32 x i8]* %"@foo_val", i64 0)
-  %3 = bitcast i64* %"@foo_key" to i8*
+  %3 = bitcast [32 x i8]* %"@foo_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [32 x i8]* %"@foo_val" to i8*
+  %4 = bitcast i64* %"@foo_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   %5 = bitcast i64* %"@foo_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
@@ -56,8 +56,6 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i8*, i64)*)(i64 %pseudo3, i64* %"@str_key", i8* %10, i64 0)
   %12 = bitcast i64* %"@str_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast [32 x i8]* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_semicolon_1.ll
+++ b/tests/codegen/llvm/struct_semicolon_1.ll
@@ -3,6 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %printf_t = type { i64, i64 }
 
 ; Function Attrs: nounwind
@@ -10,25 +11,50 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %printf_args = alloca %printf_t
-  %1 = bitcast %printf_t* %printf_args to i8*
+  %helper_error_t = alloca %helper_error_t
+  %lookup_fmtstr_key = alloca i32
+  %1 = bitcast i32* %lookup_fmtstr_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 16, i1 false)
-  %3 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %3
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 256)
-  %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %4 = shl i64 %get_pid_tgid, 32
-  %5 = or i64 %get_stackid, %4
-  %6 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %5, i64* %6
+  store i32 0, i32* %lookup_fmtstr_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %2 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext %printf_t* %lookup_fmtstr_map to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %5 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %6
+  %7 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %7
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %9
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo1, i64 %get_cpu_id, %printf_t* %printf_args, i64 16)
-  %7 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %11 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 16, i1 false)
+  %12 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, i64* %12
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo2, i64 256)
+  %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
+  %13 = shl i64 %get_pid_tgid, 32
+  %14 = or i64 %get_stackid, %13
+  %15 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 1
+  store i64 %14, i64* %15
+  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %perf_event_output4 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo3, i64 4294967295, %printf_t* %lookup_fmtstr_map, i64 16)
   ret i64 0
 }
 
@@ -36,10 +62,10 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/struct_semicolon_2.ll
+++ b/tests/codegen/llvm/struct_semicolon_2.ll
@@ -3,6 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %printf_t = type { i64, i64 }
 
 ; Function Attrs: nounwind
@@ -10,25 +11,50 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %printf_args = alloca %printf_t
-  %1 = bitcast %printf_t* %printf_args to i8*
+  %helper_error_t = alloca %helper_error_t
+  %lookup_fmtstr_key = alloca i32
+  %1 = bitcast i32* %lookup_fmtstr_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 16, i1 false)
-  %3 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %3
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 256)
-  %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %4 = shl i64 %get_pid_tgid, 32
-  %5 = or i64 %get_stackid, %4
-  %6 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %5, i64* %6
+  store i32 0, i32* %lookup_fmtstr_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %2 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext %printf_t* %lookup_fmtstr_map to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %5 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %6
+  %7 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %7
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %9
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo1, i64 %get_cpu_id, %printf_t* %printf_args, i64 16)
-  %7 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %11 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 16, i1 false)
+  %12 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, i64* %12
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo2, i64 256)
+  %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
+  %13 = shl i64 %get_pid_tgid, 32
+  %14 = or i64 %get_stackid, %13
+  %15 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 1
+  store i64 %14, i64* %15
+  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %perf_event_output4 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo3, i64 4294967295, %printf_t* %lookup_fmtstr_map, i64 16)
   ret i64 0
 }
 
@@ -36,10 +62,10 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/struct_short_1.ll
+++ b/tests/codegen/llvm/struct_short_1.ll
@@ -3,44 +3,72 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Foo.x" = alloca i16
-  %"$foo" = alloca [2 x i8]
-  %1 = bitcast [2 x i8]* %"$foo" to i8*
+  %helper_error_t = alloca %helper_error_t
+  %"lookup_$foo_key" = alloca i32
+  %1 = bitcast i32* %"lookup_$foo_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast [2 x i8]* %"$foo" to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 2, i1 false)
-  %3 = bitcast [2 x i8]* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [2 x i8]* %"$foo" to i8*
-  %5 = bitcast i64 0 to i8 addrspace(64)*
-  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %4, i8 addrspace(64)* align 1 %5, i64 2, i1 false)
-  %6 = add [2 x i8]* %"$foo", i64 0
-  %7 = bitcast i16* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i16*, i32, [2 x i8]*)*)(i16* %"struct Foo.x", i32 2, [2 x i8]* %6)
-  %8 = load i16, i16* %"struct Foo.x"
-  %9 = sext i16 %8 to i64
-  %10 = bitcast i16* %"struct Foo.x" to i8*
+  store i32 0, i32* %"lookup_$foo_key"
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %"lookup_$foo_map" = call [2 x i8]* inttoptr (i64 1 to [2 x i8]* (i64, i32*)*)(i64 %pseudo, i32* %"lookup_$foo_key")
+  %2 = bitcast i32* %"lookup_$foo_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext [2 x i8]* %"lookup_$foo_map" to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %5 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %6
+  %7 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %7
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %9
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %11 = bitcast [2 x i8]* %"lookup_$foo_map" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 2, i1 false)
+  %12 = bitcast [2 x i8]* %"lookup_$foo_map" to i8*
+  %13 = bitcast i64 0 to i8 addrspace(64)*
+  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %12, i8 addrspace(64)* align 1 %13, i64 2, i1 false)
+  %14 = add [2 x i8]* %"lookup_$foo_map", i64 0
+  %15 = bitcast i16* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i16*, i32, [2 x i8]*)*)(i16* %"struct Foo.x", i32 2, [2 x i8]* %14)
+  %16 = load i16, i16* %"struct Foo.x"
+  %17 = sext i16 %16 to i64
+  %18 = bitcast i16* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  %19 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
+  store i64 %17, i64* %"@x_val"
+  %20 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %20)
   store i64 0, i64* %"@x_key"
-  %12 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  store i64 %9, i64* %"@x_val"
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %13 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@x_key", i64* %"@x_val", i64 0)
+  %21 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  %22 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
   ret i64 0
 }
 
@@ -48,13 +76,13 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.memcpy.p0i8.p64i8.i64(i8* nocapture writeonly, i8 addrspace(64)* nocapture readonly, i64, i1) #1
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/struct_short_2.ll
+++ b/tests/codegen/llvm/struct_short_2.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Foo.x" = alloca i16
   %"$foo" = alloca i64
   %1 = bitcast i64* %"$foo" to i8*
@@ -27,17 +27,17 @@ entry:
   %7 = sext i16 %6 to i64
   %8 = bitcast i16* %"struct Foo.x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@x_key" to i8*
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store i64 0, i64* %"@x_key"
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 %7, i64* %"@x_val"
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %11 = bitcast i64* %"@x_key" to i8*
+  %11 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_val" to i8*
+  %12 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_string_array_1.ll
+++ b/tests/codegen/llvm/struct_string_array_1.ll
@@ -3,6 +3,8 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
@@ -10,29 +12,55 @@ define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %"@mystr_key" = alloca i64
   %"struct Foo.str" = alloca [32 x i8]
-  %"$foo" = alloca [32 x i8]
-  %1 = bitcast [32 x i8]* %"$foo" to i8*
+  %helper_error_t = alloca %helper_error_t
+  %"lookup_$foo_key" = alloca i32
+  %1 = bitcast i32* %"lookup_$foo_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast [32 x i8]* %"$foo" to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 32, i1 false)
-  %3 = bitcast [32 x i8]* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [32 x i8]* %"$foo" to i8*
-  %5 = bitcast i64 0 to i8 addrspace(64)*
-  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %4, i8 addrspace(64)* align 1 %5, i64 32, i1 false)
-  %6 = add [32 x i8]* %"$foo", i64 0
-  %7 = bitcast [32 x i8]* %"struct Foo.str" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([32 x i8]*, i32, [32 x i8]*)*)([32 x i8]* %"struct Foo.str", i32 32, [32 x i8]* %6)
-  %8 = bitcast i64* %"@mystr_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  store i64 0, i64* %"@mystr_key"
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [32 x i8]*, i64)*)(i64 %pseudo, i64* %"@mystr_key", [32 x i8]* %"struct Foo.str", i64 0)
-  %9 = bitcast i64* %"@mystr_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast [32 x i8]* %"struct Foo.str" to i8*
+  store i32 0, i32* %"lookup_$foo_key"
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %"lookup_$foo_map" = call [32 x i8]* inttoptr (i64 1 to [32 x i8]* (i64, i32*)*)(i64 %pseudo, i32* %"lookup_$foo_key")
+  %2 = bitcast i32* %"lookup_$foo_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext [32 x i8]* %"lookup_$foo_map" to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %5 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %6
+  %7 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %7
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %9
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %11 = bitcast [32 x i8]* %"lookup_$foo_map" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 32, i1 false)
+  %12 = bitcast [32 x i8]* %"lookup_$foo_map" to i8*
+  %13 = bitcast i64 0 to i8 addrspace(64)*
+  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %12, i8 addrspace(64)* align 1 %13, i64 32, i1 false)
+  %14 = add [32 x i8]* %"lookup_$foo_map", i64 0
+  %15 = bitcast [32 x i8]* %"struct Foo.str" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  %probe_read = call i64 inttoptr (i64 4 to i64 ([32 x i8]*, i32, [32 x i8]*)*)([32 x i8]* %"struct Foo.str", i32 32, [32 x i8]* %14)
+  %16 = bitcast i64* %"@mystr_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
+  store i64 0, i64* %"@mystr_key"
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [32 x i8]*, i64)*)(i64 %pseudo2, i64* %"@mystr_key", [32 x i8]* %"struct Foo.str", i64 0)
+  %17 = bitcast i64* %"@mystr_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %18 = bitcast [32 x i8]* %"struct Foo.str" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
   ret i64 0
 }
 
@@ -40,13 +68,13 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.memcpy.p0i8.p64i8.i64(i8* nocapture writeonly, i8 addrspace(64)* nocapture readonly, i64, i1) #1
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/struct_string_ptr.ll
+++ b/tests/codegen/llvm/struct_string_ptr.ll
@@ -3,6 +3,8 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
@@ -10,7 +12,8 @@ define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %"@mystr_key" = alloca i64
   %"struct Foo.str" = alloca i64
-  %str = alloca [64 x i8]
+  %helper_error_t = alloca %helper_error_t
+  %lookup_str_key = alloca i32
   %strlen = alloca i64
   %"$foo" = alloca i64
   %1 = bitcast i64* %"$foo" to i8*
@@ -21,35 +24,57 @@ entry:
   store i64 0, i64* %"$foo"
   %3 = bitcast i64* %strlen to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %strlen to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 8, i1 false)
   store i64 64, i64* %strlen
-  %5 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 64, i1 false)
-  %7 = load i64, i64* %"$foo"
-  %8 = add i64 %7, 0
-  %9 = bitcast i64* %"struct Foo.str" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.str", i32 8, i64 %8)
-  %10 = load i64, i64* %"struct Foo.str"
-  %11 = bitcast i64* %"struct Foo.str" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = load i64, i64* %strlen
-  %13 = trunc i64 %12 to i32
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %13, i64 %10)
-  %14 = bitcast i64* %strlen to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@mystr_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  %4 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i32 0, i32* %lookup_str_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %lookup_str_map = call [64 x i8]* inttoptr (i64 1 to [64 x i8]* (i64, i32*)*)(i64 %pseudo, i32* %lookup_str_key)
+  %5 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = sext [64 x i8]* %lookup_str_map to i32
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %8 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %9
+  %10 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %10
+  %11 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %6, i32* %11
+  %12 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %12
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %13 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %14 = bitcast [64 x i8]* %lookup_str_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %14, i8 0, i64 64, i1 false)
+  %15 = load i64, i64* %"$foo"
+  %16 = add i64 %15, 0
+  %17 = bitcast i64* %"struct Foo.str" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.str", i32 8, i64 %16)
+  %18 = load i64, i64* %"struct Foo.str"
+  %19 = bitcast i64* %"struct Foo.str" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  %20 = load i64, i64* %strlen
+  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %lookup_str_map, i64 %20, i64 %18)
+  %21 = bitcast i64* %strlen to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  %22 = bitcast i64* %"@mystr_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %22)
   store i64 0, i64* %"@mystr_key"
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* %"@mystr_key", [64 x i8]* %str, i64 0)
-  %16 = bitcast i64* %"@mystr_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo2, i64* %"@mystr_key", [64 x i8]* %lookup_str_map, i64 0)
+  %23 = bitcast i64* %"@mystr_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
   ret i64 0
 }
 
@@ -57,10 +82,10 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/ternary_int.ll
+++ b/tests/codegen/llvm/ternary_int.ll
@@ -8,19 +8,16 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %buf = alloca i64
+  %"@x_val" = alloca i64
   %result = alloca i64
   %1 = bitcast i64* %result to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast i64* %buf to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %3 = lshr i64 %get_pid_tgid, 32
-  %4 = icmp ult i64 %3, 10000
-  %5 = zext i1 %4 to i64
-  %true_cond = icmp ne i64 %5, 0
+  %2 = lshr i64 %get_pid_tgid, 32
+  %3 = icmp ult i64 %2, 10000
+  %4 = zext i1 %3 to i64
+  %true_cond = icmp ne i64 %4, 0
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
@@ -32,19 +29,19 @@ right:                                            ; preds = %entry
   br label %done
 
 done:                                             ; preds = %right, %left
-  %6 = load i64, i64* %result
+  %5 = load i64, i64* %result
+  %6 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  store i64 %5, i64* %"@x_val"
   %7 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   store i64 0, i64* %"@x_key"
-  %8 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  store i64 %6, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
+  %8 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
   %9 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/ternary_none.ll
+++ b/tests/codegen/llvm/ternary_none.ll
@@ -3,6 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %printf_t = type { i64 }
 
 ; Function Attrs: nounwind
@@ -11,7 +12,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %perfdata = alloca i64
-  %printf_args = alloca %printf_t
+  %helper_error_t = alloca %helper_error_t
+  %lookup_fmtstr_key = alloca i32
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = lshr i64 %get_pid_tgid, 32
   %2 = icmp ult i64 %1, 10000
@@ -20,32 +22,55 @@ entry:
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
-  %4 = bitcast %printf_t* %printf_args to i8*
+  %4 = bitcast i32* %lookup_fmtstr_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  %5 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %5, i8 0, i64 8, i1 false)
-  %6 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %6
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* %printf_args, i64 8)
-  %7 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  br label %done
+  store i32 0, i32* %lookup_fmtstr_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %5 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = sext %printf_t* %lookup_fmtstr_map to i32
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %helper_merge, label %helper_failure
 
 right:                                            ; preds = %entry
   %8 = bitcast i64* %perfdata to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 30000, i64* %perfdata
-  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id2 = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output3 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, i64*, i64)*)(i8* %0, i64 %pseudo1, i64 %get_cpu_id2, i64* %perfdata, i64 8)
+  %pseudo4 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output5 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, i64*, i64)*)(i8* %0, i64 %pseudo4, i64 4294967295, i64* %perfdata, i64 8)
   %9 = bitcast i64* %perfdata to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   ret i64 0
 
-done:                                             ; preds = %deadcode, %left
+done:                                             ; preds = %deadcode, %helper_merge
   ret i64 0
+
+helper_failure:                                   ; preds = %left
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %11
+  %12 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %12
+  %13 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %6, i32* %13
+  %14 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %14
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %15 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  ret i64 0
+
+helper_merge:                                     ; preds = %left
+  %16 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %16, i8 0, i64 8, i1 false)
+  %17 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, i64* %17
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output3 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo2, i64 4294967295, %printf_t* %lookup_fmtstr_map, i64 8)
+  br label %done
 
 deadcode:                                         ; No predecessors!
   br label %done
@@ -55,10 +80,10 @@ deadcode:                                         ; No predecessors!
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/ternary_str.ll
+++ b/tests/codegen/llvm/ternary_str.ll
@@ -3,70 +3,158 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64
-  %str1 = alloca [64 x i8]
-  %str = alloca [64 x i8]
-  %buf = alloca [64 x i8]
-  %result = alloca [64 x i8]
-  %1 = bitcast [64 x i8]* %result to i8*
+  %helper_error_t15 = alloca %helper_error_t
+  %lookup_str_key10 = alloca i32
+  %helper_error_t7 = alloca %helper_error_t
+  %lookup_str_key2 = alloca i32
+  %helper_error_t = alloca %helper_error_t
+  %lookup_str_key = alloca i32
+  %1 = bitcast i32* %lookup_str_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast [64 x i8]* %buf to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i32 2, i32* %lookup_str_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %lookup_str_map = call [64 x i8]* inttoptr (i64 1 to [64 x i8]* (i64, i32*)*)(i64 %pseudo, i32* %lookup_str_key)
+  %2 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext [64 x i8]* %lookup_str_map to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %helper_merge, label %helper_failure
+
+left:                                             ; preds = %helper_merge
+  %5 = bitcast i32* %lookup_str_key2 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i32 0, i32* %lookup_str_key2
+  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %lookup_str_map4 = call [64 x i8]* inttoptr (i64 1 to [64 x i8]* (i64, i32*)*)(i64 %pseudo3, i32* %lookup_str_key2)
+  %6 = bitcast i32* %lookup_str_key2 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = sext [64 x i8]* %lookup_str_map4 to i32
+  %8 = icmp ne i32 %7, 0
+  br i1 %8, label %helper_merge6, label %helper_failure5
+
+right:                                            ; preds = %helper_merge
+  %9 = bitcast i32* %lookup_str_key10 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i32 1, i32* %lookup_str_key10
+  %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %lookup_str_map12 = call [64 x i8]* inttoptr (i64 1 to [64 x i8]* (i64, i32*)*)(i64 %pseudo11, i32* %lookup_str_key10)
+  %10 = bitcast i32* %lookup_str_key10 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = sext [64 x i8]* %lookup_str_map12 to i32
+  %12 = icmp ne i32 %11, 0
+  br i1 %12, label %helper_merge14, label %helper_failure13
+
+done:                                             ; preds = %helper_merge14, %helper_merge6
+  %13 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  store i64 0, i64* %"@x_key"
+  %pseudo18 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo18, i64* %"@x_key", [64 x i8]* %lookup_str_map, i64 0)
+  %14 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = bitcast [64 x i8]* %lookup_str_map to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  ret i64 0
+
+helper_failure:                                   ; preds = %entry
+  %16 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
+  %17 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %17
+  %18 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %18
+  %19 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %19
+  %20 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %20
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %21 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %22 = bitcast [64 x i8]* %lookup_str_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %22, i8 0, i64 64, i1 false)
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %3 = lshr i64 %get_pid_tgid, 32
-  %4 = icmp ult i64 %3, 10000
-  %5 = zext i1 %4 to i64
-  %true_cond = icmp ne i64 %5, 0
+  %23 = lshr i64 %get_pid_tgid, 32
+  %24 = icmp ult i64 %23, 10000
+  %25 = zext i1 %24 to i64
+  %true_cond = icmp ne i64 %25, 0
   br i1 %true_cond, label %left, label %right
 
-left:                                             ; preds = %entry
-  %6 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  store [64 x i8] c"lo\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str
-  %7 = bitcast [64 x i8]* %buf to i8*
-  %8 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %7, i8* align 1 %8, i64 64, i1 false)
-  br label %done
-
-right:                                            ; preds = %entry
-  %9 = bitcast [64 x i8]* %str1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store [64 x i8] c"hi\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str1
-  %10 = bitcast [64 x i8]* %buf to i8*
-  %11 = bitcast [64 x i8]* %str1 to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %10, i8* align 1 %11, i64 64, i1 false)
-  br label %done
-
-done:                                             ; preds = %right, %left
-  %12 = bitcast [64 x i8]* %str1 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
-  store i64 0, i64* %"@x_key"
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* %"@x_key", [64 x i8]* %buf, i64 0)
-  %15 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
-  %16 = bitcast [64 x i8]* %buf to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+helper_failure5:                                  ; preds = %left
+  %26 = bitcast %helper_error_t* %helper_error_t7 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %26)
+  %27 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t7, i64 0, i32 0
+  store i64 30006, i64* %27
+  %28 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t7, i64 0, i32 1
+  store i64 1, i64* %28
+  %29 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t7, i64 0, i32 2
+  store i32 %7, i32* %29
+  %30 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t7, i64 0, i32 3
+  store i8 1, i8* %30
+  %pseudo8 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %perf_event_output9 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo8, i64 4294967295, %helper_error_t* %helper_error_t7, i64 21)
+  %31 = bitcast %helper_error_t* %helper_error_t7 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %31)
   ret i64 0
+
+helper_merge6:                                    ; preds = %left
+  %32 = bitcast [64 x i8]* %lookup_str_map4 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %32, i8 0, i64 64, i1 false)
+  store [3 x i8] c"lo\00", [64 x i8]* %lookup_str_map4
+  %33 = bitcast [64 x i8]* %lookup_str_map to i8*
+  %34 = bitcast [64 x i8]* %lookup_str_map4 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %33, i8* align 1 %34, i64 64, i1 false)
+  br label %done
+
+helper_failure13:                                 ; preds = %right
+  %35 = bitcast %helper_error_t* %helper_error_t15 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %35)
+  %36 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t15, i64 0, i32 0
+  store i64 30006, i64* %36
+  %37 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t15, i64 0, i32 1
+  store i64 2, i64* %37
+  %38 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t15, i64 0, i32 2
+  store i32 %11, i32* %38
+  %39 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t15, i64 0, i32 3
+  store i8 1, i8* %39
+  %pseudo16 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %perf_event_output17 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo16, i64 4294967295, %helper_error_t* %helper_error_t15, i64 21)
+  %40 = bitcast %helper_error_t* %helper_error_t15 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %40)
+  ret i64 0
+
+helper_merge14:                                   ; preds = %right
+  %41 = bitcast [64 x i8]* %lookup_str_map12 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %41, i8 0, i64 64, i1 false)
+  store [3 x i8] c"hi\00", [64 x i8]* %lookup_str_map12
+  %42 = bitcast [64 x i8]* %lookup_str_map to i8*
+  %43 = bitcast [64 x i8]* %lookup_str_map12 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %42, i8* align 1 %43, i64 64, i1 false)
+  br label %done
 }
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #1
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/tuple.ll
+++ b/tests/codegen/llvm/tuple.ll
@@ -3,6 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %"int64_int64_string[64]__tuple_t" = type <{ i64, i64, [64 x i8] }>
 
 ; Function Attrs: nounwind
@@ -11,7 +12,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %"@t_key" = alloca i64
-  %str = alloca [64 x i8]
+  %helper_error_t = alloca %helper_error_t
+  %lookup_str_key = alloca i32
   %tuple = alloca %"int64_int64_string[64]__tuple_t"
   %1 = bitcast %"int64_int64_string[64]__tuple_t"* %tuple to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -19,24 +21,51 @@ entry:
   store i64 1, i64* %2
   %3 = getelementptr %"int64_int64_string[64]__tuple_t", %"int64_int64_string[64]__tuple_t"* %tuple, i32 0, i32 1
   store i64 2, i64* %3
-  %4 = bitcast [64 x i8]* %str to i8*
+  %4 = bitcast i32* %lookup_str_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  store [64 x i8] c"str\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str
-  %5 = getelementptr %"int64_int64_string[64]__tuple_t", %"int64_int64_string[64]__tuple_t"* %tuple, i32 0, i32 2
-  %6 = bitcast [64 x i8]* %5 to i8*
-  %7 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %6, i8* align 1 %7, i64 64, i1 false)
-  %8 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@t_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i32 0, i32* %lookup_str_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %lookup_str_map = call [64 x i8]* inttoptr (i64 1 to [64 x i8]* (i64, i32*)*)(i64 %pseudo, i32* %lookup_str_key)
+  %5 = bitcast i32* %lookup_str_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = sext [64 x i8]* %lookup_str_map to i32
+  %7 = icmp ne i32 %6, 0
+  br i1 %7, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %8 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %9
+  %10 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %10
+  %11 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %6, i32* %11
+  %12 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %12
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %13 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %14 = bitcast [64 x i8]* %lookup_str_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %14, i8 0, i64 64, i1 false)
+  store [4 x i8] c"str\00", [64 x i8]* %lookup_str_map
+  %15 = getelementptr %"int64_int64_string[64]__tuple_t", %"int64_int64_string[64]__tuple_t"* %tuple, i32 0, i32 2
+  %16 = bitcast [64 x i8]* %15 to i8*
+  %17 = bitcast [64 x i8]* %lookup_str_map to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %16, i8* align 1 %17, i64 64, i1 false)
+  %18 = bitcast i64* %"@t_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
   store i64 0, i64* %"@t_key"
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %"int64_int64_string[64]__tuple_t"*, i64)*)(i64 %pseudo, i64* %"@t_key", %"int64_int64_string[64]__tuple_t"* %tuple, i64 0)
-  %10 = bitcast i64* %"@t_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast %"int64_int64_string[64]__tuple_t"* %tuple to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %"int64_int64_string[64]__tuple_t"*, i64)*)(i64 %pseudo2, i64* %"@t_key", %"int64_int64_string[64]__tuple_t"* %tuple, i64 0)
+  %19 = bitcast i64* %"@t_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  %20 = bitcast %"int64_int64_string[64]__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
   ret i64 0
 }
 
@@ -44,10 +73,13 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #1
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/unroll.ll
+++ b/tests/codegen/llvm/unroll.ll
@@ -8,39 +8,39 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @BEGIN(i8*) section "s_BEGIN_1" {
 entry:
-  %"@i_val56" = alloca i64
-  %"@i_key55" = alloca i64
+  %"@i_key56" = alloca i64
+  %"@i_val55" = alloca i64
   %lookup_elem_val52 = alloca i64
   %"@i_key46" = alloca i64
-  %"@i_val43" = alloca i64
-  %"@i_key42" = alloca i64
+  %"@i_key43" = alloca i64
+  %"@i_val42" = alloca i64
   %lookup_elem_val39 = alloca i64
   %"@i_key33" = alloca i64
-  %"@i_val30" = alloca i64
-  %"@i_key29" = alloca i64
+  %"@i_key30" = alloca i64
+  %"@i_val29" = alloca i64
   %lookup_elem_val26 = alloca i64
   %"@i_key20" = alloca i64
-  %"@i_val17" = alloca i64
-  %"@i_key16" = alloca i64
+  %"@i_key17" = alloca i64
+  %"@i_val16" = alloca i64
   %lookup_elem_val13 = alloca i64
   %"@i_key7" = alloca i64
-  %"@i_val4" = alloca i64
-  %"@i_key3" = alloca i64
+  %"@i_key4" = alloca i64
+  %"@i_val3" = alloca i64
   %lookup_elem_val = alloca i64
   %"@i_key1" = alloca i64
-  %"@i_val" = alloca i64
   %"@i_key" = alloca i64
-  %1 = bitcast i64* %"@i_key" to i8*
+  %"@i_val" = alloca i64
+  %1 = bitcast i64* %"@i_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@i_key"
-  %2 = bitcast i64* %"@i_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 0, i64* %"@i_val"
+  %2 = bitcast i64* %"@i_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@i_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@i_key", i64* %"@i_val", i64 0)
-  %3 = bitcast i64* %"@i_key" to i8*
+  %3 = bitcast i64* %"@i_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@i_val" to i8*
+  %4 = bitcast i64* %"@i_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   %5 = bitcast i64* %"@i_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
@@ -69,17 +69,17 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   %10 = bitcast i64* %"@i_key1" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   %11 = add i64 %8, 1
-  %12 = bitcast i64* %"@i_key3" to i8*
+  %12 = bitcast i64* %"@i_val3" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  store i64 0, i64* %"@i_key3"
-  %13 = bitcast i64* %"@i_val4" to i8*
+  store i64 %11, i64* %"@i_val3"
+  %13 = bitcast i64* %"@i_key4" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  store i64 %11, i64* %"@i_val4"
+  store i64 0, i64* %"@i_key4"
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem6 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo5, i64* %"@i_key3", i64* %"@i_val4", i64 0)
-  %14 = bitcast i64* %"@i_key3" to i8*
+  %update_elem6 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo5, i64* %"@i_key4", i64* %"@i_val3", i64 0)
+  %14 = bitcast i64* %"@i_val3" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@i_val4" to i8*
+  %15 = bitcast i64* %"@i_key4" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
   %16 = bitcast i64* %"@i_key7" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
@@ -108,17 +108,17 @@ lookup_merge12:                                   ; preds = %lookup_failure11, %
   %21 = bitcast i64* %"@i_key7" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
   %22 = add i64 %19, 1
-  %23 = bitcast i64* %"@i_key16" to i8*
+  %23 = bitcast i64* %"@i_val16" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
-  store i64 0, i64* %"@i_key16"
-  %24 = bitcast i64* %"@i_val17" to i8*
+  store i64 %22, i64* %"@i_val16"
+  %24 = bitcast i64* %"@i_key17" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %24)
-  store i64 %22, i64* %"@i_val17"
+  store i64 0, i64* %"@i_key17"
   %pseudo18 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem19 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo18, i64* %"@i_key16", i64* %"@i_val17", i64 0)
-  %25 = bitcast i64* %"@i_key16" to i8*
+  %update_elem19 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo18, i64* %"@i_key17", i64* %"@i_val16", i64 0)
+  %25 = bitcast i64* %"@i_val16" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %25)
-  %26 = bitcast i64* %"@i_val17" to i8*
+  %26 = bitcast i64* %"@i_key17" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %26)
   %27 = bitcast i64* %"@i_key20" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %27)
@@ -147,17 +147,17 @@ lookup_merge25:                                   ; preds = %lookup_failure24, %
   %32 = bitcast i64* %"@i_key20" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %32)
   %33 = add i64 %30, 1
-  %34 = bitcast i64* %"@i_key29" to i8*
+  %34 = bitcast i64* %"@i_val29" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %34)
-  store i64 0, i64* %"@i_key29"
-  %35 = bitcast i64* %"@i_val30" to i8*
+  store i64 %33, i64* %"@i_val29"
+  %35 = bitcast i64* %"@i_key30" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %35)
-  store i64 %33, i64* %"@i_val30"
+  store i64 0, i64* %"@i_key30"
   %pseudo31 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem32 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo31, i64* %"@i_key29", i64* %"@i_val30", i64 0)
-  %36 = bitcast i64* %"@i_key29" to i8*
+  %update_elem32 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo31, i64* %"@i_key30", i64* %"@i_val29", i64 0)
+  %36 = bitcast i64* %"@i_val29" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %36)
-  %37 = bitcast i64* %"@i_val30" to i8*
+  %37 = bitcast i64* %"@i_key30" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %37)
   %38 = bitcast i64* %"@i_key33" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %38)
@@ -186,17 +186,17 @@ lookup_merge38:                                   ; preds = %lookup_failure37, %
   %43 = bitcast i64* %"@i_key33" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %43)
   %44 = add i64 %41, 1
-  %45 = bitcast i64* %"@i_key42" to i8*
+  %45 = bitcast i64* %"@i_val42" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %45)
-  store i64 0, i64* %"@i_key42"
-  %46 = bitcast i64* %"@i_val43" to i8*
+  store i64 %44, i64* %"@i_val42"
+  %46 = bitcast i64* %"@i_key43" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %46)
-  store i64 %44, i64* %"@i_val43"
+  store i64 0, i64* %"@i_key43"
   %pseudo44 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem45 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo44, i64* %"@i_key42", i64* %"@i_val43", i64 0)
-  %47 = bitcast i64* %"@i_key42" to i8*
+  %update_elem45 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo44, i64* %"@i_key43", i64* %"@i_val42", i64 0)
+  %47 = bitcast i64* %"@i_val42" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %47)
-  %48 = bitcast i64* %"@i_val43" to i8*
+  %48 = bitcast i64* %"@i_key43" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %48)
   %49 = bitcast i64* %"@i_key46" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %49)
@@ -225,17 +225,17 @@ lookup_merge51:                                   ; preds = %lookup_failure50, %
   %54 = bitcast i64* %"@i_key46" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %54)
   %55 = add i64 %52, 1
-  %56 = bitcast i64* %"@i_key55" to i8*
+  %56 = bitcast i64* %"@i_val55" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %56)
-  store i64 0, i64* %"@i_key55"
-  %57 = bitcast i64* %"@i_val56" to i8*
+  store i64 %55, i64* %"@i_val55"
+  %57 = bitcast i64* %"@i_key56" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %57)
-  store i64 %55, i64* %"@i_val56"
+  store i64 0, i64* %"@i_key56"
   %pseudo57 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem58 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo57, i64* %"@i_key55", i64* %"@i_val56", i64 0)
-  %58 = bitcast i64* %"@i_key55" to i8*
+  %update_elem58 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo57, i64* %"@i_key56", i64* %"@i_val55", i64 0)
+  %58 = bitcast i64* %"@i_val55" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %58)
-  %59 = bitcast i64* %"@i_val56" to i8*
+  %59 = bitcast i64* %"@i_key56" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %59)
   ret i64 0
 }

--- a/tests/codegen/llvm/variable.ll
+++ b/tests/codegen/llvm/variable.ll
@@ -3,6 +3,8 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
@@ -10,38 +12,64 @@ define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %"@y_key" = alloca i64
   %"@x_key" = alloca i64
-  %"$var" = alloca [16 x i8]
-  %1 = bitcast [16 x i8]* %"$var" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast [16 x i8]* %"$var" to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 16, i1 false)
   %comm = alloca [16 x i8]
-  %3 = bitcast [16 x i8]* %comm to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [16 x i8]* %comm to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 16, i1 false)
-  %get_comm = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* %comm, i64 16)
-  %5 = bitcast [16 x i8]* %"$var" to i8*
+  %helper_error_t = alloca %helper_error_t
+  %"lookup_$var_key" = alloca i32
+  %1 = bitcast i32* %"lookup_$var_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i32 0, i32* %"lookup_$var_key"
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
+  %"lookup_$var_map" = call [16 x i8]* inttoptr (i64 1 to [16 x i8]* (i64, i32*)*)(i64 %pseudo, i32* %"lookup_$var_key")
+  %2 = bitcast i32* %"lookup_$var_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext [16 x i8]* %"lookup_$var_map" to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %5 = bitcast %helper_error_t* %helper_error_t to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = bitcast [16 x i8]* %"$var" to i8*
-  %7 = bitcast [16 x i8]* %comm to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %6, i8* align 1 %7, i64 16, i1 false)
-  %8 = bitcast [16 x i8]* %comm to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store i64 0, i64* %"@x_key"
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [16 x i8]*, i64)*)(i64 %pseudo, i64* %"@x_key", [16 x i8]* %"$var", i64 0)
-  %10 = bitcast i64* %"@x_key" to i8*
+  %6 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %6
+  %7 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %7
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %9
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 4)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %11 = bitcast [16 x i8]* %"lookup_$var_map" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 16, i1 false)
+  %12 = bitcast [16 x i8]* %comm to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %13 = bitcast [16 x i8]* %comm to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %13, i8 0, i64 16, i1 false)
+  %get_comm = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* %comm, i64 16)
+  %14 = bitcast [16 x i8]* %"lookup_$var_map" to i8*
+  %15 = bitcast [16 x i8]* %comm to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %14, i8* align 1 %15, i64 16, i1 false)
+  %16 = bitcast [16 x i8]* %comm to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
+  store i64 0, i64* %"@x_key"
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [16 x i8]*, i64)*)(i64 %pseudo2, i64* %"@x_key", [16 x i8]* %"lookup_$var_map", i64 0)
+  %18 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  %19 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
   store i64 0, i64* %"@y_key"
-  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [16 x i8]*, i64)*)(i64 %pseudo1, i64* %"@y_key", [16 x i8]* %"$var", i64 0)
-  %12 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [16 x i8]*, i64)*)(i64 %pseudo3, i64* %"@y_key", [16 x i8]* %"lookup_$var_map", i64 0)
+  %20 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
   ret i64 0
 }
 
@@ -49,13 +77,13 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #1
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/variable_increment_decrement.ll
+++ b/tests/codegen/llvm/variable_increment_decrement.ll
@@ -3,20 +3,25 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
-%printf_t.2 = type { i64, i64 }
-%printf_t.1 = type { i64, i64 }
-%printf_t.0 = type { i64, i64 }
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %printf_t = type { i64, i64 }
+%printf_t.0 = type { i64, i64 }
+%printf_t.1 = type { i64, i64 }
+%printf_t.2 = type { i64, i64 }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @BEGIN(i8*) section "s_BEGIN_1" {
 entry:
-  %printf_args9 = alloca %printf_t.2
-  %printf_args5 = alloca %printf_t.1
-  %printf_args1 = alloca %printf_t.0
-  %printf_args = alloca %printf_t
+  %helper_error_t29 = alloca %helper_error_t
+  %lookup_fmtstr_key24 = alloca i32
+  %helper_error_t19 = alloca %helper_error_t
+  %lookup_fmtstr_key14 = alloca i32
+  %helper_error_t9 = alloca %helper_error_t
+  %lookup_fmtstr_key4 = alloca i32
+  %helper_error_t = alloca %helper_error_t
+  %lookup_fmtstr_key = alloca i32
   %"$x" = alloca i64
   %1 = bitcast i64* %"$x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -24,70 +29,166 @@ entry:
   %2 = bitcast i64* %"$x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 10, i64* %"$x"
-  %3 = bitcast %printf_t* %printf_args to i8*
+  %3 = bitcast i32* %lookup_fmtstr_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 16, i1 false)
-  %5 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %5
-  %6 = load i64, i64* %"$x"
-  %7 = add i64 %6, 1
-  store i64 %7, i64* %"$x"
-  %8 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %6, i64* %8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* %printf_args, i64 16)
-  %9 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast %printf_t.0* %printf_args1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  %11 = bitcast %printf_t.0* %printf_args1 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 16, i1 false)
-  %12 = getelementptr %printf_t.0, %printf_t.0* %printf_args1, i32 0, i32 0
-  store i64 1, i64* %12
-  %13 = load i64, i64* %"$x"
-  %14 = add i64 %13, 1
-  store i64 %14, i64* %"$x"
-  %15 = getelementptr %printf_t.0, %printf_t.0* %printf_args1, i32 0, i32 1
-  store i64 %14, i64* %15
+  store i32 0, i32* %lookup_fmtstr_key
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %4 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  %5 = sext %printf_t* %lookup_fmtstr_map to i32
+  %6 = icmp ne i32 %5, 0
+  br i1 %6, label %helper_merge, label %helper_failure
+
+helper_failure:                                   ; preds = %entry
+  %7 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %9
+  %10 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %5, i32* %10
+  %11 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %11
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %12 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  ret i64 0
+
+helper_merge:                                     ; preds = %entry
+  %13 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %13, i8 0, i64 16, i1 false)
+  %14 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, i64* %14
+  %15 = load i64, i64* %"$x"
+  %16 = add i64 %15, 1
+  store i64 %16, i64* %"$x"
+  %17 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 1
+  store i64 %15, i64* %17
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id3 = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output4 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.0*, i64)*)(i8* %0, i64 %pseudo2, i64 %get_cpu_id3, %printf_t.0* %printf_args1, i64 16)
-  %16 = bitcast %printf_t.0* %printf_args1 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = bitcast %printf_t.1* %printf_args5 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
-  %18 = bitcast %printf_t.1* %printf_args5 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %18, i8 0, i64 16, i1 false)
-  %19 = getelementptr %printf_t.1, %printf_t.1* %printf_args5, i32 0, i32 0
-  store i64 2, i64* %19
-  %20 = load i64, i64* %"$x"
-  %21 = sub i64 %20, 1
-  store i64 %21, i64* %"$x"
-  %22 = getelementptr %printf_t.1, %printf_t.1* %printf_args5, i32 0, i32 1
-  store i64 %20, i64* %22
-  %pseudo6 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id7 = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output8 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.1*, i64)*)(i8* %0, i64 %pseudo6, i64 %get_cpu_id7, %printf_t.1* %printf_args5, i64 16)
-  %23 = bitcast %printf_t.1* %printf_args5 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
-  %24 = bitcast %printf_t.2* %printf_args9 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %24)
-  %25 = bitcast %printf_t.2* %printf_args9 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %25, i8 0, i64 16, i1 false)
-  %26 = getelementptr %printf_t.2, %printf_t.2* %printf_args9, i32 0, i32 0
-  store i64 3, i64* %26
-  %27 = load i64, i64* %"$x"
-  %28 = sub i64 %27, 1
-  store i64 %28, i64* %"$x"
-  %29 = getelementptr %printf_t.2, %printf_t.2* %printf_args9, i32 0, i32 1
-  store i64 %28, i64* %29
+  %perf_event_output3 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo2, i64 4294967295, %printf_t* %lookup_fmtstr_map, i64 16)
+  %18 = bitcast i32* %lookup_fmtstr_key4 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
+  store i32 0, i32* %lookup_fmtstr_key4
+  %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_fmtstr_map6 = call %printf_t.0* inttoptr (i64 1 to %printf_t.0* (i64, i32*)*)(i64 %pseudo5, i32* %lookup_fmtstr_key4)
+  %19 = bitcast i32* %lookup_fmtstr_key4 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  %20 = sext %printf_t.0* %lookup_fmtstr_map6 to i32
+  %21 = icmp ne i32 %20, 0
+  br i1 %21, label %helper_merge8, label %helper_failure7
+
+helper_failure7:                                  ; preds = %helper_merge
+  %22 = bitcast %helper_error_t* %helper_error_t9 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %22)
+  %23 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t9, i64 0, i32 0
+  store i64 30006, i64* %23
+  %24 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t9, i64 0, i32 1
+  store i64 1, i64* %24
+  %25 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t9, i64 0, i32 2
+  store i32 %20, i32* %25
+  %26 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t9, i64 0, i32 3
+  store i8 1, i8* %26
   %pseudo10 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %get_cpu_id11 = call i64 inttoptr (i64 8 to i64 ()*)()
-  %perf_event_output12 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.2*, i64)*)(i8* %0, i64 %pseudo10, i64 %get_cpu_id11, %printf_t.2* %printf_args9, i64 16)
-  %30 = bitcast %printf_t.2* %printf_args9 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %30)
+  %perf_event_output11 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo10, i64 4294967295, %helper_error_t* %helper_error_t9, i64 21)
+  %27 = bitcast %helper_error_t* %helper_error_t9 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %27)
+  ret i64 0
+
+helper_merge8:                                    ; preds = %helper_merge
+  %28 = bitcast %printf_t.0* %lookup_fmtstr_map6 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %28, i8 0, i64 16, i1 false)
+  %29 = getelementptr %printf_t.0, %printf_t.0* %lookup_fmtstr_map6, i32 0, i32 0
+  store i64 1, i64* %29
+  %30 = load i64, i64* %"$x"
+  %31 = add i64 %30, 1
+  store i64 %31, i64* %"$x"
+  %32 = getelementptr %printf_t.0, %printf_t.0* %lookup_fmtstr_map6, i32 0, i32 1
+  store i64 %31, i64* %32
+  %pseudo12 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output13 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.0*, i64)*)(i8* %0, i64 %pseudo12, i64 4294967295, %printf_t.0* %lookup_fmtstr_map6, i64 16)
+  %33 = bitcast i32* %lookup_fmtstr_key14 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %33)
+  store i32 0, i32* %lookup_fmtstr_key14
+  %pseudo15 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_fmtstr_map16 = call %printf_t.1* inttoptr (i64 1 to %printf_t.1* (i64, i32*)*)(i64 %pseudo15, i32* %lookup_fmtstr_key14)
+  %34 = bitcast i32* %lookup_fmtstr_key14 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %34)
+  %35 = sext %printf_t.1* %lookup_fmtstr_map16 to i32
+  %36 = icmp ne i32 %35, 0
+  br i1 %36, label %helper_merge18, label %helper_failure17
+
+helper_failure17:                                 ; preds = %helper_merge8
+  %37 = bitcast %helper_error_t* %helper_error_t19 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %37)
+  %38 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t19, i64 0, i32 0
+  store i64 30006, i64* %38
+  %39 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t19, i64 0, i32 1
+  store i64 2, i64* %39
+  %40 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t19, i64 0, i32 2
+  store i32 %35, i32* %40
+  %41 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t19, i64 0, i32 3
+  store i8 1, i8* %41
+  %pseudo20 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output21 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo20, i64 4294967295, %helper_error_t* %helper_error_t19, i64 21)
+  %42 = bitcast %helper_error_t* %helper_error_t19 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %42)
+  ret i64 0
+
+helper_merge18:                                   ; preds = %helper_merge8
+  %43 = bitcast %printf_t.1* %lookup_fmtstr_map16 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %43, i8 0, i64 16, i1 false)
+  %44 = getelementptr %printf_t.1, %printf_t.1* %lookup_fmtstr_map16, i32 0, i32 0
+  store i64 2, i64* %44
+  %45 = load i64, i64* %"$x"
+  %46 = sub i64 %45, 1
+  store i64 %46, i64* %"$x"
+  %47 = getelementptr %printf_t.1, %printf_t.1* %lookup_fmtstr_map16, i32 0, i32 1
+  store i64 %45, i64* %47
+  %pseudo22 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output23 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.1*, i64)*)(i8* %0, i64 %pseudo22, i64 4294967295, %printf_t.1* %lookup_fmtstr_map16, i64 16)
+  %48 = bitcast i32* %lookup_fmtstr_key24 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %48)
+  store i32 0, i32* %lookup_fmtstr_key24
+  %pseudo25 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_fmtstr_map26 = call %printf_t.2* inttoptr (i64 1 to %printf_t.2* (i64, i32*)*)(i64 %pseudo25, i32* %lookup_fmtstr_key24)
+  %49 = bitcast i32* %lookup_fmtstr_key24 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %49)
+  %50 = sext %printf_t.2* %lookup_fmtstr_map26 to i32
+  %51 = icmp ne i32 %50, 0
+  br i1 %51, label %helper_merge28, label %helper_failure27
+
+helper_failure27:                                 ; preds = %helper_merge18
+  %52 = bitcast %helper_error_t* %helper_error_t29 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %52)
+  %53 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t29, i64 0, i32 0
+  store i64 30006, i64* %53
+  %54 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t29, i64 0, i32 1
+  store i64 3, i64* %54
+  %55 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t29, i64 0, i32 2
+  store i32 %50, i32* %55
+  %56 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t29, i64 0, i32 3
+  store i8 1, i8* %56
+  %pseudo30 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output31 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo30, i64 4294967295, %helper_error_t* %helper_error_t29, i64 21)
+  %57 = bitcast %helper_error_t* %helper_error_t29 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %57)
+  ret i64 0
+
+helper_merge28:                                   ; preds = %helper_merge18
+  %58 = bitcast %printf_t.2* %lookup_fmtstr_map26 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %58, i8 0, i64 16, i1 false)
+  %59 = getelementptr %printf_t.2, %printf_t.2* %lookup_fmtstr_map26, i32 0, i32 0
+  store i64 3, i64* %59
+  %60 = load i64, i64* %"$x"
+  %61 = sub i64 %60, 1
+  store i64 %61, i64* %"$x"
+  %62 = getelementptr %printf_t.2, %printf_t.2* %lookup_fmtstr_map26, i32 0, i32 1
+  store i64 %61, i64* %62
+  %pseudo32 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output33 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.2*, i64)*)(i8* %0, i64 %pseudo32, i64 4294967295, %printf_t.2* %lookup_fmtstr_map26, i64 16)
   ret i64 0
 }
 
@@ -95,10 +196,10 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
-declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -709,7 +709,7 @@ TEST(semantic_analyser, call_uaddr)
 
 TEST(semantic_analyser, call_cgroupid)
 {
-  // Handle args above STRING_SIZE
+  // Handle args above strlen_
   test("kprobe:f { cgroupid("
        //          1         2         3         4         5         6
        "\"123456789/123456789/123456789/123456789/123456789/123456789/12345\""


### PR DESCRIPTION
I've iterated on https://github.com/iovisor/bpftrace/pull/1357 based on review feedback.

Resolves https://github.com/iovisor/bpftrace/issues/305.

Incorporates @mmarchini's RFC https://github.com/iovisor/bpftrace/pull/750.

The design is a lot simpler now. We allocate a per-CPU array map, big enough for your largest string. str() probe-reads strings into this map. Then, printf() probe-reads strings out of that map into its own map, which is submitted as a perf event.

Compared to the previous proposal: this design does not have the data race and coordination with userspace, nor does it introduce a "different" string structure, so should interoperate better with the existing string functions.

I found that I had to change printf()'s argvalue memcpy() into a probe_read(). We may find other interoperability problems like that between string functions, but they're easily solved.