### PR TITLE
Map batch prep

### DIFF
--- a/cmake/FindLibBpf.cmake
+++ b/cmake/FindLibBpf.cmake
@@ -55,6 +55,8 @@ if (LIBBPF_FOUND)
     set(LIBBPF_BTF_DUMP_FOUND TRUE)
   endif()
   check_symbol_exists(btf_dump__emit_type_decl "${LIBBPF_INCLUDE_DIRS}/bpf/btf.h" HAVE_LIBBPF_BTF_DUMP_EMIT_TYPE_DECL)
+
+  check_symbol_exists(bpf_map_lookup_batch "${LIBBPF_INCLUDE_DIRS}/bpf/bpf.h" HAVE_LIBBPF_MAP_BATCH)
   SET(CMAKE_REQUIRED_DEFINITIONS)
   SET(CMAKE_REQUIRED_LIBRARIES)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -57,6 +57,11 @@ endif(LIBBPF_BTF_DUMP_FOUND)
 if (LIBBPF_FOUND)
   target_compile_definitions(bpftrace PRIVATE HAVE_LIBBPF)
 endif(LIBBPF_FOUND)
+
+if (HAVE_LIBBPF_MAP_BATCH)
+  target_compile_definitions(bpftrace PRIVATE HAVE_LIBBPF_MAP_BATCH)
+endif()
+
 if (HAVE_BCC_KFUNC)
   target_compile_definitions(bpftrace PRIVATE HAVE_BCC_KFUNC)
 endif(HAVE_BCC_KFUNC)

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -122,7 +122,7 @@ void CodegenLLVM::visit(Builtin &builtin)
     AllocaInst *key = b_.CreateAllocaBPF(b_.getInt64Ty(), "elapsed_key");
     b_.CreateStore(b_.getInt64(0), key);
 
-    auto &map = bpftrace_.elapsed_map_;
+    auto *map = bpftrace_.maps[MapManager::Type::Elapsed].value();
     auto type = CreateUInt64();
     auto start = b_.CreateMapLookupElem(
         ctx_, map->mapfd_, key, type, builtin.loc);
@@ -852,7 +852,7 @@ void CodegenLLVM::visit(Call &call)
                                        elements.at(0)),
                      aa_ptr);
 
-    auto id = bpftrace_.maps_[map.ident]->id;
+    auto id = bpftrace_.maps[map.ident].value()->id;
     auto *ident_ptr = b_.CreateGEP(buf, { b_.getInt64(0), b_.getInt32(1) });
     b_.CreateStore(b_.GetIntSameSize(id, elements.at(1)), ident_ptr);
 
@@ -2500,7 +2500,7 @@ void CodegenLLVM::createPrintMapCall(Call &call)
   b_.CreateStore(b_.getInt64(asyncactionint(AsyncAction::print)),
                  b_.CreateGEP(buf, { b_.getInt64(0), b_.getInt32(0) }));
 
-  auto id = bpftrace_.maps_[map.ident]->id;
+  auto id = bpftrace_.maps[map.ident].value()->id;
   auto *ident_ptr = b_.CreateGEP(buf, { b_.getInt64(0), b_.getInt32(1) });
   b_.CreateStore(b_.GetIntSameSize(id, elements.at(1)), ident_ptr);
 

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -63,9 +63,9 @@ public:
   void visit(AttachPoint &ap) override;
   void visit(Probe &probe) override;
   void visit(Program &program) override;
+  int create_maps(bool debug);
 
   int analyse();
-  int create_maps(bool debug=false);
 
 private:
   Node *root_;
@@ -90,6 +90,8 @@ private:
 
   void builtin_args_tracepoint(AttachPoint *attach_point, Builtin &builtin);
   ProbeType single_provider_type(void);
+  template <typename T>
+  int create_maps_impl(void);
 
   bool in_loop(void)
   {

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -272,7 +272,7 @@ bool BPFfeature::has_map_batch()
       map_fd, nullptr, nullptr, keys, values, &count, nullptr);
   close(map_fd);
 
-  has_map_batch_ = std::make_optional<bool>(err >= 0);
+  has_map_batch_ = err >= 0;
   return *has_map_batch_;
 
 #endif

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -59,7 +59,7 @@ public:
   // don't work. Move works but doesn't make sense as the `has_*` functions
   // will just reassign the unique_ptr.
   // A single bpffeature should be constructed in main() and passed around,
