### PR TITLE
Fix some runtime tests relying on vfs_read

### DIFF
--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -37,26 +37,31 @@ NAME comm
 RUN bpftrace -v -e 'k:vfs_read { printf("SUCCESS '$test' %s\n", comm); exit(); }'
 EXPECT SUCCESS comm .*
 TIMEOUT 5
+AFTER ./testprogs/syscall read
 
 NAME stack
 RUN bpftrace -v -e 'k:vfs_read{ printf("SUCCESS '$test' %s\n", stack); exit(); }'
 EXPECT SUCCESS stack
 TIMEOUT 5
+AFTER ./testprogs/syscall read
 
 NAME kstack
 RUN bpftrace -v -e 'k:vfs_read{ printf("SUCCESS '$test' %s\n", kstack); exit(); }'
 EXPECT SUCCESS kstack
 TIMEOUT 5
+AFTER ./testprogs/syscall read
 
 NAME ustack
 RUN bpftrace -v -e 'k:vfs_read { printf("SUCCESS '$test' %s\n", ustack); exit(); }'
 EXPECT SUCCESS ustack
 TIMEOUT 5
+AFTER ./testprogs/syscall read
 
 NAME arg
 RUN bpftrace -v -e 'k:vfs_read { printf("SUCCESS '$test' %d\n", arg0); exit(); }'
 EXPECT SUCCESS arg -?[0-9][0-9]*
 TIMEOUT 5
+AFTER ./testprogs/syscall read
 
 NAME sarg
 RUN bpftrace -v -e 'uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS '$test' %d %d\n", sarg0, sarg1); exit(); }'
@@ -83,11 +88,13 @@ NAME retval
 RUN bpftrace -v -e 'kretprobe:vfs_read { printf("SUCCESS '$test' %d\n", retval); exit(); }'
 EXPECT SUCCESS retval .*
 TIMEOUT 5
+AFTER ./testprogs/syscall read
 
 NAME func
 RUN bpftrace -v -e 'k:vfs_read { printf("SUCCESS '$test' %s\n", func); exit(); }'
 EXPECT SUCCESS func .*
 TIMEOUT 5
+AFTER ./testprogs/syscall read
 
 NAME func_uprobe
 RUN bpftrace -v -e 'uprobe:./testprogs/uprobe_negative_retval:function1 { printf("SUCCESS %s\n", func); exit(); }'

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -2,11 +2,13 @@ NAME kprobe
 RUN bpftrace -v -e 'kprobe:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT SUCCESS kprobe [0-9][0-9]*
 TIMEOUT 5
+AFTER ./testprogs/syscall read
 
 NAME kprobe_short_name
 RUN bpftrace -v -e 'k:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT SUCCESS kprobe_short_name [0-9][0-9]*
 TIMEOUT 5
+AFTER ./testprogs/syscall read
 
 NAME kprobe_target
 RUN bpftrace -v -e 'kprobe:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", pid); exit(); }'
@@ -23,6 +25,7 @@ NAME kprobe_offset
 RUN bpftrace -v -e 'kprobe:vfs_read+0 { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT SUCCESS kprobe_offset [0-9][0-9]*
 TIMEOUT 5
+AFTER ./testprogs/syscall read
 
 NAME kprobe_offset_fail_size
 RUN bpftrace -v -e 'kprobe:vfs_read+1000000 { printf("SUCCESS '$test' %d\n", pid); exit(); }'
@@ -33,11 +36,13 @@ NAME kretprobe
 RUN bpftrace -v -e 'kretprobe:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT SUCCESS kretprobe [0-9][0-9]*
 TIMEOUT 5
+AFTER ./testprogs/syscall read
 
 NAME kretprobe_short_name
 RUN bpftrace -v -e 'kr:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT SUCCESS kretprobe_short_name [0-9][0-9]*
 TIMEOUT 5
+AFTER ./testprogs/syscall read
 
 NAME kretprobe_target
 RUN bpftrace -v -e 'kretprobe:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", pid); exit(); }'


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->
Some runtime tests in builtin and probe expect the system to generate vfs_read
events for them, which in some cases might cause timeout error. This PR
explicitly generates the events for these tests with testprog/syscall.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
