### PR TITLE
Remove registers that are not in struct pt_regs (x86-64)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ and this project adheres to
   - [#1370](https://github.com/iovisor/bpftrace/pull/1370)
 - Reduce high memory consumption when using usdt semaphore
   - [#1374](https://github.com/iovisor/bpftrace/pull/1374)
+- Remove registers that are not in struct pt_regs (x86-64)
+  - [#1383](https://github.com/iovisor/bpftrace/issues/1383)
 
 #### Tools
 

--- a/src/arch/x86_64.cpp
+++ b/src/arch/x86_64.cpp
@@ -32,12 +32,6 @@ static std::array<std::string, 27> registers = {
   "flags",
   "sp",
   "ss",
-  "fs_base",
-  "gs_base",
-  "ds",
-  "es",
-  "fs",
-  "gs",
 };
 
 static std::array<std::string, 6> arg_registers = {


### PR DESCRIPTION
cf. [x86-64 struct pt_regs](https://github.com/torvalds/linux/blob/master/arch/x86/include/uapi/asm/ptrace.h).

Fix the following errors.

```
% ./src/bpftrace -e 'k:f {  printf("%d\n", reg("fs_base")); }'
Attaching 1 probe...
Error loading program: kprobe:f (try -v)
```

```
% sudo ./src/bpftrace -e 'i:s:1 {  printf("%d, %d\n", reg("fs_base"), ctx->sample_period); }'
Attaching 1 probe...
1000000000, 1000000000
^C
```

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
