### PR TITLE
Disable failing kfunc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to
 #### Deprecated
 
 #### Removed
+- Disable some kfunc probes whose tracing crashes
+  - [#1432](https://github.com/iovisor/bpftrace/pull/1432)
 
 #### Tools
 

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -3,9 +3,11 @@
 #include <cstddef>
 #include <cstdio>
 #include <fcntl.h>
+#include <fstream>
 #include <unistd.h>
 
 #include "btf.h"
+#include "list.h"
 #include "utils.h"
 
 namespace bpftrace {
@@ -54,11 +56,14 @@ static bool try_load(enum libbpf::bpf_prog_type prog_type,
   // get added to BPF_PROG_TYPE_TRACING
   if (prog_type == libbpf::BPF_PROG_TYPE_TRACING)
   {
+    // List of available functions must be readable
+    std::ifstream traceable_funcs(kprobe_path);
     // bcc checks the name (first arg) for the magic strings. If the bcc we
     // build against doesn't support kfunc then we will fail here. That's fine
     // because it still means kfunc doesn't work, only from a library side, not
     // a kernel side.
-    return try_load(
+    return traceable_funcs.good() &&
+           try_load(
                "kfunc__strlen", prog_type, insns, len, 0, logbuf, log_size) &&
            try_load(
                "kretfunc__strlen", prog_type, insns, len, 0, logbuf, log_size);

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -1,4 +1,5 @@
 #include "btf.h"
+#include "arch/arch.h"
 #include "bpftrace.h"
 #include "types.h"
 #include "utils.h"
@@ -445,6 +446,9 @@ int BTF::resolve_args(const std::string &func,
 
     const struct btf_param *p = btf_params(t);
     __u16 vlen = btf_vlen(t);
+    if (vlen > arch::max_arg() + 1)
+      return -1;
+
     int j = 0;
 
     for (; j < vlen; j++, p++)
@@ -531,6 +535,9 @@ std::unique_ptr<std::istream> BTF::get_funcs(std::regex *re,
     }
 
     if (!is_traceable_func(func_name))
+      continue;
+
+    if (btf_vlen(t) > arch::max_arg() + 1)
       continue;
 
     if (re && !match_re(prefix + func_name, *re))

--- a/src/btf.h
+++ b/src/btf.h
@@ -44,9 +44,11 @@ private:
   std::unique_ptr<std::istream> get_funcs(std::regex* re,
                                           bool params,
                                           std::string prefix) const;
+  bool is_traceable_func(const std::string& func_name) const;
 
   struct btf* btf;
   enum state state = NODATA;
+  std::unordered_set<std::string> traceable_funcs_;
 };
 
 inline bool BTF::has_data(void) const

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -16,9 +16,6 @@
 
 namespace bpftrace {
 
-const std::string kprobe_path = "/sys/kernel/debug/tracing/available_filter_functions";
-const std::string tp_path = "/sys/kernel/debug/tracing/events";
-
 inline bool search_probe(const std::string &probe, const std::regex& re)
 {
   try {

--- a/src/list.h
+++ b/src/list.h
@@ -8,6 +8,10 @@
 
 namespace bpftrace {
 
+const std::string kprobe_path =
+    "/sys/kernel/debug/tracing/available_filter_functions";
+const std::string tp_path = "/sys/kernel/debug/tracing/events";
+
 struct ProbeListItem
 {
   std::string path;

--- a/src/utils.h
+++ b/src/utils.h
@@ -7,6 +7,7 @@
 #include <string>
 #include <sys/utsname.h>
 #include <tuple>
+#include <unordered_set>
 #include <vector>
 
 namespace bpftrace {
@@ -133,6 +134,7 @@ std::tuple<std::string, std::string> get_kernel_dirs(
 std::vector<std::string> get_kernel_cflags(const char *uname_machine,
                                            const std::string &ksrc,
                                            const std::string &kobj);
+std::unordered_set<std::string> get_traceable_funcs();
 const std::string &is_deprecated(const std::string &str);
 bool is_unsafe_func(const std::string &func_name);
 bool is_compile_time_func(const std::string &func_name);

--- a/tests/btf_common.h
+++ b/tests/btf_common.h
@@ -5,38 +5,61 @@
 class test_btf : public ::testing::Test
 {
 protected:
-  void SetUp() override
+  static bool create_tmp_with_data(char *path,
+                                   const unsigned char *data,
+                                   unsigned int data_len)
   {
-    char *path = strdup("/tmp/XXXXXX");
     if (!path)
-      return;
+      return false;
 
     int fd = mkstemp(path);
     if (fd < 0)
     {
       std::remove(path);
-      return;
+      return false;
     }
 
-    if (write(fd, btf_data, btf_data_len) != btf_data_len)
+    if (write(fd, data, data_len) != data_len)
     {
       close(fd);
       std::remove(path);
-      return;
+      return false;
     }
 
     close(fd);
-    setenv("BPFTRACE_BTF", path, true);
-    path_ = path;
+    return true;
+  }
+
+  void SetUp() override
+  {
+    // BTF data file
+    char *btf_path = strdup("/tmp/btf_dataXXXXXX");
+    if (create_tmp_with_data(btf_path, btf_data, btf_data_len))
+    {
+      setenv("BPFTRACE_BTF", btf_path, true);
+      btf_path_ = btf_path;
+    }
+
+    // available functions file
+    char *funcs_path = strdup("/tmp/available_filter_functionsXXXXXX");
+    if (create_tmp_with_data(funcs_path, func_list, func_list_len))
+    {
+      setenv("BPFTRACE_AVAILABLE_FUNCTIONS_TEST", funcs_path, true);
+      funcs_path_ = funcs_path;
+    }
   }
 
   void TearDown() override
   {
-    // clear the environment and remove the temp file
+    // clear the environment and remove the temp files
     unsetenv("BPFTRACE_BTF");
-    if (path_)
-      std::remove(path_);
+    unsetenv("BPFTRACE_AVAILABLE_FUNCTIONS_TEST");
+    if (btf_path_)
+      std::remove(btf_path_);
+    if (funcs_path_)
+      std::remove(funcs_path_);
   }
 
-  char *path_ = nullptr;
+  char *btf_path_ = nullptr;
+  char *funcs_path_ = nullptr;
 };

--- a/tests/data/btf_data.h
+++ b/tests/data/btf_data.h
@@ -110,3 +110,10 @@ unsigned char btf_data[] = {
 };
 
 unsigned int btf_data_len = sizeof(btf_data) / sizeof(btf_data[0]);
+
+// List of functions from the above data
+unsigned char func_list[] = "func_1\n"
+                            "func_2\n"
+                            "func_3\n";
+
+unsigned int func_list_len = sizeof(func_list) / sizeof(func_list[0]);


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

There is a number of functions that are listed as traceable in kfunc, but their tracing crashes bpftrace. This PR disables tracing of 2 kinds of such functions:
1. Functions not listed in `/sys/kernel/debug/tracing/available_filter_functions` (e.g. inlined functions or functions marked as "notrace"). These should not be traceable even though there is BTF info for them (which makes them appear on the kfunc list). This fixes #1366.
2. Functions having more than 6 parameters. Kernel currently doesn't support BPF trampolines for functions with more than 6 parameters.

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
