### PR TITLE
Fix PR #1416: unsigned int overflow bug and unstable tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to
 #### Removed
 
 #### Fixed
+- Fix negative overflow bug and unstable tests in PR #1416
+  - [#1436](https://github.com/iovisor/bpftrace/pull/1436)
 - Fix `print` outputs nothing when used on hist() maps with large top args
   - [#1437](https://github.com/iovisor/bpftrace/pull/1437)
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -287,11 +287,9 @@ void TextOutput::map_stats(
     auto &key = key_count.first;
     auto &value = values_by_key.at(key);
 
-    if (map.type_.IsAvgTy() && top)
-    {
-      if (i++ < (values_by_key.size() - top))
-        continue;
-    }
+    if (map.type_.IsAvgTy() && top && values_by_key.size() > top &&
+        i++ < (values_by_key.size() - top))
+      continue;
 
     out_ << map.name_ << map.key_.argument_value_list_str(bpftrace, key) << ": ";
 
@@ -604,11 +602,9 @@ void JsonOutput::map_stats(
     auto &key = key_count.first;
     auto &value = values_by_key.at(key);
 
-    if (map.type_.IsAvgTy() && top)
-    {
-      if (j++ < (values_by_key.size() - top))
-        continue;
-    }
+    if (map.type_.IsAvgTy() && top && values_by_key.size() > top &&
+        j++ < (values_by_key.size() - top))
+      continue;
 
     std::vector<std::string> args = map.key_.argument_value_list(bpftrace, key);
     if (i > 0)

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -216,14 +216,14 @@ RUN bpftrace -v -e 'BEGIN { @[nsecs] = strftime("%m/%d/%y", nsecs); exit();}'
 EXPECT @\[[0-9]*\]: [0-9]{2}\/[0-9]{2}\/[0-9]{2}
 TIMEOUT 5
 
-NAME print_avg_map_top
-RUN bpftrace -e 'i:ms:1 { @[nsecs/100000] = avg(1) } i:ms:10 { print(@, 3, 0); exit(); } END {clear(@)}' | grep -c -v "^ *$"
-EXPECT ^4$
+NAME print_avg_map_args
+RUN bpftrace -e 'BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 2, 10); print("END"); clear(@); exit(); }'
+EXPECT Attaching 1 probe\.\.\.\n@\[c\]: 3\n@\[d\]: 4\n\nEND
 TIMEOUT 1
 
-NAME print_avg_map_div
-RUN bpftrace -e 'i:ms:1 { @[nsecs/1000000] = avg(10) } i:ms:10 { print(@, 1, 10) ;exit();} END {clear(@)}'
-EXPECT ^@\[[0-9]+\]: 1$
+NAME print_avg_map_with_large_top
+RUN bpftrace -e 'BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 10, 10); print("END"); clear(@); exit(); }'
+EXPECT Attaching 1 probe\.\.\.\n@\[a\]: 1\n@\[b\]: 2\n@\[c\]: 3\n@\[d\]: 4\n\nEND
 TIMEOUT 1
 
 NAME print_hist_with_top_arg

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -106,8 +106,13 @@ EXPECT ^{"type": "value", "data": \[1,2,"string"\]}$
 TIMEOUT 1
 
 NAME print_avg_map_args
-RUN bpftrace -f json -e 'i:ms:1 { @[nsecs/100000] = avg(10) } i:ms:10 { print(@, 1, 10); exit(); } END {clear(@)}'
-EXPECT ^{"type": "stats", "data": {"@": { *"[0-9]*": 1}}}$
+RUN bpftrace -f json -e 'BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 2, 10); clear(@); exit(); }'
+EXPECT {"type": "stats", "data": {"@": { *"c": 3, *"d": 4}}}
+TIMEOUT 1
+
+NAME print_avg_map_with_large_top
+RUN bpftrace -f json -e 'BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 10, 10); clear(@); exit(); }'
+EXPECT {"type": "stats", "data": {"@": { *"a": 1, *"b": 2, *"c": 3, *"d": 4}}}
 TIMEOUT 1
 
 NAME print_hist_with_top_arg
@@ -118,4 +123,3 @@ TIMEOUT 1
 NAME print_hist_with_large_top_arg
 RUN bpftrace -f json -e 'BEGIN { @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 10); clear(@); exit(); }'
 EXPECT {"type": "hist", "data": {"@": {"1": \[{"min": 8, "max": 15, "count": 1}\], "2": \[{"min": 16, "max": 31, "count": 1}\], "3": \[{"min": 16, "max": 31, "count": 1}\]}}}
-TIMEOUT 1


### PR DESCRIPTION
Related to #1416.The merged PR which enables `top` and `div` args of `print` for `avg` maps has
two issues that need addressing:

1. It came with subtractions of unsigned integers which can easily cause
negative overflows.
2. The runtime tests it came with are somehow unstable and fails randomly. This
patch brings more straightforward tests.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
