### PR TITLE
Plug leak in perf buffers

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1121,6 +1121,9 @@ int BPFtrace::run(std::unique_ptr<BpfOrc> bpforc)
 
   poll_perf_events(epollfd, true);
 
+  // Calls perf_reader_free() on all open perf buffers.
+  open_perf_buffers_.clear();
+
   return 0;
 }
 
@@ -1144,6 +1147,10 @@ int BPFtrace::setup_perf_events()
       LOG(ERROR) << "Failed to open perf buffer";
       return -1;
     }
+    // Store the perf buffer pointers in a vector of unique_ptrs.
+    // When open_perf_buffers_ is cleared or destroyed,
+    // perf_reader_free is automatically called.
+    open_perf_buffers_.emplace_back(reader, perf_reader_free);
 
     struct epoll_event ev = {};
     ev.events = EPOLLIN;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -207,6 +207,8 @@ private:
   std::vector<std::string> params_;
   int next_probe_id_ = 0;
 
+  std::vector<std::unique_ptr<void, void (*)(void *)>> open_perf_buffers_;
+
   std::vector<std::unique_ptr<AttachedProbe>> attach_usdt_probe(
       Probe &probe,
       std::tuple<uint8_t *, uintptr_t> func,


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

Small change to remove a memory leak in the perf buffers. Otherwise, the missing `perf_reader_free()` triggers ASAN leak check.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
