### PR TITLE
codegen: Introduce safer accept()

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -241,7 +241,11 @@ void CodegenLLVM::visit(Builtin &builtin)
     dyn_cast<LoadInst>(expr_)->setVolatile(true);
 
     if (builtin.type.IsUsymTy())
+    {
       expr_ = b_.CreateUSym(expr_);
+      Value *expr = expr_;
+      expr_deleter_ = [this, expr]() { b_.CreateLifetimeEnd(expr); };
+    }
   }
   else if (!builtin.ident.compare(0, 4, "sarg") && builtin.ident.size() == 5 &&
       builtin.ident.at(4) >= '0' && builtin.ident.at(4) <= '9')
@@ -326,7 +330,7 @@ void CodegenLLVM::visit(Call &call)
     Value *oldval = b_.CreateMapLookupElem(ctx_, map, key, call.loc);
     AllocaInst *newval = b_.CreateAllocaBPF(map.type, map.ident + "_val");
 
-    call.vargs->front()->accept(*this);
+    auto scoped_del = accept(call.vargs->front());
     // promote int to 64-bit
     expr_ = b_.CreateIntCast(expr_,
                              b_.getInt64Ty(),
@@ -349,7 +353,7 @@ void CodegenLLVM::visit(Call &call)
     // Store the max of (0xffffffff - val), so that our SGE comparison with uninitialized
     // elements will always store on the first occurrence. Revent this later when printing.
     Function *parent = b_.GetInsertBlock()->getParent();
-    call.vargs->front()->accept(*this);
+    auto scoped_del = accept(call.vargs->front());
     // promote int to 64-bit
     expr_ = b_.CreateIntCast(expr_,
                              b_.getInt64Ty(),
@@ -377,7 +381,7 @@ void CodegenLLVM::visit(Call &call)
     AllocaInst *newval = b_.CreateAllocaBPF(map.type, map.ident + "_val");
 
     Function *parent = b_.GetInsertBlock()->getParent();
-    call.vargs->front()->accept(*this);
+    auto scoped_del = accept(call.vargs->front());
     // promote int to 64-bit
     expr_ = b_.CreateIntCast(expr_,
                              b_.getInt64Ty(),
@@ -413,7 +417,7 @@ void CodegenLLVM::visit(Call &call)
     AllocaInst *total_key = getHistMapKey(map, b_.getInt64(1));
     Value *total_old = b_.CreateMapLookupElem(ctx_, map, total_key, call.loc);
     AllocaInst *total_new = b_.CreateAllocaBPF(map.type, map.ident + "_val");
-    call.vargs->front()->accept(*this);
+    auto scoped_del = accept(call.vargs->front());
     // promote int to 64-bit
     expr_ = b_.CreateIntCast(expr_,
                              b_.getInt64Ty(),
@@ -431,7 +435,7 @@ void CodegenLLVM::visit(Call &call)
       log2_func_ = createLog2Function();
 
     Map &map = *call.map;
-    call.vargs->front()->accept(*this);
+    auto scoped_del = accept(call.vargs->front());
     // promote int to 64-bit
     expr_ = b_.CreateIntCast(expr_,
                              b_.getInt64Ty(),
@@ -455,21 +459,21 @@ void CodegenLLVM::visit(Call &call)
       linear_func_ = createLinearFunction();
 
     Map &map = *call.map;
-    call.vargs->front()->accept(*this);
+    auto scoped_del = accept(call.vargs->front());
 
     // prepare arguments
-    Integer &value_arg = static_cast<Integer&>(*call.vargs->at(0));
-    Integer &min_arg = static_cast<Integer&>(*call.vargs->at(1));
-    Integer &max_arg = static_cast<Integer&>(*call.vargs->at(2));
-    Integer &step_arg = static_cast<Integer&>(*call.vargs->at(3));
+    Integer *value_arg = static_cast<Integer *>(call.vargs->at(0));
+    Integer *min_arg = static_cast<Integer *>(call.vargs->at(1));
+    Integer *max_arg = static_cast<Integer *>(call.vargs->at(2));
+    Integer *step_arg = static_cast<Integer *>(call.vargs->at(3));
     Value *value, *min, *max, *step;
-    value_arg.accept(*this);
+    auto scoped_del_value_arg = accept(value_arg);
     value = expr_;
-    min_arg.accept(*this);
+    auto scoped_del_min_arg = accept(min_arg);
     min = expr_;
-    max_arg.accept(*this);
+    auto scoped_del_max_arg = accept(max_arg);
     max = expr_;
-    step_arg.accept(*this);
+    auto scoped_del_step_arg = accept(step_arg);
     step = expr_;
 
     // promote int to 64-bit
@@ -510,7 +514,7 @@ void CodegenLLVM::visit(Call &call)
     AllocaInst *strlen = b_.CreateAllocaBPF(b_.getInt64Ty(), "strlen");
     b_.CREATE_MEMSET(strlen, b_.getInt8(0), sizeof(uint64_t), 1);
     if (call.vargs->size() > 1) {
-      call.vargs->at(1)->accept(*this);
+      auto scoped_del = accept(call.vargs->at(1));
       Value *proposed_strlen = b_.CreateAdd(expr_, b_.getInt64(1)); // add 1 to accommodate probe_read_str's null byte
 
       // largest read we'll allow = our global string buffer size
@@ -527,7 +531,7 @@ void CodegenLLVM::visit(Call &call)
     }
     AllocaInst *buf = b_.CreateAllocaBPF(bpftrace_.strlen_, "str");
     b_.CREATE_MEMSET(buf, b_.getInt8(0), bpftrace_.strlen_, 1);
-    call.vargs->front()->accept(*this);
+    auto scoped_del = accept(call.vargs->front());
     b_.CreateProbeReadStr(ctx_, buf, b_.CreateLoad(strlen), expr_, call.loc);
     b_.CreateLifetimeEnd(strlen);
 
@@ -543,7 +547,7 @@ void CodegenLLVM::visit(Call &call)
     if (call.vargs->size() > 1)
     {
       auto &arg = *call.vargs->at(1);
-      arg.accept(*this);
+      auto scoped_del = accept(&arg);
 
       Value *proposed_length = expr_;
       Value *cmp = b_.CreateICmp(
@@ -582,7 +586,7 @@ void CodegenLLVM::visit(Call &call)
                      fixed_buffer_length,
                      1);
 
-    call.vargs->front()->accept(*this);
+    auto scoped_del = accept(call.vargs->front());
     b_.CreateProbeRead(ctx_,
                        static_cast<AllocaInst *>(buf_data_offset),
                        length,
@@ -619,7 +623,7 @@ void CodegenLLVM::visit(Call &call)
   }
   else if (call.func == "join")
   {
-    call.vargs->front()->accept(*this);
+    auto scoped_del = accept(call.vargs->front());
     AllocaInst *first = b_.CreateAllocaBPF(b_.getInt64Ty(),
                                            call.func + "_first");
     AllocaInst *second = b_.CreateAllocaBPF(b_.getInt64Ty(),
@@ -685,11 +689,11 @@ void CodegenLLVM::visit(Call &call)
   else if (call.func == "ksym")
   {
     // We want expr_ to just pass through from the child node - don't set it here
-    call.vargs->front()->accept(*this);
+    auto scoped_del = accept(call.vargs->front());
   }
   else if (call.func == "usym")
   {
-    call.vargs->front()->accept(*this);
+    auto scoped_del = accept(call.vargs->front());
     expr_ = b_.CreateUSym(expr_);
   }
   else if (call.func == "ntop")
@@ -726,7 +730,7 @@ void CodegenLLVM::visit(Call &call)
     else
     {
       inet = call.vargs->at(1);
-      call.vargs->at(0)->accept(*this);
+      auto scoped_del = accept(call.vargs->at(0));
       af_type = b_.CreateIntCast(expr_, b_.getInt64Ty(), true);
     }
     b_.CreateStore(af_type, af_offset);
@@ -734,7 +738,7 @@ void CodegenLLVM::visit(Call &call)
     Value *inet_offset = b_.CreateGEP(buf, {b_.getInt32(0), b_.getInt32(1)});
     b_.CREATE_MEMSET(inet_offset, b_.getInt8(0), 16, 1);
 
-    inet->accept(*this);
+    auto scoped_del = accept(inet);
     if (inet->type.IsArray())
     {
       b_.CreateProbeRead(ctx_,
@@ -873,13 +877,11 @@ void CodegenLLVM::visit(Call &call)
     b_.CreateStore(b_.GetIntSameSize(strftime_id_, elements.at(0)),
                    b_.CreateGEP(buf, { b_.getInt64(0), b_.getInt32(0) }));
     strftime_id_++;
-    Expression &arg = *call.vargs->at(1);
-    arg.accept(*this);
+    Expression *arg = call.vargs->at(1);
+    auto scoped_del = accept(arg);
     b_.CreateStore(expr_,
                    b_.CreateGEP(buf, { b_.getInt64(0), b_.getInt32(1) }));
     expr_ = buf;
-    expr_deleter_ = [this, buf]() { b_.CreateLifetimeEnd(buf); };
-    // b_.CreateLifetimeEnd(buf);
   }
   else if (call.func == "kstack" || call.func == "ustack")
   {
@@ -912,7 +914,7 @@ void CodegenLLVM::visit(Call &call)
       b_.CreateSignal(ctx_, b_.getInt32(sigid), call.loc);
       return;
     }
-    arg.accept(*this);
+    auto scoped_del = accept(&arg);
     expr_ = b_.CreateIntCast(expr_, b_.getInt32Ty(), arg.type.IsSigned());
     b_.CreateSignal(ctx_, expr_, call.loc);
   }
@@ -928,32 +930,24 @@ void CodegenLLVM::visit(Call &call)
     // If one of the strings is fixed, we can avoid storing the
     // literal in memory by calling a different function.
     if (right_arg->is_literal) {
-      left_arg->accept(*this);
+      auto scoped_del = accept(left_arg);
       Value *left_string = expr_;
       const auto& string_literal = static_cast<String *>(right_arg)->str;
       expr_ = b_.CreateStrncmp(
           ctx_, left_string, string_literal, size, call.loc, false);
-      if (!left_arg->is_variable && dyn_cast<AllocaInst>(left_string))
-        b_.CreateLifetimeEnd(left_string);
     } else if (left_arg->is_literal) {
-      right_arg->accept(*this);
+      auto scoped_del = accept(right_arg);
       Value *right_string = expr_;
       const auto& string_literal = static_cast<String *>(left_arg)->str;
       expr_ = b_.CreateStrncmp(
           ctx_, right_string, string_literal, size, call.loc, false);
-      if (!right_arg->is_variable && dyn_cast<AllocaInst>(right_string))
-        b_.CreateLifetimeEnd(right_string);
     } else {
-      right_arg->accept(*this);
+      auto scoped_del_right = accept(right_arg);
       Value *right_string = expr_;
-      left_arg->accept(*this);
+      auto scoped_del_left = accept(left_arg);
       Value *left_string = expr_;
       expr_ = b_.CreateStrncmp(
           ctx_, left_string, right_string, size, call.loc, false);
-      if (!left_arg->is_variable && dyn_cast<AllocaInst>(left_string))
-        b_.CreateLifetimeEnd(left_string);
-      if (!right_arg->is_variable && dyn_cast<AllocaInst>(right_string))
-        b_.CreateLifetimeEnd(right_string);
     }
   }
   else if (call.func == "override")
@@ -961,7 +955,7 @@ void CodegenLLVM::visit(Call &call)
     // int bpf_override(struct pt_regs *regs, u64 rc)
     // returns: 0
     auto &arg = *call.vargs->at(0);
-    arg.accept(*this);
+    auto scoped_del = accept(&arg);
     expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), arg.type.IsSigned());
     b_.CreateOverrideReturn(ctx_, expr_);
   }
@@ -975,7 +969,11 @@ void CodegenLLVM::visit(Call &call)
 void CodegenLLVM::visit(Map &map)
 {
   AllocaInst *key = getMapKey(map);
-  expr_ = b_.CreateMapLookupElem(ctx_, map, key, map.loc);
+  Value *value = b_.CreateMapLookupElem(ctx_, map, key, map.loc);
+  expr_ = value;
+
+  if (dyn_cast<AllocaInst>(value))
+    expr_deleter_ = [this, value]() { b_.CreateLifetimeEnd(value); };
   b_.CreateLifetimeEnd(key);
 }
 
@@ -1023,22 +1021,22 @@ void CodegenLLVM::visit(Binop &binop)
     // literal in memory by calling a different function.
     if (binop.right->is_literal)
     {
-      binop.left->accept(*this);
+      auto scoped_del = accept(binop.left);
       string_literal = static_cast<String *>(binop.right)->str;
       expr_ = b_.CreateStrcmp(ctx_, expr_, string_literal, binop.loc, inverse);
     }
     else if (binop.left->is_literal)
     {
-      binop.right->accept(*this);
+      auto scoped_del = accept(binop.right);
       string_literal = static_cast<String *>(binop.left)->str;
       expr_ = b_.CreateStrcmp(ctx_, expr_, string_literal, binop.loc, inverse);
     }
     else
     {
-      binop.right->accept(*this);
+      auto scoped_del_right = accept(binop.right);
       Value * right_string = expr_;
 
-      binop.left->accept(*this);
+      auto scoped_del_left = accept(binop.left);
       Value * left_string = expr_;
 
       size_t len = std::min(binop.left->type.size, binop.right->type.size);
@@ -1061,10 +1059,10 @@ void CodegenLLVM::visit(Binop &binop)
     // strcmp returns 0 when strings are equal
     bool inverse = binop.op == bpftrace::Parser::token::EQ;
 
-    binop.right->accept(*this);
+    auto scoped_del_right = accept(binop.right);
     Value *right_string = expr_;
 
-    binop.left->accept(*this);
+    auto scoped_del_left = accept(binop.left);
     Value *left_string = expr_;
 
     size_t len = std::min(binop.left->type.size, binop.right->type.size);
@@ -1074,9 +1072,9 @@ void CodegenLLVM::visit(Binop &binop)
   else
   {
     Value *lhs, *rhs;
-    binop.left->accept(*this);
+    auto scoped_del_left = accept(binop.left);
     lhs = expr_;
-    binop.right->accept(*this);
+    auto scoped_del_right = accept(binop.right);
     rhs = expr_;
 
     bool lsign = binop.left->type.IsSigned();
@@ -1150,8 +1148,9 @@ static bool unop_skip_accept(Unop &unop)
 
 void CodegenLLVM::visit(Unop &unop)
 {
+  auto scoped_del = ScopedExprDeleter(nullptr);
   if (!unop_skip_accept(unop))
-    unop.expr->accept(*this);
+    scoped_del = accept(unop.expr);
 
   SizedType &type = unop.expr->type;
   if (type.IsIntegerTy())
@@ -1281,7 +1280,7 @@ void CodegenLLVM::visit(Ternary &ternary)
                         ? nullptr
                         : b_.CreateAllocaBPF(ternary.type, "buf");
   Value *cond;
-  ternary.cond->accept(*this);
+  auto scoped_del = accept(ternary.cond);
   cond = expr_;
   Value *zero_value = Constant::getNullValue(cond->getType());
   b_.CreateCondBr(b_.CreateICmpNE(cond, zero_value, "true_cond"),
@@ -1292,7 +1291,7 @@ void CodegenLLVM::visit(Ternary &ternary)
   {
     // fetch selected integer via CreateStore
     b_.SetInsertPoint(left_block);
-    ternary.left->accept(*this);
+    auto scoped_del_left = accept(ternary.left);
     expr_ = b_.CreateIntCast(expr_,
                              b_.GetType(ternary.type),
                              ternary.type.IsSigned());
@@ -1300,7 +1299,7 @@ void CodegenLLVM::visit(Ternary &ternary)
     b_.CreateBr(done);
 
     b_.SetInsertPoint(right_block);
-    ternary.right->accept(*this);
+    auto scoped_del_right = accept(ternary.right);
     expr_ = b_.CreateIntCast(expr_,
                              b_.GetType(ternary.type),
                              ternary.type.IsSigned());
@@ -1331,10 +1330,14 @@ void CodegenLLVM::visit(Ternary &ternary)
   {
     // Type::none
     b_.SetInsertPoint(left_block);
-    ternary.left->accept(*this);
+    {
+      auto scoped_del = accept(ternary.left);
+    }
     b_.CreateBr(done);
     b_.SetInsertPoint(right_block);
-    ternary.right->accept(*this);
+    {
+      auto scoped_del = accept(ternary.right);
+    }
     b_.CreateBr(done);
     b_.SetInsertPoint(done);
     expr_ = nullptr;
@@ -1345,7 +1348,7 @@ void CodegenLLVM::visit(FieldAccess &acc)
 {
   SizedType &type = acc.expr->type;
   assert(type.IsCastTy() || type.IsCtxTy() || type.IsTupleTy());
-  acc.expr->accept(*this);
+  auto scoped_del = accept(acc.expr);
 
   if (type.is_kfarg)
   {
@@ -1359,7 +1362,11 @@ void CodegenLLVM::visit(FieldAccess &acc)
     SizedType &elem_type = type.tuple_elems[acc.index];
 
     if (shouldBeOnStackAlready(elem_type))
+    {
       expr_ = src;
+      // Extend lifetime of source buffer
+      expr_deleter_ = scoped_del.disarm();
+    }
     else
       expr_ = b_.CreateLoad(b_.GetType(elem_type), src);
 
@@ -1393,6 +1400,8 @@ void CodegenLLVM::visit(FieldAccess &acc)
     else if (field.type.IsStringTy() || field.type.IsBufferTy())
     {
       expr_ = src;
+      // Extend lifetime of source buffer
+      expr_deleter_ = scoped_del.disarm();
     }
     else
     {
@@ -1419,6 +1428,8 @@ void CodegenLLVM::visit(FieldAccess &acc)
       // Instead of copying the entire struct Y in, we'll just store it as a
       // pointer internally and dereference later when necessary.
       expr_ = src;
+      // Extend lifetime of source buffer
+      expr_deleter_ = scoped_del.disarm();
     }
     else if (field.type.IsArrayTy())
     {
@@ -1427,6 +1438,8 @@ void CodegenLLVM::visit(FieldAccess &acc)
       // The pointer will be dereferenced when the array is accessed by a []
       // operation
       expr_ = src;
+      // Extend lifetime of source buffer
+      expr_deleter_ = scoped_del.disarm();
     }
     else if (field.type.IsStringTy() || field.type.IsBufferTy())
     {
@@ -1494,10 +1507,10 @@ void CodegenLLVM::visit(ArrayAccess &arr)
   SizedType &type = arr.expr->type;
   size_t element_size = type.GetElementTy()->size;
 
-  arr.expr->accept(*this);
+  auto scoped_del_expr = accept(arr.expr);
   array = expr_;
 
-  arr.indexpr->accept(*this);
+  auto scoped_del_index = accept(arr.indexpr);
 
   index = b_.CreateIntCast(expr_, b_.getInt64Ty(), arr.expr->type.IsSigned());
   offset = b_.CreateMul(index, b_.getInt64(type.pointee_size));
@@ -1524,7 +1537,7 @@ void CodegenLLVM::visit(ArrayAccess &arr)
 
 void CodegenLLVM::visit(Cast &cast)
 {
-  cast.expr->accept(*this);
+  auto scoped_del = accept(cast.expr);
   if (cast.type.IsIntTy())
   {
     expr_ = b_.CreateIntCast(
@@ -1556,14 +1569,14 @@ void CodegenLLVM::visit(Tuple &tuple)
 
 void CodegenLLVM::visit(ExprStatement &expr)
 {
-  expr.expr->accept(*this);
+  auto scoped_del = accept(expr.expr);
 }
 
 void CodegenLLVM::visit(AssignMapStatement &assignment)
 {
   Map &map = *assignment.map;
-
-  assignment.expr->accept(*this);
+  auto scoped_del = accept(assignment.expr);
+  bool self_alloca = false;
 
   if (!expr_) // Some functions do the assignments themselves
     return;
@@ -1588,6 +1601,7 @@ void CodegenLLVM::visit(AssignMapStatement &assignment)
       AllocaInst *dst = b_.CreateAllocaBPF(map.type, map.ident + "_ptr");
       b_.CreateStore(expr, dst);
       val = dst;
+      self_alloca = true;
     }
     else
     {
@@ -1596,6 +1610,7 @@ void CodegenLLVM::visit(AssignMapStatement &assignment)
       AllocaInst *dst = b_.CreateAllocaBPF(map.type, map.ident + "_val");
       b_.CreateProbeRead(ctx_, dst, map.type.size, expr, assignment.loc);
       val = dst;
+      self_alloca = true;
     }
   }
   else
@@ -1607,10 +1622,11 @@ void CodegenLLVM::visit(AssignMapStatement &assignment)
     }
     val = b_.CreateAllocaBPF(map.type, map.ident + "_val");
     b_.CreateStore(expr, val);
+    self_alloca = true;
   }
   b_.CreateMapUpdateElem(ctx_, map, key, val, assignment.loc);
   b_.CreateLifetimeEnd(key);
-  if (!assignment.expr->is_variable)
+  if (self_alloca)
     b_.CreateLifetimeEnd(val);
 }
 
@@ -1647,7 +1663,7 @@ void CodegenLLVM::visit(If &if_block)
                                           parent);
   BasicBlock *if_else = nullptr;
 
-  if_block.cond->accept(*this);
+  auto scoped_del = accept(if_block.cond);
   Value *zero_value = Constant::getNullValue(expr_->getType());
   Value *cond = b_.CreateICmpNE(expr_, zero_value, "true_cond");
 
@@ -1675,7 +1691,7 @@ void CodegenLLVM::visit(If &if_block)
 
   b_.SetInsertPoint(if_true);
   for (Statement *stmt : *if_block.stmts)
-    stmt->accept(*this);
+    auto scoped_del = accept(stmt);
 
   b_.CreateBr(if_end);
 
@@ -1685,7 +1701,7 @@ void CodegenLLVM::visit(If &if_block)
   {
     b_.SetInsertPoint(if_else);
     for (Statement *stmt : *if_block.else_stmts)
-      stmt->accept(*this);
+      auto scoped_del = accept(stmt);
 
     b_.CreateBr(if_end);
     b_.SetInsertPoint(if_end);
@@ -1697,7 +1713,7 @@ void CodegenLLVM::visit(Unroll &unroll)
   for (int i=0; i < unroll.var; i++) {
     for (Statement *stmt : *unroll.stmts)
     {
-      stmt->accept(*this);
+      auto scoped_del = accept(stmt);
     }
   }
 }
@@ -1763,7 +1779,7 @@ void CodegenLLVM::visit(While &while_block)
   b_.CreateBr(while_cond);
 
   b_.SetInsertPoint(while_cond);
-  while_block.cond->accept(*this);
+  auto scoped_del = accept(while_block.cond);
   Value *zero_value = Constant::getNullValue(expr_->getType());
   auto *cond = b_.CreateICmpNE(expr_, zero_value, "true_cond");
   b_.CreateCondBr(cond, while_body, while_end);
@@ -1771,7 +1787,7 @@ void CodegenLLVM::visit(While &while_block)
   b_.SetInsertPoint(while_body);
   for (Statement *stmt : *while_block.stmts)
   {
-    stmt->accept(*this);
+    auto scoped_del = accept(stmt);
   }
   b_.CreateBr(while_cond);
 
@@ -1791,7 +1807,7 @@ void CodegenLLVM::visit(Predicate &pred)
       "pred_true",
       parent);
 
-  pred.expr->accept(*this);
+  auto scoped_del = accept(pred.expr);
 
   // allow unop casts in predicates:
   expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), false);
@@ -1836,12 +1852,12 @@ void CodegenLLVM::generateProbe(Probe &probe,
   ctx_ = func->arg_begin();
   if (probe.pred)
   {
-    probe.pred->accept(*this);
+    auto scoped_del = accept(probe.pred);
   }
   variables_.clear();
   for (Statement *stmt : *probe.stmts)
   {
-    stmt->accept(*this);
+    auto scoped_del = accept(stmt);
   }
   b_.CreateRet(ConstantInt::get(module_->getContext(), APInt(64, 0)));
 }
@@ -1977,7 +1993,7 @@ void CodegenLLVM::visit(Probe &probe)
 void CodegenLLVM::visit(Program &program)
 {
   for (Probe *probe : *program.probes)
-    probe->accept(*this);
+    auto scoped_del = accept(probe);
 }
 
 int CodegenLLVM::getNextIndexForProbe(const std::string &probe_name) {
@@ -2000,10 +2016,12 @@ AllocaInst *CodegenLLVM::getMapKey(Map &map)
     if (map.vargs->size() == 1)
     {
       Expression *expr = map.vargs->at(0);
-      expr->accept(*this);
+      auto scoped_del = accept(expr);
       if (shouldBeOnStackAlready(expr->type))
       {
         key = dyn_cast<AllocaInst>(expr_);
+        // Call-ee freed
+        scoped_del.disarm();
       }
       else
       {
@@ -2099,7 +2117,7 @@ Value *CodegenLLVM::createLogicalAnd(Binop &binop)
 
   Value *result = b_.CreateAllocaBPF(b_.getInt64Ty(), "&&_result");
   Value *lhs;
-  binop.left->accept(*this);
+  auto scoped_del_left = accept(binop.left);
   lhs = expr_;
   b_.CreateCondBr(b_.CreateICmpNE(lhs, b_.GetIntSameSize(0, lhs), "lhs_true_cond"),
                   lhs_true_block,
@@ -2107,7 +2125,7 @@ Value *CodegenLLVM::createLogicalAnd(Binop &binop)
 
   b_.SetInsertPoint(lhs_true_block);
   Value *rhs;
-  binop.right->accept(*this);
+  auto scoped_del_right = accept(binop.right);
   rhs = expr_;
   b_.CreateCondBr(b_.CreateICmpNE(rhs, b_.GetIntSameSize(0, rhs), "rhs_true_cond"),
                   true_block,
@@ -2138,7 +2156,7 @@ Value *CodegenLLVM::createLogicalOr(Binop &binop)
 
   Value *result = b_.CreateAllocaBPF(b_.getInt64Ty(), "||_result");
   Value *lhs;
-  binop.left->accept(*this);
+  auto scoped_del_left = accept(binop.left);
   lhs = expr_;
   b_.CreateCondBr(b_.CreateICmpNE(lhs, b_.GetIntSameSize(0, lhs), "lhs_true_cond"),
                   true_block,
@@ -2146,7 +2164,7 @@ Value *CodegenLLVM::createLogicalOr(Binop &binop)
 
   b_.SetInsertPoint(lhs_false_block);
   Value *rhs;
-  binop.right->accept(*this);
+  auto scoped_del_right = accept(binop.right);
   rhs = expr_;
   b_.CreateCondBr(b_.CreateICmpNE(rhs, b_.GetIntSameSize(0, rhs), "rhs_true_cond"),
                   true_block,
@@ -2401,7 +2419,7 @@ void CodegenLLVM::createPrintMapCall(Call &call)
   size_t arg_idx = 1;
   for (; arg_idx < call.vargs->size(); arg_idx++)
   {
-    call.vargs->at(arg_idx)->accept(*this);
+    auto scoped_del = accept(call.vargs->at(arg_idx));
 
     b_.CreateStore(b_.CreateIntCast(expr_, elements.at(arg_idx), false),
                    b_.CreateGEP(buf,
@@ -2423,8 +2441,7 @@ void CodegenLLVM::createPrintMapCall(Call &call)
 void CodegenLLVM::createPrintNonMapCall(Call &call, int &id)
 {
   auto &arg = *call.vargs->at(0);
-  expr_deleter_ = nullptr;
-  arg.accept(*this);
+  auto scoped_del = accept(&arg);
 
   auto elements = AsyncEvent::PrintNonMap().asLLVMType(b_, arg.type.size);
   std::ostringstream struct_name;
@@ -2452,9 +2469,6 @@ void CodegenLLVM::createPrintNonMapCall(Call &call, int &id)
   else
     b_.CreateStore(expr_, content_offset);
 
-  if (expr_deleter_)
-    expr_deleter_();
-
   id++;
   b_.CreatePerfEventOutput(ctx_, buf, struct_size);
   b_.CreateLifetimeEnd(buf);
@@ -2463,7 +2477,7 @@ void CodegenLLVM::createPrintNonMapCall(Call &call, int &id)
 
 void CodegenLLVM::generate_ir()
 {
-  root_->accept(*this);
+  auto scoped_del = accept(root_);
 }
 
 void CodegenLLVM::optimize()

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -2531,5 +2531,14 @@ void CodegenLLVM::DumpIR(std::ostream &out)
   module_->print(os, nullptr, false, true);
 }
 
+CodegenLLVM::ScopedExprDeleter CodegenLLVM::accept(Node *node)
+{
+  expr_deleter_ = nullptr;
+  node->accept(*this);
+  auto deleter = std::move(expr_deleter_);
+  expr_deleter_ = nullptr;
+  return ScopedExprDeleter(deleter);
+}
+
 } // namespace ast
 } // namespace bpftrace

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -298,7 +298,9 @@ Value *IRBuilderBPF::CreateMapLookupElem(Value *ctx,
   if (needMemcpy(type))
     return value;
 
-  return CreateLoad(value);
+  Value *ret = CreateLoad(value);
+  CreateLifetimeEnd(value);
+  return ret;
 }
 
 void IRBuilderBPF::CreateMapUpdateElem(Value *ctx,

--- a/tests/codegen/llvm/args_multiple_tracepoints.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints.ll
@@ -38,16 +38,18 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %9 = load i64, i64* %lookup_elem_val
-  %10 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  %11 = add i64 %9, 1
-  store i64 %11, i64* %"@_val"
+  %10 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %12 = add i64 %9, 1
+  store i64 %12, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %12 = bitcast [8 x i8]* %"@_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@_val" to i8*
+  %13 = bitcast [8 x i8]* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
 
@@ -89,16 +91,18 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %9 = load i64, i64* %lookup_elem_val
-  %10 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  %11 = add i64 %9, 1
-  store i64 %11, i64* %"@_val"
+  %10 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %12 = add i64 %9, 1
+  store i64 %12, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %12 = bitcast [8 x i8]* %"@_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@_val" to i8*
+  %13 = bitcast [8 x i8]* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/args_multiple_tracepoints_wild.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints_wild.ll
@@ -38,16 +38,18 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %9 = load i64, i64* %lookup_elem_val
-  %10 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  %11 = add i64 %9, 1
-  store i64 %11, i64* %"@_val"
+  %10 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %12 = add i64 %9, 1
+  store i64 %12, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %12 = bitcast [8 x i8]* %"@_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@_val" to i8*
+  %13 = bitcast [8 x i8]* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
 
@@ -89,16 +91,18 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %9 = load i64, i64* %lookup_elem_val
-  %10 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  %11 = add i64 %9, 1
-  store i64 %11, i64* %"@_val"
+  %10 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %12 = add i64 %9, 1
+  store i64 %12, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %12 = bitcast [8 x i8]* %"@_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@_val" to i8*
+  %13 = bitcast [8 x i8]* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/builtin_elapsed.ll
+++ b/tests/codegen/llvm/builtin_elapsed.ll
@@ -34,22 +34,24 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %4 = load i64, i64* %lookup_elem_val
+  %5 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
   %get_ns = call i64 inttoptr (i64 5 to i64 ()*)()
-  %5 = sub i64 %get_ns, %4
-  %6 = bitcast i64* %elapsed_key to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  store i64 0, i64* %"@_key"
-  %8 = bitcast i64* %"@_val" to i8*
+  %6 = sub i64 %get_ns, %4
+  %7 = bitcast i64* %elapsed_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %8 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  store i64 %5, i64* %"@_val"
+  store i64 0, i64* %"@_key"
+  %9 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i64 %6, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %"@_val", i64 0)
-  %9 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@_val" to i8*
+  %10 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_avg.ll
+++ b/tests/codegen/llvm/call_avg.ll
@@ -36,30 +36,32 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %4 = load i64, i64* %lookup_elem_val
-  %5 = bitcast i64* %"@x_num" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = add i64 %4, 1
-  store i64 %6, i64* %"@x_num"
+  %5 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = bitcast i64* %"@x_num" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %7 = add i64 %4, 1
+  store i64 %7, i64* %"@x_num"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_num", i64 0)
-  %7 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@x_num" to i8*
+  %8 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@x_key2" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %9 = bitcast i64* %"@x_num" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@x_key2" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 1, i64* %"@x_key2"
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem4 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo3, i64* %"@x_key2")
-  %10 = bitcast i64* %lookup_elem_val8 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %lookup_elem_val8 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   %map_lookup_cond9 = icmp ne i8* %lookup_elem4, null
   br i1 %map_lookup_cond9, label %lookup_success5, label %lookup_failure6
 
 lookup_success5:                                  ; preds = %lookup_merge
   %cast10 = bitcast i8* %lookup_elem4 to i64*
-  %11 = load i64, i64* %cast10
-  store i64 %11, i64* %lookup_elem_val8
+  %12 = load i64, i64* %cast10
+  store i64 %12, i64* %lookup_elem_val8
   br label %lookup_merge7
 
 lookup_failure6:                                  ; preds = %lookup_merge
@@ -67,19 +69,21 @@ lookup_failure6:                                  ; preds = %lookup_merge
   br label %lookup_merge7
 
 lookup_merge7:                                    ; preds = %lookup_failure6, %lookup_success5
-  %12 = load i64, i64* %lookup_elem_val8
-  %13 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %13 = load i64, i64* %lookup_elem_val8
+  %14 = bitcast i64* %lookup_elem_val8 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %14 = lshr i64 %get_pid_tgid, 32
-  %15 = add i64 %14, %12
-  store i64 %15, i64* %"@x_val"
+  %16 = lshr i64 %get_pid_tgid, 32
+  %17 = add i64 %16, %13
+  store i64 %17, i64* %"@x_val"
   %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem12 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo11, i64* %"@x_key2", i64* %"@x_val", i64 0)
-  %16 = bitcast i64* %"@x_key2" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %18 = bitcast i64* %"@x_key2" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  %19 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_count.ll
+++ b/tests/codegen/llvm/call_count.ll
@@ -33,16 +33,18 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %4 = load i64, i64* %lookup_elem_val
-  %5 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = add i64 %4, 1
-  store i64 %6, i64* %"@x_val"
+  %5 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %7 = add i64 %4, 1
+  store i64 %7, i64* %"@x_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %7 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@x_val" to i8*
+  %8 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_hist.ll
+++ b/tests/codegen/llvm/call_hist.ll
@@ -36,16 +36,18 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %5 = load i64, i64* %lookup_elem_val
-  %6 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %7 = add i64 %5, 1
-  store i64 %7, i64* %"@x_val"
+  %6 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %8 = add i64 %5, 1
+  store i64 %8, i64* %"@x_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %8 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@x_val" to i8*
+  %9 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_hist_LLVM-10.ll
+++ b/tests/codegen/llvm/call_hist_LLVM-10.ll
@@ -36,16 +36,18 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %5 = load i64, i64* %lookup_elem_val
-  %6 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %7 = add i64 %5, 1
-  store i64 %7, i64* %"@x_val"
+  %6 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %8 = add i64 %5, 1
+  store i64 %8, i64* %"@x_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %8 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@x_val" to i8*
+  %9 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_lhist.ll
+++ b/tests/codegen/llvm/call_lhist.ll
@@ -38,16 +38,18 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %6 = load i64, i64* %lookup_elem_val
-  %7 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %8 = add i64 %6, 1
-  store i64 %8, i64* %"@x_val"
+  %7 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %8 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %9 = add i64 %6, 1
+  store i64 %9, i64* %"@x_val"
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %9 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_val" to i8*
+  %10 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_lhist_LLVM-10.ll
+++ b/tests/codegen/llvm/call_lhist_LLVM-10.ll
@@ -38,16 +38,18 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %6 = load i64, i64* %lookup_elem_val
-  %7 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %8 = add i64 %6, 1
-  store i64 %8, i64* %"@x_val"
+  %7 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %8 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %9 = add i64 %6, 1
+  store i64 %9, i64* %"@x_val"
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %9 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_val" to i8*
+  %10 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_max.ll
+++ b/tests/codegen/llvm/call_max.ll
@@ -33,22 +33,24 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %4 = load i64, i64* %lookup_elem_val
-  %5 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %5 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %6 = lshr i64 %get_pid_tgid, 32
-  %7 = icmp sge i64 %6, %4
-  br i1 %7, label %min.ge, label %min.lt
+  %7 = lshr i64 %get_pid_tgid, 32
+  %8 = icmp sge i64 %7, %4
+  br i1 %8, label %min.ge, label %min.lt
 
 min.lt:                                           ; preds = %min.ge, %lookup_merge
-  %8 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@x_val" to i8*
+  %9 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 
 min.ge:                                           ; preds = %lookup_merge
-  store i64 %6, i64* %"@x_val"
+  store i64 %7, i64* %"@x_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_val", i64 0)
   br label %min.lt

--- a/tests/codegen/llvm/call_min.ll
+++ b/tests/codegen/llvm/call_min.ll
@@ -33,23 +33,25 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %4 = load i64, i64* %lookup_elem_val
-  %5 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %5 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %6 = lshr i64 %get_pid_tgid, 32
-  %7 = sub i64 4294967295, %6
-  %8 = icmp sge i64 %7, %4
-  br i1 %8, label %min.ge, label %min.lt
+  %7 = lshr i64 %get_pid_tgid, 32
+  %8 = sub i64 4294967295, %7
+  %9 = icmp sge i64 %8, %4
+  br i1 %9, label %min.ge, label %min.lt
 
 min.lt:                                           ; preds = %min.ge, %lookup_merge
-  %9 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_val" to i8*
+  %10 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   ret i64 0
 
 min.ge:                                           ; preds = %lookup_merge
-  store i64 %7, i64* %"@x_val"
+  store i64 %8, i64* %"@x_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_val", i64 0)
   br label %min.lt

--- a/tests/codegen/llvm/call_ntop_key.ll
+++ b/tests/codegen/llvm/call_ntop_key.ll
@@ -41,16 +41,18 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %8 = load i64, i64* %lookup_elem_val
-  %9 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %10 = add i64 %8, 1
-  store i64 %10, i64* %"@x_val"
+  %9 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = add i64 %8, 1
+  store i64 %11, i64* %"@x_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, %inet_t*, i64*, i64)*)(i64 %pseudo1, %inet_t* %inet, i64* %"@x_val", i64 0)
-  %11 = bitcast %inet_t* %inet to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_val" to i8*
+  %12 = bitcast %inet_t* %inet to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_stats.ll
+++ b/tests/codegen/llvm/call_stats.ll
@@ -36,30 +36,32 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %4 = load i64, i64* %lookup_elem_val
-  %5 = bitcast i64* %"@x_num" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = add i64 %4, 1
-  store i64 %6, i64* %"@x_num"
+  %5 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = bitcast i64* %"@x_num" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %7 = add i64 %4, 1
+  store i64 %7, i64* %"@x_num"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_num", i64 0)
-  %7 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@x_num" to i8*
+  %8 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@x_key2" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %9 = bitcast i64* %"@x_num" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@x_key2" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 1, i64* %"@x_key2"
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem4 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo3, i64* %"@x_key2")
-  %10 = bitcast i64* %lookup_elem_val8 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %lookup_elem_val8 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   %map_lookup_cond9 = icmp ne i8* %lookup_elem4, null
   br i1 %map_lookup_cond9, label %lookup_success5, label %lookup_failure6
 
 lookup_success5:                                  ; preds = %lookup_merge
   %cast10 = bitcast i8* %lookup_elem4 to i64*
-  %11 = load i64, i64* %cast10
-  store i64 %11, i64* %lookup_elem_val8
+  %12 = load i64, i64* %cast10
+  store i64 %12, i64* %lookup_elem_val8
   br label %lookup_merge7
 
 lookup_failure6:                                  ; preds = %lookup_merge
@@ -67,19 +69,21 @@ lookup_failure6:                                  ; preds = %lookup_merge
   br label %lookup_merge7
 
 lookup_merge7:                                    ; preds = %lookup_failure6, %lookup_success5
-  %12 = load i64, i64* %lookup_elem_val8
-  %13 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %13 = load i64, i64* %lookup_elem_val8
+  %14 = bitcast i64* %lookup_elem_val8 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %14 = lshr i64 %get_pid_tgid, 32
-  %15 = add i64 %14, %12
-  store i64 %15, i64* %"@x_val"
+  %16 = lshr i64 %get_pid_tgid, 32
+  %17 = add i64 %16, %13
+  store i64 %17, i64* %"@x_val"
   %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem12 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo11, i64* %"@x_key2", i64* %"@x_val", i64 0)
-  %16 = bitcast i64* %"@x_key2" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %18 = bitcast i64* %"@x_key2" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  %19 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_strftime.ll
+++ b/tests/codegen/llvm/call_strftime.ll
@@ -30,15 +30,11 @@ entry:
   %8 = bitcast i128* %7 to i8*
   %9 = bitcast %strftime_t* %strftime_args to i8*
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %8, i8* align 1 %9, i64 16, i1 false)
-  %10 = bitcast %strftime_t* %strftime_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast %strftime_t* %strftime_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* %printf_args, i64 24)
-  %12 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %10 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_strftime_LLVM-10.ll
+++ b/tests/codegen/llvm/call_strftime_LLVM-10.ll
@@ -30,15 +30,11 @@ entry:
   %8 = bitcast i128* %7 to i8*
   %9 = bitcast %strftime_t* %strftime_args to i8*
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %8, i8* align 1 %9, i64 16, i1 false)
-  %10 = bitcast %strftime_t* %strftime_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast %strftime_t* %strftime_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* %printf_args, i64 24)
-  %12 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %10 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_sum.ll
+++ b/tests/codegen/llvm/call_sum.ll
@@ -33,18 +33,20 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %4 = load i64, i64* %lookup_elem_val
-  %5 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %5 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %6 = lshr i64 %get_pid_tgid, 32
-  %7 = add i64 %6, %4
-  store i64 %7, i64* %"@x_val"
+  %7 = lshr i64 %get_pid_tgid, 32
+  %8 = add i64 %7, %4
+  store i64 %8, i64* %"@x_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %8 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@x_val" to i8*
+  %9 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_usym_key.ll
+++ b/tests/codegen/llvm/call_usym_key.ll
@@ -40,16 +40,18 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %7 = load i64, i64* %lookup_elem_val
-  %8 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %9 = add i64 %7, 1
-  store i64 %9, i64* %"@x_val"
+  %8 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %10 = add i64 %7, 1
+  store i64 %10, i64* %"@x_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, %usym_t*, i64*, i64)*)(i64 %pseudo1, %usym_t* %usym, i64* %"@x_val", i64 0)
-  %10 = bitcast %usym_t* %usym to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_val" to i8*
+  %11 = bitcast %usym_t* %usym to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/int_propagation.ll
+++ b/tests/codegen/llvm/int_propagation.ll
@@ -48,20 +48,22 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %8 = load i64, i64* %lookup_elem_val
-  %9 = bitcast i64* %"@x_key1" to i8*
+  %9 = bitcast i64* %lookup_elem_val to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  store i64 0, i64* %"@y_key"
-  %11 = bitcast i64* %"@y_val" to i8*
+  %10 = bitcast i64* %"@x_key1" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i64 0, i64* %"@y_key"
+  %12 = bitcast i64* %"@y_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
   store i64 %8, i64* %"@y_val"
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo3, i64* %"@y_key", i64* %"@y_val", i64 0)
-  %12 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@y_val" to i8*
+  %13 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@y_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/intcast_call.ll
+++ b/tests/codegen/llvm/intcast_call.ll
@@ -33,21 +33,23 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %4 = load i64, i64* %lookup_elem_val
-  %5 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i8* %0 to i64*
-  %7 = getelementptr i64, i64* %6, i64 10
-  %retval = load volatile i64, i64* %7
+  %5 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %7 = bitcast i8* %0 to i64*
+  %8 = getelementptr i64, i64* %7, i64 10
+  %retval = load volatile i64, i64* %8
   %cast1 = trunc i64 %retval to i32
-  %8 = sext i32 %cast1 to i64
-  %9 = add i64 %8, %4
-  store i64 %9, i64* %"@_val"
+  %9 = sext i32 %cast1 to i64
+  %10 = add i64 %9, %4
+  store i64 %10, i64* %"@_val"
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@_key", i64* %"@_val", i64 0)
-  %10 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@_val" to i8*
+  %11 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/intptrcast_call.ll
+++ b/tests/codegen/llvm/intptrcast_call.ll
@@ -34,25 +34,27 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %4 = load i64, i64* %lookup_elem_val
-  %5 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i8* %0 to i64*
-  %7 = getelementptr i64, i64* %6, i64 4
-  %reg_bp = load volatile i64, i64* %7
-  %8 = sub i64 %reg_bp, 1
+  %5 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %7 = bitcast i8* %0 to i64*
+  %8 = getelementptr i64, i64* %7, i64 4
+  %reg_bp = load volatile i64, i64* %8
+  %9 = sub i64 %reg_bp, 1
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %deref)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i64)*)(i8* %deref, i32 1, i64 %8)
-  %9 = load i8, i8* %deref
-  %10 = sext i8 %9 to i64
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i64)*)(i8* %deref, i32 1, i64 %9)
+  %10 = load i8, i8* %deref
+  %11 = sext i8 %10 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %deref)
-  %11 = add i64 %10, %4
-  store i64 %11, i64* %"@_val"
+  %12 = add i64 %11, %4
+  store i64 %12, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %"@_val", i64 0)
-  %12 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@_val" to i8*
+  %13 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/literal_strncmp.ll
+++ b/tests/codegen/llvm/literal_strncmp.ll
@@ -72,16 +72,18 @@ lookup_failure:                                   ; preds = %pred_true
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %14 = load i64, i64* %lookup_elem_val
-  %15 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
-  %16 = add i64 %14, 1
-  store i64 %16, i64* %"@_val"
+  %15 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %16 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
+  %17 = add i64 %14, 1
+  store i64 %17, i64* %"@_val"
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo5, [16 x i8]* %comm3, i64* %"@_val", i64 0)
-  %17 = bitcast [16 x i8]* %comm3 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
-  %18 = bitcast i64* %"@_val" to i8*
+  %18 = bitcast [16 x i8]* %comm3 to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  %19 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/map_increment_decrement.ll
+++ b/tests/codegen/llvm/map_increment_decrement.ll
@@ -56,30 +56,32 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %8 = load i64, i64* %lookup_elem_val
-  %9 = bitcast i64* %"@x_newval" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %10 = add i64 %8, 1
-  store i64 %10, i64* %"@x_newval"
+  %9 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@x_newval" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = add i64 %8, 1
+  store i64 %11, i64* %"@x_newval"
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo3, i64* %"@x_key1", i64* %"@x_newval", i64 0)
-  %11 = bitcast i64* %"@x_key1" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_newval" to i8*
+  %12 = bitcast i64* %"@x_key1" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_key5" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %13 = bitcast i64* %"@x_newval" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@x_key5" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
   store i64 0, i64* %"@x_key5"
   %pseudo6 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem7 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo6, i64* %"@x_key5")
