### PR TITLE
Add feature specific runtime testcase support

### DIFF
--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -127,7 +127,7 @@ NAME basic while loop
 RUN bpftrace -e 'BEGIN { $a = 0; while ($a <= 100) { @=avg($a++) } exit(); }'
 EXPECT @: 50
 TIMEOUT 5
-REQUIRES bpftrace --info 2>&1 | grep "Loop support: yes"
+REQUIRES_FEATURE loop
 
 NAME basic tuple
 RUN bpftrace -e 'BEGIN { $v = 99; $t = (0, 1, "str", (5, 6), $v); printf("%d %d %s %d %d %d\n", $t.0, $t.1, $t.2, $t.3.0, $t.3.1, $t.4); exit(); }'

--- a/tests/runtime/btf
+++ b/tests/runtime/btf
@@ -2,16 +2,16 @@ NAME user_supplied_c_def_using_btf
 RUN bpftrace -v --btf -e 'struct foo { struct task_struct t; } BEGIN { exit(); }'
 EXPECT Attaching 1 probe...
 TIMEOUT 5
-REQUIRES bpftrace --info 2>&1 | grep "btf: yes"
+REQUIRES_FEATURE btf
 
 NAME tracepoint_pointer_type_resolution
 RUN bpftrace -v --btf -e 'tracepoint:syscalls:sys_enter_nanosleep { args->rqtp->tv_sec; exit(); }'
 EXPECT Attaching 1 probe...
 TIMEOUT 5
-REQUIRES bpftrace --info 2>&1 | grep "btf: yes"
+REQUIRES_FEATURE btf
 
 NAME enum_value_reference
 RUN bpftrace -v --btf -e 'BEGIN { printf("%d\n", sizeof(BTF_VAR_STATIC)); exit(); }'
 EXPECT ^8$
 TIMEOUT 5
-REQUIRES bpftrace --info 2>&1 | grep "btf: yes"
+REQUIRES_FEATURE btf

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -197,4 +197,4 @@ NAME sizeof_btf
 RUN bpftrace --btf -e 'BEGIN { printf("size=%d\n", sizeof(struct task_struct)); exit(); }'
 EXPECT ^size=
 TIMEOUT 5
-REQUIRES bpftrace --info 2>&1 | grep "btf: yes"
+REQUIRES_FEATURE btf


### PR DESCRIPTION
This adds `REQUIRES_FEATURE` field for a runtime test script. This allows
a feature specific testcase without manually writing
`REQUIRES bpftrace --info | grep xxxx`. The current supported features
are "loop" and "btf".

WIth #1424, btf related tests won't be run because the condition
"REQUIRES bpftrace --info 2>&1 | grep "btf: yes" never match. This fixes it.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
