### PR TITLE
ci: Cache docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,14 +97,37 @@ jobs:
           BASE: bionic
     steps:
     - uses: actions/checkout@v2
+    - name: Get date
+      id: get-date
+      run: echo "::set-output name=date::$(/bin/date -u "+%Y.week%g")"
+      shell: bash
+    - name: Cache docker image
+      env: ${{matrix.env}}
+      id: docker-cache
+      uses: actions/cache@v2
+      with:
+        path: /tmp/docker-save
+        # Key the cache entry by:
+        #   * the operating system
+        #   * the week (so cache gets invalidated every week)
+        #   * the image configuration (ie llvm version & distro)
+        #   * the hash of all the files in docker/
+        key: ${{ runner.os }}-docker-cache-${{ steps.get-date.outputs.date }}-${{ env.NAME }}-${{ hashFiles('docker/**') }}
     - name: Build docker container
+      if: steps.docker-cache.outputs.cache-hit != 'true'
       env: ${{matrix.env}}
       run: >
         docker build
         --build-arg LLVM_VERSION=$LLVM_VERSION
         -t bpftrace-builder-$BASE-llvm-$LLVM_VERSION
         -f docker/Dockerfile.$BASE
-        docker/
+        docker/ &&
+        mkdir -p /tmp/docker-save &&
+        docker save bpftrace-builder-$BASE-llvm-$LLVM_VERSION -o /tmp/docker-save/i.tar
+    - name: Load the cached docker image (if available)
+      if: steps.docker-cache.outputs.cache-hit == 'true'
+      run: >
+        docker load --input /tmp/docker-save/i.tar
     - name: Build and test
       env: ${{matrix.env}}
       run: >

--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -120,7 +120,24 @@ jobs:
           ALPINE_VERSION: 3.11
     steps:
     - uses: actions/checkout@v2
+    - name: Get date
+      id: get-date
+      run: echo "::set-output name=date::$(/bin/date -u "+%Y.week%g")"
+      shell: bash
+    - name: Cache docker image
+      env: ${{matrix.env}}
+      id: docker-cache
+      uses: actions/cache@v2
+      with:
+        path: /tmp/docker-save
+        # Key the cache entry by:
+        #   * the operating system
+        #   * the week (so cache gets invalidated every week)
+        #   * the image configuration (ie config + build type)
+        #   * the hash of all the files in docker/
+        key: ${{ runner.os }}-docker-cache-${{ steps.get-date.outputs.date }}-${{ env.NAME }}-${{ env.TYPE }}-${{ hashFiles('docker/**') }}
     - name: Build docker container
+      if: steps.docker-cache.outputs.cache-hit != 'true'
       run: >
         docker build
         -t bpftrace-embedded-${{ matrix.env['BASE'] }}
@@ -128,7 +145,13 @@ jobs:
         --build-arg bcc_ref=${{ matrix.env['BCC_REF'] }}
         --build-arg BASE=${{ matrix.env['BASE'] }}
         --build-arg ALPINE_VERSION=${{ matrix.env['ALPINE_VERSION'] }}
-        docker/
+        docker/ &&
+        mkdir -p /tmp/docker-save &&
+        docker save bpftrace-embedded-${{ matrix.env['BASE'] }} -o /tmp/docker-save/i.tar
+    - name: Load the cached docker image (if available)
+      if: steps.docker-cache.outputs.cache-hit == 'true'
+      run: >
+        docker load --input /tmp/docker-save/i.tar
     - name: bpftrace embedded build
       env: ${{ matrix.env }}
       run: >

--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -121,21 +121,79 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build docker container
-      run: |
-        docker build -t bpftrace-embedded-${{ matrix.env['BASE'] }} -f docker/Dockerfile.${{ matrix.env['DISTRO'] }} --build-arg bcc_ref=${{ matrix.env['BCC_REF'] }} --build-arg BASE=${{ matrix.env['BASE'] }} --build-arg ALPINE_VERSION=${{ matrix.env['ALPINE_VERSION'] }} docker/
+      run: >
+        docker build
+        -t bpftrace-embedded-${{ matrix.env['BASE'] }}
+        -f docker/Dockerfile.${{ matrix.env['DISTRO'] }}
+        --build-arg bcc_ref=${{ matrix.env['BCC_REF'] }}
+        --build-arg BASE=${{ matrix.env['BASE'] }}
+        --build-arg ALPINE_VERSION=${{ matrix.env['ALPINE_VERSION'] }}
+        docker/
     - name: bpftrace embedded build
       env: ${{ matrix.env }}
