### PR TITLE
CI: Don't use TLS for irc notifications

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,8 @@ jobs:
       with:
         nickname: bpftrace-ci-bot
         server: irc.oftc.net
+        port: 6667
+        tls: false
         channel: "#bpftrace"
         message: |
           master is BROKEN at https://github.com/iovisor/bpftrace/commit/${{github.sha}}


### PR DESCRIPTION
I think TLS support from notify-irc is kinda broken.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
