### PR TITLE
Change how `printf` parses its format string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -98,6 +98,9 @@ and this project adheres to
   - [#1383](https://github.com/iovisor/bpftrace/issues/1383)
 - Ignore trailing kernel module annotation for k[ret]probe's
   - [#1413](https://github.com/iovisor/bpftrace/pull/1413)
+- Fix `printf` not allowing format specifiers to be directly followed by
+  alphabetic characters
+  - [#1414](https://github.com/iovisor/bpftrace/pull/1414)
 
 #### Tools
 

--- a/src/printf.h
+++ b/src/printf.h
@@ -3,11 +3,24 @@
 #include <sstream>
 
 #include "ast.h"
+#include "printf_format_types.h"
 #include "types.h"
 
 namespace bpftrace {
 
-const std::regex format_specifier_re("%-?[0-9]*(\\.[0-9]+)?[a-zA-Z]+");
+static const std::string generate_pattern_string()
+{
+  std::string pattern = "%-?[0-9]*(\\.[0-9]+)?(";
+  for (const auto& e : printf_format_types)
+  {
+    pattern += e.first + "|";
+  }
+  pattern.pop_back(); // for the last "|"
+  pattern += ")";
+  return pattern;
+}
+
+const std::regex format_specifier_re(generate_pattern_string());
 
 struct Field;
 

--- a/src/printf_format_types.h
+++ b/src/printf_format_types.h
@@ -1,3 +1,4 @@
+#pragma once
 #include <unordered_map>
 
 #include "types.h"

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -4,8 +4,13 @@ EXPECT hi!
 TIMEOUT 5
 
 NAME printf_argument
-RUN bpftrace -v -e 'i:ms:1 { printf("value: %d100\n", 100); exit();}'
-EXPECT value: 100
+RUN bpftrace -v -e 'i:ms:1 { printf("value: %dms100\n", 100); exit();}'
+EXPECT value: 100ms100
+TIMEOUT 5
+
+NAME printf_llu
+RUN bpftrace -e 'BEGIN { @start = nsecs; } i:s:1 { printf("Elapsed time: %llus\n", (nsecs - @start)/1000000000); clear(@start); exit();}'  
+EXPECT Elapsed time: 1s
 TIMEOUT 5
 
 NAME printf_argument_alignment
@@ -14,8 +19,8 @@ EXPECT 123 hello 456 world
 TIMEOUT 5
 
 NAME printf_more_arguments
-RUN bpftrace -v -e 'BEGIN { printf("%d: %s; %d: %s;; %d: %s;;; %d: %s;;;;\\n", 1, "a", 2, "ab", 3, "abc", 4, "abcd"); exit(); }'
-EXPECT 1: a; 2: ab;; 3: abc;;; 4: abcd;;;;
+RUN bpftrace -v -e 'BEGIN { printf("%dst: %sa; %dnd: %sb;; %drd: %sc;;; %dth: %sd;;;;\\n", 1, "a", 2, "ab", 3, "abc", 4, "abcd"); exit(); }'
+EXPECT 1st: aa; 2nd: abb;; 3rd: abcc;;; 4th: abcdd;;;;
 TIMEOUT 5
 
 NAME time

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -905,6 +905,7 @@ TEST(semantic_analyser, printf)
   test("kprobe:f { printf(\"%d %d %d %d %d %d %d %d %d\", 1, 2, 3, 4, 5, 6, 7, "
        "8, 9); }",
        0);
+  test("kprobe:f { printf(\"%dns\", nsecs) }", 0);
 }
 
 TEST(semantic_analyser, system)


### PR DESCRIPTION
Currently `printf` does not allow string format specifiers to be directly
followed by any alphabetic characters since it would take all the following
letters as part of the specifiers. As an example:

```
bpftrace -e 'BEGIN { @start = nsecs; } i:s:1 { printf("Elapsed: %ds\n", (nsecs - @start)/1000000000); }' 
stdin:1:35-95: ERROR: printf: Unknown format string token: %ds
BEGIN { @start = nsecs; } i:s:1 { printf("Elapsed: %ds\n", (nsecs - @start)/1000000000); }
```
I think it's good to fix it since I could not think of any obvious downsides.
This PR works to address this issue by changing the way `printf` parse the
format strings. It would also affect `cat` and `system` as well. With this PR:

```
bpftrace -e 'BEGIN { @start = nsecs; } i:s:1 { printf("Elapsed: %ds\n", (nsecs - @start)/1000000000); }'  
Attaching 2 probes...
Elapsed: 1s
Elapsed: 2s
Elapsed: 3s
Elapsed: 4s
Elapsed: 5s
^C

@start: 2976003477708
```