### PR TITLE
Safer getMapKey()

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -310,21 +310,20 @@ void CodegenLLVM::visit(Call &call)
   if (call.func == "count")
   {
     Map &map = *call.map;
-    AllocaInst *key = getMapKey(map);
+    auto [key, scoped_key_deleter] = getMapKey(map);
     Value *oldval = b_.CreateMapLookupElem(ctx_, map, key, call.loc);
     AllocaInst *newval = b_.CreateAllocaBPF(map.type, map.ident + "_val");
     b_.CreateStore(b_.CreateAdd(oldval, b_.getInt64(1)), newval);
     b_.CreateMapUpdateElem(ctx_, map, key, newval, call.loc);
 
     // oldval can only be an integer so won't be in memory and doesn't need lifetime end
-    b_.CreateLifetimeEnd(key);
     b_.CreateLifetimeEnd(newval);
     expr_ = nullptr;
   }
   else if (call.func == "sum")
   {
     Map &map = *call.map;
-    AllocaInst *key = getMapKey(map);
+    auto [key, scoped_key_deleter] = getMapKey(map);
     Value *oldval = b_.CreateMapLookupElem(ctx_, map, key, call.loc);
     AllocaInst *newval = b_.CreateAllocaBPF(map.type, map.ident + "_val");
 
@@ -337,14 +336,13 @@ void CodegenLLVM::visit(Call &call)
     b_.CreateMapUpdateElem(ctx_, map, key, newval, call.loc);
 
     // oldval can only be an integer so won't be in memory and doesn't need lifetime end
-    b_.CreateLifetimeEnd(key);
     b_.CreateLifetimeEnd(newval);
     expr_ = nullptr;
   }
   else if (call.func == "min")
   {
     Map &map = *call.map;
-    AllocaInst *key = getMapKey(map);
+    auto [key, scoped_key_deleter] = getMapKey(map);
     Value *oldval = b_.CreateMapLookupElem(ctx_, map, key, call.loc);
     AllocaInst *newval = b_.CreateAllocaBPF(map.type, map.ident + "_val");
 
@@ -367,14 +365,13 @@ void CodegenLLVM::visit(Call &call)
     b_.CreateBr(lt);
 
     b_.SetInsertPoint(lt);
-    b_.CreateLifetimeEnd(key);
     b_.CreateLifetimeEnd(newval);
     expr_ = nullptr;
   }
   else if (call.func == "max")
   {
     Map &map = *call.map;
-    AllocaInst *key = getMapKey(map);
+    auto [key, scoped_key_deleter] = getMapKey(map);
     Value *oldval = b_.CreateMapLookupElem(ctx_, map, key, call.loc);
     AllocaInst *newval = b_.CreateAllocaBPF(map.type, map.ident + "_val");
 
@@ -394,7 +391,6 @@ void CodegenLLVM::visit(Call &call)
     b_.CreateBr(lt);
 
     b_.SetInsertPoint(lt);
-    b_.CreateLifetimeEnd(key);
     b_.CreateLifetimeEnd(newval);
     expr_ = nullptr;
   }
@@ -502,9 +498,8 @@ void CodegenLLVM::visit(Call &call)
   {
     auto &arg = *call.vargs->at(0);
     auto &map = static_cast<Map&>(arg);
-    AllocaInst *key = getMapKey(map);
+    auto [key, scoped_key_deleter] = getMapKey(map);
     b_.CreateMapDeleteElem(ctx_, map, key, call.loc);
-    b_.CreateLifetimeEnd(key);
     expr_ = nullptr;
   }
   else if (call.func == "str")
@@ -991,13 +986,12 @@ void CodegenLLVM::visit(Call &call)
 
 void CodegenLLVM::visit(Map &map)
 {
-  AllocaInst *key = getMapKey(map);
+  auto [key, scoped_key_deleter] = getMapKey(map);
   Value *value = b_.CreateMapLookupElem(ctx_, map, key, map.loc);
   expr_ = value;
 
   if (dyn_cast<AllocaInst>(value))
     expr_deleter_ = [this, value]() { b_.CreateLifetimeEnd(value); };
-  b_.CreateLifetimeEnd(key);
 }
 
 void CodegenLLVM::visit(Variable &var)
@@ -1217,7 +1211,7 @@ void CodegenLLVM::visit(Unop &unop)
         if (unop.expr->is_map)
         {
           Map &map = static_cast<Map&>(*unop.expr);
-          AllocaInst *key = getMapKey(map);
+          auto [key, scoped_key_deleter] = getMapKey(map);
           Value *oldval = b_.CreateMapLookupElem(ctx_, map, key, unop.loc);
           AllocaInst *newval = b_.CreateAllocaBPF(map.type, map.ident + "_newval");
           if (is_increment)
@@ -1225,7 +1219,6 @@ void CodegenLLVM::visit(Unop &unop)
           else
             b_.CreateStore(b_.CreateSub(oldval, b_.getInt64(1)), newval);
           b_.CreateMapUpdateElem(ctx_, map, key, newval, unop.loc);
-          b_.CreateLifetimeEnd(key);
 
           if (unop.is_post_op)
             expr_ = oldval;
@@ -1647,28 +1640,26 @@ void CodegenLLVM::visit(AssignMapStatement &assignment)
   if (!expr_) // Some functions do the assignments themselves
     return;
 
-  Value *val, *expr;
-  expr = expr_;
-  AllocaInst *key = getMapKey(map);
+  Value *val;
   if (shouldBeOnStackAlready(assignment.expr->type))
   {
-    val = expr;
+    val = expr_;
   }
   else if (map.type.IsRecordTy())
   {
     if (assignment.expr->type.is_internal)
     {
-      val = expr;
+      val = expr_;
     }
     else
     {
-      // expr currently contains a pointer to the struct
+      // expr_ currently contains a pointer to the struct
       // We now want to read the entire struct in so we can save it
       AllocaInst *dst = b_.CreateAllocaBPF(map.type, map.ident + "_val");
       b_.CreateProbeRead(ctx_,
                          dst,
                          map.type.size,
-                         expr,
+                         expr_,
                          assignment.expr->type.GetAS(),
                          assignment.loc);
       val = dst;
@@ -1680,12 +1671,13 @@ void CodegenLLVM::visit(AssignMapStatement &assignment)
     // expr currently contains a pointer to the struct
     // and that's what we are saving
     AllocaInst *dst = b_.CreateAllocaBPF(map.type, map.ident + "_ptr");
-    b_.CreateStore(expr, dst);
+    b_.CreateStore(expr_, dst);
     val = dst;
     self_alloca = true;
   }
   else
   {
+    Value *expr = expr_;
     if (map.type.IsIntTy())
     {
       // Integers are always stored as 64-bit in map values
@@ -1695,8 +1687,8 @@ void CodegenLLVM::visit(AssignMapStatement &assignment)
     b_.CreateStore(expr, val);
     self_alloca = true;
   }
+  auto [key, scoped_key_deleter] = getMapKey(map);
   b_.CreateMapUpdateElem(ctx_, map, key, val, assignment.loc);
-  b_.CreateLifetimeEnd(key);
   if (self_alloca)
     b_.CreateLifetimeEnd(val);
 }
@@ -2085,9 +2077,10 @@ std::string CodegenLLVM::getSectionNameForProbe(const std::string &probe_name, i
   return "s_" + probe_name + "_" + std::to_string(index);
 }
 
-AllocaInst *CodegenLLVM::getMapKey(Map &map)
+std::tuple<Value *, CodegenLLVM::ScopedExprDeleter> CodegenLLVM::getMapKey(
+    Map &map)
 {
-  AllocaInst *key;
+  Value *key;
   if (map.vargs) {
     // A single value as a map key (e.g., @[comm] = 0;)
     if (map.vargs->size() == 1)
@@ -2096,7 +2089,7 @@ AllocaInst *CodegenLLVM::getMapKey(Map &map)
       auto scoped_del = accept(expr);
       if (shouldBeOnStackAlready(expr->type))
       {
-        key = dyn_cast<AllocaInst>(expr_);
+        key = expr_;
         // Call-ee freed
         scoped_del.disarm();
       }
@@ -2146,7 +2139,11 @@ AllocaInst *CodegenLLVM::getMapKey(Map &map)
     key = b_.CreateAllocaBPF(CreateUInt64(), map.ident + "_key");
     b_.CreateStore(b_.getInt64(0), key);
   }
-  return key;
+  auto key_deleter = [this, key]() {
+    if (dyn_cast<AllocaInst>(key))
+      b_.CreateLifetimeEnd(key);
+  };
+  return std::make_tuple(key, ScopedExprDeleter(std::move(key_deleter)));
 }
 
 AllocaInst *CodegenLLVM::getHistMapKey(Map &map, Value *log2)

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -2,6 +2,7 @@
 
 #include <iostream>
 #include <ostream>
+#include <tuple>
 
 #include "ast.h"
 #include "bpftrace.h"
@@ -51,7 +52,6 @@ public:
   void visit(AttachPoint &ap) override;
   void visit(Probe &probe) override;
   void visit(Program &program) override;
-  AllocaInst *getMapKey(Map &map);
   AllocaInst *getHistMapKey(Map &map, Value *log2);
   int         getNextIndexForProbe(const std::string &probe_name);
   std::string getSectionNameForProbe(const std::string &probe_name, int index);
@@ -83,6 +83,11 @@ private:
       deleter_ = std::move(deleter);
     }
 
+    ScopedExprDeleter(const ScopedExprDeleter &other) = delete;
+    ScopedExprDeleter &operator=(const ScopedExprDeleter &other) = delete;
+    ScopedExprDeleter(ScopedExprDeleter &&other) = default;
+    ScopedExprDeleter &operator=(ScopedExprDeleter &&other) = default;
+
     ~ScopedExprDeleter()
     {
       if (deleter_)
@@ -106,6 +111,7 @@ private:
                      FunctionType *func_type,
                      bool expansion);
   [[nodiscard]] ScopedExprDeleter accept(Node *node);
+  [[nodiscard]] std::tuple<Value *, ScopedExprDeleter> getMapKey(Map &map);
 
   Function *createLog2Function();
   Function *createLinearFunction();

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -293,7 +293,7 @@ CallInst *IRBuilderBPF::CreateBpfPseudoCall(Map &map)
   return CreateBpfPseudoCall(mapfd);
 }
 
