### PR TITLE
Logging: change error/warning info to use new logging infra

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -1,4 +1,5 @@
 #include "ast.h"
+#include "log.h"
 #include "parser.tab.hh"
 #include <iostream>
 
@@ -429,8 +430,7 @@ std::string opstr(Binop &binop)
     case bpftrace::Parser::token::BOR:   return "|";
     case bpftrace::Parser::token::BXOR:  return "^";
     default:
-      std::cerr << "unknown binary operator" << std::endl;
-      abort();
+      LOG(FATAL) << "unknown binary operator";
   }
 }
 
@@ -444,8 +444,7 @@ std::string opstr(Unop &unop)
     case bpftrace::Parser::token::INCREMENT: return "++";
     case bpftrace::Parser::token::DECREMENT: return "--";
     default:
-      std::cerr << "unknown unary operator" << std::endl;
-      abort();
+      LOG(FATAL) << "unknown unary operator";
   }
 }
 

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -432,6 +432,7 @@ std::string opstr(Binop &binop)
     default:
       LOG(FATAL) << "unknown binary operator";
   }
+  // lgtm[cpp/missing-return]
 }
 
 std::string opstr(Unop &unop)
@@ -446,6 +447,7 @@ std::string opstr(Unop &unop)
     default:
       LOG(FATAL) << "unknown unary operator";
   }
+  // lgtm[cpp/missing-return]
 }
 
 std::string AttachPoint::name(const std::string &attach_target,

--- a/src/ast/field_analyser.cpp
+++ b/src/ast/field_analyser.cpp
@@ -268,7 +268,7 @@ bool FieldAnalyser::resolve_args(AttachPoint &ap)
     }
     catch (const WildcardException &e)
     {
-      std::cerr << e.what() << std::endl;
+      LOG(ERROR) << e.what();
       return false;
     }
 

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -477,11 +477,13 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
   // TODO (mmarchini): Handle base + index * scale addressing.
   // https://github.com/iovisor/bcc/pull/988
   if (argument->valid & BCC_USDT_ARGUMENT_INDEX_REGISTER_NAME)
-    std::cerr << "index register is not handled yet [" << argument->index_register_name << "]" << std::endl;
+    LOG(ERROR) << "index register is not handled yet ["
+               << argument->index_register_name << "]";
   if (argument->valid & BCC_USDT_ARGUMENT_SCALE)
-    std::cerr << "scale is not handled yet [" << argument->scale << "]" << std::endl;
+    LOG(ERROR) << "scale is not handled yet [" << argument->scale << "]";
   if (argument->valid & BCC_USDT_ARGUMENT_DEREF_IDENT)
-    std::cerr << "defer ident is not handled yet [" << argument->deref_ident << "]" << std::endl;
+    LOG(ERROR) << "defer ident is not handled yet [" << argument->deref_ident
+               << "]";
 
   if (argument->valid & BCC_USDT_ARGUMENT_CONSTANT)
     return getInt64(argument->constant);
@@ -547,7 +549,8 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
   }
 
   if (usdt == nullptr) {
-    std::cerr << "failed to initialize usdt context for probe " << attach_point->target << std::endl;
+    LOG(ERROR) << "failed to initialize usdt context for probe "
+               << attach_point->target;
     exit(-1);
   }
 
@@ -561,8 +564,9 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
                             arg_num,
                             &argument) != 0)
   {
-    std::cerr << "couldn't get argument " << arg_num << " for " << attach_point->target << ":"
-              << attach_point->ns << ":" << attach_point->func << std::endl;
+    LOG(ERROR) << "couldn't get argument " << arg_num << " for "
+               << attach_point->target << ":" << attach_point->ns << ":"
+               << attach_point->func;
     exit(-2);
   }
 

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -6,6 +6,7 @@
 #include "bpftrace.h"
 #include "codegen_helper.h"
 #include "irbuilderbpf.h"
+#include "log.h"
 #include "utils.h"
 
 #include <llvm/IR/DataLayout.h>
@@ -203,8 +204,7 @@ llvm::Type *IRBuilderBPF::GetType(const SizedType &stype)
         ty = getInt8Ty();
         break;
       default:
-        std::cerr << stype.size << " is not a valid type size for GetType" << std::endl;
-        abort();
+        LOG(FATAL) << stype.size << " is not a valid type size for GetType";
     }
   }
   return ty;
@@ -492,9 +492,8 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
     offset = arch::offset(argument->base_register_name);
     if (offset < 0)
     {
-      std::cerr << "offset for register " << argument->base_register_name
-                << " not known" << std::endl;
-      abort();
+      LOG(FATAL) << "offset for register " << argument->base_register_name
+                 << " not known";
     }
 
     // Argument size must be 1, 2, 4, or 8. See

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -17,6 +17,7 @@
 #include "bpftrace.h"
 #include "disasm.h"
 #include "list.h"
+#include "log.h"
 #include "usdt.h"
 #include <bcc/bcc_elf.h>
 #include <bcc/bcc_syms.h>
@@ -51,8 +52,7 @@ bpf_probe_attach_type attachtype(ProbeType t)
     case ProbeType::uretprobe: return BPF_PROBE_RETURN; break;
     case ProbeType::usdt:      return BPF_PROBE_ENTRY;  break;
     default:
-      std::cerr << "invalid probe attachtype \"" << probetypeName(t) << "\"" << std::endl;
-      abort();
+      LOG(FATAL) << "invalid probe attachtype \"" << probetypeName(t) << "\"";
   }
 }
 
@@ -78,8 +78,7 @@ bpf_prog_type progtype(ProbeType t)
       return static_cast<enum ::bpf_prog_type>(libbpf::BPF_PROG_TYPE_TRACING);
       break;
     default:
