### PR TITLE
Set addrspace info for various builtins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to
   - [#1514](https://github.com/iovisor/bpftrace/pull/1514)
 - Support for tracepoint __data_loc fields
   - [#1542](https://github.com/iovisor/bpftrace/pull/1542)
+- Set addrspace info for various builtins
+  - [#1504](https://github.com/iovisor/bpftrace/pull/1504)
 
 #### Changed
 - Warn if using `print` on `stats` maps with top and div arguments

--- a/src/ast/codegen_helper.h
+++ b/src/ast/codegen_helper.h
@@ -14,6 +14,10 @@ inline bool shouldBeOnStackAlready(const SizedType &type)
   return type.IsStringTy() || type.IsBufferTy() || type.IsInetTy() ||
          type.IsUsymTy() || type.IsTupleTy() || type.IsTimestampTy();
 }
+inline AddrSpace find_addrspace_stack(const SizedType &ty)
+{
+  return (shouldBeOnStackAlready(ty)) ? AddrSpace::kernel : ty.GetAS();
+}
 
 } // namespace ast
 } // namespace bpftrace

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -115,7 +115,7 @@ void CodegenLLVM::visit(Builtin &builtin)
 {
   if (builtin.ident == "nsecs")
   {
-    expr_ = b_.CreateGetNs(bpftrace_.feature_.has_helper_ktime_get_boot_ns());
+    expr_ = b_.CreateGetNs(bpftrace_.feature_->has_helper_ktime_get_boot_ns());
   }
   else if (builtin.ident == "elapsed")
   {
@@ -126,7 +126,7 @@ void CodegenLLVM::visit(Builtin &builtin)
     auto type = CreateUInt64();
     auto start = b_.CreateMapLookupElem(
         ctx_, map->mapfd_, key, type, builtin.loc);
-    expr_ = b_.CreateGetNs(bpftrace_.feature_.has_helper_ktime_get_boot_ns());
+    expr_ = b_.CreateGetNs(bpftrace_.feature_->has_helper_ktime_get_boot_ns());
     expr_ = b_.CreateSub(expr_, start);
     // start won't be on stack, no need to LifeTimeEnd it
     b_.CreateLifetimeEnd(key);

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -48,7 +48,7 @@ libbpf::bpf_func_id IRBuilderBPF::selectProbeReadHelper(AddrSpace as, bool str)
 {
   libbpf::bpf_func_id fn;
   // Assume that if a kernel has probe_read_kernel it has the other 3 too
-  if (bpftrace_.feature_.has_helper_probe_read_kernel())
+  if (bpftrace_.feature_->has_helper_probe_read_kernel())
   {
     if (as == AddrSpace::kernel)
     {

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -65,6 +65,12 @@ libbpf::bpf_func_id IRBuilderBPF::selectProbeReadHelper(AddrSpace as, bool str)
       // if the kernel has the new helpers but AS is still none it is a bug
       // in bpftrace, assert catches it for debug builds.
       // assert(as != AddrSpace::none);
+      static bool warnonce = false;
+      if (!warnonce)
+      {
+        warnonce = true;
+        LOG(WARNING) << "Addrspace is not set";
+      }
       fn = str ? libbpf::BPF_FUNC_probe_read_str : libbpf::BPF_FUNC_probe_read;
     }
   }
@@ -594,7 +600,7 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
     {
       // Zero out `dst` in case we read less than 64 bits
       CreateStore(getInt64(0), dst);
-      CreateProbeRead(ctx, dst, abs_size, reg, as, loc);
+      CreateProbeRead(ctx, dst, abs_size, reg, AddrSpace::kernel, loc);
       result = CreateLoad(dst);
     }
     CreateLifetimeEnd(dst);

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -598,10 +598,8 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
     }
     else
     {
-      // Zero out `dst` in case we read less than 64 bits
-      CreateStore(getInt64(0), dst);
-      CreateProbeRead(ctx, dst, abs_size, reg, AddrSpace::kernel, loc);
-      result = CreateLoad(dst);
+      result = CreateLoad(GetType(CreateInt(abs_size * 8)), reg);
+      result = CreateIntCast(result, getInt64Ty(), argument->size < 0);
     }
     CreateLifetimeEnd(dst);
   }

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -61,7 +61,7 @@ void SemanticAnalyser::visit(PositionalParameter &param)
               << "\". Try using str($" << param.n << ").";
         }
         // string allocated in bpf stack. See codegen.
