### PR TITLE
Move logging out of `class BPFtrace`

### DIFF
--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "log.h"
 #include "types.h"
 
 namespace bpftrace {
@@ -32,7 +33,7 @@ int AttachPointParser::parse()
       if (parse_attachpoint(*ap))
       {
         ++failed;
-        bpftrace_.error(sink_, ap->loc, errs_.str());
+        LOG(ERROR, ap->loc, sink_) << errs_.str();
         errs_.str({}); // clear buffer
       }
     }

--- a/src/ast/field_analyser.cpp
+++ b/src/ast/field_analyser.cpp
@@ -1,19 +1,10 @@
-#include <iostream>
-#include <cassert>
 #include "field_analyser.h"
+#include "log.h"
+#include <cassert>
+#include <iostream>
 
 namespace bpftrace {
 namespace ast {
-
-void FieldAnalyser::error(const std::string &msg, const location &loc)
-{
-  bpftrace_.error(err_, loc, msg);
-}
-
-void FieldAnalyser::warning(const std::string &msg, const location &loc)
-{
-  bpftrace_.warning(out_, loc, msg);
-}
 
 void FieldAnalyser::visit(Integer &integer __attribute__((unused)))
 {
@@ -44,8 +35,8 @@ void FieldAnalyser::check_kfunc_args(void)
 {
   if (has_kfunc_probe_ && has_mixed_args_)
   {
-    error("Probe has attach points with mixed arguments",
-          mixed_args_loc_);
+    LOG(ERROR, mixed_args_loc_, err_)
+        << "Probe has attach points with mixed arguments";
   }
 }
 
@@ -288,7 +279,7 @@ bool FieldAnalyser::resolve_args(AttachPoint &ap)
   }
   else if (bpftrace_.btf_.resolve_args(ap.func, ap_args_, kretfunc))
   {
-    error("Failed to resolve probe arguments", ap.loc);
+    LOG(ERROR, ap.loc, err_) << "Failed to resolve probe arguments";
     return false;
   }
 

--- a/src/ast/field_analyser.h
+++ b/src/ast/field_analyser.h
@@ -52,8 +52,6 @@ public:
   int analyse();
 
 private:
-  void warning(const std::string &msg, const location &loc);
-  void error(const std::string &msg, const location &loc);
   void check_kfunc_args(void);
   bool resolve_args(AttachPoint &ap);
   bool compare_args(const std::map<std::string, SizedType>& args1,

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -85,8 +85,6 @@ private:
   bool check_symbol(const Call &call, int arg_num);
 
   void check_stack_call(Call &call, bool kernel);
-  void error(const std::string &msg, const location &loc);
-  void warning(const std::string &msg, const location &loc);
 
   void assign_map_type(const Map &map, const SizedType &type);
 

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -100,11 +100,6 @@ public:
   inline int next_probe_id() {
     return next_probe_id_++;
   };
-  inline void source(std::string filename, std::string source) {
-    src_ = source;
-    filename_ = filename;
-  }
-  inline const std::string &source() { return src_; }
   inline IMap &get_map_by_id(uint32_t id)
   {
     return *maps_[map_ids_[id]].get();
@@ -132,9 +127,6 @@ public:
   std::string get_param(size_t index, bool is_str) const;
   size_t num_params() const;
   void request_finalize();
-  void error(std::ostream &out, const location &l, const std::string &m);
-  void warning(std::ostream &out, const location &l, const std::string &m);
-  void log_with_location(std::string, std::ostream &, const location &, const std::string &);
   bool is_aslr_enabled(int pid);
 
   std::string cmd_;
@@ -197,7 +189,6 @@ public:
   virtual std::unique_ptr<std::istream> get_symbols_from_usdt(
       int pid,
       const std::string &target) const;
-  const std::string get_source_line(unsigned int);
 
   BTF btf_;
   std::unordered_set<std::string> btf_set_;
@@ -224,9 +215,6 @@ private:
   int online_cpus_;
   std::vector<std::string> params_;
   int next_probe_id_ = 0;
-
-  std::string src_;
-  std::string filename_;
 
   std::vector<std::unique_ptr<AttachedProbe>> attach_usdt_probe(
       Probe &probe,

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -54,13 +54,13 @@ int Driver::parse()
 
 void Driver::error(const location &l, const std::string &m)
 {
-  bpftrace_.error(out_, l, m);
+  LOG(ERROR, l, out_) << m;
   failed_ = true;
 }
 
 void Driver::error(const std::string &m)
 {
-  out_ << m << std::endl;
+  LOG(ERROR, out_) << m;
   failed_ = true;
 }
 

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -2,6 +2,7 @@
 
 #include "ast/attachpoint_parser.h"
 #include "driver.h"
+#include "log.h"
 
 extern void *yy_scan_string(const char *yy_str, yyscan_t yyscanner);
 extern int yylex_init(yyscan_t *scanner);
@@ -24,6 +25,7 @@ Driver::~Driver()
 void Driver::source(std::string filename, std::string script)
 {
   bpftrace_.source(filename, script);
+  Log::get().set_source(filename, script);
 }
 
 // Kept for the test suite

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -24,7 +24,6 @@ Driver::~Driver()
 
 void Driver::source(std::string filename, std::string script)
 {
-  bpftrace_.source(filename, script);
   Log::get().set_source(filename, script);
 }
 
@@ -39,7 +38,7 @@ int Driver::parse()
 {
   // Reset source location info on every pass
   loc.initialize();
-  yy_scan_string(bpftrace_.source().c_str(), scanner_);
+  yy_scan_string(Log::get().get_source().c_str(), scanner_);
   parser_->parse();
 
   ast::AttachPointParser ap_parser(root_, bpftrace_, out_);


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

Logging in bpftrace currently relies on facilities provided by class BPFtrace.
Now that we have a new logging infrastructure #1418, we can change the callsites
to new logging APIs. This patch helps with breaking up class BPFtrace #1080 and
improving logging in bpftrace #1411 .

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