-  %14 = bitcast i64* %lookup_elem_val11 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  %15 = bitcast i64* %lookup_elem_val11 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
   %map_lookup_cond12 = icmp ne i8* %lookup_elem7, null
   br i1 %map_lookup_cond12, label %lookup_success8, label %lookup_failure9
 
 lookup_success8:                                  ; preds = %lookup_merge
   %cast13 = bitcast i8* %lookup_elem7 to i64*
-  %15 = load i64, i64* %cast13
-  store i64 %15, i64* %lookup_elem_val11
+  %16 = load i64, i64* %cast13
+  store i64 %16, i64* %lookup_elem_val11
   br label %lookup_merge10
 
 lookup_failure9:                                  ; preds = %lookup_merge
@@ -87,32 +89,34 @@ lookup_failure9:                                  ; preds = %lookup_merge
   br label %lookup_merge10
 
 lookup_merge10:                                   ; preds = %lookup_failure9, %lookup_success8
-  %16 = load i64, i64* %lookup_elem_val11
-  %17 = bitcast i64* %"@x_newval14" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
-  %18 = add i64 %16, 1
-  store i64 %18, i64* %"@x_newval14"
+  %17 = load i64, i64* %lookup_elem_val11
+  %18 = bitcast i64* %lookup_elem_val11 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  %19 = bitcast i64* %"@x_newval14" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
+  %20 = add i64 %17, 1
+  store i64 %20, i64* %"@x_newval14"
   %pseudo15 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem16 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo15, i64* %"@x_key5", i64* %"@x_newval14", i64 0)