-        if (!is_numeric(pstr))
+        if (param.is_in_str)
           param.type.SetAS(AddrSpace::kernel);
       }
       break;

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -245,7 +245,7 @@ void SemanticAnalyser::visit(Builtin &builtin)
   {
     builtin.type = CreateUInt64();
     if (builtin.ident == "cgroup" &&
-        !feature_.has_helper_get_current_cgroup_id())
+        !bpftrace_.feature_->has_helper_get_current_cgroup_id())
     {
       LOG(ERROR, builtin.loc, err_)
           << "BPF_FUNC_get_current_cgroup_id is not available for your kernel "
@@ -1022,7 +1022,7 @@ void SemanticAnalyser::visit(Call &call)
     check_stack_call(call, false);
   }
   else if (call.func == "signal") {
-    if (!feature_.has_helper_send_signal())
+    if (!bpftrace_.feature_->has_helper_send_signal())
     {
       LOG(ERROR, call.loc, err_)
           << "BPF_FUNC_send_signal not available for your kernel version";
@@ -1095,7 +1095,7 @@ void SemanticAnalyser::visit(Call &call)
   }
   else if (call.func == "override")
   {
-    if (!feature_.has_helper_override_return())
+    if (!bpftrace_.feature_->has_helper_override_return())
     {
       LOG(ERROR, call.loc, err_)
           << "BPF_FUNC_override_return not available for your kernel version";
@@ -1677,7 +1677,7 @@ void SemanticAnalyser::visit(Jump &jump)
 
 void SemanticAnalyser::visit(While &while_block)
 {
-  if (is_final_pass() && !feature_.has_loop())
+  if (is_final_pass() && !bpftrace_.feature_->has_loop())
   {
     LOG(WARNING, while_block.loc, out_)
         << "Kernel does not support bounded loops. Depending"
@@ -2335,7 +2335,8 @@ void SemanticAnalyser::visit(AttachPoint &ap)
     return;
 #endif
 
-    bool supported = feature_.has_prog_kfunc() && bpftrace_.btf_.has_data();
+    bool supported = bpftrace_.feature_->has_prog_kfunc() &&
+                     bpftrace_.btf_.has_data();
     if (!supported)
     {
       LOG(ERROR, ap.loc, err_)

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1490,7 +1490,7 @@ void SemanticAnalyser::visit(Binop &binop)
       addr_rhs != AddrSpace::none)
   {
     if (is_final_pass())
-      LOG(WARNING) << "Addrspace mismatch";
+      LOG(WARNING, binop.loc, out_) << "Addrspace mismatch";
     binop.type.SetAS(AddrSpace::none);
   }
   // Associativity from left to right for binary operator

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -17,22 +17,17 @@ class SemanticAnalyser : public Visitor {
 public:
   explicit SemanticAnalyser(Node *root,
                             BPFtrace &bpftrace,
-                            BPFfeature &feature,
                             std::ostream &out = std::cerr,
                             bool has_child = true)
       : root_(root),
         bpftrace_(bpftrace),
-        feature_(feature),
         out_(out),
         has_child_(has_child)
   {
   }
 
-  explicit SemanticAnalyser(Node *root,
-                            BPFtrace &bpftrace,
-                            BPFfeature &feature,
-                            bool has_child)
-      : SemanticAnalyser(root, bpftrace, feature, std::cerr, has_child)
+  explicit SemanticAnalyser(Node *root, BPFtrace &bpftrace, bool has_child)
+      : SemanticAnalyser(root, bpftrace, std::cerr, has_child)
   {
   }
 
@@ -70,7 +65,6 @@ public:
 private:
   Node *root_;
   BPFtrace &bpftrace_;
-  BPFfeature &feature_;
   std::ostream &out_;
   std::ostringstream err_;
   int pass_;

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -92,6 +92,7 @@ private:
   ProbeType single_provider_type(void);
   template <typename T>
   int create_maps_impl(void);
+  AddrSpace find_addrspace(ProbeType pt);
 
   bool in_loop(void)
   {

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -90,7 +90,12 @@ struct HelperErrorInfo
 class BPFtrace
 {
 public:
-  BPFtrace(std::unique_ptr<Output> o = std::make_unique<TextOutput>(std::cout)) : out_(std::move(o)),ncpus_(get_possible_cpus().size()) { }
+  BPFtrace(std::unique_ptr<Output> o = std::make_unique<TextOutput>(std::cout))
+      : out_(std::move(o)),
+        feature_(std::make_unique<BPFfeature>()),
+        ncpus_(get_possible_cpus().size())
+  {
+  }
   virtual ~BPFtrace();
   virtual int add_probe(ast::Probe &p);
   int num_probes() const;
@@ -150,7 +155,7 @@ public:
   unsigned int join_argnum_;
   unsigned int join_argsize_;
   std::unique_ptr<Output> out_;
-  BPFfeature feature_;
+  std::unique_ptr<BPFfeature> feature_;
 
   uint64_t strlen_ = 64;
   uint64_t mapmax_ = 4096;

--- a/src/lockdown.cpp
+++ b/src/lockdown.cpp
@@ -71,12 +71,12 @@ void emit_warning(std::ostream &out)
   // clang-format on
 }
 
-LockdownState detect(BPFfeature &feature)
+LockdownState detect(std::unique_ptr<BPFfeature> &feature)
 {
   // Ubuntu (19.10 at least) ships a lockdown version that fully blocks the bpf
   // syscall
-  if (is_ubuntu() && !feature.has_map_array() &&
-      !feature.has_helper_probe_read())
+  if (is_ubuntu() && !feature->has_map_array() &&
+      !feature->has_helper_probe_read())
   {
     return LockdownState::Confidentiality;
   }

--- a/src/lockdown.h
+++ b/src/lockdown.h
@@ -15,7 +15,7 @@ enum class LockdownState
   Unknown, // Could not determine whether lockdown is enabled or not
 };
 
-LockdownState detect(BPFfeature &feature);
+LockdownState detect(std::unique_ptr<BPFfeature> &feature);
 void emit_warning(std::ostream &out);
 
 } //  namespace lockdown

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -695,8 +695,7 @@ int main(int argc, char *argv[])
   if (err)
     return err;
 
-  ast::SemanticAnalyser semantics(
-      driver.root_, bpftrace, bpftrace.feature_, !cmd_str.empty());
+  ast::SemanticAnalyser semantics(driver.root_, bpftrace, !cmd_str.empty());
   err = semantics.analyse();
   if (err)
     return err;

--- a/tests/codegen/call_kstack.cpp
+++ b/tests/codegen/call_kstack.cpp
@@ -28,8 +28,9 @@ TEST(codegen, call_kstack_mapids)
   ClangParser clang;
   clang.parse(driver.root_, bpftrace);
 
-  MockBPFfeature feature;
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace, feature);
+  // Override to mockbpffeature.
+  bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
+  ast::SemanticAnalyser semantics(driver.root_, bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 
@@ -59,8 +60,9 @@ TEST(codegen, call_kstack_modes_mapids)
   ClangParser clang;
   clang.parse(driver.root_, bpftrace);
 
-  MockBPFfeature feature;
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace, feature);
+  // Override to mockbpffeature.
+  bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
+  ast::SemanticAnalyser semantics(driver.root_, bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 

--- a/tests/codegen/call_ustack.cpp
+++ b/tests/codegen/call_ustack.cpp
@@ -28,8 +28,9 @@ TEST(codegen, call_ustack_mapids)
   ClangParser clang;
   clang.parse(driver.root_, bpftrace);
 
-  MockBPFfeature feature;
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace, feature);
+  // Override to mockbpffeature.
+  bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
+  ast::SemanticAnalyser semantics(driver.root_, bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 
@@ -59,8 +60,9 @@ TEST(codegen, call_ustack_modes_mapids)
   ClangParser clang;
   clang.parse(driver.root_, bpftrace);
 
-  MockBPFfeature feature;
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace, feature);
+  // Override to mockbpffeature.
+  bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
+  ast::SemanticAnalyser semantics(driver.root_, bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -376,8 +376,9 @@ static void test(BPFtrace &bpftrace,
 
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  MockBPFfeature feature;
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace, feature);
+  // Override to mockbpffeature.
+  bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
+  ast::SemanticAnalyser semantics(driver.root_, bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -44,8 +44,9 @@ TEST(codegen, populate_sections)
   Driver driver(bpftrace);
 
   ASSERT_EQ(driver.parse_str("kprobe:foo { 1 } kprobe:bar { 1 }"), 0);
-  MockBPFfeature feature;
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace, feature);
+  // Override to mockbpffeature.
+  bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
+  ast::SemanticAnalyser semantics(driver.root_, bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
   std::stringstream out;
   ast::CodegenLLVM codegen(driver.root_, bpftrace);
@@ -72,8 +73,10 @@ TEST(codegen, printf_offsets)
             0);
   ClangParser clang;
   clang.parse(driver.root_, bpftrace);
-  MockBPFfeature feature;
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace, feature);
+
+  // Override to mockbpffeature.
+  bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
+  ast::SemanticAnalyser semantics(driver.root_, bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
   std::stringstream out;
@@ -115,8 +118,9 @@ TEST(codegen, probe_count)
   Driver driver(bpftrace);
 
   ASSERT_EQ(driver.parse_str("kprobe:f { 1; } kprobe:d { 1; }"), 0);
-  MockBPFfeature feature;
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace, feature);
+  // Override to mockbpffeature.
+  bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
+  ast::SemanticAnalyser semantics(driver.root_, bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
   ast::CodegenLLVM codegen(driver.root_, bpftrace);
   codegen.generate_ir();

--- a/tests/codegen/llvm/builtin_ctx_field.ll
+++ b/tests/codegen/llvm/builtin_ctx_field.ll
@@ -85,7 +85,7 @@ entry:
   %35 = load volatile i64, i64* %34
   %36 = add i64 %35, 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"struct c.c")
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i64)*)(i8* %"struct c.c", i32 1, i64 %36)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct c.c", i32 1, i64 %36)
   %37 = load i8, i8* %"struct c.c"
   %38 = sext i8 %37 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct c.c")

--- a/tests/codegen/llvm/builtin_sarg.ll
+++ b/tests/codegen/llvm/builtin_sarg.ll
@@ -20,7 +20,7 @@ entry:
   %3 = bitcast i64* %sarg0 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   %4 = add i64 %reg_sp, 8
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* %sarg0, i32 8, i64 %4)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %sarg0, i32 8, i64 %4)
   %5 = load i64, i64* %sarg0
   %6 = bitcast i64* %sarg0 to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
@@ -42,7 +42,7 @@ entry:
   %13 = bitcast i64* %sarg2 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
   %14 = add i64 %reg_sp1, 24
-  %probe_read2 = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* %sarg2, i32 8, i64 %14)
+  %probe_read_kernel2 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %sarg2, i32 8, i64 %14)
   %15 = load i64, i64* %sarg2
   %16 = bitcast i64* %sarg2 to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)

