### PR TITLE
irbuilderbpf.cpp, bpforc.h: Fix compilation with LLVM 11

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -202,10 +202,25 @@ llvm::Type *IRBuilderBPF::GetType(const SizedType &stype)
   return ty;
 }
 
+CallInst *IRBuilderBPF::createCall(Value *callee,
+                                   ArrayRef<Value *> args,
+                                   const Twine &Name)
+{
+#if LLVM_VERSION_MAJOR >= 11
+  auto *calleePtrType = cast<PointerType>(callee->getType());
+  auto *calleeType = cast<FunctionType>(calleePtrType->getElementType());
+  return CreateCall(calleeType, callee, args, Name);
+#else
+  return CreateCall(callee, args, Name);
+#endif
+}
+
 CallInst *IRBuilderBPF::CreateBpfPseudoCall(int mapfd)
 {
   Function *pseudo_func = module_.getFunction("llvm.bpf.pseudo");
-  return CreateCall(pseudo_func, {getInt64(BPF_PSEUDO_MAP_FD), getInt64(mapfd)}, "pseudo");
+  return createCall(pseudo_func,
+                    { getInt64(BPF_PSEUDO_MAP_FD), getInt64(mapfd) },
+                    "pseudo");
 }
 
 CallInst *IRBuilderBPF::CreateBpfPseudoCall(Map &map)
@@ -228,7 +243,7 @@ CallInst *IRBuilderBPF::createMapLookup(int mapfd, AllocaInst *key)
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_map_lookup_elem),
       lookup_func_ptr_type);
-  return CreateCall(lookup_func, { map_ptr, key }, "lookup_elem");
+  return createCall(lookup_func, { map_ptr, key }, "lookup_elem");
 }
 
 CallInst *IRBuilderBPF::CreateGetJoinMap(Value *ctx, const location &loc)
@@ -328,7 +343,7 @@ void IRBuilderBPF::CreateMapUpdateElem(Value *ctx,
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_map_update_elem),
       update_func_ptr_type);
-  CallInst *call = CreateCall(update_func,
+  CallInst *call = createCall(update_func,
                               { map_ptr, key, val, flags },
                               "update_elem");
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_map_update_elem, loc);
@@ -352,7 +367,7 @@ void IRBuilderBPF::CreateMapDeleteElem(Value *ctx,
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_map_delete_elem),
       delete_func_ptr_type);
-  CallInst *call = CreateCall(delete_func, { map_ptr, key }, "delete_elem");
+  CallInst *call = createCall(delete_func, { map_ptr, key }, "delete_elem");
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_map_delete_elem, loc);
 }
 
@@ -384,7 +399,7 @@ void IRBuilderBPF::CreateProbeRead(Value *ctx,
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_probe_read),
       proberead_func_ptr_type);
-  CallInst *call = CreateCall(proberead_func, { dst, size, src }, "probe_read");
+  CallInst *call = createCall(proberead_func, { dst, size, src }, "probe_read");
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_probe_read, loc);
 }
 
@@ -419,7 +434,7 @@ CallInst *IRBuilderBPF::CreateProbeReadStr(Value *ctx,
 {
   assert(ctx && ctx->getType() == getInt8PtrTy());
   Constant *fn = createProbeReadStrFn(dst->getType(), src->getType());
-  CallInst *call = CreateCall(fn,
+  CallInst *call = createCall(fn,
                               { dst, getInt32(size), src },
                               "probe_read_str");
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_probe_read_str, loc);
@@ -440,7 +455,7 @@ CallInst *IRBuilderBPF::CreateProbeReadStr(Value *ctx,
   auto *size_i32 = CreateIntCast(size, getInt32Ty(), false);
 
   Constant *fn = createProbeReadStrFn(dst->getType(), src->getType());
-  CallInst *call = CreateCall(fn, { dst, size_i32, src }, "probe_read_str");
+  CallInst *call = createCall(fn, { dst, size_i32, src }, "probe_read_str");
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_probe_read_str, loc);
   return call;
 }
@@ -723,7 +738,7 @@ CallInst *IRBuilderBPF::CreateGetNs()
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_ktime_get_ns),
       gettime_func_ptr_type);
-  return CreateCall(gettime_func, {}, "get_ns");
+  return createCall(gettime_func, {}, "get_ns");
 }
 
 CallInst *IRBuilderBPF::CreateGetPidTgid()
@@ -736,7 +751,7 @@ CallInst *IRBuilderBPF::CreateGetPidTgid()
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_get_current_pid_tgid),
       getpidtgid_func_ptr_type);
