### PR TITLE
Fix printing Type::array

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -28,7 +28,7 @@ std::ostream &operator<<(std::ostream &os, const SizedType &type)
   }
   else if (type.IsArrayTy())
   {
-    os << type.GetElementTy() << "[" << type.GetNumElements() << "]";
+    os << *type.GetElementTy() << "[" << type.GetNumElements() << "]";
   }
   else if (type.IsStringTy() || type.IsBufferTy())
   {


### PR DESCRIPTION
GetElementTy() returns a pointer so we need to deref. We don't expect
GetElementTy() to return null b/c an array type should have the element
type set.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
