### PR TITLE
Fixes for big endian arch

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -546,7 +546,7 @@ void CodegenLLVM::visit(Call &call)
                                               false);
     AllocaInst *buf = b_.CreateAllocaBPF(buf_struct, "buffer");
 
-    b_.CreateStore(length,
+    b_.CreateStore(b_.CreateIntCast(length, b_.getInt8Ty(), false),
                    b_.CreateGEP(buf, { b_.getInt32(0), b_.getInt32(0) }));
     Value *buf_data_offset = b_.CreateGEP(buf,
                                           { b_.getInt32(0), b_.getInt32(1) });

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1219,7 +1219,9 @@ void CodegenLLVM::visit(Unop &unop)
         }
         AllocaInst *dst = b_.CreateAllocaBPF(SizedType(type.type, size), "deref");
         b_.CreateProbeRead(ctx_, dst, size, expr_, unop.loc);
-        expr_ = b_.CreateLoad(dst);
+        expr_ = b_.CreateIntCast(b_.CreateLoad(dst),
+                                 b_.getInt64Ty(),
+                                 type.IsSigned());
         b_.CreateLifetimeEnd(dst);
         break;
       }
@@ -1238,7 +1240,9 @@ void CodegenLLVM::visit(Unop &unop)
           int size = unop.type.size;
           AllocaInst *dst = b_.CreateAllocaBPF(unop.type, "deref");
           b_.CreateProbeRead(ctx_, dst, size, expr_, unop.loc);
-          expr_ = b_.CreateLoad(dst);
+          expr_ = b_.CreateIntCast(b_.CreateLoad(dst),
+                                   b_.getInt64Ty(),
+                                   unop.type.IsSigned());
           b_.CreateLifetimeEnd(dst);
         }
         break;

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1493,7 +1493,9 @@ void CodegenLLVM::visit(ArrayAccess &arr)
   {
     AllocaInst *dst = b_.CreateAllocaBPF(stype, "array_access");
     b_.CreateProbeRead(ctx_, dst, element_size, src, arr.loc);
-    expr_ = b_.CreateLoad(dst);
+    expr_ = b_.CreateIntCast(b_.CreateLoad(dst),
+                             b_.getInt64Ty(),
+                             arr.expr->type.IsSigned());
     b_.CreateLifetimeEnd(dst);
   }
 }

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1452,12 +1452,15 @@ void CodegenLLVM::visit(FieldAccess &acc)
     {
       expr_ = b_.CreateLoad(b_.CreateIntToPtr(src, field_ty->getPointerTo()),
                             true);
+      expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), field.type.IsSigned());
     }
     else
     {
       AllocaInst *dst = b_.CreateAllocaBPF(field.type, type.cast_type + "." + acc.field);
       b_.CreateProbeRead(ctx_, dst, field.type.size, src, acc.loc);
-      expr_ = b_.CreateLoad(dst);
+      expr_ = b_.CreateIntCast(b_.CreateLoad(dst),
+                               b_.getInt64Ty(),
+                               field.type.IsSigned());
       b_.CreateLifetimeEnd(dst);
     }
   }

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -270,7 +270,7 @@ void CodegenLLVM::visit(Builtin &builtin)
       std::cerr << "BUG: Invalid cpid: " << cpid << std::endl;
       abort();
     }
-    expr_ = b_.getInt32(cpid);
+    expr_ = b_.getInt64(cpid);
   }
   else
   {

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1243,7 +1243,7 @@ std::string BPFtrace::map_value_to_str(const SizedType &stype,
     return resolve_usym(read_data<uintptr_t>(value.data()),
                         read_data<uintptr_t>(value.data() + 8));
   else if (stype.IsInetTy())
-    return resolve_inet(read_data<uint32_t>(value.data()),
+    return resolve_inet(read_data<uint64_t>(value.data()),
                         (uint8_t *)(value.data() + 8));
   else if (stype.IsUsernameTy())
     return resolve_uid(read_data<uint64_t>(value.data()));

--- a/tests/codegen/llvm/builtin_ctx_field.ll
+++ b/tests/codegen/llvm/builtin_ctx_field.ll
@@ -49,16 +49,16 @@ entry:
   %12 = add i64 %1, 16
   %13 = inttoptr i64 %12 to i8*
   %14 = load volatile i8, i8* %13, align 1
-  %15 = bitcast i64* %"@c_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %15)
+  %15 = sext i8 %14 to i64
+  %16 = bitcast i64* %"@c_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %16)
   store i64 0, i64* %"@c_key", align 8
-  %16 = sext i8 %14 to i64
   %17 = bitcast i64* %"@c_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %17)
-  store i64 %16, i64* %"@c_val", align 8
+  store i64 %15, i64* %"@c_val", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
   %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo3, i64* nonnull %"@c_key", i64* nonnull %"@c_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %15)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %16)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %17)
   %18 = add i64 %1, 24
   %19 = inttoptr i64 %18 to i64*
@@ -66,17 +66,17 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %"struct c.c")
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i64)*)(i8* nonnull %"struct c.c", i32 1, i64 %20)
   %21 = load i8, i8* %"struct c.c", align 1