-  return CreateCall(getpidtgid_func, {}, "get_pid_tgid");
+  return createCall(getpidtgid_func, {}, "get_pid_tgid");
 }
 
 CallInst *IRBuilderBPF::CreateGetCurrentCgroupId()
@@ -750,7 +765,7 @@ CallInst *IRBuilderBPF::CreateGetCurrentCgroupId()
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_get_current_cgroup_id),
       getcgroupid_func_ptr_type);
-  return CreateCall(getcgroupid_func, {}, "get_cgroup_id");
+  return createCall(getcgroupid_func, {}, "get_cgroup_id");
 }
 
 CallInst *IRBuilderBPF::CreateGetUidGid()
@@ -763,7 +778,7 @@ CallInst *IRBuilderBPF::CreateGetUidGid()
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_get_current_uid_gid),
       getuidgid_func_ptr_type);
-  return CreateCall(getuidgid_func, {}, "get_uid_gid");
+  return createCall(getuidgid_func, {}, "get_uid_gid");
 }
 
 CallInst *IRBuilderBPF::CreateGetCpuId()
@@ -776,7 +791,7 @@ CallInst *IRBuilderBPF::CreateGetCpuId()
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_get_smp_processor_id),
       getcpuid_func_ptr_type);
-  return CreateCall(getcpuid_func, {}, "get_cpu_id");
+  return createCall(getcpuid_func, {}, "get_cpu_id");
 }
 
 CallInst *IRBuilderBPF::CreateGetCurrentTask()
@@ -789,7 +804,7 @@ CallInst *IRBuilderBPF::CreateGetCurrentTask()
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_get_current_task),
       getcurtask_func_ptr_type);
-  return CreateCall(getcurtask_func, {}, "get_cur_task");
+  return createCall(getcurtask_func, {}, "get_cur_task");
 }
 
 CallInst *IRBuilderBPF::CreateGetRandom()
@@ -802,7 +817,7 @@ CallInst *IRBuilderBPF::CreateGetRandom()
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_get_prandom_u32),
       getrandom_func_ptr_type);
-  return CreateCall(getrandom_func, {}, "get_random");
+  return createCall(getrandom_func, {}, "get_random");
 }
 
 CallInst *IRBuilderBPF::CreateGetStackId(Value *ctx,
@@ -832,7 +847,7 @@ CallInst *IRBuilderBPF::CreateGetStackId(Value *ctx,
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_get_stackid),
       getstackid_func_ptr_type);
-  CallInst *call = CreateCall(getstackid_func,
+  CallInst *call = createCall(getstackid_func,
                               { ctx, map_ptr, flags_val },
                               "get_stackid");
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_get_stackid, loc);
@@ -858,7 +873,7 @@ void IRBuilderBPF::CreateGetCurrentComm(Value *ctx,
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_get_current_comm),
       getcomm_func_ptr_type);
-  CallInst *call = CreateCall(getcomm_func,
+  CallInst *call = createCall(getcomm_func,
                               { buf, getInt64(size) },
                               "get_comm");
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_get_current_comm, loc);
@@ -889,7 +904,9 @@ void IRBuilderBPF::CreatePerfEventOutput(Value *ctx, Value *data, size_t size)
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_perf_event_output),
       perfoutput_func_ptr_type);
-  CreateCall(perfoutput_func, {ctx, map_ptr, flags_val, data, size_val}, "perf_event_output");
+  createCall(perfoutput_func,
+             { ctx, map_ptr, flags_val, data, size_val },
+             "perf_event_output");
 }
 
 void IRBuilderBPF::CreateSignal(Value *ctx, Value *sig, const location &loc)
@@ -905,7 +922,7 @@ void IRBuilderBPF::CreateSignal(Value *ctx, Value *sig, const location &loc)
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_send_signal),
       signal_func_ptr_type);
-  CallInst *call = CreateCall(signal_func, { sig }, "signal");
+  CallInst *call = createCall(signal_func, { sig }, "signal");
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_send_signal, loc);
 }
 
@@ -919,7 +936,7 @@ void IRBuilderBPF::CreateOverrideReturn(Value *ctx, Value *rc)
   Constant *override_func = ConstantExpr::getCast(Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_override_return),
       override_func_ptr_type);
