### PR TITLE
Addrspace basics

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -978,6 +978,11 @@ void CodegenLLVM::visit(Call &call)
     expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), arg.type.IsSigned());
     b_.CreateOverrideReturn(ctx_, expr_);
   }
+  else if (call.func == "kptr" || call.func == "uptr")
+  {
+    auto arg = call.vargs->at(0);
+    auto scoped_del = accept(arg);
+  }
   else
   {
     LOG(FATAL) << "missing codegen for function \"" << call.func << "\"";

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -20,6 +20,62 @@ namespace libbpf {
 namespace bpftrace {
 namespace ast {
 
+namespace {
+std::string probeReadHelperName(libbpf::bpf_func_id id)
+{
+  switch (id)
+  {
+    case libbpf::BPF_FUNC_probe_read:
+      return "probe_read";
+    case libbpf::BPF_FUNC_probe_read_user:
+      return "probe_read_user";
+    case libbpf::BPF_FUNC_probe_read_kernel:
+      return "probe_read_kernel";
+    case libbpf::BPF_FUNC_probe_read_str:
+      return "probe_read_str";
+    case libbpf::BPF_FUNC_probe_read_user_str:
+      return "probe_read_user_str";
+    case libbpf::BPF_FUNC_probe_read_kernel_str:
+      return "probe_read_kernel_str";
+    default:
+      throw std::runtime_error("BUG: unknown probe_read id: " +
+                               std::to_string(id));
+  }
+}
+} // namespace
+
+libbpf::bpf_func_id IRBuilderBPF::selectProbeReadHelper(AddrSpace as, bool str)
+{
+  libbpf::bpf_func_id fn;
+  // Assume that if a kernel has probe_read_kernel it has the other 3 too
+  if (bpftrace_.feature_.has_helper_probe_read_kernel())
+  {
+    if (as == AddrSpace::kernel)
+    {
+      fn = str ? libbpf::BPF_FUNC_probe_read_kernel_str
+               : libbpf::BPF_FUNC_probe_read_kernel;
+    }
+    else if (as == AddrSpace::user)
+    {
+      fn = str ? libbpf::BPF_FUNC_probe_read_user_str
+               : libbpf::BPF_FUNC_probe_read_user;
+    }
+    else
+    {
+      // if the kernel has the new helpers but AS is still none it is a bug
+      // in bpftrace, assert catches it for debug builds.
+      // assert(as != AddrSpace::none);
+      fn = str ? libbpf::BPF_FUNC_probe_read_str : libbpf::BPF_FUNC_probe_read;
+    }
+  }
+  else
+  {
+    fn = str ? libbpf::BPF_FUNC_probe_read_str : libbpf::BPF_FUNC_probe_read;
+  }
+
+  return fn;
+}
+
 AllocaInst *IRBuilderBPF::CreateUSym(llvm::Value *val)
 {
   std::vector<llvm::Type *> elements = {
@@ -383,15 +439,17 @@ void IRBuilderBPF::CreateProbeRead(Value *ctx,
                                    AllocaInst *dst,
                                    size_t size,
                                    Value *src,
+                                   AddrSpace as,
                                    const location &loc)
 {
-  return CreateProbeRead(ctx, dst, getInt32(size), src, loc);
+  return CreateProbeRead(ctx, dst, getInt32(size), src, as, loc);
 }
 
 void IRBuilderBPF::CreateProbeRead(Value *ctx,
                                    AllocaInst *dst,
                                    llvm::Value *size,
                                    Value *src,
+                                   AddrSpace as,
                                    const location &loc)
 {
   assert(ctx && ctx->getType() == getInt8PtrTy());
@@ -400,18 +458,24 @@ void IRBuilderBPF::CreateProbeRead(Value *ctx,
 
   // int bpf_probe_read(void *dst, int size, void *src)
   // Return: 0 on success or negative error
+
+  auto read_fn = selectProbeReadHelper(as, false);
+
   FunctionType *proberead_func_type = FunctionType::get(
       getInt64Ty(), { dst->getType(), getInt32Ty(), src->getType() }, false);
   PointerType *proberead_func_ptr_type = PointerType::get(proberead_func_type, 0);
-  Constant *proberead_func = ConstantExpr::getCast(
-      Instruction::IntToPtr,
-      getInt64(libbpf::BPF_FUNC_probe_read),
-      proberead_func_ptr_type);
-  CallInst *call = createCall(proberead_func, { dst, size, src }, "probe_read");
-  CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_probe_read, loc);
+  Constant *proberead_func = ConstantExpr::getCast(Instruction::IntToPtr,
+                                                   getInt64(read_fn),
+                                                   proberead_func_ptr_type);
+  CallInst *call = createCall(proberead_func,
+                              { dst, size, src },
+                              probeReadHelperName(read_fn));
+  CreateHelperErrorCond(ctx, call, read_fn, loc);
 }
 
-Constant *IRBuilderBPF::createProbeReadStrFn(llvm::Type *dst, llvm::Type *src)
+Constant *IRBuilderBPF::createProbeReadStrFn(llvm::Type *dst,
+                                             llvm::Type *src,
+                                             AddrSpace as)
 {
   assert(src && (src->isIntegerTy() || src->isPointerTy()));
   // int bpf_probe_read_str(void *dst, int size, const void *unsafe_ptr)
@@ -420,7 +484,7 @@ Constant *IRBuilderBPF::createProbeReadStrFn(llvm::Type *dst, llvm::Type *src)
   PointerType *probereadstr_func_ptr_type = PointerType::get(
       probereadstr_func_type, 0);
   return ConstantExpr::getCast(Instruction::IntToPtr,
-                               getInt64(libbpf::BPF_FUNC_probe_read_str),
+                               getInt64(selectProbeReadHelper(as, true)),
                                probereadstr_func_ptr_type);
 }
 
@@ -428,24 +492,27 @@ CallInst *IRBuilderBPF::CreateProbeReadStr(Value *ctx,
                                            AllocaInst *dst,
                                            size_t size,
                                            Value *src,
+                                           AddrSpace as,
                                            const location &loc)
 {
   assert(ctx && ctx->getType() == getInt8PtrTy());
-  return CreateProbeReadStr(ctx, dst, getInt32(size), src, loc);
+  return CreateProbeReadStr(ctx, dst, getInt32(size), src, as, loc);
 }
 
 CallInst *IRBuilderBPF::CreateProbeReadStr(Value *ctx,
                                            Value *dst,
                                            size_t size,
                                            Value *src,
+                                           AddrSpace as,
                                            const location &loc)
 {
   assert(ctx && ctx->getType() == getInt8PtrTy());
-  Constant *fn = createProbeReadStrFn(dst->getType(), src->getType());
+  Constant *fn = createProbeReadStrFn(dst->getType(), src->getType(), as);
+  auto read_fn = selectProbeReadHelper(as, true);
   CallInst *call = createCall(fn,
                               { dst, getInt32(size), src },
-                              "probe_read_str");
-  CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_probe_read_str, loc);
+                              probeReadHelperName(read_fn));
+  CreateHelperErrorCond(ctx, call, read_fn, loc);
   return call;
 }
 
@@ -453,6 +520,7 @@ CallInst *IRBuilderBPF::CreateProbeReadStr(Value *ctx,
                                            AllocaInst *dst,
                                            llvm::Value *size,
                                            Value *src,
+                                           AddrSpace as,
                                            const location &loc)
 {
   assert(ctx && ctx->getType() == getInt8PtrTy());
@@ -462,15 +530,19 @@ CallInst *IRBuilderBPF::CreateProbeReadStr(Value *ctx,
 
   auto *size_i32 = CreateIntCast(size, getInt32Ty(), false);
 
-  Constant *fn = createProbeReadStrFn(dst->getType(), src->getType());
-  CallInst *call = createCall(fn, { dst, size_i32, src }, "probe_read_str");
-  CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_probe_read_str, loc);
+  Constant *fn = createProbeReadStrFn(dst->getType(), src->getType(), as);
+  auto read_fn = selectProbeReadHelper(as, true);
+  CallInst *call = createCall(fn,
+                              { dst, size_i32, src },
+                              probeReadHelperName(read_fn));
+  CreateHelperErrorCond(ctx, call, read_fn, loc);
   return call;
 }
 
 Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
                                             struct bcc_usdt_argument *argument,
                                             Builtin &builtin,
+                                            AddrSpace as,
                                             const location &loc)
 {
   assert(ctx && ctx->getType() == getInt8PtrTy());
@@ -513,14 +585,14 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
                              getInt64(argument->deref_offset));
       // Zero out `dst` here in case we read less than 64 bits
       CreateStore(getInt64(0), dst);
-      CreateProbeRead(ctx, dst, abs_size, ptr, loc);
+      CreateProbeRead(ctx, dst, abs_size, ptr, as, loc);
       result = CreateLoad(dst);
     }
     else
     {
       // Zero out `dst` in case we read less than 64 bits
       CreateStore(getInt64(0), dst);
-      CreateProbeRead(ctx, dst, abs_size, reg, loc);
+      CreateProbeRead(ctx, dst, abs_size, reg, as, loc);
       result = CreateLoad(dst);
     }
     CreateLifetimeEnd(dst);
@@ -534,6 +606,7 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
                                             int arg_num,
                                             Builtin &builtin,
                                             pid_t pid,
+                                            AddrSpace as,
                                             const location &loc)
 {
   assert(ctx && ctx->getType() == getInt8PtrTy());
@@ -570,7 +643,7 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
     exit(-2);
   }
 
-  Value *result = CreateUSDTReadArgument(ctx, &argument, builtin, loc);
+  Value *result = CreateUSDTReadArgument(ctx, &argument, builtin, as, loc);
 
   bcc_usdt_close(usdt);
   return result;
@@ -578,17 +651,19 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
 
 Value *IRBuilderBPF::CreateStrcmp(Value *ctx,
                                   Value *val,
+                                  AddrSpace as,
                                   std::string str,
                                   const location &loc,
                                   bool inverse)
 {
   assert(ctx && ctx->getType() == getInt8PtrTy());
   auto cmpAmount = strlen(str.c_str()) + 1;
-  return CreateStrncmp(ctx, val, str, cmpAmount, loc, inverse);
+  return CreateStrncmp(ctx, val, as, str, cmpAmount, loc, inverse);
 }
 
 Value *IRBuilderBPF::CreateStrncmp(Value *ctx __attribute__((unused)),
                                    Value *val,
+                                   AddrSpace as __attribute__((unused)),
                                    std::string str,
                                    uint64_t n,
                                    const location &loc __attribute__((unused)),
@@ -632,17 +707,22 @@ Value *IRBuilderBPF::CreateStrncmp(Value *ctx __attribute__((unused)),
 
 Value *IRBuilderBPF::CreateStrcmp(Value *ctx,
                                   Value *val1,
+                                  AddrSpace as1,
                                   Value *val2,
+                                  AddrSpace as2,
                                   const location &loc,
                                   bool inverse)
 {
   assert(ctx && ctx->getType() == getInt8PtrTy());
-  return CreateStrncmp(ctx, val1, val2, bpftrace_.strlen_, loc, inverse);
+  return CreateStrncmp(
+      ctx, val1, as1, val2, as2, bpftrace_.strlen_, loc, inverse);
 }
 
 Value *IRBuilderBPF::CreateStrncmp(Value *ctx,
                                    Value *val1,
+                                   AddrSpace as1,
                                    Value *val2,
+                                   AddrSpace as2,
                                    uint64_t n,
                                    const location &loc,
                                    bool inverse)
@@ -705,11 +785,11 @@ Value *IRBuilderBPF::CreateStrncmp(Value *ctx,
                                                      parent);
 
     auto *ptr1 = CreateGEP(val1, { getInt32(0), getInt32(i) });
-    CreateProbeRead(ctx, val_l, 1, ptr1, loc);
+    CreateProbeRead(ctx, val_l, 1, ptr1, as1, loc);
     Value *l = CreateLoad(getInt8Ty(), val_l);
 
     auto *ptr2 = CreateGEP(val2, { getInt32(0), getInt32(i) });
-    CreateProbeRead(ctx, val_r, 1, ptr2, loc);
+    CreateProbeRead(ctx, val_r, 1, ptr2, as2, loc);
     Value *r = CreateLoad(getInt8Ty(), val_r);
 
     Value *cmp = CreateICmpNE(l, r, "strcmp.cmp");

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -45,7 +45,6 @@ class IRBuilderBPF : public IRBuilder<>
 public:
   IRBuilderBPF(LLVMContext &context, Module &module, BPFtrace &bpftrace);
 
-  // clang-format off
   AllocaInst *CreateAllocaBPF(llvm::Type *ty, const std::string &name="");
   AllocaInst *CreateAllocaBPF(const SizedType &stype, const std::string &name="");
   AllocaInst *CreateAllocaBPFInit(const SizedType &stype, const std::string &name);
@@ -57,21 +56,91 @@ public:
   llvm::ConstantInt *GetIntSameSize(uint64_t C, llvm::Type *ty);
   CallInst   *CreateBpfPseudoCall(int mapfd);
   CallInst   *CreateBpfPseudoCall(Map &map);
-  Value      *CreateMapLookupElem(Value* ctx, Map &map, AllocaInst *key, const location& loc);
-  Value      *CreateMapLookupElem(Value* ctx, int mapfd, AllocaInst *key, SizedType &type, const location& loc);
-  void        CreateMapUpdateElem(Value* ctx, Map &map, AllocaInst *key, Value *val, const location& loc);
-  void        CreateMapDeleteElem(Value* ctx, Map &map, AllocaInst *key, const location& loc);
-  void        CreateProbeRead(Value *ctx, AllocaInst *dst, size_t size, Value *src, const location& loc);
-  void        CreateProbeRead(Value *ctx, AllocaInst *dst, llvm::Value *size, Value *src, const location& loc);
-  CallInst   *CreateProbeReadStr(Value* ctx, AllocaInst *dst, llvm::Value *size, Value *src, const location& loc);
-  CallInst   *CreateProbeReadStr(Value* ctx, AllocaInst *dst, size_t size, Value *src, const location& loc);
-  CallInst   *CreateProbeReadStr(Value* ctx, Value *dst, size_t size, Value *src, const location& loc);
-  Value      *CreateUSDTReadArgument(Value *ctx, AttachPoint *attach_point, int usdt_location_index, int arg_name, Builtin &builtin, pid_t pid, const location& loc);
-  Value      *CreateStrcmp(Value* ctx, Value* val, std::string str, const location& loc, bool inverse=false);
-  Value      *CreateStrcmp(Value* ctx, Value* val1, Value* val2, const location& loc, bool inverse=false);
-  Value      *CreateStrncmp(Value* ctx, Value* val, std::string str, uint64_t n, const location& loc, bool inverse=false);
-  Value      *CreateStrncmp(Value* ctx, Value* val1, Value* val2, uint64_t n, const location& loc, bool inverse=false);
-  CallInst   *CreateGetNs();
+  Value *CreateMapLookupElem(Value *ctx,
+                             Map &map,
+                             AllocaInst *key,
+                             const location &loc);
+  Value *CreateMapLookupElem(Value *ctx,
+                             int mapfd,
+                             AllocaInst *key,
+                             SizedType &type,
+                             const location &loc);
+  void CreateMapUpdateElem(Value *ctx,
+                           Map &map,
+                           AllocaInst *key,
+                           Value *val,
+                           const location &loc);
+  void CreateMapDeleteElem(Value *ctx,
+                           Map &map,
+                           AllocaInst *key,
+                           const location &loc);
+  void CreateProbeRead(Value *ctx,
+                       AllocaInst *dst,
+                       size_t size,
+                       Value *src,
+                       AddrSpace as,
+                       const location &loc);
+  void CreateProbeRead(Value *ctx,
+                       AllocaInst *dst,
+                       llvm::Value *size,
+                       Value *src,
+                       AddrSpace as,
+                       const location &loc);
+  CallInst *CreateProbeReadStr(Value *ctx,
+                               AllocaInst *dst,
+                               llvm::Value *size,
+                               Value *src,
+                               AddrSpace as,
+                               const location &loc);
+  CallInst *CreateProbeReadStr(Value *ctx,
+                               AllocaInst *dst,
+                               size_t size,
+                               Value *src,
+                               AddrSpace as,
+                               const location &loc);
+  CallInst *CreateProbeReadStr(Value *ctx,
+                               Value *dst,
+                               size_t size,
+                               Value *src,
+                               AddrSpace as,
+                               const location &loc);
+  Value *CreateUSDTReadArgument(Value *ctx,
+                                AttachPoint *attach_point,
+                                int usdt_location_index,
+                                int arg_name,
+                                Builtin &builtin,
+                                pid_t pid,
+                                AddrSpace as,
+                                const location &loc);
+  Value *CreateStrcmp(Value *ctx,
+                      Value *val,
+                      AddrSpace as,
+                      std::string str,
+                      const location &loc,
+                      bool inverse = false);
+  Value *CreateStrcmp(Value *ctx,
+                      Value *val1,
+                      AddrSpace as1,
+                      Value *val2,
+                      AddrSpace as2,
+                      const location &loc,
+                      bool inverse = false);
+  Value *CreateStrncmp(Value *ctx,
+                       Value *val,
+                       AddrSpace as,
+                       std::string str,
+                       uint64_t n,
+                       const location &loc,
+                       bool inverse = false);
+  Value *CreateStrncmp(Value *ctx,
+                       Value *val1,
+                       AddrSpace as1,
+                       Value *val2,
+                       AddrSpace as2,
+                       uint64_t n,
+                       const location &loc,
+                       bool inverse = false);
+  CallInst *CreateGetNs();
   CallInst   *CreateGetPidTgid();
   CallInst   *CreateGetCurrentCgroupId();
   CallInst   *CreateGetUidGid();
@@ -96,9 +165,16 @@ private:
   Module &module_;
   BPFtrace &bpftrace_;
 
-  Value      *CreateUSDTReadArgument(Value *ctx, struct bcc_usdt_argument *argument, Builtin &builtin, const location& loc);
+  Value *CreateUSDTReadArgument(Value *ctx,
+                                struct bcc_usdt_argument *argument,
+                                Builtin &builtin,
+                                AddrSpace as,
+                                const location &loc);
   CallInst   *createMapLookup(int mapfd, AllocaInst *key);
-  Constant   *createProbeReadStrFn(llvm::Type * dst, llvm::Type * src);
+  Constant *createProbeReadStrFn(llvm::Type *dst,
+                                 llvm::Type *src,
+                                 AddrSpace as);
+  libbpf::bpf_func_id selectProbeReadHelper(AddrSpace as, bool str);
 
   std::map<std::string, StructType *> structs_;
   // clang-format on

--- a/src/ast/printer.cpp
+++ b/src/ast/printer.cpp
@@ -14,7 +14,10 @@ std::string Printer::type(const SizedType &ty)
   std::stringstream buf;
   if (print_types)
   {
-    buf << " :: type[" << ty << " ctx: " << ty.IsCtxAccess() << "]";
+    buf << " :: type[" << ty << ", ctx: " << ty.IsCtxAccess();
+    if (ty.GetAS() != AddrSpace::none)
+      buf << ", AS(" << ty.GetAS() << ")";
+    buf << "]";
   }
   return buf.str();
 }

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1045,7 +1045,19 @@ void SemanticAnalyser::visit(Call &call)
       }
     }
   }