+  %22 = sext i8 %21 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %"struct c.c")
-  %22 = bitcast i64* %"@d_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %22)
+  %23 = bitcast i64* %"@d_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %23)
   store i64 0, i64* %"@d_key", align 8
-  %23 = sext i8 %21 to i64
   %24 = bitcast i64* %"@d_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %24)
-  store i64 %23, i64* %"@d_val", align 8
+  store i64 %22, i64* %"@d_val", align 8
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 4)
   %update_elem6 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo5, i64* nonnull %"@d_key", i64* nonnull %"@d_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %22)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %23)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %24)
   %25 = add i64 %1, 32
   %26 = getelementptr inbounds [4 x i8], [4 x i8]* %"struct x.e", i64 0, i64 0

--- a/tests/codegen/llvm/call_buf_size_literal.ll
+++ b/tests/codegen/llvm/call_buf_size_literal.ll
@@ -14,18 +14,20 @@ entry:
   %buffer = alloca %buffer_1_t, align 8
   %1 = getelementptr inbounds %buffer_1_t, %buffer_1_t* %buffer, i64 0, i32 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  store i64 1, i8* %1, align 8
+  store i8 1, i8* %1, align 8
   %2 = getelementptr inbounds %buffer_1_t, %buffer_1_t* %buffer, i64 0, i32 1
-  %3 = getelementptr i8, i8* %0, i64 112
-  %4 = bitcast i8* %3 to i64*
-  %arg0 = load volatile i64, i64* %4, align 8
+  %3 = getelementptr inbounds [1 x i8], [1 x i8]* %2, i64 0, i64 0
+  store i8 0, i8* %3, align 1
+  %4 = getelementptr i8, i8* %0, i64 112
+  %5 = bitcast i8* %4 to i64*
+  %arg0 = load volatile i64, i64* %5, align 8
   %probe_read = call i64 inttoptr (i64 4 to i64 ([1 x i8]*, i32, i64)*)([1 x i8]* nonnull %2, i64 1, i64 %arg0)
-  %5 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %6 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %buffer_1_t*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %buffer_1_t* nonnull %buffer, i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_buf_size_nonliteral.ll
+++ b/tests/codegen/llvm/call_buf_size_nonliteral.ll
@@ -19,20 +19,21 @@ entry:
   %length.select = select i1 %3, i64 %arg1, i64 64
   %4 = getelementptr inbounds %buffer_64_t, %buffer_64_t* %buffer, i64 0, i32 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  store i64 %length.select, i8* %4, align 8
