### PR TITLE
Fix kfarg access

### DIFF
--- a/src/ast/field_analyser.cpp
+++ b/src/ast/field_analyser.cpp
@@ -193,6 +193,7 @@ void FieldAnalyser::visit(FieldAccess &acc)
         type_ = "";
     }
 
+    bpftrace_.btf_set_.insert(type_);
     has_builtin_args_ = false;
   }
   else if (!type_.empty())

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1846,6 +1846,12 @@ void SemanticAnalyser::visit(AssignVarStatement &assignment)
   auto search = variable_val_.find(var_ident);
   assignment.var->type = assignment.expr->type;
 
+  auto *builtin = dynamic_cast<Builtin *>(assignment.expr);
+  if (builtin && builtin->ident == "args" && builtin->type.is_kfarg)
+  {
+    LOG(ERROR, assignment.loc, err_) << "args cannot be assigned to a variable";
+  }
+
   if (search != variable_val_.end()) {
     if (search->second.IsNoneTy())
     {

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -531,8 +531,8 @@ void SemanticAnalyser::visit(Call &call)
       if (!t.IsIntegerTy() && !t.IsPtrTy())
       {
         LOG(ERROR, call.loc, err_)
-            << "() expects an integer or a pointer type as first "
-            << "argument ( " << t << " provided)";
+            << call.func << "() expects an integer or a pointer type as first "
+            << "argument (" << t << " provided)";
       }
       call.type = CreateString(bpftrace_.strlen_);
       if (is_final_pass() && call.vargs->size() > 1) {
@@ -1573,7 +1573,7 @@ void SemanticAnalyser::visit(FieldAccess &acc)
     if (it != ap_args_.end())
       acc.type = it->second;
     else
-      LOG(ERROR, acc.loc, err_) << "Can't find a field";
+      LOG(ERROR, acc.loc, err_) << "Can't find a field " << acc.field;
     return;
   }
 

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1395,17 +1395,8 @@ void SemanticAnalyser::visit(Unop &unop)
     }
     else if (type.IsRecordTy())
     {
-      if (type.is_kfarg)
-      {
-        // args->arg access, we need to push the args builtin
-        // type further through the expression ladder
-        unop.type = type;
-      }
-      else {
-        LOG(ERROR, unop.loc, err_)
-            << "Can not dereference struct/union of type '" << type.GetName()
-            << "'. It is not a pointer.";
-      }
+      LOG(ERROR, unop.loc, err_) << "Can not dereference struct/union of type '"
+                                 << type.GetName() << "'. It is not a pointer.";
     }
     else if (type.IsIntTy())
     {

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1387,9 +1387,11 @@ void SemanticAnalyser::visit(Unop &unop)
     {
       unop.type = SizedType(*type.GetPointeeTy());
       if (type.IsCtxAccess())
+      {
         unop.type.MarkCtxAccess();
-      unop.type.is_kfarg = type.is_kfarg;
-      unop.type.is_tparg = type.is_tparg;
+        unop.type.is_kfarg = type.is_kfarg;
+        unop.type.is_tparg = type.is_tparg;
+      }
     }
     else if (type.IsRecordTy())
     {

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -394,15 +394,10 @@ SizedType BTF::get_stype(__u32 id)
   }
   else if (btf_is_ptr(t))
   {
-    // get the pointer type..
-    t = btf__type_by_id(btf, t->type);
-    // .. and skip the trash.
-    t = btf_type_skip_modifiers(t);
-
+    // t->type is the pointee type
     stype = CreatePointer(get_stype(t->type));
   }
 
-  stype.is_kfarg = true;
   return stype;
 }
 
@@ -464,6 +459,7 @@ int BTF::resolve_args(const std::string &func,
 
       SizedType stype = get_stype(p->type);
       stype.kfarg_idx = j;
+      stype.is_kfarg = true;
       args.insert({ str, stype });
     }
 
@@ -471,6 +467,7 @@ int BTF::resolve_args(const std::string &func,
     {
       SizedType stype = get_stype(t->type);
       stype.kfarg_idx = j;
+      stype.is_kfarg = true;
       args.insert({ "$retval", stype });
     }
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1849,7 +1849,8 @@ TEST_F(semantic_analyser_btf, kfunc)
 {
   test("kfunc:func_1 { 1 }", 0);
   test("kretfunc:func_1 { 1 }", 0);
-  test("kfunc:func_1 { $x = args->a; $y = args->foo1; }", 0);
+  test("kfunc:func_1 { $x = args->a; $y = args->foo1; $z = args->foo2->f.a; }",
+       0);
   test("kretfunc:func_1 { $x = retval; }", 0);
   test("kretfunc:func_1 { $x = args->foo; }", 1);
   // func_1 and func_2 have different args, but none of them

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1853,6 +1853,7 @@ TEST_F(semantic_analyser_btf, kfunc)
        0);
   test("kretfunc:func_1 { $x = retval; }", 0);
   test("kretfunc:func_1 { $x = args->foo; }", 1);
+  test("kretfunc:func_1 { $x = args; }", 1);
   // func_1 and func_2 have different args, but none of them
   // is used in probe code, so we're good -> PASS
   test("kfunc:func_1, kfunc:func_2 { }", 0);


### PR DESCRIPTION
Fix kfarg access so that a chain of dereference works.

Example:

```
% bpftrace -e 'kfunc:vfs_open { printf("%s\n", str(args->path->dentry->d_name.name));}'
Attaching 1 probe...
cmdline
^C
```

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
