### PR TITLE
Support non-map print()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to
   - [#1367](https://github.com/iovisor/bpftrace/pull/1367)
 - Add support for time units `us` and `hz` for probe `interval`
   - [#1377](https://github.com/iovisor/bpftrace/pull/1377)
+- Add support for non-map print()
+  - [#1381](https://github.com/iovisor/bpftrace/pull/1381)
 
 #### Changed
 

--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -31,6 +31,23 @@ struct Print
   }
 } __attribute__((packed));
 
+struct PrintNonMap
+{
+  uint64_t action_id;
+  uint64_t print_id;
+  // See below why we don't use a flexible length array
+  uint8_t content[0];
+
+  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b, size_t size)
+  {
+    return {
+      b.getInt64Ty(),                            // asyncid
+      b.getInt64Ty(),                            // print id
+      llvm::ArrayType::get(b.getInt8Ty(), size), // content
+    };
+  }
+} __attribute__((packed));
+
 struct MapEvent
 {
   uint64_t action_id;

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -71,6 +71,7 @@ public:
   void createFormatStringCall(Call &call, int &id, CallArgs &call_args,
                               const std::string &call_name, AsyncAction async_action);
   void createPrintMapCall(Call &call);
+  void createPrintNonMapCall(Call &call, int &id);
   std::unique_ptr<BpfOrc> compile(DebugLevel debug=DebugLevel::kNone, std::ostream &out=std::cout);
 
 private:
@@ -103,6 +104,7 @@ private:
   int cat_id_ = 0;
   uint64_t join_id_ = 0;
   int system_id_ = 0;
+  int non_map_print_id_ = 0;
 
   size_t getStructSize(StructType *s)
   {

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -70,6 +70,7 @@ public:
   void createLinearFunction();
   void createFormatStringCall(Call &call, int &id, CallArgs &call_args,
                               const std::string &call_name, AsyncAction async_action);
+  void createPrintMapCall(Call &call);
   std::unique_ptr<BpfOrc> compile(DebugLevel debug=DebugLevel::kNone, std::ostream &out=std::cout);
 
 private:

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -478,6 +478,19 @@ void perf_event_printer(void *cb_cookie, void *data, int size __attribute__((unu
                                "\", err=" + std::to_string(err));
     return;
   }
+  else if (printf_id == asyncactionint(AsyncAction::print_non_map))
+  {
+    auto print = static_cast<AsyncEvent::PrintNonMap *>(data);
+    const SizedType &ty = bpftrace->non_map_print_args_.at(print->print_id);
+
+    std::vector<uint8_t> bytes;
+    for (size_t i = 0; i < ty.size; ++i)
+      bytes.emplace_back(reinterpret_cast<uint8_t>(print->content[i]));
+
+    bpftrace->out_->value(*bpftrace, ty, bytes);
+
+    return;
+  }
   else if (printf_id == asyncactionint(AsyncAction::clear))
   {
     auto mapevent = static_cast<AsyncEvent::MapEvent *>(data);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -154,6 +154,7 @@ public:
   std::vector<std::string> join_args_;
   std::vector<std::string> time_args_;
   std::vector<std::tuple<std::string, std::vector<Field>>> cat_args_;
+  std::vector<SizedType> non_map_print_args_;
   std::unordered_map<int64_t, struct HelperErrorInfo> helper_error_info_;
   std::unordered_map<StackType, std::unique_ptr<IMap>> stackid_maps_;
   std::unique_ptr<IMap> join_map_;

--- a/src/output.h
+++ b/src/output.h
@@ -11,8 +11,10 @@ namespace bpftrace {
 
 enum class MessageType
 {
-  // don't forget to update std::ostream& operator<<(std::ostream& out, MessageType type) in output.cpp
+  // don't forget to update std::ostream& operator<<(std::ostream& out,
+  // MessageType type) in output.cpp
   map,
+  value,
   hist,
   stats,
   printf,
@@ -44,6 +46,9 @@ public:
   virtual void map_stats(BPFtrace &bpftrace, IMap &map,
                          const std::map<std::vector<uint8_t>, std::vector<int64_t>> &values_by_key,
                          const std::vector<std::pair<std::vector<uint8_t>, int64_t>> &total_counts_by_key) const = 0;
+  virtual void value(BPFtrace &bpftrace,
+                     const SizedType &ty,
+                     const std::vector<uint8_t> &value) const = 0;
 
   virtual void message(MessageType type, const std::string& msg, bool nl = true) const = 0;
   virtual void lost_events(uint64_t lost) const = 0;
@@ -68,6 +73,9 @@ public:
   void map_stats(BPFtrace &bpftrace, IMap &map,
                  const std::map<std::vector<uint8_t>, std::vector<int64_t>> &values_by_key,
                  const std::vector<std::pair<std::vector<uint8_t>, int64_t>> &total_counts_by_key) const override;
+  virtual void value(BPFtrace &bpftrace,
+                     const SizedType &ty,
+                     const std::vector<uint8_t> &value) const override;
 
   void message(MessageType type, const std::string& msg, bool nl = true) const override;
   void lost_events(uint64_t lost) const override;
@@ -95,6 +103,9 @@ public:
   void map_stats(BPFtrace &bpftrace, IMap &map,
                  const std::map<std::vector<uint8_t>, std::vector<int64_t>> &values_by_key,
                  const std::vector<std::pair<std::vector<uint8_t>, int64_t>> &total_counts_by_key) const override;
+  virtual void value(BPFtrace &bpftrace,
+                     const SizedType &ty,
+                     const std::vector<uint8_t> &value) const override;
 
   void message(MessageType type, const std::string& msg, bool nl = true) const override;
   void message(MessageType type, const std::string& field, uint64_t value) const;

--- a/src/types.h
+++ b/src/types.h
@@ -392,6 +392,7 @@ enum class AsyncAction
   time,
   join,
   helper_error,
+  print_non_map,
   // clang-format on
 };
 

--- a/src/types.h
+++ b/src/types.h
@@ -114,6 +114,13 @@ public:
   bool operator==(const SizedType &t) const;
   bool operator!=(const SizedType &t) const;
 
+  bool IsPrintableTy()
+  {
+    return type != Type::none && type != Type::cast && type != Type::ctx &&
+           type != Type::stack_mode && type != Type::array &&
+           type != Type::record;
+  }
+
   bool IsSigned(void) const;
 
   size_t GetIntBitWidth() const

--- a/tests/codegen/call_print_non_map.cpp
+++ b/tests/codegen/call_print_non_map.cpp
@@ -1,0 +1,16 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, call_print_non_map)
+{
+  test(R"_(k:f { print(3) })_",
+
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/call_print_non_map.ll
+++ b/tests/codegen/llvm/call_print_non_map.ll
@@ -1,0 +1,36 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%print_integer_8_t = type <{ i64, i64, [8 x i8] }>
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
+entry:
+  %print_integer_8_t = alloca %print_integer_8_t, align 8
+  %1 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  %2 = getelementptr inbounds %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 0
+  store i64 30007, i64* %2, align 8
+  %3 = getelementptr inbounds %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 1
+  %4 = getelementptr inbounds %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 2
+  store i64 0, i64* %3, align 8
+  store i64 3, [8 x i8]* %4, align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %print_integer_8_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %print_integer_8_t* nonnull %print_integer_8_t, i64 24)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -165,3 +165,18 @@ NAME usym
 RUN bpftrace -e 'i:ms:100 { @=usym(1); @a=@; exit(); }'
 EXPECT ^@a: 0x1$
 TIMEOUT 5
+
+NAME print_non_map
+RUN bpftrace -e 'BEGIN { $x = 5; print($x); exit() }'
+EXPECT 5
+TIMEOUT 1
+
+NAME print_non_map_builtin
+RUN bpftrace -e 'BEGIN { print(comm); exit() }'
+EXPECT bpftrace
+TIMEOUT 1
+
+NAME print_non_map_tuple
+RUN bpftrace -e 'BEGIN { $t = (1, 2, "string"); print($t); exit() }'
+EXPECT (1, 2, string)
+TIMEOUT 1

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -89,3 +89,18 @@ NAME tuple
 RUN bpftrace -f json -e 'BEGIN { @ = (1, 2, "string", (4, 5)); exit(); }'
 EXPECT ^{"type": "map", "data": {"@": \[1,2,"string",\[4,5\]\]}}$
 TIMEOUT 5
+
+NAME print_non_map
+RUN bpftrace -f json -e 'BEGIN { $x = 5; print($x); exit() }'
+EXPECT ^{"type": "value", "data": 5}$
+TIMEOUT 1
+
+NAME print_non_map_builtin
+RUN bpftrace -f json -e 'BEGIN { print(comm); exit() }'
+EXPECT ^{"type": "value", "data": "bpftrace"}$
+TIMEOUT 1
+
+NAME print_non_map_tuple
+RUN bpftrace -f json -e 'BEGIN { $t = (1, 2, "string"); print($t); exit() }'
+EXPECT ^{"type": "value", "data": \[1,2,"string"\]}$
+TIMEOUT 1

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -463,6 +463,25 @@ TEST(semantic_analyser, call_print)
   test("kprobe:f { @x = count(); print(@x) ? 0 : 1; }", 10);
 }
 
+TEST(semantic_analyser, call_print_non_map)
+{
+  test(R"_(BEGIN { print(1) })_", 0);
+  test(R"_(BEGIN { print(comm) })_", 0);
+  test(R"_(BEGIN { print(nsecs) })_", 0);
+  test(R"_(BEGIN { print("string") })_", 0);
+  test(R"_(BEGIN { print((1, 2, "tuple")) })_", 0);
+  test(R"_(BEGIN { $x = 1; print($x) })_", 0);
+  test(R"_(BEGIN { $x = 1; $y = $x + 3; print($y) })_", 0);
+
+  test(R"_(BEGIN { print(3, 5) })_", 1);
+  test(R"_(BEGIN { print(3, 5, 2) })_", 1);
+
+  test(R"_(BEGIN { print(exit()) })_", 10);
+  test(R"_(BEGIN { print(count()) })_", 1);
+  test(R"_(BEGIN { print(ctx) })_", 10);
+  test(R"_(BEGIN { print((int8 *)0) })_", 10);
+}
+
 TEST(semantic_analyser, call_clear)
 {
   test("kprobe:f { @x = count(); clear(@x); }", 0);


### PR DESCRIPTION
This implements non-map prints as described in #356.

Note that non-map `print()`s are synchronous, meaning they do not
work the same as map `print()`s. I think this is a pretty nice feature.

Example:
```
# bpftrace -e 'BEGIN { $t = (1, "string"); print(123); print($t); print(comm) }'
Attaching 1 probe...
123
(1, string)
bpftrace
^C
```
We have a growing number of types in the type system so I may have
missed a corner case somewhere. I think I got most of it right, though.

This closes #356.

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
