### PR TITLE
Disable reg() for kfunc

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -670,8 +670,11 @@ void SemanticAnalyser::visit(Call &call)
     if (check_nargs(call, 1)) {
       for (auto &attach_point : *probe_->attach_points) {
         ProbeType type = probetype(attach_point->provider);
-        if (type == ProbeType::tracepoint) {
-          error("The reg function cannot be used with 'tracepoint' probes",
+        if (type == ProbeType::tracepoint || type == ProbeType::kfunc ||
+            type == ProbeType::kretfunc)
+        {
+          error("The reg function cannot be used with '" +
+                    attach_point->provider + "' probes",
                 call.loc);
           continue;
         }

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -666,6 +666,7 @@ TEST(semantic_analyser, call_reg)
   test("kprobe:f { reg(\"blah\"); }", 1);
   test("kprobe:f { reg(); }", 1);
   test("kprobe:f { reg(123); }", 1);
+  test("tracepoint:category:event { reg(\"ip\") }", 1);
 }
 
 TEST(semantic_analyser, call_func)
@@ -1773,6 +1774,8 @@ TEST_F(semantic_analyser_btf, kfunc)
   test("kfunc:func_1 { $x = args->a; $y = args->foo1; }", 0);
   test("kretfunc:func_1 { $x = retval; }", 0);
   test("kretfunc:func_1 { $x = args->foo; }", 1);
+  test("kfunc:func_1 { reg(\"ip\") }", 1);
+  test("kretfunc:func_1 { reg(\"ip\") }", 1);
 }
 
 TEST_F(semantic_analyser_btf, short_name)


### PR DESCRIPTION
"reg()" is not usable in kfunc since its context data does not contain
struct pt_regs. Disable it in the semantic analyzer.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