-  // making these as deleted to avoid accidentally copying/moving it.
+  // marking these as deleted to avoid accidentally copying/moving it.
   BPFfeature(const BPFfeature&) = delete;
   BPFfeature& operator=(const BPFfeature&) = delete;
   BPFfeature(BPFfeature&&) = delete;

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -68,6 +68,7 @@ public:
   int instruction_limit();
   bool has_loop();
   bool has_btf();
+  bool has_map_batch();
 
   std::string report(void);
 
@@ -95,6 +96,7 @@ public:
 protected:
   std::optional<bool> has_loop_;
   std::optional<int> insns_limit_;
+  std::optional<bool> has_map_batch_;
 
 private:
   bool detect_map(enum libbpf::bpf_map_type map_type);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1638,6 +1638,8 @@ int64_t BPFtrace::min_value(const std::vector<uint8_t> &value, int nvalues)
 
 std::vector<uint8_t> BPFtrace::find_empty_key(IMap &map, size_t size) const
 {
+  // 4.12 and above kernel supports passing NULL to BPF_MAP_GET_NEXT_KEY
+  // to get first key of the map. For older kernels, the call will fail.
   if (size == 0) size = 8;
   auto key = std::vector<uint8_t>(size);
   uint32_t nvalues = map.is_per_cpu_type() ? ncpus_ : 1;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -14,7 +14,8 @@
 #include "bpffeature.h"
 #include "btf.h"
 #include "child.h"
-#include "imap.h"
+#include "map.h"
+#include "mapmanager.h"
 #include "output.h"
 #include "printf.h"
 #include "procmon.h"
@@ -101,10 +102,6 @@ public:
   inline int next_probe_id() {
     return next_probe_id_++;
   };
-  inline IMap &get_map_by_id(uint32_t id)
-  {
-    return *maps_[map_ids_[id]].get();
-  };
   std::string get_stack(uint64_t stackidpid, bool ustack, StackType stack_type, int indent=0);
   std::string resolve_buf(char *buf, size_t size);
   std::string resolve_ksym(uintptr_t addr, bool show_offset=false);
@@ -135,11 +132,7 @@ public:
   // Global variable checking if an exit signal was received
   static volatile sig_atomic_t exitsig_recv;
 
-  std::map<std::string, std::unique_ptr<IMap>> maps_;
-
-  // Maps a map id back to the map identifier. See get_map_by_id()
-  std::vector<std::string> map_ids_;
-
+  MapManager maps;
   std::map<std::string, Struct> structs_;
   std::map<std::string, std::string> macros_;
   std::map<std::string, uint64_t> enums_;
@@ -151,10 +144,7 @@ public:
   std::vector<std::tuple<std::string, std::vector<Field>>> cat_args_;
   std::vector<SizedType> non_map_print_args_;
   std::unordered_map<int64_t, struct HelperErrorInfo> helper_error_info_;
-  std::unordered_map<StackType, std::unique_ptr<IMap>> stackid_maps_;
-  std::unique_ptr<IMap> join_map_;
-  std::unique_ptr<IMap> elapsed_map_;
-  std::unique_ptr<IMap> perf_event_map_;
+
   std::vector<std::string> probe_ids_;
   unsigned int join_argnum_;
   unsigned int join_argsize_;

--- a/src/fake_map.cpp
+++ b/src/fake_map.cpp
@@ -6,7 +6,19 @@ int FakeMap::next_mapfd_ = 1;
 
 FakeMap::FakeMap(const std::string &name __attribute__((unused)),
                  const SizedType &type __attribute__((unused)),
-                 const MapKey &key __attribute__((unused)))
+                 const MapKey &key __attribute__((unused)),
+                 int min __attribute__((unused)),
+                 int max __attribute__((unused)),
+                 int step __attribute__((unused)),
+                 int max_entries __attribute__((unused)))
+{
+  mapfd_ = next_mapfd_++;
+}
+
+FakeMap::FakeMap(const std::string &name __attribute__((unused)),
+                 const SizedType &type __attribute__((unused)),
+                 const MapKey &key __attribute__((unused)),
+                 int max_entries __attribute__((unused)))
 {
   mapfd_ = next_mapfd_++;
 }

