### PR TITLE
Fix: print() no output when used on hist() maps with large top args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to
 #### Removed
 
 #### Fixed
+- Fix `print` outputs nothing when used on hist() maps with large top args
+  - [#1437](https://github.com/iovisor/bpftrace/pull/1437)
 
 #### Tools
 

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -258,11 +258,8 @@ void TextOutput::map_hist(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t 
     auto &key = key_count.first;
     auto &value = values_by_key.at(key);
 
-    if (top)
-    {
-      if (i++ < (values_by_key.size() - top))
-        continue;
-    }
+    if (top && values_by_key.size() > top && i++ < (values_by_key.size() - top))
+      continue;
 
     out_ << map.name_ << map.key_.argument_value_list_str(bpftrace, key) << ": " << std::endl;
 
@@ -560,11 +557,8 @@ void JsonOutput::map_hist(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t 
     auto &key = key_count.first;
     auto &value = values_by_key.at(key);
 
-    if (top)
-    {
-      if (j++ < (values_by_key.size() - top))
-        continue;
-    }
+    if (top && values_by_key.size() > top && j++ < (values_by_key.size() - top))
+      continue;
 
     std::vector<std::string> args = map.key_.argument_value_list(bpftrace, key);
     if (i > 0)

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -225,3 +225,13 @@ NAME print_avg_map_div
 RUN bpftrace -e 'i:ms:1 { @[nsecs/1000000] = avg(10) } i:ms:10 { print(@, 1, 10) ;exit();} END {clear(@)}'
 EXPECT ^@\[[0-9]+\]: 1$
 TIMEOUT 1
+
+NAME print_hist_with_top_arg
+RUN bpftrace -e 'BEGIN { print("BEGIN"); @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 2); print("END"); clear(@); exit(); } '
+EXPECT BEGIN\n@\[2\]:(.*\n)+@\[3\]:(.*\n)+END
+TIMEOUT 1
+
+NAME print_hist_with_large_top_arg
+RUN bpftrace -e 'BEGIN { print("BEGIN"); @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 10); print("END"); clear(@); exit(); } '
+EXPECT BEGIN\n@\[1\]:(.*\n)+@\[2\]:(.*\n)+@\[3\]:(.*\n)+END
+TIMEOUT 1

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -109,3 +109,13 @@ NAME print_avg_map_args
 RUN bpftrace -f json -e 'i:ms:1 { @[nsecs/100000] = avg(10) } i:ms:10 { print(@, 1, 10); exit(); } END {clear(@)}'
 EXPECT ^{"type": "stats", "data": {"@": { *"[0-9]*": 1}}}$
 TIMEOUT 1
+
+NAME print_hist_with_top_arg
+RUN bpftrace -f json -e 'BEGIN { @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 2); clear(@); exit(); }'
+EXPECT {"type": "hist", "data": {"@": {"2": \[{"min": 16, "max": 31, "count": 1}\], "3": \[{"min": 16, "max": 31, "count": 1}\]}}}
+TIMEOUT 1
+
+NAME print_hist_with_large_top_arg
+RUN bpftrace -f json -e 'BEGIN { @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 10); clear(@); exit(); }'
+EXPECT {"type": "hist", "data": {"@": {"1": \[{"min": 8, "max": 15, "count": 1}\], "2": \[{"min": 16, "max": 31, "count": 1}\], "3": \[{"min": 16, "max": 31, "count": 1}\]}}}
+TIMEOUT 1


### PR DESCRIPTION
Currently, using `print` with a large `top` arg (any number larger than number
of map keys) on `hist` maps would result in a negative overflow bug, which will
make `print` fail to produce any output. This patch resolves this issue.
```
output.cpp
void TextOutput::map_hist
{
...
    if (top)
    {
        std::cerr << "values_by_key.size()       = " << values_by_key.size()       << std::endl;
        std::cerr << "                       top = " <<                        top << std::endl;
        std::cerr << "values_by_key.size() - top = " << values_by_key.size() - top << std::endl;
        if (i++ < (values_by_key.size() - top))
            continue;
    }
...
}

// output
# bpftrace -e 'kretprobe:vfs_read { @bytes = hist(retval); } i:s:5 {print(@bytes, 2, 1); exit();} END { clear(@bytes); }'
values_by_key.size()       = 1
                       top = 2
values_by_key.size() - top = 18446744073709551615
```
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