-      std::cerr << "program type not found" << std::endl;
-      abort();
+      LOG(FATAL) << "program type not found";
   }
 }
 
@@ -93,8 +92,7 @@ std::string progtypeName(bpf_prog_type t)
     case BPF_PROG_TYPE_PERF_EVENT: return "BPF_PROG_TYPE_PERF_EVENT"; break;
     // clang-format on
     default:
-      std::cerr << "invalid program type: " << t << std::endl;
-      abort();
+      LOG(FATAL) << "invalid program type: " << t;
   }
 }
 
@@ -173,8 +171,8 @@ AttachedProbe::AttachedProbe(Probe &probe, std::tuple<uint8_t *, uintptr_t> func
       attach_kfunc();
       break;
     default:
-      std::cerr << "invalid attached probe type \"" << probetypeName(probe_.type) << "\"" << std::endl;
-      abort();
+      LOG(FATAL) << "invalid attached probe type \""
+                 << probetypeName(probe_.type) << "\"";
   }
 }
 
@@ -191,8 +189,8 @@ AttachedProbe::AttachedProbe(Probe &probe, std::tuple<uint8_t *, uintptr_t> func
       attach_watchpoint(pid, probe.mode);
       break;
     default:
-      std::cerr << "invalid attached probe type \"" << probetypeName(probe_.type) << "\"" << std::endl;
-      abort();
+      LOG(FATAL) << "invalid attached probe type \""
+                 << probetypeName(probe_.type) << "\"";
   }
 }
 
@@ -234,8 +232,8 @@ AttachedProbe::~AttachedProbe()
     case ProbeType::hardware:
       break;
     default:
-      std::cerr << "invalid attached probe type \"" << probetypeName(probe_.type) << "\" at destructor" << std::endl;
-      abort();
+      LOG(FATAL) << "invalid attached probe type \""
+                 << probetypeName(probe_.type) << "\" at destructor";
   }
   if (err)
     std::cerr << "Error detaching probe: " << probe_.name << std::endl;
@@ -253,8 +251,7 @@ std::string AttachedProbe::eventprefix() const
     case BPF_PROBE_RETURN:
       return "r_";
     default:
-      std::cerr << "invalid eventprefix" << std::endl;
-      abort();
+      LOG(FATAL) << "invalid eventprefix";
   }
 }
 
@@ -277,8 +274,8 @@ std::string AttachedProbe::eventname() const
     case ProbeType::tracepoint:
       return probe_.attach_point;
     default:
-      std::cerr << "invalid eventname probe \"" << probetypeName(probe_.type) << "\"" << std::endl;
-      abort();
+      LOG(FATAL) << "invalid eventname probe \"" << probetypeName(probe_.type)
+                 << "\"";
   }
 }
 
@@ -644,8 +641,7 @@ static unsigned kernel_version(int attempt)
     default:
       break;
   }
-  std::cerr << "invalid kernel version" << std::endl;
-  abort();
+  LOG(FATAL) << "invalid kernel version";
 }
 
 void AttachedProbe::load_prog()
@@ -957,8 +953,7 @@ void AttachedProbe::attach_profile()
   }
   else
   {
-    std::cerr << "invalid profile path \"" << probe_.path << "\"" << std::endl;
-    abort();
+    LOG(FATAL) << "invalid profile path \"" << probe_.path << "\"";
   }
 
   std::vector<int> cpus = get_online_cpus();
