### PR TITLE
Fix FieldAnalyzer::error

### DIFF
--- a/src/ast/field_analyser.cpp
+++ b/src/ast/field_analyser.cpp
@@ -7,7 +7,7 @@ namespace ast {
 
 void FieldAnalyser::error(const std::string &msg, const location &loc)
 {
-  bpftrace_.error(out_, loc, msg);
+  bpftrace_.error(err_, loc, msg);
 }
 
 void FieldAnalyser::warning(const std::string &msg, const location &loc)
@@ -369,7 +369,7 @@ int FieldAnalyser::analyse()
   std::string errors = err_.str();
   if (!errors.empty())
   {
-    std::cerr << errors;
+    out_ << errors;
     return 1;
   }
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -59,21 +59,23 @@ void test(BPFtrace &bpftrace,
           bool has_child = false,
           int expected_field_analyser = 0)
 {
+  std::stringstream out;
+  std::stringstream msg;
+  msg << "\nInput:\n" << input << "\n\nOutput:\n";
+
   bpftrace.safe_mode_ = safe_mode;
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.root_, bpftrace);
-  EXPECT_EQ(fields.analyse(), expected_field_analyser);
+  ast::FieldAnalyser fields(driver.root_, bpftrace, out);
+  EXPECT_EQ(fields.analyse(), expected_field_analyser) << msg.str() + out.str();
 
   ClangParser clang;
   clang.parse(driver.root_, bpftrace);
 
   ASSERT_EQ(driver.parse_str(input), 0);
-  std::stringstream out;
+  out.str("");
   ast::SemanticAnalyser semantics(
       driver.root_, bpftrace, feature, out, has_child);
-  std::stringstream msg;
-  msg << "\nInput:\n" << input << "\n\nOutput:\n";
   EXPECT_EQ(expected_result, semantics.analyse()) << msg.str() + out.str();
 }
 


### PR DESCRIPTION
Use `err_` instead of `out_` so that we can check whether errors
occur later by checking the length of `err_`.
Also fix tests to prevent an error message from being printed to stderr.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
