### PR TITLE
List retprobes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to
   - [#1444](https://github.com/iovisor/bpftrace/pull/1444)
 - Support scientific notation for integer literals
   - [#1476](https://github.com/iovisor/bpftrace/pull/1476)
+- List retprobes
+  - [#1484](https://github.com/iovisor/bpftrace/pull/1484)
 
 #### Changed
 - Warn if using `print` on `stats` maps with top and div arguments

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -601,12 +601,12 @@ std::unique_ptr<std::istream> BTF::get_funcs(std::regex *re,
   return std::make_unique<std::istringstream>(funcs);
 }
 
-void BTF::display_kfunc(std::regex *re) const
+void BTF::display_kfunc(std::regex *re, const bool retprobe = false) const
 {
   if (!has_data())
     return;
 
-  auto funcs = get_funcs(re, bt_verbose, "kfunc:");
+  auto funcs = get_funcs(re, bt_verbose, retprobe ? "kretfunc:" : "kfunc:");
   if (!funcs)
     return;
 
@@ -730,7 +730,8 @@ int BTF::resolve_args(const std::string &func __attribute__((__unused__)),
   return -1;
 }
 
-void BTF::display_kfunc(std::regex* re __attribute__((__unused__))) const
+void BTF::display_kfunc(std::regex* re __attribute__((__unused__)),
+                        const bool retporbe __attribute__((__unused__))) const
 {
 }
 

--- a/src/btf.h
+++ b/src/btf.h
@@ -29,7 +29,7 @@ public:
   std::string c_def(const std::unordered_set<std::string>& set) const;
   std::string type_of(const std::string& name, const std::string& field);
   std::string type_of(const btf_type* type, const std::string& field);
-  void display_kfunc(std::regex* re) const;
+  void display_kfunc(std::regex* re, const bool retfunc) const;
   void display_structs(std::regex* re) const;
 
   std::unique_ptr<std::istream> kfunc(void) const;

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -43,9 +43,30 @@ RUN bpftrace -l | grep hardware
 EXPECT hardware
 TIMEOUT 1
 
+NAME it lists kfuncs
+RUN bpftrace -l | grep kfunc
+EXPECT kfunc
+REQUIRES_FEATURE btf
+TIMEOUT 1
+
 NAME it lists kprobes with regex filter
 RUN bpftrace -l "kprobe:*"
 EXPECT kprobe:
+TIMEOUT 1
+
+NAME it lists kretprobes with regex filter
+RUN bpftrace -l "kretprobe:*"
+EXPECT kretprobe:
+TIMEOUT 1
+
+NAME it lists uprobes with regex filter
+RUN bpftrace -l "uprobe:./testprogs/syscall:*"
+EXPECT uprobe:
+TIMEOUT 1
+
+NAME it lists uretprobes with regex filter
+RUN bpftrace -l "uretprobe:./testprogs/syscall:*"
+EXPECT uretprobe:
 TIMEOUT 1
 
 NAME it lists tracepoints with regex filter
@@ -61,6 +82,18 @@ TIMEOUT 1
 NAME it lists hardware events with regex filter
 RUN bpftrace -l "hardware:*"
 EXPECT hardware
+TIMEOUT 1
+
+NAME it lists kfuncs events with regex filter
+RUN bpftrace -l "kfunc:*"
+EXPECT kfunc
+REQUIRES_FEATURE btf
+TIMEOUT 1
+
+NAME it lists kretfuncs events with regex filter
+RUN bpftrace -l "kretfunc:*"
+EXPECT kretfunc
+REQUIRES_FEATURE btf
 TIMEOUT 1
 
 NAME errors on invalid character in search expression


### PR DESCRIPTION
`bpftrace -l` does not show retprobes (uretprobe, kretprobe, kretfunc)
even if a search keyword is given (e.g., bpftrace -l 'kr:vfs_open'), and
this may confuse users. List retprobes if a user searches them.

Example:

```
% sudo ./src/bpftrace -l 'kr:vfs*'
kretprobe:vfs_fadvise
kretprobe:vfs_fallocate
kretprobe:vfs_truncate
kretprobe:vfs_open
[...]
```

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
