### PR TITLE
Allow uprobe placement on arbitrary addresses when --unsafe is used.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to
 
 #### Added
 
+- Allow uprobe placement on arbitrary addresses when --unsafe is used
+  - [#1388](https://github.com/iovisor/bpftrace/pull/1388)
 - Support for s390x
   - [#1241](https://github.com/iovisor/bpftrace/pull/1241)
 - `buf` a new function that makes it possible to safely print arbitrary binary data

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1070,6 +1070,20 @@ Attaching 1 probe...
 Unsafe uprobe in the middle of the instruction: /bin/bash:main+1
 ```
 
+Using --unsafe option you can also place uprobes on arbitrary addresses.
+This might come in handy when the binary is stripped.
+```
+$ echo 'int main(){return 0;}' | gcc -xc -o bin -
+$ nm bin | grep main
+...
+0000000000001119 T main
+...
+$ strip bin
+# bpftrace --unsafe -e 'uprobe:bin:0x1119 { printf("main called\n"); }'
+Attaching 1 probe...
+WARNING: could not determine instruction boundary for uprobe:bin:4377 (binary appears stripped). Misaligned probes can lead to tracee crashes!
+```
+
 Examples in situ:
 [(uprobe) search /tools](https://github.com/iovisor/bpftrace/search?q=uprobe%3A+path%3Atools&type=Code)
 [(uretprobe) /tools](https://github.com/iovisor/bpftrace/search?q=uretprobe%3A+path%3Atools&type=Code)


### PR DESCRIPTION
Follow-up to #1282.
When there is no symbol found for requested address of uprobe placement and `--unsafe` is set, warning is emitted, and uprobe is placed as normally.

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
