### PR TITLE
Resolve unknown/undefined types for tracepoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to
   - [#1476](https://github.com/iovisor/bpftrace/pull/1476)
 - List retprobes
   - [#1484](https://github.com/iovisor/bpftrace/pull/1484)
-- Resolve unknown typedefs using BTF
+- Resolve unknown typedefs using BTF and give a hint when a type cannot be found
   - [#1485](https://github.com/iovisor/bpftrace/pull/1485)
 
 #### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to
   - [#1476](https://github.com/iovisor/bpftrace/pull/1476)
 - List retprobes
   - [#1484](https://github.com/iovisor/bpftrace/pull/1484)
+- Resolve unknown typedefs using BTF
+  - [#1485](https://github.com/iovisor/bpftrace/pull/1485)
 
 #### Changed
 - Warn if using `print` on `stats` maps with top and div arguments

--- a/src/clang_parser.h
+++ b/src/clang_parser.h
@@ -41,6 +41,9 @@ private:
       const std::vector<const char *> &args,
       const std::unordered_set<std::string> &complete_types);
 
+  static std::optional<std::string> get_unknown_type(
+      const std::string &diagnostic_msg);
+
   class ClangParserHandler
   {
   public:
@@ -65,10 +68,6 @@ private:
     bool check_diagnostics(const std::string &input,
                            std::vector<std::string> &error_msgs,
                            bool bail_on_error);
-    /*
-     * Runs the above method with bail_on_error=false and throws away messages.
-     */
-    bool check_diagnostics(const std::string &input);
 
     CXCursor get_translation_unit_cursor();
 

--- a/tests/codegen/llvm/struct_nested_struct_anon_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_1.ll
@@ -10,7 +10,7 @@ define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %"struct Foo::(anonymous at definitions.h:1:14).x" = alloca i32
+  %"struct Foo::(anonymous at definitions.h:2:14).x" = alloca i32
   %"$foo" = alloca [4 x i8]
   %1 = bitcast [4 x i8]* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -23,12 +23,12 @@ entry:
   call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %4, i8 addrspace(64)* align 1 %5, i64 4, i1 false)
   %6 = add [4 x i8]* %"$foo", i64 0
   %7 = add [4 x i8]* %6, i64 0
-  %8 = bitcast i32* %"struct Foo::(anonymous at definitions.h:1:14).x" to i8*
+  %8 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo::(anonymous at definitions.h:1:14).x", i32 4, [4 x i8]* %7)
-  %9 = load i32, i32* %"struct Foo::(anonymous at definitions.h:1:14).x"
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo::(anonymous at definitions.h:2:14).x", i32 4, [4 x i8]* %7)
+  %9 = load i32, i32* %"struct Foo::(anonymous at definitions.h:2:14).x"
   %10 = sext i32 %9 to i64
-  %11 = bitcast i32* %"struct Foo::(anonymous at definitions.h:1:14).x" to i8*
+  %11 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   %12 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)

--- a/tests/codegen/llvm/struct_nested_struct_anon_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_2.ll
@@ -10,7 +10,7 @@ define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %"struct Foo::(anonymous at definitions.h:1:14).x" = alloca i32
+  %"struct Foo::(anonymous at definitions.h:2:14).x" = alloca i32
   %"$foo" = alloca i64
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -21,12 +21,12 @@ entry:
   %3 = load i64, i64* %"$foo"
   %4 = add i64 %3, 0
   %5 = add i64 %4, 0
-  %6 = bitcast i32* %"struct Foo::(anonymous at definitions.h:1:14).x" to i8*
+  %6 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* %"struct Foo::(anonymous at definitions.h:1:14).x", i32 4, i64 %5)
-  %7 = load i32, i32* %"struct Foo::(anonymous at definitions.h:1:14).x"
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* %"struct Foo::(anonymous at definitions.h:2:14).x", i32 4, i64 %5)
+  %7 = load i32, i32* %"struct Foo::(anonymous at definitions.h:2:14).x"
   %8 = sext i32 %7 to i64
-  %9 = bitcast i32* %"struct Foo::(anonymous at definitions.h:1:14).x" to i8*
+  %9 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   %10 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

If a type is defined by a typedef located in a non-included header, clang parser will fail. This change analyses error messages from the clang parser and retrieves the missing typedefs from BTF (if it is used). If all types cannot be resolved, it provides the user a hint: either to include BTF (running with `--btf`) or to include relevant headers.

Resolves #1154, resolves #730. It should also help with iovisor/kubectl-trace#109.

I was also wondering, if it would make sense to get rid of the `--btf` option completely. AFAIU, it is used for tracepoints only. Using BTF automatically whenever it is available would make most of the "unknown type name" errors disappear in default bpftrace setup.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
