### PR TITLE
Syscall generator, for issue#1334

### DIFF
--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -114,7 +114,7 @@ EXPECT 10 12 12 10
 TIMEOUT 1
 
 NAME spawn child
-RUN bpftrace -e 'i:ms:500 { printf("%d\n", cpid); }' -c './testprogs/syscall nanosleep 1000000000'
+RUN bpftrace -e 'i:ms:500 { printf("%d\n", cpid); }' -c './testprogs/syscall nanosleep 1e9'
 EXPECT [0-9]+
 TIMEOUT 1
 

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -114,7 +114,7 @@ EXPECT 10 12 12 10
 TIMEOUT 1
 
 NAME spawn child
-RUN bpftrace -e 'i:ms:500 { printf("%d\n", cpid); }' -c '/bin/sleep 1'
+RUN bpftrace -e 'i:ms:500 { printf("%d\n", cpid); }' -c './testprogs/syscall nanosleep 1000000000'
 EXPECT [0-9]+
 TIMEOUT 1
 

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -104,13 +104,13 @@ NAME probe
 RUN bpftrace -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n", probe); exit(); }'
 EXPECT SUCCESS probe kprobe:do_nanosleep
 TIMEOUT 5
-AFTER ./testprogs/syscall nanosleep 100000000
+AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME begin probe
 RUN bpftrace -e 'BEGIN { printf("%s", probe);exit(); } END{printf("-%s\n", probe); }'
 EXPECT ^BEGIN-END$
 TIMEOUT 5
-AFTER ./testprogs/syscall nanosleep 100000000
+AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME curtask
 RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", curtask); exit(); }'

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -104,13 +104,13 @@ NAME probe
 RUN bpftrace -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n", probe); exit(); }'
 EXPECT SUCCESS probe kprobe:do_nanosleep
 TIMEOUT 5
-AFTER sleep 0.1
+AFTER ./testprogs/syscall nanosleep 100000000
 
 NAME begin probe
 RUN bpftrace -e 'BEGIN { printf("%s", probe);exit(); } END{printf("-%s\n", probe); }'
 EXPECT ^BEGIN-END$
 TIMEOUT 5
-AFTER sleep 0.1
+AFTER ./testprogs/syscall nanosleep 100000000
 
 NAME curtask
 RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", curtask); exit(); }'

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -96,43 +96,43 @@ NAME sum
 RUN bpftrace -v -e 'kprobe:vfs_read { @bytes[comm] = sum(arg2); exit();}'
 EXPECT @.*\[.*\]\:\s[0-9]*
 TIMEOUT 5
-AFTER cat /dev/null
+AFTER ./testprogs/syscall read
 
 NAME avg
 RUN bpftrace -v -e 'kprobe:vfs_read { @bytes[comm] = avg(arg2); exit();}'
 EXPECT @.*\[.*\]\:\s[0-9]*
 TIMEOUT 5
-AFTER cat /dev/null
+AFTER ./testprogs/syscall read
 
 NAME min
 RUN bpftrace -v -e 'kprobe:vfs_read { @bytes[comm] = min(arg2); exit();}'
 EXPECT @.*\[.*\]\:\s[0-9]*
 TIMEOUT 5
-AFTER cat /dev/null
+AFTER ./testprogs/syscall read
 
 NAME max
 RUN bpftrace -v -e 'kprobe:vfs_read { @bytes[comm] = max(arg2); exit();}'
 EXPECT @.*\[.*\]\:\s[0-9]*
-AFTER cat /dev/null
+AFTER ./testprogs/syscall read
 TIMEOUT 5
 
 NAME stats
 RUN bpftrace -v -e 'kprobe:vfs_read { @bytes[comm] = stats(arg2); exit();}'
 EXPECT @.*\[.*\]\:\scount\s[0-9]*\,\saverage\s[0-9]*\,\stotal\s[0-9]*
 TIMEOUT 5