-CallInst *IRBuilderBPF::createMapLookup(int mapfd, AllocaInst *key)
+CallInst *IRBuilderBPF::createMapLookup(int mapfd, Value *key)
 {
   Value *map_ptr = CreateBpfPseudoCall(mapfd);
   // void *map_lookup_elem(struct bpf_map * map, void * key)
@@ -322,7 +322,7 @@ CallInst *IRBuilderBPF::CreateGetJoinMap(Value *ctx, const location &loc)
 
 Value *IRBuilderBPF::CreateMapLookupElem(Value *ctx,
                                          Map &map,
-                                         AllocaInst *key,
+                                         Value *key,
                                          const location &loc)
 {
   assert(ctx && ctx->getType() == getInt8PtrTy());
@@ -332,7 +332,7 @@ Value *IRBuilderBPF::CreateMapLookupElem(Value *ctx,
 
 Value *IRBuilderBPF::CreateMapLookupElem(Value *ctx,
                                          int mapfd,
-                                         AllocaInst *key,
+                                         Value *key,
                                          SizedType &type,
                                          const location &loc)
 {
@@ -384,7 +384,7 @@ Value *IRBuilderBPF::CreateMapLookupElem(Value *ctx,
 
 void IRBuilderBPF::CreateMapUpdateElem(Value *ctx,
                                        Map &map,
-                                       AllocaInst *key,
+                                       Value *key,
                                        Value *val,
                                        const location &loc)
 {
@@ -415,7 +415,7 @@ void IRBuilderBPF::CreateMapUpdateElem(Value *ctx,
 
 void IRBuilderBPF::CreateMapDeleteElem(Value *ctx,
                                        Map &map,
-                                       AllocaInst *key,
+                                       Value *key,
                                        const location &loc)
 {
   assert(ctx && ctx->getType() == getInt8PtrTy());

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -58,21 +58,21 @@ public:
   CallInst   *CreateBpfPseudoCall(Map &map);
   Value *CreateMapLookupElem(Value *ctx,
                              Map &map,
-                             AllocaInst *key,
+                             Value *key,
                              const location &loc);
   Value *CreateMapLookupElem(Value *ctx,
                              int mapfd,
-                             AllocaInst *key,
+                             Value *key,
                              SizedType &type,
                              const location &loc);
   void CreateMapUpdateElem(Value *ctx,
                            Map &map,
-                           AllocaInst *key,
+                           Value *key,
                            Value *val,
                            const location &loc);
   void CreateMapDeleteElem(Value *ctx,
                            Map &map,
-                           AllocaInst *key,
+                           Value *key,
                            const location &loc);
   void CreateProbeRead(Value *ctx,
                        AllocaInst *dst,
@@ -170,7 +170,7 @@ private:
                                 Builtin &builtin,
                                 AddrSpace as,
                                 const location &loc);
-  CallInst   *createMapLookup(int mapfd, AllocaInst *key);
+  CallInst *createMapLookup(int mapfd, Value *key);
   Constant *createProbeReadStrFn(llvm::Type *dst,
                                  llvm::Type *src,
                                  AddrSpace as);

--- a/tests/codegen/llvm/args_multiple_tracepoints.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints.ll
@@ -46,9 +46,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %12, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  %13 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@_val" to i8*
+  %14 = bitcast [8 x i8]* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
@@ -99,9 +99,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %12, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  %13 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@_val" to i8*
+  %14 = bitcast [8 x i8]* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }

--- a/tests/codegen/llvm/args_multiple_tracepoints_category_wild.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints_category_wild.ll
@@ -46,9 +46,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %12, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  %13 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@_val" to i8*
+  %14 = bitcast [8 x i8]* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
@@ -99,9 +99,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %12, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  %13 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@_val" to i8*
+  %14 = bitcast [8 x i8]* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
@@ -146,9 +146,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %12, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  %13 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@_val" to i8*
+  %14 = bitcast [8 x i8]* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }

--- a/tests/codegen/llvm/args_multiple_tracepoints_wild.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints_wild.ll
@@ -46,9 +46,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %12, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  %13 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@_val" to i8*
+  %14 = bitcast [8 x i8]* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
@@ -99,9 +99,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %12, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  %13 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@_val" to i8*
+  %14 = bitcast [8 x i8]* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }

--- a/tests/codegen/llvm/basic_while_loop.ll
+++ b/tests/codegen/llvm/basic_while_loop.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"interval:s:1"(i8*) section "s_interval:s:1_1" {
 entry:
-  %"@_val" = alloca i64
   %"@_key" = alloca i64
+  %"@_val" = alloca i64
   %"$a" = alloca i64
   %1 = bitcast i64* %"$a" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -30,17 +30,17 @@ while_body:                                       ; preds = %while_cond
   %6 = load i64, i64* %"$a"
   %7 = add i64 %6, 1
   store i64 %7, i64* %"$a"
-  %8 = bitcast i64* %"@_key" to i8*
+  %8 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  store i64 0, i64* %"@_key"
-  %9 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 %6, i64* %"@_val"
+  %9 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i64 0, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
-  %10 = bitcast i64* %"@_key" to i8*
+  %10 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@_val" to i8*
+  %11 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   br label %while_cond
 

--- a/tests/codegen/llvm/bitshift_left.ll
+++ b/tests/codegen/llvm/bitshift_left.ll
@@ -8,19 +8,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 1024, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/bitshift_right.ll
+++ b/tests/codegen/llvm/bitshift_right.ll
@@ -8,19 +8,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 2, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/bitwise_not.ll
+++ b/tests/codegen/llvm/bitwise_not.ll
@@ -8,19 +8,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @BEGIN(i8*) section "s_BEGIN_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 -11, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_arg.ll
+++ b/tests/codegen/llvm/builtin_arg.ll
@@ -8,39 +8,39 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@y_val" = alloca i64
   %"@y_key" = alloca i64
-  %"@x_val" = alloca i64
+  %"@y_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 14
   %arg0 = load volatile i64, i64* %2
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@x_key"
-  %4 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"@x_val"
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %5 = bitcast i64* %"@x_key" to i8*
+  %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@x_val" to i8*
+  %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   %7 = bitcast i8* %0 to i64*
   %8 = getelementptr i64, i64* %7, i64 12
   %arg2 = load volatile i64, i64* %8
-  %9 = bitcast i64* %"@y_key" to i8*
+  %9 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store i64 0, i64* %"@y_key"
-  %10 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 %arg2, i64* %"@y_val"
+  %10 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i64 0, i64* %"@y_key"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem2 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@y_key", i64* %"@y_val", i64 0)
-  %11 = bitcast i64* %"@y_key" to i8*
+  %11 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@y_val" to i8*
+  %12 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_cpid.ll
+++ b/tests/codegen/llvm/builtin_cpid.ll
@@ -8,19 +8,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@_val" = alloca i64
   %"@_key" = alloca i64
-  %1 = bitcast i64* %"@_key" to i8*
+  %"@_val" = alloca i64
+  %1 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@_key"
-  %2 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 1337, i64* %"@_val"
+  %2 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
-  %3 = bitcast i64* %"@_key" to i8*
+  %3 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@_val" to i8*
+  %4 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_cpu.ll
+++ b/tests/codegen/llvm/builtin_cpu.ll
@@ -8,20 +8,20 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
-  %1 = bitcast i64* %"@x_key" to i8*
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 %get_cpu_id, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_ctx.ll
+++ b/tests/codegen/llvm/builtin_ctx.ll
@@ -8,20 +8,20 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %1 = ptrtoint i8* %0 to i64
-  %2 = bitcast i64* %"@x_key" to i8*
+  %2 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 0, i64* %"@x_key"
-  %3 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   store i64 %1, i64* %"@x_val"
+  %3 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %4 = bitcast i64* %"@x_key" to i8*
+  %4 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
-  %5 = bitcast i64* %"@x_val" to i8*
+  %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_ctx_field.ll
+++ b/tests/codegen/llvm/builtin_ctx_field.ll
@@ -10,15 +10,15 @@ define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %"@e_key" = alloca i64
   %"struct x.e" = alloca [4 x i8]
-  %"@d_val" = alloca i64
   %"@d_key" = alloca i64
+  %"@d_val" = alloca i64
   %"struct c.c" = alloca i8
-  %"@c_val" = alloca i64
   %"@c_key" = alloca i64
-  %"@b_val" = alloca i64
+  %"@c_val" = alloca i64
   %"@b_key" = alloca i64
-  %"@a_val" = alloca i64
+  %"@b_val" = alloca i64
   %"@a_key" = alloca i64
+  %"@a_val" = alloca i64
   %"$x" = alloca i64
   %1 = bitcast i64* %"$x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -31,35 +31,35 @@ entry:
   %5 = add i64 %4, 0
   %6 = inttoptr i64 %5 to i64*
   %7 = load volatile i64, i64* %6
-  %8 = bitcast i64* %"@a_key" to i8*
+  %8 = bitcast i64* %"@a_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  store i64 0, i64* %"@a_key"
-  %9 = bitcast i64* %"@a_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 %7, i64* %"@a_val"
+  %9 = bitcast i64* %"@a_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i64 0, i64* %"@a_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@a_key", i64* %"@a_val", i64 0)
-  %10 = bitcast i64* %"@a_key" to i8*
+  %10 = bitcast i64* %"@a_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@a_val" to i8*
+  %11 = bitcast i64* %"@a_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   %12 = load i64, i64* %"$x"
   %13 = add i64 %12, 8
   %14 = add i64 %13, 0
   %15 = inttoptr i64 %14 to i16*
   %16 = load volatile i16, i16* %15
-  %17 = bitcast i64* %"@b_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
-  store i64 0, i64* %"@b_key"
-  %18 = sext i16 %16 to i64
-  %19 = bitcast i64* %"@b_val" to i8*
+  %17 = sext i16 %16 to i64
+  %18 = bitcast i64* %"@b_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
+  store i64 %17, i64* %"@b_val"
+  %19 = bitcast i64* %"@b_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
-  store i64 %18, i64* %"@b_val"
+  store i64 0, i64* %"@b_key"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem2 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@b_key", i64* %"@b_val", i64 0)
-  %20 = bitcast i64* %"@b_key" to i8*
+  %20 = bitcast i64* %"@b_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  %21 = bitcast i64* %"@b_val" to i8*
+  %21 = bitcast i64* %"@b_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
   %22 = load i64, i64* %"$x"
   %23 = add i64 %22, 16
@@ -67,17 +67,17 @@ entry:
   %25 = inttoptr i64 %24 to i8*
   %26 = load volatile i8, i8* %25
   %27 = sext i8 %26 to i64
-  %28 = bitcast i64* %"@c_key" to i8*
+  %28 = bitcast i64* %"@c_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %28)
-  store i64 0, i64* %"@c_key"
-  %29 = bitcast i64* %"@c_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %29)
   store i64 %27, i64* %"@c_val"
+  %29 = bitcast i64* %"@c_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %29)
+  store i64 0, i64* %"@c_key"
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
   %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo3, i64* %"@c_key", i64* %"@c_val", i64 0)
-  %30 = bitcast i64* %"@c_key" to i8*
+  %30 = bitcast i64* %"@c_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %30)
-  %31 = bitcast i64* %"@c_val" to i8*
+  %31 = bitcast i64* %"@c_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %31)
   %32 = load i64, i64* %"$x"
   %33 = add i64 %32, 24
@@ -89,17 +89,17 @@ entry:
   %37 = load i8, i8* %"struct c.c"
   %38 = sext i8 %37 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct c.c")
-  %39 = bitcast i64* %"@d_key" to i8*
+  %39 = bitcast i64* %"@d_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %39)
-  store i64 0, i64* %"@d_key"
-  %40 = bitcast i64* %"@d_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %40)
   store i64 %38, i64* %"@d_val"
+  %40 = bitcast i64* %"@d_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %40)
+  store i64 0, i64* %"@d_key"
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 4)
   %update_elem6 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo5, i64* %"@d_key", i64* %"@d_val", i64 0)
-  %41 = bitcast i64* %"@d_key" to i8*
+  %41 = bitcast i64* %"@d_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %41)
-  %42 = bitcast i64* %"@d_val" to i8*
+  %42 = bitcast i64* %"@d_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %42)
   %43 = load i64, i64* %"$x"
   %44 = add i64 %43, 32

--- a/tests/codegen/llvm/builtin_curtask.ll
+++ b/tests/codegen/llvm/builtin_curtask.ll
@@ -8,20 +8,20 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_ptr" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_ptr" = alloca i64
   %get_cur_task = call i64 inttoptr (i64 35 to i64 ()*)()
-  %1 = bitcast i64* %"@x_key" to i8*
+  %1 = bitcast i64* %"@x_ptr" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_ptr" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 %get_cur_task, i64* %"@x_ptr"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_ptr", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_ptr" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_ptr" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_elapsed.ll
+++ b/tests/codegen/llvm/builtin_elapsed.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"interval:s:1"(i8*) section "s_interval:s:1_1" {
 entry:
-  %"@_val" = alloca i64
   %"@_key" = alloca i64
+  %"@_val" = alloca i64
   %lookup_elem_val = alloca i64
   %elapsed_key = alloca i64
   %1 = bitcast i64* %elapsed_key to i8*
@@ -40,17 +40,17 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   %6 = sub i64 %get_ns, %4
   %7 = bitcast i64* %elapsed_key to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@_key" to i8*
+  %8 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  store i64 0, i64* %"@_key"
-  %9 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 %6, i64* %"@_val"
+  %9 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i64 0, i64* %"@_key"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %"@_val", i64 0)
-  %10 = bitcast i64* %"@_key" to i8*
+  %10 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@_val" to i8*
+  %11 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_func.ll
+++ b/tests/codegen/llvm/builtin_func.ll
@@ -8,22 +8,22 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 16
   %func = load volatile i64, i64* %2
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@x_key"
-  %4 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %func, i64* %"@x_val"
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %5 = bitcast i64* %"@x_key" to i8*
+  %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@x_val" to i8*
+  %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_func_wild.ll
+++ b/tests/codegen/llvm/builtin_func_wild.ll
@@ -8,22 +8,22 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:do_execve*"(i8*) section "s_kprobe:do_execve*_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 16
   %func = load volatile i64, i64* %2
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@x_key"
-  %4 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %func, i64* %"@x_val"
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %5 = bitcast i64* %"@x_key" to i8*
+  %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@x_val" to i8*
+  %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_kstack.ll
+++ b/tests/codegen/llvm/builtin_kstack.ll
@@ -8,21 +8,21 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 0)
-  %1 = bitcast i64* %"@x_key" to i8*
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 %get_stackid, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_nsecs.ll
+++ b/tests/codegen/llvm/builtin_nsecs.ll
@@ -8,20 +8,20 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %get_ns = call i64 inttoptr (i64 5 to i64 ()*)()
-  %1 = bitcast i64* %"@x_key" to i8*
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 %get_ns, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_pid_tid.ll
+++ b/tests/codegen/llvm/builtin_pid_tid.ll
@@ -8,37 +8,37 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@y_val" = alloca i64
   %"@y_key" = alloca i64
-  %"@x_val" = alloca i64
+  %"@y_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = lshr i64 %get_pid_tgid, 32
-  %2 = bitcast i64* %"@x_key" to i8*
+  %2 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 0, i64* %"@x_key"
-  %3 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   store i64 %1, i64* %"@x_val"
+  %3 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %4 = bitcast i64* %"@x_key" to i8*
+  %4 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
-  %5 = bitcast i64* %"@x_val" to i8*
+  %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to i64 ()*)()
   %6 = and i64 %get_pid_tgid1, 4294967295
-  %7 = bitcast i64* %"@y_key" to i8*
+  %7 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  store i64 0, i64* %"@y_key"
-  %8 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 %6, i64* %"@y_val"
+  %8 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 0, i64* %"@y_key"
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem3 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@y_key", i64* %"@y_val", i64 0)
-  %9 = bitcast i64* %"@y_key" to i8*
+  %9 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@y_val" to i8*
+  %10 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_probe.ll
+++ b/tests/codegen/llvm/builtin_probe.ll
@@ -8,19 +8,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"tracepoint:sched:sched_one"(i8*) section "s_tracepoint:sched:sched_one_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 0, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_probe_wild.ll
+++ b/tests/codegen/llvm/builtin_probe_wild.ll
@@ -8,19 +8,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"tracepoint:sched:sched_one"(i8*) section "s_tracepoint:sched:sched_one_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 0, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_rand.ll
+++ b/tests/codegen/llvm/builtin_rand.ll
@@ -8,20 +8,20 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %get_random = call i64 inttoptr (i64 7 to i64 ()*)()
-  %1 = bitcast i64* %"@x_key" to i8*
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 %get_random, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_retval.ll
+++ b/tests/codegen/llvm/builtin_retval.ll
@@ -8,22 +8,22 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kretprobe:f"(i8*) section "s_kretprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 10
   %retval = load volatile i64, i64* %2
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@x_key"
-  %4 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %retval, i64* %"@x_val"
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %5 = bitcast i64* %"@x_key" to i8*
+  %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@x_val" to i8*
+  %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_sarg.ll
+++ b/tests/codegen/llvm/builtin_sarg.ll
@@ -8,11 +8,11 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@y_val" = alloca i64
   %"@y_key" = alloca i64
+  %"@y_val" = alloca i64
   %sarg2 = alloca i64
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %sarg0 = alloca i64
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 19
@@ -24,17 +24,17 @@ entry:
   %5 = load i64, i64* %sarg0
   %6 = bitcast i64* %sarg0 to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast i64* %"@x_key" to i8*
+  %7 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  store i64 0, i64* %"@x_key"
-  %8 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 %5, i64* %"@x_val"
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %9 = bitcast i64* %"@x_key" to i8*
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_val" to i8*
+  %10 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   %11 = bitcast i8* %0 to i64*
   %12 = getelementptr i64, i64* %11, i64 19
@@ -46,17 +46,17 @@ entry:
   %15 = load i64, i64* %sarg2
   %16 = bitcast i64* %sarg2 to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = bitcast i64* %"@y_key" to i8*
+  %17 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
-  store i64 0, i64* %"@y_key"
-  %18 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
   store i64 %15, i64* %"@y_val"
+  %18 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
+  store i64 0, i64* %"@y_key"
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo3, i64* %"@y_key", i64* %"@y_val", i64 0)
-  %19 = bitcast i64* %"@y_key" to i8*
+  %19 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
-  %20 = bitcast i64* %"@y_val" to i8*
+  %20 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_uid_gid.ll
+++ b/tests/codegen/llvm/builtin_uid_gid.ll
@@ -8,37 +8,37 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@y_val" = alloca i64
   %"@y_key" = alloca i64