-  else {
+  else if (call.func == "kptr" || call.func == "uptr")
+  {
+    if (!check_nargs(call, 1))
+      return;
+    if (!check_arg(call, Type::pointer, 0))
+      return;
+
+    auto as = (call.func == "kptr" ? AddrSpace::kernel : AddrSpace::user);
+    call.type = call.vargs->front()->type;
+    call.type.SetAS(as);
+  }
+  else
+  {
     LOG(ERROR, call.loc, err_) << "Unknown function: '" << call.func << "'";
     call.type = CreateNone();
   }

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -30,7 +30,7 @@ vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#\*])*:
 builtin  arg[0-9]|args|cgroup|comm|cpid|cpu|ctx|curtask|elapsed|func|gid|nsecs|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
-call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|ksym|lhist|max|min|ntop|override|print|printf|reg|signal|sizeof|stats|str|strftime|strncmp|sum|system|time|uaddr|usym|zero
+call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|max|min|ntop|override|print|printf|reg|signal|sizeof|stats|str|strftime|strncmp|sum|system|time|uaddr|uptr|usym|zero
 
 /* Don't add to this! Use builtin OR call not both */
 call_and_builtin kstack|ustack

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -13,6 +13,12 @@ std::ostream &operator<<(std::ostream &os, Type type)
   return os;
 }
 