-  %19 = bitcast i64* %"@x_key5" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
-  %20 = load i64, i64* %"@x_newval14"
-  %21 = bitcast i64* %"@x_newval14" to i8*
+  %21 = bitcast i64* %"@x_key5" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
-  %22 = bitcast i64* %"@x_key17" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %22)
+  %22 = load i64, i64* %"@x_newval14"
+  %23 = bitcast i64* %"@x_newval14" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
+  %24 = bitcast i64* %"@x_key17" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %24)
   store i64 0, i64* %"@x_key17"
   %pseudo18 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem19 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo18, i64* %"@x_key17")
-  %23 = bitcast i64* %lookup_elem_val23 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
+  %25 = bitcast i64* %lookup_elem_val23 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %25)
   %map_lookup_cond24 = icmp ne i8* %lookup_elem19, null
   br i1 %map_lookup_cond24, label %lookup_success20, label %lookup_failure21
 
 lookup_success20:                                 ; preds = %lookup_merge10
   %cast25 = bitcast i8* %lookup_elem19 to i64*
-  %24 = load i64, i64* %cast25
-  store i64 %24, i64* %lookup_elem_val23
+  %26 = load i64, i64* %cast25
+  store i64 %26, i64* %lookup_elem_val23
   br label %lookup_merge22
 
 lookup_failure21:                                 ; preds = %lookup_merge10