-  %"@x_val" = alloca i64
+  %"@y_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %get_uid_gid = call i64 inttoptr (i64 15 to i64 ()*)()
   %1 = and i64 %get_uid_gid, 4294967295
-  %2 = bitcast i64* %"@x_key" to i8*
+  %2 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 0, i64* %"@x_key"
-  %3 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   store i64 %1, i64* %"@x_val"
+  %3 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %4 = bitcast i64* %"@x_key" to i8*
+  %4 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
-  %5 = bitcast i64* %"@x_val" to i8*
+  %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
   %get_uid_gid1 = call i64 inttoptr (i64 15 to i64 ()*)()
   %6 = lshr i64 %get_uid_gid1, 32
-  %7 = bitcast i64* %"@y_key" to i8*
+  %7 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  store i64 0, i64* %"@y_key"
-  %8 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 %6, i64* %"@y_val"
+  %8 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 0, i64* %"@y_key"
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem3 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@y_key", i64* %"@y_val", i64 0)
-  %9 = bitcast i64* %"@y_key" to i8*
+  %9 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@y_val" to i8*
+  %10 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_username.ll
+++ b/tests/codegen/llvm/builtin_username.ll
@@ -8,37 +8,37 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@y_val" = alloca i64
   %"@y_key" = alloca i64
-  %"@x_val" = alloca i64
+  %"@y_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %get_uid_gid = call i64 inttoptr (i64 15 to i64 ()*)()
   %1 = and i64 %get_uid_gid, 4294967295
-  %2 = bitcast i64* %"@x_key" to i8*
+  %2 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 0, i64* %"@x_key"
-  %3 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   store i64 %1, i64* %"@x_val"
+  %3 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %4 = bitcast i64* %"@x_key" to i8*
+  %4 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
-  %5 = bitcast i64* %"@x_val" to i8*
+  %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
   %get_uid_gid1 = call i64 inttoptr (i64 15 to i64 ()*)()
   %6 = lshr i64 %get_uid_gid1, 32
-  %7 = bitcast i64* %"@y_key" to i8*
+  %7 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  store i64 0, i64* %"@y_key"
-  %8 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 %6, i64* %"@y_val"
+  %8 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 0, i64* %"@y_key"
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem3 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@y_key", i64* %"@y_val", i64 0)
-  %9 = bitcast i64* %"@y_key" to i8*
+  %9 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@y_val" to i8*
+  %10 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }

--- a/tests/codegen/llvm/builtin_ustack.ll
+++ b/tests/codegen/llvm/builtin_ustack.ll
@@ -8,24 +8,24 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 256)
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = shl i64 %get_pid_tgid, 32
   %2 = or i64 %get_stackid, %1
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@x_key"
-  %4 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %2, i64* %"@x_val"
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 0, i64* %"@x_key"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %5 = bitcast i64* %"@x_key" to i8*
+  %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@x_val" to i8*
+  %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_cgroup.ll
+++ b/tests/codegen/llvm/call_cgroup.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"tracepoint:syscalls:sys_enter_openat"(i8*) section "s_tracepoint:syscalls:sys_enter_openat_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %get_cgroup_id = call i64 inttoptr (i64 80 to i64 ()*)()
   %1 = icmp eq i64 %get_cgroup_id, 4294967297
   %2 = zext i1 %1 to i64