--- a/tests/codegen/llvm/call_buf_implicit_size.ll
+++ b/tests/codegen/llvm/call_buf_implicit_size.ll
@@ -28,7 +28,7 @@ entry:
   call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 16, i1 false)
   %7 = load i64, i64* %"$foo"
   %8 = add i64 %7, 0
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* %5, i32 16, i64 %8)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* %5, i32 16, i64 %8)
   %9 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 0, i64* %"@x_key"

--- a/tests/codegen/llvm/call_buf_size_literal.ll
+++ b/tests/codegen/llvm/call_buf_size_literal.ll
@@ -22,7 +22,7 @@ entry:
   %5 = bitcast i8* %0 to i64*
   %6 = getelementptr i64, i64* %5, i64 14
   %arg0 = load volatile i64, i64* %6
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([1 x i8]*, i32, i64)*)([1 x i8]* %3, i32 1, i64 %arg0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([1 x i8]*, i32, i64)*)([1 x i8]* %3, i32 1, i64 %arg0)
   %7 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   store i64 0, i64* %"@x_key"

--- a/tests/codegen/llvm/call_buf_size_nonliteral.ll
+++ b/tests/codegen/llvm/call_buf_size_nonliteral.ll
@@ -29,7 +29,7 @@ entry:
   %9 = getelementptr i64, i64* %8, i64 14
   %arg0 = load volatile i64, i64* %9
   %10 = zext i8 %5 to i32
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %6, i32 %10, i64 %arg0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %6, i32 %10, i64 %arg0)
   %11 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   store i64 0, i64* %"@x_key"

--- a/tests/codegen/llvm/call_ntop_char16.ll
+++ b/tests/codegen/llvm/call_ntop_char16.ll
@@ -19,7 +19,7 @@ entry:
   %3 = getelementptr %inet_t, %inet_t* %inet, i32 0, i32 1
   %4 = bitcast [16 x i8]* %3 to i8*
   call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 16, i1 false)
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* %3, i32 16, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* %3, i32 16, i64 0)
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
   store i64 0, i64* %"@x_key"

--- a/tests/codegen/llvm/call_ntop_char4.ll
+++ b/tests/codegen/llvm/call_ntop_char4.ll
@@ -19,7 +19,7 @@ entry:
   %3 = getelementptr %inet_t, %inet_t* %inet, i32 0, i32 1
   %4 = bitcast [16 x i8]* %3 to i8*
   call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 16, i1 false)
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* %3, i32 4, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* %3, i32 4, i64 0)
   %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
   store i64 0, i64* %"@x_key"

--- a/tests/codegen/llvm/call_printf.ll
+++ b/tests/codegen/llvm/call_printf.ll
@@ -29,7 +29,7 @@ entry:
   %6 = load i64, i64* %"$foo"
   %7 = add i64 %6, 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"struct Foo.c")
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.c", i32 1, i64 %7)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.c", i32 1, i64 %7)
   %8 = load i8, i8* %"struct Foo.c"
   %9 = sext i8 %8 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct Foo.c")
@@ -39,7 +39,7 @@ entry:
   %12 = add i64 %11, 8
   %13 = bitcast i64* %"struct Foo.l" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.l", i32 8, i64 %12)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.l", i32 8, i64 %12)
   %14 = load i64, i64* %"struct Foo.l"
   %15 = bitcast i64* %"struct Foo.l" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)

--- a/tests/codegen/llvm/call_printf_LLVM-10.ll
+++ b/tests/codegen/llvm/call_printf_LLVM-10.ll
@@ -29,7 +29,7 @@ entry:
   %6 = load i64, i64* %"$foo"
   %7 = add i64 %6, 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"struct Foo.c")
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.c", i32 1, i64 %7)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.c", i32 1, i64 %7)
   %8 = load i8, i8* %"struct Foo.c"
   %9 = sext i8 %8 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct Foo.c")
@@ -39,7 +39,7 @@ entry:
   %12 = add i64 %11, 8
   %13 = bitcast i64* %"struct Foo.l" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.l", i32 8, i64 %12)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.l", i32 8, i64 %12)
   %14 = load i64, i64* %"struct Foo.l"
   %15 = bitcast i64* %"struct Foo.l" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)

--- a/tests/codegen/llvm/call_str.ll
+++ b/tests/codegen/llvm/call_str.ll
@@ -25,7 +25,7 @@ entry:
   %arg0 = load volatile i64, i64* %6
   %7 = load i64, i64* %strlen
   %8 = trunc i64 %7 to i32
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %8, i64 %arg0)
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %8, i64 %arg0)
   %9 = bitcast i64* %strlen to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   %10 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/call_str_2_expr.ll
+++ b/tests/codegen/llvm/call_str_2_expr.ll
@@ -31,7 +31,7 @@ entry:
   %arg0 = load volatile i64, i64* %9
   %10 = load i64, i64* %strlen
   %11 = trunc i64 %10 to i32
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %11, i64 %arg0)
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %11, i64 %arg0)
   %12 = bitcast i64* %strlen to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   %13 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/call_str_2_lit.ll
+++ b/tests/codegen/llvm/call_str_2_lit.ll
@@ -25,7 +25,7 @@ entry:
   %arg0 = load volatile i64, i64* %6
   %7 = load i64, i64* %strlen
   %8 = trunc i64 %7 to i32
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %8, i64 %arg0)
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %8, i64 %arg0)
   %9 = bitcast i64* %strlen to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   %10 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/call_uptr_1.ll
+++ b/tests/codegen/llvm/call_uptr_1.ll
@@ -16,7 +16,7 @@ entry:
   %arg0 = load volatile i64, i64* %2
   %3 = bitcast i16* %deref to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i16*, i32, i64)*)(i16* %deref, i32 2, i64 %arg0)
