### PR TITLE
Fix calling ntop on tracepoint args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ and this project adheres to
   - [#1341](https://github.com/iovisor/bpftrace/pull/1341)
 - Fix `KBUILD_MODNAME`
   - [#1352](https://github.com/iovisor/bpftrace/pull/1352)
+- Fix `ntop()` not accepting tracepoint arguments
+  - [#1365](https://github.com/iovisor/bpftrace/pull/1365)
 
 #### Tools
 

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -702,7 +702,7 @@ void CodegenLLVM::visit(Call &call)
     b_.CREATE_MEMSET(inet_offset, b_.getInt8(0), 16, 1);
 
     inet->accept(*this);
-    if (inet->type.IsArrayTy())
+    if (inet->type.IsArray())
     {
       b_.CreateProbeRead(ctx_,
                          static_cast<AllocaInst *>(inet_offset),

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -624,7 +624,7 @@ void SemanticAnalyser::visit(Call &call)
       check_arg(call, Type::integer, 0);
     }
 
-    if (!arg->type.IsIntTy() && !arg->type.IsArrayTy())
+    if (!arg->type.IsIntTy() && !arg->type.IsArray())
       ERR(call.func << "() expects an integer or array argument, got "
                     << arg->type.type,
           call.loc);
@@ -641,16 +641,9 @@ void SemanticAnalyser::visit(Call &call)
     int buffer_size = 24;
     auto type = arg->type;
 
-    // Ensure u8 array of either 4 or 16 elements
-    if (type.IsArrayTy())
-    {
-      if (!(type.GetElementTy()->IsIntTy() &&
-            type.GetElementTy()->GetIntBitWidth() == 8 &&
-            (type.GetNumElements() == 4 || type.GetNumElements() == 16)))
-      {
-        error(call.func + "() invalid array", call.loc);
-      }
-    }
+    if (arg->type.IsArray() && type.size != 4 && type.size != 16)
+      error(call.func + "() argument must be 4 or 16 bytes in size", call.loc);
+
     call.type = CreateInet(buffer_size);
   }
   else if (call.func == "join") {

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -76,6 +76,16 @@ void setup_mock_bpftrace(MockBPFtrace &bpftrace)
                       .bitfield = {},
                   } } },
   };
+  bpftrace.structs_["struct _tracepoint_tcp_some_tcp_tp"] = Struct{
+    .size = 16,
+    .fields = { { "saddr_v6",
+                  Field{
+                      .type = CreateArray(16, CreateUInt(8)),
+                      .offset = 0,
+                      .is_bitfield = false,
+                      .bitfield = {},
+                  } } },
+  };
 
   auto ptr_type = CreateUInt64();
   ptr_type.is_pointer = true;

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -22,3 +22,9 @@ NAME modulo_operator
 RUN bpftrace -v -e 'BEGIN { @x = 4; printf("%d\n", @x % 2) }'
 EXPECT 0
 TIMEOUT 5
+
+NAME ntop_tracepoint_args
+RUN bpftrace -v -e 'tracepoint:tcp:tcp_destroy_sock { printf("%s\n", ntop(args->daddr)); exit(); }'
+EXPECT [0-9]+.[0-9]+.[0-9]+.[0-9]+
+AFTER curl www.google.com &> /dev/null
+TIMEOUT 5

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -590,6 +590,9 @@ TEST(semantic_analyser, call_ntop)
   test(structs + "kprobe:f { @x = ntop(((struct inet*)0)->ipv4); }", 0);
   test(structs + "kprobe:f { @x = ntop(((struct inet*)0)->ipv6); }", 0);
 
+  // Regression test that ntop can use arguments from the prog context
+  test("tracepoint:tcp:some_tcp_tp { ntop(args->saddr_v6); }", 0);
+
   test("kprobe:f { ntop(); }", 1);
   test("kprobe:f { ntop(2, \"hello\"); }", 1);
   test("kprobe:f { ntop(\"hello\"); }", 1);


### PR DESCRIPTION
Commit f05b4cda691e82ab ("Introduce Type::ctx") introduced a `ctx` type
for values that come from the bpf prog context. This subtly broke ntop()
because ntop was not yet aware of Type::ctx.

Fix this by relaxing semantic analyser check to include Type::ctx.
Similarly relax for codegen.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