@@ -999,8 +994,7 @@ void AttachedProbe::attach_interval()
   }
   else
   {
-    std::cerr << "invalid interval path \"" << probe_.path << "\"" << std::endl;
-    abort();
+    LOG(FATAL) << "invalid interval path \"" << probe_.path << "\"";
   }
 
   int perf_event_fd = bpf_attach_perf_event(progfd_,

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -125,9 +125,7 @@ std::string format(std::string fmt,
   auto check_snprintf_ret = [](int r) {
     if (r < 0)
     {
-      std::cerr << "format() error occurred: " << std::strerror(errno)
-                << std::endl;
-      abort();
+      LOG(FATAL) << "format() error occurred: " << std::strerror(errno);
     }
   };
   // Args have been made safe for printing by now, so replace nonstandard format
@@ -606,8 +604,7 @@ void perf_event_printer(void *cb_cookie, void *data, int size __attribute__((unu
   {
     if (bpftrace->safe_mode_)
     {
-      std::cerr << "syscall() not allowed in safe mode" << std::endl;
-      abort();
+      LOG(FATAL) << "syscall() not allowed in safe mode";
     }
 
     auto id = printf_id - asyncactionint(AsyncAction::syscall);
@@ -670,10 +667,9 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(const std::vec
                 *reinterpret_cast<uint8_t *>(arg_data + arg.offset)));
             break;
           default:
-            std::cerr << "get_arg_values: invalid integer size. 8, 4, 2 and "
-                         "byte supported. "
-                      << arg.type.size << "provided" << std::endl;
-            abort();
+            LOG(FATAL) << "get_arg_values: invalid integer size. 8, 4, 2 and "
+                          "byte supported. "
+                       << arg.type.size << "provided";
         }
         break;
       case Type::string:
@@ -750,8 +746,7 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(const std::vec
         break;
         // fall through
       default:
-        std::cerr << "invalid argument type" << std::endl;
-        abort();
+        LOG(FATAL) << "invalid argument type";
     }
   }
 
@@ -2034,8 +2029,8 @@ void BPFtrace::sort_by_key(std::vector<SizedType> key_args,
       }
       else
       {
-        std::cerr << "invalid integer argument size. 4 or 8  expected, but " << arg.size << " provided" << std::endl;
-        abort();
+        LOG(FATAL) << "invalid integer argument size. 4 or 8  expected, but "
+                   << arg.size << " provided";
       }
 
     }

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -224,7 +224,7 @@ int BPFtrace::add_probe(ast::Probe &p)
       }
       catch (const WildcardException &e)
       {
-        std::cerr << e.what() << std::endl;
+        LOG(ERROR) << e.what();
         return 1;
       }
       attach_funcs.insert(attach_funcs.end(), matches.begin(), matches.end());
@@ -555,14 +555,14 @@ void perf_event_printer(void *cb_cookie, void *data, int size __attribute__((unu
     t = time(NULL);
     if (!localtime_r(&t, &tmp))
     {
-      std::cerr << "localtime_r: " << strerror(errno) << std::endl;
+      LOG(ERROR) << "localtime_r: " << strerror(errno);
       return;
     }
     auto time = static_cast<AsyncEvent::Time *>(data);
     auto fmt = bpftrace->time_args_[time->time_id].c_str();
     if (strftime(timestr, sizeof(timestr), fmt, &tmp) == 0)
     {
-      std::cerr << "strftime returned 0" << std::endl;
+      LOG(ERROR) << "strftime returned 0";
       return;
     }
     bpftrace->out_->message(MessageType::time, timestr, false);
@@ -802,7 +802,7 @@ std::vector<std::unique_ptr<AttachedProbe>> BPFtrace::attach_usdt_probe(
   const char *p;
   if (!(p = realpath(probe.path.c_str(), nullptr)))
   {
-    std::cerr << "Failed to resolve " << probe.path << std::endl;
+    LOG(ERROR) << "Failed to resolve " << probe.path;
     return ret;
   }
   std::string resolved(p);
@@ -849,7 +849,7 @@ std::vector<std::unique_ptr<AttachedProbe>> BPFtrace::attach_usdt_probe(
   }
 
   if (ret.empty())
-    std::cerr << "Failed to find processes running " << probe.path << std::endl;
+    LOG(ERROR) << "Failed to find processes running " << probe.path;
 
   return ret;
 }
@@ -874,9 +874,10 @@ std::vector<std::unique_ptr<AttachedProbe>> BPFtrace::attach_probe(
   if (func == bpforc.sections_.end())
   {
     if (probe.name != probe.orig_name)
-      std::cerr << "Code not generated for probe: " << probe.name << " from: " << probe.orig_name << std::endl;
+      LOG(ERROR) << "Code not generated for probe: " << probe.name
+                 << " from: " << probe.orig_name;
     else
-      std::cerr << "Code not generated for probe: " << probe.name << std::endl;
+      LOG(ERROR) << "Code not generated for probe: " << probe.name;
     return ret;
   }
   try
@@ -907,7 +908,7 @@ std::vector<std::unique_ptr<AttachedProbe>> BPFtrace::attach_probe(
   }
   catch (std::runtime_error &e)
   {
-    std::cerr << e.what() << std::endl;
+    LOG(ERROR) << e.what();
     ret.clear();
   }
   return ret;
@@ -987,7 +988,7 @@ int BPFtrace::run(std::unique_ptr<BpfOrc> bpforc)
     }
     catch (std::runtime_error &e)
     {
-      std::cerr << "Failed to setup child: " << e.what() << std::endl;
+      LOG(ERROR) << "Failed to setup child: " << e.what();
       return -1;
     }
   }
@@ -1036,7 +1037,7 @@ int BPFtrace::run(std::unique_ptr<BpfOrc> bpforc)
     }
     catch (std::runtime_error &e)
     {
-      std::cerr << "Failed to run child: " << e.what() << std::endl;
+      LOG(ERROR) << "Failed to run child: " << e.what();
       return -1;
     }
   }
@@ -1064,7 +1065,7 @@ int BPFtrace::setup_perf_events()
   int epollfd = epoll_create1(EPOLL_CLOEXEC);
   if (epollfd == -1)
   {
-    std::cerr << "Failed to create epollfd" << std::endl;
+    LOG(ERROR) << "Failed to create epollfd";
     return -1;
   }
 
@@ -1076,7 +1077,7 @@ int BPFtrace::setup_perf_events()
         &perf_event_printer, &perf_event_lost, this, -1, cpu, perf_rb_pages_);
     if (reader == nullptr)
     {
-      std::cerr << "Failed to open perf buffer" << std::endl;
+      LOG(ERROR) << "Failed to open perf buffer";
       return -1;
     }
 
@@ -1088,7 +1089,7 @@ int BPFtrace::setup_perf_events()
     bpf_update_elem(perf_event_map_->mapfd_, &cpu, &reader_fd, 0);
     if (epoll_ctl(epollfd, EPOLL_CTL_ADD, reader_fd, &ev) == -1)
     {
-      std::cerr << "Failed to add perf reader to epoll" << std::endl;
+      LOG(ERROR) << "Failed to add perf reader to epoll";
       return -1;
     }
   }
@@ -1157,8 +1158,8 @@ int BPFtrace::clear_map(IMap &map)
   }
   catch (std::runtime_error &e)
   {
-    std::cerr << "Error getting key for map '" << map.name_ << "': "
-              << e.what() << std::endl;
+    LOG(ERROR) << "failed to get key for map '" << map.name_
+               << "': " << e.what();
     return -2;
   }
   auto key(old_key);
@@ -1176,7 +1177,7 @@ int BPFtrace::clear_map(IMap &map)
     int err = bpf_delete_elem(map.mapfd_, key.data());
     if (err)
     {
-      std::cerr << "Error looking up elem: " << err << std::endl;
+      LOG(ERROR) << "failed to look up elem: " << err;
       return -1;
     }
   }
@@ -1200,8 +1201,8 @@ int BPFtrace::zero_map(IMap &map)
   }
   catch (std::runtime_error &e)
   {
-    std::cerr << "Error getting key for map '" << map.name_ << "': "
-              << e.what() << std::endl;
+    LOG(ERROR) << "failed to get key for map '" << map.name_
+               << "': " << e.what();
     return -2;
   }
   auto key(old_key);