+  %probe_read_user = call i64 inttoptr (i64 112 to i64 (i16*, i32, i64)*)(i16* %deref, i32 2, i64 %arg0)
   %4 = load i16, i16* %deref
   %5 = sext i16 %4 to i64
   %6 = bitcast i16* %deref to i8*

--- a/tests/codegen/llvm/call_uptr_1_LLVM-10.ll
+++ b/tests/codegen/llvm/call_uptr_1_LLVM-10.ll
@@ -16,7 +16,7 @@ entry:
   %arg0 = load volatile i64, i64* %2
   %3 = bitcast i16* %deref to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i16*, i32, i64)*)(i16* %deref, i32 2, i64 %arg0)
+  %probe_read_user = call i64 inttoptr (i64 112 to i64 (i16*, i32, i64)*)(i16* %deref, i32 2, i64 %arg0)
   %4 = load i16, i16* %deref
   %5 = sext i16 %4 to i64
   %6 = bitcast i16* %deref to i8*

--- a/tests/codegen/llvm/call_uptr_2.ll
+++ b/tests/codegen/llvm/call_uptr_2.ll
@@ -16,7 +16,7 @@ entry:
   %arg0 = load volatile i64, i64* %2
   %3 = bitcast i32* %deref to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %arg0)
+  %probe_read_user = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %arg0)
   %4 = load i32, i32* %deref
   %5 = sext i32 %4 to i64
   %6 = bitcast i32* %deref to i8*

--- a/tests/codegen/llvm/call_uptr_2_LLVM-10.ll
+++ b/tests/codegen/llvm/call_uptr_2_LLVM-10.ll
@@ -16,7 +16,7 @@ entry:
   %arg0 = load volatile i64, i64* %2
   %3 = bitcast i32* %deref to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %arg0)
+  %probe_read_user = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %arg0)
   %4 = load i32, i32* %deref
   %5 = sext i32 %4 to i64
   %6 = bitcast i32* %deref to i8*

--- a/tests/codegen/llvm/intptrcast_assign_var.ll
+++ b/tests/codegen/llvm/intptrcast_assign_var.ll
@@ -16,7 +16,7 @@ entry:
   %reg_bp = load volatile i64, i64* %2
   %3 = sub i64 %reg_bp, 1
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %deref)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i64)*)(i8* %deref, i32 1, i64 %3)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %deref, i32 1, i64 %3)
   %4 = load i8, i8* %deref
   %5 = sext i8 %4 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %deref)

--- a/tests/codegen/llvm/intptrcast_call.ll
+++ b/tests/codegen/llvm/intptrcast_call.ll
@@ -43,7 +43,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   %reg_bp = load volatile i64, i64* %8
   %9 = sub i64 %reg_bp, 1
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %deref)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i64)*)(i8* %deref, i32 1, i64 %9)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %deref, i32 1, i64 %9)
   %10 = load i8, i8* %deref
   %11 = sext i8 %10 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %deref)

--- a/tests/codegen/llvm/logical_and_or_different_type.ll
+++ b/tests/codegen/llvm/logical_and_or_different_type.ll
@@ -40,7 +40,7 @@ entry:
   %10 = add [4 x i8]* %"$foo", i64 0
   %11 = bitcast i32* %"struct Foo.m" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m", i32 4, [4 x i8]* %10)
+  %probe_read_user = call i64 inttoptr (i64 112 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m", i32 4, [4 x i8]* %10)
   %12 = load i32, i32* %"struct Foo.m"
   %13 = sext i32 %12 to i64
   %14 = bitcast i32* %"struct Foo.m" to i8*
@@ -71,7 +71,7 @@ entry:
   %18 = add [4 x i8]* %"$foo", i64 0
   %19 = bitcast i32* %"struct Foo.m6" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
-  %probe_read7 = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m6", i32 4, [4 x i8]* %18)
+  %probe_read_user7 = call i64 inttoptr (i64 112 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m6", i32 4, [4 x i8]* %18)
   %20 = load i32, i32* %"struct Foo.m6"
   %21 = sext i32 %20 to i64
   %22 = bitcast i32* %"struct Foo.m6" to i8*
@@ -96,7 +96,7 @@ entry:
   %26 = add [4 x i8]* %"$foo", i64 0
   %27 = bitcast i32* %"struct Foo.m8" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %27)
-  %probe_read9 = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m8", i32 4, [4 x i8]* %26)
+  %probe_read_user9 = call i64 inttoptr (i64 112 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m8", i32 4, [4 x i8]* %26)
   %28 = load i32, i32* %"struct Foo.m8"
   %29 = sext i32 %28 to i64
   %30 = bitcast i32* %"struct Foo.m8" to i8*
@@ -127,7 +127,7 @@ entry:
   %34 = add [4 x i8]* %"$foo", i64 0
   %35 = bitcast i32* %"struct Foo.m16" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %35)
-  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m16", i32 4, [4 x i8]* %34)
+  %probe_read_user17 = call i64 inttoptr (i64 112 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m16", i32 4, [4 x i8]* %34)
   %36 = load i32, i32* %"struct Foo.m16"
   %37 = sext i32 %36 to i64
   %38 = bitcast i32* %"struct Foo.m16" to i8*

--- a/tests/codegen/llvm/optional_positional_parameter.ll
+++ b/tests/codegen/llvm/optional_positional_parameter.ll
@@ -42,7 +42,7 @@ entry:
   store [1 x i8] zeroinitializer, [1 x i8]* %str1
   %11 = load i64, i64* %strlen
   %12 = trunc i64 %11 to i32
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, [1 x i8]*)*)([64 x i8]* %str, i32 %12, [1 x i8]* %str1)
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, [1 x i8]*)*)([64 x i8]* %str, i32 %12, [1 x i8]* %str1)
   %13 = bitcast i64* %strlen to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   %14 = bitcast [1 x i8]* %str1 to i8*

--- a/tests/codegen/llvm/strncmp.ll
+++ b/tests/codegen/llvm/strncmp.ll
@@ -36,7 +36,7 @@ entry:
   %10 = load volatile i64, i64* %9
   %11 = load i64, i64* %strlen
   %12 = trunc i64 %11 to i32
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %12, i64 %10)
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %12, i64 %10)
   %13 = bitcast i64* %strlen to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   %14 = bitcast i1* %strcmp.result to i8*
@@ -45,10 +45,10 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %strcmp.char_l)
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %strcmp.char_r)
   %15 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 0
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %15)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %15)
   %16 = load i8, i8* %strcmp.char_l
   %17 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 0
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %17)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %17)
   %18 = load i8, i8* %strcmp.char_r
   %strcmp.cmp = icmp ne i8 %16, %18
   br i1 %strcmp.cmp, label %strcmp.false, label %strcmp.loop_null_cmp
@@ -91,10 +91,10 @@ strcmp.done:                                      ; preds = %strcmp.loop92, %str
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
   %28 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 1
-  %probe_read4 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %28)
+  %probe_read_kernel4 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %28)
   %29 = load i8, i8* %strcmp.char_l
   %30 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 1
-  %probe_read5 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %30)
+  %probe_read_kernel5 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %30)
   %31 = load i8, i8* %strcmp.char_r
   %strcmp.cmp6 = icmp ne i8 %29, %31
   br i1 %strcmp.cmp6, label %strcmp.false, label %strcmp.loop_null_cmp3
