### PR TITLE
Support multi-matched globbed target files for uprobe and usdt

### DIFF
--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -98,7 +98,7 @@ jobs:
           EMBED_BINUTILS: OFF
           RUN_ALL_TESTS: 1
           TEST_GROUPS_DISABLE: "tools-parsing-test"
-          RUNTIME_TEST_DISABLE: json-output.join_delim,other.string compare map lookup,probe.kprobe_offset_fail_size,usdt."usdt probes - attach to fully specified probe of child",usdt."usdt probes - all probes by wildcard and file with child",usdt."usdt probes - attach to probe by wildcard and file with child",usdt."usdt probes - attach to probes by wildcard file with child",usdt."usdt probes - attach to probe with probe builtin and args by file with child",usdt."usdt probes - list probes by pid in separate mountns",usdt."usdt sized arguments",uprobe."uprobes - list probes by pid; uprobes only",uprobe."uprobes - list probes by pid in separate mount namespace"
+          RUNTIME_TEST_DISABLE: json-output.join_delim,other.string compare map lookup,probe.kprobe_offset_fail_size,usdt."usdt probes - attach to fully specified probe of child",usdt."usdt probes - all probes by wildcard and file with child",usdt."usdt probes - attach to probe by wildcard and file with child",usdt."usdt probes - attach to probes by wildcard file with child",usdt."usdt probes - attach to probe on multiple files by wildcard",usdt."usdt probes - attach to probe with probe builtin and args by file with child",usdt."usdt probes - list probes by pid in separate mountns",usdt."usdt sized arguments",uprobe."uprobes - list probes by pid; uprobes only",uprobe."uprobes - list probes by pid in separate mount namespace"
           BASE: alpine
           DISTRO: alpine
           ALPINE_VERSION: 3.11
@@ -114,7 +114,7 @@ jobs:
           EMBED_LIBELF: OFF
           EMBED_BINUTILS: OFF
           RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: other.string compare map lookup,probe.kprobe_offset_fail_size,usdt."usdt probes - attach to fully specified probe of child",usdt."usdt probes - all probes by wildcard and file with child",usdt."usdt probes - attach to probe by wildcard and file with child",usdt."usdt probes - attach to probes by wildcard file with child",usdt."usdt probes - attach to probe with probe builtin and args by file with child",usdt."usdt probes - list probes by pid in separate mountns",usdt."usdt sized arguments",uprobe."uprobes - list probes by pid; uprobes only",uprobe."uprobes - list probes by pid in separate mount namespace"
