### PR TITLE
Add the compile option to run with BPF ring buffer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,3 +169,7 @@ add_subdirectory(tools)
 if (ENABLE_MAN)
 add_subdirectory(man)
 endif(ENABLE_MAN)
+
+if(USE_BPF_RINGBUF)
+unset(USE_BPF_RINGBUF CACHE)
+endif(USE_BPF_RINGBUF)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -138,3 +138,7 @@ if(NOT "${retcode}" STREQUAL "0")
 endif()
 
 add_definitions("-DBPFTRACE_VERSION=\"${BPFTRACE_VERSION}\"")
+
+if(USE_BPF_RINGBUF)
+  target_compile_definitions(bpftrace PRIVATE USE_BPF_RINGBUF)
+endif(USE_BPF_RINGBUF)

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -68,3 +68,7 @@ else()
   endif()
   target_link_libraries(ast libclang)
 endif()
+
+if(USE_BPF_RINGBUF)
+  target_compile_definitions(ast PRIVATE USE_BPF_RINGBUF)
+endif(USE_BPF_RINGBUF)

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -82,6 +82,10 @@ public:
   CallInst   *CreateGetJoinMap(Value *ctx, const location& loc);
   void        CreateGetCurrentComm(Value *ctx, AllocaInst *buf, size_t size, const location& loc);
   void        CreatePerfEventOutput(Value *ctx, Value *data, size_t size);
+#ifdef USE_BPF_RINGBUF
+  void        CreateRingbufOutput(Value *ctx, Value* data, size_t size);
+  void        CreateAtomicIncCounter(Value *ctx, int mapfd, uint32_t idx);
+#endif
   void        CreateSignal(Value *ctx, Value *sig, const location &loc);
   void        CreateOverrideReturn(Value *ctx, Value *rc);
   void        CreateHelperError(Value *ctx, Value *return_value, libbpf::bpf_func_id func_id, const location& loc);

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -2306,8 +2306,14 @@ int SemanticAnalyser::create_maps(bool debug)
       bpftrace_.elapsed_map_ =
           std::make_unique<bpftrace::FakeMap>(map_ident, type, key);
     }
-
+#ifdef USE_BPF_RINGBUF
+    bpftrace_.perf_event_map_ = std::make_unique<bpftrace::FakeMap>(
+        BPF_MAP_TYPE_RINGBUF);
+    bpftrace_.event_loss_counter_ = std::make_unique<bpftrace::FakeMap>(
+        BPF_MAP_TYPE_ARRAY);
+#else
     bpftrace_.perf_event_map_ = std::make_unique<bpftrace::FakeMap>(BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+#endif
   }
   else
   {
@@ -2330,7 +2336,15 @@ int SemanticAnalyser::create_maps(bool debug)
           std::make_unique<bpftrace::Map>(map_ident, type, key, 1);
       failed_maps += is_invalid_map(bpftrace_.elapsed_map_->mapfd_);
     }
+#ifdef USE_BPF_RINGBUF
+    bpftrace_.perf_event_map_ = std::make_unique<bpftrace::Map>(
+        BPF_MAP_TYPE_RINGBUF);
+    bpftrace_.event_loss_counter_ = std::make_unique<bpftrace::Map>(
+        BPF_MAP_TYPE_ARRAY);
+    failed_maps += is_invalid_map(bpftrace_.event_loss_counter_->mapfd_);
+#else
     bpftrace_.perf_event_map_ = std::make_unique<bpftrace::Map>(BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+#endif
     failed_maps += is_invalid_map(bpftrace_.perf_event_map_->mapfd_);
   }
 

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -20,7 +20,6 @@
 #include "struct.h"
 #include "types.h"
 #include "utils.h"