+std::ostream &operator<<(std::ostream &os, ProbeType type)
+{
+  os << probetypeName(type);
+  return os;
+}
+
 std::ostream &operator<<(std::ostream &os, const SizedType &type)
 {
   if (type.IsRecordTy())

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -325,11 +325,12 @@ SizedType CreateArray(size_t num_elements, const SizedType &element_type)
   return ty;
 }
 
-SizedType CreatePointer(const SizedType &pointee_type)
+SizedType CreatePointer(const SizedType &pointee_type, AddrSpace as)
 {
   // Pointer itself is always an uint64
   auto ty = SizedType(Type::pointer, 8);
   ty.element_type_ = new SizedType(pointee_type);
+  ty.SetAS(as);
   return ty;
 }
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -13,6 +13,12 @@ std::ostream &operator<<(std::ostream &os, Type type)
   return os;
 }
 
+std::ostream &operator<<(std::ostream &os, AddrSpace as)
+{
+  os << addrspacestr(as);
+  return os;
+}
+
 std::ostream &operator<<(std::ostream &os, ProbeType type)
 {
   os << probetypeName(type);
@@ -115,6 +121,25 @@ bool SizedType::IsAggregate() const
 bool SizedType::IsStack() const
 {
   return type == Type::ustack || type == Type::kstack;
+}
+
+std::string addrspacestr(AddrSpace as)
+{
+  switch (as)
+  {
+    case AddrSpace::kernel:
+      return "kernel";
+      break;
+    case AddrSpace::user:
+      return "user";
+      break;
+    case AddrSpace::none:
+      return "none";
+      break;
+    default:
+      std::cerr << "Unknown addrspace" << std::endl;
+      abort();
+  }
 }
 
 std::string typestr(Type t)

--- a/src/types.h
+++ b/src/types.h
@@ -292,7 +292,7 @@ public:
   friend SizedType CreateArray(size_t num_elements,
                                const SizedType &element_type);
 
-  friend SizedType CreatePointer(const SizedType &pointee_type);
+  friend SizedType CreatePointer(const SizedType &pointee_type, AddrSpace as);
   friend SizedType CreateRecord(size_t size, const std::string &name);
 };
 // Type helpers