@@ -105,10 +105,10 @@ strcmp.loop_null_cmp:                             ; preds = %entry
 
 strcmp.loop2:                                     ; preds = %strcmp.loop_null_cmp3
   %32 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 2
-  %probe_read10 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %32)
+  %probe_read_kernel10 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %32)
   %33 = load i8, i8* %strcmp.char_l
   %34 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 2
-  %probe_read11 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %34)
+  %probe_read_kernel11 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %34)
   %35 = load i8, i8* %strcmp.char_r
   %strcmp.cmp12 = icmp ne i8 %33, %35
   br i1 %strcmp.cmp12, label %strcmp.false, label %strcmp.loop_null_cmp9
@@ -119,10 +119,10 @@ strcmp.loop_null_cmp3:                            ; preds = %strcmp.loop
 
 strcmp.loop8:                                     ; preds = %strcmp.loop_null_cmp9
   %36 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 3
-  %probe_read16 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %36)
+  %probe_read_kernel16 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %36)
   %37 = load i8, i8* %strcmp.char_l
   %38 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 3
-  %probe_read17 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %38)
+  %probe_read_kernel17 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %38)
   %39 = load i8, i8* %strcmp.char_r
   %strcmp.cmp18 = icmp ne i8 %37, %39
   br i1 %strcmp.cmp18, label %strcmp.false, label %strcmp.loop_null_cmp15
@@ -133,10 +133,10 @@ strcmp.loop_null_cmp9:                            ; preds = %strcmp.loop2
 
 strcmp.loop14:                                    ; preds = %strcmp.loop_null_cmp15
   %40 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 4
-  %probe_read22 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %40)
+  %probe_read_kernel22 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %40)
   %41 = load i8, i8* %strcmp.char_l
   %42 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 4
-  %probe_read23 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %42)
+  %probe_read_kernel23 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %42)
   %43 = load i8, i8* %strcmp.char_r
   %strcmp.cmp24 = icmp ne i8 %41, %43
   br i1 %strcmp.cmp24, label %strcmp.false, label %strcmp.loop_null_cmp21
@@ -147,10 +147,10 @@ strcmp.loop_null_cmp15:                           ; preds = %strcmp.loop8
 
 strcmp.loop20:                                    ; preds = %strcmp.loop_null_cmp21
   %44 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 5
-  %probe_read28 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %44)
+  %probe_read_kernel28 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %44)
   %45 = load i8, i8* %strcmp.char_l
   %46 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 5
-  %probe_read29 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %46)
+  %probe_read_kernel29 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %46)
   %47 = load i8, i8* %strcmp.char_r
   %strcmp.cmp30 = icmp ne i8 %45, %47
   br i1 %strcmp.cmp30, label %strcmp.false, label %strcmp.loop_null_cmp27
@@ -161,10 +161,10 @@ strcmp.loop_null_cmp21:                           ; preds = %strcmp.loop14
 
 strcmp.loop26:                                    ; preds = %strcmp.loop_null_cmp27
   %48 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 6
-  %probe_read34 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %48)
+  %probe_read_kernel34 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %48)
   %49 = load i8, i8* %strcmp.char_l
   %50 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 6
-  %probe_read35 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %50)
+  %probe_read_kernel35 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %50)
   %51 = load i8, i8* %strcmp.char_r
   %strcmp.cmp36 = icmp ne i8 %49, %51
   br i1 %strcmp.cmp36, label %strcmp.false, label %strcmp.loop_null_cmp33
@@ -175,10 +175,10 @@ strcmp.loop_null_cmp27:                           ; preds = %strcmp.loop20
 
 strcmp.loop32:                                    ; preds = %strcmp.loop_null_cmp33
   %52 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 7
-  %probe_read40 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %52)
+  %probe_read_kernel40 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %52)
   %53 = load i8, i8* %strcmp.char_l
   %54 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 7
-  %probe_read41 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %54)
+  %probe_read_kernel41 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %54)
   %55 = load i8, i8* %strcmp.char_r
   %strcmp.cmp42 = icmp ne i8 %53, %55
   br i1 %strcmp.cmp42, label %strcmp.false, label %strcmp.loop_null_cmp39
@@ -189,10 +189,10 @@ strcmp.loop_null_cmp33:                           ; preds = %strcmp.loop26
 
 strcmp.loop38:                                    ; preds = %strcmp.loop_null_cmp39
   %56 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 8
-  %probe_read46 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %56)
+  %probe_read_kernel46 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %56)
   %57 = load i8, i8* %strcmp.char_l
   %58 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 8
-  %probe_read47 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %58)
+  %probe_read_kernel47 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %58)
   %59 = load i8, i8* %strcmp.char_r
   %strcmp.cmp48 = icmp ne i8 %57, %59
   br i1 %strcmp.cmp48, label %strcmp.false, label %strcmp.loop_null_cmp45
@@ -203,10 +203,10 @@ strcmp.loop_null_cmp39:                           ; preds = %strcmp.loop32
 
 strcmp.loop44:                                    ; preds = %strcmp.loop_null_cmp45
   %60 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 9
-  %probe_read52 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %60)
+  %probe_read_kernel52 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %60)
   %61 = load i8, i8* %strcmp.char_l
   %62 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 9
-  %probe_read53 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %62)
+  %probe_read_kernel53 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %62)
   %63 = load i8, i8* %strcmp.char_r
   %strcmp.cmp54 = icmp ne i8 %61, %63
   br i1 %strcmp.cmp54, label %strcmp.false, label %strcmp.loop_null_cmp51
@@ -217,10 +217,10 @@ strcmp.loop_null_cmp45:                           ; preds = %strcmp.loop38
 
 strcmp.loop50:                                    ; preds = %strcmp.loop_null_cmp51
   %64 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 10
-  %probe_read58 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %64)
+  %probe_read_kernel58 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %64)
   %65 = load i8, i8* %strcmp.char_l
   %66 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 10
-  %probe_read59 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %66)
+  %probe_read_kernel59 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %66)
   %67 = load i8, i8* %strcmp.char_r
   %strcmp.cmp60 = icmp ne i8 %65, %67
   br i1 %strcmp.cmp60, label %strcmp.false, label %strcmp.loop_null_cmp57
@@ -231,10 +231,10 @@ strcmp.loop_null_cmp51:                           ; preds = %strcmp.loop44
 
 strcmp.loop56:                                    ; preds = %strcmp.loop_null_cmp57
   %68 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 11
-  %probe_read64 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %68)
+  %probe_read_kernel64 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %68)
   %69 = load i8, i8* %strcmp.char_l
   %70 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 11
-  %probe_read65 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %70)
+  %probe_read_kernel65 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %70)
   %71 = load i8, i8* %strcmp.char_r
   %strcmp.cmp66 = icmp ne i8 %69, %71
   br i1 %strcmp.cmp66, label %strcmp.false, label %strcmp.loop_null_cmp63
@@ -245,10 +245,10 @@ strcmp.loop_null_cmp57:                           ; preds = %strcmp.loop50
 
 strcmp.loop62:                                    ; preds = %strcmp.loop_null_cmp63
   %72 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 12
