### PR TITLE
Improve work with positional parameters

### DIFF
--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -98,7 +98,7 @@ jobs:
           EMBED_BINUTILS: OFF
           RUN_ALL_TESTS: 1
           TEST_GROUPS_DISABLE: "tools-parsing-test"
-          RUNTIME_TEST_DISABLE: json-output.join_delim,other.string compare map lookup,probe.kprobe_offset_fail_size,usdt."usdt probes - attach to fully specified probe of child",usdt."usdt probes - all probes by wildcard and file with child",usdt."usdt probes - attach to probe by wildcard and file with child",usdt."usdt probes - attach to probes by wildcard file with child",usdt."usdt probes - attach to probe on multiple files by wildcard",usdt."usdt probes - attach to probe with probe builtin and args by file with child",usdt."usdt probes - list probes by pid in separate mountns",usdt."usdt sized arguments",uprobe."uprobes - list probes by pid; uprobes only",uprobe."uprobes - list probes by pid in separate mount namespace"
+          RUNTIME_TEST_DISABLE: json-output.join_delim,other.string compare map lookup,probe.kprobe_offset_fail_size,usdt."usdt probes - attach to fully specified probe of child",usdt."usdt probes - all probes by wildcard and file with child",usdt."usdt probes - attach to probe by wildcard and file with child",usdt."usdt probes - attach to probes by wildcard file with child",usdt."usdt probes - attach to probe on multiple files by wildcard",usdt."usdt probes - attach to probe with probe builtin and args by file with child",usdt."usdt probes - list probes by pid in separate mountns",usdt."usdt sized arguments",uprobe."uprobes - list probes by pid; uprobes only",uprobe."uprobes - list probes by pid in separate mount namespace",other.positional pointer arithmetics
           BASE: alpine
           DISTRO: alpine
           ALPINE_VERSION: 3.11
@@ -114,7 +114,7 @@ jobs:
           EMBED_LIBELF: OFF
           EMBED_BINUTILS: OFF
           RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: other.string compare map lookup,probe.kprobe_offset_fail_size,usdt."usdt probes - attach to fully specified probe of child",usdt."usdt probes - all probes by wildcard and file with child",usdt."usdt probes - attach to probe by wildcard and file with child",usdt."usdt probes - attach to probes by wildcard file with child",usdt."usdt probes - attach to probe on multiple files by wildcard",usdt."usdt probes - attach to probe with probe builtin and args by file with child",usdt."usdt probes - list probes by pid in separate mountns",usdt."usdt sized arguments",uprobe."uprobes - list probes by pid; uprobes only",uprobe."uprobes - list probes by pid in separate mount namespace"