-      run: |
-        docker run --privileged -v $(pwd):$(pwd) -w $(pwd) -v /sys/kernel/debug:/sys/kernel/debug:rw -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -e STATIC_LINKING=${STATIC_LINKING} -e STATIC_LIBC=${STATIC_LIBC} -e EMBED_LLVM=${EMBED_LLVM} -e EMBED_CLANG=${EMBED_CLANG} -e EMBED_BCC=${EMBED_BCC} -e EMBED_LIBELF=${EMBED_LIBELF} -e EMBED_LIBCLANG_ONLY=${EMBED_LIBCLANG_ONLY} -e EMBED_BINUTILS=${EMBED_BINUTILS} -e RUN_ALL_TESTS=${RUN_ALL_TESTS} -e CMAKE_EXTRA_FLAGS="${CMAKE_EXTRA_FLAGS}" -e TEST_GROUPS_DISABLE="${TEST_GROUPS_DISABLE}" -e RUNTIME_TEST_DISABLE="${RUNTIME_TEST_DISABLE}" bpftrace-embedded-${{ matrix.env['BASE'] }} $(pwd)/build-embedded ${TYPE} -j`nproc`
+      run: >
+        docker run --privileged
+        -v $(pwd):$(pwd)
+        -w $(pwd)
+        -v /sys/kernel/debug:/sys/kernel/debug:rw
+        -v /lib/modules:/lib/modules:ro
+        -v /usr/src:/usr/src:ro
+        -e STATIC_LINKING=${STATIC_LINKING}
+        -e STATIC_LIBC=${STATIC_LIBC}
+        -e EMBED_LLVM=${EMBED_LLVM}
+        -e EMBED_CLANG=${EMBED_CLANG}
+        -e EMBED_BCC=${EMBED_BCC}
+        -e EMBED_LIBELF=${EMBED_LIBELF}
+        -e EMBED_LIBCLANG_ONLY=${EMBED_LIBCLANG_ONLY}
+        -e EMBED_BINUTILS=${EMBED_BINUTILS}
+        -e RUN_ALL_TESTS=${RUN_ALL_TESTS}
+        -e CMAKE_EXTRA_FLAGS="${CMAKE_EXTRA_FLAGS}"
+        -e TEST_GROUPS_DISABLE="${TEST_GROUPS_DISABLE}"
+        -e RUNTIME_TEST_DISABLE="${RUNTIME_TEST_DISABLE}"
+        bpftrace-embedded-${{ matrix.env['BASE'] }}
+        $(pwd)/build-embedded ${TYPE}
+        -j`nproc`
     - name: Check linked libs
       env: ${{ matrix.env }}
-      run: |
-        docker run --privileged -v $(pwd):$(pwd) -w $(pwd) -v /sys/kernel/debug:/sys/kernel/debug:rw -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -e STATIC_LINKING=${STATIC_LINKING} -e STATIC_LIBC=${STATIC_LIBC} -e EMBED_LLVM=${EMBED_LLVM} -e EMBED_CLANG=${EMBED_CLANG} -e EMBED_BCC=${EMBED_BCC} -e EMBED_LIBELF=${EMBED_LIBELF} -e EMBED_LIBCLANG_ONLY=${EMBED_LIBCLANG_ONLY} -e EMBED_BINUTILS=${EMBED_BINUTILS} --entrypoint /bin/bash bpftrace-embedded-${{ matrix.env['BASE'] }} -c "[[ -f $(pwd)/build-embedded/src/bpftrace ]] && ! readelf --dynamic $(pwd)/build-embedded/src/bpftrace | grep NEEDED | grep -v 'libm\|libc\|ld-linux\|libpthread\|libdl'"
+      run: >
+        docker run --privileged
+        -v $(pwd):$(pwd)
+        -w $(pwd)
+        -v /sys/kernel/debug:/sys/kernel/debug:rw
+        -v /lib/modules:/lib/modules:ro
+        -v /usr/src:/usr/src:ro
+        -e STATIC_LINKING=${STATIC_LINKING}
+        -e STATIC_LIBC=${STATIC_LIBC}
+        -e EMBED_LLVM=${EMBED_LLVM}
+        -e EMBED_CLANG=${EMBED_CLANG}
+        -e EMBED_BCC=${EMBED_BCC}
+        -e EMBED_LIBELF=${EMBED_LIBELF}
+        -e EMBED_LIBCLANG_ONLY=${EMBED_LIBCLANG_ONLY}
+        -e EMBED_BINUTILS=${EMBED_BINUTILS}
+        --entrypoint /bin/bash
+        bpftrace-embedded-${{ matrix.env['BASE'] }}
+        -c "[[ -f $(pwd)/build-embedded/src/bpftrace ]] && ! readelf --dynamic $(pwd)/build-embedded/src/bpftrace | grep NEEDED | grep -v 'libm\|libc\|ld-linux\|libpthread\|libdl'"
     - name: Strip artifacts
       env: ${{ matrix.env }}
       if: matrix.env['TYPE'] == 'Release'