-  %probe_read70 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %72)
+  %probe_read_kernel70 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %72)
   %73 = load i8, i8* %strcmp.char_l
   %74 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 12
-  %probe_read71 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %74)
+  %probe_read_kernel71 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %74)
   %75 = load i8, i8* %strcmp.char_r
   %strcmp.cmp72 = icmp ne i8 %73, %75
   br i1 %strcmp.cmp72, label %strcmp.false, label %strcmp.loop_null_cmp69
@@ -259,10 +259,10 @@ strcmp.loop_null_cmp63:                           ; preds = %strcmp.loop56
 
 strcmp.loop68:                                    ; preds = %strcmp.loop_null_cmp69
   %76 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 13
-  %probe_read76 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %76)
+  %probe_read_kernel76 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %76)
   %77 = load i8, i8* %strcmp.char_l
   %78 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 13
-  %probe_read77 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %78)
+  %probe_read_kernel77 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %78)
   %79 = load i8, i8* %strcmp.char_r
   %strcmp.cmp78 = icmp ne i8 %77, %79
   br i1 %strcmp.cmp78, label %strcmp.false, label %strcmp.loop_null_cmp75
@@ -273,10 +273,10 @@ strcmp.loop_null_cmp69:                           ; preds = %strcmp.loop62
 
 strcmp.loop74:                                    ; preds = %strcmp.loop_null_cmp75
   %80 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 14
-  %probe_read82 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %80)
+  %probe_read_kernel82 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %80)
   %81 = load i8, i8* %strcmp.char_l
   %82 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 14
-  %probe_read83 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %82)
+  %probe_read_kernel83 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %82)
   %83 = load i8, i8* %strcmp.char_r
   %strcmp.cmp84 = icmp ne i8 %81, %83
   br i1 %strcmp.cmp84, label %strcmp.false, label %strcmp.loop_null_cmp81
@@ -287,10 +287,10 @@ strcmp.loop_null_cmp75:                           ; preds = %strcmp.loop68
 
 strcmp.loop80:                                    ; preds = %strcmp.loop_null_cmp81
   %84 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 15
-  %probe_read88 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %84)
+  %probe_read_kernel88 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %84)
   %85 = load i8, i8* %strcmp.char_l
   %86 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 15
-  %probe_read89 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %86)
+  %probe_read_kernel89 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %86)
   %87 = load i8, i8* %strcmp.char_r
   %strcmp.cmp90 = icmp ne i8 %85, %87
   br i1 %strcmp.cmp90, label %strcmp.false, label %strcmp.loop_null_cmp87
@@ -301,10 +301,10 @@ strcmp.loop_null_cmp81:                           ; preds = %strcmp.loop74
 
 strcmp.loop86:                                    ; preds = %strcmp.loop_null_cmp87
   %88 = getelementptr [64 x i8], [64 x i8]* %str, i32 0, i32 16
-  %probe_read94 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %88)
+  %probe_read_kernel94 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_l, i32 1, i8* %88)
   %89 = load i8, i8* %strcmp.char_l
   %90 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 16
-  %probe_read95 = call i64 inttoptr (i64 4 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %90)
+  %probe_read_kernel95 = call i64 inttoptr (i64 113 to i64 (i8*, i32, i8*)*)(i8* %strcmp.char_r, i32 1, i8* %90)
   %91 = load i8, i8* %strcmp.char_r
   %strcmp.cmp96 = icmp ne i8 %89, %91
   br i1 %strcmp.cmp96, label %strcmp.false, label %strcmp.loop_null_cmp93

--- a/tests/codegen/llvm/struct_char_1.ll
+++ b/tests/codegen/llvm/struct_char_1.ll
@@ -23,7 +23,7 @@ entry:
   call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %4, i8 addrspace(64)* align 1 %5, i64 1, i1 false)
   %6 = add [1 x i8]* %"$foo", i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"struct Foo.x")
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, [1 x i8]*)*)(i8* %"struct Foo.x", i32 1, [1 x i8]* %6)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, [1 x i8]*)*)(i8* %"struct Foo.x", i32 1, [1 x i8]* %6)
   %7 = load i8, i8* %"struct Foo.x"
   %8 = sext i8 %7 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct Foo.x")

--- a/tests/codegen/llvm/struct_char_2.ll
+++ b/tests/codegen/llvm/struct_char_2.ll
@@ -21,7 +21,7 @@ entry:
   %3 = load i64, i64* %"$foo"
   %4 = add i64 %3, 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"struct Foo.x")
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.x", i32 1, i64 %4)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.x", i32 1, i64 %4)
   %5 = load i8, i8* %"struct Foo.x"
   %6 = sext i8 %5 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct Foo.x")

--- a/tests/codegen/llvm/struct_integer_ptr_1.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_1.ll
@@ -25,13 +25,13 @@ entry:
   %6 = add [8 x i8]* %"$foo", i64 0
   %7 = bitcast i64* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, [8 x i8]*)*)(i64* %"struct Foo.x", i32 8, [8 x i8]* %6)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, [8 x i8]*)*)(i64* %"struct Foo.x", i32 8, [8 x i8]* %6)
   %8 = load i64, i64* %"struct Foo.x"
   %9 = bitcast i64* %"struct Foo.x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   %10 = bitcast i32* %deref to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %8)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %8)
   %11 = load i32, i32* %deref
   %12 = sext i32 %11 to i64
   %13 = bitcast i32* %deref to i8*

--- a/tests/codegen/llvm/struct_integer_ptr_2.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_2.ll
@@ -23,13 +23,13 @@ entry:
   %4 = add i64 %3, 0
   %5 = bitcast i64* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.x", i32 8, i64 %4)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.x", i32 8, i64 %4)
   %6 = load i64, i64* %"struct Foo.x"
   %7 = bitcast i64* %"struct Foo.x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   %8 = bitcast i32* %deref to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %6)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %6)
   %9 = load i32, i32* %deref
   %10 = sext i32 %9 to i64
   %11 = bitcast i32* %deref to i8*

--- a/tests/codegen/llvm/struct_integers_1.ll
+++ b/tests/codegen/llvm/struct_integers_1.ll
@@ -24,7 +24,7 @@ entry:
   %6 = add [4 x i8]* %"$foo", i64 0
   %7 = bitcast i32* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.x", i32 4, [4 x i8]* %6)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.x", i32 4, [4 x i8]* %6)
   %8 = load i32, i32* %"struct Foo.x"
   %9 = sext i32 %8 to i64
   %10 = bitcast i32* %"struct Foo.x" to i8*

--- a/tests/codegen/llvm/struct_integers_2.ll
+++ b/tests/codegen/llvm/struct_integers_2.ll
@@ -22,7 +22,7 @@ entry:
   %4 = add i64 %3, 0
   %5 = bitcast i32* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.x", i32 4, i64 %4)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.x", i32 4, i64 %4)
   %6 = load i32, i32* %"struct Foo.x"
   %7 = sext i32 %6 to i64
   %8 = bitcast i32* %"struct Foo.x" to i8*

