### PR TITLE
syncsnoop: trace sync_file_range2 when needed

### DIFF
--- a/tools/syncsnoop.bt
+++ b/tools/syncsnoop.bt
@@ -25,7 +25,7 @@ tracepoint:syscalls:sys_enter_sync,
 tracepoint:syscalls:sys_enter_syncfs,
 tracepoint:syscalls:sys_enter_fsync,
 tracepoint:syscalls:sys_enter_fdatasync,
-tracepoint:syscalls:sys_enter_sync_file_range,
+tracepoint:syscalls:sys_enter_sync_file_range*,
 tracepoint:syscalls:sys_enter_msync
 {
 	time("%H:%M:%S  ");


### PR DESCRIPTION
Some architecture like ppc64, don't use sync_file_range but
sync_file_range2. We can use a wildcard to get them both cover.

Fixes the following error:

$ /usr/share/bpftrace/tools/syncsnoop.bt
Attaching 7 probes...
open(/sys/kernel/debug/tracing/events/syscalls/sys_enter_sync_file_range/id): No such file or directory
Error attaching probe: tracepoint:syscalls:sys_enter_sync_file_range

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