@@ -120,31 +124,33 @@ lookup_failure21:                                 ; preds = %lookup_merge10
   br label %lookup_merge22
 
 lookup_merge22:                                   ; preds = %lookup_failure21, %lookup_success20
-  %25 = load i64, i64* %lookup_elem_val23
-  %26 = bitcast i64* %"@x_newval26" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %26)
-  %27 = sub i64 %25, 1
-  store i64 %27, i64* %"@x_newval26"
-  %pseudo27 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem28 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo27, i64* %"@x_key17", i64* %"@x_newval26", i64 0)
-  %28 = bitcast i64* %"@x_key17" to i8*
+  %27 = load i64, i64* %lookup_elem_val23
+  %28 = bitcast i64* %lookup_elem_val23 to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %28)
   %29 = bitcast i64* %"@x_newval26" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %29)
-  %30 = bitcast i64* %"@x_key29" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %30)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %29)
+  %30 = sub i64 %27, 1
+  store i64 %30, i64* %"@x_newval26"
+  %pseudo27 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem28 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo27, i64* %"@x_key17", i64* %"@x_newval26", i64 0)
+  %31 = bitcast i64* %"@x_key17" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %31)
+  %32 = bitcast i64* %"@x_newval26" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %32)
+  %33 = bitcast i64* %"@x_key29" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %33)
   store i64 0, i64* %"@x_key29"
   %pseudo30 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem31 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo30, i64* %"@x_key29")
