### PR TITLE
Pointer type

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1350,7 +1350,7 @@ void CodegenLLVM::visit(Ternary &ternary)
 void CodegenLLVM::visit(FieldAccess &acc)
 {
   SizedType &type = acc.expr->type;
-  assert(type.IsRecordTy() || type.IsCastTy() || type.IsCtxTy() || type.IsTupleTy());
+  assert(type.IsRecordTy() || type.IsTupleTy());
   auto scoped_del = accept(acc.expr);
 
   bool is_ctx = type.IsCtxAccess();
@@ -1611,15 +1611,6 @@ void CodegenLLVM::visit(AssignMapStatement &assignment)
     if (assignment.expr->type.is_internal)
     {
       val = expr;
-    }
-    else if (assignment.expr->type.is_pointer)
-    {
-      // expr currently contains a pointer to the struct
-      // and that's what we are saving
-      AllocaInst *dst = b_.CreateAllocaBPF(map.type, map.ident + "_ptr");
-      b_.CreateStore(expr, dst);
-      val = dst;
-      self_alloca = true;
     }
     else
     {

--- a/src/ast/field_analyser.cpp
+++ b/src/ast/field_analyser.cpp
@@ -71,10 +71,15 @@ void FieldAnalyser::visit(Builtin &builtin)
 
     auto it = ap_args_.find("$retval");
 
-    if (it != ap_args_.end() && it->second.IsCastTy())
-      type_ = it->second.cast_type;
-    else
-      type_ = "";
+    if (it != ap_args_.end())
+    {
+      if (it->second.IsRecordTy())
+        type_ = it->second.GetName();
+      else if (it->second.IsPtrTy() && it->second.GetPointeeTy()->IsRecordTy())
+        type_ = it->second.GetPointeeTy()->GetName();
+      else
+        type_ = "";
+    }
   }
 }
 
@@ -171,10 +176,15 @@ void FieldAnalyser::visit(FieldAccess &acc)
 
     auto it = ap_args_.find(acc.field);
 
-    if (it != ap_args_.end() && it->second.IsCastTy())
-      type_ = it->second.cast_type;
-    else
-      type_ = "";
+    if (it != ap_args_.end())
+    {
+      if (it->second.IsRecordTy())
+        type_ = it->second.GetName();
+      else if (it->second.IsPtrTy() && it->second.GetPointeeTy()->IsRecordTy())
+        type_ = it->second.GetPointeeTy()->GetName();
+      else
+        type_ = "";
+    }
 
     has_builtin_args_ = false;
   }
@@ -338,8 +348,8 @@ void FieldAnalyser::visit(AttachPoint &ap)
       {
         auto stype = arg.second;
 
-        if (stype.IsCastTy())
-          bpftrace_.btf_set_.insert(stype.cast_type);
+        if (stype.IsRecordTy())
+          bpftrace_.btf_set_.insert(stype.GetName());
       }
     }
   }

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -175,6 +175,14 @@ llvm::Type *IRBuilderBPF::GetType(const SizedType &stype)
 
     ty = GetStructType(ty_name.str(), llvm_elems, true);
   }
+  else if (stype.IsPtrTy())
+  {
+    ty = getInt64Ty();
+  }
+  else if (stype.IsRecordTy())
+  {
+    ty = ArrayType::get(getInt8Ty(), stype.size);
+  }
   else
   {
     switch (stype.size)

--- a/src/ast/printer.cpp
+++ b/src/ast/printer.cpp
@@ -14,7 +14,7 @@ std::string Printer::type(const SizedType &ty)
   std::stringstream buf;
   if (print_types)
   {
-    buf << " :: type[" << ty << "]";
+    buf << " :: type[" << ty << " ctx: " << ty.IsCtxAccess() << "]";
   }
   return buf.str();
 }

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -107,8 +107,8 @@ void SemanticAnalyser::visit(Identifier &identifier)
   }
   else if (bpftrace_.structs_.count(identifier.ident) != 0)
   {
-    identifier.type = CreateRecord(
-        8 * bpftrace_.structs_[identifier.ident].size, identifier.ident);
+    identifier.type = CreateRecord(bpftrace_.structs_[identifier.ident].size,
+                                   identifier.ident);
   }
   else if (getIntcasts().count(identifier.ident) != 0)
   {
@@ -141,8 +141,7 @@ void SemanticAnalyser::builtin_args_tracepoint(AttachPoint *attach_point,
         match);
     Struct &cstruct = bpftrace_.structs_[tracepoint_struct];
 
-    builtin.type = CreatePointer(
-        CreateRecord(8 * cstruct.size, tracepoint_struct));
+    builtin.type = CreatePointer(CreateRecord(cstruct.size, tracepoint_struct));
     builtin.type.MarkCtxAccess();
     builtin.type.is_tparg = true;
   }