--- a/tests/codegen/llvm/struct_long_1.ll
+++ b/tests/codegen/llvm/struct_long_1.ll
@@ -24,7 +24,7 @@ entry:
   %6 = add [8 x i8]* %"$foo", i64 0
   %7 = bitcast i64* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, [8 x i8]*)*)(i64* %"struct Foo.x", i32 8, [8 x i8]* %6)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, [8 x i8]*)*)(i64* %"struct Foo.x", i32 8, [8 x i8]* %6)
   %8 = load i64, i64* %"struct Foo.x"
   %9 = bitcast i64* %"struct Foo.x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)

--- a/tests/codegen/llvm/struct_long_2.ll
+++ b/tests/codegen/llvm/struct_long_2.ll
@@ -22,7 +22,7 @@ entry:
   %4 = add i64 %3, 0
   %5 = bitcast i64* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.x", i32 8, i64 %4)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.x", i32 8, i64 %4)
   %6 = load i64, i64* %"struct Foo.x"
   %7 = bitcast i64* %"struct Foo.x" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)

--- a/tests/codegen/llvm/struct_nested_struct_anon_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_1.ll
@@ -25,7 +25,7 @@ entry:
   %7 = add [4 x i8]* %6, i64 0
   %8 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo::(anonymous at definitions.h:2:14).x", i32 4, [4 x i8]* %7)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo::(anonymous at definitions.h:2:14).x", i32 4, [4 x i8]* %7)
   %9 = load i32, i32* %"struct Foo::(anonymous at definitions.h:2:14).x"
   %10 = sext i32 %9 to i64
   %11 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*

--- a/tests/codegen/llvm/struct_nested_struct_anon_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_2.ll
@@ -23,7 +23,7 @@ entry:
   %5 = add i64 %4, 0
   %6 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* %"struct Foo::(anonymous at definitions.h:2:14).x", i32 4, i64 %5)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Foo::(anonymous at definitions.h:2:14).x", i32 4, i64 %5)
   %7 = load i32, i32* %"struct Foo::(anonymous at definitions.h:2:14).x"
   %8 = sext i32 %7 to i64
   %9 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*

--- a/tests/codegen/llvm/struct_nested_struct_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_1.ll
@@ -25,7 +25,7 @@ entry:
   %7 = add [4 x i8]* %6, i64 0
   %8 = bitcast i32* %"struct Bar.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Bar.x", i32 4, [4 x i8]* %7)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Bar.x", i32 4, [4 x i8]* %7)
   %9 = load i32, i32* %"struct Bar.x"
   %10 = sext i32 %9 to i64
   %11 = bitcast i32* %"struct Bar.x" to i8*

--- a/tests/codegen/llvm/struct_nested_struct_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_2.ll
@@ -23,7 +23,7 @@ entry:
   %5 = add i64 %4, 0
   %6 = bitcast i32* %"struct Bar.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %5)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %5)
   %7 = load i32, i32* %"struct Bar.x"
   %8 = sext i32 %7 to i64
   %9 = bitcast i32* %"struct Bar.x" to i8*

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
@@ -25,14 +25,14 @@ entry:
   %6 = add [8 x i8]* %"$foo", i64 0
   %7 = bitcast i64* %"struct Foo.bar" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, [8 x i8]*)*)(i64* %"struct Foo.bar", i32 8, [8 x i8]* %6)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, [8 x i8]*)*)(i64* %"struct Foo.bar", i32 8, [8 x i8]* %6)
   %8 = load i64, i64* %"struct Foo.bar"
   %9 = bitcast i64* %"struct Foo.bar" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   %10 = add i64 %8, 0
   %11 = bitcast i32* %"struct Bar.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %10)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %10)
   %12 = load i32, i32* %"struct Bar.x"
   %13 = sext i32 %12 to i64
   %14 = bitcast i32* %"struct Bar.x" to i8*

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
@@ -23,14 +23,14 @@ entry:
   %4 = add i64 %3, 0
   %5 = bitcast i64* %"struct Foo.bar" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.bar", i32 8, i64 %4)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.bar", i32 8, i64 %4)
   %6 = load i64, i64* %"struct Foo.bar"
   %7 = bitcast i64* %"struct Foo.bar" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   %8 = add i64 %6, 0
   %9 = bitcast i32* %"struct Bar.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %probe_read1 = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %8)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %8)
   %10 = load i32, i32* %"struct Bar.x"
   %11 = sext i32 %10 to i64
   %12 = bitcast i32* %"struct Bar.x" to i8*

--- a/tests/codegen/llvm/struct_save_1.ll
+++ b/tests/codegen/llvm/struct_save_1.ll
@@ -15,7 +15,7 @@ entry:
   store i64 0, i64* %"@foo_key"
   %2 = bitcast [12 x i8]* %"@foo_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([12 x i8]*, i32, i64)*)([12 x i8]* %"@foo_val", i32 12, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([12 x i8]*, i32, i64)*)([12 x i8]* %"@foo_val", i32 12, i64 0)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [12 x i8]*, i64)*)(i64 %pseudo, i64* %"@foo_key", [12 x i8]* %"@foo_val", i64 0)
   %3 = bitcast i64* %"@foo_key" to i8*

--- a/tests/codegen/llvm/struct_save_2.ll
+++ b/tests/codegen/llvm/struct_save_2.ll
@@ -15,7 +15,7 @@ entry:
   store i64 0, i64* %"@foo_key"
   %2 = bitcast [12 x i8]* %"@foo_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([12 x i8]*, i32, i64)*)([12 x i8]* %"@foo_val", i32 12, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([12 x i8]*, i32, i64)*)([12 x i8]* %"@foo_val", i32 12, i64 0)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [12 x i8]*, i64)*)(i64 %pseudo, i64* %"@foo_key", [12 x i8]* %"@foo_val", i64 0)
   %3 = bitcast i64* %"@foo_key" to i8*

--- a/tests/codegen/llvm/struct_save_nested.ll
+++ b/tests/codegen/llvm/struct_save_nested.ll
@@ -24,7 +24,7 @@ entry:
   store i64 0, i64* %"@foo_key"
   %2 = bitcast [16 x i8]* %"@foo_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* %"@foo_val", i32 16, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* %"@foo_val", i32 16, i64 0)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [16 x i8]*, i64)*)(i64 %pseudo, i64* %"@foo_key", [16 x i8]* %"@foo_val", i64 0)
   %3 = bitcast i64* %"@foo_key" to i8*

--- a/tests/codegen/llvm/struct_save_string.ll
+++ b/tests/codegen/llvm/struct_save_string.ll
@@ -18,7 +18,7 @@ entry:
   store i64 0, i64* %"@foo_key"
   %2 = bitcast [32 x i8]* %"@foo_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([32 x i8]*, i32, i64)*)([32 x i8]* %"@foo_val", i32 32, i64 0)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([32 x i8]*, i32, i64)*)([32 x i8]* %"@foo_val", i32 32, i64 0)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [32 x i8]*, i64)*)(i64 %pseudo, i64* %"@foo_key", [32 x i8]* %"@foo_val", i64 0)
   %3 = bitcast i64* %"@foo_key" to i8*