@@ -312,7 +312,8 @@ SizedType CreateUInt64();
 
 SizedType CreateString(size_t size);
 SizedType CreateArray(size_t num_elements, const SizedType &element_type);
-SizedType CreatePointer(const SizedType &pointee_type);
+SizedType CreatePointer(const SizedType &pointee_type,
+                        AddrSpace as = AddrSpace::none);
 /**
    size in bytes
  */

--- a/src/types.h
+++ b/src/types.h
@@ -48,7 +48,15 @@ enum class Type
   // clang-format on
 };
 
+enum class AddrSpace
+{
+  none,
+  kernel,
+  user,
+};
+
 std::ostream &operator<<(std::ostream &os, Type type);
+std::ostream &operator<<(std::ostream &os, AddrSpace as);
 
 enum class StackMode
 {
@@ -95,8 +103,19 @@ private:
   size_t num_elements_;               // for array like types
   std::string name_; // name of this type, for named types like struct
   bool ctx_ = false; // Is bpf program context
+  AddrSpace as_ = AddrSpace::none;
 
 public:
+  AddrSpace GetAS() const
+  {
+    return as_;
+  }
+
+  void SetAS(AddrSpace as)
+  {
+    as_ = as;
+  }
+
   bool IsCtxAccess() const
   {
     return ctx_;
@@ -367,8 +386,9 @@ const std::vector<ProbeItem> PROBE_LIST =
   { "kretfunc", "fr", ProbeType::kretfunc },
 };
 
-std::string typestr(Type t);
 ProbeType probetype(const std::string &type);
+std::string addrspacestr(AddrSpace as);
+std::string typestr(Type t);
 std::string probetypeName(const std::string &type);
 std::string probetypeName(ProbeType t);
 

--- a/src/types.h
+++ b/src/types.h
@@ -339,6 +339,8 @@ enum class ProbeType
   kretfunc,
 };
 