@@ -185,8 +184,7 @@ void SemanticAnalyser::visit(Builtin &builtin)
     {
       case BPF_PROG_TYPE_KPROBE:
         builtin.type = CreatePointer(
-            CreateRecord(bpftrace_.structs_["pt_regs"].size * 8,
-                         "struct pt_regs"));
+            CreateRecord(bpftrace_.structs_["pt_regs"].size, "struct pt_regs"));
         builtin.type.MarkCtxAccess();
         break;
       case BPF_PROG_TYPE_TRACEPOINT:
@@ -195,7 +193,7 @@ void SemanticAnalyser::visit(Builtin &builtin)
         break;
       case BPF_PROG_TYPE_PERF_EVENT:
         builtin.type = CreatePointer(
-            CreateRecord(bpftrace_.structs_["bpf_perf_event_data"].size * 8,
+            CreateRecord(bpftrace_.structs_["bpf_perf_event_data"].size,
                          "struct bpf_perf_event_data"));
         builtin.type.MarkCtxAccess();
         break;
@@ -1712,7 +1710,7 @@ void SemanticAnalyser::visit(Cast &cast)
     return;
   }
 
-  cast_size = bpftrace_.structs_[cast.cast_type].size * 8;
+  cast_size = bpftrace_.structs_[cast.cast_type].size;
   if (cast.is_pointer)
     cast.type = CreatePointer(CreateRecord(cast_size, cast.cast_type));
   else

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -751,6 +751,10 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(const std::vec
               *reinterpret_cast<uint64_t*>(arg_data+arg.offset)));
           break;
         }
+      case Type::pointer:
+        arg_values.push_back(std::make_unique<PrintableInt>(
+            *reinterpret_cast<uint64_t *>(arg_data + arg.offset)));
+        break;
         // fall through
       default:
         std::cerr << "invalid argument type" << std::endl;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -651,36 +651,29 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(const std::vec
     switch (arg.type.type)
     {
       case Type::integer:
-        // If no casting is performed, we have already promoted the ty.size to 8
-        if (arg.type.cast_type == "" || arg.type.cast_type == "uint64" ||
-            arg.type.cast_type == "int64")
+        switch (arg.type.size)
         {
-          arg_values.push_back(std::make_unique<PrintableInt>(
-              *reinterpret_cast<uint64_t *>(arg_data + arg.offset)));
-        }
-        else if (arg.type.cast_type == "uint32" ||
-                 arg.type.cast_type == "int32")
-        {
-          arg_values.push_back(std::make_unique<PrintableInt>(
-              *reinterpret_cast<uint32_t *>(arg_data + arg.offset)));
-        }
-        else if (arg.type.cast_type == "uint16" ||
-                 arg.type.cast_type == "int16")
-        {
-          arg_values.push_back(std::make_unique<PrintableInt>(
-              *reinterpret_cast<uint16_t *>(arg_data + arg.offset)));
-        }
-        else if (arg.type.cast_type == "uint8" || arg.type.cast_type == "int8")
-        {
-          arg_values.push_back(std::make_unique<PrintableInt>(
-              *reinterpret_cast<uint8_t *>(arg_data + arg.offset)));
-        }
-        else
-        {
-          std::cerr << "get_arg_values: invalid integer size. 8, 4, 2 and byte "
-                       "supported. "
-                    << arg.type.size << "provided" << std::endl;
-          abort();
+          case 8:
+            arg_values.push_back(std::make_unique<PrintableInt>(
+                *reinterpret_cast<uint64_t *>(arg_data + arg.offset)));
+            break;
+          case 4:
+            arg_values.push_back(std::make_unique<PrintableInt>(
+                *reinterpret_cast<uint32_t *>(arg_data + arg.offset)));
+            break;
+          case 2:
+            arg_values.push_back(std::make_unique<PrintableInt>(
+                *reinterpret_cast<uint16_t *>(arg_data + arg.offset)));
+            break;
+          case 1:
+            arg_values.push_back(std::make_unique<PrintableInt>(
+                *reinterpret_cast<uint8_t *>(arg_data + arg.offset)));
+            break;
+          default:
+            std::cerr << "get_arg_values: invalid integer size. 8, 4, 2 and "
+                         "byte supported. "
+                      << arg.type.size << "provided" << std::endl;
+            abort();
         }
         break;
       case Type::string:

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -744,13 +744,6 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(const std::vec
                 reinterpret_cast<AsyncEvent::Strftime *>(arg_data + arg.offset)
                     ->nsecs_since_boot)));
         break;
