### PR TITLE
Allow wildcards for tracepoint categories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 ## Unreleased
 
 #### Added
+- Allow wildcards for tracepoint categories
+  - [#1445](https://github.com/iovisor/bpftrace/pull/1445)
 - Add wildcard support for kfunc probe types
   - [#1410](https://github.com/iovisor/bpftrace/pull/1410)
 - Add builtin function: `strftime`

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -449,11 +449,12 @@ std::string opstr(Unop &unop)
   }
 }
 
-std::string AttachPoint::name(const std::string &attach_point) const
+std::string AttachPoint::name(const std::string &attach_target,
+                              const std::string &attach_point) const
 {
   std::string n = provider;
-  if (target != "")
-    n += ":" + target;
+  if (attach_target != "")
+    n += ":" + attach_target;
   if (ns != "")
     n += ":" + ns;
   if (attach_point != "")
@@ -471,6 +472,11 @@ std::string AttachPoint::name(const std::string &attach_point) const
   if (mode.size())
     n += ":" + mode;
   return n;
+}
+
+std::string AttachPoint::name(const std::string &attach_point) const
+{
+  return name(target, attach_point);
 }
 
 int AttachPoint::index(std::string name) {

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -321,6 +321,8 @@ public:
 
   void accept(Visitor &v) override;
   std::string name(const std::string &attach_point) const;
+  std::string name(const std::string &attach_target,
+                   const std::string &attach_point) const;
 
   int index(std::string name);
   void set_index(std::string name, int index);

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -137,7 +137,7 @@ void SemanticAnalyser::builtin_args_tracepoint(AttachPoint *attach_point,
   {
     auto &match = *matches.begin();
     std::string tracepoint_struct = TracepointFormatParser::get_struct_name(
-        attach_point->target, match);
+        match);
     Struct &cstruct = bpftrace_.structs_[tracepoint_struct];
     builtin.type = CreateCTX(cstruct.size, tracepoint_struct);
     builtin.type.is_pointer = true;
@@ -1604,9 +1604,8 @@ void SemanticAnalyser::visit(FieldAccess &acc)
 
       auto matches = bpftrace_.find_wildcard_matches(*attach_point);
       for (auto &match : matches) {
-        std::string tracepoint_struct =
-            TracepointFormatParser::get_struct_name(attach_point->target,
-                                                    match);
+        std::string tracepoint_struct = TracepointFormatParser::get_struct_name(
+            match);
         structs[tracepoint_struct] = bpftrace_.structs_[tracepoint_struct].fields;
       }
     }

--- a/src/tracepoint_format_parser.h
+++ b/src/tracepoint_format_parser.h
@@ -138,6 +138,7 @@ public:
   static bool parse(ast::Program *program, BPFtrace &bpftrace);
   static std::string get_struct_name(const std::string &category,
                                      const std::string &event_name);
+  static std::string get_struct_name(const std::string &probe_id);
 
 private:
   static std::string parse_field(const std::string &line,

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -168,6 +168,14 @@ std::vector<std::string> split_string(const std::string &str,
   return elems;
 }
 
+/// Erase prefix up to the first colon (:) from str and return the prefix
+std::string erase_prefix(std::string &str)
+{
+  std::string prefix = str.substr(0, str.find(':'));
+  str.erase(0, prefix.length() + 1);
+  return prefix;
+}
+
 bool wildcard_match(const std::string &str, std::vector<std::string> &tokens, bool start_wildcard, bool end_wildcard) {
   size_t next = 0;
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -122,6 +122,7 @@ bool has_wildcard(const std::string &str);
 std::vector<std::string> split_string(const std::string &str,
                                       char delimiter,
                                       bool remove_empty = false);
+std::string erase_prefix(std::string &str);
 bool wildcard_match(const std::string &str,
                     std::vector<std::string> &tokens,
                     bool start_wildcard,

--- a/tests/codegen/args_multiple_tracepoints_category_wild.cpp
+++ b/tests/codegen/args_multiple_tracepoints_category_wild.cpp
@@ -1,0 +1,22 @@
+#include "../mocks.h"
+#include "common.h"
+
+using ::testing::_;
+using ::testing::Return;
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, args_multiple_tracepoints_category_wild)
+{
+  auto bpftrace = get_mock_bpftrace();
+
+  test(*bpftrace,
+       "tracepoint:sched*:sched_* { @[args->common_field] = count(); }",
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/args_multiple_tracepoints_category_wild.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints_category_wild.ll
@@ -1,0 +1,157 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+define i64 @"tracepoint:sched:sched_one"(i8*) section "s_tracepoint:sched:sched_one_1" {
+entry:
+  %"@_val" = alloca i64
+  %lookup_elem_val = alloca i64
+  %"@_key" = alloca [8 x i8]
+  %1 = ptrtoint i8* %0 to i64
+  %2 = add i64 %1, 8
+  %3 = inttoptr i64 %2 to i64*
+  %4 = load volatile i64, i64* %3
+  %5 = bitcast [8 x i8]* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast [8 x i8]* %"@_key" to i64*
+  store i64 %4, i64* %6
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* %"@_key")
+  %7 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %cast = bitcast i8* %lookup_elem to i64*
+  %8 = load i64, i64* %cast
+  store i64 %8, i64* %lookup_elem_val
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  store i64 0, i64* %lookup_elem_val
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %9 = load i64, i64* %lookup_elem_val
+  %10 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %12 = add i64 %9, 1
+  store i64 %12, i64* %"@_val"
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
+  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+define i64 @"tracepoint:sched:sched_two"(i8*) section "s_tracepoint:sched:sched_two_2" {
+entry:
+  %"@_val" = alloca i64
+  %lookup_elem_val = alloca i64
+  %"@_key" = alloca [8 x i8]
+  %1 = ptrtoint i8* %0 to i64
+  %2 = add i64 %1, 16
+  %3 = inttoptr i64 %2 to i64*
+  %4 = load volatile i64, i64* %3
+  %5 = bitcast [8 x i8]* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast [8 x i8]* %"@_key" to i64*
+  store i64 %4, i64* %6
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* %"@_key")
+  %7 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %cast = bitcast i8* %lookup_elem to i64*
+  %8 = load i64, i64* %cast
+  store i64 %8, i64* %lookup_elem_val
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  store i64 0, i64* %lookup_elem_val
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %9 = load i64, i64* %lookup_elem_val
+  %10 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %12 = add i64 %9, 1
+  store i64 %12, i64* %"@_val"
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
+  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  ret i64 0
+}
+
+define i64 @"tracepoint:sched_extra:sched_extra"(i8*) section "s_tracepoint:sched_extra:sched_extra_3" {
+entry:
+  %"@_val" = alloca i64
+  %lookup_elem_val = alloca i64
+  %"@_key" = alloca [8 x i8]
+  %1 = ptrtoint i8* %0 to i64
+  %2 = add i64 %1, 24
+  %3 = inttoptr i64 %2 to i64*
+  %4 = load volatile i64, i64* %3
+  %5 = bitcast [8 x i8]* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast [8 x i8]* %"@_key" to i64*
+  store i64 %4, i64* %6
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* %"@_key")
+  %7 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %cast = bitcast i8* %lookup_elem to i64*
+  %8 = load i64, i64* %cast
+  store i64 %8, i64* %lookup_elem_val
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  store i64 0, i64* %lookup_elem_val
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %9 = load i64, i64* %lookup_elem_val
+  %10 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %12 = add i64 %9, 1
+  store i64 %12, i64* %"@_val"
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
+  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  ret i64 0
+}
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -30,6 +30,7 @@ void setup_mock_bpftrace(MockBPFtrace &bpftrace)
         std::string tracepoints = "sched:sched_one\n"
                                   "sched:sched_two\n"
                                   "sched:foo\n"
+                                  "sched_extra:sched_extra\n"
                                   "notsched:bar\n"
                                   "file:filename\n";
         return std::unique_ptr<std::istream>(new std::istringstream(tracepoints));
@@ -73,6 +74,17 @@ void setup_mock_bpftrace(MockBPFtrace &bpftrace)
                       .type = CreateUInt64(),
                       .offset = 16, // different offset than
                                     // sched_one.common_field
+                      .is_bitfield = false,
+                      .bitfield = {},
+                  } } },
+  };
+  bpftrace.structs_["struct _tracepoint_sched_extra_sched_extra"] = Struct{
+    .size = 8,
+    .fields = { { "common_field",
+                  Field{
+                      .type = CreateUInt64(),
+                      .offset = 24, // different offset than
+                                    // sched_(one|two).common_field
                       .is_bitfield = false,
                       .bitfield = {},
                   } } },


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

It is now possible to run e.g. this:

    bpftrace -e 'tracepoint:kvm*:* { @[probe] = count(); }'

Resolves #1212. 

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
