### PR TITLE
Fix type resolution for field access via variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to
   - [#1437](https://github.com/iovisor/bpftrace/pull/1437)
 - Fix array indexing regression
   - [#1457](https://github.com/iovisor/bpftrace/pull/1457)
+- Fix type resolution for struct field access via variables
+  - [#1450](https://github.com/iovisor/bpftrace/pull/1450)
 
 #### Tools
 

--- a/src/ast/field_analyser.cpp
+++ b/src/ast/field_analyser.cpp
@@ -100,10 +100,17 @@ void FieldAnalyser::visit(Map &map)
       expr->accept(*this);
     }
   }
+
+  auto it = var_types_.find(map.ident);
+  if (it != var_types_.end())
+    type_ = it->second;
 }
 
 void FieldAnalyser::visit(Variable &var __attribute__((unused)))
 {
+  auto it = var_types_.find(var.ident);
+  if (it != var_types_.end())
+    type_ = it->second;
 }
 
 void FieldAnalyser::visit(ArrayAccess &arr)
@@ -218,11 +225,13 @@ void FieldAnalyser::visit(AssignMapStatement &assignment)
 {
   assignment.map->accept(*this);
   assignment.expr->accept(*this);
+  var_types_.emplace(assignment.map->ident, type_);
 }
 
 void FieldAnalyser::visit(AssignVarStatement &assignment)
 {
   assignment.expr->accept(*this);
+  var_types_.emplace(assignment.var->ident, type_);
 }
 
 void FieldAnalyser::visit(Predicate &pred)

--- a/src/ast/field_analyser.h
+++ b/src/ast/field_analyser.h
@@ -71,6 +71,7 @@ private:
   std::ostringstream  err_;
 
   std::map<std::string, SizedType> ap_args_;
+  std::map<std::string, std::string> var_types_;
 };
 
 } // namespace ast

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -634,6 +634,27 @@ TEST_F(clang_parser_btf, btf_field_struct)
   EXPECT_NE(bpftrace.btf_set_.find("struct Foo2"), bpftrace.btf_set_.end());
   EXPECT_NE(bpftrace.btf_set_.find("char"), bpftrace.btf_set_.end());
 }
+
+TEST_F(clang_parser_btf, btf_variable_field_struct)
+{
+  BPFtrace bpftrace;
+  parse("",
+        bpftrace,
+        true,
+        "kprobe:sys_read {\n"
+        "  @x1 = ((struct Foo3 *) curtask);\n"
+        "  @x2 = ((struct Foo1 *) curtask);\n"
+        "  @x3 = @x1->foo2;\n"
+        "}");
+
+  EXPECT_EQ(bpftrace.btf_set_.size(), 4U);
+  EXPECT_NE(bpftrace.btf_set_.find("struct task_struct"),
+            bpftrace.btf_set_.end());
+  EXPECT_NE(bpftrace.btf_set_.find("struct Foo1"), bpftrace.btf_set_.end());
+  // struct Foo2 should be added by @x1->foo2
+  EXPECT_NE(bpftrace.btf_set_.find("struct Foo2"), bpftrace.btf_set_.end());
+  EXPECT_NE(bpftrace.btf_set_.find("struct Foo3"), bpftrace.btf_set_.end());
+}
 #endif // HAVE_LIBBPF_BTF_DUMP
 
 TEST(clang_parser, struct_typedef)


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->
Fixes #1362 

The problem is that the field analyser was not able to correctly resolve struct field types if a variable (of struct type) was used because it doesn't remember the variable type.

It only worked for cases when the variable was used right after its definition since the type was remembered in the `type_` field of the field analyser (see the linked issue for examples).

This PR fixes the problem by storing the variable type and using it when the variable is used.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