@@ -1222,7 +1223,7 @@ int BPFtrace::zero_map(IMap &map)
 
     if (err)
     {
-      std::cerr << "Error looking up elem: " << err << std::endl;
+      LOG(ERROR) << "failed to look up elem: " << err;
       return -1;
     }
   }
@@ -1299,8 +1300,8 @@ int BPFtrace::print_map(IMap &map, uint32_t top, uint32_t div)
   }
   catch (std::runtime_error &e)
   {
-    std::cerr << "Error getting key for map '" << map.name_ << "': "
-              << e.what() << std::endl;
+    LOG(ERROR) << "failed to get key for map '" << map.name_
+               << "': " << e.what();
     return -2;
   }
   auto key(old_key);
@@ -1321,7 +1322,7 @@ int BPFtrace::print_map(IMap &map, uint32_t top, uint32_t div)
     }
     else if (err)
     {
-      std::cerr << "Error looking up elem: " << err << std::endl;
+      LOG(ERROR) << "failed to look up elem: " << err;
       return -1;
     }
 
@@ -1380,8 +1381,8 @@ int BPFtrace::print_map_hist(IMap &map, uint32_t top, uint32_t div)
   }
   catch (std::runtime_error &e)
   {
-    std::cerr << "Error getting key for map '" << map.name_ << "': "
-              << e.what() << std::endl;
+    LOG(ERROR) << "failed to get key for map '" << map.name_
+               << "': " << e.what();
     return -2;
   }
   auto key(old_key);
@@ -1407,7 +1408,7 @@ int BPFtrace::print_map_hist(IMap &map, uint32_t top, uint32_t div)
     }
     else if (err)
     {
-      std::cerr << "Error looking up elem: " << err << std::endl;
+      LOG(ERROR) << "failed to look up elem: " << err;
       return -1;
     }
 
@@ -1459,8 +1460,8 @@ int BPFtrace::print_map_stats(IMap &map, uint32_t top, uint32_t div)
   }
   catch (std::runtime_error &e)
   {
-    std::cerr << "Error getting key for map '" << map.name_ << "': "
-              << e.what() << std::endl;
+    LOG(ERROR) << "failed to get key for map '" << map.name_
+               << "': " << e.what();
     return -2;
   }
   auto key(old_key);
@@ -1486,7 +1487,7 @@ int BPFtrace::print_map_stats(IMap &map, uint32_t top, uint32_t div)
     }
     else if (err)
     {
-      std::cerr << "Error looking up elem: " << err << std::endl;
+      LOG(ERROR) << "failed to look up elem: " << err;
       return -1;
     }
 
@@ -1606,7 +1607,8 @@ std::string BPFtrace::get_stack(uint64_t stackidpid, bool ustack, StackType stac
   {
     // ignore EFAULT errors: eg, kstack used but no kernel stack
     if (stackid != -EFAULT)
-      std::cerr << "Error looking up stack id " << stackid << " (pid " << pid << "): " << err << std::endl;
+      LOG(ERROR) << "failed to look up stack id " << stackid << " (pid " << pid
+                 << "): " << err;
     return "";
   }
 
@@ -1649,7 +1651,7 @@ std::string BPFtrace::resolve_uid(uintptr_t addr) const
   std::ifstream file(file_name);
   if (file.fail())
   {
-    std::cerr << strerror(errno) << ": " << file_name << std::endl;
+    LOG(ERROR) << strerror(errno) << ": " << file_name;
     return username;
   }
 
@@ -1677,9 +1679,9 @@ std::string BPFtrace::resolve_timestamp(uint32_t strftime_id,
 {
   if (btime == 0)
   {
-    std::cerr << "Cannot resolve the timestamp returned by strftime due to the "
-                 "previous failure to get btime from /proc/stat."
-              << std::endl;
+    LOG(ERROR)
+        << "Cannot resolve the timestamp returned by strftime due to the "
+           "previous failure to get btime from /proc/stat.";
     return "(?)";
   }
   auto fmt = strftime_args_[strftime_id].c_str();
@@ -1688,12 +1690,12 @@ std::string BPFtrace::resolve_timestamp(uint32_t strftime_id,
   time_t time = btime + nsecs_since_boot / 1e9;
   if (!localtime_r(&time, &tmp))
   {
-    std::cerr << "localtime_r: " << strerror(errno) << std::endl;
+    LOG(ERROR) << "localtime_r: " << strerror(errno);
     return "(?)";
   }
   if (strftime(timestr, sizeof(timestr), fmt, &tmp) == 0)
   {
-    std::cerr << "strftime returned 0" << std::endl;
+    LOG(ERROR) << "strftime returned 0";
     return "(?)";
   }
   return timestr;
@@ -1734,7 +1736,7 @@ uint64_t BPFtrace::resolve_kname(const std::string &name) const
   std::ifstream file(file_name);
   if (file.fail())
   {
-    std::cerr << strerror(errno) << ": " << file_name << std::endl;
+    LOG(ERROR) << strerror(errno) << ": " << file_name;
     return addr;
   }
 
@@ -1874,8 +1876,8 @@ std::string BPFtrace::resolve_inet(int af, const uint8_t* inet) const
       addrstr = resolve_inetv6(inet);
       break;
     default:
-    std::cerr << "ntop() got unsupported AF type: " << af << std::endl;
-    addrstr = std::string("");
+      LOG(ERROR) << "ntop() got unsupported AF type: " << af;
+      addrstr = std::string("");
   }
 
   // TODO(mmarchini): handle inet_ntop errors
@@ -1896,8 +1898,7 @@ bool BPFtrace::is_aslr_enabled(int pid)
     if (file.fail())
     {
       if (bt_verbose)
-        std::cerr << strerror(errno) << ": " << randomize_va_space_file
-                  << std::endl;
+        LOG(ERROR) << strerror(errno) << ": " << randomize_va_space_file;
       // conservatively return true
       return true;
     }
@@ -1915,7 +1916,7 @@ bool BPFtrace::is_aslr_enabled(int pid)
     if (file.fail())
     {
       if (bt_verbose)
-        std::cerr << strerror(errno) << ": " << personality_file << std::endl;
+        LOG(ERROR) << strerror(errno) << ": " << personality_file;
       return true;
     }
     std::string line;

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -2,6 +2,7 @@
 #include "arch/arch.h"
 #include "bpftrace.h"
 #include "list.h"
+#include "log.h"
 #include "types.h"
 #include "utils.h"
 #include <cstring>
@@ -74,7 +75,7 @@ static struct btf* btf_raw(char *file)
   data = get_data(file, &size);
   if (!data)
   {
-    std::cerr << "BTF: failed to read data from: " << file << std::endl;
+    LOG(ERROR) << "BTF: failed to read data from: " << file;
     return nullptr;
   }
 
@@ -119,7 +120,8 @@ static struct btf *btf_open(const struct vmlinux_location *locs)
         char err_buf[256];
 
         libbpf_strerror(libbpf_get_error(btf), err_buf, sizeof(err_buf));
-        std::cerr << "BTF: failed to read data (" << err_buf << ") from: " << path << std::endl;
+        LOG(ERROR) << "BTF: failed to read data (" << err_buf
+                   << ") from: " << path;
       }
       continue;
     }
@@ -161,7 +163,7 @@ BTF::BTF(void) : btf(nullptr), state(NODATA)
   }
   else if (bt_debug != DebugLevel::kNone)
   {
-    std::cerr << "BTF: failed to find BTF data " << std::endl;
+    LOG(ERROR) << "BTF: failed to find BTF data ";
   }
 }
 
