### PR TITLE
Add a logging framework to bpftrace

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -14,6 +14,7 @@ add_executable(bpftrace
   fake_map.cpp
   list.cpp
   lockdown.cpp
+  log.cpp
   main.cpp
   map.cpp
   mapkey.cpp

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -1,0 +1,196 @@
+#include "log.h"
+
+namespace bpftrace {
+
+std::string logtype_str(LogType t)
+{
+  switch (t)
+  {
+    // clang-format off
+    case LogType::DEBUG   : return "DEBUG";
+    case LogType::INFO    : return "INFO";
+    case LogType::WARNING : return "WARNING";
+    case LogType::ERROR   : return "ERROR";
+    // clang-format on
+    default:
+      std::cerr << "Invalid log type." << std::endl;
+      abort();
+  }
+}
+
+Log& Log::get()
+{
+  static Log log;
+  return log;
+}
+
+void Log::take_input(LogType type,
+                     const std::optional<location>& loc,
+                     std::ostream& out,
+                     std::string&& input)
+{
+  auto print_out = [&]() {
+    out << logtype_str(type) << ": " << input << std::endl;
+  };
+
+  if (loc)
+  {
+    if (src_.empty())
+    {
+      std::cerr << "Log: cannot resolve location before calling set_source()."
+                << std::endl;
+      print_out();
+    }
+    else if (loc->begin.line == 0)
+    {
+      std::cerr << "Log: invalid location." << std::endl;
+      print_out();
+    }
+    else if (loc->begin.line > loc->end.line)
+    {
+      std::cerr << "Log: loc.begin > loc.end: " << loc->begin << ":" << loc->end
+                << std::endl;
+      print_out();
+    }
+    else
+    {
+      log_with_location(type, loc.value(), out, input);
+    }
+  }
+  else
+  {
+    print_out();
+  }
+}
+
+const std::string Log::get_source_line(unsigned int n)
+{
+  // Get the Nth source line (N is 0-based). Return an empty string if it
+  // doesn't exist
+  std::string line;
+  std::stringstream ss(src_);
+  for (unsigned int idx = 0; idx <= n; idx++)
+  {
+    std::getline(ss, line);
+    if (ss.eof() && idx == n)
+      return line;
+    if (!ss)
+      return "";
+  }
+  return line;
+}
+
+void Log::log_with_location(LogType type,
+                            const location& l,
+                            std::ostream& out,
+                            const std::string& m)
+{
+  if (filename_.size())
+  {
+    out << filename_ << ":";
+  }
+
+  std::string msg(m);
+  const std::string& typestr = logtype_str(type);
+
+  if (!msg.empty() && msg.back() == '\n')
+  {
+    msg.pop_back();
+  }
+
+  /* For a multi line error only the line range is printed:
+     <filename>:<start_line>-<end_line>: ERROR: <message>
+  */
+  if (l.begin.line < l.end.line)
+  {
+    out << l.begin.line << "-" << l.end.line << ": " << typestr << ": " << msg
+        << std::endl;
+    return;
+  }
+
+  /*
+    For a single line error the format is:
+
+    <filename>:<line>:<start_col>-<end_col>: ERROR: <message>
+    <source line>
+    <marker>
+
+    E.g.
+
+    file.bt:1:10-20: error: <message>
+    i:s:1   /1 < "str"/
+            ~~~~~~~~~~
+  */
+  out << l.begin.line << ":" << l.begin.column << "-" << l.end.column;
+  out << ": " << typestr << ": " << msg << std::endl;
+
+  // for bpftrace::position, valid line# starts from 1
+  std::string srcline = get_source_line(l.begin.line - 1);
+
+  if (srcline == "")
+    return;
+
+  // To get consistent printing all tabs will be replaced with 4 spaces
+  for (auto c : srcline)
+  {
+    if (c == '\t')
+      out << "    ";
+    else
+      out << c;
+  }
+  out << std::endl;
+
+  for (unsigned int x = 0;
+       x < srcline.size() && x < (static_cast<unsigned int>(l.end.column) - 1);
+       x++)
+  {
+    char marker = (x < (static_cast<unsigned int>(l.begin.column) - 1)) ? ' '
+                                                                        : '~';
+    if (srcline[x] == '\t')
+    {
+      out << std::string(4, marker);
+    }
+    else
+    {
+      out << marker;
+    }
+  }
+  out << std::endl;
+}
+
+LogStream::LogStream(const std::string& file,
+                     int line,
+                     LogType type,
+                     std::ostream& out)
+    : sink_(Log::get()),
+      type_(type),
+      loc_(std::nullopt),
+      out_(out),
+      log_file_(file),
+      log_line_(line)
+{
+}
+
+LogStream::LogStream(const std::string& file,
+                     int line,
+                     LogType type,
+                     const location& loc,
+                     std::ostream& out)
+    : sink_(Log::get()),
+      type_(type),
+      loc_(loc),
+      out_(out),
+      log_file_(file),
+      log_line_(line)
+{
+}
+
+LogStream::~LogStream()
+{
+  std::string prefix = "";
+  if (type_ == LogType::DEBUG)
+    prefix = "[" + log_file_ + ":" + std::to_string(log_line_) + "]\n";
+  sink_.take_input(type_, loc_, out_, prefix + buf_.str());
+}
+
+}; // namespace bpftrace

--- a/src/log.h
+++ b/src/log.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include <iostream>
+#include <optional>
+#include <sstream>
+
+#include "bpftrace.h"
+
+namespace bpftrace {
+
+// clang-format off
+enum class LogType
+{
+  DEBUG,
+  INFO,
+  WARNING,
+  ERROR
+};
+// clang-format on
+
+class Log
+{
+public:
+  static Log& get();
+  void take_input(LogType type,
+                  const std::optional<location>& loc,
+                  std::ostream& out,
+                  std::string&& input);
+  inline void set_source(const std::string& filename, const std::string& source)
+  {
+    src_ = source;
+    filename_ = filename;
+  }
+  inline const std::string& get_source()
+  {
+    return src_;
+  }
+  const std::string get_source_line(unsigned int n);
+
+  // Can only construct with get()
+  Log(const Log& other) = delete;
+  Log& operator=(const Log& other) = delete;
+
+private:
+  Log() = default;
+  ~Log() = default;
+  std::string src_;
+  std::string filename_;
+  void log_with_location(LogType,
+                         const location&,
+                         std::ostream&,
+                         const std::string&);
+};
+
+class LogStream
+{
+public:
+  LogStream(const std::string& file,
+            int line,
+            LogType type,
+            std::ostream& out = std::cerr);
+  LogStream(const std::string& file,
+            int line,
+            LogType type,
+            const location& loc,
+            std::ostream& out = std::cerr);
+  template <typename T>
+  LogStream& operator<<(const T& v)
+  {
+    buf_ << v;
+    return *this;
+  }
+  ~LogStream();
+
+private:
+  Log& sink_;
+  LogType type_;
+  const std::optional<location> loc_;
+  std::ostream& out_;
+  std::string log_file_;
+  int log_line_;
+  std::ostringstream buf_;
+};
+
+// Usage examples:
+// 1. LOG(WARNING) << "this is a " << "warning!"; (this goes to std::cerr)
+// 2. LOG(DEBUG, std::cout) << "this is a " << " message.";
+// 3. LOG(ERROR, call.loc, std::cerr) << "this is a semantic error";
+// Note: LogType::DEBUG will prepend __FILE__ and __LINE__ to the debug message
+
+#define LOG(...) LogStream(__FILE__, __LINE__, LogType::__VA_ARGS__)
+}; // namespace bpftrace

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(bpftrace_test
   bpftrace.cpp
   child.cpp
   clang_parser.cpp
+  log.cpp
   main.cpp
   mocks.cpp
   parser.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -41,6 +41,7 @@ add_executable(bpftrace_test
   ${CMAKE_SOURCE_DIR}/src/disasm.cpp
   ${CMAKE_SOURCE_DIR}/src/driver.cpp
   ${CMAKE_SOURCE_DIR}/src/fake_map.cpp
+  ${CMAKE_SOURCE_DIR}/src/log.cpp
   ${CMAKE_SOURCE_DIR}/src/map.cpp
   ${CMAKE_SOURCE_DIR}/src/mapkey.cpp
   ${CMAKE_SOURCE_DIR}/src/output.cpp

--- a/tests/log.cpp
+++ b/tests/log.cpp
@@ -1,0 +1,59 @@
+#include "log.h"
+#include "mocks.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include <iostream>
+
+namespace bpftrace {
+namespace test {
+namespace log {
+
+TEST(LogStream, basic)
+{
+  std::ostringstream ss;
+  const std::string content_1 = "hello world";
+  const std::string content_2 = "some messages 100###**";
+
+  // clang-format off
+  LOG(DEBUG, ss) << content_1; std::string file = __FILE__; int line = __LINE__;
+  // clang-format on
+  std::string prefix = "[" + file + ":" + std::to_string(line) + "]\n";
+  EXPECT_EQ(ss.str(), "DEBUG: " + prefix + content_1 + "\n");
+  ss.str({});
+
+  LOG(WARNING, ss) << content_1 << content_2;
+  EXPECT_EQ(ss.str(), "WARNING: " + content_1 + content_2 + "\n");
+  ss.str({});
+
+  LOG(ERROR, ss) << content_1 << content_2 << content_1 << content_2 << "\n"
+                 << content_1 << content_2 << content_1 << content_2 << "\n";
+  const std::string content_long = content_1 + content_2 + content_1 +
+                                   content_2;
+  EXPECT_EQ(ss.str(), "ERROR: " + content_long + "\n" + content_long + "\n\n");
+  ss.str({});
+
+  // test macro with 1 argument
+  auto cerr_buf = std::cerr.rdbuf(ss.rdbuf());
+  LOG(INFO) << content_1 << content_2;
+  EXPECT_EQ(ss.str(), "INFO: " + content_1 + content_2 + "\n");
+  std::cerr.rdbuf(cerr_buf);
+}
+
+TEST(LogStream, with_location)
+{
+  std::ostringstream ss;
+  const std::string filename = "stdin";
+  const std::string source = "i:s:1 { print(1, 2); }";
+  const std::string expected =
+      "stdin:1:9-20: ERROR: Non-map print() only takes 1 argument, 2 "
+      "found\ni:s:1 { print(1, 2); }\n        ~~~~~~~~~~~\n";
+  bpftrace::location loc(bpftrace::position(nullptr, 1, 9),
+                         bpftrace::position(nullptr, 1, 20));
+  Log::get().set_source(filename, source);
+  LOG(ERROR, loc, ss) << "Non-map print() only takes 1 argument, 2 found";
+  EXPECT_EQ(ss.str(), expected);
+}
+
+} // namespace log
+} // namespace test
+} // namespace bpftrace


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->
This PR introduces a stream-style logging infrastructure. It supports the basic
functionalities for now and can be extended with future PRs.

There are several benefits for including it in bpftrace:
- It would be more convinient for developers to keep track of inner status of
bpftrace and debug.
- It can help to print consistent error/warning messages.
- Future work will offer users the option to toggle on/off certain messages.

Some usage examples and their output:
```
LOG(ERROR, call.loc, std::cerr)
    << "Non-map print() only takes 1 argument, " << call.vargs->size()
    << " found";
stdin:1:7-18: ERROR: Non-map print() only takes 1 argument, 2 found
i:s:1 {print(1,2)}
      ~~~~~~~~~~~

LOG(WARNING) << "this is a warning!";
WARNING: this is a warning!

LOG(DEBUG, std::cout) << "this is a message.";
DEBUG: [/home/yue/bpftrace/src/ast/semantic_analyser.cpp:861]
this is a message.
```
Related to #1411

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
