### PR TITLE
Stop runtime tests if the parser error occurs 

### DIFF
--- a/tests/runtime/engine/main.py
+++ b/tests/runtime/engine/main.py
@@ -5,14 +5,18 @@ from datetime import timedelta
 import argparse
 
 from utils import Utils, ok, fail, warn
-from parser import TestParser
+from parser import TestParser, UnknownFieldError, RequiredFieldError
 
 
 def main(test_filter = None):
     if not test_filter:
         test_filter = "*"
 
-    test_suite = list(TestParser.read_all(test_filter))
+    try:
+        test_suite = list(TestParser.read_all(test_filter))
+    except (UnknownFieldError, RequiredFieldError) as error:
+        print(fail(str(error)))
+        exit(1)
 
     total_tests = 0
     for fname, suite_tests in test_suite:

--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -5,8 +5,6 @@ from collections import namedtuple
 import os
 import platform
 
-from utils import ERROR_COLOR, NO_COLOR
-
 
 class RequiredFieldError(Exception):
     pass
@@ -22,19 +20,16 @@ TestStruct = namedtuple('TestStruct', 'name run expect timeout before after suit
 class TestParser(object):
     @staticmethod
     def read_all(test_filter):
-        try:
-            for root, subdirs, files in os.walk('./runtime'):
-                for ignore_dir in ["engine", "scripts", "outputs"]:
-                    if ignore_dir in subdirs:
-                        subdirs.remove(ignore_dir)
-                for filename in files:
-                    if filename.startswith("."):
-                        continue
-                    parser = TestParser.read(root + '/' + filename, test_filter)
-                    if parser[1]:
-                        yield parser
-        except RequiredFieldError as error:
-            print(ERROR_COLOR + str(error) + NO_COLOR)
+        for root, subdirs, files in os.walk('./runtime'):
+            for ignore_dir in ["engine", "scripts", "outputs"]:
+                if ignore_dir in subdirs:
+                    subdirs.remove(ignore_dir)
+            for filename in files:
+                if filename.startswith("."):
+                    continue
+                parser = TestParser.read(root + '/' + filename, test_filter)
+                if parser[1]:
+                    yield parser
 
     @staticmethod
     def read(file_name, test_filter):

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -123,3 +123,4 @@ TIMEOUT 1
 NAME print_hist_with_large_top_arg
 RUN bpftrace -f json -e 'BEGIN { @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 10); clear(@); exit(); }'
 EXPECT {"type": "hist", "data": {"@": {"1": \[{"min": 8, "max": 15, "count": 1}\], "2": \[{"min": 16, "max": 31, "count": 1}\], "3": \[{"min": 16, "max": 31, "count": 1}\]}}}
+TIMEOUT 1


### PR DESCRIPTION
#1436 accidentally removes a TIMEOUT field from print_hist_with_large_top_arg test.
This causes the runtime parser error, but nonetheless the runtime tests continue.
As a result, the tests pass though some tests are skipped.
Fix this by calling exit(1) if the parser error occurs. Also fix the test.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
