### PR TITLE
codegen: add option to emit elf file

### DIFF
--- a/scripts/compare_tool_elf.sh
+++ b/scripts/compare_tool_elf.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Compare the IR generated for the shipped
+# Compare the ELF generated for the shipped
 # tools between two bpftrace builds
 #
 
@@ -8,31 +8,23 @@ set -o pipefail
 set -e
 set -u
 
-if [[ "$#" -ne 3 ]]; then
+if [[ "$#" -ne 4 ]]; then
   echo "Compare IR generated between two bpftrace builds"
   echo ""
   echo "USAGE:"
-  echo "$(basename $0) <bpftrace_A> <bpftrace_B> <tooldir>"
+  echo "$(basename $0) <bpftrace_A> <bpftrace_B> <objdump> <tooldir>"
   echo ""
   echo "EXAMPLE:"
-  echo "$(basename $0) bpftrace bpftrace_master /vagrant/tools"
+  echo "$(basename $0) bpftrace_master bpftrace llvm-objdump-7 /vagrant/tools"
   echo ""
   exit 1
 fi
 
-TOOLDIR=$3
 BPF_A=$(command -v "$1") || ( echo "ERROR: $1 not found"; exit 1 )
 BPF_B=$(command -v "$2") || ( echo "ERROR: $2 not found"; exit 1 )
+OBJDUMP=$(command -v "$3") || (echo "ERROR: $3 not found"; exit 1 )
+TOOLDIR=$4
 [[ -d "$TOOLDIR" ]] || (echo "tooldir does not appear to be a directory: ${TOOLDIR}"; exit 1)
-
-# Set to 1 to only compare result after opt
-AFTER_OPT=0
-
-if [ $AFTER_OPT -eq 1 ]; then
-  FLAGS="-d"
-else
-  FLAGS="-dd"
-fi
 
 TMPDIR=$(mktemp -d)
 [[ $? -ne 0 || -z $TMPDIR ]] && (echo "Failed to create tmp dir"; exit 10)
@@ -45,17 +37,13 @@ function hash() {
     sha1sum "${1}" | awk '{print $1}'
 }
 
-function fix_timestamp() {
-    cat $@ | awk '/(add|sub) i64 %get_ns/ { $NF = ""} {print}'
-}
-
 echo "Using version $($BPF_A -V) and $($BPF_B -V)"
 
 for script in ${TOOLDIR}/*.bt; do
     s=$(basename ${script/.bt/})
     echo "Checking $s"
-    2>&1 $BPF_A "$FLAGS" "$script" | fix_timestamp > "a_${s}"
-    2>&1 $BPF_B "$FLAGS" "$script" | fix_timestamp > "b_${s}"
+    2>&1 $BPF_A --emit-elf "a_${s}" "$script" >/dev/null
+    2>&1 $BPF_B --emit-elf "b_${s}" "$script" >/dev/null
     if [ $? -ne 0 ]; then
         echo "###############################"
         echo "bpftrace failed on script: ${s}"
@@ -65,7 +53,7 @@ for script in ${TOOLDIR}/*.bt; do
     if [[ $(hash "a_${s}") != $(hash "b_${s}")  ]]; then
         echo "###############################"
         echo "Change detected for script: ${s}"
-        diff -b -u "a_${s}" "b_${s}"
+        diff -u <($OBJDUMP "a_${s}") <($OBJDUMP "b_${s}")
     fi
 done
 

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -70,6 +70,7 @@ public:
   void generate_ir(void);
   void optimize(void);
   std::unique_ptr<BpfOrc> emit(void);
+  void emit_elf(const std::string &filename);
   // Combine generate_ir, optimize and emit into one call
   std::unique_ptr<BpfOrc> compile(void);
 
@@ -112,6 +113,7 @@ private:
   LLVMContext context_;
   std::unique_ptr<Module> module_;
   std::unique_ptr<ExecutionEngine> ee_;
+  TargetMachine *TM_;
   IRBuilderBPF b_;
   DataLayout layout_;
   Value *expr_ = nullptr;
@@ -144,6 +146,15 @@ private:
   }
 
   std::vector<std::tuple<BasicBlock *, BasicBlock *>> loops_;
+
+  enum class State
+  {
+    INIT,
+    IR,
+    OPT,
+    DONE,
+  };
+  State state_ = State::INIT;
 };
 
 } // namespace ast

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -225,7 +225,7 @@ int main(int argc, char *argv[])
   bool force_btf = false;
   bool usdt_file_activation = false;
   int helper_check_level = 0;
-  std::string script, search, file_name, output_file, output_format;
+  std::string script, search, file_name, output_file, output_format, output_elf;
   OutputBufferConfig obc = OutputBufferConfig::UNSET;
   int c;
 
@@ -238,6 +238,7 @@ int main(int argc, char *argv[])
     option{ "btf", no_argument, nullptr, 'b' },
     option{ "include", required_argument, nullptr, '#' },
     option{ "info", no_argument, nullptr, 2000 },
+    option{ "emit-elf", required_argument, nullptr, 2001 },
     option{ nullptr, 0, nullptr, 0 }, // Must be last
   };
   std::vector<std::string> include_dirs;
@@ -251,6 +252,9 @@ int main(int argc, char *argv[])
         if (is_root())
           return info();
         return 1;
+        break;
+      case 2001: // --emit-elf
+        output_elf = optarg;
         break;
       case 'o':
         output_file = optarg;
@@ -705,7 +709,17 @@ int main(int argc, char *argv[])
       }
       llvm.DumpIR();
     }
+    if (!output_elf.empty())
+    {
+      llvm.emit_elf(output_elf);
+      return 0;
+    }
     bpforc = llvm.emit();
+  }
+  catch (const std::system_error& ex)
+  {
+    std::cerr << "failed to write elf: " << ex.what() << std::endl;
+    return 1;
   }
   catch (const std::exception& ex)
   {


### PR DESCRIPTION
While debugging it is sometimes useful to see the BPF created by LLVM.
Currently the only way to do that is to use bpftool to dump the program
after it has been loaded into the kernel, which is quite a lot of
hassle.

This adds a simple pass that emits an elf file. This pass can
(currently) only be called after the optimization pass as that does some
setup. To prevent some programmer errors I've added some assert() to
make sure all passes are called in the correct order.

LLVM 6 doesn't support the raw_fd_ostream API so that uses the svector
based one, that part is basically a copy of
`tools/perf/util/c++/clang.cpp` in the linux kernel.


This new flag hasn't been documented as I don't want to expose it to
users.