--- a/tests/codegen/llvm/struct_short_1.ll
+++ b/tests/codegen/llvm/struct_short_1.ll
@@ -24,7 +24,7 @@ entry:
   %6 = add [2 x i8]* %"$foo", i64 0
   %7 = bitcast i16* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i16*, i32, [2 x i8]*)*)(i16* %"struct Foo.x", i32 2, [2 x i8]* %6)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i16*, i32, [2 x i8]*)*)(i16* %"struct Foo.x", i32 2, [2 x i8]* %6)
   %8 = load i16, i16* %"struct Foo.x"
   %9 = sext i16 %8 to i64
   %10 = bitcast i16* %"struct Foo.x" to i8*

--- a/tests/codegen/llvm/struct_short_2.ll
+++ b/tests/codegen/llvm/struct_short_2.ll
@@ -22,7 +22,7 @@ entry:
   %4 = add i64 %3, 0
   %5 = bitcast i16* %"struct Foo.x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i16*, i32, i64)*)(i16* %"struct Foo.x", i32 2, i64 %4)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i16*, i32, i64)*)(i16* %"struct Foo.x", i32 2, i64 %4)
   %6 = load i16, i16* %"struct Foo.x"
   %7 = sext i16 %6 to i64
   %8 = bitcast i16* %"struct Foo.x" to i8*

--- a/tests/codegen/llvm/struct_string_array_1.ll
+++ b/tests/codegen/llvm/struct_string_array_1.ll
@@ -23,7 +23,7 @@ entry:
   %6 = add [32 x i8]* %"$foo", i64 0
   %7 = bitcast [32 x i8]* %"struct Foo.str" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([32 x i8]*, i32, [32 x i8]*)*)([32 x i8]* %"struct Foo.str", i32 32, [32 x i8]* %6)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([32 x i8]*, i32, [32 x i8]*)*)([32 x i8]* %"struct Foo.str", i32 32, [32 x i8]* %6)
   %8 = bitcast i64* %"@mystr_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 0, i64* %"@mystr_key"

--- a/tests/codegen/llvm/struct_string_array_2.ll
+++ b/tests/codegen/llvm/struct_string_array_2.ll
@@ -21,7 +21,7 @@ entry:
   %4 = add i64 %3, 0
   %5 = bitcast [32 x i8]* %"struct Foo.str" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %probe_read = call i64 inttoptr (i64 4 to i64 ([32 x i8]*, i32, i64)*)([32 x i8]* %"struct Foo.str", i32 32, i64 %4)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([32 x i8]*, i32, i64)*)([32 x i8]* %"struct Foo.str", i32 32, i64 %4)
   %6 = bitcast i64* %"@mystr_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   store i64 0, i64* %"@mystr_key"

--- a/tests/codegen/llvm/struct_string_ptr.ll
+++ b/tests/codegen/llvm/struct_string_ptr.ll
@@ -32,13 +32,13 @@ entry:
   %8 = add i64 %7, 0
   %9 = bitcast i64* %"struct Foo.str" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.str", i32 8, i64 %8)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.str", i32 8, i64 %8)
   %10 = load i64, i64* %"struct Foo.str"
   %11 = bitcast i64* %"struct Foo.str" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   %12 = load i64, i64* %strlen
   %13 = trunc i64 %12 to i32
-  %probe_read_str = call i64 inttoptr (i64 45 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %13, i64 %10)
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %13, i64 %10)
   %14 = bitcast i64* %strlen to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   %15 = bitcast i64* %"@mystr_key" to i8*

--- a/tests/codegen/regression.cpp
+++ b/tests/codegen/regression.cpp
@@ -22,8 +22,8 @@ TEST(codegen, regression_957)
   Driver driver(*bpftrace);
 
   ASSERT_EQ(driver.parse_str("t:sched:sched_one* { cat(\"%s\", probe); }"), 0);
-  MockBPFfeature feature;
-  ast::SemanticAnalyser semantics(driver.root_, *bpftrace, feature);
+  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+  ast::SemanticAnalyser semantics(driver.root_, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
   ast::CodegenLLVM codegen(driver.root_, *bpftrace);

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -68,6 +68,7 @@ public:
     has_override_return_ = std::make_optional<bool>(has_features);
     prog_kfunc_ = std::make_optional<bool>(has_features);
     has_loop_ = std::make_optional<bool>(has_features);
+    has_probe_read_kernel_ = std::make_optional<bool>(has_features);
   };
 };
 

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -69,7 +69,9 @@ public:
     prog_kfunc_ = std::make_optional<bool>(has_features);
     has_loop_ = std::make_optional<bool>(has_features);
     has_probe_read_kernel_ = std::make_optional<bool>(has_features);
+    has_features_ = has_features;
   };
+  bool has_features_;
 };
 
 class MockChildProc : public ChildProcBase

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -32,8 +32,9 @@ void gen_bytecode(const std::string &input, std::stringstream &out)
   ClangParser clang;
   clang.parse(driver.root_, *bpftrace);
 
-  MockBPFfeature feature;
-  ast::SemanticAnalyser semantics(driver.root_, *bpftrace, feature);
+  // Override to mockbpffeature.
+  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+  ast::SemanticAnalyser semantics(driver.root_, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1839,14 +1839,14 @@ TEST(semantic_analyser, call_kptr_uptr)
   test("k:f { @  = kptr((int8*) arg0); }", 0);
   test("k:f { $a = kptr((int8*) arg0); }", 0);
 
-  test("k:f { @ = kptr(arg0); }", 10);
-  test("k:f { $a = kptr(arg0); }", 10);
+  test("k:f { @ = kptr(arg0); }", 0);
+  test("k:f { $a = kptr(arg0); }", 0);
 
   test("k:f { @  = uptr((int8*) arg0); }", 0);
   test("k:f { $a = uptr((int8*) arg0); }", 0);
 
-  test("k:f { @ = uptr(arg0); }", 10);
-  test("k:f { $a = uptr(arg0); }", 10);
+  test("k:f { @ = uptr(arg0); }", 0);
+  test("k:f { $a = uptr(arg0); }", 0);
 }
 
 #ifdef HAVE_LIBBPF_BTF_DUMP


### PR DESCRIPTION
1. Usecases are described on https://github.com/iovisor/bpftrace/issues/614
2. https://github.com/iovisor/bpftrace/pull/1427

Implemented usecases:
- *addr(), str(addr) -> Use bpf_probe_read_kernel or
   bpf_probe_read_user based on addrspace context.
   Addrspace context:
   - kprobe, kretprobe, kfunc, kretfunc, tracepoints without syscalls
        -> bpf_probe_read_kernel
   - usdt, uprobes, uretprobes, usdt, tracepoint with syscalls
        -> bpf_probe_read_user
- *uptr(addr), str(uptr(addr)) -> use bpf_probe_read_user
- *kptr(addr), str(kptr(addr)) -> use bpf_probe_read_kernel

- argX, retval on kernel context -> bpf_probe_read_kernel
- argX, retval  on user context -> bpf_probe_read_user
- args->field -> bpf_probe_read_user

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