-      case Type::cast:
-        if (arg.type.is_pointer) {
-          arg_values.push_back(
-            std::make_unique<PrintableInt>(
-              *reinterpret_cast<uint64_t*>(arg_data+arg.offset)));
-          break;
-        }
       case Type::pointer:
         arg_values.push_back(std::make_unique<PrintableInt>(
             *reinterpret_cast<uint64_t *>(arg_data + arg.offset)));

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -371,12 +371,10 @@ const struct btf_type *BTF::btf_type_skip_modifiers(const struct btf_type *t)
 
 SizedType BTF::get_stype(__u32 id)
 {
-  SizedType stype = SizedType(Type::none, 8);
-
   const struct btf_type *t = btf__type_by_id(btf, id);
 
   if (!t)
-    return stype;
+    return CreateNone();
 
   t = btf_type_skip_modifiers(t);
 
@@ -384,10 +382,11 @@ SizedType BTF::get_stype(__u32 id)
 
   if (btf_is_int(t) || btf_is_enum(t))
   {
-    stype.type = Type::integer;
+    return CreateInteger(btf_int_bits(t), btf_int_encoding(t) & BTF_INT_SIGNED);
   }
   else if (btf_is_ptr(t))
   {
+    SizedType stype;
     stype.is_pointer = true;
 
     // get the pointer type..
@@ -413,7 +412,7 @@ SizedType BTF::get_stype(__u32 id)
     }
   }
 
-  return stype;
+  return CreateNone();
 }
 
 int BTF::resolve_args(const std::string &func,

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -290,7 +290,7 @@ static SizedType get_sized_type(CXType clang_type)
     case CXType_ULongLong:
       return CreateUInt(size);
     case CXType_Record:
-      return CreateRecord(size, typestr);
+      return CreateRecord(size / 8, typestr);
     case CXType_Char_S:
     case CXType_SChar:
     case CXType_Short:

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -290,7 +290,7 @@ static SizedType get_sized_type(CXType clang_type)
     case CXType_ULongLong:
       return CreateUInt(size);
     case CXType_Record:
-      return CreateCast(size, typestr);
+      return CreateRecord(size, typestr);
     case CXType_Char_S:
     case CXType_SChar:
     case CXType_Short:
@@ -303,20 +303,7 @@ static SizedType get_sized_type(CXType clang_type)
     case CXType_Pointer:
     {
       auto pointee_type = clang_getPointeeType(clang_type);
-      SizedType type;
-      if (pointee_type.kind == CXType_Record)
-      {
-        auto pointee_typestr = get_unqualified_type_name(pointee_type);
-        type = CreateCast(8 * sizeof(uintptr_t), pointee_typestr);
-      }
-      else
-      {
-        type = CreateUInt(8 * sizeof(uintptr_t));
-      }
-      auto pointee_size = clang_Type_getSizeOf(pointee_type);
-      type.is_pointer = true;
-      type.pointee_size = pointee_size;
-      return type;
+      return CreatePointer(get_sized_type(pointee_type));
     }
     case CXType_ConstantArray:
     {

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -111,13 +111,12 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
       auto p = static_cast<const char *>(data) + 1;
       return hex_format_buffer(p, arg.size - 1);
     }
-    case Type::cast:
-      if (arg.is_pointer) {
-        // use case: show me these pointer values
-        ptr << "0x" << std::hex << read_data<int64_t>(data);
-        return ptr.str();
-      }
-      // fall through
+    case Type::pointer:
+    {
+      // use case: show me these pointer values
+      ptr << "0x" << std::hex << read_data<int64_t>(data);
+      return ptr.str();
+    }
     default:
       std::cerr << "invalid mapkey argument type" << std::endl;
   }

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -39,7 +39,7 @@ std::string verify_format_string(const std::string &fmt, std::vector<Field> args
         arg_type == Type::kstack || arg_type == Type::ustack ||
         arg_type == Type::inet || arg_type == Type::timestamp)
       arg_type = Type::string; // Symbols should be printed as strings