+std::ostream &operator<<(std::ostream &os, ProbeType type);
+
 struct ProbeItem
 {
   std::string name;

--- a/tests/codegen/call_uptr.cpp
+++ b/tests/codegen/call_uptr.cpp
@@ -1,0 +1,15 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, call_uptr)
+{
+  test("k:f { @=*uptr((int16*) arg0 ); }", std::string(NAME) + "_1");
+  test("k:f { @=*uptr((int32*) arg0 ); }", std::string(NAME) + "_2");
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/call_uptr_1.ll
+++ b/tests/codegen/llvm/call_uptr_1.ll
@@ -1,0 +1,46 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
+entry:
+  %"@_val" = alloca i64
+  %"@_key" = alloca i64
+  %deref = alloca i16
+  %1 = bitcast i8* %0 to i64*
+  %2 = getelementptr i64, i64* %1, i64 14
+  %arg0 = load volatile i64, i64* %2
+  %3 = bitcast i16* %deref to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i16*, i32, i64)*)(i16* %deref, i32 2, i64 %arg0)
+  %4 = load i16, i16* %deref
+  %5 = sext i16 %4 to i64
+  %6 = bitcast i16* %deref to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i64 0, i64* %"@_key"
+  %8 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 %5, i64* %"@_val"
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
+  %9 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/call_uptr_1_LLVM-10.ll
+++ b/tests/codegen/llvm/call_uptr_1_LLVM-10.ll
@@ -1,0 +1,46 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
+entry:
+  %"@_val" = alloca i64
+  %"@_key" = alloca i64
+  %deref = alloca i16
+  %1 = bitcast i8* %0 to i64*
+  %2 = getelementptr i64, i64* %1, i64 14
+  %arg0 = load volatile i64, i64* %2
+  %3 = bitcast i16* %deref to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i16*, i32, i64)*)(i16* %deref, i32 2, i64 %arg0)
+  %4 = load i16, i16* %deref
+  %5 = sext i16 %4 to i64
+  %6 = bitcast i16* %deref to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i64 0, i64* %"@_key"
+  %8 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 %5, i64* %"@_val"
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
+  %9 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind willreturn }