-  CreateCall(override_func, { ctx, rc }, "override");
+  createCall(override_func, { ctx, rc }, "override");
 }
 
 Value *IRBuilderBPF::CreatKFuncArg(Value *ctx,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -80,6 +80,7 @@ public:
   CallInst   *CreateGetRandom();
   CallInst   *CreateGetStackId(Value *ctx, bool ustack, StackType stack_type, const location& loc);
   CallInst   *CreateGetJoinMap(Value *ctx, const location& loc);
+  CallInst   *createCall(Value *callee, ArrayRef<Value *> args, const Twine &Name);
   void        CreateGetCurrentComm(Value *ctx, AllocaInst *buf, size_t size, const location& loc);
   void        CreatePerfEventOutput(Value *ctx, Value *data, size_t size);
   void        CreateSignal(Value *ctx, Value *sig, const location &loc);

--- a/src/bpforc.h
+++ b/src/bpforc.h
@@ -96,9 +96,15 @@ public:
       : TM(TM_),
         Resolver(createLegacyLookupResolver(
             ES,
+#if LLVM_VERSION_MAJOR >= 11
+            [](llvm::StringRef Name __attribute__((unused))) -> JITSymbol {
+              return nullptr;
+            },
+#else
             [](const std::string &Name __attribute__((unused))) -> JITSymbol {
               return nullptr;
             },
+#endif
             [](Error Err) { cantFail(std::move(Err), "lookup failed"); })),
 #if LLVM_VERSION_MAJOR > 8
         ObjectLayer(AcknowledgeORCv1Deprecation,


### PR DESCRIPTION
Fixes: #1384

Fix the following build errors when compiling with LLVM 11:

 #1
----
/llvm/include/llvm/ExecutionEngine/Orc/Legacy.h:118:35: error: no match for call to ‘(bpftrace::BpfOrc::BpfOrc(llvm::TargetMachine*)::<lambda(const string&)>) (llvm::StringRef)’
  118 |     if (JITSymbol Sym = FindSymbol(*S)) {
      |                         ~~~~~~~~~~^~~~
/llvm/include/llvm/ExecutionEngine/Orc/Legacy.h:118:35: note: candidate: ‘llvm::JITSymbol (*)(const string&)’ {aka ‘llvm::JITSymbol (*)(const std::__cxx11::basic_string<char>&)’} <conversion>
/llvm/include/llvm/ExecutionEngine/Orc/Legacy.h:118:35: note:   candidate expects 2 arguments, 2 provided
In file included from /work/src/github.com/iovisor/bpftrace/src/ast/codegen_llvm.cpp:5:
/work/src/github.com/iovisor/bpftrace/src/bpforc.h:99:13: note: candidate: ‘bpftrace::BpfOrc::BpfOrc(llvm::TargetMachine*)::<lambda(const string&)>’
   99 |             [](const std::string &Name __attribute__((unused))) -> JITSymbol {
      |             ^
/work/src/github.com/iovisor/bpftrace/src/bpforc.h:99:13: note:   no known conversion for argument 1 from ‘llvm::StringRef’ to ‘const string&’ {aka ‘const std::__cxx11::basic_string<char>&’}
In file included from /llvm/include/llvm/ExecutionEngine/Orc/RTDyldObjectLinkingLayer.h:23,

 #2
----
| /src/ast/irbuilderbpf.cpp: In member function 'llvm::CallInst* bpftrace::ast::IRBuilderBPF::createMapLookup(int, llvm::AllocaInst*)':
| /src/ast/irbuilderbpf.cpp:230:65: error: no matching function for call to 'bpftrace::ast::IRBuilderBPF::CreateCall(llvm::Constant*&, <brace-enclosed initializer list>, const char [12])'
|   230 |   return CreateCall(lookup_func, { map_ptr, key }, "lookup_elem");
|       |                                                                 ^
| In file included from /src/ast/irbuilderbpf.h:9,
|                  from /src/ast/async_event_types.h:3,
|                  from /src/ast/irbuilderbpf.cpp:5:
| /usr/include/llvm/IR/IRBuilder.h:2324:13: note: candidate: 'llvm::CallInst* llvm::IRBuilderBase::CreateCall(llvm::FunctionType*, llvm::Value*, llvm::ArrayRef<llvm::Value*>, const llvm::Twine&, llvm::MDNode*)'
|  2324 |   CallInst *CreateCall(FunctionType *FTy, Value *Callee,
|       |             ^~~~~~~~~~
| /usr/include/llvm/IR/IRBuilder.h:2324:38: note:   no known conversion for argument 1 from 'llvm::Constant*' to 'llvm::FunctionType*'
|  2324 |   CallInst *CreateCall(FunctionType *FTy, Value *Callee,
|       |                        ~~~~~~~~~~~~~~^~~

The CreateCall part is based on the llvm 11 fix from bcc:
https://github.com/iovisor/bcc/commit/45e63f2b316cdce2d8cc925f6f14a8726ade9ff6

Signed-off-by: Ovidiu Panait <ovidiu.panait@windriver.com>

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
