### PR TITLE
Add a semantic warning for printing stats maps with top/div args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to
   - [#1416](https://github.com/iovisor/bpftrace/pull/1416)
 
 #### Changed
+- Warn if using `print` on `stats` maps with top and div arguments
+  - [#1433](https://github.com/iovisor/bpftrace/pull/1433)
 
 #### Deprecated
 

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -836,6 +836,12 @@ void SemanticAnalyser::visit(Call &call)
             check_arg(call, Type::integer, 1, true);
           if (call.vargs->size() > 2)
             check_arg(call, Type::integer, 2, true);
+          if (map.type.IsStatsTy() && call.vargs->size() > 1)
+          {
+            warning("print()'s top and div arguments are ignored when used on "
+                    "stats() maps.",
+                    call.loc);
+          }
         }
       }
       // Note that IsPrintableTy() is somewhat disingenuous here. Printing a

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -473,6 +473,11 @@ TEST(semantic_analyser, call_print)
   test("kprobe:f { @x = count(); @[print(@x)] = 1; }", 1);
   test("kprobe:f { @x = count(); if(print(@x)) { 123 } }", 10);
   test("kprobe:f { @x = count(); print(@x) ? 0 : 1; }", 10);
+
+  test_for_warning("kprobe:f { @x = stats(10); print(@x, 2); }",
+                   "top and div arguments are ignored");
+  test_for_warning("kprobe:f { @x = stats(10); print(@x, 2, 3); }",
+                   "top and div arguments are ignored");
 }
 
 TEST(semantic_analyser, call_print_non_map)


### PR DESCRIPTION
Both `top` and `div` are ambiguous when printing stats maps. `top` does not
specify which statistic it's based on and it would cause confusion to define a
default behavior for it. As for `div`, it would also somehow be strange: if use
`div` on all three statistics, then the output does not have avg * count == sum
anymore; if only on sum and avg, it might be misleading. 

Related to #1416.
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
