### PR TITLE
Add path builtin function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 ## Unreleased
 
 #### Added
+- Add path builtin
+  - [#1492](https://github.com/iovisor/bpftrace/pull/1492)
 - Allow wildcards for tracepoint categories
   - [#1445](https://github.com/iovisor/bpftrace/pull/1445)
 - Add wildcard support for kfunc probe types

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -90,6 +90,7 @@ discussion to other files in /docs, the /tools/\*\_examples.txt files, or blog p
     - [22. `sizeof()`: Size of type or expression](#22-sizeof-size-of-type-or-expression)
     - [23. `print()`: Print Value](#23-print-print-value)
     - [24. `strftime()`: Formatted timestamp](#24-strftime-formatted-timestamp)
+    - [25. `path()`: Return full path](#25-path-return-full-path)
 - [Map Functions](#map-functions)
     - [1. Builtins](#1-builtins-2)
     - [2. `count()`: Count](#2-count-count)
@@ -1958,6 +1959,7 @@ Tracing block I/O sizes > 0 bytes
 - `signal(char[] signal | u32 signal)` - Send a signal to the current task
 - `strncmp(char *s1, char *s2, int length)` - Compare first n characters of two strings
 - `override(u64 rc)` - Override return value
+- `path(struct path *path)` - Return full path
 
 Some of these are asynchronous: the kernel queues the event, but some time later (milliseconds) it is
 processed in user-space. The asynchronous actions are: `printf()`, `time()`, and `join()`. Both `ksym()`
@@ -2750,6 +2752,33 @@ Attaching 1 probe...
 13:11:25
 13:11:26
 ^C
+```
+
+## 25. `path()`: Return full path
+
+Syntax:
+- `path(struct path *path)`
+
+Return full path referenced by struct path pointer in argument.
+There's list of allowed kernel functions, that can use this
+helper in probe.
+
+Examples:
+```
+# bpftrace  -e 'kfunc:filp_close { printf("%s\n", path(args->filp->f_path)); }'
+Attaching 1 probe...
+/proc/sys/net/ipv6/conf/eno2/disable_ipv6
+/proc/sys/net/ipv6/conf/eno2/use_tempaddr
+socket:[23276]
+/proc/sys/net/ipv6/conf/eno2/disable_ipv6
+socket:[17655]
+/sys/devices/pci0000:00/0000:00:1c.5/0000:04:00.1/net/eno2/type
+socket:[38745]
+/proc/sys/net/ipv6/conf/eno2/disable_ipv6
+
+# bpftrace  -e 'kretfunc:dentry_open { printf("%s\n", path(retval->f_path)); }'
+Attaching 1 probe...
+/dev/pts/1 -> /dev/pts/1
 ```
 
 # Map Functions

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -606,7 +606,7 @@ void CodegenLLVM::visit(Call &call)
     AllocaInst *buf = b_.CreateAllocaBPF(bpftrace_.strlen_, "path");
     b_.CREATE_MEMSET(buf, b_.getInt8(0), bpftrace_.strlen_, 1);
     call.vargs->front()->accept(*this);
-    b_.CreatePath(buf, expr_);
+    b_.CreatePath(ctx_, buf, expr_, call.loc);
     expr_ = buf;
     expr_deleter_ = [this, buf]() { b_.CreateLifetimeEnd(buf); };
   }

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -601,6 +601,15 @@ void CodegenLLVM::visit(Call &call)
     expr_ = buf;
     expr_deleter_ = [this, buf]() { b_.CreateLifetimeEnd(buf); };
   }
+  else if (call.func == "path")
+  {
+    AllocaInst *buf = b_.CreateAllocaBPF(bpftrace_.strlen_, "path");
+    b_.CREATE_MEMSET(buf, b_.getInt8(0), bpftrace_.strlen_, 1);
+    call.vargs->front()->accept(*this);
+    b_.CreatePath(buf, expr_);
+    expr_ = buf;
+    expr_deleter_ = [this, buf]() { b_.CreateLifetimeEnd(buf); };
+  }
   else if (call.func == "kaddr")
   {
     uint64_t addr;

--- a/src/ast/field_analyser.cpp
+++ b/src/ast/field_analyser.cpp
@@ -358,6 +358,9 @@ void FieldAnalyser::visit(AttachPoint &ap)
       {
         auto stype = arg.second;
 
+        if (stype.IsPtrTy())
+          stype = *stype.GetPointeeTy();
+
         if (stype.IsRecordTy())
           bpftrace_.btf_set_.insert(stype.GetName());
       }

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1147,5 +1147,19 @@ void IRBuilderBPF::CreateHelperErrorCond(Value *ctx,
   SetInsertPoint(helper_merge_block);
 }
 
+void IRBuilderBPF::CreatePath(AllocaInst *buf, Value *path)
+{
+  // int bpf_d_path(struct path *path, char *buf, u32 sz)
+  // Return: 0 or error
+  FunctionType *d_path_func_type = FunctionType::get(
+      getInt64Ty(), { getInt8PtrTy(), buf->getType(), getInt32Ty() }, false);
+  PointerType *d_path_func_ptr_type = PointerType::get(d_path_func_type, 0);
+  Constant *d_path_func = ConstantExpr::getCast(Instruction::IntToPtr,
+                                                getInt64(
+                                                    libbpf::BPF_FUNC_d_path),
+                                                d_path_func_ptr_type);
+  createCall(d_path_func, { path, buf, getInt32(bpftrace_.strlen_) }, "d_path");
+}
+
 } // namespace ast
 } // namespace bpftrace

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1147,7 +1147,10 @@ void IRBuilderBPF::CreateHelperErrorCond(Value *ctx,
   SetInsertPoint(helper_merge_block);
 }
 
-void IRBuilderBPF::CreatePath(AllocaInst *buf, Value *path)
+void IRBuilderBPF::CreatePath(Value *ctx,
+                              AllocaInst *buf,
+                              Value *path,
+                              const location &loc)
 {
   // int bpf_d_path(struct path *path, char *buf, u32 sz)
   // Return: 0 or error
@@ -1158,7 +1161,10 @@ void IRBuilderBPF::CreatePath(AllocaInst *buf, Value *path)
                                                 getInt64(
                                                     libbpf::BPF_FUNC_d_path),
                                                 d_path_func_ptr_type);
-  createCall(d_path_func, { path, buf, getInt32(bpftrace_.strlen_) }, "d_path");
+  CallInst *call = createCall(d_path_func,
+                              { path, buf, getInt32(bpftrace_.strlen_) },
+                              "d_path");
+  CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_d_path, loc);
 }
 
 } // namespace ast

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -159,6 +159,7 @@ public:
   StructType *GetStructType(std::string name, const std::vector<llvm::Type *> & elements, bool packed = false);
   AllocaInst *CreateUSym(llvm::Value *val);
   Value      *CreatKFuncArg(Value *ctx, SizedType& type, std::string& name);
+  void        CreatePath(AllocaInst *buf, Value *path);
   int helper_error_id_ = 0;
 
 private:

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -159,7 +159,10 @@ public:
   StructType *GetStructType(std::string name, const std::vector<llvm::Type *> & elements, bool packed = false);
   AllocaInst *CreateUSym(llvm::Value *val);
   Value      *CreatKFuncArg(Value *ctx, SizedType& type, std::string& name);
-  void        CreatePath(AllocaInst *buf, Value *path);
+  void CreatePath(Value *ctx,
+                  AllocaInst *buf,
+                  Value *path,
+                  const location &loc);
   int helper_error_id_ = 0;
 
 private:

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -75,7 +75,11 @@ private:
   bool check_assignment(const Call &call, bool want_map, bool want_var, bool want_map_key);
   bool check_nargs(const Call &call, size_t expected_nargs);
   bool check_varargs(const Call &call, size_t min_nargs, size_t max_nargs);
-  bool check_arg(const Call &call, Type type, int arg_num, bool want_literal=false);
+  bool check_arg(const Call &call,
+                 Type type,
+                 int arg_num,
+                 bool want_literal = false,
+                 bool fail = true);
   bool check_symbol(const Call &call, int arg_num);
 
   void check_stack_call(Call &call, bool kernel);

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -69,6 +69,7 @@ public:
   bool has_loop();
   bool has_btf();
   bool has_map_batch();
+  bool has_d_path();
 
   std::string report(void);
 
@@ -95,6 +96,7 @@ public:
 
 protected:
   std::optional<bool> has_loop_;
+  std::optional<bool> has_d_path_;
   std::optional<int> insns_limit_;
   std::optional<bool> has_map_batch_;
 

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -30,7 +30,7 @@ vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#\*])*:
 builtin  arg[0-9]|args|cgroup|comm|cpid|cpu|ctx|curtask|elapsed|func|gid|nsecs|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
-call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|max|min|ntop|override|print|printf|reg|signal|sizeof|stats|str|strftime|strncmp|sum|system|time|uaddr|uptr|usym|zero
+call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|max|min|ntop|override|print|printf|reg|signal|sizeof|stats|str|strftime|strncmp|sum|system|time|uaddr|uptr|usym|zero|path
 
 /* Don't add to this! Use builtin OR call not both */
 call_and_builtin kstack|ustack

--- a/src/libbpf/bpf.h
+++ b/src/libbpf/bpf.h
@@ -201,7 +201,19 @@ enum bpf_prog_type {
 	FN(ringbuf_submit),		\
 	FN(ringbuf_discard),		\
 	FN(ringbuf_query),		\
-	FN(csum_level),
+	FN(csum_level),			\
+	FN(skc_to_tcp6_sock),		\
+	FN(skc_to_tcp_sock),		\
+	FN(skc_to_tcp_timewait_sock),	\
+	FN(skc_to_tcp_request_sock),	\
+	FN(skc_to_udp6_sock),		\
+	FN(get_task_stack),		\
+	FN(load_hdr_opt),		\
+	FN(store_hdr_opt),		\
+	FN(reserve_hdr_opt),		\
+	FN(inode_storage_get),		\
+	FN(inode_storage_delete),	\
+	FN(d_path),
 
 
 /* integer value in 'imm' field of BPF_CALL instruction selects which helper

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -70,6 +70,7 @@ public:
     has_loop_ = std::make_optional<bool>(has_features);
     has_probe_read_kernel_ = std::make_optional<bool>(has_features);
     has_features_ = has_features;
+    has_d_path_ = std::make_optional<bool>(has_features);
   };
   bool has_features_;
 };

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -242,3 +242,10 @@ NAME print_hist_with_large_top_arg
 RUN bpftrace -e 'BEGIN { print("BEGIN"); @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 10); print("END"); clear(@); exit(); } '
 EXPECT BEGIN\n@\[1\]:(.*\n)+@\[2\]:(.*\n)+@\[3\]:(.*\n)+END
 TIMEOUT 1
+
+NAME path
+RUN bpftrace -ve 'kfunc:filp_close { $f = path(args->filp->f_path); if (!strncmp($f, "/tmp/bpftrace_runtime_test_syscall_gen_read_temp", 49)) { printf("OK\n"); exit(); } }'
+EXPECT OK
+REQUIRES_FEATURE dpath
+TIMEOUT 5
+AFTER ./testprogs/syscall read

--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -98,7 +98,7 @@ class TestParser(object):
                 arch = [x.strip() for x in line.split("|")]
             elif item_name == 'REQUIRES_FEATURE':
                 feature_requirement = {x.strip() for x in line.split(" ")}
-                unknown = feature_requirement - {"loop", "btf", "probe_read_kernel"}
+                unknown = feature_requirement - {"loop", "btf", "probe_read_kernel", "dpath"}
                 if len(unknown) > 0:
                     raise UnknownFieldError('%s is invalid for REQUIRES_FEATURE. Suite: %s' % (','.join(unknown), test_suite))
             else:

--- a/tests/runtime/engine/utils.py
+++ b/tests/runtime/engine/utils.py
@@ -98,6 +98,7 @@ class Utils(object):
         bpffeature["loop"] = output.find("Loop support: yes") != -1
         bpffeature["probe_read_kernel"] = output.find("probe_read_kernel: yes") != -1
         bpffeature["btf"] = output.find("btf (depends on Build:libbpf): yes") != -1
+        bpffeature["dpath"] = output.find("dpath: yes") != -1
         return bpffeature
 
     @staticmethod

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1858,6 +1858,19 @@ TEST(semantic_analyser, call_kptr_uptr)
   test("k:f { $a = uptr(arg0); }", 0);
 }
 
+TEST(semantic_analyser, call_path)
+{
+  test("kprobe:f { $k = path( arg0 ) }", 1);
+  test("kretprobe:f { $k = path( arg0 ) }", 1);
+  test("tracepoint:category:event { $k = path( NULL ) }", 1);
+  test("kprobe:f { $k = path( arg0 ) }", 1);
+  test("kretprobe:f{ $k = path( \"abc\" ) }", 1);
+  test("tracepoint:category:event { $k = path( -100 ) }", 1);
+  test("uprobe:/bin/bash:f { $k = path( arg0 ) }", 1);
+  test("BEGIN { $k = path( 1 ) }", 1);
+  test("END { $k = path( 1 ) }", 1);
+}
+
 #ifdef HAVE_LIBBPF_BTF_DUMP
 
 #include "btf_common.h"
@@ -1899,6 +1912,12 @@ TEST_F(semantic_analyser_btf, short_name)
 {
   test("f:func_1 { 1 }", 0);
   test("fr:func_1 { 1 }", 0);
+}
+
+TEST_F(semantic_analyser_btf, call_path)
+{
+  test("kfunc:func_1 { $k = path( args->foo1 ) }", 0);
+  test("kretfunc:func_1 { $k = path( retval->foo1 ) }", 0);
 }
 
 #endif // HAVE_LIBBPF_BTF_DUMP


### PR DESCRIPTION
Adding dpath builtin function that returns full path
referenced by struct path pointer in argument.

`  dpath(struct path *path)`

Example:

```
  # bpftrace  -e 'kfunc:filp_close { printf("%s\n", dpath(args->filp->f_path)); }'
  Attaching 1 probe...
  /proc/sys/net/ipv6/conf/eno2/disable_ipv6
  /proc/sys/net/ipv6/conf/eno2/use_tempaddr
  socket:[23276]
  /proc/sys/net/ipv6/conf/eno2/disable_ipv6
  socket:[17655]
  /sys/devices/pci0000:00/0000:00:1c.5/0000:04:00.1/net/eno2/type
  socket:[38745]
  /proc/sys/net/ipv6/conf/eno2/disable_ipv6
```

The dpath returns the string with the path or empty string
on error. I don't think it's necessary to return error code
at the moment, however it can be added later in the second
optional argument.
