### PR TITLE
Logging: add an option to disable warning messages.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to
   - [#1414](https://github.com/iovisor/bpftrace/pull/1414)
 - Fix `top` and `div` arguments of `print()` not working for Type::avg maps
   - [#1416](https://github.com/iovisor/bpftrace/pull/1416)
+- Add an option to disable warning messages
+  - [#1444](https://github.com/iovisor/bpftrace/pull/1444)
 
 #### Changed
 - Warn if using `print` on `stats` maps with top and div arguments

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -442,12 +442,14 @@ open path: .com.google.Chrome.R1234s
 
 ## 8. Other Options
 
-The `--version` option prints the bpftrace version:
+- The `--version` option prints the bpftrace version:
 
 ```
 # bpftrace --version
 bpftrace v0.8-90-g585e-dirty
 ```
+
+- The `--no-warnings` option disables warnings.
 
 ## 9. Environment Variables
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -18,6 +18,14 @@ std::string logtype_str(LogType t)
   }
 }
 
+Log::Log()
+{
+  enabled_map_[LogType::ERROR] = true;
+  enabled_map_[LogType::WARNING] = true;
+  enabled_map_[LogType::INFO] = true;
+  enabled_map_[LogType::DEBUG] = true;
+}
+
 Log& Log::get()
 {
   static Log log;
@@ -187,10 +195,13 @@ LogStream::LogStream(const std::string& file,
 
 LogStream::~LogStream()
 {
-  std::string prefix = "";
-  if (type_ == LogType::DEBUG)
-    prefix = "[" + log_file_ + ":" + std::to_string(log_line_) + "]\n";
-  sink_.take_input(type_, loc_, out_, prefix + buf_.str());
+  if (sink_.is_enabled(type_))
+  {
+    std::string prefix = "";
+    if (type_ == LogType::DEBUG)
+      prefix = "[" + log_file_ + ":" + std::to_string(log_line_) + "]\n";
+    sink_.take_input(type_, loc_, out_, prefix + buf_.str());
+  }
 }
 
 }; // namespace bpftrace

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 #include "field_analyser.h"
 #include "list.h"
 #include "lockdown.h"
+#include "log.h"
 #include "output.h"
 #include "printer.h"
 #include "procmon.h"
@@ -64,7 +65,9 @@ void usage()
   std::cerr << "    --info         Print information about kernel BPF support" << std::endl;
   std::cerr << "    -k             emit a warning when a bpf helper returns an error (except read functions)" << std::endl;
   std::cerr << "    -kk            check all bpf helper functions" << std::endl;
-  std::cerr << "    -V, --version  bpftrace version" << std::endl << std::endl;
+  std::cerr << "    -V, --version  bpftrace version" << std::endl;
+  std::cerr << "    --no-warnings  disable all warning messages" << std::endl;
+  std::cerr << std::endl;
   std::cerr << "ENVIRONMENT:" << std::endl;
   std::cerr << "    BPFTRACE_STRLEN             [default: 64] bytes on BPF stack per str()" << std::endl;
   std::cerr << "    BPFTRACE_NO_CPP_DEMANGLE    [default: 0] disable C++ symbol demangling" << std::endl;
@@ -239,6 +242,7 @@ int main(int argc, char *argv[])
     option{ "include", required_argument, nullptr, '#' },
     option{ "info", no_argument, nullptr, 2000 },
     option{ "emit-elf", required_argument, nullptr, 2001 },
+    option{ "no-warnings", no_argument, nullptr, 2002 },
     option{ nullptr, 0, nullptr, 0 }, // Must be last
   };
   std::vector<std::string> include_dirs;
@@ -255,6 +259,9 @@ int main(int argc, char *argv[])
         break;
       case 2001: // --emit-elf
         output_elf = optarg;
+        break;
+      case 2002: // --no-warnings
+        DISABLE_LOG(WARNING);
         break;
       case 'o':
         output_file = optarg;

--- a/tests/log.cpp
+++ b/tests/log.cpp
@@ -54,6 +54,26 @@ TEST(LogStream, with_location)
   EXPECT_EQ(ss.str(), expected);
 }
 
+TEST(Log, disable_log_type)
+{
+  std::ostringstream ss;
+  const std::string content = "This is the warning message";
+  LOG(WARNING, ss) << content;
+  EXPECT_EQ(ss.str(), "WARNING: " + content + "\n");
+  ss.str({});
+  Log::get().disable(LogType::WARNING);
+  LOG(WARNING, ss) << content;
+  EXPECT_EQ(ss.str(), "");
+  // make sure other log types are not affected
+  LOG(ERROR, ss) << content;
+  EXPECT_EQ(ss.str(), "ERROR: " + content + "\n");
+  ss.str({});
+  Log::get().enable(LogType::WARNING);
+  LOG(WARNING, ss) << content;
+  EXPECT_EQ(ss.str(), "WARNING: " + content + "\n");
+  ss.str({});
+}
+
 } // namespace log
 } // namespace test
 } // namespace bpftrace

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -145,3 +145,8 @@ NAME tuple print
 RUN bpftrace -e 'BEGIN { @ = (1, 2, "string", (4, 5)); exit(); }'
 EXPECT ^@: \(1, 2, string, \(4, 5\)\)$
 TIMEOUT 5
+
+NAME disable warnings
+RUN bpftrace --no-warnings -e 'BEGIN { @x = stats(10); print(@x, 2); clear(@x); exit();}' 2>&1| grep -c -E "WARNING|invalid option"
+EXPECT ^0$
+TIMEOUT 1


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->
It would be nice for bpftrace to provide an option which hides warning messages.
This patch proposes using `-w` to diable warnings, just like in gcc.
Related to #1267 and #1411 .
##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
