### PR TITLE
btf: tracepoint: Prefer BTF data if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to
 #### Changed
 - Warn if using `print` on `stats` maps with top and div arguments
   - [#1433](https://github.com/iovisor/bpftrace/pull/1433)
+- Prefer BTF data if available to resolve tracepoint arguments
+  - [#1439](https://github.com/iovisor/bpftrace/pull/1439)
 
 #### Deprecated
 

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -26,7 +26,7 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
     return true;
 
   ast::TracepointArgsVisitor n{};
-  if (!bpftrace.force_btf_)
+  if (!bpftrace.btf_.has_data())
     program->c_definitions += "#include <linux/types.h>\n";
   for (ast::Probe *probe : probes_with_tracepoint)
   {


### PR DESCRIPTION
Before, if a tracepoint argument was accessed, bpftrace would prefer
using headers instead of BTF. This causes some friction for users/hosts
that don't have headers installed. They would have to pass in --btf to
override the default headers behavior.

This commit makes BTF the default if it's available. Now, users don't
need to pass in --btf.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
