### PR TITLE
Add clang build in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,14 @@ jobs:
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size
           BASE: bionic
+        - NAME: LLVM 10 Clang Debug
+          TYPE: Debug
+          LLVM_VERSION: 10
+          CC: clang-10
+          CXX: clang++-10
+          RUN_ALL_TESTS: 1
+          RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size
+          BASE: bionic
     steps:
     - uses: actions/checkout@v2
     - name: Build docker container
@@ -109,6 +117,8 @@ jobs:
         -e RUN_ALL_TESTS=${RUN_ALL_TESTS}
         -e CMAKE_EXTRA_FLAGS="${CMAKE_EXTRA_FLAGS}"
         -e RUNTIME_TEST_DISABLE="${RUNTIME_TEST_DISABLE}"
+        -e CC="${CC}"
+        -e CXX="${CXX}"
         bpftrace-builder-$BASE-llvm-$LLVM_VERSION
         ${PWD}/build-$TYPE-$BASE
         $TYPE

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -12,6 +12,8 @@ EMBED_LIBCLANG_ONLY=${EMBED_LIBCLANG_ONLY:-OFF}
 DEPS_ONLY=${DEPS_ONLY:-OFF}
 RUN_TESTS=${RUN_TESTS:-1}
 CI_TIMEOUT=${CI_TIMEOUT:-0}
+CC=${CC:cc}
+CXX=${CXX:c++}
 
 # If running on Travis, we may need several builds incrementally building up
 # the cache in order to cold-start the build cache within the 50 minute travis


### PR DESCRIPTION
In rare cases, gcc build passes tests but clang build not. Check this by adding clang build in CI. 
Only add Clang/LLVM 10 debug build.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