+          RUNTIME_TEST_DISABLE: other.string compare map lookup,probe.kprobe_offset_fail_size,usdt."usdt probes - attach to fully specified probe of child",usdt."usdt probes - all probes by wildcard and file with child",usdt."usdt probes - attach to probe by wildcard and file with child",usdt."usdt probes - attach to probes by wildcard file with child",usdt."usdt probes - attach to probe on multiple files by wildcard",usdt."usdt probes - attach to probe with probe builtin and args by file with child",usdt."usdt probes - list probes by pid in separate mountns",usdt."usdt sized arguments",uprobe."uprobes - list probes by pid; uprobes only",uprobe."uprobes - list probes by pid in separate mount namespace"
           BASE: alpine
           DISTRO: alpine
           ALPINE_VERSION: 3.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to
   - [#1484](https://github.com/iovisor/bpftrace/pull/1484)
 - Resolve unknown typedefs using BTF and give a hint when a type cannot be found
   - [#1485](https://github.com/iovisor/bpftrace/pull/1485)
+- Support multi-matched globbed targets for uprobe and ustd probes
+  - [#1499](https://github.com/iovisor/bpftrace/pull/1499)
 
 #### Changed
 - Warn if using `print` on `stats` maps with top and div arguments

--- a/docker/Dockerfile.bionic
+++ b/docker/Dockerfile.bionic
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y \
       binutils-dev \
       cmake \
       flex \
-      g++ \
+      g++-8 \
       git \
       libelf-dev \
       zlib1g-dev \
@@ -34,6 +34,9 @@ RUN apt-get update && apt-get install -y \
       libllvm${LLVM_VERSION} \
       systemtap-sdt-dev \
       python3
+
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 60 \
+                        --slave /usr/bin/g++ g++ /usr/bin/g++-8
 
 COPY build.sh /build.sh
 RUN chmod 755 /build.sh

--- a/docker/Dockerfile.ubuntu-glibc
+++ b/docker/Dockerfile.ubuntu-glibc
@@ -63,15 +63,15 @@ RUN if [ "${BASE}" = "xenial" ]; then \
     apt install -y cmake \
     ; fi
 
-# Install C++17 compatible compiler if running on xenial
+# Install C++17 compatible compiler
 RUN if [ "${BASE}" = "xenial" ]; then \
     apt-get install -y software-properties-common \
     && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
     && apt update \
-    && apt install -y g++-7 \
-    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 60 \
-                           --slave /usr/bin/g++ g++ /usr/bin/g++-7 \
-    ; fi
+    ; fi \
+    ; apt install -y g++-8 \
+    && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 60 \
+                           --slave /usr/bin/g++ g++ /usr/bin/g++-8
 
 # Build BCC and install static libs
 RUN mkdir -p /src && git clone https://github.com/$bcc_org/bcc /src/bcc

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -108,6 +108,12 @@ else()
   target_link_libraries(bpftrace ${LIBELF_LIBRARIES})
 endif(STATIC_LINKING)
 
+# Support for std::filesystem
+# GCC version <9 and Clang (all versions) require -lstdc++fs
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS "9")
+  target_link_libraries(bpftrace "stdc++fs")
+endif()
+
 if (BUILD_ASAN)
   if(${CMAKE_VERSION} VERSION_LESS "3.13.0")
     # target_link_options is supported in CMake 3.13 and newer

--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -360,7 +360,7 @@ int AttachPointParser::usdt_parser()
 
   if (ap_->target.find('*') != std::string::npos ||
       ap_->ns.find('*') != std::string::npos || ap_->ns.empty() ||
-      ap_->func.find('*') != std::string::npos)
+      ap_->func.find('*') != std::string::npos || bpftrace_.pid())
     ap_->need_expansion = true;
 
   return 0;

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -2047,10 +2047,13 @@ void CodegenLLVM::visit(Probe &probe)
           if (attach_point->provider == "BEGIN" ||
               attach_point->provider == "END")
             probefull_ = attach_point->provider;
-          else if (probetype(attach_point->provider) == ProbeType::tracepoint)
+          else if ((probetype(attach_point->provider) ==
+                        ProbeType::tracepoint ||
+                    probetype(attach_point->provider) == ProbeType::uprobe ||
+                    probetype(attach_point->provider) == ProbeType::uretprobe))
           {
-            // Tracepoint probes must specify both a category (target) and
-            // a function name
+            // Tracepoint and uprobe probes must specify both a target
+            // (tracepoint category) and a function name
             std::string func = match;
             std::string category = erase_prefix(func);
 

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -2033,6 +2033,7 @@ void SemanticAnalyser::visit(AttachPoint &ap)
       default:
         // If we are doing a PATH lookup (ie not glob), we follow shell
         // behavior and take the first match.
+        // Otherwise we keep the target with glob, it will be expanded later
         if (ap.target.find("*") == std::string::npos)
         {
           LOG(WARNING, ap.loc, out_)
@@ -2041,11 +2042,6 @@ void SemanticAnalyser::visit(AttachPoint &ap)
               << " binaries";
           ap.target = paths.front();
         }
-        else
-          LOG(ERROR, ap.loc, err_)
-              << "usdt target file '" << ap.target
-              << "' must refer to a unique binary but matched "
-              << std::to_string(paths.size());
       }
     }
 
@@ -2055,7 +2051,8 @@ void SemanticAnalyser::visit(AttachPoint &ap)
     }
     else if (ap.target != "")
     {
-      USDTHelper::probes_for_path(ap.target);
+      for (auto &path : resolve_binary_path(ap.target))
+        USDTHelper::probes_for_path(path);
     }
     else
     {

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -2003,6 +2003,7 @@ void SemanticAnalyser::visit(AttachPoint &ap)
     default:
       // If we are doing a PATH lookup (ie not glob), we follow shell
       // behavior and take the first match.
+      // Otherwise we keep the target with glob, it will be expanded later
       if (ap.target.find("*") == std::string::npos)
       {
         LOG(WARNING, ap.loc, out_)
@@ -2010,11 +2011,6 @@ void SemanticAnalyser::visit(AttachPoint &ap)
             << "' but matched " << std::to_string(paths.size()) << " binaries";
         ap.target = paths.front();
       }
-      else
-        LOG(ERROR, ap.loc, err_)
-            << "uprobe target file '" << ap.target
-            << "' must refer to a unique binary but matched "
-            << std::to_string(paths.size());
     }
   }
   else if (ap.provider == "usdt") {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -3,6 +3,7 @@
 #include <cmath>
 #include <cstring>
 #include <fcntl.h>
+#include <filesystem>
 #include <fstream>
 #include <glob.h>
 #include <link.h>
@@ -910,6 +911,12 @@ uint32_t kernel_version(int attempt)
       throw std::runtime_error("BUG: kernel_version(): Invalid attempt: " +
                                std::to_string(attempt));
   }