--- a/src/fake_map.cpp
+++ b/src/fake_map.cpp
@@ -4,7 +4,7 @@ namespace bpftrace {
 
 int FakeMap::next_mapfd_ = 1;
 
-FakeMap::FakeMap(const std::string &name __attribute__((unused)),
+FakeMap::FakeMap(const std::string &name,
                  const SizedType &type __attribute__((unused)),
                  const MapKey &key __attribute__((unused)),
                  int min __attribute__((unused)),
@@ -12,14 +12,16 @@ FakeMap::FakeMap(const std::string &name __attribute__((unused)),
                  int step __attribute__((unused)),
                  int max_entries __attribute__((unused)))
 {
+  name_ = name;
   mapfd_ = next_mapfd_++;
 }
 
-FakeMap::FakeMap(const std::string &name __attribute__((unused)),
+FakeMap::FakeMap(const std::string &name,
                  const SizedType &type __attribute__((unused)),
                  const MapKey &key __attribute__((unused)),
                  int max_entries __attribute__((unused)))
 {
+  name_ = name;
   mapfd_ = next_mapfd_++;
 }
 

--- a/src/fake_map.h
+++ b/src/fake_map.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "imap.h"
+#include "map.h"
 
 namespace bpftrace {
 

--- a/src/fake_map.h
+++ b/src/fake_map.h
@@ -7,9 +7,19 @@ namespace bpftrace {
 class FakeMap : public IMap
 {
 public:
-  FakeMap(const std::string &name, const SizedType &type, const MapKey &key);
+  FakeMap(const std::string &name,
+          const SizedType &type,
+          const MapKey &key,
+          int max_entries = 0);
   FakeMap(const SizedType &type);
   FakeMap(enum bpf_map_type map_type);
+  FakeMap(const std::string &name,
+          const SizedType &type,
+          const MapKey &key,
+          int min,
+          int max,
+          int step,
+          int max_entries);
 
   static int next_mapfd_;
 };

--- a/src/map.h
+++ b/src/map.h
@@ -30,5 +30,4 @@ public:
                  int max_entries,
                  int flags);
 };
-
 } // namespace bpftrace

--- a/src/mapmanager.h
+++ b/src/mapmanager.h
@@ -1,0 +1,96 @@
+#pragma once
+
+#include "imap.h"
+#include <map>
+#include <memory>
+#include <unordered_map>
+
+namespace bpftrace {
+
+/**
+   A container for all maps created during program execution.
+
+*/
+class MapManager
+{
+public:
+  MapManager() = default;
+
+  MapManager(const MapManager &) = delete;
+  MapManager &operator=(const MapManager &) = delete;
+  MapManager(MapManager &&) = delete;
+  MapManager &operator=(MapManager &&) = delete;
+
+  /**
+     Store and lookup named maps
+  */
+  void Add(std::unique_ptr<IMap> map);
+  bool Has(const std::string &name);
+  std::optional<IMap *> Lookup(const std::string &name);
+  std::optional<IMap *> Lookup(ssize_t id);
+
+  std::optional<IMap *> operator[](ssize_t id)
+  {
+    return Lookup(id);
+  };
+  std::optional<IMap *> operator[](const std::string &name)
+  {
+    return Lookup(name);
+  };
+
+  /**
+     Iterate over named maps, vector like iteration
+  */
+  auto begin()
+  {
+    return maps_by_id_.begin();
+  };
+  auto end()
+  {
+    return maps_by_id_.end();
+  };
+
+  /**
+     Internal maps
+  */
+  enum class Type
+  {
+    // Also update to_string
+    PerfEvent,
+    Join,
+    Elapsed,
+  };
+
+  void Set(Type t, std::unique_ptr<IMap> map);
+  std::optional<IMap *> Lookup(Type t);
+  std::optional<IMap *> operator[](Type t)
+  {
+    return Lookup(t);
+  };
+  bool Has(Type t);
+
+  /**
+     Stack maps
+  */
+  void Set(StackType t, std::unique_ptr<IMap> map);
+  std::optional<IMap *> Lookup(StackType t);
+  std::optional<IMap *> operator[](StackType t)
+  {
+    return Lookup(t);
+  };
+  bool Has(StackType t);
+  ssize_t CountStackTypes()
+  {
+    return stackid_maps_.size();
+  };
+
+private:
+  std::vector<std::unique_ptr<IMap>> maps_by_id_;
+  std::unordered_map<std::string, IMap *> maps_by_name_;
+  std::unordered_map<Type, std::unique_ptr<IMap>> maps_by_type_;
+  std::unordered_map<StackType, std::unique_ptr<IMap>> stackid_maps_;
+};
+
+std::string to_string(MapManager::Type t);
+
+} // namespace bpftrace

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -58,6 +58,10 @@ add_executable(bpftrace_test
   ${BFD_DISASM_SRC}
 )
 
+if (HAVE_LIBBPF_MAP_BATCH)
+  target_compile_definitions(bpftrace_test PRIVATE HAVE_LIBBPF_MAP_BATCH)
+endif()
+
 if(HAVE_NAME_TO_HANDLE_AT)
   target_compile_definitions(bpftrace_test PRIVATE HAVE_NAME_TO_HANDLE_AT=1)
 endif(HAVE_NAME_TO_HANDLE_AT)

--- a/tests/codegen/call_kstack.cpp
+++ b/tests/codegen/call_kstack.cpp
@@ -37,13 +37,13 @@ TEST(codegen, call_kstack_mapids)
   codegen.compile();
 
   ASSERT_EQ(FakeMap::next_mapfd_, 7);
-  ASSERT_EQ(bpftrace.stackid_maps_.size(), 2U);
+  ASSERT_EQ(bpftrace.maps.CountStackTypes(), 2U);
 
   StackType stack_type;
   stack_type.limit = 5;
-  ASSERT_EQ(bpftrace.stackid_maps_.count(stack_type), 1U);
+  ASSERT_TRUE(bpftrace.maps.Has(stack_type));
   stack_type.limit = 6;
-  ASSERT_EQ(bpftrace.stackid_maps_.count(stack_type), 1U);
+  ASSERT_TRUE(bpftrace.maps.Has(stack_type));
 }
 
 TEST(codegen, call_kstack_modes_mapids)
@@ -68,13 +68,13 @@ TEST(codegen, call_kstack_modes_mapids)
   codegen.compile();
 
   ASSERT_EQ(FakeMap::next_mapfd_, 7);
-  ASSERT_EQ(bpftrace.stackid_maps_.size(), 2U);
+  ASSERT_EQ(bpftrace.maps.CountStackTypes(), 2U);
 
   StackType stack_type;
   stack_type.mode = StackMode::perf;
-  ASSERT_EQ(bpftrace.stackid_maps_.count(stack_type), 1U);
+  ASSERT_TRUE(bpftrace.maps.Has(stack_type));
   stack_type.mode = StackMode::bpftrace;
-  ASSERT_EQ(bpftrace.stackid_maps_.count(stack_type), 1U);
+  ASSERT_TRUE(bpftrace.maps.Has(stack_type));
 }
 
 } // namespace codegen

