### PR TITLE
Remove the --btf option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to
 #### Removed
 - Disable some kfunc probes whose tracing crashes
   - [#1432](https://github.com/iovisor/bpftrace/pull/1432)
+- Disable the --btf option
+  - [#1506](https://github.com/iovisor/bpftrace/pull/1506)
 
 #### Fixed
 - Fix negative overflow bug and unstable tests in PR #1416

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -138,7 +138,6 @@ OPTIONS:
     -B MODE        output buffering mode ('line', 'full', or 'none')
     -d             debug info dry run
     -dd            verbose debug info dry run
-    -b             force BTF (BPF type format) processing
     -e 'program'   execute this program
     -h             show this help message
     -I DIR         add the specified DIR to the search path for include files.
@@ -2686,7 +2685,7 @@ Attaching 1 probe...
 Attaching 1 probe...
 8
 
-# bpftrace --btf -e 'BEGIN { printf("%d\n", sizeof(struct task_struct)); }'
+# bpftrace -e 'BEGIN { printf("%d\n", sizeof(struct task_struct)); }'
 Attaching 1 probe...
 13120
 

--- a/man/man8/bpftrace.8
+++ b/man/man8/bpftrace.8
@@ -73,10 +73,6 @@ Enable unsafe builtin functions. By default, bpftrace runs in safe mode. Safe mo
 Unsafe builtin functions are marked as such in \fBBUILTINS (functions)\fR.
 .
 .TP
-\fB\--btf\fR
-Force BTF data processing if it's available. By default it's enabled only if the user does not specify any types/includes.
-.
-.TP
 \fB\-v\fR
 Verbose messages.
 .

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -393,6 +393,15 @@ void Program::accept(Visitor &v) {
   v.visit(*this);
 }
 
+bool Program::has_userspace_probes() const
+{
+  for (const auto &probe : *probes)
+    for (const auto &ap : *probe->attach_points)
+      if (is_userspace_probe(ap->provider))
+        return true;
+  return false;
+}
+
 std::string opstr(Jump &jump)
 {
   switch (jump.ident)

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -358,6 +358,8 @@ public:
   ProbeList *probes;
 
   void accept(Visitor &v) override;
+
+  bool has_userspace_probes() const;
 };
 
 class Visitor {

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -171,7 +171,6 @@ public:
   bool resolve_user_symbols_ = true;
   bool cache_user_symbols_ = true;
   bool safe_mode_ = true;
-  bool force_btf_ = false;
   bool has_usdt_ = false;
   bool usdt_file_activation_ = false;
   int helper_check_level_ = 0;

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -592,8 +592,11 @@ bool ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<s
     args.push_back(flag.c_str());
   }
 
-  bool process_btf = program->c_definitions.empty() ||
-                     (bpftrace.force_btf_ && bpftrace.btf_.has_data());
+  // Don't parse BTF for programs containing userspace probes if the user
+  // defined some custom data types, since those may conflict with BTF types.
+  bool process_btf = bpftrace.btf_.has_data() &&
+                     (!program->has_userspace_probes() ||
+                      program->c_definitions.empty());
 
   // We set these args early because some systems may not have <linux/types.h>
   // (containers) and fully rely on BTF.
@@ -661,10 +664,10 @@ bool ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<s
   {
     for (auto &msg : error_msgs)
     {
-      if (get_unknown_type(msg) != "" && !bpftrace.force_btf_)
+      if (get_unknown_type(msg))
       {
-        LOG(ERROR) << "Try running with --btf to force BTF processing or "
-                      "include headers with missing type definitions";
+        LOG(ERROR) << "Include headers with missing type definitions or "
+                      "install BTF information to your system";
       }
     }
     return false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -53,7 +53,6 @@ void usage()
   std::cerr << "    -o file        redirect bpftrace output to file" << std::endl;
   std::cerr << "    -d             debug info dry run" << std::endl;
   std::cerr << "    -dd            verbose debug info dry run" << std::endl;
-  std::cerr << "    -b             force BTF (BPF type format) processing" << std::endl;
   std::cerr << "    -e 'program'   execute this program" << std::endl;
   std::cerr << "    -h, --help     show this help message" << std::endl;
   std::cerr << "    -I DIR         add the directory to the include search path" << std::endl;
@@ -259,7 +258,6 @@ int main(int argc, char *argv[])
   std::string cmd_str;
   bool listing = false;
   bool safe_mode = true;
-  bool force_btf = false;
   bool usdt_file_activation = false;
   int helper_check_level = 0;
   std::string script, search, file_name, output_file, output_format, output_elf;
@@ -350,7 +348,6 @@ int main(int argc, char *argv[])
         safe_mode = false;
         break;
       case 'b':
-        force_btf = true;
         break;
       case 'h':
         usage();
@@ -437,7 +434,6 @@ int main(int argc, char *argv[])
 
   bpftrace.usdt_file_activation_ = usdt_file_activation;
   bpftrace.safe_mode_ = safe_mode;
-  bpftrace.force_btf_ = force_btf;
   bpftrace.helper_check_level_ = helper_check_level;
   bpftrace.boottime_ = get_boottime();
 

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -212,11 +212,8 @@ std::string TracepointFormatParser::parse_field(const std::string &line,
   if (field_name.find("[") == std::string::npos)
     field_type = adjust_integer_types(field_type, size);
 
-  // With --btf on, we try not to use any header files, including
-  // <linux/types.h>. That means we must request all the types we need
-  // from BTF. Note we don't need to gate this on --btf because the
-  // expensive type reslution is already gated on --btf (adding to a set
-  // is cheap).
+  // If BTF is available, we try not to use any header files, including
+  // <linux/types.h> and request all the types we need from BTF.
   bpftrace.btf_set_.emplace(field_type);
 
   return extra + "  " + field_type + " " + field_name + ";\n";

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -236,7 +236,7 @@ std::string probetypeName(ProbeType t)
   // lgtm[cpp/missing-return]
 }
 
-bool is_userspace_probe(std::string &probe_name)
+bool is_userspace_probe(const std::string &probe_name)
 {
   auto probe_type = probetype(probe_name);
   return (probe_type == ProbeType::uprobe && probe_name != "BEGIN" &&

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -236,6 +236,14 @@ std::string probetypeName(ProbeType t)
   // lgtm[cpp/missing-return]
 }
 
+bool is_userspace_probe(std::string &probe_name)
+{
+  auto probe_type = probetype(probe_name);
+  return (probe_type == ProbeType::uprobe && probe_name != "BEGIN" &&
+          probe_name != "END") ||
+         probe_type == ProbeType::uretprobe || probe_type == ProbeType::usdt;
+}
+
 uint64_t asyncactionint(AsyncAction a)
 {
   return (uint64_t)a;

--- a/src/types.h
+++ b/src/types.h
@@ -399,7 +399,7 @@ std::string addrspacestr(AddrSpace as);
 std::string typestr(Type t);
 std::string probetypeName(const std::string &type);
 std::string probetypeName(ProbeType t);
-bool is_userspace_probe(std::string &probe_name);
+bool is_userspace_probe(const std::string &probe_name);
 
 struct Probe
 {

--- a/src/types.h
+++ b/src/types.h
@@ -399,6 +399,7 @@ std::string addrspacestr(AddrSpace as);
 std::string typestr(Type t);
 std::string probetypeName(const std::string &type);
 std::string probetypeName(ProbeType t);
+bool is_userspace_probe(std::string &probe_name);
 
 struct Probe
 {

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -661,7 +661,6 @@ TEST(clang_parser, btf_unresolved_typedef)
   // size_t is defined in stddef.h, but if we have BTF, it should be possible to
   // extract it from there
   BPFtrace bpftrace;
-  bpftrace.force_btf_ = true;
   parse("struct Foo { size_t x; };", bpftrace);
 
   StructMap &structs = bpftrace.structs_;
@@ -675,6 +674,23 @@ TEST(clang_parser, btf_unresolved_typedef)
   EXPECT_EQ(structs["struct Foo"].fields["x"].type.type, Type::integer);
   EXPECT_EQ(structs["struct Foo"].fields["x"].type.size, 8U);
   EXPECT_EQ(structs["struct Foo"].fields["x"].offset, 0);
+}
+
+TEST_F(clang_parser_btf, btf_uprobe_type_override)
+{
+  // Overriding a structure from BTF should not fail for a userspace probe
+  BPFtrace bpftrace;
+  parse("struct Foo1 { int a; };\n",
+        bpftrace,
+        true,
+        "uprobe:/bin/sh:f {@x = (struct Foo1 *) curtask;}");
+
+  StructMap &structs = bpftrace.structs_;
+  ASSERT_EQ(structs.size(), 1U);
+  ASSERT_EQ(structs.count("struct Foo1"), 1U);
+
+  ASSERT_EQ(structs["struct Foo1"].fields.size(), 1U);
+  ASSERT_EQ(structs["struct Foo1"].fields.count("a"), 1U);
 }
 #endif // HAVE_LIBBPF_BTF_DUMP
 

--- a/tests/runtime/btf
+++ b/tests/runtime/btf
@@ -1,17 +1,17 @@
 NAME user_supplied_c_def_using_btf
-RUN bpftrace -v --btf -e 'struct foo { struct task_struct t; } BEGIN { exit(); }'
+RUN bpftrace -v -e 'struct foo { struct task_struct t; } BEGIN { exit(); }'
 EXPECT Attaching 1 probe...
 TIMEOUT 5
 REQUIRES_FEATURE btf
 
 NAME tracepoint_pointer_type_resolution
-RUN bpftrace -v --btf -e 'tracepoint:syscalls:sys_enter_nanosleep { args->rqtp->tv_sec; exit(); }'
+RUN bpftrace -v -e 'tracepoint:syscalls:sys_enter_nanosleep { args->rqtp->tv_sec; exit(); }'
 EXPECT Attaching 1 probe...
 TIMEOUT 5
 REQUIRES_FEATURE btf
 
 NAME enum_value_reference
-RUN bpftrace -v --btf -e 'BEGIN { printf("%d\n", sizeof(BTF_VAR_STATIC)); exit(); }'
+RUN bpftrace -v -e 'BEGIN { printf("%d\n", sizeof(BTF_VAR_STATIC)); exit(); }'
 EXPECT ^8$
 TIMEOUT 5
 REQUIRES_FEATURE btf

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -124,11 +124,6 @@ RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", curtask); exit(); }'
 EXPECT SUCCESS curtask -?[0-9][0-9]*
 TIMEOUT 5
 
-NAME curtask_field
-RUN bpftrace -v -e 'struct task_struct {int x;} i:ms:1 { printf("SUCCESS '$test' %d\n", curtask->x); exit(); }'
-EXPECT SUCCESS curtask_field -?[0-9][0-9]*
-TIMEOUT 5
-
 NAME rand
 RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", rand); exit(); }'
 EXPECT SUCCESS rand -?[0-9][0-9]*
@@ -194,7 +189,7 @@ EXPECT ^8 8$
 TIMEOUT 5
 
 NAME sizeof_btf
-RUN bpftrace --btf -e 'BEGIN { printf("size=%d\n", sizeof(struct task_struct)); exit(); }'
+RUN bpftrace -e 'BEGIN { printf("size=%d\n", sizeof(struct task_struct)); exit(); }'
 EXPECT ^size=
 TIMEOUT 5
 REQUIRES_FEATURE btf

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1204,7 +1204,6 @@ TEST(semantic_analyser, field_access)
   test(structs + "kprobe:f { ((struct type1)cpu).field }", 0);
   test(structs + "kprobe:f { $x = (struct type1)cpu; $x.field }", 0);
   test(structs + "kprobe:f { @x = (struct type1)cpu; @x.field }", 0);
-  test("struct task_struct {int x;} kprobe:f { curtask->x }", 0);
 }
 
 TEST(semantic_analyser, field_access_wrong_field)


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

Parse BTF by default if it is available. Actually, this was already done for all probe types, except tracepoints.

The only problem is that now the user cannot override types if BTF is available. This won't work:
```
bpftrace -e 'struct task_struct {int x;} i:ms:1 { printf("%d\n", curtask->x); }'
```
I don't see why someone would want to do that, but I may be missing something.

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
