### PR TITLE
Ensure symbols are exported for bpftrace executable

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,7 @@ add_executable(bpftrace
   utils.cpp
   ${BFD_DISASM_SRC}
 )
+set_property(TARGET bpftrace PROPERTY ENABLE_EXPORTS 1)
 
 if(HAVE_NAME_TO_HANDLE_AT)
   target_compile_definitions(bpftrace PRIVATE HAVE_NAME_TO_HANDLE_AT=1)


### PR DESCRIPTION
bpftrace executable needs to lookup `BEGIN_trigger` and `END_trigger`
symbols. Since the bump of the minimal versin of CMake in
1a1a4a92f7bcb154282df228d080d5c3083e04f8, these symbols are stripped
from bpftrace: the executable is built without the `-rdynamic` option
and the symbol is not present anymore (tested with GCC 10). To restore
this compile option, we can instruct CMake to export symbols for
bpftrace executable.

Also, see #954.