### PR TITLE
Ignore trailing kernel module annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ and this project adheres to
   - [#1374](https://github.com/iovisor/bpftrace/pull/1374)
 - Remove registers that are not in struct pt_regs (x86-64)
   - [#1383](https://github.com/iovisor/bpftrace/issues/1383)
+- Ignore trailing kernel module annotation for k[ret]probe's
+  - [#1413](https://github.com/iovisor/bpftrace/pull/1413)
 
 #### Tools
 

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -148,11 +148,7 @@ void SemanticAnalyser::builtin_args_tracepoint(AttachPoint *attach_point,
    * 2. sets is_tparg so that codegen does the real type setting after
    *    expansion.
    */
-  auto symbol_stream = bpftrace_.get_symbols_from_file(
-      "/sys/kernel/debug/tracing/available_events");
-  auto matches = bpftrace_.find_wildcard_matches(attach_point->target,
-                                                 attach_point->func,
-                                                 *symbol_stream);
+  auto matches = bpftrace_.find_wildcard_matches(*attach_point);
   if (!matches.empty())
   {
     auto &match = *matches.begin();
@@ -1611,11 +1607,7 @@ void SemanticAnalyser::visit(FieldAccess &acc)
         continue;
       }
 
-      auto symbol_stream = bpftrace_.get_symbols_from_file(
-          "/sys/kernel/debug/tracing/available_events");
-      auto matches = bpftrace_.find_wildcard_matches(attach_point->target,
-                                                     attach_point->func,
-                                                     *symbol_stream);
+      auto matches = bpftrace_.find_wildcard_matches(*attach_point);
       for (auto &match : matches) {
         std::string tracepoint_struct =
             TracepointFormatParser::get_struct_name(attach_point->target,

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -187,10 +187,6 @@ public:
           &values_by_key);
   std::set<std::string> find_wildcard_matches(
       const ast::AttachPoint &attach_point) const;
-  std::set<std::string> find_wildcard_matches(
-      const std::string &prefix,
-      const std::string &func,
-      std::istream &symbol_stream) const;
   std::set<std::string> find_symbol_matches(
       const ast::AttachPoint &attach_point) const;
   virtual std::unique_ptr<std::istream> get_symbols_from_file(

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -11,14 +11,15 @@ using ::testing::StrictMock;
 void setup_mock_bpftrace(MockBPFtrace &bpftrace)
 {
   ON_CALL(bpftrace,
-          get_symbols_from_file("/sys/kernel/debug/tracing/available_filter_functions"))
-      .WillByDefault([](const std::string &)
-      {
+          get_symbols_from_file(
+              "/sys/kernel/debug/tracing/available_filter_functions"))
+      .WillByDefault([](const std::string &) {
         std::string ksyms = "SyS_read\n"
                             "sys_read\n"
                             "sys_write\n"
                             "my_one\n"
-                            "my_two\n";
+                            "my_two\n"
+                            "func_in_mod [kernel_mod]\n";
         auto myval = std::unique_ptr<std::istream>(new std::istringstream(ksyms));
         return myval;
       });


### PR DESCRIPTION
Before, `find_wildcard_matches` would choke on lines
available_filter_functions like:

    ehci_disable_ASE [ehci_hcd]

This patch has k[ret]probes ignore the module annotation.

This closes #1036 .

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
