### PR TITLE
usdt: Decrement usdt semaphore value during probe detach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ and this project adheres to
   - [#1365](https://github.com/iovisor/bpftrace/pull/1365)
 - Fix attaching to usdt probes in multiple binaries
   - [#1356](https://github.com/iovisor/bpftrace/pull/1356)
+- Decrement usdt semaphore count after bpftrace execution
+  - [#1370](https://github.com/iovisor/bpftrace/pull/1370)
 
 #### Tools
 

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <string>
 #include <tuple>
 #include <vector>
@@ -52,6 +53,7 @@ private:
 #ifdef HAVE_BCC_KFUNC
   int tracing_fd_ = -1;
 #endif
+  std::function<void()> usdt_destructor_;
 };
 
 } // namespace bpftrace


### PR DESCRIPTION
Before, I think we were intentionally leaking the bcc usdt context so
that usdt semaphore values would not go back to zero. Reason is that
bcc_usdt_close() decrements usdt semaphore value.

However, this causes issues if we don't eventually decrement the counter
as the tracee will forever be on more expensive code paths.

This commit defers semaphore decrement until probe is detached.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