--- a/tests/codegen/call_ustack.cpp
+++ b/tests/codegen/call_ustack.cpp
@@ -37,13 +37,13 @@ TEST(codegen, call_ustack_mapids)
   codegen.compile();
 
   ASSERT_EQ(FakeMap::next_mapfd_, 7);
-  ASSERT_EQ(bpftrace.stackid_maps_.size(), 2U);
+  ASSERT_EQ(bpftrace.maps.CountStackTypes(), 2U);
 
   StackType stack_type;
   stack_type.limit = 5;
-  ASSERT_EQ(bpftrace.stackid_maps_.count(stack_type), 1U);
+  ASSERT_TRUE(bpftrace.maps.Has(stack_type));
   stack_type.limit = 6;
-  ASSERT_EQ(bpftrace.stackid_maps_.count(stack_type), 1U);
+  ASSERT_TRUE(bpftrace.maps.Has(stack_type));
 }
 
 TEST(codegen, call_ustack_modes_mapids)
@@ -68,13 +68,13 @@ TEST(codegen, call_ustack_modes_mapids)
   codegen.compile();
 
   ASSERT_EQ(FakeMap::next_mapfd_, 7);
-  ASSERT_EQ(bpftrace.stackid_maps_.size(), 2U);
+  ASSERT_EQ(bpftrace.maps.CountStackTypes(), 2U);
 
   StackType stack_type;
   stack_type.mode = StackMode::perf;
-  ASSERT_EQ(bpftrace.stackid_maps_.count(stack_type), 1U);
+  ASSERT_TRUE(bpftrace.maps.Has(stack_type));
   stack_type.mode = StackMode::bpftrace;
-  ASSERT_EQ(bpftrace.stackid_maps_.count(stack_type), 1U);
+  ASSERT_TRUE(bpftrace.maps.Has(stack_type));
 }
 
 } // namespace codegen


### PR DESCRIPTION
While implementing batch operators for #1470 I saw some things that could use a cleanup. This is that part, the map batch implementation will follow at some point.

This does 3 things:

- detect batch operator, both in libbpf and runtime
- deduplicate the fakemap/map creation code in the semanticanalyser
- move the map storage from `BPFtrace` into a std::map like container type.