-  %31 = bitcast i64* %lookup_elem_val35 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %31)
+  %34 = bitcast i64* %lookup_elem_val35 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %34)
   %map_lookup_cond36 = icmp ne i8* %lookup_elem31, null
   br i1 %map_lookup_cond36, label %lookup_success32, label %lookup_failure33
 
 lookup_success32:                                 ; preds = %lookup_merge22
   %cast37 = bitcast i8* %lookup_elem31 to i64*
-  %32 = load i64, i64* %cast37
-  store i64 %32, i64* %lookup_elem_val35
+  %35 = load i64, i64* %cast37
+  store i64 %35, i64* %lookup_elem_val35
   br label %lookup_merge34
 
 lookup_failure33:                                 ; preds = %lookup_merge22
@@ -152,18 +158,20 @@ lookup_failure33:                                 ; preds = %lookup_merge22
   br label %lookup_merge34
 
 lookup_merge34:                                   ; preds = %lookup_failure33, %lookup_success32
-  %33 = load i64, i64* %lookup_elem_val35
-  %34 = bitcast i64* %"@x_newval38" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %34)
-  %35 = sub i64 %33, 1
-  store i64 %35, i64* %"@x_newval38"
+  %36 = load i64, i64* %lookup_elem_val35
+  %37 = bitcast i64* %lookup_elem_val35 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %37)
+  %38 = bitcast i64* %"@x_newval38" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %38)
+  %39 = sub i64 %36, 1
+  store i64 %39, i64* %"@x_newval38"
   %pseudo39 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem40 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo39, i64* %"@x_key29", i64* %"@x_newval38", i64 0)
-  %36 = bitcast i64* %"@x_key29" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %36)
-  %37 = load i64, i64* %"@x_newval38"
-  %38 = bitcast i64* %"@x_newval38" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %38)
+  %40 = bitcast i64* %"@x_key29" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %40)
+  %41 = load i64, i64* %"@x_newval38"
+  %42 = bitcast i64* %"@x_newval38" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %42)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/map_key_probe.ll
+++ b/tests/codegen/llvm/map_key_probe.ll
@@ -35,22 +35,24 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %5 = load i64, i64* %lookup_elem_val
-  %6 = bitcast [8 x i8]* %"@x_key" to i8*
+  %6 = bitcast i64* %lookup_elem_val to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = add i64 %5, 1
-  %8 = bitcast [8 x i8]* %"@x_key1" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %9 = bitcast [8 x i8]* %"@x_key1" to i64*
-  store i64 0, i64* %9
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  store i64 %7, i64* %"@x_val"
+  %7 = bitcast [8 x i8]* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %8 = add i64 %5, 1
+  %9 = bitcast [8 x i8]* %"@x_key1" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %10 = bitcast [8 x i8]* %"@x_key1" to i64*
+  store i64 0, i64* %10
+  %11 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i64 %8, i64* %"@x_val"
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo2, [8 x i8]* %"@x_key1", i64* %"@x_val", i64 0)
-  %11 = bitcast [8 x i8]* %"@x_key1" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_val" to i8*
+  %12 = bitcast [8 x i8]* %"@x_key1" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }
 
@@ -89,22 +91,24 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %5 = load i64, i64* %lookup_elem_val
-  %6 = bitcast [8 x i8]* %"@x_key" to i8*
+  %6 = bitcast i64* %lookup_elem_val to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = add i64 %5, 1
-  %8 = bitcast [8 x i8]* %"@x_key1" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %9 = bitcast [8 x i8]* %"@x_key1" to i64*
-  store i64 1, i64* %9
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  store i64 %7, i64* %"@x_val"
+  %7 = bitcast [8 x i8]* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %8 = add i64 %5, 1
+  %9 = bitcast [8 x i8]* %"@x_key1" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %10 = bitcast [8 x i8]* %"@x_key1" to i64*
+  store i64 1, i64* %10
+  %11 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i64 %8, i64* %"@x_val"
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo2, [8 x i8]* %"@x_key1", i64* %"@x_val", i64 0)
-  %11 = bitcast [8 x i8]* %"@x_key1" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_val" to i8*
+  %12 = bitcast [8 x i8]* %"@x_key1" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/nested_while_loop.ll
+++ b/tests/codegen/llvm/nested_while_loop.ll
@@ -76,19 +76,21 @@ lookup_failure:                                   ; preds = %while_body2
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %16 = load i64, i64* %lookup_elem_val
-  %17 = bitcast i64* %"@_newval" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
-  %18 = add i64 %16, 1
-  store i64 %18, i64* %"@_newval"
+  %17 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %18 = bitcast i64* %"@_newval" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
+  %19 = add i64 %16, 1
+  store i64 %19, i64* %"@_newval"
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo5, i64* %"@_key", i64* %"@_newval", i64 0)
-  %19 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
-  %20 = bitcast i64* %"@_newval" to i8*
+  %20 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  %21 = load i64, i64* %"$j"
-  %22 = add i64 %21, 1
-  store i64 %22, i64* %"$j"
+  %21 = bitcast i64* %"@_newval" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  %22 = load i64, i64* %"$j"
+  %23 = add i64 %22, 1
+  store i64 %23, i64* %"$j"
   br label %while_cond1
 }
 

--- a/tests/codegen/llvm/optional_positional_parameter.ll
+++ b/tests/codegen/llvm/optional_positional_parameter.ll
@@ -45,15 +45,17 @@ entry:
   %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, [1 x i8]*)*)([64 x i8]* %str, i32 %12, [1 x i8]* %str1)
   %13 = bitcast i64* %strlen to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  %14 = bitcast [1 x i8]* %str1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
   store i64 0, i64* %"@y_key"
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem3 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo2, i64* %"@y_key", [64 x i8]* %str, i64 0)
-  %15 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
-  %16 = bitcast [64 x i8]* %str to i8*
+  %16 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/runtime_error_check.ll
+++ b/tests/codegen/llvm/runtime_error_check.ll
@@ -36,37 +36,39 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %4 = load i64, i64* %lookup_elem_val
-  %5 = bitcast i64* %"@_newval" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = add i64 %4, 1
-  store i64 %6, i64* %"@_newval"
+  %5 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = bitcast i64* %"@_newval" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %7 = add i64 %4, 1
+  store i64 %7, i64* %"@_newval"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %"@_newval", i64 0)
-  %7 = trunc i64 %update_elem to i32
-  %8 = icmp sge i32 %7, 0
-  br i1 %8, label %helper_merge, label %helper_failure
+  %8 = trunc i64 %update_elem to i32
+  %9 = icmp sge i32 %8, 0
+  br i1 %9, label %helper_merge, label %helper_failure
 
 helper_failure:                                   ; preds = %lookup_merge
-  %9 = bitcast %helper_error_t* %helper_error_t to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %10 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
-  store i64 30006, i64* %10
-  %11 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
-  store i64 0, i64* %11
-  %12 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
-  store i32 %7, i32* %12
+  %10 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %11
+  %12 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %12
+  %13 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %8, i32* %13
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo2, i64 %get_cpu_id, %helper_error_t* %helper_error_t, i64 20)
-  %13 = bitcast %helper_error_t* %helper_error_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   br label %helper_merge
 
 helper_merge:                                     ; preds = %helper_failure, %lookup_merge
-  %14 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@_newval" to i8*
+  %15 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %16 = bitcast i64* %"@_newval" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/runtime_error_check_lookup.ll
+++ b/tests/codegen/llvm/runtime_error_check_lookup.ll
@@ -50,37 +50,39 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %9 = load i64, i64* %lookup_elem_val
-  %10 = bitcast i64* %"@_newval" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  %11 = add i64 %9, 1
-  store i64 %11, i64* %"@_newval"
+  %10 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@_newval" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %12 = add i64 %9, 1
+  store i64 %12, i64* %"@_newval"
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@_key", i64* %"@_newval", i64 0)
-  %12 = trunc i64 %update_elem to i32
-  %13 = icmp sge i32 %12, 0
-  br i1 %13, label %helper_merge, label %helper_failure
+  %13 = trunc i64 %update_elem to i32
+  %14 = icmp sge i32 %13, 0
+  br i1 %14, label %helper_merge, label %helper_failure
 
 helper_failure:                                   ; preds = %lookup_merge
-  %14 = bitcast %helper_error_t* %helper_error_t3 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
-  %15 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t3, i64 0, i32 0
-  store i64 30006, i64* %15
-  %16 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t3, i64 0, i32 1
-  store i64 1, i64* %16
-  %17 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t3, i64 0, i32 2
-  store i32 %12, i32* %17
+  %15 = bitcast %helper_error_t* %helper_error_t3 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  %16 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t3, i64 0, i32 0
+  store i64 30006, i64* %16
+  %17 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t3, i64 0, i32 1
+  store i64 1, i64* %17
+  %18 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t3, i64 0, i32 2
+  store i32 %13, i32* %18
   %pseudo4 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %get_cpu_id5 = call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output6 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo4, i64 %get_cpu_id5, %helper_error_t* %helper_error_t3, i64 20)
-  %18 = bitcast %helper_error_t* %helper_error_t3 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  %19 = bitcast %helper_error_t* %helper_error_t3 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
   br label %helper_merge
 
 helper_merge:                                     ; preds = %helper_failure, %lookup_merge
-  %19 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
-  %20 = bitcast i64* %"@_newval" to i8*
+  %20 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
+  %21 = bitcast i64* %"@_newval" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/string_equal_comparison.ll
+++ b/tests/codegen/llvm/string_equal_comparison.ll
@@ -45,31 +45,33 @@ strcmp.false:                                     ; preds = %strcmp.loop7, %strc
   %8 = load i8, i8* %strcmp.result
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %strcmp.result)
   %9 = zext i8 %8 to i64
+  %10 = bitcast [16 x i8]* %comm to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   %predcond = icmp eq i64 %9, 0
   br i1 %predcond, label %pred_false, label %pred_true
 
 strcmp.loop:                                      ; preds = %entry
-  %10 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 1
-  %11 = load i8, i8* %10
-  %strcmp.cmp2 = icmp ne i8 %11, 115
+  %11 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 1
+  %12 = load i8, i8* %11
+  %strcmp.cmp2 = icmp ne i8 %12, 115
   br i1 %strcmp.cmp2, label %strcmp.false, label %strcmp.loop1
 
 strcmp.loop1:                                     ; preds = %strcmp.loop
-  %12 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 2
-  %13 = load i8, i8* %12
-  %strcmp.cmp4 = icmp ne i8 %13, 104
+  %13 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 2
+  %14 = load i8, i8* %13
+  %strcmp.cmp4 = icmp ne i8 %14, 104
   br i1 %strcmp.cmp4, label %strcmp.false, label %strcmp.loop3
 
 strcmp.loop3:                                     ; preds = %strcmp.loop1
-  %14 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 3
-  %15 = load i8, i8* %14
-  %strcmp.cmp6 = icmp ne i8 %15, 100
+  %15 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 3
+  %16 = load i8, i8* %15
+  %strcmp.cmp6 = icmp ne i8 %16, 100
   br i1 %strcmp.cmp6, label %strcmp.false, label %strcmp.loop5
 
 strcmp.loop5:                                     ; preds = %strcmp.loop3