@@ -227,7 +229,7 @@ std::string BTF::c_def(const std::unordered_set<std::string> &set) const
   if (err)
   {
       libbpf_strerror(err, err_buf, sizeof(err_buf));
-      std::cerr << "BTF: failed to initialize dump (" << err_buf << ")" << std::endl;
+      LOG(ERROR) << "BTF: failed to initialize dump (" << err_buf << ")";
       return std::string("");
   }
 
@@ -511,8 +513,7 @@ std::unique_ptr<std::istream> BTF::get_funcs(std::regex *re,
   if (err)
   {
     libbpf_strerror(err, err_buf, sizeof(err_buf));
-    std::cerr << "BTF: failed to initialize dump (" << err_buf << ")"
-              << std::endl;
+    LOG(ERROR) << "BTF: failed to initialize dump (" << err_buf << ")";
     return nullptr;
   }
 
@@ -531,8 +532,7 @@ std::unique_ptr<std::istream> BTF::get_funcs(std::regex *re,
     {
       /* bad.. */
       if (!bt_verbose)
-        std::cerr << "ERROR: " << func_name
-                  << " function does not have FUNC_PROTO record" << std::endl;
+        LOG(ERROR) << func_name << " function does not have FUNC_PROTO record";
       break;
     }
 
@@ -569,8 +569,7 @@ std::unique_ptr<std::istream> BTF::get_funcs(std::regex *re,
       err = btf_dump__emit_type_decl(dump, p->type, &decl_opts);
       if (err)
       {
-        std::cerr << "ERROR: failed to dump argument: " << arg_name
-                  << std::endl;
+        LOG(ERROR) << "failed to dump argument: " << arg_name;
         break;
       }
 
@@ -586,7 +585,7 @@ std::unique_ptr<std::istream> BTF::get_funcs(std::regex *re,
     err = btf_dump__emit_type_decl(dump, t->type, &decl_opts);
     if (err)
     {
-      std::cerr << "ERROR: failed to dump type for: " << func_name << std::endl;
+      LOG(ERROR) << "failed to dump type for: " << func_name;
       break;
     }
 
@@ -595,8 +594,7 @@ std::unique_ptr<std::istream> BTF::get_funcs(std::regex *re,
   }
 
   if (id != (max + 1))
-    std::cerr << "ERROR: BTF data inconsistency " << id << "," << max
-              << std::endl;
+    LOG(ERROR) << "BTF data inconsistency " << id << "," << max;
 
   btf_dump__free(dump);
 
@@ -639,8 +637,7 @@ void BTF::display_structs(std::regex *re) const
   if (err)
   {
     libbpf_strerror(err, err_buf, sizeof(err_buf));
-    std::cerr << "BTF: failed to initialize dump (" << err_buf << ")"
-              << std::endl;
+    LOG(ERROR) << "BTF: failed to initialize dump (" << err_buf << ")";
     return;
   }
 
@@ -663,8 +660,7 @@ void BTF::display_structs(std::regex *re) const
   }
 
   if (id != (max + 1))
-    std::cerr << "ERROR: BTF data inconsistency " << id << "," << max
-              << std::endl;
+    LOG(ERROR) << " BTF data inconsistency " << id << "," << max;
 
   btf_dump__free(dump);
 

--- a/src/child.cpp
+++ b/src/child.cpp
@@ -12,6 +12,7 @@
 #include <unistd.h>
 
 #include "child.h"
+#include "log.h"
 #include "utils.h"
 
 extern char** environ;
@@ -287,9 +288,9 @@ void ChildProc::check_child(bool block)
       throw std::runtime_error("BUG: waitpid() EINVAL");
     else
     {
-      std::cerr << "waitpid(" << child_pid_
-                << ") returned unexpected error: " << errno
-                << ". Marking the child as dead" << std::endl;
+      LOG(ERROR) << "waitpid(" << child_pid_
+                 << ") returned unexpected error: " << errno
+                 << ". Marking the child as dead";
       state_ = State::DIED;
       return;
     }

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -6,12 +6,13 @@
 #include "llvm/Config/llvm-config.h"
 
 #include "ast.h"
+#include "btf.h"
 #include "clang_parser.h"
+#include "field_analyser.h"
+#include "headers.h"
+#include "log.h"
 #include "types.h"
 #include "utils.h"
-#include "headers.h"
-#include "btf.h"
-#include "field_analyser.h"
 
 namespace bpftrace {
 namespace {
@@ -371,7 +372,7 @@ bool ClangParser::ClangParserHandler::check_diagnostics(
         severity == CXDiagnostic_Fatal)
     {
       if (bt_debug >= DebugLevel::kDebug)
-        std::cerr << "Input (" << input.size() << "): " << input << std::endl;
+        LOG(ERROR) << "Input (" << input.size() << "): " << input;
       return false;
     }
   }
@@ -436,7 +437,7 @@ bool ClangParser::visit_children(CXCursor &cursor, BPFtrace &bpftrace)
               structs[ptypestr].fields[ident].bitfield != bitfield &&
               structs[ptypestr].size                   != ptypesize)
           {
-            std::cerr << "type mismatch for " << ptypestr << "::" << ident << std::endl;
+            LOG(WARNING) << "type mismatch for " << ptypestr << "::" << ident;
           }
           else
           {
@@ -485,9 +486,9 @@ std::unordered_set<std::string> ClangParser::get_incomplete_types(
   if (error)
   {
     if (bt_debug == DebugLevel::kFullDebug)
-      std::cerr
+      LOG(ERROR)
           << "Clang error while parsing BTF dependencies in C definitions: "
-          << error << std::endl;
+          << error;
 
     // We don't need to worry about properly reporting an error here because
     // clang should fail again when we run the parser the second time.
@@ -626,8 +627,8 @@ bool ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<s
   if (error)
   {
     if (bt_debug == DebugLevel::kFullDebug) {
-      std::cerr << "Clang error while parsing C definitions: " << error << std::endl;
-      std::cerr << "Input (" << input.size() << "): " << input << std::endl;
+      LOG(ERROR) << "Clang error while parsing C definitions: " << error
+                 << "Input (" << input.size() << "): " << input;
     }
     return false;
   }

--- a/src/list.cpp
+++ b/src/list.cpp
@@ -12,6 +12,7 @@
 #include "bpftrace.h"
 #include "btf.h"
 #include "list.h"
+#include "log.h"
 #include "utils.h"
 
 namespace bpftrace {
@@ -72,7 +73,7 @@ void print_tracepoint_args(const std::string &category, const std::string &event
 
   if (format_file.fail())
   {
-    std::cerr << "ERROR: tracepoint format file not found: " << format_file_path << std::endl;
+    LOG(ERROR) << "tracepoint format file not found: " << format_file_path;
     return;
   }
 
@@ -122,13 +123,16 @@ static void list_uprobes(const BPFtrace& bpftrace,
       switch (paths.size())
       {
       case 0:
-        std::cerr << "uprobe target '" << executable << "' does not exist or is not executable" << std::endl;
+        LOG(ERROR) << "uprobe target '" << executable
+                   << "' does not exist or is not executable";
         return;
       case 1:
         absolute_exe = paths.front();
         break;
       default:
-        std::cerr << "path '" << executable << "' must refer to a unique binary but matched " << paths.size() << std::endl;
+        LOG(ERROR) << "path '" << executable
+                   << "' must refer to a unique binary but matched "
+                   << paths.size();
         return;
       }
     }
@@ -172,16 +176,16 @@ static void list_usdt(const BPFtrace& bpftrace,
     switch (paths.size())
     {
       case 0:
-        std::cerr << "usdt target '" << usdt_path
-                  << "' does not exist or is not executable" << std::endl;
+        LOG(ERROR) << "usdt target '" << usdt_path
+                   << "' does not exist or is not executable";
         return;
       case 1:
         usdt_probes = USDTHelper::probes_for_path(paths.front());
         break;
       default:
-        std::cerr << "usdt target '" << usdt_path
-                  << "' must refer to a unique binary but matched "
-                  << paths.size() << std::endl;
+        LOG(ERROR) << "usdt target '" << usdt_path
+                   << "' must refer to a unique binary but matched "
+                   << paths.size();
         return;
     }
   }
@@ -233,7 +237,7 @@ static void list_kprobes(const std::string& search, const std::regex& re)
   std::ifstream file(kprobe_path);
   if (file.fail())
   {
-    std::cerr << strerror(errno) << ": " << kprobe_path << std::endl;
+    LOG(ERROR) << strerror(errno) << ": " << kprobe_path;
     return;
   }
 
@@ -297,7 +301,7 @@ void list_probes(const BPFtrace& bpftrace, const std::string& search_input)
   }
   catch (std::regex_error& e)
   {
-    std::cerr << "ERROR: invalid character in search expression." << std::endl;
+    LOG(ERROR) << "invalid character in search expression.";
     return;
   }
 

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -11,6 +11,7 @@ std::string logtype_str(LogType t)
     case LogType::INFO    : return "INFO";
     case LogType::WARNING : return "WARNING";
     case LogType::ERROR   : return "ERROR";
+    case LogType::FATAL   : return "FATAL";
     // clang-format on
     default:
       std::cerr << "Invalid log type." << std::endl;
@@ -24,6 +25,7 @@ Log::Log()
   enabled_map_[LogType::WARNING] = true;
   enabled_map_[LogType::INFO] = true;
   enabled_map_[LogType::DEBUG] = true;
+  enabled_map_[LogType::FATAL] = true;
 }
 
 Log& Log::get()
@@ -202,6 +204,12 @@ LogStream::~LogStream()
       prefix = "[" + log_file_ + ":" + std::to_string(log_line_) + "]\n";
     sink_.take_input(type_, loc_, out_, prefix + buf_.str());
   }
+}
+
+[[noreturn]] LogStreamFatal::~LogStreamFatal()
+{
+  sink_.take_input(type_, loc_, out_, buf_.str());
+  abort();
 }
 
 }; // namespace bpftrace

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -4,6 +4,7 @@
 #include <linux/version.h>
 
 #include "bpftrace.h"
+#include "log.h"
 #include "utils.h"
 #include <bcc/libbpf.h>
 
@@ -71,8 +72,8 @@ Map::Map(const SizedType &type) {
 #ifdef DEBUG
   // TODO (mmarchini): replace with DCHECK
   if (!type.IsStack()) {
-    std::cerr << "Map::Map(SizedType) constructor should be called only with stack types" << std::endl;
-    abort();
+    LOG(FATAL) << "Map::Map(SizedType) constructor should be called only with "
+                  "stack types";
   }
 #endif
   type_ = type;
@@ -105,8 +106,7 @@ Map::Map(enum bpf_map_type map_type)
   // TODO (mmarchini): replace with DCHECK
   if (map_type == BPF_MAP_TYPE_STACK_TRACE)
   {
-    std::cerr << "Use Map::Map(SizedType) constructor instead" << std::endl;
-    abort();
+    LOG(FATAL) << "Use Map::Map(SizedType) constructor instead";
   }
 #endif
   if (map_type == BPF_MAP_TYPE_PERF_EVENT_ARRAY)
@@ -120,8 +120,7 @@ Map::Map(enum bpf_map_type map_type)
   }
   else
   {
-    std::cerr << "invalid map type" << std::endl;
-    abort();
+    LOG(FATAL) << "invalid map type";
   }
 
   mapfd_ = create_map(map_type, name.c_str(), key_size, value_size, max_entries, flags);

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -63,8 +63,8 @@ Map::Map(const std::string &name, const SizedType &type, const MapKey &key, int 
   mapfd_ = create_map(map_type_, name.c_str(), key_size, value_size, max_entries, flags);
   if (mapfd_ < 0)
   {
-    std::cerr << "Error creating map: '" << name_ << "': " << strerror(errno)
-              << std::endl;
+    LOG(ERROR) << "failed to create map: '" << name_
+               << "': " << strerror(errno);
   }
 }
 
@@ -87,12 +87,13 @@ Map::Map(const SizedType &type) {
   mapfd_ = create_map(map_type, name.c_str(), key_size, value_size, max_entries, flags);
   if (mapfd_ < 0)
   {
-    std::cerr << "Error creating stack id map" << std::endl;
-    // TODO (mmarchini): Check perf_event_max_stack in the semantic_analyzer
-    std::cerr << "This might have happened because kernel.perf_event_max_stack "
-      << "is smaller than " << type.stack_type.limit
-      << ". Try to tweak this value with "
-      << "sysctl kernel.perf_event_max_stack=<new value>" << std::endl;
+    LOG(ERROR)
+        << "failed to create stack id map\n"
+        // TODO (mmarchini): Check perf_event_max_stack in the semantic_analyzer
+        << "This might have happened because kernel.perf_event_max_stack "
+        << "is smaller than " << type.stack_type.limit
+        << ". Try to tweak this value with "
+        << "sysctl kernel.perf_event_max_stack=<new value>";
   }
 }
 
@@ -126,7 +127,7 @@ Map::Map(enum bpf_map_type map_type)
   mapfd_ = create_map(map_type, name.c_str(), key_size, value_size, max_entries, flags);
   if (mapfd_ < 0)
   {
-    std::cerr << "Error creating " << name << " map: " << strerror(errno) << std::endl;
+    LOG(ERROR) << "failed to create " << name << " map: " << strerror(errno);
   }
 }
 

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -2,6 +2,7 @@
 
 #include "async_event_types.h"
 #include "bpftrace.h"
+#include "log.h"
 #include "mapkey.h"
 #include "utils.h"
 
@@ -118,7 +119,7 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
       return ptr.str();
     }
     default:
-      std::cerr << "invalid mapkey argument type" << std::endl;
+      LOG(ERROR) << "invalid mapkey argument type";
   }
   abort();
 }

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -58,7 +58,7 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
                 LOG(ERROR, ap->loc, std::cerr)
                     << "Did you mean syscalls:" << event_name << "?";
               if (bt_verbose) {
-                  std::cerr << strerror(errno) << ": " << format_file_path << std::endl;
+                LOG(ERROR) << strerror(errno) << ": " << format_file_path;
               }
               return false;
             }