--- a/tests/codegen/llvm/call_uptr_2.ll
+++ b/tests/codegen/llvm/call_uptr_2.ll
@@ -1,0 +1,46 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
+entry:
+  %"@_val" = alloca i64
+  %"@_key" = alloca i64
+  %deref = alloca i32
+  %1 = bitcast i8* %0 to i64*
+  %2 = getelementptr i64, i64* %1, i64 14
+  %arg0 = load volatile i64, i64* %2
+  %3 = bitcast i32* %deref to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %arg0)
+  %4 = load i32, i32* %deref
+  %5 = sext i32 %4 to i64
+  %6 = bitcast i32* %deref to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i64 0, i64* %"@_key"
+  %8 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 %5, i64* %"@_val"
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
+  %9 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/call_uptr_2_LLVM-10.ll
+++ b/tests/codegen/llvm/call_uptr_2_LLVM-10.ll
@@ -1,0 +1,46 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
+entry:
+  %"@_val" = alloca i64
+  %"@_key" = alloca i64
+  %deref = alloca i32
+  %1 = bitcast i8* %0 to i64*
+  %2 = getelementptr i64, i64* %1, i64 14
+  %arg0 = load volatile i64, i64* %2
+  %3 = bitcast i32* %deref to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %arg0)
+  %4 = load i32, i32* %deref
+  %5 = sext i32 %4 to i64
+  %6 = bitcast i32* %deref to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i64 0, i64* %"@_key"
+  %8 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 %5, i64* %"@_val"
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
+  %9 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind willreturn }