-  %16 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 4
-  %17 = load i8, i8* %16
-  %strcmp.cmp8 = icmp ne i8 %17, 0
+  %17 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 4
+  %18 = load i8, i8* %17
+  %strcmp.cmp8 = icmp ne i8 %18, 0
   br i1 %strcmp.cmp8, label %strcmp.false, label %strcmp.loop7
 
 strcmp.loop7:                                     ; preds = %strcmp.loop5
@@ -78,8 +80,8 @@ strcmp.loop7:                                     ; preds = %strcmp.loop5
 
 lookup_success:                                   ; preds = %pred_true
   %cast = bitcast i8* %lookup_elem to i64*
-  %18 = load i64, i64* %cast
-  store i64 %18, i64* %lookup_elem_val
+  %19 = load i64, i64* %cast
+  store i64 %19, i64* %lookup_elem_val
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %pred_true
@@ -87,17 +89,19 @@ lookup_failure:                                   ; preds = %pred_true
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %19 = load i64, i64* %lookup_elem_val
-  %20 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %20)
-  %21 = add i64 %19, 1
-  store i64 %21, i64* %"@_val"
+  %20 = load i64, i64* %lookup_elem_val
+  %21 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  %22 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %22)
+  %23 = add i64 %20, 1
+  store i64 %23, i64* %"@_val"
   %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo11, [16 x i8]* %comm9, i64* %"@_val", i64 0)
-  %22 = bitcast [16 x i8]* %comm9 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
-  %23 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
+  %24 = bitcast [16 x i8]* %comm9 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
+  %25 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %25)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/string_not_equal_comparison.ll
+++ b/tests/codegen/llvm/string_not_equal_comparison.ll
@@ -45,31 +45,33 @@ strcmp.false:                                     ; preds = %strcmp.loop7, %strc
   %8 = load i8, i8* %strcmp.result
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %strcmp.result)
   %9 = zext i8 %8 to i64
+  %10 = bitcast [16 x i8]* %comm to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   %predcond = icmp eq i64 %9, 0
   br i1 %predcond, label %pred_false, label %pred_true
 
 strcmp.loop:                                      ; preds = %entry
-  %10 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 1
-  %11 = load i8, i8* %10
-  %strcmp.cmp2 = icmp ne i8 %11, 115
+  %11 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 1
+  %12 = load i8, i8* %11
+  %strcmp.cmp2 = icmp ne i8 %12, 115
   br i1 %strcmp.cmp2, label %strcmp.false, label %strcmp.loop1
 
 strcmp.loop1:                                     ; preds = %strcmp.loop
-  %12 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 2
-  %13 = load i8, i8* %12
-  %strcmp.cmp4 = icmp ne i8 %13, 104
+  %13 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 2
+  %14 = load i8, i8* %13
+  %strcmp.cmp4 = icmp ne i8 %14, 104
   br i1 %strcmp.cmp4, label %strcmp.false, label %strcmp.loop3
 
 strcmp.loop3:                                     ; preds = %strcmp.loop1
-  %14 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 3
-  %15 = load i8, i8* %14
-  %strcmp.cmp6 = icmp ne i8 %15, 100
+  %15 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 3
+  %16 = load i8, i8* %15
+  %strcmp.cmp6 = icmp ne i8 %16, 100
   br i1 %strcmp.cmp6, label %strcmp.false, label %strcmp.loop5
 
 strcmp.loop5:                                     ; preds = %strcmp.loop3
-  %16 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 4
-  %17 = load i8, i8* %16
-  %strcmp.cmp8 = icmp ne i8 %17, 0
+  %17 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 4
+  %18 = load i8, i8* %17
+  %strcmp.cmp8 = icmp ne i8 %18, 0
   br i1 %strcmp.cmp8, label %strcmp.false, label %strcmp.loop7
 
 strcmp.loop7:                                     ; preds = %strcmp.loop5
@@ -78,8 +80,8 @@ strcmp.loop7:                                     ; preds = %strcmp.loop5
 
 lookup_success:                                   ; preds = %pred_true
   %cast = bitcast i8* %lookup_elem to i64*
-  %18 = load i64, i64* %cast
-  store i64 %18, i64* %lookup_elem_val
+  %19 = load i64, i64* %cast
+  store i64 %19, i64* %lookup_elem_val
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %pred_true
@@ -87,17 +89,19 @@ lookup_failure:                                   ; preds = %pred_true
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %19 = load i64, i64* %lookup_elem_val
-  %20 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %20)
-  %21 = add i64 %19, 1
-  store i64 %21, i64* %"@_val"
+  %20 = load i64, i64* %lookup_elem_val
+  %21 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  %22 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %22)
+  %23 = add i64 %20, 1
+  store i64 %23, i64* %"@_val"
   %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo11, [16 x i8]* %comm9, i64* %"@_val", i64 0)
-  %22 = bitcast [16 x i8]* %comm9 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
-  %23 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
+  %24 = bitcast [16 x i8]* %comm9 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
+  %25 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %25)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/strncmp.ll
+++ b/tests/codegen/llvm/strncmp.ll
@@ -76,6 +76,10 @@ strcmp.false:                                     ; preds = %strcmp.done, %strcm
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %strcmp.char_l)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %strcmp.char_r)
   %23 = zext i8 %22 to i64
+  %24 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
+  %25 = bitcast [16 x i8]* %comm to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %25)
   %predcond = icmp eq i64 %23, 0
   br i1 %predcond, label %pred_false, label %pred_true
 
@@ -84,13 +88,13 @@ strcmp.done:                                      ; preds = %strcmp.loop92, %str
   br label %strcmp.false
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
-  %24 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 1
-  %probe_read4 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %24)
-  %25 = load i8, i8* %strcmp.char_l
-  %26 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 1
-  %probe_read5 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %26)
-  %27 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp6 = icmp ne i8 %25, %27
+  %26 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 1
+  %probe_read4 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %26)
+  %27 = load i8, i8* %strcmp.char_l
+  %28 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 1
+  %probe_read5 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %28)
+  %29 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp6 = icmp ne i8 %27, %29
   br i1 %strcmp.cmp6, label %strcmp.false, label %strcmp.loop_null_cmp3
 
 strcmp.loop_null_cmp:                             ; preds = %entry
@@ -98,220 +102,220 @@ strcmp.loop_null_cmp:                             ; preds = %entry
   br i1 %strcmp.cmp_null, label %strcmp.done, label %strcmp.loop
 
 strcmp.loop2:                                     ; preds = %strcmp.loop_null_cmp3
-  %28 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 2
-  %probe_read10 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %28)
-  %29 = load i8, i8* %strcmp.char_l
-  %30 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 2
-  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %30)
-  %31 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp12 = icmp ne i8 %29, %31
+  %30 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 2
+  %probe_read10 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %30)
+  %31 = load i8, i8* %strcmp.char_l
+  %32 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 2
+  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %32)
+  %33 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp12 = icmp ne i8 %31, %33
   br i1 %strcmp.cmp12, label %strcmp.false, label %strcmp.loop_null_cmp9
 
 strcmp.loop_null_cmp3:                            ; preds = %strcmp.loop
-  %strcmp.cmp_null7 = icmp eq i8 %25, 0
+  %strcmp.cmp_null7 = icmp eq i8 %27, 0
   br i1 %strcmp.cmp_null7, label %strcmp.done, label %strcmp.loop2
 
 strcmp.loop8:                                     ; preds = %strcmp.loop_null_cmp9
-  %32 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 3
-  %probe_read16 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %32)
-  %33 = load i8, i8* %strcmp.char_l
-  %34 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 3
-  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %34)
-  %35 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp18 = icmp ne i8 %33, %35
+  %34 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 3
+  %probe_read16 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %34)
+  %35 = load i8, i8* %strcmp.char_l
+  %36 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 3
+  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %36)
+  %37 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp18 = icmp ne i8 %35, %37
   br i1 %strcmp.cmp18, label %strcmp.false, label %strcmp.loop_null_cmp15
 
 strcmp.loop_null_cmp9:                            ; preds = %strcmp.loop2
-  %strcmp.cmp_null13 = icmp eq i8 %29, 0
+  %strcmp.cmp_null13 = icmp eq i8 %31, 0
   br i1 %strcmp.cmp_null13, label %strcmp.done, label %strcmp.loop8
 
 strcmp.loop14:                                    ; preds = %strcmp.loop_null_cmp15
-  %36 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 4
-  %probe_read22 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %36)
-  %37 = load i8, i8* %strcmp.char_l
-  %38 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 4
-  %probe_read23 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %38)
-  %39 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp24 = icmp ne i8 %37, %39
+  %38 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 4
+  %probe_read22 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %38)
+  %39 = load i8, i8* %strcmp.char_l
+  %40 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 4
+  %probe_read23 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %40)
+  %41 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp24 = icmp ne i8 %39, %41
   br i1 %strcmp.cmp24, label %strcmp.false, label %strcmp.loop_null_cmp21
 
 strcmp.loop_null_cmp15:                           ; preds = %strcmp.loop8
-  %strcmp.cmp_null19 = icmp eq i8 %33, 0
+  %strcmp.cmp_null19 = icmp eq i8 %35, 0
   br i1 %strcmp.cmp_null19, label %strcmp.done, label %strcmp.loop14
 
 strcmp.loop20:                                    ; preds = %strcmp.loop_null_cmp21
-  %40 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 5
-  %probe_read28 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %40)
-  %41 = load i8, i8* %strcmp.char_l
-  %42 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 5
-  %probe_read29 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %42)
-  %43 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp30 = icmp ne i8 %41, %43
+  %42 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 5
+  %probe_read28 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %42)
+  %43 = load i8, i8* %strcmp.char_l
+  %44 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 5
+  %probe_read29 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %44)
+  %45 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp30 = icmp ne i8 %43, %45
   br i1 %strcmp.cmp30, label %strcmp.false, label %strcmp.loop_null_cmp27
 
 strcmp.loop_null_cmp21:                           ; preds = %strcmp.loop14
-  %strcmp.cmp_null25 = icmp eq i8 %37, 0
+  %strcmp.cmp_null25 = icmp eq i8 %39, 0
   br i1 %strcmp.cmp_null25, label %strcmp.done, label %strcmp.loop20
 
 strcmp.loop26:                                    ; preds = %strcmp.loop_null_cmp27
-  %44 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 6
-  %probe_read34 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %44)
-  %45 = load i8, i8* %strcmp.char_l
-  %46 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 6
-  %probe_read35 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %46)
-  %47 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp36 = icmp ne i8 %45, %47
+  %46 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 6
+  %probe_read34 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %46)
+  %47 = load i8, i8* %strcmp.char_l
+  %48 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 6
+  %probe_read35 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %48)
+  %49 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp36 = icmp ne i8 %47, %49
   br i1 %strcmp.cmp36, label %strcmp.false, label %strcmp.loop_null_cmp33
 
 strcmp.loop_null_cmp27:                           ; preds = %strcmp.loop20
-  %strcmp.cmp_null31 = icmp eq i8 %41, 0
+  %strcmp.cmp_null31 = icmp eq i8 %43, 0
   br i1 %strcmp.cmp_null31, label %strcmp.done, label %strcmp.loop26
 
 strcmp.loop32:                                    ; preds = %strcmp.loop_null_cmp33
-  %48 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 7
-  %probe_read40 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %48)
-  %49 = load i8, i8* %strcmp.char_l
-  %50 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 7
-  %probe_read41 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %50)
-  %51 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp42 = icmp ne i8 %49, %51
+  %50 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 7
+  %probe_read40 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %50)
+  %51 = load i8, i8* %strcmp.char_l
+  %52 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 7
+  %probe_read41 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %52)
+  %53 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp42 = icmp ne i8 %51, %53
   br i1 %strcmp.cmp42, label %strcmp.false, label %strcmp.loop_null_cmp39
 
 strcmp.loop_null_cmp33:                           ; preds = %strcmp.loop26
-  %strcmp.cmp_null37 = icmp eq i8 %45, 0
+  %strcmp.cmp_null37 = icmp eq i8 %47, 0
   br i1 %strcmp.cmp_null37, label %strcmp.done, label %strcmp.loop32
 
 strcmp.loop38:                                    ; preds = %strcmp.loop_null_cmp39
-  %52 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 8
-  %probe_read46 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %52)
-  %53 = load i8, i8* %strcmp.char_l
-  %54 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 8
-  %probe_read47 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %54)
-  %55 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp48 = icmp ne i8 %53, %55
+  %54 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 8
+  %probe_read46 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %54)
+  %55 = load i8, i8* %strcmp.char_l
+  %56 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 8
+  %probe_read47 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %56)
+  %57 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp48 = icmp ne i8 %55, %57
   br i1 %strcmp.cmp48, label %strcmp.false, label %strcmp.loop_null_cmp45
 
 strcmp.loop_null_cmp39:                           ; preds = %strcmp.loop32