+}
+
+std::string abs_path(const std::string &rel_path)
+{
+  auto p = std::filesystem::path(rel_path);
+  return std::filesystem::canonical(std::filesystem::absolute(p)).string();
 }
 
 } // namespace bpftrace

--- a/src/utils.h
+++ b/src/utils.h
@@ -150,6 +150,7 @@ bool is_numeric(const std::string &str);
 bool symbol_has_cpp_mangled_signature(const std::string &sym_name);
 pid_t parse_pid(const std::string &str);
 std::string hex_format_buffer(const char *buf, size_t size);
+std::string abs_path(const std::string &rel_path);
 
 // trim from end of string (right)
 inline std::string &rtrim(std::string &s)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -126,6 +126,12 @@ else()
   target_link_libraries(bpftrace_test ${LIBELF_LIBRARIES})
 endif(STATIC_LINKING)
 
+# Support for std::filesystem
+# GCC version <9 and Clang (all versions) require -lstdc++fs
+if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_VERSION} VERSION_LESS "9")
+  target_link_libraries(bpftrace_test "stdc++fs")
+endif()
+
 find_package(Threads REQUIRED)
 
 # Ninja build system needs the byproducts set explicilty so it can

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -537,7 +537,7 @@ TEST(bpftrace, add_probes_usdt_wildcard)
 {
   ast::AttachPoint a("");
   a.provider = "usdt";
-  a.target = "/bin/sh";
+  a.target = "/bin/*sh";
   a.ns = "prov*";
   a.func = "tp*";
   a.usdt.num_locations = 1;
@@ -546,19 +546,30 @@ TEST(bpftrace, add_probes_usdt_wildcard)
   ast::Probe probe(&attach_points, nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
-  EXPECT_CALL(*bpftrace, get_symbols_from_usdt(0, "/bin/sh")).Times(1);
+  EXPECT_CALL(*bpftrace, get_symbols_from_usdt(0, "/bin/*sh")).Times(1);
 
   ASSERT_EQ(0, bpftrace->add_probe(probe));
-  ASSERT_EQ(3U, bpftrace->get_probes().size());
+  ASSERT_EQ(4U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
   check_usdt(bpftrace->get_probes().at(0),
-             "/bin/sh", "prov1", "tp1",
-             "usdt:/bin/sh:prov1:tp1");
+             "/bin/bash",
+             "prov1",
+             "tp3",
+             "usdt:/bin/bash:prov1:tp3");
   check_usdt(bpftrace->get_probes().at(1),
-             "/bin/sh", "prov1", "tp2",
-             "usdt:/bin/sh:prov1:tp2");
+             "/bin/sh",
+             "prov1",
+             "tp1",
+             "usdt:/bin/sh:prov1:tp1");
   check_usdt(bpftrace->get_probes().at(2),
-             "/bin/sh", "prov2", "tp",
+             "/bin/sh",
+             "prov1",
+             "tp2",
+             "usdt:/bin/sh:prov1:tp2");
+  check_usdt(bpftrace->get_probes().at(3),
+             "/bin/sh",
+             "prov2",
+             "tp",
              "usdt:/bin/sh:prov2:tp");
 }
 

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -344,6 +344,30 @@ TEST(bpftrace, add_probes_uprobe_wildcard)
   check_uprobe(bpftrace->get_probes().at(1), "/bin/sh", "second_open", probe_orig_name);
 }
 