-
 namespace bpftrace {
 
 struct symbol
@@ -175,7 +174,12 @@ public:
   bool usdt_file_activation_ = false;
   int helper_check_level_ = 0;
   uint64_t btime = 0;
-
+#ifdef USE_BPF_RINGBUF
+  struct ring_buffer *ringbuf_ = nullptr;
+  std::unique_ptr<IMap> event_loss_counter_;
+  void set_event_loss_counter();
+  void get_event_loss_counter();
+#endif
   static void sort_by_key(
       std::vector<SizedType> key_args,
       std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>

--- a/src/libbpf/bpf.h
+++ b/src/libbpf/bpf.h
@@ -29,6 +29,7 @@ enum bpf_map_type {
 	BPF_MAP_TYPE_SK_STORAGE,
 	BPF_MAP_TYPE_DEVMAP_HASH,
 	BPF_MAP_TYPE_STRUCT_OPS,
+	BPF_MAP_TYPE_RINGBUF,
 };
 
 enum bpf_prog_type {
@@ -183,7 +184,25 @@ enum bpf_prog_type {
 	FN(probe_read_kernel_str),     \
 	FN(tcp_send_ack),              \
 	FN(send_signal_thread),        \
-	FN(jiffies64),
+	FN(jiffies64),				   \
+	FN(read_branch_records),	   \
+	FN(get_ns_current_pid_tgid),   \
+	FN(xdp_output),			       \
+	FN(get_netns_cookie),		   \
+	FN(get_current_ancestor_cgroup_id),	\
+	FN(sk_assign),			       \
+	FN(ktime_get_boot_ns),		   \
+	FN(seq_printf),			       \
+	FN(seq_write),			       \
+	FN(sk_cgroup_id),		       \
+	FN(sk_ancestor_cgroup_id),	   \
+	FN(ringbuf_output),		       \
+	FN(ringbuf_reserve),		   \
+	FN(ringbuf_submit),		       \
+	FN(ringbuf_discard),		   \
+	FN(ringbuf_query),		       \
+	FN(csum_level),			       \
+	
 
 
 /* integer value in 'imm' field of BPF_CALL instruction selects which helper

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -475,6 +475,10 @@ int main(int argc, char *argv[])
     driver.source("stdin", script);
   }
 
+#ifdef USE_BPF_RINGBUF
+  std::cerr << "Using BPF ring buffer" << std::endl;
+#endif
+
   // Load positional parameters before driver runs so positional
   // parameters used inside attach point definitions can be resolved.
   while (optind < argc)
@@ -753,8 +757,13 @@ int main(int argc, char *argv[])
   }
   else
     bpftrace.out_->attached_probes(num_probes);
-
+#ifdef USE_BPF_RINGBUF
+  bpftrace.set_event_loss_counter();
+#endif
   err = bpftrace.run(move(bpforc));
+#ifdef USE_BPF_RINGBUF
+  bpftrace.get_event_loss_counter();
+#endif
   if (err)
     return err;
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -118,6 +118,25 @@ Map::Map(enum bpf_map_type map_type)
     max_entries = cpus.size();
     flags = 0;
   }
+#ifdef USE_BPF_RINGBUF
+  if (map_type == BPF_MAP_TYPE_RINGBUF)
+  {
+    name = "printf_ringbuf";
+    key_size = 0;
+    value_size = 0;
+    max_entries = 4096 * 64; // page_size *
+                             // Bptrace_default_BPFTRACE_PERF_RB_PAGES
+    flags = 0;
+  }
+  else if (map_type == BPF_MAP_TYPE_ARRAY)
+  {
+    name = "event loss counter";
+    key_size = 4;
+    value_size = 8;
+    max_entries = 1;
+    flags = 0;
+  }
+#endif
   else
   {
     std::cerr << "invalid map type" << std::endl;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -243,3 +243,7 @@ if(ENABLE_TEST_VALIDATE_CODEGEN)
 else()
   message(STATUS "codegen-validator test disabled")
 endif()
+
+if(USE_BPF_RINGBUF)
+  target_compile_definitions(bpftrace_test PRIVATE USE_BPF_RINGBUF)
+endif(USE_BPF_RINGBUF)

--- a/tests/benchmark/profile/profile_100k.bt
+++ b/tests/benchmark/profile/profile_100k.bt
@@ -1,0 +1,4 @@
+profile:hz:100000 { printf("hello 1\n"); }
+
+i:s:10 {exit();} 
+

--- a/tests/benchmark/profile/profile_120k.bt
+++ b/tests/benchmark/profile/profile_120k.bt
@@ -1,0 +1,5 @@
+profile:hz:60000 { printf("hello 1\n"); }
+profile:hz:60000 { printf("hello 1\n"); }
+
+i:s:10 {exit();} 
+

--- a/tests/benchmark/profile/profile_140k.bt
+++ b/tests/benchmark/profile/profile_140k.bt
@@ -1,0 +1,5 @@
+profile:hz:70000 { printf("hello 1\n"); }
+profile:hz:70000 { printf("hello 1\n"); }
+
+i:s:10 {exit();} 
+

--- a/tests/benchmark/profile/profile_160k.bt
+++ b/tests/benchmark/profile/profile_160k.bt
@@ -1,0 +1,5 @@
+profile:hz:80000 { printf("hello 1\n"); }
+profile:hz:80000 { printf("hello 1\n"); }
+
+i:s:10 {exit();} 
+

--- a/tests/benchmark/profile/profile_180k.bt
+++ b/tests/benchmark/profile/profile_180k.bt
@@ -1,0 +1,5 @@
+profile:hz:90000 { printf("hello 1\n"); }
+profile:hz:90000 { printf("hello 1\n"); }
+
+i:s:10 {exit();} 
+

--- a/tests/benchmark/profile/profile_200k.bt
+++ b/tests/benchmark/profile/profile_200k.bt
@@ -1,0 +1,5 @@
+profile:hz:100000 { printf("hello 1\n"); }
+profile:hz:100000 { printf("hello 1\n"); }
+
+i:s:10 {exit();} // bt i.bt > log && cat log | grep -c -E "^hello.*" 
+

--- a/tests/benchmark/profile/profile_40k.bt
+++ b/tests/benchmark/profile/profile_40k.bt
@@ -1,0 +1,4 @@
+profile:hz:40000 { printf("hello 1\n"); }
+
+i:s:10 {exit();} 
+

--- a/tests/benchmark/profile/profile_60k.bt
+++ b/tests/benchmark/profile/profile_60k.bt
@@ -1,0 +1,4 @@
+profile:hz:60000 { printf("hello 1\n"); }
+
+i:s:10 {exit();} 
+

--- a/tests/benchmark/profile/profile_80k.bt
+++ b/tests/benchmark/profile/profile_80k.bt
@@ -1,0 +1,4 @@
+profile:hz:80000 { printf("hello 1\n"); }
+
+i:s:10 {exit();} 
+

--- a/tests/benchmark/profile_event_loss.py
+++ b/tests/benchmark/profile_event_loss.py
@@ -1,0 +1,96 @@
+#!/usr/bin/python3
+import os
+import sys
+import signal
+import subprocess
+import time
+import matplotlib.pyplot as plt
+
+
+def process_output(lines):
+    lost_events = 0
+    handled_events = 0
+    for line in lines:
+        columns = line.split()
+        try:
+            col1 = columns[0]
+            col2 = int(columns[1])
+            if (col1 == 'Lost' and col2 > 0):
+                lost_events += col2
+            if (col1 == 'hello'):
+                handled_events += 1
+        except IndexError:
+            # ignore
+            pass
+
+    total = handled_events + lost_events
+    loss_rate = lost_events / total
+    print(f'handled events: {handled_events!r}')
+    print(f'   lost events: {lost_events!r}')
+    print(f'  total events: {total!r}')
+    print(f'     loss rate: {loss_rate:.2%}')
+    return loss_rate
+
+
+def run(nth, test):
+    loss_rate = 0
+    is_ringbuf = False
+    lines = []
+    print(f"*********BEGIN: {nth:d}*********")
+    try:
+        proc = subprocess.Popen(
+            ['bpftrace', test], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        out, err = proc.communicate(timeout=13)
+        lines = out.decode('utf-8').splitlines()
+        err_txt = err.decode('utf-8')
+        print(err_txt)
+        if ('ring buffer' in err_txt):
+            is_ringbuf = True
+        loss_rate = process_output(lines)
+        if proc.returncode:
+            print(f'Error in the execution, return code: {proc.returncode:d}')
+    except subprocess.TimeoutExpired:
+        # bpf ringbuf: to get the # of lost events
+        proc.send_signal(signal.SIGINT)
+        out, err = proc.communicate()
+        lines = out.decode('utf-8').splitlines()
+        err_txt = err.decode('utf-8')
+        print(err_txt)
+        if ('ring buffer' in err_txt):
+            is_ringbuf = True
+        loss_rate = process_output(lines)
+        print("Timeout!")
+    print("************END*************\n")
+    return loss_rate, is_ringbuf
+
+
+if __name__ == "__main__":
+    stats = {}
+    is_ringbuf = False
+    logname = 'profilelog-' + time.strftime("%Y%m%d-%H%M%S")
+    sys.stdout = open(logname, 'w')
+    files = os.listdir('./profile')
+    nums = [int(x.replace('profile_', '').replace('k.bt', '')) for x in files]
+    tests = sorted(zip(files, nums), key=lambda pair: pair[1])
+    done = 0
+    for test in tests:
+        print('Running test: ' + test[0])
+        print(str(done) + ' done, ' + str(len(files) - done) + ' to go')
+        test_name = os.path.join('./profile', test[0])
+        stats[test[1]] = []
+        for i in range(6):
+            loss_rate, is_ringbuf = run(i, test_name)
+            stats[test[1]].append(loss_rate)
+            # time.sleep(5) # cool down a bit, not sure if necessary
+        print(stats[test[1]])
+        print('\n')
+        done += 1
+
+    plt.boxplot(stats.values(), positions=list(stats.keys()))
+    print(stats.values())
+    plt.title('BPF ringbuf' if is_ringbuf else 'BPF perfbuf')
+    plt.xlabel('thousand profiling events per sec')
+    plt.ylabel('event loss rate')
+    plt.ylim(-0.03, 1)
+    plt.savefig(logname+'.png', format='png')
+    plt.show()


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->
BPF ring buffer is a new BPF map type introduced in linux 5.8 and it has the
potential to improve memory efficiency and solve event re-ordering problems
comparing with BPF perf buffer. This patch adds a compile option
`USE_BPF_RINGBUF` that enables bpftrace to run with BPF ring buffer. This
patch is experimental and follow-ups can benchmark between BPF ring buffer and
BPF perf buffer. The second commit adds a simple benchmark test on event loss
rate.
##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
