### PR TITLE
Plugging Leak: call clang_disposeString()

### DIFF
--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -256,6 +256,7 @@ static bool translateMacro(CXCursor cursor, std::string &name, std::string &valu
           value += text;
       }
     }
+    clang_disposeString(tokenText);
   }
   clang_disposeTokens(transUnit, tokens, numTokens);
   return value.length() != 0;


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

I'm using BPFTrace in a project, and ran into some memory leaks identified by ASAN. I have fixed various different ones, and plan to contribute them back. This first one is a simple one-liner.

Note that without this fix, one gets a errors like the following when running ASAN.

```
==718901==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 1843 byte(s) in 322 object(s) allocated from:
#0 0x2f6a64d in malloc /llvm_all/llvm-project/compiler-rt/lib/asan/asan_malloc_linux.cpp:145:3
#1 0x6fe1849 in clang::cxstring::createDup(llvm::StringRef) (/home/oazizi/.cache/bazel/_bazel_oazizi/b26a4188b901df362a314e6f6307b112/execroot/pl/bazel-out/k8-dbg/bin/src/stirling/bpftrace_connector_bpf_test+0x6fe1849)
#2 0x556844c in bpftrace::ClangParser::visit_children(CXCursor&, bpftrace::BPFtrace&)::$_0::operator()(CXCursor, CXCursor, void*) const /proc/self/cwd/third_party/bpftrace/src/clang_parser.cpp:403:15
#3 0x5567bd2 in bpftrace::ClangParser::visit_children(CXCursor&, bpftrace::BPFtrace&)::$_0::__invoke(CXCursor, CXCursor, void*) /proc/self/cwd/third_party/bpftrace/src/clang_parser.cpp:397:7
#4 0x6fb1064 in clang::cxcursor::CursorVisitor::Visit(CXCursor, bool) (/home/oazizi/.cache/bazel/_bazel_oazizi/b26a4188b901df362a314e6f6307b112/execroot/pl/bazel-out/k8-dbg/bin/src/stirling/bpftrace_connector_bpf_test+0x6fb1064)

SUMMARY: AddressSanitizer: 1843 byte(s) leaked in 322 allocation(s).
```

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