+TEST(bpftrace, add_probes_uprobe_wildcard_file)
+{
+  ast::AttachPoint a("");
+  a.provider = "uprobe";
+  a.target = "/bin/*sh";
+  a.func = "first_open";
+  a.need_expansion = true;
+  ast::AttachPointList attach_points = { &a };
+  ast::Probe probe(&attach_points, nullptr, nullptr);
+
+  auto bpftrace = get_strict_mock_bpftrace();
+  EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/*sh")).Times(1);
+
+  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(2U, bpftrace->get_probes().size());
+  ASSERT_EQ(0U, bpftrace->get_special_probes().size());
+
+  std::string probe_orig_name = "uprobe:/bin/*sh:first_open";
+  check_uprobe(
+      bpftrace->get_probes().at(0), "/bin/bash", "first_open", probe_orig_name);
+  check_uprobe(
+      bpftrace->get_probes().at(1), "/bin/sh", "first_open", probe_orig_name);
+}
+
 TEST(bpftrace, add_probes_uprobe_wildcard_no_matches)
 {
   ast::AttachPoint a("");

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -36,14 +36,17 @@ void setup_mock_bpftrace(MockBPFtrace &bpftrace)
         return std::unique_ptr<std::istream>(new std::istringstream(tracepoints));
       });
 
-  std::string usyms = "first_open\n"
-                      "second_open\n"
-                      "open_as_well\n"
-                      "something_else\n"
-                      "_Z11cpp_mangledi\n"
-                      "_Z11cpp_mangledv\n";
-  ON_CALL(bpftrace, extract_func_symbols_from_path(_))
-      .WillByDefault(Return(usyms));
+  std::string sh_usyms = "/bin/sh:first_open\n"
+                         "/bin/sh:second_open\n"
+                         "/bin/sh:open_as_well\n"
+                         "/bin/sh:something_else\n"
+                         "/bin/sh:_Z11cpp_mangledi\n"
+                         "/bin/sh:_Z11cpp_mangledv\n";
+  std::string bash_usyms = "/bin/bash:first_open\n";
+  ON_CALL(bpftrace, extract_func_symbols_from_path("/bin/sh"))
+      .WillByDefault(Return(sh_usyms));
+  ON_CALL(bpftrace, extract_func_symbols_from_path("/bin/*sh"))
+      .WillByDefault(Return(sh_usyms + bash_usyms));
 
   ON_CALL(bpftrace, get_symbols_from_usdt(_, _))
       .WillByDefault([](int, const std::string &)

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -49,13 +49,13 @@ void setup_mock_bpftrace(MockBPFtrace &bpftrace)
       .WillByDefault(Return(sh_usyms + bash_usyms));
 
   ON_CALL(bpftrace, get_symbols_from_usdt(_, _))
-      .WillByDefault([](int, const std::string &)
-      {
-        std::string usdt_syms = "prov1:tp1\n"
-                                "prov1:tp2\n"
-                                "prov2:tp\n"
-                                "prov2:notatp\n"
-                                "nahprov:tp\n";
+      .WillByDefault([](int, const std::string &) {
+        std::string usdt_syms = "/bin/sh:prov1:tp1\n"
+                                "/bin/sh:prov1:tp2\n"
+                                "/bin/sh:prov2:tp\n"
+                                "/bin/sh:prov2:notatp\n"
+                                "/bin/sh:nahprov:tp\n"
+                                "/bin/bash:prov1:tp3";
         return std::unique_ptr<std::istream>(new std::istringstream(usdt_syms));
       });
 

--- a/tests/runtime/uprobe
+++ b/tests/runtime/uprobe
@@ -8,9 +8,9 @@ RUN bpftrace -l 'uprobe:./testprogs/uprobe_test:func*'
 EXPECT uprobe:./testprogs/uprobe_test:function1
 TIMEOUT 5
 
-NAME "uprobes - list probes with ambiguous wildcarded file fails"
-RUN bpftrace -l 'uprobe:./testprogs/u*:*'
-EXPECT must refer to a unique binary
+NAME "uprobes - list probes with wildcarded file matching multiple files"
+RUN bpftrace -l 'uprobe:./testprogs/uprobe*:*'
+EXPECT uprobe:./testprogs/uprobe_test:function1
 TIMEOUT 5
 
 NAME "uprobes - list probes by file with wildcarded file and filter"

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -114,9 +114,9 @@ RUN bpftrace -e 'usdt:./testprogs/usdt_test*::* { printf("here\n" ); exit(); }' 
 EXPECT Attaching 3 probes...
 TIMEOUT 5
 
-NAME "usdt probes - attach to probe with ambiguous wildcard file fails"
-RUN bpftrace -e 'usdt:./testprogs/u*::* { printf("here\n" ); exit(); }'
-EXPECT must refer to a unique binary
+NAME "usdt probes - attach to probe on multiple files by wildcard"
+RUN bpftrace -e 'usdt:./testprogs/usdt*::* { printf("here\n" ); exit(); }'
+EXPECT Attaching 9 probes...
 TIMEOUT 5
 
 NAME "usdt probes - attach to probe on multiple providers by wildcard and pid"


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

The change is pretty straightforward, it's mostly achieved by changing the form of strings returned by `find_wildcard_matches` for these probe types (the new form is `target:function` for uprobe and `target:namespace:probename` for usdt) and handling the new form where needed.

A noticeable behavior is for usdt probes when a process PID is specified. By default, all binaries and libraries executed by the process are searched for usdt probes. If a target path is specified along with a PID, only the binaries/libraries matching the path are searched. I wonder if this information should be put into the Reference Guide.

Resolves #1113.

Note: this change introduces usage of `std::filesystem`. This requires some changes, in particular adding the `-lstdc++fs` linker flag for some compiler versions and using GCC version 8 in Docker images (since GCC 7 does not support `std::filesystem`). These changes will probably be needed for #1263, too.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
