### PR TITLE
execsnoop.bt: hook up onto all execve calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to
   - [#1450](https://github.com/iovisor/bpftrace/pull/1450)
 
 #### Tools
+- Hook up execsnoop.bt script onto `execveat` call
+  - [#1490](https://github.com/iovisor/bpftrace/pull/1490)
 
 #### Documentation
 

--- a/tools/execsnoop.bt
+++ b/tools/execsnoop.bt
@@ -20,7 +20,7 @@ BEGIN
 	printf("%-10s %-5s %s\n", "TIME(ms)", "PID", "ARGS");
 }
 
-tracepoint:syscalls:sys_enter_execve
+tracepoint:syscalls:sys_enter_exec*
 {
 	printf("%-10u %-5d ", elapsed / 1e6, pid);
 	join(args->argv);


### PR DESCRIPTION
Besides execve there's also execveat event. Hook up onto both of them and also any other that could get possibly added by using a `*`.

##### Checklist

- [ x ] Language changes are updated in `docs/reference_guide.md`
- [ ✓ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ x ] The new behaviour is covered by tests
