### PR TITLE
Enable top and div args for printing Type::avg maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ and this project adheres to
 - Fix `printf` not allowing format specifiers to be directly followed by
   alphabetic characters
   - [#1414](https://github.com/iovisor/bpftrace/pull/1414)
+- Fix `top` and `div` arguments of `print()` not working for Type::avg maps
+  - [#1416](https://github.com/iovisor/bpftrace/pull/1416)
 
 #### Changed
 

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1304,7 +1304,7 @@ int BPFtrace::print_map(IMap &map, uint32_t top, uint32_t div)
   if (map.type_.IsHistTy() || map.type_.IsLhistTy())
     return print_map_hist(map, top, div);
   else if (map.type_.IsAvgTy() || map.type_.IsStatsTy())
-    return print_map_stats(map);
+    return print_map_stats(map, top, div);
 
   uint32_t nvalues = map.is_per_cpu_type() ? ncpus_ : 1;
   std::vector<uint8_t> old_key;
@@ -1461,7 +1461,7 @@ int BPFtrace::print_map_hist(IMap &map, uint32_t top, uint32_t div)
   return 0;
 }
 
-int BPFtrace::print_map_stats(IMap &map)
+int BPFtrace::print_map_stats(IMap &map, uint32_t top, uint32_t div)
 {
   uint32_t nvalues = map.is_per_cpu_type() ? ncpus_ : 1;
   // stats() and avg() maps add an extra 8 bytes onto the end of their key for
@@ -1534,7 +1534,9 @@ int BPFtrace::print_map_stats(IMap &map)
     return a.second < b.second;
   });
 
-  out_->map_stats(*this, map, values_by_key, total_counts_by_key);
+  if (div == 0)
+    div = 1;
+  out_->map_stats(*this, map, top, div, values_by_key, total_counts_by_key);
   return 0;
 }
 

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -239,7 +239,7 @@ private:
   int setup_perf_events();
   void poll_perf_events(int epollfd, bool drain = false);
   int print_map_hist(IMap &map, uint32_t top, uint32_t div);
-  int print_map_stats(IMap &map);
+  int print_map_stats(IMap &map, uint32_t top, uint32_t div);
   template <typename T>
   static T reduce_value(const std::vector<uint8_t> &value, int nvalues);
   static int64_t min_value(const std::vector<uint8_t> &value, int nvalues);

--- a/src/output.h
+++ b/src/output.h
@@ -43,9 +43,14 @@ public:
   virtual void map_hist(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t div,
                         const std::map<std::vector<uint8_t>, std::vector<uint64_t>> &values_by_key,
                         const std::vector<std::pair<std::vector<uint8_t>, uint64_t>> &total_counts_by_key) const = 0;
-  virtual void map_stats(BPFtrace &bpftrace, IMap &map,
-                         const std::map<std::vector<uint8_t>, std::vector<int64_t>> &values_by_key,
-                         const std::vector<std::pair<std::vector<uint8_t>, int64_t>> &total_counts_by_key) const = 0;
+  virtual void map_stats(
+      BPFtrace &bpftrace,
+      IMap &map,
+      uint32_t top,
+      uint32_t div,
+      const std::map<std::vector<uint8_t>, std::vector<int64_t>> &values_by_key,
+      const std::vector<std::pair<std::vector<uint8_t>, int64_t>>
+          &total_counts_by_key) const = 0;
   virtual void value(BPFtrace &bpftrace,
                      const SizedType &ty,
                      const std::vector<uint8_t> &value) const = 0;
@@ -70,9 +75,14 @@ public:
   void map_hist(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t div,
                 const std::map<std::vector<uint8_t>, std::vector<uint64_t>> &values_by_key,
                 const std::vector<std::pair<std::vector<uint8_t>, uint64_t>> &total_counts_by_key) const override;
-  void map_stats(BPFtrace &bpftrace, IMap &map,
-                 const std::map<std::vector<uint8_t>, std::vector<int64_t>> &values_by_key,
-                 const std::vector<std::pair<std::vector<uint8_t>, int64_t>> &total_counts_by_key) const override;
+  void map_stats(
+      BPFtrace &bpftrace,
+      IMap &map,
+      uint32_t top,
+      uint32_t div,
+      const std::map<std::vector<uint8_t>, std::vector<int64_t>> &values_by_key,
+      const std::vector<std::pair<std::vector<uint8_t>, int64_t>>
+          &total_counts_by_key) const override;
   virtual void value(BPFtrace &bpftrace,
                      const SizedType &ty,
                      const std::vector<uint8_t> &value) const override;
@@ -100,9 +110,14 @@ public:
   void map_hist(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t div,
                 const std::map<std::vector<uint8_t>, std::vector<uint64_t>> &values_by_key,
                 const std::vector<std::pair<std::vector<uint8_t>, uint64_t>> &total_counts_by_key) const override;
-  void map_stats(BPFtrace &bpftrace, IMap &map,
-                 const std::map<std::vector<uint8_t>, std::vector<int64_t>> &values_by_key,
-                 const std::vector<std::pair<std::vector<uint8_t>, int64_t>> &total_counts_by_key) const override;
+  void map_stats(
+      BPFtrace &bpftrace,
+      IMap &map,
+      uint32_t top,
+      uint32_t div,
+      const std::map<std::vector<uint8_t>, std::vector<int64_t>> &values_by_key,
+      const std::vector<std::pair<std::vector<uint8_t>, int64_t>>
+          &total_counts_by_key) const override;
   virtual void value(BPFtrace &bpftrace,
                      const SizedType &ty,
                      const std::vector<uint8_t> &value) const override;

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -215,3 +215,13 @@ NAME strftime_as_map_value
 RUN bpftrace -v -e 'BEGIN { @[nsecs] = strftime("%m/%d/%y", nsecs); exit();}'
 EXPECT @\[[0-9]*\]: [0-9]{2}\/[0-9]{2}\/[0-9]{2}
 TIMEOUT 5
+
+NAME print_avg_map_top
+RUN bpftrace -e 'i:ms:1 { @[nsecs/100000] = avg(1) } i:ms:10 { print(@, 3, 0); exit(); } END {clear(@)}' | grep -c -v "^ *$"
+EXPECT ^4$
+TIMEOUT 1
+
+NAME print_avg_map_div
+RUN bpftrace -e 'i:ms:1 { @[nsecs/1000000] = avg(10) } i:ms:10 { print(@, 1, 10) ;exit();} END {clear(@)}'
+EXPECT ^@\[[0-9]+\]: 1$
+TIMEOUT 1

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -104,3 +104,8 @@ NAME print_non_map_tuple
 RUN bpftrace -f json -e 'BEGIN { $t = (1, 2, "string"); print($t); exit() }'
 EXPECT ^{"type": "value", "data": \[1,2,"string"\]}$
 TIMEOUT 1
+
+NAME print_avg_map_args
+RUN bpftrace -f json -e 'i:ms:1 { @[nsecs/100000] = avg(10) } i:ms:10 { print(@, 1, 10); exit(); } END {clear(@)}'
+EXPECT ^{"type": "stats", "data": {"@": { *"[0-9]*": 1}}}$
+TIMEOUT 1


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->
The top and div arguments of `print()` currently does not work for avg maps
because it wasn't implemented. I think it makes sense to have them supported.

Resolves #1385.
##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [X] User-visible and non-trivial changes updated in `CHANGELOG.md`