@@ -21,17 +21,17 @@ pred_false:                                       ; preds = %entry
 
 pred_true:                                        ; preds = %entry
   %get_cgroup_id1 = call i64 inttoptr (i64 80 to i64 ()*)()
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@x_key"
-  %4 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %get_cgroup_id1, i64* %"@x_val"
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %5 = bitcast i64* %"@x_key" to i8*
+  %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@x_val" to i8*
+  %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_clear.ll
+++ b/tests/codegen/llvm/call_clear.ll
@@ -10,19 +10,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @BEGIN(i8*) section "s_BEGIN_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 1, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_count.ll
+++ b/tests/codegen/llvm/call_count.ll
@@ -41,9 +41,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %7, i64* %"@x_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %8 = bitcast i64* %"@x_key" to i8*
+  %8 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@x_val" to i8*
+  %9 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_delete.ll
+++ b/tests/codegen/llvm/call_delete.ll
@@ -9,19 +9,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %"@x_key1" = alloca i64
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 1, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   %5 = bitcast i64* %"@x_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)

--- a/tests/codegen/llvm/call_exit.ll
+++ b/tests/codegen/llvm/call_exit.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@_val" = alloca i64
   %"@_key" = alloca i64
+  %"@_val" = alloca i64
   %perfdata = alloca i64
   %1 = bitcast i64* %perfdata to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -22,17 +22,17 @@ entry:
   ret i64 0
 
 deadcode:                                         ; No predecessors!
-  %3 = bitcast i64* %"@_key" to i8*
+  %3 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@_key"
-  %4 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 10, i64* %"@_val"
+  %4 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 0, i64* %"@_key"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %"@_val", i64 0)
-  %5 = bitcast i64* %"@_key" to i8*
+  %5 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@_val" to i8*
+  %6 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_kstack.ll
+++ b/tests/codegen/llvm/call_kstack.ll
@@ -8,37 +8,37 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@y_val" = alloca i64
   %"@y_key" = alloca i64
-  %"@x_val" = alloca i64
+  %"@y_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 4)
   %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 0)
-  %1 = bitcast i64* %"@x_key" to i8*
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 %get_stackid, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
   %get_stackid3 = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo2, i64 0)
-  %5 = bitcast i64* %"@y_key" to i8*
+  %5 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  store i64 0, i64* %"@y_key"
-  %6 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   store i64 %get_stackid3, i64* %"@y_val"
+  %6 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  store i64 0, i64* %"@y_key"
   %pseudo4 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem5 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo4, i64* %"@y_key", i64* %"@y_val", i64 0)
-  %7 = bitcast i64* %"@y_key" to i8*
+  %7 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@y_val" to i8*
+  %8 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_max.ll
+++ b/tests/codegen/llvm/call_max.ll
@@ -43,9 +43,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   br i1 %8, label %min.ge, label %min.lt
 
 min.lt:                                           ; preds = %min.ge, %lookup_merge
-  %9 = bitcast i64* %"@x_key" to i8*
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_val" to i8*
+  %10 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 

--- a/tests/codegen/llvm/call_min.ll
+++ b/tests/codegen/llvm/call_min.ll
@@ -44,9 +44,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   br i1 %9, label %min.ge, label %min.lt
 
 min.lt:                                           ; preds = %min.ge, %lookup_merge
-  %10 = bitcast i64* %"@x_key" to i8*
+  %10 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_val" to i8*
+  %11 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   ret i64 0
 

--- a/tests/codegen/llvm/call_ntop_key.ll
+++ b/tests/codegen/llvm/call_ntop_key.ll
@@ -49,9 +49,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %11, i64* %"@x_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, %inet_t*, i64*, i64)*)(i64 %pseudo1, %inet_t* %inet, i64* %"@x_val", i64 0)
-  %12 = bitcast %inet_t* %inet to i8*
+  %12 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_val" to i8*
+  %13 = bitcast %inet_t* %inet to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_print.ll
+++ b/tests/codegen/llvm/call_print.ll
@@ -10,19 +10,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @BEGIN(i8*) section "s_BEGIN_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 1, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_reg.ll
+++ b/tests/codegen/llvm/call_reg.ll
@@ -8,22 +8,22 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 16
   %reg_ip = load volatile i64, i64* %2
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@x_key"
-  %4 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %reg_ip, i64* %"@x_val"
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %5 = bitcast i64* %"@x_key" to i8*
+  %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@x_val" to i8*
+  %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_sizeof.ll
+++ b/tests/codegen/llvm/call_sizeof.ll
@@ -8,19 +8,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @BEGIN(i8*) section "s_BEGIN_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 8, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_sum.ll
+++ b/tests/codegen/llvm/call_sum.ll
@@ -43,9 +43,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %8, i64* %"@x_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %9 = bitcast i64* %"@x_key" to i8*
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_val" to i8*
+  %10 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_uptr_1.ll
+++ b/tests/codegen/llvm/call_uptr_1.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@_val" = alloca i64
   %"@_key" = alloca i64
+  %"@_val" = alloca i64
   %deref = alloca i16
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 14
@@ -21,17 +21,17 @@ entry:
   %5 = sext i16 %4 to i64
   %6 = bitcast i16* %deref to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast i64* %"@_key" to i8*
+  %7 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  store i64 0, i64* %"@_key"
-  %8 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 %5, i64* %"@_val"
+  %8 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 0, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
-  %9 = bitcast i64* %"@_key" to i8*
+  %9 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@_val" to i8*
+  %10 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_uptr_2.ll
+++ b/tests/codegen/llvm/call_uptr_2.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@_val" = alloca i64
   %"@_key" = alloca i64
+  %"@_val" = alloca i64
   %deref = alloca i32
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 14
@@ -21,17 +21,17 @@ entry:
   %5 = sext i32 %4 to i64
   %6 = bitcast i32* %deref to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast i64* %"@_key" to i8*
+  %7 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  store i64 0, i64* %"@_key"
-  %8 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 %5, i64* %"@_val"
+  %8 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 0, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
-  %9 = bitcast i64* %"@_key" to i8*
+  %9 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@_val" to i8*
+  %10 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_ustack.ll
+++ b/tests/codegen/llvm/call_ustack.ll
@@ -8,43 +8,43 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@y_val" = alloca i64
   %"@y_key" = alloca i64
-  %"@x_val" = alloca i64
+  %"@y_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 4)
   %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 256)
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = shl i64 %get_pid_tgid, 32
   %2 = or i64 %get_stackid, %1
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@x_key"
-  %4 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %2, i64* %"@x_val"
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 0, i64* %"@x_key"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %5 = bitcast i64* %"@x_key" to i8*
+  %5 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@x_val" to i8*
+  %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
   %get_stackid3 = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo2, i64 256)
   %get_pid_tgid4 = call i64 inttoptr (i64 14 to i64 ()*)()
   %7 = shl i64 %get_pid_tgid4, 32
   %8 = or i64 %get_stackid3, %7
-  %9 = bitcast i64* %"@y_key" to i8*
+  %9 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store i64 0, i64* %"@y_key"
-  %10 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 %8, i64* %"@y_val"
+  %10 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i64 0, i64* %"@y_key"
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem6 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo5, i64* %"@y_key", i64* %"@y_val", i64 0)
-  %11 = bitcast i64* %"@y_key" to i8*
+  %11 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@y_val" to i8*
+  %12 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_usym_key.ll
+++ b/tests/codegen/llvm/call_usym_key.ll
@@ -48,9 +48,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %10, i64* %"@x_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, %usym_t*, i64*, i64)*)(i64 %pseudo1, %usym_t* %usym, i64* %"@x_val", i64 0)
-  %11 = bitcast %usym_t* %usym to i8*
+  %11 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_val" to i8*
+  %12 = bitcast %usym_t* %usym to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_zero.ll
+++ b/tests/codegen/llvm/call_zero.ll
@@ -10,19 +10,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @BEGIN(i8*) section "s_BEGIN_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 1, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/comparison_extend.ll
+++ b/tests/codegen/llvm/comparison_extend.ll
@@ -8,24 +8,24 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@_val" = alloca i64
   %"@_key" = alloca i64
+  %"@_val" = alloca i64
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 14
   %arg0 = load volatile i64, i64* %2
   %3 = icmp ult i64 1, %arg0
   %4 = zext i1 %3 to i64
-  %5 = bitcast i64* %"@_key" to i8*
+  %5 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  store i64 0, i64* %"@_key"
-  %6 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   store i64 %4, i64* %"@_val"
+  %6 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  store i64 0, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
-  %7 = bitcast i64* %"@_key" to i8*
+  %7 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@_val" to i8*
+  %8 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
   ret i64 0
 }

--- a/tests/codegen/llvm/dereference.ll
+++ b/tests/codegen/llvm/dereference.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %deref = alloca i64
   %1 = bitcast i64* %deref to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -17,17 +17,17 @@ entry:
   %2 = load i64, i64* %deref
   %3 = bitcast i64* %deref to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_key" to i8*
+  %4 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  store i64 0, i64* %"@x_key"
-  %5 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
   store i64 %2, i64* %"@x_val"
+  %5 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %6 = bitcast i64* %"@x_key" to i8*
+  %6 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast i64* %"@x_val" to i8*
+  %7 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   ret i64 0
 }

--- a/tests/codegen/llvm/enum_declaration.ll
+++ b/tests/codegen/llvm/enum_declaration.ll
@@ -8,33 +8,33 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@b_val" = alloca i64
   %"@b_key" = alloca i64
-  %"@a_val" = alloca i64
+  %"@b_val" = alloca i64
   %"@a_key" = alloca i64
-  %1 = bitcast i64* %"@a_key" to i8*
+  %"@a_val" = alloca i64
+  %1 = bitcast i64* %"@a_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@a_key"
-  %2 = bitcast i64* %"@a_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 42, i64* %"@a_val"
+  %2 = bitcast i64* %"@a_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@a_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@a_key", i64* %"@a_val", i64 0)
-  %3 = bitcast i64* %"@a_key" to i8*
+  %3 = bitcast i64* %"@a_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@a_val" to i8*
+  %4 = bitcast i64* %"@a_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
-  %5 = bitcast i64* %"@b_key" to i8*
+  %5 = bitcast i64* %"@b_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  store i64 0, i64* %"@b_key"
-  %6 = bitcast i64* %"@b_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   store i64 43, i64* %"@b_val"
+  %6 = bitcast i64* %"@b_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  store i64 0, i64* %"@b_key"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem2 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@b_key", i64* %"@b_val", i64 0)
-  %7 = bitcast i64* %"@b_key" to i8*
+  %7 = bitcast i64* %"@b_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@b_val" to i8*
+  %8 = bitcast i64* %"@b_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
   ret i64 0
 }

--- a/tests/codegen/llvm/int_propagation.ll
+++ b/tests/codegen/llvm/int_propagation.ll
@@ -8,23 +8,23 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@y_val" = alloca i64
   %"@y_key" = alloca i64
+  %"@y_val" = alloca i64
   %lookup_elem_val = alloca i64
   %"@x_key1" = alloca i64
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 1234, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   %5 = bitcast i64* %"@x_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
@@ -52,17 +52,17 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   %10 = bitcast i64* %"@x_key1" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@y_key" to i8*
+  %11 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  store i64 0, i64* %"@y_key"
-  %12 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
   store i64 %8, i64* %"@y_val"