-    if (arg_type == Type::cast && args.at(i).type.is_pointer)
+    if (arg_type == Type::pointer)
       arg_type = Type::integer; // Casts (pointers) can be printed as integers
     int offset = 1;
 

--- a/src/struct.h
+++ b/src/struct.h
@@ -31,7 +31,7 @@ using FieldsMap = std::map<std::string, Field>;
 
 struct Struct
 {
-  int size;
+  int size; // in bytes
   FieldsMap fields;
 };
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -53,9 +53,6 @@ std::ostream &operator<<(std::ostream &os, const SizedType &type)
     os << type.type;
   }
 
-  if (type.is_pointer)
-    os << "*";
-
   return os;
 }
 
@@ -135,14 +132,12 @@ std::string typestr(Type t)
     case Type::string:   return "string";   break;
     case Type::ksym:     return "ksym";     break;
     case Type::usym:     return "usym";     break;
-    case Type::cast:     return "cast";     break;
     case Type::join:     return "join";     break;
     case Type::probe:    return "probe";    break;
     case Type::username: return "username"; break;
     case Type::inet:     return "inet";     break;
     case Type::stack_mode:return "stack mode";break;
     case Type::array:    return "array";    break;
-    case Type::ctx:      return "ctx";      break;
     case Type::buffer:   return "buffer";   break;
     case Type::tuple:    return "tuple";    break;
     case Type::timestamp:return "timestamp";break;
@@ -288,17 +283,6 @@ SizedType CreateNone()
 SizedType CreateStackMode()
 {
   return SizedType(Type::stack_mode, 0);
-}
-
-SizedType CreateCast(size_t size, std::string name)
-{
-  assert(size % 8 == 0);
-  return SizedType(Type::cast, size / 8, name);
-}
-
-SizedType CreateCTX(size_t size, std::string name)
-{
-  return SizedType(Type::ctx, size, name);
 }
 
 SizedType CreateArray(size_t num_elements, const SizedType &element_type)

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -304,7 +304,7 @@ SizedType CreatePointer(const SizedType &pointee_type)
 
 SizedType CreateRecord(size_t size, const std::string &name)
 {
-  auto ty = SizedType(Type::record, size / 8);
+  auto ty = SizedType(Type::record, size);
   ty.name_ = name;
   return ty;
 }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -96,6 +96,8 @@ std::string typestr(Type t)
     // clang-format off
     case Type::none:     return "none";     break;
     case Type::integer:  return "integer";  break;
+    case Type::pointer:  return "pointer";  break;
+    case Type::record:   return "record";   break;
     case Type::hist:     return "hist";     break;
     case Type::lhist:    return "lhist";    break;
     case Type::count:    return "count";    break;
@@ -281,6 +283,21 @@ SizedType CreateArray(size_t num_elements, const SizedType &element_type)
   ty.num_elements_ = num_elements;
   ty.element_type_ = new SizedType(element_type);
   ty.pointee_size = element_type.size;
+  return ty;
+}
+
+SizedType CreatePointer(const SizedType &pointee_type)
+{
+  // Pointer itself is always an uint64
+  auto ty = SizedType(Type::pointer, 8);
+  ty.element_type_ = new SizedType(pointee_type);
+  return ty;
+}
+
+SizedType CreateRecord(size_t size, const std::string &name)
+{
+  auto ty = SizedType(Type::record, size);
+  ty.name_ = name;
   return ty;
 }
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -290,7 +290,6 @@ SizedType CreateArray(size_t num_elements, const SizedType &element_type)
   auto ty = SizedType(Type::array, num_elements);
   ty.num_elements_ = num_elements;
   ty.element_type_ = new SizedType(element_type);
-  ty.pointee_size = element_type.size;
   return ty;
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -91,7 +91,6 @@ public:
 
   size_t size;                 // in bytes
   StackType stack_type;
-  std::string cast_type;
   bool is_internal = false;
   bool is_pointer = false;
   bool is_tparg = false;
@@ -102,6 +101,7 @@ public:
   std::vector<SizedType> tuple_elems;
 
 private:
+  std::string cast_type;
   bool is_signed_ = false;
   SizedType *element_type_ = nullptr; // for "container" and pointer
                                       // (like) types