--- a/tests/runtime/addrspace
+++ b/tests/runtime/addrspace
@@ -1,0 +1,5 @@
+NAME openat uptr
+RUN bpftrace -v -e 't:syscalls:sys_enter_openat /comm == "syscall"/ { print(str(uptr(args->filename))) }' -c "./testprogs/syscall openat"
+EXPECT bpftrace_runtime_test_syscall
+REQUIRES_FEATURE probe_read_kernel
+TIMEOUT 5

--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -98,7 +98,7 @@ class TestParser(object):
                 arch = [x.strip() for x in line.split("|")]
             elif item_name == 'REQUIRES_FEATURE':
                 feature_requirement = {x.strip() for x in line.split(" ")}
-                unknown = feature_requirement - {"loop", "btf"}
+                unknown = feature_requirement - {"loop", "btf", "probe_read_kernel"}
                 if len(unknown) > 0:
                     raise UnknownFieldError('%s is invalid for REQUIRES_FEATURE. Suite: %s' % (','.join(unknown), test_suite))
             else:

--- a/tests/runtime/engine/utils.py
+++ b/tests/runtime/engine/utils.py
@@ -96,6 +96,7 @@ class Utils(object):
         output = p.communicate()[0]
         bpffeature = {}
         bpffeature["loop"] = output.find("Loop support: yes") != -1