-  %5 = getelementptr inbounds %buffer_64_t, %buffer_64_t* %buffer, i64 0, i32 1
-  %6 = getelementptr inbounds [64 x i8], [64 x i8]* %5, i64 0, i64 0
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %6, i8 0, i64 64, i1 false)
-  %7 = getelementptr i8, i8* %0, i64 112
-  %8 = bitcast i8* %7 to i64*
-  %arg0 = load volatile i64, i64* %8, align 8
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* nonnull %5, i64 %length.select, i64 %arg0)
-  %9 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
+  %5 = trunc i64 %length.select to i8
+  store i8 %5, i8* %4, align 8
+  %6 = getelementptr inbounds %buffer_64_t, %buffer_64_t* %buffer, i64 0, i32 1
+  %7 = getelementptr inbounds [64 x i8], [64 x i8]* %6, i64 0, i64 0
+  call void @llvm.memset.p0i8.i64(i8* nonnull align 1 %7, i8 0, i64 64, i1 false)
+  %8 = getelementptr i8, i8* %0, i64 112
+  %9 = bitcast i8* %8 to i64*
+  %arg0 = load volatile i64, i64* %9, align 8
+  %probe_read = call i64 inttoptr (i64 4 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* nonnull %6, i64 %length.select, i64 %arg0)
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %10)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %buffer_64_t*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", %buffer_64_t* nonnull %buffer, i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %10)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_printf.ll
+++ b/tests/codegen/llvm/call_printf.ll
@@ -15,21 +15,22 @@ entry:
   %printf_args = alloca %printf_t, align 8
   %1 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 %2, i8 0, i64 16, i1 false)
+  %2 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
+  store i64 0, i64* %2, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %"struct Foo.c")
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i64)*)(i8* nonnull %"struct Foo.c", i32 1, i64 0)
   %3 = load i8, i8* %"struct Foo.c", align 1
+  %4 = sext i8 %3 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %"struct Foo.c")
-  %4 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
-  store i8 %3, i64* %4, align 8
-  %5 = bitcast i64* %"struct Foo.l" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %5 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
+  store i64 %4, i64* %5, align 8
+  %6 = bitcast i64* %"struct Foo.l" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   %probe_read1 = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* nonnull %"struct Foo.l", i32 8, i64 8)
-  %6 = load i64, i64* %"struct Foo.l", align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
-  %7 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2
-  store i64 %6, i64* %7, align 8
+  %7 = load i64, i64* %"struct Foo.l", align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  %8 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2
+  store i64 %7, i64* %8, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 24)
@@ -39,9 +40,6 @@ entry:
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1

--- a/tests/codegen/llvm/call_printf_LLVM-10.ll
+++ b/tests/codegen/llvm/call_printf_LLVM-10.ll
@@ -15,21 +15,22 @@ entry:
   %printf_args = alloca %printf_t, align 8
   %1 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
-  %2 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* nonnull align 8 dereferenceable(24) %2, i8 0, i64 16, i1 false)
+  %2 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
+  store i64 0, i64* %2, align 8
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %"struct Foo.c")
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i64)*)(i8* nonnull %"struct Foo.c", i32 1, i64 0)
   %3 = load i8, i8* %"struct Foo.c", align 1
+  %4 = sext i8 %3 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %"struct Foo.c")
-  %4 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
-  store i8 %3, i64* %4, align 8
-  %5 = bitcast i64* %"struct Foo.l" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %5 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 1
+  store i64 %4, i64* %5, align 8
+  %6 = bitcast i64* %"struct Foo.l" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   %probe_read1 = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* nonnull %"struct Foo.l", i32 8, i64 8)
-  %6 = load i64, i64* %"struct Foo.l", align 8
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
-  %7 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2
-  store i64 %6, i64* %7, align 8
+  %7 = load i64, i64* %"struct Foo.l", align 8
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
+  %8 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 2
+  store i64 %7, i64* %8, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 24)
@@ -39,9 +40,6 @@ entry:
 
 ; Function Attrs: argmemonly nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
-
-; Function Attrs: argmemonly nounwind willreturn
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #1
 
 ; Function Attrs: argmemonly nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1

--- a/tests/codegen/llvm/intptrcast_assign_var.ll
+++ b/tests/codegen/llvm/intptrcast_assign_var.ll
@@ -18,17 +18,17 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %deref)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i64)*)(i8* nonnull %deref, i32 1, i64 %3)
   %4 = load i8, i8* %deref, align 1
+  %5 = sext i8 %4 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %deref)
-  %5 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %6 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@_key", align 8
-  %6 = sext i8 %4 to i64
   %7 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  store i64 %6, i64* %"@_val", align 8
+  store i64 %5, i64* %"@_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@_key", i64* nonnull %"@_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
 }

--- a/tests/codegen/llvm/intptrcast_call.ll
+++ b/tests/codegen/llvm/intptrcast_call.ll
@@ -35,8 +35,8 @@ lookup_merge:                                     ; preds = %entry, %lookup_succ
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %deref)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i64)*)(i8* nonnull %deref, i32 1, i64 %6)
   %7 = load i8, i8* %deref, align 1
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %deref)
   %8 = sext i8 %7 to i64
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %deref)
   %9 = add i64 %lookup_elem_val.0, %8
   store i64 %9, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)

