### PR TITLE
Add support for strftime() builtin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 ## Unreleased
 
 #### Added
+- Add builtin function: `strftime`
+  - [#1387](https://github.com/iovisor/bpftrace/pull/1387)
 - Fix `printf` not allowing format specifiers to be directly followed by
   alphabetic characters
   - [#1414](https://github.com/iovisor/bpftrace/pull/1414)
@@ -72,6 +74,7 @@ and this project adheres to
   - [#1404](https://github.com/iovisor/bpftrace/pull/1404)
 - Enable the `ternary` operator to evaluate builtin calls
   - [#1405](https://github.com/iovisor/bpftrace/pull/1405)
+
 
 #### Changed
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -89,6 +89,7 @@ discussion to other files in /docs, the /tools/\*\_examples.txt files, or blog p
     - [21. `buf()`: Buffers](#21-buf-buffers)
     - [22. `sizeof()`: Size of type or expression](#22-sizeof-size-of-type-or-expression)
     - [23. `print()`: Print Value](#23-print-print-value)
+    - [24. `strftime()`: Formatted timestamp](#24-strftime-formatted-timestamp)
 - [Map Functions](#map-functions)
     - [1. Builtins](#1-builtins-2)
     - [2. `count()`: Count](#2-count-count)
@@ -2701,6 +2702,28 @@ contains the memcopy'd value so the value at `print()` invocation time will be
 printed.  However for maps, only the handle to the map is queued up, so the
 printed map may be different than the map at `print()` invocation.
 
+## 24. `strftime()`: Formatted timestamp
+
+Syntax:
+- `strftime(const char *format, int nsecs)`
+
+This returns a formatted timestamp that is printable with `printf`. The format
+string must be supported by `strftime(3)`. Use format specifier "%s" when
+printing the return value. Note that `strftime` does not actually return a
+string in bpf (kernel), the formatting happens in userspace.
+
+Examples:
+
+```
+# bpftrace -e 'i:s:1 { printf("%s\n", strftime("%H:%M:%S", nsecs)); }'
+Attaching 1 probe...
+13:11:22
+13:11:23
+13:11:24
+13:11:25
+13:11:26
+^C
+```
 
 # Map Functions
 

--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -76,6 +76,20 @@ struct Time
   }
 } __attribute__((packed));
 
+struct Strftime
+{
+  uint64_t strftime_id;
+  uint64_t nsecs_since_boot;
+
+  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b)
+  {
+    return {
+      b.getInt64Ty(), // strftime id
+      b.getInt64Ty(), // strftime arg, time elapsed since boot
+    };
+  }
+} __attribute__((packed));
+
 struct Buf
 {
   uint8_t length;

--- a/src/ast/codegen_helper.h
+++ b/src/ast/codegen_helper.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "bpftrace.h"
+
+namespace bpftrace {
+namespace ast {
+
+inline bool needMemcpy(const SizedType &stype)
+{
+  return stype.IsAggregate() || stype.IsTimestampTy();
+}
+
+inline bool shouldBeOnStackAlready(const SizedType &type)
+{
+  return type.IsStringTy() || type.IsBufferTy() || type.IsInetTy() ||
+         type.IsUsymTy() || type.IsTupleTy() || type.IsTimestampTy();
+}
+
+} // namespace ast
+} // namespace bpftrace

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -102,6 +102,7 @@ private:
   int printf_id_ = 0;
   int time_id_ = 0;
   int cat_id_ = 0;
+  int strftime_id_ = 0;
   uint64_t join_id_ = 0;
   int system_id_ = 0;
   int non_map_print_id_ = 0;

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -915,6 +915,18 @@ void SemanticAnalyser::visit(Call &call)
       }
     }
   }
+  else if (call.func == "strftime")
+  {
+    call.type = CreateTimestamp();
+    if (check_varargs(call, 2, 2) && is_final_pass() &&
+        check_arg(call, Type::string, 0, true) &&
+        check_arg(call, Type::integer, 1, false))
+    {
+      auto &fmt_arg = *call.vargs->at(0);
+      String &fmt = static_cast<String &>(fmt_arg);
+      bpftrace_.strftime_args_.push_back(fmt.str);
+    }
+  }
   else if (call.func == "kstack") {
     check_stack_call(call, true);
   }

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -775,7 +775,7 @@ void SemanticAnalyser::visit(Call &call)
         {
           auto ty = (*iter)->type;
           // Promote to 64-bit if it's not an aggregate type
-          if (!ty.IsAggregate())
+          if (!ty.IsAggregate() && !ty.IsTimestampTy())
             ty.size = 8;
           args.push_back(Field{
             .type =  ty,

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -115,6 +115,7 @@ public:
   std::string resolve_usym(uintptr_t addr, int pid, bool show_offset=false, bool show_module=false);
   std::string resolve_inet(int af, const uint8_t* inet) const;
   std::string resolve_uid(uintptr_t addr) const;
+  std::string resolve_timestamp(uint32_t strftime_id, uint64_t nsecs);
   uint64_t resolve_kname(const std::string &name) const;
   virtual int resolve_uname(const std::string &name,
                             struct symbol *sym,
@@ -181,6 +182,7 @@ public:
   bool has_usdt_ = false;
   bool usdt_file_activation_ = false;
   int helper_check_level_ = 0;
+  uint64_t btime = 0;
 
   static void sort_by_key(
       std::vector<SizedType> key_args,

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -153,6 +153,7 @@ public:
   std::vector<std::tuple<std::string, std::vector<Field>>> system_args_;
   std::vector<std::string> join_args_;
   std::vector<std::string> time_args_;
+  std::vector<std::string> strftime_args_;
   std::vector<std::tuple<std::string, std::vector<Field>>> cat_args_;
   std::vector<SizedType> non_map_print_args_;
   std::unordered_map<int64_t, struct HelperErrorInfo> helper_error_info_;

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -29,7 +29,7 @@ vspace  [\n\r]
 space   {hspace}|{vspace}
 path    :(\\.|[_\-\./a-zA-Z0-9#\*])*:
 builtin arg[0-9]|args|cgroup|comm|cpid|cpu|ctx|curtask|elapsed|func|gid|nsecs|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
-call    avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|ksym|lhist|max|min|ntop|override|print|printf|reg|signal|sizeof|stats|str|strncmp|sum|system|time|uaddr|usym|zero
+call    avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|ksym|lhist|max|min|ntop|override|print|printf|reg|signal|sizeof|stats|str|strftime|strncmp|sum|system|time|uaddr|usym|zero
 
 /* Don't add to this! Use builtin OR call not both */
 call_and_builtin kstack|ustack

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -182,6 +182,39 @@ static int info()
   return 0;
 }
 
+static uint64_t get_btime(void)
+{
+  std::ifstream file("/proc/stat");
+  if (!file)
+  {
+    std::cerr << "Fail to open file /proc/stat: " << std::strerror(errno)
+              << std::endl
+              << "Builtin function strftime won't work properly." << std::endl;
+    return 0;
+  }
+  std::string line, field;
+  uint64_t btime = 0;
+  while (std::getline(file, line))
+  {
+    std::stringstream ss(line);
+    ss >> field;
+    if (field == "btime")
+    {
+      ss >> btime;
+      if (ss.fail())
+        btime = 0;
+      break;
+    }
+  }
+  if (btime == 0)
+  {
+    std::cerr << "Fail to read btime from /proc/stat. Builtin function "
+                 "strftime won't work properly."
+              << std::endl;
+  }
+  return btime;
+}
+
 int main(int argc, char *argv[])
 {
   int err;
@@ -361,6 +394,7 @@ int main(int argc, char *argv[])
   bpftrace.safe_mode_ = safe_mode;
   bpftrace.force_btf_ = force_btf;
   bpftrace.helper_check_level_ = helper_check_level;
+  bpftrace.btime = get_btime();
 
   if (!pid_str.empty())
   {

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -1,5 +1,6 @@
 #include <cstring>
 
+#include "async_event_types.h"
 #include "bpftrace.h"
 #include "mapkey.h"
 #include "utils.h"
@@ -83,6 +84,11 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
     case Type::ustack:
       return bpftrace.get_stack(
           read_data<uint64_t>(data), true, arg.stack_type, 4);
+    case Type::timestamp:
+    {
+      auto p = static_cast<const AsyncEvent::Strftime *>(data);
+      return bpftrace.resolve_timestamp(p->strftime_id, p->nsecs_since_boot);
+    }
     case Type::ksym:
       return bpftrace.resolve_ksym(read_data<uint64_t>(data));
     case Type::usym:

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -34,9 +34,10 @@ std::string verify_format_string(const std::string &fmt, std::vector<Field> args
   for (int i=0; i<num_args; i++, token_iter++)
   {
     Type arg_type = args.at(i).type.type;
-    if (arg_type == Type::ksym || arg_type == Type::usym || arg_type == Type::probe ||
-        arg_type == Type::username || arg_type == Type::kstack || arg_type == Type::ustack ||
-        arg_type == Type::inet)
+    if (arg_type == Type::ksym || arg_type == Type::usym ||
+        arg_type == Type::probe || arg_type == Type::username ||
+        arg_type == Type::kstack || arg_type == Type::ustack ||
+        arg_type == Type::inet || arg_type == Type::timestamp)
       arg_type = Type::string; // Symbols should be printed as strings
     if (arg_type == Type::cast && args.at(i).type.is_pointer)
       arg_type = Type::integer; // Casts (pointers) can be printed as integers

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -119,6 +119,7 @@ std::string typestr(Type t)
     case Type::ctx:      return "ctx";      break;
     case Type::buffer:   return "buffer";   break;
     case Type::tuple:    return "tuple";    break;
+    case Type::timestamp:return "timestamp";break;
     // clang-format on
     default:
       std::cerr << "call or probe type not found" << std::endl;
@@ -364,6 +365,11 @@ SizedType CreateJoin(size_t argnum, size_t argsize)
 SizedType CreateBuffer(size_t size)
 {
   return SizedType(Type::buffer, size);
+}
+
+SizedType CreateTimestamp()
+{
+  return SizedType(Type::timestamp, 16);
 }
 
 bool SizedType::IsSigned(void) const

--- a/src/types.h
+++ b/src/types.h
@@ -256,6 +256,10 @@ public:
   {
     return type == Type::tuple;
   };
+  bool IsTimestampTy(void) const
+  {
+    return type == Type::timestamp;
+  };
 
   friend std::ostream &operator<<(std::ostream &, const SizedType &);
   friend std::ostream &operator<<(std::ostream &, Type);

--- a/src/types.h
+++ b/src/types.h
@@ -46,6 +46,7 @@ enum class Type
   record, // struct or union
   buffer,
   tuple,
+  timestamp
   // clang-format on
 };
 
@@ -304,6 +305,7 @@ SizedType CreateUSym();
 SizedType CreateKSym();
 SizedType CreateJoin(size_t argnum, size_t argsize);
 SizedType CreateBuffer(size_t size);
+SizedType CreateTimestamp();
 
 std::ostream &operator<<(std::ostream &os, const SizedType &type);
 
@@ -393,6 +395,7 @@ enum class AsyncAction
   join,
   helper_error,
   print_non_map,
+  strftime
   // clang-format on
 };
 

--- a/tests/codegen/call_strftime.cpp
+++ b/tests/codegen/call_strftime.cpp
@@ -1,0 +1,14 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, call_strftime)
+{
+  test("kprobe:f { printf(\"%s\", strftime(\"%M:%S\", nsecs)); }", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/call_strftime.ll
+++ b/tests/codegen/llvm/call_strftime.ll
@@ -1,0 +1,40 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%printf_t = type { i64, i128 }
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
+entry:
+  %printf_args = alloca %printf_t, align 8
+  %1 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  %2 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
+  store i64 0, i64* %2, align 8
+  %get_ns = tail call i64 inttoptr (i64 5 to i64 ()*)()
+  %3 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
+  %4 = bitcast i128* %3 to i8*
+  %strftime_args.sroa.0.0..sroa_cast = bitcast i128* %3 to i64*
+  store i64 0, i64* %strftime_args.sroa.0.0..sroa_cast, align 8
+  %strftime_args.sroa.5.0..sroa_idx = getelementptr inbounds i8, i8* %4, i64 8
+  %strftime_args.sroa.5.0..sroa_cast = bitcast i8* %strftime_args.sroa.5.0..sroa_idx to i64*
+  store i64 %get_ns, i64* %strftime_args.sroa.5.0..sroa_cast, align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 24)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -200,3 +200,18 @@ NAME print_non_map_tuple
 RUN bpftrace -e 'BEGIN { $t = (1, 2, "string"); print($t); exit() }'
 EXPECT (1, 2, string)
 TIMEOUT 1
+
+NAME strftime
+RUN bpftrace -v -e 'BEGIN { $ts = strftime("%m/%d/%y", nsecs); printf("%s\n", $ts); exit(); } '
+EXPECT [0-9]{2}\/[0-9]{2}\/[0-9]{2}
+TIMEOUT 5
+
+NAME strftime_as_map_key
+RUN bpftrace -v -e 'BEGIN { @[strftime("%m/%d/%y", nsecs)] = 1; exit();}'
+EXPECT \[[0-9]{2}\/[0-9]{2}\/[0-9]{2}\]: 1
+TIMEOUT 5
+
+NAME strftime_as_map_value
+RUN bpftrace -v -e 'BEGIN { @[nsecs] = strftime("%m/%d/%y", nsecs); exit();}'
+EXPECT @\[[0-9]*\]: [0-9]{2}\/[0-9]{2}\/[0-9]{2}
+TIMEOUT 5

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -534,6 +534,25 @@ TEST(semantic_analyser, call_time)
   test("kprobe:f { time() ? 0 : 1; }", 10);
 }
 
+TEST(semantic_analyser, call_strftime)
+{
+  test("kprobe:f { strftime(\"%M:%S\", 1); }", 0);
+  test("kprobe:f { strftime(\"%M:%S\", nsecs); }", 0);
+  test("kprobe:f { strftime(\"%M:%S\", \"\"); }", 10);
+  test("kprobe:f { strftime(1, nsecs); }", 10);
+  test("kprobe:f { $var = \"str\"; strftime($var, nsecs); }", 10);
+  test("kprobe:f { strftime(); }", 1);
+  test("kprobe:f { strftime(\"%M:%S\"); }", 1);
+  test("kprobe:f { strftime(\"%M:%S\", 1, 1); }", 1);
+  test("kprobe:f { strftime(1, 1, 1); }", 1);
+  test("kprobe:f { strftime(\"%M:%S\", \"\", 1); }", 1);
+  test("kprobe:f { $ts = strftime(\"%M:%S\", 1); }", 0);
+  test("kprobe:f { @ts = strftime(\"%M:%S\", nsecs); }", 0);
+  test("kprobe:f { @[strftime(\"%M:%S\", nsecs)] = 1; }", 0);
+  test("kprobe:f { printf(\"%s\", strftime(\"%M:%S\", nsecs)); }", 0);
+  test("kprobe:f { strncmp(\"str\", strftime(\"%M:%S\", nsecs), 10); }", 10);
+}
+
 TEST(semantic_analyser, call_str)
 {
   test("kprobe:f { str(arg0); }", 0);


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->
This PR introduces a new builtin function `strftime`. This function makes it possible to print the current time with `printf`:

```
bpftrace -e 'i:s:1 { printf("%s\n", strftime("%H:%M:%S", nsecs)); }'
```

Although `time` can print current time on its own, printing timestamp with `printf` can produce more concise and more readable output. Resolves #1337 .
##### Checklist
- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
