### PR TITLE
Improve error messages for kfunc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to
   - [#1433](https://github.com/iovisor/bpftrace/pull/1433)
 - Prefer BTF data if available to resolve tracepoint arguments
   - [#1439](https://github.com/iovisor/bpftrace/pull/1439)
+- Improve error messages for kfunc probe types
+  - [#1451](https://github.com/iovisor/bpftrace/pull/1451)
 
 #### Deprecated
 


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

Most of the errors for kfunc (including, e.g., detecting a non-existing or a non-traceable function) occur when resolving kfunc arguments. This PR proposes to print more informative messages (instead of a generic "resolving kfunc arguments failed") that could help user to identify the problem.

Related to #841 

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
