### PR TITLE
Add time units for `interval` probe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to
   - [#1340](https://github.com/iovisor/bpftrace/pull/1340)
 - Add libbpf build into in --info
   - [#1367](https://github.com/iovisor/bpftrace/pull/1367)
+- Add support for time units `us` and `hz` for probe `interval`
+  - [#1377](https://github.com/iovisor/bpftrace/pull/1377)
 
 #### Changed
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1297,6 +1297,8 @@ Syntax:
 ```
 interval:ms:rate
 interval:s:rate
+interval:us:rate
+interval:hz:rate
 ```
 
 This fires on one CPU only, and can be used for generating per-interval output.

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -2035,7 +2035,9 @@ void SemanticAnalyser::visit(AttachPoint &ap)
     if (ap.target == "")
       error("interval probe must have unit of time", ap.loc);
     else if (ap.target != "ms" &&
-             ap.target != "s")
+             ap.target != "s" &&
+             ap.target != "us" &&
+             ap.target != "hz")
       error(ap.target + " is not an accepted unit of time", ap.loc);
     if (ap.func != "")
       error("interval probe must have an integer frequency", ap.loc);

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -2034,9 +2034,7 @@ void SemanticAnalyser::visit(AttachPoint &ap)
   else if (ap.provider == "interval") {
     if (ap.target == "")
       error("interval probe must have unit of time", ap.loc);
-    else if (ap.target != "ms" &&
-             ap.target != "s" &&
-             ap.target != "us" &&
+    else if (ap.target != "ms" && ap.target != "s" && ap.target != "us" &&
              ap.target != "hz")
       error(ap.target + " is not an accepted unit of time", ap.loc);
     if (ap.func != "")

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -916,14 +916,26 @@ void AttachedProbe::attach_interval()
   int group_fd = -1;
   int cpu = 0;
 
-  uint64_t period;
+  uint64_t period, freq;
   if (probe_.path == "s")
   {
     period = probe_.freq * 1e9;
+    freq = 0;
   }
   else if (probe_.path == "ms")
   {
     period = probe_.freq * 1e6;
+    freq = 0;
+  }
+  else if (probe_.path == "us")
+  {
+    period = probe_.freq * 1e3;
+    freq = 0;
+  }
+  else if (probe_.path == "hz")
+  {
+    period = 0;
+    freq = probe_.freq;
   }
   else
   {
@@ -932,7 +944,7 @@ void AttachedProbe::attach_interval()
   }
 
   int perf_event_fd = bpf_attach_perf_event(progfd_, PERF_TYPE_SOFTWARE,
-      PERF_COUNT_SW_CPU_CLOCK, period, 0, pid, cpu, group_fd);
+      PERF_COUNT_SW_CPU_CLOCK, period, freq, pid, cpu, group_fd);
 
   if (perf_event_fd < 0)
     throw std::runtime_error("Error attaching probe: " + probe_.name);

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -943,8 +943,14 @@ void AttachedProbe::attach_interval()
     abort();
   }
 
-  int perf_event_fd = bpf_attach_perf_event(progfd_, PERF_TYPE_SOFTWARE,
-      PERF_COUNT_SW_CPU_CLOCK, period, freq, pid, cpu, group_fd);
+  int perf_event_fd = bpf_attach_perf_event(progfd_,
+                                            PERF_TYPE_SOFTWARE,
+                                            PERF_COUNT_SW_CPU_CLOCK,
+                                            period,
+                                            freq,
+                                            pid,
+                                            cpu,
+                                            group_fd);
 
   if (perf_event_fd < 0)
     throw std::runtime_error("Error attaching probe: " + probe_.name);

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -916,25 +916,21 @@ void AttachedProbe::attach_interval()
   int group_fd = -1;
   int cpu = 0;
 
-  uint64_t period, freq;
+  uint64_t period = 0, freq = 0;
   if (probe_.path == "s")
   {
     period = probe_.freq * 1e9;
-    freq = 0;
   }
   else if (probe_.path == "ms")
   {
     period = probe_.freq * 1e6;
-    freq = 0;
   }
   else if (probe_.path == "us")
   {
     period = probe_.freq * 1e3;
-    freq = 0;
   }
   else if (probe_.path == "hz")
   {
-    period = 0;
     freq = probe_.freq;
   }
   else

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1096,6 +1096,15 @@ TEST(semantic_analyser, profile)
   test("profile:unit:100 { 1 }", 1);
 }
 
+TEST(semantic_analyser, interval)
+{
+  test("interval:hz:997 { 1 }", 0);
+  test("interval:s:10 { 1 }", 0);
+  test("interval:ms:100 { 1 }", 0);
+  test("interval:us:100 { 1 }", 0);
+  test("interval:unit:100 { 1 }", 1);
+}
+
 TEST(semantic_analyser, variable_cast_types)
 {
   std::string structs = "struct type1 { int field; } struct type2 { int field; }";


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->
This patch adds support for new time units `us` and `hz` for probe `interval`.

Such changes make the time units of `interval` consistent with those of `profile`. To address [#issue1335](https://github.com/iovisor/bpftrace/issues/1335)

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