--- a/tests/codegen/llvm/struct_char_1.ll
+++ b/tests/codegen/llvm/struct_char_1.ll
@@ -21,17 +21,17 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %"struct Foo.x")
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, [1 x i8]*)*)(i8* nonnull %"struct Foo.x", i32 1, [1 x i8]* nonnull %"$foo")
   %3 = load i8, i8* %"struct Foo.x", align 1
+  %4 = sext i8 %3 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %"struct Foo.x")
-  %4 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  %5 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   store i64 0, i64* %"@x_key", align 8
-  %5 = sext i8 %3 to i64
   %6 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
-  store i64 %5, i64* %"@x_val", align 8
+  store i64 %4, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_char_2.ll
+++ b/tests/codegen/llvm/struct_char_2.ll
@@ -14,17 +14,17 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %"struct Foo.x")
   %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i64)*)(i8* nonnull %"struct Foo.x", i32 1, i64 0)
   %1 = load i8, i8* %"struct Foo.x", align 1
+  %2 = sext i8 %1 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %"struct Foo.x")
-  %2 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  %3 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   store i64 0, i64* %"@x_key", align 8
-  %3 = sext i8 %1 to i64
   %4 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
-  store i64 %3, i64* %"@x_val", align 8
+  store i64 %2, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_integer_ptr_1.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_1.ll
@@ -29,17 +29,17 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   %probe_read1 = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* nonnull %deref, i32 4, i64 %4)
   %6 = load i32, i32* %deref, align 4
+  %7 = zext i32 %6 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
-  %7 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 0, i64* %"@x_key", align 8
-  %8 = zext i32 %6 to i64
   %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
-  store i64 %8, i64* %"@x_val", align 8
+  store i64 %7, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_integer_ptr_2.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_2.ll
@@ -21,17 +21,17 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   %probe_read1 = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* nonnull %deref, i32 4, i64 %2)
   %4 = load i32, i32* %deref, align 4
+  %5 = zext i32 %4 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  %5 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %6 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@x_key", align 8
-  %6 = zext i32 %4 to i64
   %7 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  store i64 %6, i64* %"@x_val", align 8
+  store i64 %5, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_integers_1.ll
+++ b/tests/codegen/llvm/struct_integers_1.ll
@@ -23,17 +23,17 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* nonnull %"struct Foo.x", i32 4, [4 x i8]* nonnull %tmpcast)
   %4 = load i32, i32* %"struct Foo.x", align 4
+  %5 = sext i32 %4 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  %5 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %6 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@x_key", align 8
-  %6 = sext i32 %4 to i64
   %7 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  store i64 %6, i64* %"@x_val", align 8
+  store i64 %5, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_integers_2.ll
+++ b/tests/codegen/llvm/struct_integers_2.ll
@@ -15,17 +15,17 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* nonnull %"struct Foo.x", i32 4, i64 0)
   %2 = load i32, i32* %"struct Foo.x", align 4
+  %3 = sext i32 %2 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  %3 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
-  %4 = sext i32 %2 to i64
   %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  store i64 %4, i64* %"@x_val", align 8
+  store i64 %3, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_nested_struct_anon_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_1.ll
@@ -23,17 +23,17 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* nonnull %"struct Foo::(anonymous at definitions.h:1:14).x", i32 4, [4 x i8]* nonnull %tmpcast)
   %4 = load i32, i32* %"struct Foo::(anonymous at definitions.h:1:14).x", align 4
+  %5 = sext i32 %4 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  %5 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %6 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@x_key", align 8
-  %6 = sext i32 %4 to i64
   %7 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  store i64 %6, i64* %"@x_val", align 8
+  store i64 %5, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_nested_struct_anon_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_2.ll
@@ -15,17 +15,17 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* nonnull %"struct Foo::(anonymous at definitions.h:1:14).x", i32 4, i64 0)
   %2 = load i32, i32* %"struct Foo::(anonymous at definitions.h:1:14).x", align 4
