### PR TITLE
embedded-ci: Don't strip END_trigger

### DIFF
--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -216,7 +216,7 @@ jobs:
         -e EMBED_BINUTILS=${EMBED_BINUTILS}
         --entrypoint /bin/bash
         bpftrace-embedded-${{ matrix.env['BASE'] }}
-        -c "strip --keep-symbol BEGIN_trigger $(pwd)/build-embedded/src/bpftrace"
+        -c "strip --keep-symbol BEGIN_trigger --keep-symbol END_trigger $(pwd)/build-embedded/src/bpftrace"
 
     - uses: actions/upload-artifact@v1
       with:


### PR DESCRIPTION
The symbol is needed to run `END` probes.

This fixes #1512 .

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
