### PR TITLE
Revert "Ensure symbols are exported for bpftrace executable"

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,7 +29,6 @@ add_executable(bpftrace
   utils.cpp
   ${BFD_DISASM_SRC}
 )
-set_property(TARGET bpftrace PROPERTY ENABLE_EXPORTS 1)
 
 if(HAVE_NAME_TO_HANDLE_AT)
   target_compile_definitions(bpftrace PRIVATE HAVE_NAME_TO_HANDLE_AT=1)


### PR DESCRIPTION
This reverts commit 38f1c69b38b5f53969883d9cd0fd77a3dfb52ecc.

It was breaking the embedded builds.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
