### PR TITLE
CI: Fix IRC notification on build failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,8 @@ jobs:
   irc:
     # Notify IRC of build failures on pushes only if we are running from
     # the main repo. We don't want this rule to trigger from forked repos.
+    needs:
+      - build_test
     if: "failure() && github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository == 'iovisor/bpftrace'"
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
I think to prevent job `irc` from being skipped you need to specify the
dependency.

See
https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idneeds

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
