### PR TITLE
Enable the ternary operator to evaluate builtin calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to
   - [#1377](https://github.com/iovisor/bpftrace/pull/1377)
 - Add support for non-map print()
   - [#1381](https://github.com/iovisor/bpftrace/pull/1381)
+- Enable the `ternary` operator to evaluate builtin calls
+  - [#1405](https://github.com/iovisor/bpftrace/pull/1405)
 
 #### Changed
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -658,7 +658,7 @@ member to dereference).
 
 ## 6. `? :`: ternary operators
 
-Example:
+Examples:
 
 ```
 # bpftrace -e 'tracepoint:syscalls:sys_exit_read { @error[args->ret < 0 ? - args->ret : 0] = count(); }'
@@ -667,6 +667,12 @@ Attaching 1 probe...
 
 @error[11]: 24
 @error[0]: 78
+```
+
+```
+# bpftrace -e 'BEGIN { pid & 1 ? printf("Odd\n") : printf("Even\n"); exit(); }'
+Attaching 1 probe...
+Odd
 ```
 
 ## 7. `if () {...} else {...}`: if-else statements

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1424,6 +1424,8 @@ void SemanticAnalyser::visit(Ternary &ternary)
     ternary.type = CreateString(STRING_SIZE);
   else if (lhs == Type::integer)
     ternary.type = CreateInteger(64, ternary.left->type.IsSigned());
+  else if (lhs == Type::none)
+    ternary.type = CreateNone();
   else {
     ERR("Ternary return type unsupported " << lhs, ternary.loc);
   }

--- a/tests/codegen/llvm/ternary_none.ll
+++ b/tests/codegen/llvm/ternary_none.ll
@@ -1,0 +1,48 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%printf_t = type { i64 }
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+define i64 @"kprobe:f"(i8*) local_unnamed_addr section "s_kprobe:f_1" {
+entry:
+  %perfdata = alloca i64, align 8
+  %printf_args = alloca %printf_t, align 8
+  %get_pid_tgid = tail call i64 inttoptr (i64 14 to i64 ()*)()
+  %1 = icmp ult i64 %get_pid_tgid, 42949672960000
+  br i1 %1, label %left, label %right
+
+left:                                             ; preds = %entry
+  %2 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  %3 = getelementptr inbounds %printf_t, %printf_t* %printf_args, i64 0, i32 0
+  store i64 0, i64* %3, align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %get_cpu_id = tail call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* nonnull %printf_args, i64 8)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  ret i64 0
+
+right:                                            ; preds = %entry
+  %4 = bitcast i64* %perfdata to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 30000, i64* %perfdata, align 8
+  %pseudo1 = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %get_cpu_id2 = tail call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output3 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, i64*, i64)*)(i8* %0, i64 %pseudo1, i64 %get_cpu_id2, i64* nonnull %perfdata, i64 8)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/ternary_none.cpp
+++ b/tests/codegen/ternary_none.cpp
@@ -1,0 +1,14 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, ternary_none)
+{
+  test("kprobe:f { pid < 10000 ? printf(\"hello\") : exit(); }", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -48,6 +48,11 @@ RUN bpftrace -v -e 'i:ms:1 { $a = 1 ? (int8)1 : 0; printf("%d\n", $a); exit();}'
 EXPECT 1
 TIMEOUT 5
 
+NAME ternary_none_type
+RUN bpftrace -v -e 'i:ms:1 { nsecs ? printf("yes\n") : printf("no") ; exit(); }'
+EXPECT  yes
+TIMEOUT 5
+
 NAME unroll
 RUN bpftrace -v -e 'i:ms:1 {$a = 1; unroll (10) { $a = $a + 1; } printf("a=%d\n", $a); exit();}'
 EXPECT a=11

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -245,6 +245,10 @@ TEST(semantic_analyser, ternary_expressions)
 {
   test("kprobe:f { @x = pid < 10000 ? 1 : 2 }", 0);
   test("kprobe:f { @x = pid < 10000 ? \"lo\" : \"high\" }", 0);
+  test("kprobe:f { pid < 10000 ? printf(\"lo\") : exit() }", 0);
+  test("kprobe:f { @x = pid < 10000 ? printf(\"lo\") : cat(\"/proc/uptime\") }",
+       10);
+  test("kprobe:f { pid < 10000 ? 3 : cat(\"/proc/uptime\") }", 10);
   test("kprobe:f { @x = pid < 10000 ? 1 : \"high\" }", 10);
   test("kprobe:f { @x = pid < 10000 ? \"lo\" : 2 }", 10);
 }


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

Currently, the ternary operator can only works to evaluate strings and integers. This PR tries to include builtin calls:
```
# bpftrace -e 'BEGIN { pid > 10000 ? printf("%s %d\n", comm, pid) : exit(); }'
```

Although if-else statement can server the purpose, using ternary can be more concise especially when users run bpftrace in comand line. In bpftrace, builtin calls have `none` types so it makes sense for the ternary operator to support them. Resolves #1333.

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