-AFTER cat /dev/null
+AFTER ./testprogs/syscall read
 
 NAME hist
 RUN bpftrace -v -e 'kretprobe:vfs_read { @bytes = hist(retval); exit();}'
 EXPECT @bytes: *\n[\[(].*
-AFTER cat /dev/null
+AFTER ./testprogs/syscall read
 TIMEOUT 5
 
 NAME lhist
 RUN bpftrace -v -e 'kretprobe:vfs_read { @bytes = lhist(retval, 0, 10000, 1000); exit()}'
 EXPECT @bytes: *\n[\[(].*
 TIMEOUT 5
-AFTER cat /dev/null
+AFTER ./testprogs/syscall read
 
 NAME kstack
 RUN bpftrace -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n%s\n", kstack(), kstack(1)); exit(); }'

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -35,7 +35,7 @@ TIMEOUT 5
 
 NAME str
 RUN bpftrace -v -e 't:syscalls:sys_enter_execve { printf("P: %s\n", str(args->filename)); exit();}'
-AFTER ls
+AFTER ./testprogs/syscall execve /bin/ls
 EXPECT P: /*.
 TIMEOUT 5
 

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -59,28 +59,28 @@ RUN bpftrace -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("ip"))); exit(
 EXPECT do_nanosleep
 TIMEOUT 5
 ARCH x86_64
-AFTER ./testprogs/syscall nanosleep 100000000
+AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME ksym
 RUN bpftrace -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("pswaddr"))); exit();}'
 EXPECT do_nanosleep
 TIMEOUT 5
 ARCH s390x
-AFTER ./testprogs/syscall nanosleep 100000000
+AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME ksym
 RUN bpftrace -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("pc"))); exit();}'
 EXPECT do_nanosleep
 TIMEOUT 5
 ARCH aarch64
-AFTER ./testprogs/syscall nanosleep 100000000
+AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME ksym
 RUN bpftrace -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("nip"))); exit();}'
 EXPECT do_nanosleep
 TIMEOUT 5
 ARCH ppc64|ppc64le
-AFTER ./testprogs/syscall nanosleep 100000000
+AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME system
 RUN bpftrace --unsafe -v -e 'i:ms:100 { system("echo 'ok_system'"); exit();}'
@@ -138,13 +138,13 @@ NAME kstack
 RUN bpftrace -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n%s\n", kstack(), kstack(1)); exit(); }'
 EXPECT SUCCESS kstack
 TIMEOUT 5
-AFTER ./testprogs/syscall nanosleep 100000000
+AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME ustack
 RUN bpftrace -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n%s\n", ustack(), ustack(1)); exit(); }'
 EXPECT SUCCESS ustack
 TIMEOUT 5
-AFTER ./testprogs/syscall nanosleep 100000000
+AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME cat
 RUN bpftrace -v -e 'i:ms:1 { cat("/proc/uptime"); exit();}'

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -59,28 +59,28 @@ RUN bpftrace -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("ip"))); exit(
 EXPECT do_nanosleep
 TIMEOUT 5
 ARCH x86_64
-AFTER sleep 0.1
+AFTER ./testprogs/syscall nanosleep 100000000
 
 NAME ksym
 RUN bpftrace -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("pswaddr"))); exit();}'
 EXPECT do_nanosleep
 TIMEOUT 5
 ARCH s390x
-AFTER sleep 0.1
+AFTER ./testprogs/syscall nanosleep 100000000
 
 NAME ksym
 RUN bpftrace -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("pc"))); exit();}'
 EXPECT do_nanosleep
 TIMEOUT 5
 ARCH aarch64
-AFTER sleep 0.1
+AFTER ./testprogs/syscall nanosleep 100000000
 
 NAME ksym
 RUN bpftrace -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("nip"))); exit();}'
 EXPECT do_nanosleep
 TIMEOUT 5
 ARCH ppc64|ppc64le
-AFTER sleep 0.1
+AFTER ./testprogs/syscall nanosleep 100000000
 
 NAME system
 RUN bpftrace --unsafe -v -e 'i:ms:100 { system("echo 'ok_system'"); exit();}'
@@ -138,13 +138,13 @@ NAME kstack
 RUN bpftrace -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n%s\n", kstack(), kstack(1)); exit(); }'
 EXPECT SUCCESS kstack
 TIMEOUT 5
-AFTER sleep 0.1
+AFTER ./testprogs/syscall nanosleep 100000000
 
 NAME ustack
 RUN bpftrace -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n%s\n", ustack(), ustack(1)); exit(); }'
 EXPECT SUCCESS ustack
 TIMEOUT 5
-AFTER sleep 0.1
+AFTER ./testprogs/syscall nanosleep 100000000
 
 NAME cat
 RUN bpftrace -v -e 'i:ms:1 { cat("/proc/uptime"); exit();}'

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -74,7 +74,7 @@ EXPECT ^{"type": "syscall", "data": "a b c\\n"}$
 TIMEOUT 5
 
 NAME join_delim
-RUN bpftrace --unsafe -f json -e 'tracepoint:syscalls:sys_enter_execve { join(args->argv, ","); exit(); }' -c "/bin/echo 'A'"
+RUN bpftrace --unsafe -f json -e 'tracepoint:syscalls:sys_enter_execve { join(args->argv, ","); }' -c "./testprogs/syscall execve /bin/echo 'A'"
 EXPECT ^{"type": "join", "data": "/bin/echo,'A'"}
 TIMEOUT 5
 

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -167,7 +167,7 @@ NAME sigint under heavy load
 RUN bpftrace --unsafe -v -e 'tracepoint:sched:sched_switch { system("echo foo"); } END { printf("end"); }'
 EXPECT end
 TIMEOUT 5
-AFTER  ./testprogs/syscall nanosleep 2000000000; pkill -SIGINT bpftrace
+AFTER  ./testprogs/syscall nanosleep 2e9; pkill -SIGINT bpftrace
 
 NAME bitfield access
 RUN bpftrace -v -e 'struct Foo { unsigned int a:4, b:8, c:3, d:1, e:16; } uprobe:./testprogs/bitfield_test:func{ $foo = (struct Foo *)arg0; printf("%d %d %d %d %d\n", $foo->a, $foo->b, $foo->c, $foo->d, $foo->e); exit()}'

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -99,8 +99,8 @@ EXPECT hello world
 TIMEOUT 1
 
 NAME string compare map lookup
-RUN bpftrace -v -e 't:syscalls:sys_enter_openat /comm == "cat"/ { @[comm] = 1; }' -c "/bin/cat /dev/null"
-EXPECT @\[cat\]: 1
+RUN bpftrace -v -e 't:syscalls:sys_enter_openat /comm == "syscall"/ { @[comm] = 1; }' -c "./testprogs/syscall openat"
+EXPECT @\[syscall\]: 1
 TIMEOUT 5
 
 NAME struct partial string compare - pass

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -167,7 +167,7 @@ NAME sigint under heavy load
 RUN bpftrace --unsafe -v -e 'tracepoint:sched:sched_switch { system("echo foo"); } END { printf("end"); }'
 EXPECT end
 TIMEOUT 5
-AFTER  sleep 2; pkill -SIGINT bpftrace
+AFTER  ./testprogs/syscall nanosleep 2000000000; pkill -SIGINT bpftrace
 
 NAME bitfield access
 RUN bpftrace -v -e 'struct Foo { unsigned int a:4, b:8, c:3, d:1, e:16; } uprobe:./testprogs/bitfield_test:func{ $foo = (struct Foo *)arg0; printf("%d %d %d %d %d\n", $foo->a, $foo->b, $foo->c, $foo->d, $foo->e); exit()}'

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -99,23 +99,23 @@ AFTER /bin/bash -c "echo lala"; /bin/bash -c "echo lala"
 NAME tracepoint
 RUN bpftrace -v -e 'tracepoint:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", gid); exit(); }'
 EXPECT SUCCESS tracepoint [0-9][0-9]*
-AFTER ./testprogs/syscall nanosleep 100000000
+AFTER ./testprogs/syscall nanosleep 1e8
 TIMEOUT 5
 
 NAME tracepoint_short_name
 RUN bpftrace -v -e 't:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", gid); exit(); }'
 EXPECT SUCCESS tracepoint_short_name [0-9][0-9]*
-AFTER ./testprogs/syscall nanosleep 100000000
+AFTER ./testprogs/syscall nanosleep 1e8
 TIMEOUT 5
 
 NAME tracepoint_order
 RUN bpftrace -v runtime/scripts/tracepoint_order.bt
 EXPECT first second
 TIMEOUT 5
-AFTER ./testprogs/syscall nanosleep 100000000; ./testprogs/syscall nanosleep 100000000
+AFTER ./testprogs/syscall nanosleep 1e8; ./testprogs/syscall nanosleep 1e8
 
 NAME tracepoint_expansion
-RUN bpftrace -v -e 'tracepoint:syscalls:sys_*_nanosleep { printf("hit "); }' -c "./testprogs/syscall nanosleep 100000000"
+RUN bpftrace -v -e 'tracepoint:syscalls:sys_*_nanosleep { printf("hit "); }' -c "./testprogs/syscall nanosleep 1e8"
 EXPECT hit hit
 TIMEOUT 5
 

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -17,7 +17,7 @@ NAME kprobe_order
 RUN bpftrace -v runtime/scripts/kprobe_order.bt
 EXPECT first second
 TIMEOUT 5
-AFTER /bin/bash -c "sleep 1e-6"; /bin/bash -c "sleep 1e-6"
+AFTER /bin/bash -c "./testprogs/syscall nanosleep 1000"; /bin/bash -c "./testprogs/syscall nanosleep 1000"
 
 NAME kprobe_offset
 RUN bpftrace -v -e 'kprobe:vfs_read+0 { printf("SUCCESS '$test' %d\n", pid); exit(); }'
@@ -48,7 +48,7 @@ NAME kretprobe_order
 RUN bpftrace -v runtime/scripts/kretprobe_order.bt
 EXPECT first second
 TIMEOUT 5
-AFTER /bin/bash -c "sleep 1e-6"; /bin/bash -c "sleep 1e-6"
+AFTER /bin/bash -c "./testprogs/syscall nanosleep 1000"; /bin/bash -c "./testprogs/syscall nanosleep 1000"
 
 NAME uprobe
 RUN bpftrace -v -e 'uprobe:/bin/bash:echo_builtin { printf("arg0: %d\n", arg0); exit();}'
@@ -99,23 +99,23 @@ AFTER /bin/bash -c "echo lala"; /bin/bash -c "echo lala"
 NAME tracepoint
 RUN bpftrace -v -e 'tracepoint:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", gid); exit(); }'
 EXPECT SUCCESS tracepoint [0-9][0-9]*
-AFTER sleep 0.1
+AFTER ./testprogs/syscall nanosleep 100000000
 TIMEOUT 5
 
 NAME tracepoint_short_name
 RUN bpftrace -v -e 't:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", gid); exit(); }'
 EXPECT SUCCESS tracepoint_short_name [0-9][0-9]*
-AFTER sleep 0.1
+AFTER ./testprogs/syscall nanosleep 100000000
 TIMEOUT 5
 
 NAME tracepoint_order
 RUN bpftrace -v runtime/scripts/tracepoint_order.bt
 EXPECT first second
 TIMEOUT 5
-AFTER sleep 0.1; sleep 0.1
+AFTER ./testprogs/syscall nanosleep 100000000; ./testprogs/syscall nanosleep 100000000
 
 NAME tracepoint_expansion
-RUN bpftrace -v -e 'tracepoint:syscalls:sys_*_nanosleep { printf("hit "); }' -c "/bin/sleep 0.1"
+RUN bpftrace -v -e 'tracepoint:syscalls:sys_*_nanosleep { printf("hit "); }' -c "./testprogs/syscall nanosleep 100000000"
 EXPECT hit hit
 TIMEOUT 5
 

--- a/tests/runtime/sigint
+++ b/tests/runtime/sigint
@@ -1,9 +1,9 @@
 NAME strace no quit
-RUN bpftrace -v -e 'i:s:1 { printf("%s %d\n", "SUCCESS", 1); exit() }' & (./testprogs/syscall nanosleep  500000000 && strace -p $! -o /dev/null)
+RUN bpftrace -v -e 'i:s:1 { printf("%s %d\n", "SUCCESS", 1); exit() }' & (./testprogs/syscall nanosleep 5e8 && strace -p $! -o /dev/null)
 EXPECT SUCCESS 1
 TIMEOUT 3
 
 NAME sigint quit
-RUN bpftrace -v -e 'END { printf("%s %d", "SUCCESS", 1) }' & (./testprogs/syscall nanosleep 1000000000 && /usr/bin/env kill -s SIGINT $!)
+RUN bpftrace -v -e 'END { printf("%s %d", "SUCCESS", 1) }' & (./testprogs/syscall nanosleep 1e9 && /usr/bin/env kill -s SIGINT $!)
 EXPECT ^SUCCESS 1$
 TIMEOUT 2

--- a/tests/runtime/sigint
+++ b/tests/runtime/sigint
@@ -1,9 +1,9 @@
 NAME strace no quit
-RUN bpftrace -v -e 'i:s:1 { printf("%s %d\n", "SUCCESS", 1); exit() }' & (sleep 0.5 && strace -p $! -o /dev/null)
+RUN bpftrace -v -e 'i:s:1 { printf("%s %d\n", "SUCCESS", 1); exit() }' & (./testprogs/syscall nanosleep  500000000 && strace -p $! -o /dev/null)
 EXPECT SUCCESS 1
 TIMEOUT 3
 
 NAME sigint quit
-RUN bpftrace -v -e 'END { printf("%s %d", "SUCCESS", 1) }' & (sleep 1 && /usr/bin/env kill -s SIGINT $!)
+RUN bpftrace -v -e 'END { printf("%s %d", "SUCCESS", 1) }' & (./testprogs/syscall nanosleep 1000000000 && /usr/bin/env kill -s SIGINT $!)
 EXPECT ^SUCCESS 1$
 TIMEOUT 2

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -37,13 +37,13 @@ NAME global_associative_arrays
 RUN bpftrace -v -e 'k:vfs_read { @start[tid] = nsecs; } kretprobe:vfs_read /@start[tid] != 0/ { printf("slept for %d ms\n", (nsecs - @start[tid]) / 1000000); delete(@start[tid]); exit();}'
 EXPECT slept for [0-9]+ ms
 TIMEOUT 5
-AFTER cat /dev/null
+AFTER ./testprogs/syscall read
 
 NAME scratch
 RUN bpftrace -v -e 'k:vfs_read { @start[tid] = nsecs; } kretprobe:vfs_read /@start[tid] != 0/ { $delta = nsecs - @start[tid]; printf("slept for %d ms\n", $delta / 1000000); delete(@start[tid]); exit(); }'
 EXPECT slept for [0-9]* ms
 TIMEOUT 5
-AFTER cat /dev/null
+AFTER ./testprogs/syscall read
 
 NAME 32-bit tracepoint arg
 RUN bpftrace -v -e 'tracepoint:random:urandom_read { $i = args->got_bits; printf("bits: %d\n", $i); if ($i == 24) { exit() } }'

--- a/tests/testprogs/syscall.c
+++ b/tests/testprogs/syscall.c
@@ -7,7 +7,7 @@
 #include <stdlib.h>
 #include <fcntl.h>
 
-#define MAX_NAME_LENGTH 50
+#define FILE_NAME_LENGTH 50
 #define TEMP_FILE_NAME "RUNTIME_TEST_SYSCALL_GEN_TEMP"
 
 void usage() {
@@ -17,6 +17,7 @@ void usage() {
     printf("\t nanosleep [$N] (default args: 100ns)\n");
     printf("\t open\n");
     printf("\t openat\n");
+    printf("\t read\n");
 }
 
 int main(int argc, char *argv[]) {
@@ -52,7 +53,7 @@ int main(int argc, char *argv[]) {
             printf("Error in syscall %s: %d\n", syscall_name, errno);
     }
 
-    else if (strcmp("open", syscall_name) || strcmp("openat", syscall_name)){
+    else if (strcmp("open", syscall_name) == 0 || strcmp("openat", syscall_name) == 0) {
         //char *file_name = tempnam("./", TEMP_FILE_NAME);
         const char *file_name = TEMP_FILE_NAME;
         if (file_name == NULL) {
@@ -64,6 +65,20 @@ int main(int argc, char *argv[]) {
             printf("Error in syscall %s: %d\n", syscall_name, errno);
             exit(0);
         }
+        close(fd);
+        remove(file_name);
+    }
+
+    else if (strcmp("read", syscall_name) == 0) {
+        char file_name[FILE_NAME_LENGTH];
+        strncpy(file_name, "TEMP_FILE_SYS_READ_XXXXXX", FILE_NAME_LENGTH - 1);
+        int fd = mkstemp(file_name);
+        if (fd < 0) {
+            printf("Error in syscall %s when creating temp file: %d\n", syscall_name, errno);
+            exit(0);
+        }
+        char buf[10];
+        int r = syscall(SYS_read, fd, (void *)buf, 0);
         close(fd);
         remove(file_name);
     }

--- a/tests/testprogs/syscall.c
+++ b/tests/testprogs/syscall.c
@@ -9,9 +9,6 @@
 #include <time.h>
 #include <unistd.h>
 
-#define FILE_NAME_LENGTH 50
-#define MAX_ARG_LENGTH 20
-
 void usage()
 {
   printf("Usage:\n");
@@ -45,11 +42,6 @@ void gen_nanosleep(int argc, char *argv[])
     if (tail != '\0')
     {
       printf("Argument '%s' should only contain numerial charactors\n", arg);
-      exit(1);
-    }
-    if (time < 0)
-    {
-      printf("Invalid argument '%s', the argument should be non negative", arg);
       exit(1);
     }
     // if time is less than 1 nsec, round up to 1 nsec, as with sleep command

--- a/tests/testprogs/syscall.c
+++ b/tests/testprogs/syscall.c
@@ -1,87 +1,138 @@
-#include <stdio.h>
-#include <sys/syscall.h>
-#include <unistd.h>
-#include <time.h>
+#include <ctype.h>
 #include <errno.h>
-#include <string.h>
-#include <stdlib.h>
 #include <fcntl.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/syscall.h>
+#include <time.h>
+#include <unistd.h>
 
 #define FILE_NAME_LENGTH 50
-#define TEMP_FILE_NAME "RUNTIME_TEST_SYSCALL_GEN_TEMP"
+#define MAX_ARG_LENGTH 20
 
-void usage() {
-    printf("Usage:\n");
-    printf("\t./syscall <syscall name> [<arguments>]\n");
-    printf("Supported Syscalls:\n");
-    printf("\t nanosleep [$N] (default args: 100ns)\n");
-    printf("\t open\n");
-    printf("\t openat\n");
-    printf("\t read\n");
+void usage()
+{
+  printf("Usage:\n");
+  printf("\t./syscall <syscall name> [<arguments>]\n");
+  printf("Supported Syscalls:\n");
+  printf("\t nanosleep [$N] (default args: 100ns)\n");
+  printf("\t open\n");
+  printf("\t openat\n");
+  printf("\t read\n");
 }
 
-int main(int argc, char *argv[]) {
-    if (argc < 2) {
-        usage();
-        exit(0);
+void gen_nanosleep(int argc, char *argv[])
+{
+  struct timespec req;
+  const char *arg = argv[2];
+  req.tv_sec = 0;
+  req.tv_nsec = 100;
+  if (argc > 2)
+  {
+    if (!isdigit(*arg) || !isdigit(arg[strlen(arg) - 1]))
+    {
+      printf("Invalid argument: %s; the argument should be a non-negative "
+             "number with no sign\n",
+             arg);
+      return;
     }
-    const char *syscall_name = argv[1];
-    int r;
-
-    if (strcmp("nanosleep", syscall_name) == 0) {
-        struct timespec req;
-        const char * arg = argv[2];
-        req.tv_sec = 0;
-        req.tv_nsec = 100;
-        if (argc > 2) {
-            long long n = atoll(arg);
-            if (n == 0 && arg[strspn(arg, "0")] != '\0') {
-                printf("Cannot convert argument '%s' to a number.\n", arg);
-                exit(0);
-            }
-
-            if (n < 0) {
-                printf("Invalid argument '%s', argument should not be negative", arg);
-                exit(0);
-            }
-
-            req.tv_sec = n / 1000000000;
-            req.tv_nsec = n % 1000000000;
-        }
-        r = syscall(SYS_nanosleep, &req, NULL);
-        if (r)
-            printf("Error in syscall %s: %d\n", syscall_name, errno);
+    double time;
+    char tail = '\0';
+    sscanf(arg, "%le%c", &time, &tail);
+    if (tail != '\0')
+    {
+      printf("Argument '%s' should only contain numerial charactors.\n", arg);
+      return;
     }
-
-    else if (strcmp("open", syscall_name) == 0 || strcmp("openat", syscall_name) == 0) {
-        //char *file_name = tempnam("./", TEMP_FILE_NAME);
-        const char *file_name = TEMP_FILE_NAME;
-        if (file_name == NULL) {
-            printf("Error when getting file name: %d\n", errno);
-            exit(0);
-        }
-        int fd = strcmp("open", syscall_name) ? syscall(SYS_openat, AT_FDCWD, file_name, O_CREAT) : syscall(SYS_open, file_name, O_CREAT);
-        if (fd < 0) {
-            printf("Error in syscall %s: %d\n", syscall_name, errno);
-            exit(0);
-        }
-        close(fd);
-        remove(file_name);
+    if (time < 0)
+    {
+      printf("Invalid argument '%s', the argument should not be negative", arg);
+      return;
     }
-
-    else if (strcmp("read", syscall_name) == 0) {
-        char file_name[FILE_NAME_LENGTH];
-        strncpy(file_name, "TEMP_FILE_SYS_READ_XXXXXX", FILE_NAME_LENGTH - 1);
-        int fd = mkstemp(file_name);
-        if (fd < 0) {
-            printf("Error in syscall %s when creating temp file: %d\n", syscall_name, errno);
-            exit(0);
-        }
-        char buf[10];
-        int r = syscall(SYS_read, fd, (void *)buf, 0);
-        close(fd);
-        remove(file_name);
+    // if time is less than 1 nsec, round up to 1 nsec, as with sleep command
+    if (time > 0 && time < 1)
+    {
+      time = 1;
     }
+    req.tv_sec = (int)(time / 1e9);
+    req.tv_nsec = (int)(time - req.tv_sec * 1e9);
+  }
+  int r = syscall(SYS_nanosleep, &req, NULL);
+  if (r)
+    perror("Error in syscall nanosleep");
+}
 
+void gen_open_openat(bool is_sys_open)
+{
+  const char *file_path = "/tmp/bpftrace_runtime_test_syscall_gen_open_temp";
+  int fd = is_sys_open ? syscall(SYS_open, file_path, O_CREAT)
+                       : syscall(SYS_openat, AT_FDCWD, file_path, O_CREAT);
+  if (fd < 0)
+  {
+    perror("Error in syscall open/openat");
+    return;
+  }
+  close(fd);
+  remove(file_path);
+}
+
+void gen_read()
+{
+  const char *file_path = "/tmp/bpftrace_runtime_test_syscall_gen_read_temp";
+  int fd = open(file_path, O_CREAT);
+  if (fd < 0)
+  {
+    perror("Error in syscall read when creating temp file");
+    return;
+  }
+  char buf[10];
+  int r = syscall(SYS_read, fd, (void *)buf, 0);
+  if (r < 0)
+  {
+    perror("Error in syscall read");
+  }
+  close(fd);
+  remove(file_path);
+}
+
+int main(int argc, char *argv[])
+{
+  if (argc < 2)
+  {
+    usage();
     return 0;
+  }
+  const char *syscall_name = argv[1];
+  bool is_sys_open = false;
+
+  if (strcmp("--help", syscall_name) == 0 || strcmp("-h", syscall_name) == 0)
+  {
+    usage();
+  }
+  else if (strcmp("nanosleep", syscall_name) == 0)
+  {
+    gen_nanosleep(argc, argv);
+  }
+  else if ((is_sys_open = (strcmp("open", syscall_name) == 0)) ||
+           strcmp("openat", syscall_name) == 0)
+  {
+    gen_open_openat(is_sys_open);
+  }
+  else if (strcmp("read", syscall_name) == 0)
+  {
+    gen_read();
+  }
+  else if (strcmp("nop", syscall_name) == 0)
+  {
+    // do nothing
+  }
+  else
+  {
+    printf("%s is not supported yet\n", syscall_name);
+    usage();
+  }
+
+  return 0;
 }

--- a/tests/testprogs/syscall.c
+++ b/tests/testprogs/syscall.c
@@ -1,0 +1,72 @@
+#include <stdio.h>
+#include <sys/syscall.h>
+#include <unistd.h>
+#include <time.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+#include <fcntl.h>
+
+#define MAX_NAME_LENGTH 50
+#define TEMP_FILE_NAME "RUNTIME_TEST_SYSCALL_GEN_TEMP"
+
+void usage() {
+    printf("Usage:\n");
+    printf("\t./syscall <syscall name> [<arguments>]\n");
+    printf("Supported Syscalls:\n");
+    printf("\t nanosleep [$N] (default args: 100ns)\n");
+    printf("\t open\n");
+    printf("\t openat\n");
+}
+
+int main(int argc, char *argv[]) {
+    if (argc < 2) {
+        usage();
+        exit(0);
+    }
+    const char *syscall_name = argv[1];
+    int r;
+
+    if (strcmp("nanosleep", syscall_name) == 0) {
+        struct timespec req;
+        const char * arg = argv[2];
+        req.tv_sec = 0;
+        req.tv_nsec = 100;
+        if (argc > 2) {
+            long long n = atoll(arg);
+            if (n == 0 && arg[strspn(arg, "0")] != '\0') {
+                printf("Cannot convert argument '%s' to a number.\n", arg);
+                exit(0);
+            }
+
+            if (n < 0) {
+                printf("Invalid argument '%s', argument should not be negative", arg);
+                exit(0);
+            }
+
+            req.tv_sec = n / 1000000000;
+            req.tv_nsec = n % 1000000000;
+        }
+        r = syscall(SYS_nanosleep, &req, NULL);
+        if (r)
+            printf("Error in syscall %s: %d\n", syscall_name, errno);
+    }
+
+    else if (strcmp("open", syscall_name) || strcmp("openat", syscall_name)){
+        //char *file_name = tempnam("./", TEMP_FILE_NAME);
+        const char *file_name = TEMP_FILE_NAME;
+        if (file_name == NULL) {
+            printf("Error when getting file name: %d\n", errno);
+            exit(0);
+        }
+        int fd = strcmp("open", syscall_name) ? syscall(SYS_openat, AT_FDCWD, file_name, O_CREAT) : syscall(SYS_open, file_name, O_CREAT);
+        if (fd < 0) {
+            printf("Error in syscall %s: %d\n", syscall_name, errno);
+            exit(0);
+        }
+        close(fd);
+        remove(file_name);
+    }
+
+    return 0;
+}

--- a/tests/testprogs/syscall.c
+++ b/tests/testprogs/syscall.c
@@ -18,7 +18,7 @@ void usage()
   printf("\t open\n");
   printf("\t openat\n");
   printf("\t read\n");
-  printf("\t execve <path> [<argument>] (allows at most 1 argument for now)\n");
+  printf("\t execve <path> [<arguments>] (at most 128 arguments)\n");
 }
 
 int gen_nanosleep(int argc, char *argv[])
@@ -127,11 +127,18 @@ int gen_execve(int argc, char *argv[])
     printf("Indicate which process to execute.\n");
     return 1;
   }
-  char *newargv[] = { argv[2], NULL, NULL };
+  char *newargv[129] = { NULL };
   char *newenv[] = { NULL };
-  if (argc > 3)
+  newargv[0] = argv[2];
+  int arg_nm = argc - 3;
+  if (arg_nm > 128)
   {
-    newargv[1] = argv[3];
+    printf("Too many arguments: at most 128 arguments, %d given\n", arg_nm);
+    return 1;
+  }
+  for (int i = 0; i < argc; ++i)
+  {
+    newargv[1 + i] = argv[3 + i];
   }
   syscall(SYS_execve, argv[2], newargv, newenv);
   // execve returns on error


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->
This patch aims to replace the external tools which are used in runtime tests to trigger syscalls. It can generate sys_nanosleep, sys_open, sys_openat, sys_read and sys_execve.

There are two reasons why it is important not to rely on external tools to trigger syscalls. The first is that some tools are not always available on some systems. And the other is that, the tools don't essentially work to generate certain syscalls. It would be more portable if we can have an program working to provide these syscalls.
##### Checklist
- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
