### PR TITLE
[RFC] Link to discourse server

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![Build Status](https://github.com/iovisor/bpftrace/workflows/CI/badge.svg?branch=master)](https://github.com/iovisor/bpftrace/actions?query=workflow%3ACI+branch%3Amaster)
 [![IRC #bpftrace](https://img.shields.io/badge/IRC-bpftrace-blue.svg)](http://irc.lc/oftc/bpftrace/web@@@)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/iovisor/bpftrace.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/iovisor/bpftrace/alerts/)
+[![Discourse topics](https://img.shields.io/discourse/topics?server=https%3A%2F%2Fbpftrace.discourse.group%2F)](https://bpftrace.discourse.group/)
 
 bpftrace is a high-level tracing language for Linux enhanced Berkeley Packet Filter (eBPF) available in recent Linux kernels (4.x). bpftrace uses LLVM as a backend to compile scripts to BPF-bytecode and makes use of [BCC](https://github.com/iovisor/bcc) for interacting with the Linux BPF system, as well as existing Linux tracing capabilities: kernel dynamic tracing (kprobes), user-level dynamic tracing (uprobes), and tracepoints. The bpftrace language is inspired by awk and C, and predecessor tracers such as DTrace and SystemTap. bpftrace was created by [Alastair Robertson](https://github.com/ajor).
 
@@ -96,6 +97,10 @@ For more eBPF observability tools, see [bcc tools](https://github.com/iovisor/bc
 <center><a href="images/bpftrace_probes_2018.png"><img src="images/bpftrace_probes_2018.png" border=0 width=700></a></center>
 
 See the [Reference Guide](docs/reference_guide.md) for more detail.
+
+## Support
+
+For additional help / discussion, please use our [discourse](https://bpftrace.discourse.group/).
 
 ## Contributing
 


### PR DESCRIPTION
Discourse is a somewhat popular open source forum software. For example,
rust uses it: https://users.rust-lang.org/ .

I think it'd be nice if we had a bpftrace forum so commonly asked questions
can be catalogued and searched. It seems like discourse also supports
mailing lists so email-lovers can continue with that if they'd like. It also looks
like discourse has support for admin/moderator boards, so we can have
more private contributor discussions there instead of via email.