-  %strcmp.cmp_null43 = icmp eq i8 %49, 0
+  %strcmp.cmp_null43 = icmp eq i8 %51, 0
   br i1 %strcmp.cmp_null43, label %strcmp.done, label %strcmp.loop38
 
 strcmp.loop44:                                    ; preds = %strcmp.loop_null_cmp45
-  %56 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 9
-  %probe_read52 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %56)
-  %57 = load i8, i8* %strcmp.char_l
-  %58 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 9
-  %probe_read53 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %58)
-  %59 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp54 = icmp ne i8 %57, %59
+  %58 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 9
+  %probe_read52 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %58)
+  %59 = load i8, i8* %strcmp.char_l
+  %60 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 9
+  %probe_read53 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %60)
+  %61 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp54 = icmp ne i8 %59, %61
   br i1 %strcmp.cmp54, label %strcmp.false, label %strcmp.loop_null_cmp51
 
 strcmp.loop_null_cmp45:                           ; preds = %strcmp.loop38
-  %strcmp.cmp_null49 = icmp eq i8 %53, 0
+  %strcmp.cmp_null49 = icmp eq i8 %55, 0
   br i1 %strcmp.cmp_null49, label %strcmp.done, label %strcmp.loop44
 
 strcmp.loop50:                                    ; preds = %strcmp.loop_null_cmp51
-  %60 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 10
-  %probe_read58 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %60)
-  %61 = load i8, i8* %strcmp.char_l
-  %62 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 10
-  %probe_read59 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %62)
-  %63 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp60 = icmp ne i8 %61, %63
+  %62 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 10
+  %probe_read58 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %62)
+  %63 = load i8, i8* %strcmp.char_l
+  %64 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 10
+  %probe_read59 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %64)
+  %65 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp60 = icmp ne i8 %63, %65
   br i1 %strcmp.cmp60, label %strcmp.false, label %strcmp.loop_null_cmp57
 
 strcmp.loop_null_cmp51:                           ; preds = %strcmp.loop44
-  %strcmp.cmp_null55 = icmp eq i8 %57, 0
+  %strcmp.cmp_null55 = icmp eq i8 %59, 0
   br i1 %strcmp.cmp_null55, label %strcmp.done, label %strcmp.loop50
 
 strcmp.loop56:                                    ; preds = %strcmp.loop_null_cmp57
-  %64 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 11
-  %probe_read64 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %64)
-  %65 = load i8, i8* %strcmp.char_l
-  %66 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 11
-  %probe_read65 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %66)
-  %67 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp66 = icmp ne i8 %65, %67
+  %66 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 11
+  %probe_read64 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %66)
+  %67 = load i8, i8* %strcmp.char_l
+  %68 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 11
+  %probe_read65 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %68)
+  %69 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp66 = icmp ne i8 %67, %69
   br i1 %strcmp.cmp66, label %strcmp.false, label %strcmp.loop_null_cmp63
 
 strcmp.loop_null_cmp57:                           ; preds = %strcmp.loop50
-  %strcmp.cmp_null61 = icmp eq i8 %61, 0
+  %strcmp.cmp_null61 = icmp eq i8 %63, 0
   br i1 %strcmp.cmp_null61, label %strcmp.done, label %strcmp.loop56
 
 strcmp.loop62:                                    ; preds = %strcmp.loop_null_cmp63
-  %68 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 12
-  %probe_read70 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %68)
-  %69 = load i8, i8* %strcmp.char_l
-  %70 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 12
-  %probe_read71 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %70)
-  %71 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp72 = icmp ne i8 %69, %71
+  %70 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 12
+  %probe_read70 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %70)
+  %71 = load i8, i8* %strcmp.char_l
+  %72 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 12
+  %probe_read71 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %72)
+  %73 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp72 = icmp ne i8 %71, %73
   br i1 %strcmp.cmp72, label %strcmp.false, label %strcmp.loop_null_cmp69
 
 strcmp.loop_null_cmp63:                           ; preds = %strcmp.loop56
-  %strcmp.cmp_null67 = icmp eq i8 %65, 0
+  %strcmp.cmp_null67 = icmp eq i8 %67, 0
   br i1 %strcmp.cmp_null67, label %strcmp.done, label %strcmp.loop62
 
 strcmp.loop68:                                    ; preds = %strcmp.loop_null_cmp69
-  %72 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 13
-  %probe_read76 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %72)
-  %73 = load i8, i8* %strcmp.char_l
-  %74 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 13
-  %probe_read77 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %74)
-  %75 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp78 = icmp ne i8 %73, %75
+  %74 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 13
+  %probe_read76 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %74)
+  %75 = load i8, i8* %strcmp.char_l
+  %76 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 13
+  %probe_read77 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %76)
+  %77 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp78 = icmp ne i8 %75, %77
   br i1 %strcmp.cmp78, label %strcmp.false, label %strcmp.loop_null_cmp75
 
 strcmp.loop_null_cmp69:                           ; preds = %strcmp.loop62
-  %strcmp.cmp_null73 = icmp eq i8 %69, 0
+  %strcmp.cmp_null73 = icmp eq i8 %71, 0
   br i1 %strcmp.cmp_null73, label %strcmp.done, label %strcmp.loop68
 
 strcmp.loop74:                                    ; preds = %strcmp.loop_null_cmp75
-  %76 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 14
-  %probe_read82 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %76)
-  %77 = load i8, i8* %strcmp.char_l
-  %78 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 14
-  %probe_read83 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %78)
-  %79 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp84 = icmp ne i8 %77, %79
+  %78 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 14
+  %probe_read82 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %78)
+  %79 = load i8, i8* %strcmp.char_l
+  %80 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 14
+  %probe_read83 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %80)
+  %81 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp84 = icmp ne i8 %79, %81
   br i1 %strcmp.cmp84, label %strcmp.false, label %strcmp.loop_null_cmp81
 
 strcmp.loop_null_cmp75:                           ; preds = %strcmp.loop68
-  %strcmp.cmp_null79 = icmp eq i8 %73, 0
+  %strcmp.cmp_null79 = icmp eq i8 %75, 0
   br i1 %strcmp.cmp_null79, label %strcmp.done, label %strcmp.loop74
 
 strcmp.loop80:                                    ; preds = %strcmp.loop_null_cmp81
-  %80 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 15
-  %probe_read88 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %80)
-  %81 = load i8, i8* %strcmp.char_l
-  %82 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 15
-  %probe_read89 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %82)
-  %83 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp90 = icmp ne i8 %81, %83
+  %82 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 15
+  %probe_read88 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %82)
+  %83 = load i8, i8* %strcmp.char_l
+  %84 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 15
+  %probe_read89 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %84)
+  %85 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp90 = icmp ne i8 %83, %85
   br i1 %strcmp.cmp90, label %strcmp.false, label %strcmp.loop_null_cmp87
 
 strcmp.loop_null_cmp81:                           ; preds = %strcmp.loop74
-  %strcmp.cmp_null85 = icmp eq i8 %77, 0
+  %strcmp.cmp_null85 = icmp eq i8 %79, 0
   br i1 %strcmp.cmp_null85, label %strcmp.done, label %strcmp.loop80
 
 strcmp.loop86:                                    ; preds = %strcmp.loop_null_cmp87
-  %84 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 16
-  %probe_read94 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %84)
-  %85 = load i8, i8* %strcmp.char_l
-  %86 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 16
-  %probe_read95 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %86)
-  %87 = load i8, i8* %strcmp.char_r
-  %strcmp.cmp96 = icmp ne i8 %85, %87
+  %86 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 16
+  %probe_read94 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %86)
+  %87 = load i8, i8* %strcmp.char_l
+  %88 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 16
+  %probe_read95 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %88)
+  %89 = load i8, i8* %strcmp.char_r
+  %strcmp.cmp96 = icmp ne i8 %87, %89
   br i1 %strcmp.cmp96, label %strcmp.false, label %strcmp.loop_null_cmp93
 
 strcmp.loop_null_cmp87:                           ; preds = %strcmp.loop80
-  %strcmp.cmp_null91 = icmp eq i8 %81, 0
+  %strcmp.cmp_null91 = icmp eq i8 %83, 0
   br i1 %strcmp.cmp_null91, label %strcmp.done, label %strcmp.loop86
 
 strcmp.loop92:                                    ; preds = %strcmp.loop_null_cmp93
   br label %strcmp.done
 
 strcmp.loop_null_cmp93:                           ; preds = %strcmp.loop86
-  %strcmp.cmp_null97 = icmp eq i8 %85, 0
+  %strcmp.cmp_null97 = icmp eq i8 %87, 0
   br i1 %strcmp.cmp_null97, label %strcmp.done, label %strcmp.loop92
 }
 

--- a/tests/codegen/llvm/struct_save_nested.ll
+++ b/tests/codegen/llvm/struct_save_nested.ll
@@ -59,58 +59,64 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   %12 = bitcast [8 x i8]* %"internal_struct Foo.bar" to i8*
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %12, i8* align 1 %10, i64 8, i1 false)
-  %13 = bitcast i64* %"@bar_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %13 = bitcast [16 x i8]* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@bar_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
   store i64 0, i64* %"@bar_key"
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [8 x i8]*, i64)*)(i64 %pseudo3, i64* %"@bar_key", [8 x i8]* %"internal_struct Foo.bar", i64 0)
-  %14 = bitcast i64* %"@bar_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast [8 x i8]* %"internal_struct Foo.bar" to i8*
+  %15 = bitcast i64* %"@bar_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
-  %16 = bitcast i64* %"@foo_key5" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
+  %16 = bitcast [8 x i8]* %"internal_struct Foo.bar" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = bitcast i64* %"@foo_key5" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
   store i64 0, i64* %"@foo_key5"
   %pseudo6 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %lookup_elem7 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo6, i64* %"@foo_key5")
-  %17 = bitcast [16 x i8]* %lookup_elem_val11 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
+  %18 = bitcast [16 x i8]* %lookup_elem_val11 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
   %map_lookup_cond12 = icmp ne i8* %lookup_elem7, null
   br i1 %map_lookup_cond12, label %lookup_success8, label %lookup_failure9
 
 lookup_success8:                                  ; preds = %lookup_merge
-  %18 = bitcast [16 x i8]* %lookup_elem_val11 to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %18, i8* align 1 %lookup_elem7, i64 16, i1 false)
+  %19 = bitcast [16 x i8]* %lookup_elem_val11 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %19, i8* align 1 %lookup_elem7, i64 16, i1 false)
   br label %lookup_merge10
 
 lookup_failure9:                                  ; preds = %lookup_merge
-  %19 = bitcast [16 x i8]* %lookup_elem_val11 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %19, i8 0, i64 16, i1 false)
+  %20 = bitcast [16 x i8]* %lookup_elem_val11 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %20, i8 0, i64 16, i1 false)
   br label %lookup_merge10
 
 lookup_merge10:                                   ; preds = %lookup_failure9, %lookup_success8
-  %20 = bitcast i64* %"@foo_key5" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  %21 = getelementptr [16 x i8], [16 x i8]* %lookup_elem_val11, i64 0, i64 4
-  %22 = bitcast [8 x i8]* %"internal_struct Foo.bar13" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %22)
+  %21 = bitcast i64* %"@foo_key5" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  %22 = getelementptr [16 x i8], [16 x i8]* %lookup_elem_val11, i64 0, i64 4
   %23 = bitcast [8 x i8]* %"internal_struct Foo.bar13" to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %23, i8* align 1 %21, i64 8, i1 false)
-  %24 = getelementptr [8 x i8], [8 x i8]* %"internal_struct Foo.bar13", i64 0, i64 0
-  %25 = load i32, i8* %24
-  %26 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %26)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
+  %24 = bitcast [8 x i8]* %"internal_struct Foo.bar13" to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %24, i8* align 1 %22, i64 8, i1 false)
+  %25 = bitcast [16 x i8]* %lookup_elem_val11 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %25)
+  %26 = getelementptr [8 x i8], [8 x i8]* %"internal_struct Foo.bar13", i64 0, i64 0
+  %27 = load i32, i8* %26
+  %28 = bitcast [8 x i8]* %"internal_struct Foo.bar13" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %28)
+  %29 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %29)
   store i64 0, i64* %"@x_key"
-  %27 = sext i32 %25 to i64
-  %28 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %28)
-  store i64 %27, i64* %"@x_val"
+  %30 = sext i32 %27 to i64
+  %31 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %31)
+  store i64 %30, i64* %"@x_val"
   %pseudo14 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
   %update_elem15 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo14, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %29 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %29)
