### PR TITLE
RFC: drop capabilities

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,7 @@ include_directories(SYSTEM ${LIBBCC_INCLUDE_DIRS})
 find_package(LibElf REQUIRED)
 include_directories(SYSTEM ${LIBELF_INCLUDE_DIRS})
 
+find_package(LibCap REQUIRED)
 find_package(BISON REQUIRED)
 find_package(FLEX REQUIRED)
 bison_target(bison_parser src/parser.yy ${CMAKE_BINARY_DIR}/parser.tab.cc VERBOSE)

--- a/cmake/FindLibCap.cmake
+++ b/cmake/FindLibCap.cmake
@@ -1,0 +1,15 @@
+find_path (LIBCAP_INCLUDE_DIRS
+  NAMES
+    capability.h
+  PATH_SUFFIXES
+    sys
+)
+
+find_library (LIBCAP_LIBRARIES
+  NAMES
+    cap
+)
+
+find_package_handle_standard_args(LibCap "Please install libcap and it's development package"
+  LIBCAP_LIBRARIES
+  LIBCAP_INCLUDE_DIRS)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -7,6 +7,7 @@ add_executable(bpftrace
   bpffeature.cpp
   bpftrace.cpp
   btf.cpp
+  capabilities.cpp
   child.cpp
   clang_parser.cpp
   disasm.cpp
@@ -86,6 +87,7 @@ if (ALLOW_UNSAFE_PROBE)
 endif(ALLOW_UNSAFE_PROBE)
 
 target_link_libraries(bpftrace arch ast parser resources)
+target_link_libraries(bpftrace ${LIBCAP_LIBRARIES})
 
 target_link_libraries(bpftrace ${LIBBCC_LIBRARIES})
 if(STATIC_LINKING)

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1832,7 +1832,7 @@ std::string BPFtrace::extract_func_symbols_from_path(const std::string &path) co
   std::set<std::string> syms;
   int err = bcc_elf_foreach_sym(path.c_str(), add_symbol, &symbol_option, &syms);
   if (err)
-    throw std::runtime_error("Could not list function symbols: " + path);
+    throw std::runtime_error("Could not list function symbols: " + path + ": " + strerror(errno));
 
   std::ostringstream oss;
   std::copy(syms.begin(),

--- a/src/capabilities.cpp
+++ b/src/capabilities.cpp
@@ -1,0 +1,117 @@
+#include <system_error>
+#include <fstream>
+#include <string>
+
+#include <sys/capability.h>
+
+#include "capabilities.h"
+
+namespace {
+std::system_error SYS_ERR(const std::string& msg)
+{
+  return std::system_error(errno, std::generic_category(), msg);
+}
+
+int get_last_cap(void)
+{
+  std::string cap_last_cap("/proc/sys/kernel/cap_last_cap");
+  std::ifstream file(cap_last_cap);
+  if (file.fail())
+    throw SYS_ERR("open(" + cap_last_cap + ")");
+
+  std::string line;
+  std::getline(file, line);
+  return std::stoi(line);
+}
+}// namespace
+
+Capabilities::Capabilities(void)
+{
+  current_ = cap_get_proc();
+  if (current_ == nullptr)
+    throw SYS_ERR("cap_get_proc()");
+  max_cap_ = get_last_cap();
+}
+
+void Capabilities::drop_to(std::vector<cap_value_t> caps)
+{
+  cap_t tmpcap = cap_init();
+  if (tmpcap == nullptr)
+    throw SYS_ERR("cap_init()");
+
+  try
+  {
+    if (cap_clear(tmpcap) < 0)
+      throw SYS_ERR("cap_clear()");
+
+    if (cap_set_flag(tmpcap, CAP_EFFECTIVE, caps.size(), &caps[0], CAP_SET) < 0)
+      throw SYS_ERR("cap_set_flags(CAP_EFFECTIVE)");
+
+    if (cap_set_flag(tmpcap, CAP_PERMITTED, caps.size(), &caps[0], CAP_SET) < 0)
+      throw SYS_ERR("cap_set_flags(CAP_PERMITTED)");
+
+    if (cap_set_proc(tmpcap) < 0)
+      throw SYS_ERR("cap_set_proc(" + to_string(tmpcap) + ")");
+
+    cap_free(current_);
+    current_ = tmpcap;
+  }
+  catch (const std::runtime_error& e)
+  {
+    cap_free(tmpcap);
+    throw e;
+  }
+}
+
+std::string Capabilities::to_string(cap_value_t cap)
+{
+  char * buf = cap_to_name(cap);
+  if (buf == nullptr)
+    throw SYS_ERR("cap_to_name()");
+  std::string name(buf);
+  cap_free(buf);
+  return name;
+}
+
+std::string Capabilities::to_string(cap_t cap)
+{
+  char * buf = cap_to_text(cap, nullptr);
+  if (buf == nullptr)
+    return "";
+  std::string str(buf);
+  cap_free(buf);
+  str.erase(0,2);
+  return str;
+}
+
+void Capabilities::drop(cap_value_t cap)
+{
+  cap_t tmpcap = cap_dup(current_);
+  if (tmpcap == nullptr)
+    throw SYS_ERR("cap_dup()");
+
+  try
+  {
+    if (cap_set_flag(tmpcap, CAP_EFFECTIVE, 1, &cap, CAP_CLEAR) < 0)
+      throw SYS_ERR("cap_set_flags(CAP_EFFECTIVE)");
+
+    if (cap_set_flag(tmpcap, CAP_PERMITTED, 1, &cap, CAP_CLEAR) < 0)
+      throw SYS_ERR("cap_set_flags(CAP_PERMITTED)");
+
+    if (cap_set_proc(tmpcap) < 0)
+      throw SYS_ERR("cap_set_proc(" + to_string(cap) + ")");
+  }
+  catch (const std::runtime_error& e)
+  {
+    cap_free(tmpcap);
+    throw e;
+  }
+
+  cap_free(current_);
+  current_ = tmpcap;
+}
+
+bool Capabilities::system_has_cap(cap_value_t cap)
+{
+  return cap <= max_cap_;
+}

--- a/src/capabilities.h
+++ b/src/capabilities.h
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <vector>
+#include <sys/capability.h>
+
+class Capabilities {
+public:
+  Capabilities(void);
+  /**
+     Drop down to the specified capability set
+  */
+  void drop_to(std::vector<cap_value_t> caps);
+  /**
+     Drop a single capability
+  */
+  void drop(cap_value_t cap);
+
+  /**
+     Do we currently have this capability?
+  */
+  bool has_cap(cap_value_t cap);
+
+  /**
+     Check whether the system supports this capability
+  */
+  bool system_has_cap(cap_value_t cap);
+
+  std::string to_string(cap_t cap);
+  std::string to_string(void) { return to_string(current_); };
+  std::string to_string(cap_value_t cap);
+
+private:
+  cap_t current_;
+
+  // Highest cap the system supports
+  ssize_t max_cap_;
+};


### PR DESCRIPTION
First attempt at #1454 

This drops our capabilities down to the minimum required to run bpftrace. As a "command" (`-c`) might need more permissions than the fork happens before the capabilities are dropped[1][2]. The `system()` call is impacted by this. I'm not sure if anyone uses it to do "dangerous stuff", you probably shouldn't but if we do this it will break existing behaviour.

The capabilities are currently static with a fixed "profile" for all. But using the `system_has_cap` function we could auto detect what the kernel has and use that instead. But that has the same problem as we had with bpffeature. If we want to be portable and run on newer kernel we need to make sure those symbols are defined, so that means pulling (part of) `capability.h` into our tree, which I'm not a big fan of (it's ok now, but not if we keep adding files).

This seems to work well in ubuntu-19.10 vagrant, but fails to list probes with `-l -p` on the fedora-32 box.  Not sure what the issues is there yet. Might be related to the slightly different pidfd code path.

I'm not entirely convinced by this yet. Over al I don't think it hurts to have this but I don't think it protects us against a real exploit either. Seccomp might be a better approach, we could add an earlier analyser pass that analyses what we need for the run and use only that.


[1]: . If we want to limit the childproc further we should add flags to change user and drop caps, libcap can parse strings to cap values, so maybe `--child-capabilities CAP_CHOWN,CAP_NET_RAW+ep`
[2]: The `watchpoint` tests fail if capabilties are dropped first