+  %3 = sext i32 %2 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  %3 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
-  %4 = sext i32 %2 to i64
   %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  store i64 %4, i64* %"@x_val", align 8
+  store i64 %3, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_nested_struct_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_1.ll
@@ -23,17 +23,17 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* nonnull %"struct Bar.x", i32 4, [4 x i8]* nonnull %tmpcast)
   %4 = load i32, i32* %"struct Bar.x", align 4
+  %5 = sext i32 %4 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  %5 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %6 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@x_key", align 8
-  %6 = sext i32 %4 to i64
   %7 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  store i64 %6, i64* %"@x_val", align 8
+  store i64 %5, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_nested_struct_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_2.ll
@@ -15,17 +15,17 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* nonnull %"struct Bar.x", i32 4, i64 0)
   %2 = load i32, i32* %"struct Bar.x", align 4
+  %3 = sext i32 %2 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  %3 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
-  %4 = sext i32 %2 to i64
   %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  store i64 %4, i64* %"@x_val", align 8
+  store i64 %3, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
@@ -29,17 +29,17 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
   %probe_read1 = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* nonnull %"struct Bar.x", i32 4, i64 %4)
   %6 = load i32, i32* %"struct Bar.x", align 4
+  %7 = sext i32 %6 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
-  %7 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %8)
   store i64 0, i64* %"@x_key", align 8
-  %8 = sext i32 %6 to i64
   %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %9)
-  store i64 %8, i64* %"@x_val", align 8
+  store i64 %7, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %8)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %9)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
@@ -21,17 +21,17 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   %probe_read1 = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* nonnull %"struct Bar.x", i32 4, i64 %2)
   %4 = load i32, i32* %"struct Bar.x", align 4
+  %5 = sext i32 %4 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  %5 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %6 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@x_key", align 8
-  %6 = sext i32 %4 to i64
   %7 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  store i64 %6, i64* %"@x_val", align 8
+  store i64 %5, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_short_1.ll
+++ b/tests/codegen/llvm/struct_short_1.ll
@@ -23,17 +23,17 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i16*, i32, [2 x i8]*)*)(i16* nonnull %"struct Foo.x", i32 2, [2 x i8]* nonnull %tmpcast)
   %4 = load i16, i16* %"struct Foo.x", align 2
+  %5 = sext i16 %4 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
-  %5 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
+  %6 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %6)
   store i64 0, i64* %"@x_key", align 8
-  %6 = sext i16 %4 to i64
   %7 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %7)
-  store i64 %6, i64* %"@x_val", align 8
+  store i64 %5, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %6)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %7)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_short_2.ll
+++ b/tests/codegen/llvm/struct_short_2.ll
@@ -15,17 +15,17 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
   %probe_read = call i64 inttoptr (i64 4 to i64 (i16*, i32, i64)*)(i16* nonnull %"struct Foo.x", i32 2, i64 0)
   %2 = load i16, i16* %"struct Foo.x", align 2
+  %3 = sext i16 %2 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
-  %3 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
   store i64 0, i64* %"@x_key", align 8
-  %4 = sext i16 %2 to i64
   %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %5)
-  store i64 %4, i64* %"@x_val", align 8
+  store i64 %3, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %5)
   ret i64 0
 }

--- a/tests/runtime/intptrcast
+++ b/tests/runtime/intptrcast
@@ -28,7 +28,7 @@ AFTER ./testprogs/intptrcast
 
 NAME Sum casted value
 RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r15")+160)); exit();}'
-EXPECT ^@: 3258
+EXPECT ^@: 4077
 TIMEOUT 5
 ARCH s390x
 AFTER ./testprogs/intptrcast
@@ -63,7 +63,7 @@ AFTER ./testprogs/intptrcast
 
 NAME Casting ints
 RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("r15")+160); printf("%d\n", $a); exit();}'
-EXPECT 3258
+EXPECT 4077
 TIMEOUT 5
 ARCH s390x
 AFTER ./testprogs/intptrcast


### PR DESCRIPTION

Hi @fbs, @danobi, @mmisono 

This patchset tries to reduce failures in big endian architectures. The problem occurs due to type conversion issues. I have tried to put detailed analysis in the commit, so that we can avoid these in future. Let me know, if it is fine. Thank you!!