-  %30 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %30)
+  %32 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %32)
+  %33 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %33)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_save_string.ll
+++ b/tests/codegen/llvm/struct_save_string.ll
@@ -56,7 +56,8 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i8*, i64)*)(i64 %pseudo3, i64* %"@str_key", i8* %10, i64 0)
   %12 = bitcast i64* %"@str_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %13 = bitcast [32 x i8]* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/ternary_str.ll
+++ b/tests/codegen/llvm/ternary_str.ll
@@ -31,22 +31,22 @@ left:                                             ; preds = %entry
   %7 = bitcast [64 x i8]* %buf to i8*
   %8 = bitcast [64 x i8]* %str to i8*
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %7, i8* align 1 %8, i64 64, i1 false)
-  %9 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   br label %done
 
 right:                                            ; preds = %entry
-  %10 = bitcast [64 x i8]* %str1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %9 = bitcast [64 x i8]* %str1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store [64 x i8] c"hi\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str1
-  %11 = bitcast [64 x i8]* %buf to i8*
-  %12 = bitcast [64 x i8]* %str1 to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %11, i8* align 1 %12, i64 64, i1 false)
-  %13 = bitcast [64 x i8]* %str1 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %10 = bitcast [64 x i8]* %buf to i8*
+  %11 = bitcast [64 x i8]* %str1 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %10, i8* align 1 %11, i64 64, i1 false)
   br label %done
 
 done:                                             ; preds = %right, %left
+  %12 = bitcast [64 x i8]* %str1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   %14 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
   store i64 0, i64* %"@x_key"

--- a/tests/codegen/llvm/unroll.ll
+++ b/tests/codegen/llvm/unroll.ll
@@ -64,35 +64,37 @@ lookup_failure:                                   ; preds = %entry
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %8 = load i64, i64* %lookup_elem_val
-  %9 = bitcast i64* %"@i_key1" to i8*
+  %9 = bitcast i64* %lookup_elem_val to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = add i64 %8, 1
-  %11 = bitcast i64* %"@i_key3" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  store i64 0, i64* %"@i_key3"
-  %12 = bitcast i64* %"@i_val4" to i8*
+  %10 = bitcast i64* %"@i_key1" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = add i64 %8, 1
+  %12 = bitcast i64* %"@i_key3" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  store i64 %10, i64* %"@i_val4"
+  store i64 0, i64* %"@i_key3"
+  %13 = bitcast i64* %"@i_val4" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  store i64 %11, i64* %"@i_val4"
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem6 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo5, i64* %"@i_key3", i64* %"@i_val4", i64 0)
-  %13 = bitcast i64* %"@i_key3" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@i_val4" to i8*
+  %14 = bitcast i64* %"@i_key3" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@i_key7" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  %15 = bitcast i64* %"@i_val4" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %16 = bitcast i64* %"@i_key7" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
   store i64 0, i64* %"@i_key7"
   %pseudo8 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem9 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo8, i64* %"@i_key7")
-  %16 = bitcast i64* %lookup_elem_val13 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
+  %17 = bitcast i64* %lookup_elem_val13 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
   %map_lookup_cond14 = icmp ne i8* %lookup_elem9, null
   br i1 %map_lookup_cond14, label %lookup_success10, label %lookup_failure11
 
 lookup_success10:                                 ; preds = %lookup_merge
   %cast15 = bitcast i8* %lookup_elem9 to i64*
-  %17 = load i64, i64* %cast15
-  store i64 %17, i64* %lookup_elem_val13
+  %18 = load i64, i64* %cast15
+  store i64 %18, i64* %lookup_elem_val13
   br label %lookup_merge12
 
 lookup_failure11:                                 ; preds = %lookup_merge
@@ -100,36 +102,38 @@ lookup_failure11:                                 ; preds = %lookup_merge
   br label %lookup_merge12
 
 lookup_merge12:                                   ; preds = %lookup_failure11, %lookup_success10
-  %18 = load i64, i64* %lookup_elem_val13
-  %19 = bitcast i64* %"@i_key7" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
-  %20 = add i64 %18, 1
-  %21 = bitcast i64* %"@i_key16" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21)
+  %19 = load i64, i64* %lookup_elem_val13
+  %20 = bitcast i64* %lookup_elem_val13 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
+  %21 = bitcast i64* %"@i_key7" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  %22 = add i64 %19, 1
+  %23 = bitcast i64* %"@i_key16" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
   store i64 0, i64* %"@i_key16"
-  %22 = bitcast i64* %"@i_val17" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %22)
-  store i64 %20, i64* %"@i_val17"
+  %24 = bitcast i64* %"@i_val17" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %24)
+  store i64 %22, i64* %"@i_val17"
   %pseudo18 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem19 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo18, i64* %"@i_key16", i64* %"@i_val17", i64 0)
-  %23 = bitcast i64* %"@i_key16" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
-  %24 = bitcast i64* %"@i_val17" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
-  %25 = bitcast i64* %"@i_key20" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %25)
+  %25 = bitcast i64* %"@i_key16" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %25)
+  %26 = bitcast i64* %"@i_val17" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %26)
+  %27 = bitcast i64* %"@i_key20" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %27)
   store i64 0, i64* %"@i_key20"
   %pseudo21 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem22 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo21, i64* %"@i_key20")
-  %26 = bitcast i64* %lookup_elem_val26 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %26)
+  %28 = bitcast i64* %lookup_elem_val26 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %28)
   %map_lookup_cond27 = icmp ne i8* %lookup_elem22, null
   br i1 %map_lookup_cond27, label %lookup_success23, label %lookup_failure24
 
 lookup_success23:                                 ; preds = %lookup_merge12
   %cast28 = bitcast i8* %lookup_elem22 to i64*
-  %27 = load i64, i64* %cast28
-  store i64 %27, i64* %lookup_elem_val26
+  %29 = load i64, i64* %cast28
+  store i64 %29, i64* %lookup_elem_val26
   br label %lookup_merge25
 
 lookup_failure24:                                 ; preds = %lookup_merge12
@@ -137,36 +141,38 @@ lookup_failure24:                                 ; preds = %lookup_merge12
   br label %lookup_merge25
 
 lookup_merge25:                                   ; preds = %lookup_failure24, %lookup_success23
-  %28 = load i64, i64* %lookup_elem_val26
-  %29 = bitcast i64* %"@i_key20" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %29)
-  %30 = add i64 %28, 1
-  %31 = bitcast i64* %"@i_key29" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %31)
+  %30 = load i64, i64* %lookup_elem_val26
+  %31 = bitcast i64* %lookup_elem_val26 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %31)
+  %32 = bitcast i64* %"@i_key20" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %32)
+  %33 = add i64 %30, 1
+  %34 = bitcast i64* %"@i_key29" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %34)
   store i64 0, i64* %"@i_key29"
-  %32 = bitcast i64* %"@i_val30" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %32)
-  store i64 %30, i64* %"@i_val30"
+  %35 = bitcast i64* %"@i_val30" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %35)
+  store i64 %33, i64* %"@i_val30"
   %pseudo31 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem32 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo31, i64* %"@i_key29", i64* %"@i_val30", i64 0)
-  %33 = bitcast i64* %"@i_key29" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %33)
-  %34 = bitcast i64* %"@i_val30" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %34)
-  %35 = bitcast i64* %"@i_key33" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %35)
+  %36 = bitcast i64* %"@i_key29" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %36)
+  %37 = bitcast i64* %"@i_val30" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %37)
+  %38 = bitcast i64* %"@i_key33" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %38)
   store i64 0, i64* %"@i_key33"
   %pseudo34 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem35 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo34, i64* %"@i_key33")
-  %36 = bitcast i64* %lookup_elem_val39 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %36)
+  %39 = bitcast i64* %lookup_elem_val39 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %39)
   %map_lookup_cond40 = icmp ne i8* %lookup_elem35, null
   br i1 %map_lookup_cond40, label %lookup_success36, label %lookup_failure37
 
 lookup_success36:                                 ; preds = %lookup_merge25
   %cast41 = bitcast i8* %lookup_elem35 to i64*
-  %37 = load i64, i64* %cast41
-  store i64 %37, i64* %lookup_elem_val39
+  %40 = load i64, i64* %cast41
+  store i64 %40, i64* %lookup_elem_val39
   br label %lookup_merge38
 
 lookup_failure37:                                 ; preds = %lookup_merge25
@@ -174,36 +180,38 @@ lookup_failure37:                                 ; preds = %lookup_merge25
   br label %lookup_merge38
 
 lookup_merge38:                                   ; preds = %lookup_failure37, %lookup_success36
-  %38 = load i64, i64* %lookup_elem_val39
-  %39 = bitcast i64* %"@i_key33" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %39)
-  %40 = add i64 %38, 1
-  %41 = bitcast i64* %"@i_key42" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %41)
+  %41 = load i64, i64* %lookup_elem_val39
+  %42 = bitcast i64* %lookup_elem_val39 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %42)
+  %43 = bitcast i64* %"@i_key33" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %43)
+  %44 = add i64 %41, 1
+  %45 = bitcast i64* %"@i_key42" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %45)
   store i64 0, i64* %"@i_key42"
-  %42 = bitcast i64* %"@i_val43" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %42)
-  store i64 %40, i64* %"@i_val43"
+  %46 = bitcast i64* %"@i_val43" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %46)
+  store i64 %44, i64* %"@i_val43"
   %pseudo44 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem45 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo44, i64* %"@i_key42", i64* %"@i_val43", i64 0)
-  %43 = bitcast i64* %"@i_key42" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %43)
-  %44 = bitcast i64* %"@i_val43" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %44)
-  %45 = bitcast i64* %"@i_key46" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %45)
+  %47 = bitcast i64* %"@i_key42" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %47)
+  %48 = bitcast i64* %"@i_val43" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %48)
+  %49 = bitcast i64* %"@i_key46" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %49)
   store i64 0, i64* %"@i_key46"
   %pseudo47 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem48 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo47, i64* %"@i_key46")
-  %46 = bitcast i64* %lookup_elem_val52 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %46)
+  %50 = bitcast i64* %lookup_elem_val52 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %50)
   %map_lookup_cond53 = icmp ne i8* %lookup_elem48, null
   br i1 %map_lookup_cond53, label %lookup_success49, label %lookup_failure50
 
 lookup_success49:                                 ; preds = %lookup_merge38
   %cast54 = bitcast i8* %lookup_elem48 to i64*
-  %47 = load i64, i64* %cast54
-  store i64 %47, i64* %lookup_elem_val52
+  %51 = load i64, i64* %cast54
+  store i64 %51, i64* %lookup_elem_val52
   br label %lookup_merge51
 
 lookup_failure50:                                 ; preds = %lookup_merge38
@@ -211,22 +219,24 @@ lookup_failure50:                                 ; preds = %lookup_merge38
   br label %lookup_merge51
 
 lookup_merge51:                                   ; preds = %lookup_failure50, %lookup_success49
-  %48 = load i64, i64* %lookup_elem_val52
-  %49 = bitcast i64* %"@i_key46" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %49)
-  %50 = add i64 %48, 1
-  %51 = bitcast i64* %"@i_key55" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %51)
+  %52 = load i64, i64* %lookup_elem_val52
+  %53 = bitcast i64* %lookup_elem_val52 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %53)
+  %54 = bitcast i64* %"@i_key46" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %54)
+  %55 = add i64 %52, 1
+  %56 = bitcast i64* %"@i_key55" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %56)
   store i64 0, i64* %"@i_key55"
-  %52 = bitcast i64* %"@i_val56" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %52)
-  store i64 %50, i64* %"@i_val56"
+  %57 = bitcast i64* %"@i_val56" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %57)
+  store i64 %55, i64* %"@i_val56"
   %pseudo57 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem58 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo57, i64* %"@i_key55", i64* %"@i_val56", i64 0)
-  %53 = bitcast i64* %"@i_key55" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %53)
-  %54 = bitcast i64* %"@i_val56" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %54)
+  %58 = bitcast i64* %"@i_key55" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %58)
+  %59 = bitcast i64* %"@i_val56" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %59)
   ret i64 0
 }
 


### PR DESCRIPTION
While looking at codegen, I noticed that it's quite easy to forget to
end the lifetime of an alloca buffer. This PR proposes an interface that
should make it harder to forget ending lifetimes.

This patchset is best viewed one commit at a time in the order I've
laid them out.

Commits 1-3 should be fairly straightforward. The final commit,
"Update all callsites to use safer accept()" was quite tricky to write
so I'm not sure if I've fully considered all the cases. The final commit
should warrant some serious scrutiny, as marking a lifetime longer
than actually is doesn't result in logical bugs -- only higher memory
use. However, marking a lifetime shorter than it really is can cause
corruption.

Fortunately, accidentally shortening lifetimes is pretty rare in our
codebase. It's pretty much only used in FieldAccess.

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
