### PR TITLE
biosnoop: Output disk name, offset and length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to
   - [#1457](https://github.com/iovisor/bpftrace/pull/1457)
 
 #### Tools
+- biosnoop: Added output of disk name, offset and length
+  - [#1460](https://github.com/iovisor/bpftrace/pull/1460)
 
 #### Documentation
 

--- a/man/man8/biosnoop.8
+++ b/man/man8/biosnoop.8
@@ -4,9 +4,10 @@ biosnoop.bt \- Block I/O tracing tool, showing per I/O latency. Uses bpftrace/eB
 .SH SYNOPSIS
 .B biosnoop.bt
 .SH DESCRIPTION
-This is a basic block I/O (disk I/O) tracing tool, showing each I/O event
-along with the issuing process ID, and the I/O latency. This can be used to
-investigate disk I/O performance issues.
+This is a basic block I/O (disk I/O) tracing tool, showing each I/O event along
+with the issuing process ID, name, I/O latency, disk, offset and length. This
+can be used to investigate disk I/O performance issues. It also outputs the
+system time at startup to reference against the TIME field of each output row.
 
 This tool currently works by dynamic tracing of the blk_account*() kernel
 functions, which will need updating to match any changes to these functions
@@ -17,7 +18,7 @@ Since this uses BPF, only the root user can use this tool.
 CONFIG_BPF and bpftrace.
 .SH EXAMPLES
 .TP
-Trace block I/O events, printing per-line summaries:
+Trace block I/O events, printing one line per operation:
 #
 .B biosnoop.bt
 .SH FIELDS
@@ -31,8 +32,19 @@ Issuing process name. This often identifies the issuing application process, but
 PID
 Issuing process ID. This often identifies the issuing application process, but I/O may be initiated from kernel threads only.
 .TP
-ARGS
-Process name and arguments (16 word maximum).
+DISK
+The name of the target disk, be aware that this will generally show the
+underlying disk receiving the operation if some kind of translation layer such
+as RAID or bcache is used.
+.TP
+OFFSET
+The offset of the I/O operation in bytes.
+.TP
+LEN
+The length of the I/O operation in bytes.
+.TP
+LAT(ms)
+The latency of the I/O operation in milliseconds (ms).
 .SH OVERHEAD
 Since block device I/O usually has a relatively low frequency (< 10,000/s),
 the overhead for this tool is expected to be negligible. For high IOPS storage
@@ -55,5 +67,6 @@ Linux
 Unstable - in development.
 .SH AUTHOR
 Brendan Gregg
+Trent Lloyd
 .SH SEE ALSO
 opensnoop(8)

--- a/tools/biosnoop.bt
+++ b/tools/biosnoop.bt
@@ -3,36 +3,53 @@
  * biosnoop.bt   Block I/O tracing tool, showing per I/O latency.
  *               For Linux, uses bpftrace, eBPF.
  *
- * TODO: switch to block tracepoints. Add device, offset, and size columns.
+ * TODO: switch to block tracepoints.
  *
  * This is a bpftrace version of the bcc tool of the same name.
  *
  * 15-Nov-2017	Brendan Gregg	Created this.
+ * 31-Jul-2020	Trent Lloyd	Added support for disk name, offset and length.
+ *				Requires bpftrace >0.11 for >6 printf args.
  */
+
+#include <linux/blkdev.h>
 
 BEGIN
 {
-	printf("%-12s %-16s %-6s %7s\n", "TIME(ms)", "COMM", "PID", "LAT(ms)");
+	printf("%-12s %-16s %-7s %-8s %-13s %-6s %7s\n", "TIME(ms)", "COMM", "PID", "DISK", "OFFSET", "LEN", "LAT(ms)");
 }
 
 kprobe:blk_account_io_start
 {
+	$req = ((struct request *)arg0);
+
 	@start[arg0] = nsecs;
 	@iopid[arg0] = pid;
 	@iocomm[arg0] = comm;
+	@iolen[arg0] = ((struct request *)arg0)->__data_len;
+	@iostart[arg0] = $req->__sector * $req->q->limits.logical_block_size
 }
 
 kprobe:blk_account_io_done
 /@start[arg0] != 0 && @iopid[arg0] != 0 && @iocomm[arg0] != ""/
 {
 	$now = nsecs;
-	printf("%-12u %-16s %-6d %7d\n",
-	    elapsed / 1000000, @iocomm[arg0], @iopid[arg0],
+	$req = ((struct request *)arg0);
+
+	printf("%-12u %-16s %-7d %-8s %-13u %-6d %7d\n",
+	    elapsed / 1000000,
+	    @iocomm[arg0],
+	    @iopid[arg0],
+	    $req->rq_disk->disk_name,
+	    @iostart[arg0],
+	    @iolen[arg0],
 	    ($now - @start[arg0]) / 1000000);
 
 	delete(@start[arg0]);
 	delete(@iopid[arg0]);
 	delete(@iocomm[arg0]);
+	delete(@iolen[arg0]);
+	delete(@iostart[arg0]);
 }
 
 END
@@ -40,4 +57,6 @@ END
 	clear(@start);
 	clear(@iopid);
 	clear(@iocomm);
+	clear(@iolen);
+	clear(@iostart);
 }

--- a/tools/biosnoop_example.txt
+++ b/tools/biosnoop_example.txt
@@ -2,36 +2,22 @@ Demonstrations of biosnoop, the Linux BPF/bpftrace version.
 
 
 This traces block I/O, and shows the issuing process (at least, the process
-that was on-CPU at the time of queue insert) and the latency of the I/O:
+that was on-CPU at the time of queue insert) and the latency of the I/O along
+with relative completion time (since program start), disk name, offset and
+length.
 
-# ./biosnoop.bt
 Attaching 4 probes...
-TIME(ms)     COMM             PID    LAT(ms)
-611          bash             4179        10
-611          cksum            4179         0
-627          cksum            4179        15
-641          cksum            4179        13
-644          cksum            4179         3
-658          cksum            4179        13
-673          cksum            4179        14
-686          cksum            4179        13
-701          cksum            4179        14
-710          cksum            4179         8
-717          cksum            4179         6
-728          cksum            4179        10
-735          cksum            4179         6
-751          cksum            4179        10
-758          cksum            4179        17
-783          cksum            4179        12
-796          cksum            4179        25
-802          cksum            4179        32
-[...]
+Start Time: 2020-07-31 16:03:09
+TIME(ms)     COMM             PID     DISK     OFFSET        LEN    LAT(ms)
+720          bash             1319718 nvme0n1  777994240     4096         0
+724          cksum            1321648 nvme0n1  680353792     16384       13
+725          cksum            1321648 nvme0n1  2021421056    4096        10
+725          cksum            1321648 nvme0n1  2021355520    4096         6
+725          cksum            1321648 nvme0n1  777986048     4096        10
+726          cksum            1321648 nvme0n1  1331789824    4096        15
 
 This output shows the cksum process was issuing block I/O, which were
-completing with around 12 milliseconds of latency. Each block I/O event is
-printed out, with a completion time as the first column, measured from
-program start.
-
+completing with around 12 milliseconds of latency.
 
 An example of some background flushing:
 


### PR DESCRIPTION
- Add support for outputting disk name, offset and length
- Outputs the system time and startup to compare to the relative timestamps
- Requires bpftrace v0.11.0 due to using more than 7 arguments to printf

##### Checklist

- [N/A] Language changes are updated in `docs/reference_guide.md`
- [Yes] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [No] The new behaviour is covered by tests - there currently seems to be no test framework for the example tools
