### PR TITLE
Fix array indexing regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to
   - [#1436](https://github.com/iovisor/bpftrace/pull/1436)
 - Fix `print` outputs nothing when used on hist() maps with large top args
   - [#1437](https://github.com/iovisor/bpftrace/pull/1437)
+- Fix array indexing regression
+  - [#1457](https://github.com/iovisor/bpftrace/pull/1457)
 
 #### Tools
 

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1182,7 +1182,8 @@ void SemanticAnalyser::visit(ArrayAccess &arr)
           !type.GetElementTy()->IsNoneTy()))
     {
       LOG(ERROR, arr.loc, err_)
-          << "The array index operator [] can only be used on arrays.";
+          << "The array index operator [] can only be used on arrays, found "
+          << type.type << ".";
       return;
     }
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -280,6 +280,7 @@ SizedType CreateArray(size_t num_elements, const SizedType &element_type)
   auto ty = SizedType(Type::array, num_elements);
   ty.num_elements_ = num_elements;
   ty.element_type_ = new SizedType(element_type);
+  ty.pointee_size = element_type.size;
   return ty;
 }
 

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -28,3 +28,8 @@ RUN bpftrace -v -e 'tracepoint:tcp:tcp_destroy_sock { printf("%s\n", ntop(args->
 EXPECT [0-9]+.[0-9]+.[0-9]+.[0-9]+
 AFTER curl -s www.google.com > /dev/null
 TIMEOUT 5
+
+NAME c_array_indexing
+RUN bpftrace -v -e 'struct Foo { int a; uint8_t b[10]; } uprobe:testprogs/uprobe_test:function2 { $foo = (struct Foo *)arg0; printf("%c %c %c %c %c\n", $foo->b[0], $foo->b[1], $foo->b[2], $foo->b[3], $foo->b[4]) }' -c ./testprogs/uprobe_test
+EXPECT h e l l o
+TIMEOUT 5


### PR DESCRIPTION
We regressed on array indexing because the CreateArray() helper forgot
to set pointee_size. This caused all array indexes to silently index to
index 0.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
