### PR TITLE
ustd: better handling of empty namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to
   - [#1439](https://github.com/iovisor/bpftrace/pull/1439)
 - Improve error messages for kfunc probe types
   - [#1451](https://github.com/iovisor/bpftrace/pull/1451)
+- Better handling of empty usdt namespaces
+  - [#1486](https://github.com/iovisor/bpftrace/pull/1486)
 
 #### Deprecated
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1224,7 +1224,7 @@ usdt:library_path:probe_name
 usdt:library_path:[probe_namespace]:probe_name
 ```
 
-Where the `probe_namespace` is optional, and will default to the basename of the binary or library path.
+Where `probe_namespace` is optional if `probe_name` is unique within the binary.
 
 Examples:
 
@@ -1239,22 +1239,29 @@ hi
 ^C
 ```
 
-The basename of a path will be used for the namespace of a probe. If it doesn't match, the probe won't be
-found. In this example, the function name `loop` is in the namespace `tick`. If we rename the binary to
-`tock`, it won't be found:
+The namespace of the probe is deduced automatically. If the binary `/root/tick` contained multiple probes 
+with the name `loop` (e.g. `tick:loop` and `tock:loop`), no probe would be attached. 
+This may be solved by manually specifying the namespace or by using a wildcard:
 
 ```
-mv /root/tick /root/tock
-bpftrace -e 'usdt:/root/tock:loop { printf("hi\n"); }'
+# bpftrace -e 'usdt:/root/tick:loop { printf("hi\n"); }'
+ERROR: namespace for usdt:/root/tick:loop not specified, matched 2 probes
+INFO: please specify a unique namespace or use '*' to attach to all matched probes
+No probes to attach
+
+# bpftrace -e 'usdt:/root/tick:tock:loop { printf("hi\n"); }'
 Attaching 1 probe...
-Error finding location for probe: usdt:/root/tock:loop
-```
+hi
+hi
+^C
 
-The probe namespace can be manually specified, between the path and probe function name. This allows for
-the probe to be found, regardless of the name of the binary:
-
-```
-bpftrace -e 'usdt:/root/tock:tick:loop { printf("hi\n"); }'
+# bpftrace -e 'usdt:/root/tick:*:loop { printf("hi\n"); }'
+Attaching 2 probes...
+hi
+hi
+hi
+hi
+^C
 ```
 
 bpftrace also supports USDT semaphores. You may activate semaphores by passing in `-p $PID` or

--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -359,7 +359,7 @@ int AttachPointParser::usdt_parser()
   }
 
   if (ap_->target.find('*') != std::string::npos ||
-      ap_->ns.find('*') != std::string::npos ||
+      ap_->ns.find('*') != std::string::npos || ap_->ns.empty() ||
       ap_->func.find('*') != std::string::npos)
     ap_->need_expansion = true;
 

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -544,7 +544,7 @@ TEST(bpftrace, add_probes_usdt_empty_namespace)
   a.provider = "usdt";
   a.target = "/bin/sh";
   a.ns = "";
-  a.func = "tp";
+  a.func = "tp1";
   a.usdt.num_locations = 1;
   a.need_expansion = true;
   ast::AttachPointList attach_points = { &a };
@@ -554,14 +554,31 @@ TEST(bpftrace, add_probes_usdt_empty_namespace)
   EXPECT_CALL(*bpftrace, get_symbols_from_usdt(0, "/bin/sh")).Times(1);
 
   ASSERT_EQ(0, bpftrace->add_probe(probe));
-  ASSERT_EQ(2U, bpftrace->get_probes().size());
+  ASSERT_EQ(1U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
   check_usdt(bpftrace->get_probes().at(0),
-             "/bin/sh", "nahprov", "tp",
-             "usdt:/bin/sh:nahprov:tp");
-  check_usdt(bpftrace->get_probes().at(1),
-             "/bin/sh", "prov2", "tp",
-             "usdt:/bin/sh:prov2:tp");
+             "/bin/sh",
+             "prov1",
+             "tp1",
+             "usdt:/bin/sh:prov1:tp1");
+}
+
+TEST(bpftrace, add_probes_usdt_empty_namespace_conflict)
+{
+  ast::AttachPoint a("");
+  a.provider = "usdt";
+  a.target = "/bin/sh";
+  a.ns = "";
+  a.func = "tp";
+  a.usdt.num_locations = 1;
+  a.need_expansion = true;
+  ast::AttachPointList attach_points = { &a };
+  ast::Probe probe(&attach_points, nullptr, nullptr);
+
+  auto bpftrace = get_strict_mock_bpftrace();
+  EXPECT_CALL(*bpftrace, get_symbols_from_usdt(0, "/bin/sh")).Times(1);
+
+  ASSERT_EQ(1, bpftrace->add_probe(probe));
 }
 
 TEST(bpftrace, add_probes_usdt_duplicate_markers)


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

If an empty namespace is given, it is deduced automatically. We assume that a single probe with the given name exists. If multiple probes having the same name but different namespaces are matched, no probes are attached to and the user is told to use an explicit wildcard for the namespace.

This solves dicrepancy between the tests (which treat an empty namespace as a wildcard) and the reference guide (which says that an empty namespace is replaced by the binary name).

Resolves #1469 and fixes #1466.

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
