### PR TITLE
Remove call to deprecated bpf_detach_kfunc helper

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -116,6 +116,7 @@ void AttachedProbe::attach_kfunc(void)
 int AttachedProbe::detach_kfunc(void)
 {
   close(tracing_fd_);
+  return 0;
 }
 #else
 void AttachedProbe::attach_kfunc(void)

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -116,7 +116,6 @@ void AttachedProbe::attach_kfunc(void)
 int AttachedProbe::detach_kfunc(void)
 {
   close(tracing_fd_);
-  return bpf_detach_kfunc(progfd_, NULL);
 }
 #else
 void AttachedProbe::attach_kfunc(void)


### PR DESCRIPTION
As per discussion in https://github.com/iovisor/bcc/pull/2979, the `bpf_detach_kfunc` function has been removed from libbcc, as it was effectively a NOP. This pull request removes the call to `bpf_detach_kfunc` from bpftrace's `AttachedProbe::detach_kfunc` in order to make bpftrace work with the latest bcc release.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