+  %12 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  store i64 0, i64* %"@y_key"
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo3, i64* %"@y_key", i64* %"@y_val", i64 0)
-  %13 = bitcast i64* %"@y_key" to i8*
+  %13 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@y_val" to i8*
+  %14 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }

--- a/tests/codegen/llvm/intcast_call.ll
+++ b/tests/codegen/llvm/intcast_call.ll
@@ -46,9 +46,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %10, i64* %"@_val"
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@_key", i64* %"@_val", i64 0)
-  %11 = bitcast i64* %"@_key" to i8*
+  %11 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@_val" to i8*
+  %12 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }

--- a/tests/codegen/llvm/intcast_retval.ll
+++ b/tests/codegen/llvm/intcast_retval.ll
@@ -8,24 +8,24 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kretprobe:f"(i8*) section "s_kretprobe:f_1" {
 entry:
-  %"@_val" = alloca i64
   %"@_key" = alloca i64
+  %"@_val" = alloca i64
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 10
   %retval = load volatile i64, i64* %2
   %cast = trunc i64 %retval to i32
-  %3 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@_key"
-  %4 = sext i32 %cast to i64
-  %5 = bitcast i64* %"@_val" to i8*
+  %3 = sext i32 %cast to i64
+  %4 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 %3, i64* %"@_val"
+  %5 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  store i64 %4, i64* %"@_val"
+  store i64 0, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
-  %6 = bitcast i64* %"@_key" to i8*
+  %6 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast i64* %"@_val" to i8*
+  %7 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   ret i64 0
 }

--- a/tests/codegen/llvm/intptrcast_assign_var.ll
+++ b/tests/codegen/llvm/intptrcast_assign_var.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kretprobe:f"(i8*) section "s_kretprobe:f_1" {
 entry:
-  %"@_val" = alloca i64
   %"@_key" = alloca i64
+  %"@_val" = alloca i64
   %deref = alloca i8
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 4
@@ -20,17 +20,17 @@ entry:
   %4 = load i8, i8* %deref
   %5 = sext i8 %4 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %deref)
-  %6 = bitcast i64* %"@_key" to i8*
+  %6 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  store i64 0, i64* %"@_key"
-  %7 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   store i64 %5, i64* %"@_val"
+  %7 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i64 0, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
-  %8 = bitcast i64* %"@_key" to i8*
+  %8 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@_val" to i8*
+  %9 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   ret i64 0
 }

--- a/tests/codegen/llvm/intptrcast_call.ll
+++ b/tests/codegen/llvm/intptrcast_call.ll
@@ -51,9 +51,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %12, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %"@_val", i64 0)
-  %13 = bitcast i64* %"@_key" to i8*
+  %13 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@_val" to i8*
+  %14 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }

--- a/tests/codegen/llvm/literal_strncmp.ll
+++ b/tests/codegen/llvm/literal_strncmp.ll
@@ -82,9 +82,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %19, i64* %"@_val"
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo5, [16 x i8]* %comm3, i64* %"@_val", i64 0)
-  %20 = bitcast [16 x i8]* %comm3 to i8*
+  %20 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  %21 = bitcast i64* %"@_val" to i8*
+  %21 = bitcast [16 x i8]* %comm3 to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
   ret i64 0
 }

--- a/tests/codegen/llvm/logical_and.ll
+++ b/tests/codegen/llvm/logical_and.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"&&_result" = alloca i64
   %1 = bitcast i64* %"&&_result" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -38,17 +38,17 @@ entry:
 
 "&&_merge":                                       ; preds = %"&&_false", %"&&_true"
   %8 = load i64, i64* %"&&_result"
-  %9 = bitcast i64* %"@x_key" to i8*
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store i64 0, i64* %"@x_key"
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 %8, i64* %"@x_val"
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %11 = bitcast i64* %"@x_key" to i8*
+  %11 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_val" to i8*
+  %12 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }

--- a/tests/codegen/llvm/logical_not.ll
+++ b/tests/codegen/llvm/logical_not.ll
@@ -8,33 +8,33 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @BEGIN(i8*) section "s_BEGIN_1" {
 entry:
-  %"@y_val" = alloca i64
   %"@y_key" = alloca i64
-  %"@x_val" = alloca i64
+  %"@y_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 0, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
-  %5 = bitcast i64* %"@y_key" to i8*
+  %5 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  store i64 0, i64* %"@y_key"
-  %6 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   store i64 1, i64* %"@y_val"
+  %6 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  store i64 0, i64* %"@y_key"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem2 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@y_key", i64* %"@y_val", i64 0)
-  %7 = bitcast i64* %"@y_key" to i8*
+  %7 = bitcast i64* %"@y_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@y_val" to i8*
+  %8 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
   ret i64 0
 }

--- a/tests/codegen/llvm/logical_or.ll
+++ b/tests/codegen/llvm/logical_or.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"||_result" = alloca i64
   %1 = bitcast i64* %"||_result" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -38,17 +38,17 @@ entry:
 
 "||_merge":                                       ; preds = %"||_true", %"||_false"
   %8 = load i64, i64* %"||_result"
-  %9 = bitcast i64* %"@x_key" to i8*
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store i64 0, i64* %"@x_key"
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 %8, i64* %"@x_val"
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %11 = bitcast i64* %"@x_key" to i8*
+  %11 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_val" to i8*
+  %12 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }

--- a/tests/codegen/llvm/macro_definition.ll
+++ b/tests/codegen/llvm/macro_definition.ll
@@ -8,19 +8,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@_val" = alloca i64
   %"@_key" = alloca i64
-  %1 = bitcast i64* %"@_key" to i8*
+  %"@_val" = alloca i64
+  %1 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@_key"
-  %2 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 100, i64* %"@_val"
+  %2 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
-  %3 = bitcast i64* %"@_key" to i8*
+  %3 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@_val" to i8*
+  %4 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/map_assign_int.ll
+++ b/tests/codegen/llvm/map_assign_int.ll
@@ -8,19 +8,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 1, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/map_increment_decrement.ll
+++ b/tests/codegen/llvm/map_increment_decrement.ll
@@ -20,19 +20,19 @@ entry:
   %"@x_newval" = alloca i64
   %lookup_elem_val = alloca i64
   %"@x_key1" = alloca i64
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 10, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   %5 = bitcast i64* %"@x_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
@@ -64,9 +64,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %11, i64* %"@x_newval"
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo3, i64* %"@x_key1", i64* %"@x_newval", i64 0)
-  %12 = bitcast i64* %"@x_key1" to i8*
+  %12 = bitcast i64* %"@x_newval" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_newval" to i8*
+  %13 = bitcast i64* %"@x_key1" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   %14 = bitcast i64* %"@x_key5" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
@@ -98,10 +98,10 @@ lookup_merge10:                                   ; preds = %lookup_failure9, %l
   store i64 %20, i64* %"@x_newval14"
   %pseudo15 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem16 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo15, i64* %"@x_key5", i64* %"@x_newval14", i64 0)
-  %21 = bitcast i64* %"@x_key5" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
-  %22 = load i64, i64* %"@x_newval14"
-  %23 = bitcast i64* %"@x_newval14" to i8*
+  %21 = load i64, i64* %"@x_newval14"
+  %22 = bitcast i64* %"@x_newval14" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
+  %23 = bitcast i64* %"@x_key5" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
   %24 = bitcast i64* %"@x_key17" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %24)
@@ -133,9 +133,9 @@ lookup_merge22:                                   ; preds = %lookup_failure21, %
   store i64 %30, i64* %"@x_newval26"
   %pseudo27 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem28 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo27, i64* %"@x_key17", i64* %"@x_newval26", i64 0)
-  %31 = bitcast i64* %"@x_key17" to i8*
+  %31 = bitcast i64* %"@x_newval26" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %31)
-  %32 = bitcast i64* %"@x_newval26" to i8*
+  %32 = bitcast i64* %"@x_key17" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %32)
   %33 = bitcast i64* %"@x_key29" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %33)
@@ -167,10 +167,10 @@ lookup_merge34:                                   ; preds = %lookup_failure33, %
   store i64 %39, i64* %"@x_newval38"
   %pseudo39 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem40 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo39, i64* %"@x_key29", i64* %"@x_newval38", i64 0)
-  %40 = bitcast i64* %"@x_key29" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %40)
-  %41 = load i64, i64* %"@x_newval38"
-  %42 = bitcast i64* %"@x_newval38" to i8*
+  %40 = load i64, i64* %"@x_newval38"
+  %41 = bitcast i64* %"@x_newval38" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %41)
+  %42 = bitcast i64* %"@x_key29" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %42)
   ret i64 0
 }

--- a/tests/codegen/llvm/map_key_int.ll
+++ b/tests/codegen/llvm/map_key_int.ll
@@ -8,27 +8,27 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca [24 x i8]
-  %1 = bitcast [24 x i8]* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = getelementptr [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 0
-  %3 = bitcast i8* %2 to i64*
-  store i64 11, i64* %3
-  %4 = getelementptr [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 8
-  %5 = bitcast i8* %4 to i64*
-  store i64 22, i64* %5
-  %6 = getelementptr [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 16
-  %7 = bitcast i8* %6 to i64*
-  store i64 33, i64* %7
-  %8 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 44, i64* %"@x_val"
+  %2 = bitcast [24 x i8]* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  %3 = getelementptr [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 0
+  %4 = bitcast i8* %3 to i64*
+  store i64 11, i64* %4
+  %5 = getelementptr [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 8
+  %6 = bitcast i8* %5 to i64*
+  store i64 22, i64* %6
+  %7 = getelementptr [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 16
+  %8 = bitcast i8* %7 to i64*
+  store i64 33, i64* %8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [24 x i8]*, i64*, i64)*)(i64 %pseudo, [24 x i8]* %"@x_key", i64* %"@x_val", i64 0)
-  %9 = bitcast [24 x i8]* %"@x_key" to i8*
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_val" to i8*
+  %10 = bitcast [24 x i8]* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }

--- a/tests/codegen/llvm/map_key_probe.ll
+++ b/tests/codegen/llvm/map_key_probe.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"tracepoint:sched:sched_one"(i8*) section "s_tracepoint:sched:sched_one_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key1" = alloca [8 x i8]
+  %"@x_val" = alloca i64
   %lookup_elem_val = alloca i64
   %"@x_key" = alloca [8 x i8]
   %1 = bitcast [8 x i8]* %"@x_key" to i8*
@@ -40,18 +40,18 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   %7 = bitcast [8 x i8]* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   %8 = add i64 %5, 1
-  %9 = bitcast [8 x i8]* %"@x_key1" to i8*
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %10 = bitcast [8 x i8]* %"@x_key1" to i64*
-  store i64 0, i64* %10
-  %11 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   store i64 %8, i64* %"@x_val"
+  %10 = bitcast [8 x i8]* %"@x_key1" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = bitcast [8 x i8]* %"@x_key1" to i64*
+  store i64 0, i64* %11
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo2, [8 x i8]* %"@x_key1", i64* %"@x_val", i64 0)
-  %12 = bitcast [8 x i8]* %"@x_key1" to i8*
+  %12 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_val" to i8*
+  %13 = bitcast [8 x i8]* %"@x_key1" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }
@@ -64,8 +64,8 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 
 define i64 @"tracepoint:sched:sched_two"(i8*) section "s_tracepoint:sched:sched_two_2" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key1" = alloca [8 x i8]
+  %"@x_val" = alloca i64
   %lookup_elem_val = alloca i64
   %"@x_key" = alloca [8 x i8]
   %1 = bitcast [8 x i8]* %"@x_key" to i8*
@@ -96,18 +96,18 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   %7 = bitcast [8 x i8]* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   %8 = add i64 %5, 1
-  %9 = bitcast [8 x i8]* %"@x_key1" to i8*
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %10 = bitcast [8 x i8]* %"@x_key1" to i64*
-  store i64 1, i64* %10
-  %11 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   store i64 %8, i64* %"@x_val"
+  %10 = bitcast [8 x i8]* %"@x_key1" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = bitcast [8 x i8]* %"@x_key1" to i64*
+  store i64 1, i64* %11
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo2, [8 x i8]* %"@x_key1", i64* %"@x_val", i64 0)
-  %12 = bitcast [8 x i8]* %"@x_key1" to i8*
+  %12 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_val" to i8*
+  %13 = bitcast [8 x i8]* %"@x_key1" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }

--- a/tests/codegen/llvm/map_key_string.ll
+++ b/tests/codegen/llvm/map_key_string.ll
@@ -8,36 +8,36 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %str1 = alloca [64 x i8]
   %str = alloca [64 x i8]
   %"@x_key" = alloca [128 x i8]
-  %1 = bitcast [128 x i8]* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store [64 x i8] c"a\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str
-  %3 = getelementptr [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 0
-  %4 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %3, i8* align 1 %4, i64 64, i1 false)
-  %5 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast [64 x i8]* %str1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  store [64 x i8] c"b\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str1
-  %7 = getelementptr [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 64
-  %8 = bitcast [64 x i8]* %str1 to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %7, i8* align 1 %8, i64 64, i1 false)
-  %9 = bitcast [64 x i8]* %str1 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 44, i64* %"@x_val"
+  %2 = bitcast [128 x i8]* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  %3 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  store [64 x i8] c"a\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str
+  %4 = getelementptr [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 0
+  %5 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %4, i8* align 1 %5, i64 64, i1 false)
+  %6 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast [64 x i8]* %str1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store [64 x i8] c"b\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str1
+  %8 = getelementptr [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 64
+  %9 = bitcast [64 x i8]* %str1 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %8, i8* align 1 %9, i64 64, i1 false)
+  %10 = bitcast [64 x i8]* %str1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [128 x i8]*, i64*, i64)*)(i64 %pseudo, [128 x i8]* %"@x_key", i64* %"@x_val", i64 0)
-  %11 = bitcast [128 x i8]* %"@x_key" to i8*
+  %11 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_val" to i8*
+  %12 = bitcast [128 x i8]* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }

--- a/tests/codegen/llvm/nested_while_loop.ll
+++ b/tests/codegen/llvm/nested_while_loop.ll
@@ -84,9 +84,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %19, i64* %"@_newval"
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo5, i64* %"@_key", i64* %"@_newval", i64 0)
-  %20 = bitcast i64* %"@_key" to i8*
+  %20 = bitcast i64* %"@_newval" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  %21 = bitcast i64* %"@_newval" to i8*
+  %21 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
   %22 = load i64, i64* %"$j"
   %23 = add i64 %22, 1

--- a/tests/codegen/llvm/optional_positional_parameter.ll
+++ b/tests/codegen/llvm/optional_positional_parameter.ll
@@ -12,19 +12,19 @@ entry:
   %str1 = alloca [1 x i8]
   %str = alloca [64 x i8]
   %strlen = alloca i64
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
-  %1 = bitcast i64* %"@x_key" to i8*
+  %"@x_val" = alloca i64
+  %1 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key"
-  %2 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 0, i64* %"@x_val"
+  %2 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   %5 = bitcast i64* %strlen to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)

--- a/tests/codegen/llvm/pred_binop.ll
+++ b/tests/codegen/llvm/pred_binop.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = lshr i64 %get_pid_tgid, 32
   %2 = icmp eq i64 %1, 1234
@@ -21,17 +21,17 @@ pred_false:                                       ; preds = %entry
   ret i64 0
 
 pred_true:                                        ; preds = %entry
-  %4 = bitcast i64* %"@x_key" to i8*
+  %4 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  store i64 0, i64* %"@x_key"
-  %5 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
   store i64 1, i64* %"@x_val"
+  %5 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %6 = bitcast i64* %"@x_key" to i8*
+  %6 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast i64* %"@x_val" to i8*
+  %7 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   ret i64 0
 }

--- a/tests/codegen/llvm/runtime_error_check.ll
+++ b/tests/codegen/llvm/runtime_error_check.ll
@@ -65,9 +65,9 @@ helper_failure:                                   ; preds = %lookup_merge
   br label %helper_merge
 
 helper_merge:                                     ; preds = %helper_failure, %lookup_merge
-  %15 = bitcast i64* %"@_key" to i8*
+  %15 = bitcast i64* %"@_newval" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
-  %16 = bitcast i64* %"@_newval" to i8*
+  %16 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
   ret i64 0
 }

--- a/tests/codegen/llvm/runtime_error_check_lookup.ll
+++ b/tests/codegen/llvm/runtime_error_check_lookup.ll
@@ -79,9 +79,9 @@ helper_failure:                                   ; preds = %lookup_merge
   br label %helper_merge
 
 helper_merge:                                     ; preds = %helper_failure, %lookup_merge
-  %20 = bitcast i64* %"@_key" to i8*
+  %20 = bitcast i64* %"@_newval" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  %21 = bitcast i64* %"@_newval" to i8*
+  %21 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
   ret i64 0
 }

--- a/tests/codegen/llvm/string_equal_comparison.ll
+++ b/tests/codegen/llvm/string_equal_comparison.ll
@@ -100,9 +100,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %25, i64* %"@_val"
   %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo11, [16 x i8]* %comm9, i64* %"@_val", i64 0)
-  %26 = bitcast [16 x i8]* %comm9 to i8*
+  %26 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %26)
-  %27 = bitcast i64* %"@_val" to i8*
+  %27 = bitcast [16 x i8]* %comm9 to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %27)
   ret i64 0
 }

--- a/tests/codegen/llvm/string_not_equal_comparison.ll
+++ b/tests/codegen/llvm/string_not_equal_comparison.ll
@@ -100,9 +100,9 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   store i64 %25, i64* %"@_val"
   %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo11, [16 x i8]* %comm9, i64* %"@_val", i64 0)
-  %26 = bitcast [16 x i8]* %comm9 to i8*
+  %26 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %26)
-  %27 = bitcast i64* %"@_val" to i8*
+  %27 = bitcast [16 x i8]* %comm9 to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %27)
   ret i64 0
 }

--- a/tests/codegen/llvm/strncmp.ll
+++ b/tests/codegen/llvm/strncmp.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"tracepoint:file:filename"(i8*) section "s_tracepoint:file:filename_1" {
 entry:
-  %"@_val" = alloca i64
   %"@_key" = alloca i64
+  %"@_val" = alloca i64
   %strcmp.char_r = alloca i8
   %strcmp.char_l = alloca i8
   %strcmp.result = alloca i1
@@ -57,17 +57,17 @@ pred_false:                                       ; preds = %strcmp.false
   ret i64 0
 
 pred_true:                                        ; preds = %strcmp.false
-  %19 = bitcast i64* %"@_key" to i8*
+  %19 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
-  store i64 0, i64* %"@_key"
-  %20 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %20)
   store i64 1, i64* %"@_val"
+  %20 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %20)
+  store i64 0, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
-  %21 = bitcast i64* %"@_key" to i8*
+  %21 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
-  %22 = bitcast i64* %"@_val" to i8*
+  %22 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
   ret i64 0
 

--- a/tests/codegen/llvm/struct_char_1.ll
+++ b/tests/codegen/llvm/struct_char_1.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Foo.x" = alloca i8
   %"$foo" = alloca [1 x i8]
   %1 = bitcast [1 x i8]* %"$foo" to i8*
@@ -27,17 +27,17 @@ entry:
   %7 = load i8, i8* %"struct Foo.x"
   %8 = sext i8 %7 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct Foo.x")
-  %9 = bitcast i64* %"@x_key" to i8*
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store i64 0, i64* %"@x_key"
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 %8, i64* %"@x_val"
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %11 = bitcast i64* %"@x_key" to i8*
+  %11 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_val" to i8*
+  %12 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_char_2.ll
+++ b/tests/codegen/llvm/struct_char_2.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Foo.x" = alloca i8
   %"$foo" = alloca i64
   %1 = bitcast i64* %"$foo" to i8*
@@ -25,17 +25,17 @@ entry:
   %5 = load i8, i8* %"struct Foo.x"
   %6 = sext i8 %5 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct Foo.x")
-  %7 = bitcast i64* %"@x_key" to i8*
+  %7 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  store i64 0, i64* %"@x_key"
-  %8 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 %6, i64* %"@x_val"
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %9 = bitcast i64* %"@x_key" to i8*
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_val" to i8*
+  %10 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_integer_ptr_1.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_1.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %deref = alloca i32
   %"struct Foo.x" = alloca i64
   %"$foo" = alloca [8 x i8]
@@ -36,17 +36,17 @@ entry:
   %12 = sext i32 %11 to i64
   %13 = bitcast i32* %deref to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@x_key" to i8*
+  %14 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
-  store i64 0, i64* %"@x_key"
-  %15 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
   store i64 %12, i64* %"@x_val"
+  %15 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %16 = bitcast i64* %"@x_key" to i8*
+  %16 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = bitcast i64* %"@x_val" to i8*
+  %17 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_integer_ptr_2.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_2.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %deref = alloca i32
   %"struct Foo.x" = alloca i64
   %"$foo" = alloca i64
@@ -34,17 +34,17 @@ entry:
   %10 = sext i32 %9 to i64
   %11 = bitcast i32* %deref to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_key" to i8*
+  %12 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  store i64 0, i64* %"@x_key"
-  %13 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
   store i64 %10, i64* %"@x_val"
+  %13 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %14 = bitcast i64* %"@x_key" to i8*
+  %14 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@x_val" to i8*
+  %15 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_integers_1.ll
+++ b/tests/codegen/llvm/struct_integers_1.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Foo.x" = alloca i32
   %"$foo" = alloca [4 x i8]
   %1 = bitcast [4 x i8]* %"$foo" to i8*
@@ -29,17 +29,17 @@ entry:
   %9 = sext i32 %8 to i64
   %10 = bitcast i32* %"struct Foo.x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_key" to i8*