+        bpffeature["probe_read_kernel"] = output.find("probe_read_kernel: yes") != -1
         bpffeature["btf"] = output.find("btf (depends on Build:libbpf): yes") != -1
         return bpffeature
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1837,6 +1837,21 @@ TEST(semantic_analyser, multi_pass_type_inference_zero_size_int)
   test(*bpftrace, "BEGIN { if (!@i) { @i++; } }", 0);
 }
 
+TEST(semantic_analyser, call_kptr_uptr)
+{
+  test("k:f { @  = kptr((int8*) arg0); }", 0);
+  test("k:f { $a = kptr((int8*) arg0); }", 0);
+
+  test("k:f { @ = kptr(arg0); }", 10);
+  test("k:f { $a = kptr(arg0); }", 10);
+
+  test("k:f { @  = uptr((int8*) arg0); }", 0);
+  test("k:f { $a = uptr((int8*) arg0); }", 0);
+
+  test("k:f { @ = uptr(arg0); }", 10);
+  test("k:f { $a = uptr(arg0); }", 10);
+}
+
 #ifdef HAVE_LIBBPF_BTF_DUMP
 
 #include "btf_common.h"


### PR DESCRIPTION
To correctly read data on architectures with overlapping address spaces `probe_read` got split up in a `_kernel` and a `_user` variant. As we're responsible for selecting the right helper we have to keep track of the address space a pointer is in.

This PR implements the basics  required to do so, it;

- updates the pointer type to support address space information
- extends the probe_read irbuilder methods to select the right helper based on the addrspace info passed
- extends the ast printer to include addrspace info
- adds 2 new calls, kptr() and uptr() that change the addrspace of a pointer. This is left undocumented for now.

I initially tried to implement this in one go (#1141) but that had some corner cases that where hard to fix. Getting the basics in first makes reviewing easier and makes it easier for others to help out with it.

---

### warning

as this depends on a new kernel  the new behaviour won't be covered by the runtime tests in the ci