@@ -127,12 +127,13 @@ public:
   bool IsEqual(const SizedType &t) const;
   bool operator==(const SizedType &t) const;
   bool operator!=(const SizedType &t) const;
+  bool IsSameType(const SizedType &t) const;
 
   bool IsPrintableTy()
   {
-    return type != Type::none && type != Type::cast && type != Type::ctx &&
-           type != Type::stack_mode && type != Type::array &&
-           type != Type::record;
+    return type != Type::none && type != Type::record &&
+           type != Type::pointer && type != Type::stack_mode &&
+           type != Type::array && type != Type::record && !IsCtxAccess();
   }
 
   bool IsSigned(void) const;
@@ -149,7 +150,7 @@ public:
     return size;
   };
 
-  const std::string &GetName() const
+  const std::string GetName() const
   {
     assert(IsRecordTy());
     return name_;
@@ -313,6 +314,11 @@ SizedType CreateUInt64();
 SizedType CreateString(size_t size);
 SizedType CreateArray(size_t num_elements, const SizedType &element_type);
 SizedType CreatePointer(const SizedType &pointee_type);
+/**
+   Create a record type
+
+   \param size size in bits
+*/
 SizedType CreateRecord(size_t size, const std::string &name);
 
 SizedType CreateStackMode();

--- a/src/types.h
+++ b/src/types.h
@@ -80,15 +80,11 @@ public:
   }
 
   Type type;
-  Type elem_type = Type::none; // Array element type if accessing elements of an
-                               // array
-
   size_t size;                 // in bytes
   StackType stack_type;
   bool is_internal = false;
   bool is_tparg = false;
   bool is_kfarg = false;
-  size_t pointee_size = 0;
   int kfarg_idx = -1;
   // Only valid if `type == Type::tuple`
   std::vector<SizedType> tuple_elems;

--- a/src/types.h
+++ b/src/types.h
@@ -107,8 +107,19 @@ private:
                                       // (like) types
   size_t num_elements_;               // for array like types
   std::string name_; // name of this type, for named types like struct
+  bool ctx_ = false; // Is bpf program context
 
 public:
+  bool IsCtxAccess() const
+  {
+    return ctx_;
+  };
+
+  void MarkCtxAccess()
+  {
+    ctx_ = true;
+  };
+
   bool IsArray() const;
   bool IsAggregate() const;
   bool IsStack() const;

--- a/src/types.h
+++ b/src/types.h
@@ -300,10 +300,8 @@ SizedType CreateString(size_t size);
 SizedType CreateArray(size_t num_elements, const SizedType &element_type);
 SizedType CreatePointer(const SizedType &pointee_type);
 /**
-   Create a record type
-
-   \param size size in bits
-*/
+   size in bytes
+ */
 SizedType CreateRecord(size_t size, const std::string &name);
 
 SizedType CreateStackMode();

--- a/tests/codegen/llvm/struct_integer_ptr_1.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_1.ll
@@ -33,7 +33,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   %probe_read1 = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %8)
   %11 = load i32, i32* %deref
-  %12 = zext i32 %11 to i64
+  %12 = sext i32 %11 to i64
   %13 = bitcast i32* %deref to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   %14 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/struct_integer_ptr_2.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_2.ll
@@ -31,7 +31,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   %probe_read1 = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %6)
   %9 = load i32, i32* %deref
-  %10 = zext i32 %9 to i64
+  %10 = sext i32 %9 to i64
   %11 = bitcast i32* %deref to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   %12 = bitcast i64* %"@x_key" to i8*

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -100,9 +100,7 @@ void setup_mock_bpftrace(MockBPFtrace &bpftrace)
                   } } },
   };
 
-  auto ptr_type = CreateUInt64();
-  ptr_type.is_pointer = true;
-  ptr_type.pointee_size = 1;
+  auto ptr_type = CreatePointer(CreateInt8());
   bpftrace.structs_["struct _tracepoint_file_filename"] = Struct{
     .size = 8,
     .fields = { { "filename",


### PR DESCRIPTION
This is based on #1393 which adds a bit of noise

This PR replaces the `cast` and `ctx` types with `record` (struct/union) and `pointer` types.

The `cast` and `ctx` types are confusing as they can be either pointers or structures or more, depending on some optional attributes.

I still have to do more testing but the original test suite passes with minimal changes, which is a good sign. 