### PR TITLE
docs: Document quoted strings in attachpoint defs

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -834,6 +834,9 @@ Attaching 1 probe...
 Some probe types allow wildcards to match multiple probes, eg, `kprobe:vfs_*`. You may also specify
 multiple attach points for an action block using a comma separated list.
 
+Quoted strings (eg. `uprobe:"/usr/lib/c++lib.so":foo`) may be used to escape
+characters in attach point definitions.
+
 ## 1. `kprobe`/`kretprobe`: Dynamic Tracing, Kernel-Level
 
 Syntax:


### PR DESCRIPTION
This closes #1487 .

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