@@ -114,8 +114,7 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
             if (bt_verbose) {
               // Having the location info isn't really useful here, so no
               // bpftrace.error
-              std::cerr << strerror(saved_errno) << ": " << format_file_path
-                        << std::endl;
+              LOG(ERROR) << strerror(saved_errno) << ": " << format_file_path;
             }
             return false;
           }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -2,6 +2,7 @@
 #include <cassert>
 #include <iostream>
 
+#include "log.h"
 #include "types.h"
 
 namespace bpftrace {
@@ -143,8 +144,7 @@ std::string typestr(Type t)
     case Type::timestamp:return "timestamp";break;
     // clang-format on
     default:
-      std::cerr << "call or probe type not found" << std::endl;
-      abort();
+      LOG(FATAL) << "call or probe type not found";
   }
 }
 
@@ -199,8 +199,7 @@ std::string probetypeName(ProbeType t)
     case ProbeType::kfunc:       return "kfunc";       break;
     case ProbeType::kretfunc:    return "kretfunc";    break;
     default:
-      std::cerr << "probe type not found" << std::endl;
-      abort();
+      LOG(FATAL) << "probe type not found";
   }
 }
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -146,6 +146,7 @@ std::string typestr(Type t)
     default:
       LOG(FATAL) << "call or probe type not found";
   }