+          RUNTIME_TEST_DISABLE: other.string compare map lookup,probe.kprobe_offset_fail_size,usdt."usdt probes - attach to fully specified probe of child",usdt."usdt probes - all probes by wildcard and file with child",usdt."usdt probes - attach to probe by wildcard and file with child",usdt."usdt probes - attach to probes by wildcard file with child",usdt."usdt probes - attach to probe on multiple files by wildcard",usdt."usdt probes - attach to probe with probe builtin and args by file with child",usdt."usdt probes - list probes by pid in separate mountns",usdt."usdt sized arguments",uprobe."uprobes - list probes by pid; uprobes only",uprobe."uprobes - list probes by pid in separate mount namespace",other.positional pointer arithmetics
           BASE: alpine
           DISTRO: alpine
           ALPINE_VERSION: 3.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to
   - [#1485](https://github.com/iovisor/bpftrace/pull/1485)
 - Support multi-matched globbed targets for uprobe and ustd probes
   - [#1499](https://github.com/iovisor/bpftrace/pull/1499)
+- Positional parameters: support numbers as strings and params as string literals
+  - [#1514](https://github.com/iovisor/bpftrace/pull/1514)
 
 #### Changed
 - Warn if using `print` on `stats` maps with top and div arguments
@@ -60,6 +62,8 @@ and this project adheres to
   - [#1450](https://github.com/iovisor/bpftrace/pull/1450)
 - Fix wrong setting of vmlinux_location.raw when offset kprobe used
   - [#1530](https://github.com/iovisor/bpftrace/pull/1530)
+- Fix pointer arithmetic for positional parameters
+  - [#1514](https://github.com/iovisor/bpftrace/pull/1514)
 
 #### Tools
 - Hook up execsnoop.bt script onto `execveat` call

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1862,18 +1862,26 @@ be used as a string in the `str()` call. If a parameter is used that was not pro
 zero for numeric context, and "" for string context. Positional parameters may also be used in probe
 argument and will be treated as a string parameter.
 
+If a positional parameter is used in `str()`, it is interpreted as a pointer to the actual given string 
+literal, which allows to do pointer arithmetic on it. Only addition of a single constant, less or equal to
+the length of the supplied string, is allowed.
+
 `$#` returns the number of positional arguments supplied.
 
 This allows scripts to be written that use basic arguments to change their behavior. If you develop a
 script that requires more complex argument processing, it may be better suited for bcc instead, which
 supports Python's argparse and completely custom argument processing.
 
-One-liner example:
+One-liner examples:
 
 ```
 # bpftrace -e 'BEGIN { printf("I got %d, %s (%d args)\n", $1, str($2), $#); }' 42 "hello"
 Attaching 1 probe...
 I got 42, hello (2 args)
+
+# bpftrace -e 'BEGIN { printf("%s\n", str($1 + 1)) }' "hello"
+Attaching 1 probe...
+ello
 ```
 
 Script example, bsize.d:

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -600,13 +600,13 @@ void CodegenLLVM::visit(Call &call)
   else if (call.func == "kaddr")
   {
     uint64_t addr;
-    auto &name = static_cast<String&>(*call.vargs->at(0)).str;
+    auto name = bpftrace_.get_string_literal(call.vargs->at(0));
     addr = bpftrace_.resolve_kname(name);
     expr_ = b_.getInt64(addr);
   }
   else if (call.func == "uaddr")
   {
-    auto &name = static_cast<String&>(*call.vargs->at(0)).str;
+    auto name = bpftrace_.get_string_literal(call.vargs->at(0));
     struct symbol sym = {};
     int err =
         bpftrace_.resolve_uname(name, &sym, current_attach_point_->target);
@@ -618,7 +618,7 @@ void CodegenLLVM::visit(Call &call)
   else if (call.func == "cgroupid")
   {
     uint64_t cgroupid;
-    auto &path = static_cast<String&>(*call.vargs->at(0)).str;
+    auto path = bpftrace_.get_string_literal(call.vargs->at(0));
     cgroupid = bpftrace_.resolve_cgroupid(path);
     expr_ = b_.getInt64(cgroupid);
   }
@@ -766,7 +766,7 @@ void CodegenLLVM::visit(Call &call)
   }
   else if (call.func == "reg")
   {
-    auto &reg_name = static_cast<String&>(*call.vargs->at(0)).str;
+    auto reg_name = bpftrace_.get_string_literal(call.vargs->at(0));
     int offset = arch::offset(reg_name);
     if (offset == -1)
     {
@@ -919,7 +919,7 @@ void CodegenLLVM::visit(Call &call)
     auto &arg = *call.vargs->at(0);
     if (arg.type.IsStringTy())
     {
-      auto signame = static_cast<String&>(arg).str;
+      auto signame = bpftrace_.get_string_literal(&arg);
       int sigid = signal_name_to_num(signame);
       // Should be caught in semantic analyser
       if (sigid < 1) {
@@ -949,7 +949,7 @@ void CodegenLLVM::visit(Call &call)
     {
       auto scoped_del = accept(left_arg);
       Value *left_string = expr_;
-      const auto& string_literal = static_cast<String *>(right_arg)->str;
+      const auto string_literal = bpftrace_.get_string_literal(right_arg);
       expr_ = b_.CreateStrncmp(
           ctx_, left_string, left_as, string_literal, size, call.loc, false);
     }
@@ -957,7 +957,7 @@ void CodegenLLVM::visit(Call &call)
     {
       auto scoped_del = accept(right_arg);
       Value *right_string = expr_;
-      const auto& string_literal = static_cast<String *>(left_arg)->str;
+      const auto string_literal = bpftrace_.get_string_literal(left_arg);
       expr_ = b_.CreateStrncmp(
           ctx_, right_string, right_as, string_literal, size, call.loc, false);
     }
@@ -1056,14 +1056,14 @@ void CodegenLLVM::visit(Binop &binop)
     if (binop.right->is_literal)
     {
       auto scoped_del = accept(binop.left);
-      string_literal = static_cast<String *>(binop.right)->str;
+      string_literal = bpftrace_.get_string_literal(binop.right);
       expr_ = b_.CreateStrcmp(
           ctx_, expr_, left_as, string_literal, binop.loc, inverse);
     }
     else if (binop.left->is_literal)
     {
       auto scoped_del = accept(binop.right);
-      string_literal = static_cast<String *>(binop.left)->str;
+      string_literal = bpftrace_.get_string_literal(binop.left);
       expr_ = b_.CreateStrcmp(
           ctx_, expr_, right_as, string_literal, binop.loc, inverse);
     }

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -66,7 +66,7 @@ void CodegenLLVM::visit(PositionalParameter &param)
     case PositionalParameterType::positional:
       {
         std::string pstr = bpftrace_.get_param(param.n, param.is_in_str);
-        if (is_numeric(pstr))
+        if (!param.is_in_str)
         {
           expr_ = b_.getInt64(std::stoll(pstr, nullptr, 0));
         }

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -41,6 +41,11 @@ void SemanticAnalyser::visit(Integer &integer)
 void SemanticAnalyser::visit(PositionalParameter &param)
 {
   param.type = CreateInt64();
+  if (is_in_str)
+  {
+    param.is_in_str = true;
+    has_pos_param = true;
+  }
   switch (param.ptype)
   {
     case PositionalParameterType::positional:
@@ -54,14 +59,6 @@ void SemanticAnalyser::visit(PositionalParameter &param)
           LOG(ERROR, param.loc, err_)
               << "$" << param.n << " used numerically but given \"" << pstr
               << "\". Try using str($" << param.n << ").";
-        }
-        if (is_numeric(pstr) && param.is_in_str)
-        {
-          // This is blocked due to current limitations in our codegen
-          LOG(ERROR, param.loc, err_)
-              << "$" << param.n
-              << " used in str(), but given numeric value: " << pstr
-              << ". Try $" << param.n << " instead of str($" << param.n << ").";
         }
       }
       break;
@@ -400,6 +397,9 @@ void SemanticAnalyser::visit(Call &call)
 
   func_setter scope_bound_func_setter{ *this, call.func };
 
+  if (call.func == "str")
+    is_in_str = true;
+
   if (call.vargs) {
     for (Expression *expr : *call.vargs) {
       expr->accept(*this);
@@ -527,7 +527,8 @@ void SemanticAnalyser::visit(Call &call)
   }
   else if (call.func == "str") {
     if (check_varargs(call, 1, 2)) {
-      auto &t = call.vargs->at(0)->type;
+      auto *arg = call.vargs->at(0);
+      auto &t = arg->type;
       if (!t.IsIntegerTy() && !t.IsPtrTy())
       {
         LOG(ERROR, call.loc, err_)
@@ -535,13 +536,26 @@ void SemanticAnalyser::visit(Call &call)
             << "argument (" << t << " provided)";
       }
       call.type = CreateString(bpftrace_.strlen_);
+      if (has_pos_param)
+      {
+        auto binop = dynamic_cast<Binop *>(arg);
+        if (!(dynamic_cast<PositionalParameter *>(arg) ||
+              (binop && (dynamic_cast<PositionalParameter *>(binop->left) ||
+                         dynamic_cast<PositionalParameter *>(binop->right)))))
+        {
+          // Only str($1), str($1 + CONST), or str(CONST + $1) are allowed
+          LOG(ERROR, call.loc, err_)
+              << call.func << "() only accepts positional parameters"
+              << " directly or with a single constant offset added";
+        }
+        has_pos_param = false;
+      }
+
       if (is_final_pass() && call.vargs->size() > 1) {
         check_arg(call, Type::integer, 1, false);
       }
-      if (auto *param = dynamic_cast<PositionalParameter*>(call.vargs->at(0))) {
-        param->is_in_str = true;
-      }
     }
+    is_in_str = false;
   }
   else if (call.func == "buf")
   {
@@ -591,11 +605,6 @@ void SemanticAnalyser::visit(Call &call)
 
     buffer_size++; // extra byte is used to embed the length of the buffer
     call.type = CreateBuffer(buffer_size);
-
-    if (auto *param = dynamic_cast<PositionalParameter *>(call.vargs->at(0)))
-    {
-      param->is_in_str = true;
-    }
   }
   else if (call.func == "ksym" || call.func == "usym") {
     if (check_nargs(call, 1)) {
@@ -1335,6 +1344,32 @@ void SemanticAnalyser::visit(Binop &binop)
               << "signed operands for '" << opstr(binop)
               << "' can lead to undefined behavior "
               << "(cast to unsigned to silence warning)";
+        }
+      }
+
+      if (is_in_str)
+      {
+        // Check if one of the operands is a positional parameter
+        // The other one should be a constant offset
+        auto pos_param = dynamic_cast<PositionalParameter *>(left);
+        auto offset = dynamic_cast<Integer *>(right);
+        if (!pos_param)
+        {
+          pos_param = dynamic_cast<PositionalParameter *>(right);
+          offset = dynamic_cast<Integer *>(left);
+        }
+
+        if (pos_param)
+        {
+          auto len = bpftrace_.get_param(pos_param->n, true).length();
+          if (!offset || binop.op != bpftrace::Parser::token::PLUS ||
+              offset->n < 0 || (size_t)offset->n > len)
+          {
+            LOG(ERROR, binop.loc + binop.right->loc, err_)
+                << "only addition of a single constant less or equal to the "
+                << "length of $" << pos_param->n << " (which is " << len << ")"
+                << " is allowed inside str()";
+          }
         }
       }
     }

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -113,6 +113,8 @@ private:
   bool has_begin_probe_ = false;
   bool has_end_probe_ = false;
   bool has_child_ = false;
+  bool is_in_str = false;
+  bool has_pos_param = false;
 };
 
 } // namespace ast

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -2142,4 +2142,26 @@ void BPFtrace::sort_by_key(std::vector<SizedType> key_args,
   }
 }
 
+std::string BPFtrace::get_string_literal(const ast::Expression *expr) const
+{
+  if (expr->is_literal)
+  {
+    if (auto *string = dynamic_cast<const ast::String *>(expr))
+      return string->str;
+    else if (auto *str_call = dynamic_cast<const ast::Call *>(expr))
+    {
+      // Positional parameters in the form str($1) can be used as literals
+      if (str_call->func == "str")
+      {
+        if (auto *pos_param = dynamic_cast<const ast::PositionalParameter *>(
+                str_call->vargs->at(0)))
+          return get_param(pos_param->n, true);
+      }
+    }
+  }
+
+  LOG(ERROR) << "Expected string literal, got " << expr->type;
+  return "";
+}
+
 } // namespace bpftrace

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -126,6 +126,7 @@ public:
   size_t num_params() const;
   void request_finalize();
   bool is_aslr_enabled(int pid);
+  std::string get_string_literal(const ast::Expression *expr) const;
 
   std::string cmd_;
   bool finalize_ = false;

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -143,6 +143,11 @@ RUN bpftrace -e 'BEGIN { printf("-%s-\n", str($1)); exit() }' 1
 EXPECT -1-
 TIMEOUT 1
 
+NAME positional as string literal
+RUN bpftrace -e 'BEGIN { @ = kaddr(str($1)); exit() }' vfs_read
+EXPECT Attaching 1 probe...
+TIMEOUT 5
+
 NAME positional arg count
 RUN bpftrace -v -e 'BEGIN { printf("got %d args: %s %d\n", $#, str($1), $2); exit();}' "one" 2
 EXPECT got 2 args: one 2

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -148,6 +148,11 @@ RUN bpftrace -e 'BEGIN { printf("got: %d %d 0x%x\n", $1, $2, $3); exit() }' 123 
 EXPECT got: 123 509 0x123
 TIMEOUT 5
 
+NAME positional pointer arithmetics
+RUN bpftrace -e 'BEGIN { printf("%s", str($1 + 1)); exit(); }' hello
+EXPECT ello
+TIMEOUT 1
+
 NAME lhist can be cleared
 RUN bpftrace -e 'BEGIN{ @[1] = lhist(3,0,10,1); clear(@); exit() }'
 EXPECT .*

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -138,6 +138,11 @@ RUN bpftrace -e 'BEGIN { printf("-%s-\n", str($1)); exit() }'
 EXPECT --
 TIMEOUT 1
 
+NAME positional number as string
+RUN bpftrace -e 'BEGIN { printf("-%s-\n", str($1)); exit() }' 1
+EXPECT -1-
+TIMEOUT 1
+
 NAME positional arg count
 RUN bpftrace -v -e 'BEGIN { printf("got %d args: %s %d\n", $#, str($1), $2); exit();}' "one" 2
 EXPECT got 2 args: one 2

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1306,7 +1306,7 @@ TEST(semantic_analyser, positional_parameters)
   test(bpftrace, "kprobe:f { printf(\"%s\", str($0)); }", 1);
 
   test(bpftrace, "kprobe:f { printf(\"%d\", $1); }", 0);
-  test(bpftrace, "kprobe:f { printf(\"%s\", str($1)); }", 10);
+  test(bpftrace, "kprobe:f { printf(\"%s\", str($1)); }", 0);
 
   test(bpftrace, "kprobe:f { printf(\"%s\", str($2)); }", 0);
   test(bpftrace, "kprobe:f { printf(\"%s\", str($2 + 1)); }", 0);

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1329,6 +1329,9 @@ TEST(semantic_analyser, positional_parameters)
   test(bpftrace, "kprobe:f { printf(\"%d\", $#); }", 0);
   test(bpftrace, "kprobe:f { printf(\"%s\", str($#)); }", 10);
 
+  // Parameters can be used as string literals
+  test(bpftrace, "kprobe:f { printf(\"%d\", cgroupid(str($2))); }", 0);
+
   Driver driver(bpftrace);
   test(driver, "k:f { $1 }", 0);
   auto stmt = static_cast<ast::ExprStatement *>(

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1309,9 +1309,18 @@ TEST(semantic_analyser, positional_parameters)
   test(bpftrace, "kprobe:f { printf(\"%s\", str($1)); }", 10);
 
   test(bpftrace, "kprobe:f { printf(\"%s\", str($2)); }", 0);
+  test(bpftrace, "kprobe:f { printf(\"%s\", str($2 + 1)); }", 0);
   test(bpftrace, "kprobe:f { printf(\"%d\", $2); }", 10);
 
   test(bpftrace, "kprobe:f { printf(\"%d\", $3); }", 0);
+
+  // Pointer arithmetic in str() for parameters
+  // Only str($1 + CONST) where CONST <= strlen($1) should be allowed
+  test(bpftrace, "kprobe:f { printf(\"%s\", str($1 + 1)); }", 0);
+  test(bpftrace, "kprobe:f { printf(\"%s\", str(1 + $1)); }", 0);
+  test(bpftrace, "kprobe:f { printf(\"%s\", str($1 + 4)); }", 10);
+  test(bpftrace, "kprobe:f { printf(\"%s\", str($1 * 2)); }", 10);
+  test(bpftrace, "kprobe:f { printf(\"%s\", str($1 + 1 + 1)); }", 1);
 
   // Parameters are not required to exist to be used:
   test(bpftrace, "kprobe:f { printf(\"%s\", str($4)); }", 0);


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

This brings 3 improvements to positional parameters:
- improved semantic analysis that allows to use pointer arithmetic on string params (should help with brendangregg/bpf-perf-tools-book#12)
- handling numerical params as strings if specified in a `str()` call (fixes #1168)
- using positional params in calls that require string literals (fixes #1218)

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