-      run: |
-        docker run --privileged -v $(pwd):$(pwd) -w $(pwd) -v /sys/kernel/debug:/sys/kernel/debug:rw -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -e STATIC_LINKING=${STATIC_LINKING} -e STATIC_LIBC=${STATIC_LIBC} -e EMBED_LLVM=${EMBED_LLVM} -e EMBED_CLANG=${EMBED_CLANG} -e EMBED_BCC=${EMBED_BCC} -e EMBED_LIBELF=${EMBED_LIBELF} -e EMBED_LIBCLANG_ONLY=${EMBED_LIBCLANG_ONLY} -e EMBED_BINUTILS=${EMBED_BINUTILS} --entrypoint /bin/bash bpftrace-embedded-${{ matrix.env['BASE'] }} -c "strip --keep-symbol BEGIN_trigger $(pwd)/build-embedded/src/bpftrace"
+      run: >
+        docker run --privileged
+        -v $(pwd):$(pwd)
+        -w $(pwd)
+        -v /sys/kernel/debug:/sys/kernel/debug:rw
+        -v /lib/modules:/lib/modules:ro
+        -v /usr/src:/usr/src:ro
+        -e STATIC_LINKING=${STATIC_LINKING}
+        -e STATIC_LIBC=${STATIC_LIBC}
+        -e EMBED_LLVM=${EMBED_LLVM}
+        -e EMBED_CLANG=${EMBED_CLANG}
+        -e EMBED_BCC=${EMBED_BCC}
+        -e EMBED_LIBELF=${EMBED_LIBELF}
+        -e EMBED_LIBCLANG_ONLY=${EMBED_LIBCLANG_ONLY}
+        -e EMBED_BINUTILS=${EMBED_BINUTILS}
+        --entrypoint /bin/bash
+        bpftrace-embedded-${{ matrix.env['BASE'] }}
+        -c "strip --keep-symbol BEGIN_trigger $(pwd)/build-embedded/src/bpftrace"
 
     - uses: actions/upload-artifact@v1
       with:
@@ -147,11 +205,23 @@ jobs:
         path: build-embedded/tests/bpftrace_test
 
     - name: Authenticate with docker registry
-      if: matrix.env['TYPE'] == 'Release' && github.ref == 'refs/heads/master' && github.repository == 'iovisor/bpftrace'
+      if: >
+        matrix.env['TYPE'] == 'Release' &&
+        github.ref == 'refs/heads/master' &&
+        github.repository == 'iovisor/bpftrace'
       env:
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
       run: ./docker/scripts/auth.sh ${{ github.repository }}
 
     - name: Package docker image and push to quay.io
-      if: matrix.env['TYPE'] == 'Release' && github.ref == 'refs/heads/master' && github.repository == 'iovisor/bpftrace'
-      run: ./docker/scripts/push.sh ${{ github.repository }} ${{ github.ref }} ${{ github.sha }} ${{ matrix.env['NAME'] }} ${{ matrix.env['EDGE'] }}
+      if: >
+        matrix.env['TYPE'] == 'Release' &&
+        github.ref == 'refs/heads/master' &&
+        github.repository == 'iovisor/bpftrace'
+      run: >
+        ./docker/scripts/push.sh
+        ${{ github.repository }}
+        ${{ github.ref }}
+        ${{ github.sha }}
+        ${{ matrix.env['NAME'] }}
+        ${{ matrix.env['EDGE'] }}


### PR DESCRIPTION
We're seeing more often issues with apt repos syncing and our CI
spuriously failing. We don't really need super up to date docker CI
images -- one a week is probably good enough.

This commit caches the docker build for a week if files in `docker/` are
not changed.

I tested this works by pushing this commit my personal repo, letting GH
actions run, then pushing a dummy commit and verifying cache works as
expected.

Also note that github only gives 5G of cache for free. Each image is
~300MB so that gives us ~15 images in cache. We'll probably see some
churn but hey, that's how caches work, right? Better than nothing.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