+  // lgtm[cpp/missing-return]
 }
 
 ProbeType probetype(const std::string &probeName)
@@ -201,6 +202,7 @@ std::string probetypeName(ProbeType t)
     default:
       LOG(FATAL) << "probe type not found";
   }
+  // lgtm[cpp/missing-return]
 }
 
 uint64_t asyncactionint(AsyncAction a)

--- a/src/usdt.cpp
+++ b/src/usdt.cpp
@@ -1,4 +1,5 @@
 #include "usdt.h"
+#include "log.h"
 
 #include <signal.h>
 
@@ -91,8 +92,7 @@ void USDTHelper::read_probes_for_pid(int pid)
     void *ctx = bcc_usdt_new_frompid(pid, nullptr);
     if (ctx == nullptr)
     {
-      std::cerr << "failed to initialize usdt context for pid: " << pid
-                << std::endl;
+      LOG(ERROR) << "failed to initialize usdt context for pid: " << pid;
       if (kill(pid, 0) == -1 && errno == ESRCH)
       {
         std::cerr << "hint: process not running" << std::endl;
@@ -106,8 +106,7 @@ void USDTHelper::read_probes_for_pid(int pid)
   }
   else
   {
-    std::cerr << "a pid must be specified to list USDT probes by PID"
-              << std::endl;
+    LOG(ERROR) << "a pid must be specified to list USDT probes by PID";
   }
 }
 