+  %11 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  store i64 0, i64* %"@x_key"
-  %12 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
   store i64 %9, i64* %"@x_val"
+  %12 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %13 = bitcast i64* %"@x_key" to i8*
+  %13 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@x_val" to i8*
+  %14 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_integers_2.ll
+++ b/tests/codegen/llvm/struct_integers_2.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Foo.x" = alloca i32
   %"$foo" = alloca i64
   %1 = bitcast i64* %"$foo" to i8*
@@ -27,17 +27,17 @@ entry:
   %7 = sext i32 %6 to i64
   %8 = bitcast i32* %"struct Foo.x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@x_key" to i8*
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store i64 0, i64* %"@x_key"
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 %7, i64* %"@x_val"
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %11 = bitcast i64* %"@x_key" to i8*
+  %11 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_val" to i8*
+  %12 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_long_1.ll
+++ b/tests/codegen/llvm/struct_long_1.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Foo.x" = alloca i64
   %"$foo" = alloca [8 x i8]
   %1 = bitcast [8 x i8]* %"$foo" to i8*
@@ -28,17 +28,17 @@ entry:
   %8 = load i64, i64* %"struct Foo.x"
   %9 = bitcast i64* %"struct Foo.x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key" to i8*
+  %10 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  store i64 0, i64* %"@x_key"
-  %11 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   store i64 %8, i64* %"@x_val"
+  %11 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %12 = bitcast i64* %"@x_key" to i8*
+  %12 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_val" to i8*
+  %13 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_long_2.ll
+++ b/tests/codegen/llvm/struct_long_2.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Foo.x" = alloca i64
   %"$foo" = alloca i64
   %1 = bitcast i64* %"$foo" to i8*
@@ -26,17 +26,17 @@ entry:
   %6 = load i64, i64* %"struct Foo.x"
   %7 = bitcast i64* %"struct Foo.x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@x_key" to i8*
+  %8 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  store i64 0, i64* %"@x_key"
-  %9 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 %6, i64* %"@x_val"
+  %9 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %10 = bitcast i64* %"@x_key" to i8*
+  %10 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_val" to i8*
+  %11 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_nested_struct_anon_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_1.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Foo::(anonymous at definitions.h:1:14).x" = alloca i32
   %"$foo" = alloca [4 x i8]
   %1 = bitcast [4 x i8]* %"$foo" to i8*
@@ -30,17 +30,17 @@ entry:
   %10 = sext i32 %9 to i64
   %11 = bitcast i32* %"struct Foo::(anonymous at definitions.h:1:14).x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_key" to i8*
+  %12 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  store i64 0, i64* %"@x_key"
-  %13 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
   store i64 %10, i64* %"@x_val"
+  %13 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %14 = bitcast i64* %"@x_key" to i8*
+  %14 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@x_val" to i8*
+  %15 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_nested_struct_anon_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_2.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Foo::(anonymous at definitions.h:1:14).x" = alloca i32
   %"$foo" = alloca i64
   %1 = bitcast i64* %"$foo" to i8*
@@ -28,17 +28,17 @@ entry:
   %8 = sext i32 %7 to i64
   %9 = bitcast i32* %"struct Foo::(anonymous at definitions.h:1:14).x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key" to i8*
+  %10 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  store i64 0, i64* %"@x_key"
-  %11 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   store i64 %8, i64* %"@x_val"
+  %11 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %12 = bitcast i64* %"@x_key" to i8*
+  %12 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_val" to i8*
+  %13 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_nested_struct_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_1.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Bar.x" = alloca i32
   %"$foo" = alloca [4 x i8]
   %1 = bitcast [4 x i8]* %"$foo" to i8*
@@ -30,17 +30,17 @@ entry:
   %10 = sext i32 %9 to i64
   %11 = bitcast i32* %"struct Bar.x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_key" to i8*
+  %12 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  store i64 0, i64* %"@x_key"
-  %13 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
   store i64 %10, i64* %"@x_val"
+  %13 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %14 = bitcast i64* %"@x_key" to i8*
+  %14 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@x_val" to i8*
+  %15 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_nested_struct_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_2.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Bar.x" = alloca i32
   %"$foo" = alloca i64
   %1 = bitcast i64* %"$foo" to i8*
@@ -28,17 +28,17 @@ entry:
   %8 = sext i32 %7 to i64
   %9 = bitcast i32* %"struct Bar.x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key" to i8*
+  %10 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  store i64 0, i64* %"@x_key"
-  %11 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   store i64 %8, i64* %"@x_val"
+  %11 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %12 = bitcast i64* %"@x_key" to i8*
+  %12 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_val" to i8*
+  %13 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Bar.x" = alloca i32
   %"struct Foo.bar" = alloca i64
   %"$foo" = alloca [8 x i8]
@@ -37,17 +37,17 @@ entry:
   %13 = sext i32 %12 to i64
   %14 = bitcast i32* %"struct Bar.x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@x_key" to i8*
+  %15 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
-  store i64 0, i64* %"@x_key"
-  %16 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
   store i64 %13, i64* %"@x_val"
+  %16 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %17 = bitcast i64* %"@x_key" to i8*
+  %17 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
-  %18 = bitcast i64* %"@x_val" to i8*
+  %18 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Bar.x" = alloca i32
   %"struct Foo.bar" = alloca i64
   %"$foo" = alloca i64
@@ -35,17 +35,17 @@ entry:
   %11 = sext i32 %10 to i64
   %12 = bitcast i32* %"struct Bar.x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_key" to i8*
+  %13 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  store i64 0, i64* %"@x_key"
-  %14 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
   store i64 %11, i64* %"@x_val"
+  %14 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %15 = bitcast i64* %"@x_key" to i8*
+  %15 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
-  %16 = bitcast i64* %"@x_val" to i8*
+  %16 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_save_1.ll
+++ b/tests/codegen/llvm/struct_save_1.ll
@@ -8,19 +8,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@foo_val" = alloca [12 x i8]
   %"@foo_key" = alloca i64
-  %1 = bitcast i64* %"@foo_key" to i8*
+  %"@foo_val" = alloca [12 x i8]
+  %1 = bitcast [12 x i8]* %"@foo_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@foo_key"
-  %2 = bitcast [12 x i8]* %"@foo_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   %probe_read = call i64 inttoptr (i64 4 to i64 ([12 x i8]*, i32, i64)*)([12 x i8]* %"@foo_val", i32 12, i64 0)
+  %2 = bitcast i64* %"@foo_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@foo_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [12 x i8]*, i64)*)(i64 %pseudo, i64* %"@foo_key", [12 x i8]* %"@foo_val", i64 0)
-  %3 = bitcast i64* %"@foo_key" to i8*
+  %3 = bitcast [12 x i8]* %"@foo_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [12 x i8]* %"@foo_val" to i8*
+  %4 = bitcast i64* %"@foo_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_save_2.ll
+++ b/tests/codegen/llvm/struct_save_2.ll
@@ -8,19 +8,19 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@foo_val" = alloca [12 x i8]
   %"@foo_key" = alloca i64
-  %1 = bitcast i64* %"@foo_key" to i8*
+  %"@foo_val" = alloca [12 x i8]
+  %1 = bitcast [12 x i8]* %"@foo_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@foo_key"
-  %2 = bitcast [12 x i8]* %"@foo_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   %probe_read = call i64 inttoptr (i64 4 to i64 ([12 x i8]*, i32, i64)*)([12 x i8]* %"@foo_val", i32 12, i64 0)
+  %2 = bitcast i64* %"@foo_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@foo_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [12 x i8]*, i64)*)(i64 %pseudo, i64* %"@foo_key", [12 x i8]* %"@foo_val", i64 0)
-  %3 = bitcast i64* %"@foo_key" to i8*
+  %3 = bitcast [12 x i8]* %"@foo_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [12 x i8]* %"@foo_val" to i8*
+  %4 = bitcast i64* %"@foo_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_save_nested.ll
+++ b/tests/codegen/llvm/struct_save_nested.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"internal_struct Foo.bar13" = alloca [8 x i8]
   %lookup_elem_val11 = alloca [16 x i8]
   %"@foo_key5" = alloca i64
@@ -17,19 +17,19 @@ entry:
   %"internal_struct Foo.bar" = alloca [8 x i8]
   %lookup_elem_val = alloca [16 x i8]
   %"@foo_key1" = alloca i64
-  %"@foo_val" = alloca [16 x i8]
   %"@foo_key" = alloca i64
-  %1 = bitcast i64* %"@foo_key" to i8*
+  %"@foo_val" = alloca [16 x i8]
+  %1 = bitcast [16 x i8]* %"@foo_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@foo_key"
-  %2 = bitcast [16 x i8]* %"@foo_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   %probe_read = call i64 inttoptr (i64 4 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* %"@foo_val", i32 16, i64 0)
+  %2 = bitcast i64* %"@foo_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@foo_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [16 x i8]*, i64)*)(i64 %pseudo, i64* %"@foo_key", [16 x i8]* %"@foo_val", i64 0)
-  %3 = bitcast i64* %"@foo_key" to i8*
+  %3 = bitcast [16 x i8]* %"@foo_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [16 x i8]* %"@foo_val" to i8*
+  %4 = bitcast i64* %"@foo_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   %5 = bitcast i64* %"@foo_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
@@ -104,18 +104,18 @@ lookup_merge10:                                   ; preds = %lookup_failure9, %l
   %27 = load i32, i8* %26
   %28 = bitcast [8 x i8]* %"internal_struct Foo.bar13" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %28)
-  %29 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %29)
-  store i64 0, i64* %"@x_key"
-  %30 = sext i32 %27 to i64
-  %31 = bitcast i64* %"@x_val" to i8*
+  %29 = sext i32 %27 to i64
+  %30 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %30)
+  store i64 %29, i64* %"@x_val"
+  %31 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %31)
-  store i64 %30, i64* %"@x_val"
+  store i64 0, i64* %"@x_key"
   %pseudo14 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
   %update_elem15 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo14, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %32 = bitcast i64* %"@x_key" to i8*
+  %32 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %32)
-  %33 = bitcast i64* %"@x_val" to i8*
+  %33 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %33)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_save_string.ll
+++ b/tests/codegen/llvm/struct_save_string.ll
@@ -11,19 +11,19 @@ entry:
   %"@str_key" = alloca i64
   %lookup_elem_val = alloca [32 x i8]
   %"@foo_key1" = alloca i64
-  %"@foo_val" = alloca [32 x i8]
   %"@foo_key" = alloca i64
