### PR TITLE
Calculate boot time with sub-second precision

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1677,17 +1677,16 @@ std::string BPFtrace::resolve_uid(uintptr_t addr) const
 std::string BPFtrace::resolve_timestamp(uint32_t strftime_id,
                                         uint64_t nsecs_since_boot)
 {
-  if (btime == 0)
+  if (!boottime_)
   {
-    LOG(ERROR)
-        << "Cannot resolve the timestamp returned by strftime due to the "
-           "previous failure to get btime from /proc/stat.";
+    LOG(ERROR) << "Cannot resolve timestamp due to failed boot time calcuation";
     return "(?)";
   }
   auto fmt = strftime_args_[strftime_id].c_str();
   char timestr[STRING_SIZE];
   struct tm tmp;
-  time_t time = btime + nsecs_since_boot / 1e9;
+  time_t time = boottime_->tv_sec +
+                ((boottime_->tv_nsec + nsecs_since_boot) / 1e9);
   if (!localtime_r(&time, &tmp))
   {
     LOG(ERROR) << "localtime_r: " << strerror(errno);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <unordered_map>
 #include <utility>
@@ -174,7 +175,7 @@ public:
   bool has_usdt_ = false;
   bool usdt_file_activation_ = false;
   int helper_check_level_ = 0;
-  uint64_t btime = 0;
+  std::optional<struct timespec> boottime_;
 
   static void sort_by_key(
       std::vector<SizedType> key_args,


### PR DESCRIPTION
If we do the "triple vdso sandwich" a couple of times and take the
results from the iteration that has the lowest time delta between the
first and last clock_gettime(), we can get pretty good precision.

My test showed ~30ns of accuracy.

Test plan:
```
$ sudo bpftrace -e 'i:s:1 { printf("%s\n", strftime("%D %H:%M:%S %P %Z", 0)); }'
Attaching 1 probe...
08/17/20 18:28:19 pm PDT
```

Which corresponds to my `last reboot` time:
```
$ last reboot | head -n1
reboot   system boot  5.7.12-arch1-1   Mon Aug 17 18:28   still running
```

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [NA] Language changes are updated in `docs/reference_guide.md`
- [NA] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