@@ -119,8 +118,7 @@ void USDTHelper::read_probes_for_path(const std::string &path)
   void *ctx = bcc_usdt_new_frompath(path.c_str());
   if (ctx == nullptr)
   {
-    std::cerr << "failed to initialize usdt context for path " << path
-              << std::endl;
+    LOG(ERROR) << "failed to initialize usdt context for path " << path;
     return;
   }
   bcc_usdt_foreach(ctx, usdt_probe_each);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -14,6 +14,7 @@
 #include <unistd.h>
 
 #include "list.h"
+#include "log.h"
 #include "utils.h"
 #include <bcc/bcc_elf.h>
 
@@ -121,7 +122,8 @@ bool get_uint64_env_var(const std::string &str, uint64_t &dest)
     std::istringstream stringstream(env_p);
     if (!(stringstream >> dest))
     {
-      std::cerr << "Env var '" << str << "' did not contain a valid uint64_t, or was zero-valued." << std::endl;
+      LOG(ERROR) << "Env var '" << str
+                 << "' did not contain a valid uint64_t, or was zero-valued.";
       return false;
     }
   }
@@ -424,8 +426,9 @@ const std::string &is_deprecated(const std::string &str)
     {
       if (item->show_warning)
       {
-        std::cerr << "warning: " << item->old_name << " is deprecated and will be removed in the future. ";
-        std::cerr << "Use " << item->new_name << " instead." << std::endl;
+        LOG(WARNING) << item->old_name
+                     << " is deprecated and will be removed in the future. Use "
+                     << item->new_name << " instead.";
         item->show_warning = false;
       }
 
@@ -642,8 +645,8 @@ void cat_file(const char *filename, size_t max_bytes, std::ostream &out)
   const size_t BUFSIZE = 4096;
 
   if (file.fail()){
-    std::cerr << "Error opening file '" << filename << "': ";
-    std::cerr << strerror(errno) << std::endl;
+    LOG(ERROR) << "failed to open file '" << filename
+               << "': " << strerror(errno);
     return;
   }
 
@@ -659,8 +662,8 @@ void cat_file(const char *filename, size_t max_bytes, std::ostream &out)
       return;
     }
     if (file.fail()) {
-      std::cerr << "Error opening file '" << filename << "': ";
-      std::cerr << strerror(errno) << std::endl;
+      LOG(ERROR) << "failed to open file '" << filename
+                 << "': " << strerror(errno);
       return;
     }
     bytes_read += file.gcount();

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -15,7 +15,7 @@ TIMEOUT 1
 
 NAME errors on non existent file
 RUN bpftrace non_existent_file.bt
-EXPECT Error opening file 'non_existent_file.bt': No such file or directory
+EXPECT ERROR: failed to open file 'non_existent_file.bt': No such file or directory
 TIMEOUT 1
 
 NAME piped script

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -164,7 +164,7 @@ TIMEOUT 5
 NAME log size too small
 ENV BPFTRACE_LOG_SIZE=1
 RUN bpftrace -ve 'BEGIN { if (str($1) == str($2)) { printf("%s\n", str($1)); exit() } }' "hello" "hello"
-EXPECT ^Error loading program: BEGIN
+EXPECT Error loading program: BEGIN
 TIMEOUT 5
 
 NAME increase log size
@@ -174,7 +174,7 @@ TIMEOUT 5
 
 NAME cat "no such file"
 RUN bpftrace -e 'i:ms:1 { cat("/does/not/exist/file"); exit(); }'
-EXPECT ^Error opening file '/does/not/exist/file': No such file or directory$
+EXPECT ^ERROR: failed to open file '/does/not/exist/file': No such file or directory$
 TIMEOUT 5
 
 NAME sizeof

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -1,6 +1,6 @@
 NAME invalid_format
 RUN bpftrace -f jsonx -e 'BEGIN { @scalar = 5; exit(); }'
-EXPECT ^Invalid output format "jsonx"$
+EXPECT ^ERROR: Invalid output format "jsonx"$
 TIMEOUT 5
 
 NAME scalar


### PR DESCRIPTION
This patch changes error/warning messages that are sent though std::cerr to use
new logging infra introduced in #1418.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
