### PR TITLE
Mark btf as depending on libbpf in --info

### DIFF
--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -217,7 +217,7 @@ std::string BPFfeature::report(void)
   buf << "Kernel features" << std::endl
       << "  Instruction limit: " << instruction_limit() << std::endl
       << "  Loop support: " << to_str(has_loop())
-      << "  btf: " << to_str(has_btf()) << std::endl;
+      << "  btf (depends on Build:libbpf): " << to_str(has_btf()) << std::endl;
 
   buf << "Map types" << std::endl
       << "  hash: " << to_str(has_map_hash())


### PR DESCRIPTION
The implicit dependency is confusing for users who somehow have a
bpftrace built without libbpf.

This closes #1422 .

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
