### PR TITLE
ci: Cache docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,14 +97,37 @@ jobs:
           BASE: bionic
     steps:
     - uses: actions/checkout@v2
+    - name: Get date
+      id: get-date
+      run: echo "::set-output name=date::$(/bin/date -u "+%Y.week%g")"
+      shell: bash
+    - name: Cache docker image
+      env: ${{matrix.env}}
+      id: docker-cache
+      uses: actions/cache@v2
+      with:
+        path: /tmp/docker-save
+        # Key the cache entry by:
+        #   * the operating system
+        #   * the week (so cache gets invalidated every week)
+        #   * the image configuration (ie llvm version & distro)
+        #   * the hash of all the files in docker/
+        key: ${{ runner.os }}-docker-cache-${{ steps.get-date.outputs.date }}-${{ env.NAME }}-${{ hashFiles('docker/**') }}
     - name: Build docker container
+      if: steps.docker-cache.outputs.cache-hit != 'true'
       env: ${{matrix.env}}
       run: >
         docker build
         --build-arg LLVM_VERSION=$LLVM_VERSION
         -t bpftrace-builder-$BASE-llvm-$LLVM_VERSION
         -f docker/Dockerfile.$BASE
-        docker/
+        docker/ &&
+        mkdir -p /tmp/docker-save &&
+        docker save bpftrace-builder-$BASE-llvm-$LLVM_VERSION -o /tmp/docker-save/i.tar
+    - name: Load the cached docker image (if available)
+      if: steps.docker-cache.outputs.cache-hit == 'true'
+      run: >
+        docker load --input /tmp/docker-save/i.tar
     - name: Build and test
       env: ${{matrix.env}}
       run: >


### PR DESCRIPTION
We're seeing more often issues with apt repos syncing and our CI
spuriously failing. We don't really need super up to date docker CI
images -- one a week is probably good enough.

This commit caches the docker build for a week if files in `docker/` are
not changed.

I tested this works by pushing this commit my personal repo, letting GH
actions run, then pushing a dummy commit and verifying cache works as
expected.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