-  %1 = bitcast i64* %"@foo_key" to i8*
+  %"@foo_val" = alloca [32 x i8]
+  %1 = bitcast [32 x i8]* %"@foo_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@foo_key"
-  %2 = bitcast [32 x i8]* %"@foo_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   %probe_read = call i64 inttoptr (i64 4 to i64 ([32 x i8]*, i32, i64)*)([32 x i8]* %"@foo_val", i32 32, i64 0)
+  %2 = bitcast i64* %"@foo_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@foo_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [32 x i8]*, i64)*)(i64 %pseudo, i64* %"@foo_key", [32 x i8]* %"@foo_val", i64 0)
-  %3 = bitcast i64* %"@foo_key" to i8*
+  %3 = bitcast [32 x i8]* %"@foo_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [32 x i8]* %"@foo_val" to i8*
+  %4 = bitcast i64* %"@foo_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   %5 = bitcast i64* %"@foo_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)

--- a/tests/codegen/llvm/struct_short_1.ll
+++ b/tests/codegen/llvm/struct_short_1.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Foo.x" = alloca i16
   %"$foo" = alloca [2 x i8]
   %1 = bitcast [2 x i8]* %"$foo" to i8*
@@ -29,17 +29,17 @@ entry:
   %9 = sext i16 %8 to i64
   %10 = bitcast i16* %"struct Foo.x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_key" to i8*
+  %11 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  store i64 0, i64* %"@x_key"
-  %12 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
   store i64 %9, i64* %"@x_val"
+  %12 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %13 = bitcast i64* %"@x_key" to i8*
+  %13 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@x_val" to i8*
+  %14 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }

--- a/tests/codegen/llvm/struct_short_2.ll
+++ b/tests/codegen/llvm/struct_short_2.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %"struct Foo.x" = alloca i16
   %"$foo" = alloca i64
   %1 = bitcast i64* %"$foo" to i8*
@@ -27,17 +27,17 @@ entry:
   %7 = sext i16 %6 to i64
   %8 = bitcast i16* %"struct Foo.x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@x_key" to i8*
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store i64 0, i64* %"@x_key"
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 %7, i64* %"@x_val"
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %11 = bitcast i64* %"@x_key" to i8*
+  %11 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_val" to i8*
+  %12 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }

--- a/tests/codegen/llvm/ternary_int.ll
+++ b/tests/codegen/llvm/ternary_int.ll
@@ -8,8 +8,8 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64
   %"@x_key" = alloca i64
+  %"@x_val" = alloca i64
   %buf = alloca i64
   %result = alloca i64
   %1 = bitcast i64* %result to i8*
@@ -33,17 +33,17 @@ right:                                            ; preds = %entry
 
 done:                                             ; preds = %right, %left
   %6 = load i64, i64* %result
-  %7 = bitcast i64* %"@x_key" to i8*
+  %7 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  store i64 0, i64* %"@x_key"
-  %8 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 %6, i64* %"@x_val"
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %9 = bitcast i64* %"@x_key" to i8*
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_val" to i8*
+  %10 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }

--- a/tests/codegen/llvm/unroll.ll
+++ b/tests/codegen/llvm/unroll.ll
@@ -8,39 +8,39 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 
 define i64 @BEGIN(i8*) section "s_BEGIN_1" {
 entry:
-  %"@i_val56" = alloca i64
-  %"@i_key55" = alloca i64
+  %"@i_key56" = alloca i64
+  %"@i_val55" = alloca i64
   %lookup_elem_val52 = alloca i64
   %"@i_key46" = alloca i64
-  %"@i_val43" = alloca i64
-  %"@i_key42" = alloca i64
+  %"@i_key43" = alloca i64
+  %"@i_val42" = alloca i64
   %lookup_elem_val39 = alloca i64
   %"@i_key33" = alloca i64
-  %"@i_val30" = alloca i64
-  %"@i_key29" = alloca i64
+  %"@i_key30" = alloca i64
+  %"@i_val29" = alloca i64
   %lookup_elem_val26 = alloca i64
   %"@i_key20" = alloca i64
-  %"@i_val17" = alloca i64
-  %"@i_key16" = alloca i64
+  %"@i_key17" = alloca i64
+  %"@i_val16" = alloca i64
   %lookup_elem_val13 = alloca i64
   %"@i_key7" = alloca i64
-  %"@i_val4" = alloca i64
-  %"@i_key3" = alloca i64
+  %"@i_key4" = alloca i64
+  %"@i_val3" = alloca i64
   %lookup_elem_val = alloca i64
   %"@i_key1" = alloca i64
-  %"@i_val" = alloca i64
   %"@i_key" = alloca i64
-  %1 = bitcast i64* %"@i_key" to i8*
+  %"@i_val" = alloca i64
+  %1 = bitcast i64* %"@i_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@i_key"
-  %2 = bitcast i64* %"@i_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 0, i64* %"@i_val"
+  %2 = bitcast i64* %"@i_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@i_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@i_key", i64* %"@i_val", i64 0)
-  %3 = bitcast i64* %"@i_key" to i8*
+  %3 = bitcast i64* %"@i_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@i_val" to i8*
+  %4 = bitcast i64* %"@i_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   %5 = bitcast i64* %"@i_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
@@ -69,17 +69,17 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   %10 = bitcast i64* %"@i_key1" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   %11 = add i64 %8, 1
-  %12 = bitcast i64* %"@i_key3" to i8*
+  %12 = bitcast i64* %"@i_val3" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  store i64 0, i64* %"@i_key3"
-  %13 = bitcast i64* %"@i_val4" to i8*
+  store i64 %11, i64* %"@i_val3"
+  %13 = bitcast i64* %"@i_key4" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  store i64 %11, i64* %"@i_val4"
+  store i64 0, i64* %"@i_key4"
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem6 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo5, i64* %"@i_key3", i64* %"@i_val4", i64 0)
-  %14 = bitcast i64* %"@i_key3" to i8*
+  %update_elem6 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo5, i64* %"@i_key4", i64* %"@i_val3", i64 0)
+  %14 = bitcast i64* %"@i_val3" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@i_val4" to i8*
+  %15 = bitcast i64* %"@i_key4" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
   %16 = bitcast i64* %"@i_key7" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
@@ -108,17 +108,17 @@ lookup_merge12:                                   ; preds = %lookup_failure11, %
   %21 = bitcast i64* %"@i_key7" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
   %22 = add i64 %19, 1
-  %23 = bitcast i64* %"@i_key16" to i8*
+  %23 = bitcast i64* %"@i_val16" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
-  store i64 0, i64* %"@i_key16"
-  %24 = bitcast i64* %"@i_val17" to i8*
+  store i64 %22, i64* %"@i_val16"
+  %24 = bitcast i64* %"@i_key17" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %24)
-  store i64 %22, i64* %"@i_val17"
+  store i64 0, i64* %"@i_key17"
   %pseudo18 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem19 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo18, i64* %"@i_key16", i64* %"@i_val17", i64 0)
-  %25 = bitcast i64* %"@i_key16" to i8*
+  %update_elem19 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo18, i64* %"@i_key17", i64* %"@i_val16", i64 0)
+  %25 = bitcast i64* %"@i_val16" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %25)
-  %26 = bitcast i64* %"@i_val17" to i8*
+  %26 = bitcast i64* %"@i_key17" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %26)
   %27 = bitcast i64* %"@i_key20" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %27)
@@ -147,17 +147,17 @@ lookup_merge25:                                   ; preds = %lookup_failure24, %
   %32 = bitcast i64* %"@i_key20" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %32)
   %33 = add i64 %30, 1
-  %34 = bitcast i64* %"@i_key29" to i8*
+  %34 = bitcast i64* %"@i_val29" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %34)
-  store i64 0, i64* %"@i_key29"
-  %35 = bitcast i64* %"@i_val30" to i8*
+  store i64 %33, i64* %"@i_val29"
+  %35 = bitcast i64* %"@i_key30" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %35)
-  store i64 %33, i64* %"@i_val30"
+  store i64 0, i64* %"@i_key30"
   %pseudo31 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem32 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo31, i64* %"@i_key29", i64* %"@i_val30", i64 0)
-  %36 = bitcast i64* %"@i_key29" to i8*
+  %update_elem32 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo31, i64* %"@i_key30", i64* %"@i_val29", i64 0)
+  %36 = bitcast i64* %"@i_val29" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %36)
-  %37 = bitcast i64* %"@i_val30" to i8*
+  %37 = bitcast i64* %"@i_key30" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %37)
   %38 = bitcast i64* %"@i_key33" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %38)
@@ -186,17 +186,17 @@ lookup_merge38:                                   ; preds = %lookup_failure37, %
   %43 = bitcast i64* %"@i_key33" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %43)
   %44 = add i64 %41, 1
-  %45 = bitcast i64* %"@i_key42" to i8*
+  %45 = bitcast i64* %"@i_val42" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %45)
-  store i64 0, i64* %"@i_key42"
-  %46 = bitcast i64* %"@i_val43" to i8*
+  store i64 %44, i64* %"@i_val42"
+  %46 = bitcast i64* %"@i_key43" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %46)
-  store i64 %44, i64* %"@i_val43"
+  store i64 0, i64* %"@i_key43"
   %pseudo44 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem45 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo44, i64* %"@i_key42", i64* %"@i_val43", i64 0)
-  %47 = bitcast i64* %"@i_key42" to i8*
+  %update_elem45 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo44, i64* %"@i_key43", i64* %"@i_val42", i64 0)
+  %47 = bitcast i64* %"@i_val42" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %47)
-  %48 = bitcast i64* %"@i_val43" to i8*
+  %48 = bitcast i64* %"@i_key43" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %48)
   %49 = bitcast i64* %"@i_key46" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %49)
@@ -225,17 +225,17 @@ lookup_merge51:                                   ; preds = %lookup_failure50, %
   %54 = bitcast i64* %"@i_key46" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %54)
   %55 = add i64 %52, 1
-  %56 = bitcast i64* %"@i_key55" to i8*
+  %56 = bitcast i64* %"@i_val55" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %56)
-  store i64 0, i64* %"@i_key55"
-  %57 = bitcast i64* %"@i_val56" to i8*
+  store i64 %55, i64* %"@i_val55"
+  %57 = bitcast i64* %"@i_key56" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %57)
-  store i64 %55, i64* %"@i_val56"
+  store i64 0, i64* %"@i_key56"
   %pseudo57 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem58 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo57, i64* %"@i_key55", i64* %"@i_val56", i64 0)
-  %58 = bitcast i64* %"@i_key55" to i8*
+  %update_elem58 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo57, i64* %"@i_key56", i64* %"@i_val55", i64 0)
+  %58 = bitcast i64* %"@i_val55" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %58)
-  %59 = bitcast i64* %"@i_val56" to i8*
+  %59 = bitcast i64* %"@i_key56" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %59)
   ret i64 0
 }


### PR DESCRIPTION
_This is an attempt to carve off bits from https://github.com/iovisor/bpftrace/pull/1360 to make it easier to review._

Use `ScopedExprDeleter` to guarantee that key allocated by `getMapKey()` is freed after use. Relieve consumer from having to know details of how key was allocated.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
  - No language changes
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
  - No user-visible changes
  - Changes are trivial
- [ ] The new behaviour is covered by tests
  - Behaviour is equivalent to original