### PR TITLE
Fix leaks from Bison memory allocations

### DIFF
--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -26,9 +26,9 @@ int AttachPointParser::parse()
     return 1;
 
   uint32_t failed = 0;
-  for (Probe *probe : *(root_->probes))
+  for (auto &probe : *(root_->probes))
   {
-    for (AttachPoint *ap : *(probe->attach_points))
+    for (auto &ap : *(probe->attach_points))
     {
       if (parse_attachpoint(*ap))
       {

--- a/src/ast/field_analyser.cpp
+++ b/src/ast/field_analyser.cpp
@@ -86,7 +86,8 @@ void FieldAnalyser::visit(Builtin &builtin)
 void FieldAnalyser::visit(Call &call)
 {
   if (call.vargs) {
-    for (Expression *expr : *call.vargs) {
+    for (auto &expr : *call.vargs)
+    {
       expr->accept(*this);
     }
   }
@@ -96,7 +97,8 @@ void FieldAnalyser::visit(Map &map)
 {
   MapKey key;
   if (map.vargs) {
-    for (Expression *expr : *map.vargs) {
+    for (auto &expr : *map.vargs)
+    {
       expr->accept(*this);
     }
   }
@@ -141,7 +143,7 @@ void FieldAnalyser::visit(While &while_block)
 {
   while_block.cond->accept(*this);
 
-  for (Statement *stmt : *while_block.stmts)
+  for (auto &stmt : *while_block.stmts)
   {
     stmt->accept(*this);
   }
@@ -151,12 +153,14 @@ void FieldAnalyser::visit(If &if_block)
 {
   if_block.cond->accept(*this);
 
-  for (Statement *stmt : *if_block.stmts) {
+  for (auto &stmt : *if_block.stmts)
+  {
     stmt->accept(*this);
   }
 
   if (if_block.else_stmts) {
-    for (Statement *stmt : *if_block.else_stmts) {
+    for (auto &stmt : *if_block.else_stmts)
+    {
       stmt->accept(*this);
     }
   }
@@ -165,7 +169,7 @@ void FieldAnalyser::visit(If &if_block)
 void FieldAnalyser::visit(Unroll &unroll)
 {
   // visit statements in unroll once
-  for (Statement *stmt : *unroll.stmts)
+  for (auto &stmt : *unroll.stmts)
   {
     stmt->accept(*this);
   }
@@ -213,7 +217,7 @@ void FieldAnalyser::visit(Cast &cast)
 
 void FieldAnalyser::visit(Tuple &tuple)
 {
-  for (Expression *expr : *tuple.elems)
+  for (auto &expr : *tuple.elems)
     expr->accept(*this);
 }
 
@@ -371,7 +375,8 @@ void FieldAnalyser::visit(Probe &probe)
   has_mixed_args_ = false;
   probe_ = &probe;
 
-  for (AttachPoint *ap : *probe.attach_points) {
+  for (auto &ap : *probe.attach_points)
+  {
     ap->accept(*this);
     ProbeType pt = probetype(ap->provider);
     prog_type_ = progtype(pt);
@@ -379,14 +384,15 @@ void FieldAnalyser::visit(Probe &probe)
   if (probe.pred) {
     probe.pred->accept(*this);
   }
-  for (Statement *stmt : *probe.stmts) {
+  for (auto &stmt : *probe.stmts)
+  {
     stmt->accept(*this);
   }
 }
 
 void FieldAnalyser::visit(Program &program)
 {
-  for (Probe *probe : *program.probes)
+  for (auto &probe : *program.probes)
     probe->accept(*this);
 }
 

--- a/src/ast/printer.cpp
+++ b/src/ast/printer.cpp
@@ -106,7 +106,8 @@ void Printer::visit(Call &call)
 
   ++depth_;
   if (call.vargs) {
-    for (Expression *expr : *call.vargs) {
+    for (auto &expr : *call.vargs)
+    {
       expr->accept(*this);
     }
   }
@@ -120,7 +121,8 @@ void Printer::visit(Map &map)
 
   ++depth_;
   if (map.vargs) {
-    for (Expression *expr : *map.vargs) {
+    for (auto &expr : *map.vargs)
+    {
       expr->accept(*this);
     }
   }
@@ -222,7 +224,7 @@ void Printer::visit(Tuple &tuple)
   out_ << indent << "tuple:" << std::endl;
 
   ++depth_;
-  for (Expression *expr : *tuple.elems)
+  for (auto &expr : *tuple.elems)
     expr->accept(*this);
   --depth_;
 }
@@ -266,13 +268,15 @@ void Printer::visit(If &if_block)
   ++depth_;
   out_ << indent << " then" << std::endl;
 
-  for (Statement *stmt : *if_block.stmts) {
+  for (auto &stmt : *if_block.stmts)
+  {
     stmt->accept(*this);
   }
 
   if (if_block.else_stmts) {
     out_ << indent << " else" << std::endl;
-    for (Statement *stmt : *if_block.else_stmts) {
+    for (auto &stmt : *if_block.else_stmts)
+    {
       stmt->accept(*this);
     }
   }
@@ -289,7 +293,8 @@ void Printer::visit(Unroll &unroll)
   out_ << indent << " block" << std::endl;
 
   ++depth_;
-  for (Statement *stmt : *unroll.stmts) {
+  for (auto &stmt : *unroll.stmts)
+  {
     stmt->accept(*this);
   }
   depth_ -= 2;
@@ -307,7 +312,7 @@ void Printer::visit(While &while_block)
   ++depth_;
   out_ << indent << " )" << std::endl;
 
-  for (Statement *stmt : *while_block.stmts)
+  for (auto &stmt : *while_block.stmts)
   {
     stmt->accept(*this);
   }
@@ -337,7 +342,8 @@ void Printer::visit(AttachPoint &ap)
 
 void Printer::visit(Probe &probe)
 {
-  for (AttachPoint *ap : *probe.attach_points) {
+  for (auto &ap : *probe.attach_points)
+  {
     ap->accept(*this);
   }
 
@@ -345,7 +351,8 @@ void Printer::visit(Probe &probe)
   if (probe.pred) {
     probe.pred->accept(*this);
   }
-  for (Statement *stmt : *probe.stmts) {
+  for (auto &stmt : *probe.stmts)
+  {
     stmt->accept(*this);
   }
   --depth_;
@@ -360,7 +367,7 @@ void Printer::visit(Program &program)
   out_ << indent << "Program" << std::endl;
 
   ++depth_;
-  for (Probe *probe : *program.probes)
+  for (auto &probe : *program.probes)
     probe->accept(*this);
   --depth_;
 }

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -341,7 +341,7 @@ void SemanticAnalyser::visit(Builtin &builtin)
       if (type == ProbeType::tracepoint)
       {
         probe_->need_expansion = true;
-        builtin_args_tracepoint(attach_point, builtin);
+        builtin_args_tracepoint(attach_point.get(), builtin);
       }
     }
 
@@ -401,7 +401,8 @@ void SemanticAnalyser::visit(Call &call)
   func_setter scope_bound_func_setter{ *this, call.func };
 
   if (call.vargs) {
-    for (Expression *expr : *call.vargs) {
+    for (auto &expr : *call.vargs)
+    {
       expr->accept(*this);
     }
   }
@@ -466,7 +467,7 @@ void SemanticAnalyser::visit(Call &call)
       // store args for later passing to bpftrace::Map
       auto search = map_args_.find(call.map->ident);
       if (search == map_args_.end())
-        map_args_.insert({call.map->ident, *call.vargs});
+        map_args_.insert({ call.map->ident, call.vargs.get() });
     }
     call.type = CreateLhist();
   }
@@ -538,7 +539,9 @@ void SemanticAnalyser::visit(Call &call)
       if (is_final_pass() && call.vargs->size() > 1) {
         check_arg(call, Type::integer, 1, false);
       }
-      if (auto *param = dynamic_cast<PositionalParameter*>(call.vargs->at(0))) {
+      if (auto *param = dynamic_cast<PositionalParameter *>(
+              call.vargs->at(0).get()))
+      {
         param->is_in_str = true;
       }
     }
@@ -592,7 +595,8 @@ void SemanticAnalyser::visit(Call &call)
     buffer_size++; // extra byte is used to embed the length of the buffer
     call.type = CreateBuffer(buffer_size);
 
-    if (auto *param = dynamic_cast<PositionalParameter *>(call.vargs->at(0)))
+    if (auto *param = dynamic_cast<PositionalParameter *>(
+            call.vargs->at(0).get()))
     {
       param->is_in_str = true;
     }
@@ -616,9 +620,9 @@ void SemanticAnalyser::visit(Call &call)
     if (!check_varargs(call, 1, 2))
       return;
 
-    auto arg = call.vargs->at(0);
+    auto arg = call.vargs->at(0).get();
     if (call.vargs->size() == 2) {
-      arg = call.vargs->at(1);
+      arg = call.vargs->at(1).get();
       check_arg(call, Type::integer, 0);
     }
 
@@ -1121,7 +1125,7 @@ void SemanticAnalyser::visit(Map &map)
 
   if (map.vargs) {
     for (unsigned int i = 0; i < map.vargs->size(); i++){
-      Expression * expr = map.vargs->at(i);
+      Expression *expr = map.vargs->at(i).get();
       expr->accept(*this);
 
       // Insert a cast to 64 bits if needed by injecting
@@ -1129,10 +1133,11 @@ void SemanticAnalyser::visit(Map &map)
       if (expr->type.IsIntTy() && expr->type.size < 8)
       {
         std::string type = expr->type.IsSigned() ? "int64" : "uint64";
-        Expression * cast = new ast::Cast(type, false, expr);
+        auto cast = std::unique_ptr<Expression>(
+            new ast::Cast(type, false, std::move(map.vargs->at(i))));
         cast->accept(*this);
-        map.vargs->at(i) = cast;
-        expr = cast;
+        map.vargs->at(i) = std::move(cast);
+        expr = map.vargs->at(i).get();
       }
       else if (expr->type.IsCtxAccess())
       {
@@ -1226,7 +1231,7 @@ void SemanticAnalyser::visit(ArrayAccess &arr)
 
     if (indextype.IsIntTy() && arr.indexpr->is_literal)
     {
-      Integer *index = static_cast<Integer *>(arr.indexpr);
+      Integer *index = static_cast<Integer *>(arr.indexpr.get());
 
       if ((size_t) index->n >= type.size)
         LOG(ERROR, arr.loc, err_)
@@ -1264,11 +1269,11 @@ void SemanticAnalyser::visit(Binop &binop)
     }
     // Follow what C does
     else if (lhs == Type::integer && rhs == Type::integer) {
-      auto get_int_literal = [](const auto expr) -> long {
-        return static_cast<ast::Integer*>(expr)->n;
+      auto get_int_literal = [](const auto &expr) -> long {
+        return static_cast<ast::Integer *>(expr.get())->n;
       };
-      auto left = binop.left;
-      auto right = binop.right;
+      auto &left = binop.left;
+      auto &right = binop.right;
 
       // First check if operand signedness is the same
       if (lsign != rsign) {
@@ -1463,10 +1468,10 @@ void SemanticAnalyser::visit(If &if_block)
       LOG(ERROR, if_block.loc, err_) << "Invalid condition in if(): " << cond;
   }
 
-  accept_statements(if_block.stmts);
+  accept_statements(if_block.stmts.get());
 
   if (if_block.else_stmts)
-    accept_statements(if_block.else_stmts);
+    accept_statements(if_block.else_stmts.get());
 }
 
 void SemanticAnalyser::visit(Unroll &unroll)
@@ -1475,11 +1480,11 @@ void SemanticAnalyser::visit(Unroll &unroll)
 
   unroll.var = 0;
 
-  if (auto *integer = dynamic_cast<Integer *>(unroll.expr))
+  if (auto *integer = dynamic_cast<Integer *>(unroll.expr.get()))
   {
     unroll.var = integer->n;
   }
-  else if (auto *param = dynamic_cast<PositionalParameter *>(unroll.expr))
+  else if (auto *param = dynamic_cast<PositionalParameter *>(unroll.expr.get()))
   {
     if (param->ptype == PositionalParameterType::count)
     {
@@ -1510,7 +1515,7 @@ void SemanticAnalyser::visit(Unroll &unroll)
   }
 
   for (int i = 0; i < unroll.var; i++)
-    accept_statements(unroll.stmts);
+    accept_statements(unroll.stmts.get());
 }
 
 void SemanticAnalyser::visit(Jump &jump)
@@ -1542,7 +1547,7 @@ void SemanticAnalyser::visit(While &while_block)
   while_block.cond->accept(*this);
 
   loop_depth_++;
-  accept_statements(while_block.stmts);
+  accept_statements(while_block.stmts.get());
   loop_depth_--;
 }
 
@@ -1625,7 +1630,7 @@ void SemanticAnalyser::visit(FieldAccess &acc)
 
   if (type.is_tparg)
   {
-    for (AttachPoint *attach_point : *probe_->attach_points)
+    for (auto &attach_point : *probe_->attach_points)
     {
       if (probetype(attach_point->provider) != ProbeType::tracepoint)
       {
@@ -1735,7 +1740,7 @@ void SemanticAnalyser::visit(Tuple &tuple)
 
   for (size_t i = 0; i < tuple.elems->size(); ++i)
   {
-    Expression *elem = tuple.elems->at(i);
+    auto &elem = tuple.elems->at(i);
     elem->accept(*this);
 
     type.tuple_elems.emplace_back(elem->type);
@@ -1859,7 +1864,7 @@ void SemanticAnalyser::visit(AssignVarStatement &assignment)
   auto search = variable_val_.find(var_ident);
   assignment.var->type = assignment.expr->type;
 
-  auto *builtin = dynamic_cast<Builtin *>(assignment.expr);
+  auto *builtin = dynamic_cast<Builtin *>(assignment.expr.get());
   if (builtin && builtin->ident == "args" && builtin->type.is_kfarg)
   {
     LOG(ERROR, assignment.loc, err_) << "args cannot be assigned to a variable";
@@ -2214,21 +2219,22 @@ void SemanticAnalyser::visit(Probe &probe)
   variable_val_.clear();
   probe_ = &probe;
 
-  for (AttachPoint *ap : *probe.attach_points) {
+  for (auto &ap : *probe.attach_points)
+  {
     ap->accept(*this);
   }
   if (probe.pred) {
     probe.pred->accept(*this);
   }
-  for (Statement *stmt : *probe.stmts) {
+  for (auto &stmt : *probe.stmts.get())
+  {
     stmt->accept(*this);
   }
-
 }
 
 void SemanticAnalyser::visit(Program &program)
 {
-  for (Probe *probe : *program.probes)
+  for (auto &probe : *program.probes)
     probe->accept(*this);
 }
 
@@ -2289,9 +2295,9 @@ int SemanticAnalyser::create_maps_impl(void)
         abort();
       }
 
-      Expression &min_arg = *map_args->second.at(1);
-      Expression &max_arg = *map_args->second.at(2);
-      Expression &step_arg = *map_args->second.at(3);
+      Expression &min_arg = *map_args->second->at(1);
+      Expression &max_arg = *map_args->second->at(2);
+      Expression &step_arg = *map_args->second->at(3);
       Integer &min = static_cast<Integer &>(min_arg);
       Integer &max = static_cast<Integer &>(max_arg);
       Integer &step = static_cast<Integer &>(step_arg);
@@ -2446,7 +2452,7 @@ bool SemanticAnalyser::check_assignment(const Call &call, bool want_map, bool wa
 bool SemanticAnalyser::check_nargs(const Call &call, size_t expected_nargs)
 {
   std::stringstream err;
-  std::vector<Expression*>::size_type nargs = 0;
+  ExpressionList::size_type nargs = 0;
   if (call.vargs)
     nargs = call.vargs->size();
 
@@ -2468,7 +2474,7 @@ bool SemanticAnalyser::check_nargs(const Call &call, size_t expected_nargs)
 
 bool SemanticAnalyser::check_varargs(const Call &call, size_t min_nargs, size_t max_nargs)
 {
-  std::vector<Expression*>::size_type nargs = 0;
+  ExpressionList::size_type nargs = 0;
   std::stringstream err;
   if (call.vargs)
     nargs = call.vargs->size();
@@ -2585,12 +2591,12 @@ void SemanticAnalyser::accept_statements(StatementList *stmts)
 {
   for (size_t i = 0; i < stmts->size(); i++)
   {
-    auto stmt = stmts->at(i);
+    auto &stmt = stmts->at(i);
     stmt->accept(*this);
 
     if (is_final_pass())
     {
-      auto *jump = dynamic_cast<Jump *>(stmt);
+      auto *jump = dynamic_cast<Jump *>(stmt.get());
       if (jump && i < (stmts->size() - 1))
       {
         LOG(WARNING, jump->loc, out_)

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -104,7 +104,7 @@ private:
   std::map<std::string, SizedType> variable_val_;
   std::map<std::string, SizedType> map_val_;
   std::map<std::string, MapKey> map_key_;
-  std::map<std::string, ExpressionList> map_args_;
+  std::map<std::string, ExpressionList *> map_args_;
   std::map<std::string, SizedType> ap_args_;
   std::unordered_set<StackType> needs_stackid_maps_;
   uint32_t loop_depth_ = 0;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -196,7 +196,7 @@ BPFtrace::~BPFtrace()
 
 int BPFtrace::add_probe(ast::Probe &p)
 {
-  for (auto attach_point : *p.attach_points)
+  for (auto &attach_point : *p.attach_points)
   {
     if (attach_point->provider == "BEGIN" || attach_point->provider == "END")
     {

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -41,7 +41,7 @@ int Driver::parse()
   yy_scan_string(Log::get().get_source().c_str(), scanner_);
   parser_->parse();
 
-  ast::AttachPointParser ap_parser(root_, bpftrace_, out_);
+  ast::AttachPointParser ap_parser(root_.get(), bpftrace_, out_);
   if (ap_parser.parse())
     failed_ = true;
 

--- a/src/driver.h
+++ b/src/driver.h
@@ -25,7 +25,7 @@ public:
   void error(std::ostream &, const location &, const std::string &);
   void error(const location &l, const std::string &m);
   void error(const std::string &m);
-  ast::Program *root_{ nullptr };
+  std::unique_ptr<ast::Program> root_;
 
   BPFtrace &bpftrace_;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -535,7 +535,7 @@ int main(int argc, char *argv[])
     return 1;
   }
 
-  ast::FieldAnalyser fields(driver.root_, bpftrace);
+  ast::FieldAnalyser fields(driver.root_.get(), bpftrace);
   err = fields.analyse();
   if (err)
     return err;
@@ -645,7 +645,7 @@ int main(int argc, char *argv[])
   if (!cmd_str.empty())
     bpftrace.cmd_ = cmd_str;
 
-  if (TracepointFormatParser::parse(driver.root_, bpftrace) == false)
+  if (TracepointFormatParser::parse(driver.root_.get(), bpftrace) == false)
     return 1;
 
   if (bt_debug != DebugLevel::kNone)
@@ -691,7 +691,7 @@ int main(int argc, char *argv[])
   if (!include_files.empty() && driver.root_->c_definitions.empty())
     driver.root_->c_definitions = "#define __BPFTRACE_DUMMY__";
 
-  if (!clang.parse(driver.root_, bpftrace, extra_flags))
+  if (!clang.parse(driver.root_.get(), bpftrace, extra_flags))
     return 1;
 
   err = driver.parse();
@@ -699,7 +699,7 @@ int main(int argc, char *argv[])
     return err;
 
   ast::SemanticAnalyser semantics(
-      driver.root_, bpftrace, bpftrace.feature_, !cmd_str.empty());
+      driver.root_.get(), bpftrace, bpftrace.feature_, !cmd_str.empty());
   err = semantics.analyse();
   if (err)
     return err;
@@ -730,7 +730,7 @@ int main(int argc, char *argv[])
     }
   }
 
-  ast::CodegenLLVM llvm(driver.root_, bpftrace);
+  ast::CodegenLLVM llvm(driver.root_.get(), bpftrace);
   std::unique_ptr<BpfOrc> bpforc;
   try
   {

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -115,25 +115,25 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %token <std::string> STACK_MODE "stack_mode"
 
 %type <std::string> c_definitions
-%type <ast::ProbeList *> probes
-%type <ast::Probe *> probe
-%type <ast::Predicate *> pred
-%type <ast::Ternary *> ternary
-%type <ast::StatementList *> block stmts block_or_if
-%type <ast::Statement *> if_stmt block_stmt stmt semicolon_ended_stmt compound_assignment jump_stmt loop_stmt
-%type <ast::Expression *> expr
-%type <ast::Call *> call
-%type <ast::Map *> map
-%type <ast::Variable *> var
-%type <ast::ExpressionList *> vargs
-%type <ast::AttachPointList *> attach_points
-%type <ast::AttachPoint *> attach_point
+%type <std::unique_ptr<ast::ProbeList>> probes
+%type <std::unique_ptr<ast::Probe>> probe
+%type <std::unique_ptr<ast::Predicate>> pred
+%type <std::unique_ptr<ast::Expression>> ternary
+%type <std::unique_ptr<ast::StatementList>> block stmts block_or_if
+%type <std::unique_ptr<ast::Statement>> if_stmt block_stmt stmt semicolon_ended_stmt compound_assignment jump_stmt loop_stmt
+%type <std::unique_ptr<ast::Expression>> expr
+%type <std::unique_ptr<ast::Expression>> call
+%type <std::unique_ptr<ast::Map>> map
+%type <std::unique_ptr<ast::Variable>> var
+%type <std::unique_ptr<ast::ExpressionList>> vargs
+%type <std::unique_ptr<ast::AttachPointList>> attach_points
+%type <std::unique_ptr<ast::AttachPoint>> attach_point
 %type <std::string> attach_point_def
-%type <ast::PositionalParameter *> param
+%type <std::unique_ptr<ast::Expression>> param
 %type <std::string> ident
-%type <ast::Expression *> map_or_var
-%type <ast::Expression *> pre_post_op
-%type <ast::Integer *> int
+%type <std::unique_ptr<ast::Expression>> map_or_var
+%type <std::unique_ptr<ast::Expression>> pre_post_op
+%type <std::unique_ptr<ast::Expression>> int
 
 %right ASSIGN
 %left QUES COLON
@@ -154,7 +154,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 
 %%
 
-program : c_definitions probes { driver.root_ = new ast::Program($1, $2); }
+program : c_definitions probes { driver.root_ = std::make_unique<ast::Program>($1, std::move($2)); }
         ;
 
 c_definitions : CPREPROC c_definitions    { $$ = $1 + "\n" + $2; }
@@ -163,18 +163,18 @@ c_definitions : CPREPROC c_definitions    { $$ = $1 + "\n" + $2; }
               |                           { $$ = std::string(); }
               ;
 
-probes : probes probe { $$ = $1; $1->push_back($2); }
-       | probe        { $$ = new ast::ProbeList; $$->push_back($1); }
+probes : probes probe { $1->push_back(std::move($2)); $$ = std::move($1); }
+       | probe        { $$ = std::make_unique<ast::ProbeList>(); $$->push_back(std::move($1)); }
        ;
 
-probe : attach_points pred block { $$ = new ast::Probe($1, $2, $3); }
+probe : attach_points pred block { $$ = std::make_unique<ast::Probe>(std::move($1), std::move($2), std::move($3)); }
       ;
 
-attach_points : attach_points "," attach_point { $$ = $1; $1->push_back($3); }
-              | attach_point                   { $$ = new ast::AttachPointList; $$->push_back($1); }
+attach_points : attach_points "," attach_point { $1->push_back(std::move($3)); $$ = std::move($1); }
+              | attach_point                   { $$ = std::make_unique<ast::AttachPointList>(); $$->push_back(std::move($1)); }
               ;
 
-attach_point : attach_point_def                { $$ = new ast::AttachPoint($1, @$); }
+attach_point : attach_point_def                { $$ = std::make_unique<ast::AttachPoint>($1, @$); }
              ;
 
 attach_point_def : attach_point_def ident    { $$ = $1 + $2; }
@@ -191,7 +191,7 @@ attach_point_def : attach_point_def ident    { $$ = $1 + $2; }
                  | attach_point_def LBRACKET { $$ = $1 + "["; }
                  | attach_point_def RBRACKET { $$ = $1 + "]"; }
                  | attach_point_def param    {
-                                               if ($2->ptype != PositionalParameterType::positional)
+                                               if (static_cast<ast::PositionalParameter*>($2.get())->ptype != PositionalParameterType::positional)
                                                {
                                                   error(@$, "Not a positional parameter");
                                                   YYERROR;
@@ -200,168 +200,167 @@ attach_point_def : attach_point_def ident    { $$ = $1 + $2; }
                                                // "Un-parse" the positional parameter back into text so
                                                // we can give it to the AttachPointParser. This is kind of
                                                // a hack but there doesn't look to be any other way.
-                                               $$ = $1 + "$" + std::to_string($2->n);
-                                               delete $2;
+                                               $$ = $1 + "$" + std::to_string(static_cast<ast::PositionalParameter*>($2.get())->n);
                                              }
                  |                           { $$ = ""; }
                  ;
 
-pred : DIV expr ENDPRED { $$ = new ast::Predicate($2, @$); }
+pred : DIV expr ENDPRED { $$ = std::make_unique<ast::Predicate>(std::move($2), @$); }
      |                  { $$ = nullptr; }
      ;
 
-ternary : expr QUES expr COLON expr { $$ = new ast::Ternary($1, $3, $5, @$); }
+ternary : expr QUES expr COLON expr { $$ = std::unique_ptr<ast::Expression>(new ast::Ternary(std::move($1), std::move($3), std::move($5), @$)); }
         ;
 
 param : PARAM      {
                      try {
-                       $$ = new ast::PositionalParameter(PositionalParameterType::positional, std::stol($1.substr(1, $1.size()-1)), @$);
+                       $$ = std::unique_ptr<ast::Expression>(new ast::PositionalParameter(PositionalParameterType::positional, std::stol($1.substr(1, $1.size()-1)), @$));
                      } catch (std::exception const& e) {
                        error(@1, "param " + $1 + " is out of integer range [1, " +
                              std::to_string(std::numeric_limits<long>::max()) + "]");
                        YYERROR;
                      }
                    }
-      | PARAMCOUNT { $$ = new ast::PositionalParameter(PositionalParameterType::count, 0, @$); }
+      | PARAMCOUNT { $$ = std::unique_ptr<ast::Expression>(new ast::PositionalParameter(PositionalParameterType::count, 0, @$)); }
       ;
 
-block : "{" stmts "}"     { $$ = $2; }
+block : "{" stmts "}"     { $$ = std::move($2); }
       ;
 
-semicolon_ended_stmt: stmt ";"  { $$ = $1; }
+semicolon_ended_stmt: stmt ";"  { $$ = std::move($1); }
                     ;
 
-stmts : semicolon_ended_stmt stmts { $$ = $2; $2->insert($2->begin(), $1); }
-      | block_stmt stmts           { $$ = $2; $2->insert($2->begin(), $1); }
-      | stmt                       { $$ = new ast::StatementList; $$->push_back($1); }
-      |                            { $$ = new ast::StatementList; }
+stmts : semicolon_ended_stmt stmts { $2->insert($2->begin(), std::move($1)); $$ = std::move($2); }
+      | block_stmt stmts           { $2->insert($2->begin(), std::move($1)); $$ = std::move($2); }
+      | stmt                       { $$ = std::make_unique<ast::StatementList>(); $$->push_back(std::move($1)); }
+      |                            { $$ = std::make_unique<ast::StatementList>(); }
       ;
 
-block_stmt : if_stmt                  { $$ = $1; }
-           | jump_stmt                { $$ = $1; }
-           | loop_stmt                { $$ = $1; }
+block_stmt : if_stmt                  { $$ = std::move($1); }
+           | jump_stmt                { $$ = std::move($1); }
+           | loop_stmt                { $$ = std::move($1); }
            ;
 
-jump_stmt  : BREAK    { $$ = new ast::Jump(token::BREAK, @$); }
-           | CONTINUE { $$ = new ast::Jump(token::CONTINUE, @$); }
-           | RETURN   { $$ = new ast::Jump(token::RETURN, @$); }
+jump_stmt  : BREAK    { $$ = std::unique_ptr<ast::Statement>(new ast::Jump(token::BREAK, @$)); }
+           | CONTINUE { $$ = std::unique_ptr<ast::Statement>(new ast::Jump(token::CONTINUE, @$)); }
+           | RETURN   { $$ = std::unique_ptr<ast::Statement>(new ast::Jump(token::RETURN, @$)); }
            ;
 
-loop_stmt  : UNROLL "(" int ")" block             { $$ = new ast::Unroll($3, $5, @1 + @4); }
-           | UNROLL "(" param ")" block           { $$ = new ast::Unroll($3, $5, @1 + @4); }
-           | WHILE  "(" expr ")" block            { $$ = new ast::While($3, $5, @1); }
+loop_stmt  : UNROLL "(" int ")" block             { $$ = std::unique_ptr<ast::Statement>(new ast::Unroll(std::move($3), std::move($5), @1 + @4)); }
+           | UNROLL "(" param ")" block           { $$ = std::unique_ptr<ast::Statement>(new ast::Unroll(std::move($3), std::move($5), @1 + @4)); }
+           | WHILE  "(" expr ")" block            { $$ = std::unique_ptr<ast::Statement>(new ast::While(std::move($3), std::move($5), @1)); }
            ;
 
-if_stmt : IF "(" expr ")" block                  { $$ = new ast::If($3, $5); }
-        | IF "(" expr ")" block ELSE block_or_if { $$ = new ast::If($3, $5, $7); }
+if_stmt : IF "(" expr ")" block                  { $$ = std::unique_ptr<ast::Statement>(new ast::If(std::move($3), std::move($5))); }
+        | IF "(" expr ")" block ELSE block_or_if { $$ = std::unique_ptr<ast::Statement>(new ast::If(std::move($3), std::move($5), std::move($7))); }
         ;
 
-block_or_if : block        { $$ = $1; }
-            | if_stmt      { $$ = new ast::StatementList; $$->emplace_back($1); }
+block_or_if : block        { $$ = std::move($1); }
+            | if_stmt      { $$ = std::make_unique<ast::StatementList>(); $$->emplace_back(std::move($1)); }
             ;
 
-stmt : expr                { $$ = new ast::ExprStatement($1); }
-     | compound_assignment { $$ = $1; }
-     | jump_stmt           { $$ = $1; }
-     | map "=" expr        { $$ = new ast::AssignMapStatement($1, $3, @2); }
-     | var "=" expr        { $$ = new ast::AssignVarStatement($1, $3, @2); }
+stmt : expr                { $$ = std::unique_ptr<ast::Statement>(new ast::ExprStatement(std::move($1))); }
+     | compound_assignment { $$ = std::move($1); }
+     | jump_stmt           { $$ = std::move($1); }
+     | map "=" expr        { $$ = std::unique_ptr<ast::Statement>(new ast::AssignMapStatement(std::move($1), std::move($3), @2)); }
+     | var "=" expr        { $$ = std::unique_ptr<ast::Statement>(new ast::AssignVarStatement(std::move($1), std::move($3), @2)); }
      ;
 
-compound_assignment : map LEFTASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::LEFT,  $3, @2)); }
-                    | var LEFTASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::LEFT,  $3, @2)); }
-                    | map RIGHTASSIGN expr { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::RIGHT, $3, @2)); }
-                    | var RIGHTASSIGN expr { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::RIGHT, $3, @2)); }
-                    | map PLUSASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::PLUS,  $3, @2)); }
-                    | var PLUSASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::PLUS,  $3, @2)); }
-                    | map MINUSASSIGN expr { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MINUS, $3, @2)); }
-                    | var MINUSASSIGN expr { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MINUS, $3, @2)); }
-                    | map MULASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MUL,   $3, @2)); }
-                    | var MULASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MUL,   $3, @2)); }
-                    | map DIVASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::DIV,   $3, @2)); }
-                    | var DIVASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::DIV,   $3, @2)); }
-                    | map MODASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MOD,   $3, @2)); }
-                    | var MODASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MOD,   $3, @2)); }
-                    | map BANDASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BAND,  $3, @2)); }
-                    | var BANDASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BAND,  $3, @2)); }
-                    | map BORASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BOR,   $3, @2)); }
-                    | var BORASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BOR,   $3, @2)); }
-                    | map BXORASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BXOR,  $3, @2)); }
-                    | var BXORASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BXOR,  $3, @2)); }
+compound_assignment : map LEFTASSIGN expr  { $$ = std::unique_ptr<ast::Statement>(new ast::AssignMapStatement(std::make_unique<ast::Map>(*$1), std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::LEFT, std::move($3), @2)))); }
+                    | var LEFTASSIGN expr  { $$ = std::unique_ptr<ast::Statement>(new ast::AssignVarStatement(std::make_unique<ast::Variable>(*$1), std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::LEFT, std::move($3), @2)))); }
+                    | map RIGHTASSIGN expr { $$ = std::unique_ptr<ast::Statement>(new ast::AssignMapStatement(std::make_unique<ast::Map>(*$1), std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::RIGHT, std::move($3), @2)))); }
+                    | var RIGHTASSIGN expr { $$ = std::unique_ptr<ast::Statement>(new ast::AssignVarStatement(std::make_unique<ast::Variable>(*$1), std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::RIGHT, std::move($3), @2)))); }
+                    | map PLUSASSIGN expr  { $$ = std::unique_ptr<ast::Statement>(new ast::AssignMapStatement(std::make_unique<ast::Map>(*$1), std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::PLUS, std::move($3), @2)))); }
+                    | var PLUSASSIGN expr  { $$ = std::unique_ptr<ast::Statement>(new ast::AssignVarStatement(std::make_unique<ast::Variable>(*$1), std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::PLUS, std::move($3), @2)))); }
+                    | map MINUSASSIGN expr { $$ = std::unique_ptr<ast::Statement>(new ast::AssignMapStatement(std::make_unique<ast::Map>(*$1), std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::MINUS, std::move($3), @2)))); }
+                    | var MINUSASSIGN expr { $$ = std::unique_ptr<ast::Statement>(new ast::AssignVarStatement(std::make_unique<ast::Variable>(*$1), std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::MINUS, std::move($3), @2)))); }
+                    | map MULASSIGN expr   { $$ = std::unique_ptr<ast::Statement>(new ast::AssignMapStatement(std::make_unique<ast::Map>(*$1), std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::MUL, std::move($3), @2)))); }
+                    | var MULASSIGN expr   { $$ = std::unique_ptr<ast::Statement>(new ast::AssignVarStatement(std::make_unique<ast::Variable>(*$1), std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::MUL, std::move($3), @2)))); }
+                    | map DIVASSIGN expr   { $$ = std::unique_ptr<ast::Statement>(new ast::AssignMapStatement(std::make_unique<ast::Map>(*$1), std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::DIV, std::move($3), @2)))); }
+                    | var DIVASSIGN expr   { $$ = std::unique_ptr<ast::Statement>(new ast::AssignVarStatement(std::make_unique<ast::Variable>(*$1), std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::DIV, std::move($3), @2)))); }
+                    | map MODASSIGN expr   { $$ = std::unique_ptr<ast::Statement>(new ast::AssignMapStatement(std::make_unique<ast::Map>(*$1), std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::MOD, std::move($3), @2)))); }
+                    | var MODASSIGN expr   { $$ = std::unique_ptr<ast::Statement>(new ast::AssignVarStatement(std::make_unique<ast::Variable>(*$1), std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::MOD, std::move($3), @2)))); }
+                    | map BANDASSIGN expr  { $$ = std::unique_ptr<ast::Statement>(new ast::AssignMapStatement(std::make_unique<ast::Map>(*$1), std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::BAND, std::move($3), @2)))); }
+                    | var BANDASSIGN expr  { $$ = std::unique_ptr<ast::Statement>(new ast::AssignVarStatement(std::make_unique<ast::Variable>(*$1), std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::BAND, std::move($3), @2)))); }
+                    | map BORASSIGN expr   { $$ = std::unique_ptr<ast::Statement>(new ast::AssignMapStatement(std::make_unique<ast::Map>(*$1), std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::BOR, std::move($3), @2)))); }
+                    | var BORASSIGN expr   { $$ = std::unique_ptr<ast::Statement>(new ast::AssignVarStatement(std::make_unique<ast::Variable>(*$1), std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::BOR, std::move($3), @2)))); }
+                    | map BXORASSIGN expr  { $$ = std::unique_ptr<ast::Statement>(new ast::AssignMapStatement(std::make_unique<ast::Map>(*$1), std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::BXOR, std::move($3), @2)))); }
+                    | var BXORASSIGN expr  { $$ = std::unique_ptr<ast::Statement>(new ast::AssignVarStatement(std::make_unique<ast::Variable>(*$1), std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::BXOR, std::move($3), @2)))); }
                     ;
 
-int : MINUS INT    { $$ = new ast::Integer(-1 * $2, @$); }
-    | INT          { $$ = new ast::Integer($1, @$); }
+int : MINUS INT    { $$ = std::unique_ptr<ast::Expression>(new ast::Integer(-1 * $2, @$)); }
+    | INT          { $$ = std::unique_ptr<ast::Expression>(new ast::Integer($1, @$)); }
     ;
 
-expr : int                                      { $$ = $1; }
-     | STRING                                   { $$ = new ast::String($1, @$); }
-     | BUILTIN                                  { $$ = new ast::Builtin($1, @$); }
-     | CALL_BUILTIN                             { $$ = new ast::Builtin($1, @$); }
-     | IDENT                                    { $$ = new ast::Identifier($1, @$); }
-     | STACK_MODE                               { $$ = new ast::StackMode($1, @$); }
-     | ternary                                  { $$ = $1; }
-     | param                                    { $$ = $1; }
-     | map_or_var                               { $$ = $1; }
-     | call                                     { $$ = $1; }
-     | "(" expr ")"                             { $$ = $2; }
-     | expr EQ expr                             { $$ = new ast::Binop($1, token::EQ, $3, @2); }
-     | expr NE expr                             { $$ = new ast::Binop($1, token::NE, $3, @2); }
-     | expr LE expr                             { $$ = new ast::Binop($1, token::LE, $3, @2); }
-     | expr GE expr                             { $$ = new ast::Binop($1, token::GE, $3, @2); }
-     | expr LT expr                             { $$ = new ast::Binop($1, token::LT, $3, @2); }
-     | expr GT expr                             { $$ = new ast::Binop($1, token::GT, $3, @2); }
-     | expr LAND expr                           { $$ = new ast::Binop($1, token::LAND,  $3, @2); }
-     | expr LOR expr                            { $$ = new ast::Binop($1, token::LOR,   $3, @2); }
-     | expr LEFT expr                           { $$ = new ast::Binop($1, token::LEFT,  $3, @2); }
-     | expr RIGHT expr                          { $$ = new ast::Binop($1, token::RIGHT, $3, @2); }
-     | expr PLUS expr                           { $$ = new ast::Binop($1, token::PLUS,  $3, @2); }
-     | expr MINUS expr                          { $$ = new ast::Binop($1, token::MINUS, $3, @2); }
-     | expr MUL expr                            { $$ = new ast::Binop($1, token::MUL,   $3, @2); }
-     | expr DIV expr                            { $$ = new ast::Binop($1, token::DIV,   $3, @2); }
-     | expr MOD expr                            { $$ = new ast::Binop($1, token::MOD,   $3, @2); }
-     | expr BAND expr                           { $$ = new ast::Binop($1, token::BAND,  $3, @2); }
-     | expr BOR expr                            { $$ = new ast::Binop($1, token::BOR,   $3, @2); }
-     | expr BXOR expr                           { $$ = new ast::Binop($1, token::BXOR,  $3, @2); }
-     | LNOT expr                                { $$ = new ast::Unop(token::LNOT, $2, @1); }
-     | BNOT expr                                { $$ = new ast::Unop(token::BNOT, $2, @1); }
-     | MINUS expr                               { $$ = new ast::Unop(token::MINUS, $2, @1); }
-     | MUL  expr %prec DEREF                    { $$ = new ast::Unop(token::MUL,  $2, @1); }
-     | expr DOT ident                           { $$ = new ast::FieldAccess($1, $3, @2); }
-     | expr DOT INT                             { $$ = new ast::FieldAccess($1, $3, @3); }
-     | expr PTR ident                           { $$ = new ast::FieldAccess(new ast::Unop(token::MUL, $1, @2), $3, @$); }
-     | expr "[" expr "]"                        { $$ = new ast::ArrayAccess($1, $3, @2 + @4); }
-     | "(" IDENT ")" expr %prec CAST            { $$ = new ast::Cast($2, false, $4, @1 + @3); }
-     | "(" IDENT MUL ")" expr %prec CAST        { $$ = new ast::Cast($2, true, $5, @1 + @4); }
+expr : int                                      { $$ = std::move($1); }
+     | STRING                                   { $$ = std::unique_ptr<ast::Expression>(new ast::String(std::move($1), @$)); }
+     | BUILTIN                                  { $$ = std::unique_ptr<ast::Expression>(new ast::Builtin(std::move($1), @$)); }
+     | CALL_BUILTIN                             { $$ = std::unique_ptr<ast::Expression>(new ast::Builtin(std::move($1), @$)); }
+     | IDENT                                    { $$ = std::unique_ptr<ast::Expression>(new ast::Identifier(std::move($1), @$)); }
+     | STACK_MODE                               { $$ = std::unique_ptr<ast::Expression>(new ast::StackMode(std::move($1), @$)); }
+     | ternary                                  { $$ = std::move($1); }
+     | param                                    { $$ = std::move($1); }
+     | map_or_var                               { $$ = std::move($1); }
+     | call                                     { $$ = std::move($1); }
+     | "(" expr ")"                             { $$ = std::move($2); }
+     | expr EQ expr                             { $$ = std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::EQ, std::move($3), @2)); }
+     | expr NE expr                             { $$ = std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::NE, std::move($3), @2)); }
+     | expr LE expr                             { $$ = std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::LE, std::move($3), @2)); }
+     | expr GE expr                             { $$ = std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::GE, std::move($3), @2)); }
+     | expr LT expr                             { $$ = std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::LT, std::move($3), @2)); }
+     | expr GT expr                             { $$ = std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::GT, std::move($3), @2)); }
+     | expr LAND expr                           { $$ = std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::LAND, std::move($3), @2)); }
+     | expr LOR expr                            { $$ = std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::LOR, std::move($3), @2)); }
+     | expr LEFT expr                           { $$ = std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::LEFT, std::move($3), @2)); }
+     | expr RIGHT expr                          { $$ = std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::RIGHT, std::move($3), @2)); }
+     | expr PLUS expr                           { $$ = std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::PLUS, std::move($3), @2)); }
+     | expr MINUS expr                          { $$ = std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::MINUS, std::move($3), @2)); }
+     | expr MUL expr                            { $$ = std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::MUL, std::move($3), @2)); }
+     | expr DIV expr                            { $$ = std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::DIV, std::move($3), @2)); }
+     | expr MOD expr                            { $$ = std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::MOD, std::move($3), @2)); }
+     | expr BAND expr                           { $$ = std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::BAND, std::move($3), @2)); }
+     | expr BOR expr                            { $$ = std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::BOR, std::move($3), @2)); }
+     | expr BXOR expr                           { $$ = std::unique_ptr<ast::Expression>(new ast::Binop(std::move($1), token::BXOR, std::move($3), @2)); }
+     | LNOT expr                                { $$ = std::unique_ptr<ast::Expression>(new ast::Unop(token::LNOT, std::move($2), @1)); }
+     | BNOT expr                                { $$ = std::unique_ptr<ast::Expression>(new ast::Unop(token::BNOT, std::move($2), @1)); }
+     | MINUS expr                               { $$ = std::unique_ptr<ast::Expression>(new ast::Unop(token::MINUS, std::move($2), @1)); }
+     | MUL  expr %prec DEREF                    { $$ = std::unique_ptr<ast::Expression>(new ast::Unop(token::MUL,  std::move($2), @1)); }
+     | expr DOT ident                           { $$ = std::unique_ptr<ast::Expression>(new ast::FieldAccess(std::move($1), $3, @2)); }
+     | expr DOT INT                             { $$ = std::unique_ptr<ast::Expression>(new ast::FieldAccess(std::move($1), $3, @3)); }
+     | expr PTR ident                           { $$ = std::unique_ptr<ast::Expression>(new ast::FieldAccess(std::unique_ptr<ast::Expression>(new ast::Unop(token::MUL, std::move($1), @2)), $3, @$)); }
+     | expr "[" expr "]"                        { $$ = std::unique_ptr<ast::Expression>(new ast::ArrayAccess(std::move($1), std::move($3), @2 + @4)); }
+     | "(" IDENT ")" expr %prec CAST            { $$ = std::unique_ptr<ast::Expression>(new ast::Cast(std::move($2), false, std::move($4), @1 + @3)); }
+     | "(" IDENT MUL ")" expr %prec CAST        { $$ = std::unique_ptr<ast::Expression>(new ast::Cast(std::move($2), true, std::move($5), @1 + @4)); }
      | "(" expr "," vargs ")"                   {
-                                                  auto args = new ast::ExpressionList;
-                                                  args->emplace_back($2);
-                                                  args->insert(args->end(), $4->begin(), $4->end());
-                                                  $$ = new ast::Tuple(args, @$);
+                                                  auto args = std::make_unique<ast::ExpressionList>();
+                                                  args->emplace_back(std::move($2));
+                                                  args->insert(args->end(), std::move_iterator($4->begin()), std::move_iterator($4->end()));
+                                                  $$ = std::unique_ptr<ast::Expression>(new ast::Tuple(std::move(args), @$));
                                                 }
-     | pre_post_op                              { $$ = $1; }
+     | pre_post_op                              { $$ = std::move($1); }
      ;
 
-pre_post_op : map_or_var INCREMENT   { $$ = new ast::Unop(token::INCREMENT, $1, true, @2); }
-            | map_or_var DECREMENT   { $$ = new ast::Unop(token::DECREMENT, $1, true, @2); }
-            | INCREMENT map_or_var   { $$ = new ast::Unop(token::INCREMENT, $2, @1); }
-            | DECREMENT map_or_var   { $$ = new ast::Unop(token::DECREMENT, $2, @1); }
+pre_post_op : map_or_var INCREMENT   { $$ = std::unique_ptr<ast::Expression>(new ast::Unop(token::INCREMENT, std::move($1), true, @2)); }
+            | map_or_var DECREMENT   { $$ = std::unique_ptr<ast::Expression>(new ast::Unop(token::DECREMENT, std::move($1), true, @2)); }
+            | INCREMENT map_or_var   { $$ = std::unique_ptr<ast::Expression>(new ast::Unop(token::INCREMENT, std::move($2), @1)); }
+            | DECREMENT map_or_var   { $$ = std::unique_ptr<ast::Expression>(new ast::Unop(token::DECREMENT, std::move($2), @1)); }
             | ident INCREMENT      { error(@1, "The ++ operator must be applied to a map or variable"); YYERROR; }
             | INCREMENT ident      { error(@1, "The ++ operator must be applied to a map or variable"); YYERROR; }
             | ident DECREMENT      { error(@1, "The -- operator must be applied to a map or variable"); YYERROR; }
             | DECREMENT ident      { error(@1, "The -- operator must be applied to a map or variable"); YYERROR; }
             ;
 
-ident : IDENT         { $$ = $1; }
-      | BUILTIN       { $$ = $1; }
-      | CALL          { $$ = $1; }
-      | CALL_BUILTIN  { $$ = $1; }
-      | STACK_MODE    { $$ = $1; }
+ident : IDENT         { $$ = std::move($1); }
+      | BUILTIN       { $$ = std::move($1); }
+      | CALL          { $$ = std::move($1); }
+      | CALL_BUILTIN  { $$ = std::move($1); }
+      | STACK_MODE    { $$ = std::move($1); }
       ;
 
-call : CALL "(" ")"                 { $$ = new ast::Call($1, @$); }
-     | CALL "(" vargs ")"           { $$ = new ast::Call($1, $3, @$); }
-     | CALL_BUILTIN  "(" ")"        { $$ = new ast::Call($1, @$); }
-     | CALL_BUILTIN "(" vargs ")"   { $$ = new ast::Call($1, $3, @$); }
+call : CALL "(" ")"                 { $$ = std::unique_ptr<ast::Expression>(new ast::Call($1, @$)); }
+     | CALL "(" vargs ")"           { $$ = std::unique_ptr<ast::Expression>(new ast::Call($1, std::move($3), @$)); }
+     | CALL_BUILTIN  "(" ")"        { $$ = std::unique_ptr<ast::Expression>(new ast::Call($1, @$)); }
+     | CALL_BUILTIN "(" vargs ")"   { $$ = std::unique_ptr<ast::Expression>(new ast::Call($1, std::move($3), @$)); }
      | IDENT "(" ")"                { error(@1, "Unknown function: " + $1); YYERROR;  }
      | IDENT "(" vargs ")"          { error(@1, "Unknown function: " + $1); YYERROR;  }
      | BUILTIN "(" ")"              { error(@1, "Unknown function: " + $1); YYERROR;  }
@@ -370,19 +369,19 @@ call : CALL "(" ")"                 { $$ = new ast::Call($1, @$); }
      | STACK_MODE "(" vargs ")"     { error(@1, "Unknown function: " + $1); YYERROR;  }
      ;
 
-map : MAP               { $$ = new ast::Map($1, @$); }
-    | MAP "[" vargs "]" { $$ = new ast::Map($1, $3, @$); }
+map : MAP               { $$ = std::make_unique<ast::Map>($1, @$); }
+    | MAP "[" vargs "]" { $$ = std::make_unique<ast::Map>($1, std::move($3), @$); }
     ;
 
-var : VAR { $$ = new ast::Variable($1, @$); }
+var : VAR { $$ = std::unique_ptr<ast::Variable>(new ast::Variable($1, @$)); }
     ;
 
-map_or_var : var { $$ = $1; }
-           | map { $$ = $1; }
+map_or_var : var { $$ = std::move($1); }
+           | map { $$ = std::move($1); }
            ;
 
-vargs : vargs "," expr { $$ = $1; $1->push_back($3); }
-      | expr           { $$ = new ast::ExpressionList; $$->push_back($1); }
+vargs : vargs "," expr { $1->push_back(std::move($3)); $$ = std::move($1); }
+      | expr           { $$ = std::make_unique<ast::ExpressionList>(); $$->push_back(std::move($1)); }
       ;
 
 %%

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -16,10 +16,10 @@ std::set<std::string> TracepointFormatParser::struct_list;
 bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
 {
   std::vector<ast::Probe*> probes_with_tracepoint;
-  for (ast::Probe *probe : *program->probes)
-    for (ast::AttachPoint *ap : *probe->attach_points)
+  for (auto &probe : *program->probes)
+    for (auto &ap : *probe->attach_points)
       if (ap->provider == "tracepoint") {
-        probes_with_tracepoint.push_back(probe);
+        probes_with_tracepoint.push_back(probe.get());
         continue;
       }
 
@@ -33,7 +33,7 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
   {
     n.analyse(probe);
 
-    for (ast::AttachPoint *ap : *probe->attach_points)
+    for (auto &ap : *probe->attach_points)
     {
       if (ap->provider == "tracepoint")
       {

--- a/src/tracepoint_format_parser.h
+++ b/src/tracepoint_format_parser.h
@@ -26,14 +26,16 @@ public:
   };  // Leaf
   void visit(Call &call) override {
     if (call.vargs) {
-      for (Expression *expr : *call.vargs) {
+      for (auto &expr : *call.vargs)
+      {
         expr->accept(*this);
       }
     }
   };
   void visit(Map &map) override {
     if (map.vargs) {
-      for (Expression *expr : *map.vargs) {
+      for (auto &expr : *map.vargs)
+      {
         expr->accept(*this);
       }
     }
@@ -62,7 +64,7 @@ public:
   };
   void visit(Tuple &tuple) override
   {
-    for (Expression *expr : *tuple.elems)
+    for (auto &expr : *tuple.elems)
       expr->accept(*this);
   };
   void visit(ExprStatement &expr) override {
@@ -78,18 +80,21 @@ public:
   void visit(If &if_block) override {
     if_block.cond->accept(*this);
 
-    for (Statement *stmt : *if_block.stmts) {
+    for (auto &stmt : *if_block.stmts)
+    {
       stmt->accept(*this);
     }
 
     if (if_block.else_stmts) {
-      for (Statement *stmt : *if_block.else_stmts) {
+      for (auto &stmt : *if_block.else_stmts)
+      {
         stmt->accept(*this);
       }
     }
   };
   void visit(Unroll &unroll) override {
-    for (Statement *stmt : *unroll.stmts) {
+    for (auto &stmt : *unroll.stmts)
+    {
       stmt->accept(*this);
     }
   };
@@ -97,7 +102,7 @@ public:
   {
     while_block.cond->accept(*this);
 
-    for (Statement *stmt : *while_block.stmts)
+    for (auto &stmt : *while_block.stmts)
     {
       stmt->accept(*this);
     }
@@ -108,18 +113,20 @@ public:
   void visit(__attribute__((unused)) AttachPoint &ap) override { };  // Leaf
   void visit(Probe &probe) override {
     probe_ = &probe;
-    for (AttachPoint *ap : *probe.attach_points) {
+    for (auto &ap : *probe.attach_points)
+    {
       ap->accept(*this);
     }
     if (probe.pred) {
       probe.pred->accept(*this);
     }
-    for (Statement *stmt : *probe.stmts) {
+    for (auto &stmt : *probe.stmts)
+    {
       stmt->accept(*this);
     }
   };
   void visit(Program &program) override {
-    for (Probe *probe : *program.probes)
+    for (auto &probe : *program.probes)
       probe->accept(*this);
   };
 

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -11,134 +11,160 @@ using bpftrace::ast::Probe;
 
 TEST(ast, probe_name_special)
 {
-  AttachPoint ap1("");
-  ap1.provider = "BEGIN";
-  AttachPointList attach_points1 = { &ap1 };
-  Probe begin(&attach_points1, nullptr, nullptr);
+  auto ap1 = std::make_unique<AttachPoint>("");
+  ap1->provider = "BEGIN";
+  auto attach_points1 = std::make_unique<AttachPointList>();
+  attach_points1->emplace_back(std::move(ap1));
+  Probe begin(std::move(attach_points1), nullptr, nullptr);
   EXPECT_EQ(begin.name(), "BEGIN");
 
-  AttachPoint ap2("");
-  ap2.provider = "END";
-  AttachPointList attach_points2 = { &ap2 };
-  Probe end(&attach_points2, nullptr, nullptr);
+  auto ap2 = std::make_unique<AttachPoint>("");
+  ap2->provider = "END";
+  auto attach_points2 = std::make_unique<AttachPointList>();
+  attach_points2->emplace_back(std::move(ap2));
+  Probe end(std::move(attach_points2), nullptr, nullptr);
   EXPECT_EQ(end.name(), "END");
 }
 
 TEST(ast, probe_name_kprobe)
 {
-  AttachPoint ap1("");
-  ap1.provider = "kprobe";
-  ap1.func = "sys_read";
-  AttachPointList attach_points1 = { &ap1 };
-  Probe kprobe1(&attach_points1, nullptr, nullptr);
+  auto ap1 = std::make_unique<AttachPoint>("");
+  ap1->provider = "kprobe";
+  ap1->func = "sys_read";
+  auto attach_points1 = std::make_unique<AttachPointList>();
+  attach_points1->emplace_back(std::move(ap1));
+  Probe kprobe1(std::move(attach_points1), nullptr, nullptr);
   EXPECT_EQ(kprobe1.name(), "kprobe:sys_read");
 
-  AttachPoint ap2("");
-  ap2.provider = "kprobe";
-  ap2.func = "sys_write";
-  AttachPointList attach_points2 = { &ap1, &ap2 };
-  Probe kprobe2(&attach_points2, nullptr, nullptr);
+  auto ap2 = std::make_unique<AttachPoint>("");
+  ap2->provider = "kprobe";
+  ap2->func = "sys_write";
+  auto attach_points2 = std::make_unique<AttachPointList>();
+  attach_points2->emplace_back(std::move(ap1));
+  attach_points2->emplace_back(std::move(ap2));
+  Probe kprobe2(std::move(attach_points2), nullptr, nullptr);
   EXPECT_EQ(kprobe2.name(), "kprobe:sys_read,kprobe:sys_write");
 
-  AttachPoint ap3("");
-  ap3.provider = "kprobe";
-  ap3.func = "sys_read";
-  ap3.func_offset = 10;
-  AttachPointList attach_points3 = { &ap1, &ap2, &ap3 };
-  Probe kprobe3(&attach_points3, nullptr, nullptr);
+  auto ap3 = std::make_unique<AttachPoint>("");
+  ap3->provider = "kprobe";
+  ap3->func = "sys_read";
+  ap3->func_offset = 10;
+  auto attach_points3 = std::make_unique<AttachPointList>();
+  attach_points3->emplace_back(std::move(ap1));
+  attach_points3->emplace_back(std::move(ap2));
+  attach_points3->emplace_back(std::move(ap3));
+  Probe kprobe3(std::move(attach_points3), nullptr, nullptr);
   EXPECT_EQ(kprobe3.name(),
             "kprobe:sys_read,kprobe:sys_write,kprobe:sys_read+10");
 }
 
 TEST(ast, probe_name_uprobe)
 {
-  AttachPoint ap1("");
-  ap1.provider = "uprobe";
-  ap1.target = "/bin/sh";
-  ap1.func = "readline";
-  AttachPointList attach_points1 = { &ap1 };
-  Probe uprobe1(&attach_points1, nullptr, nullptr);
+  auto ap1 = std::make_unique<AttachPoint>("");
+  ap1->provider = "uprobe";
+  ap1->target = "/bin/sh";
+  ap1->func = "readline";
+  auto attach_points1 = std::make_unique<AttachPointList>();
+  attach_points1->emplace_back(std::move(ap1));
+  Probe uprobe1(std::move(attach_points1), nullptr, nullptr);
   EXPECT_EQ(uprobe1.name(), "uprobe:/bin/sh:readline");
 
-  AttachPoint ap2("");
-  ap2.provider = "uprobe";
-  ap2.target = "/bin/sh";
-  ap2.func = "somefunc";
-  AttachPointList attach_points2 = { &ap1, &ap2 };
-  Probe uprobe2(&attach_points2, nullptr, nullptr);
+  auto ap2 = std::make_unique<AttachPoint>("");
+  ap2->provider = "uprobe";
+  ap2->target = "/bin/sh";
+  ap2->func = "somefunc";
+  auto attach_points2 = std::make_unique<AttachPointList>();
+  attach_points2->emplace_back(std::move(ap1));
+  attach_points2->emplace_back(std::move(ap2));
+  Probe uprobe2(std::move(attach_points2), nullptr, nullptr);
   EXPECT_EQ(uprobe2.name(), "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc");
 
-  AttachPoint ap3("");
-  ap3.provider = "uprobe";
-  ap3.target = "/bin/sh";
-  ap3.address = 1000;
-  AttachPointList attach_points3 = { &ap1, &ap2, &ap3 };
-  Probe uprobe3(&attach_points3, nullptr, nullptr);
+  auto ap3 = std::make_unique<AttachPoint>("");
+  ap3->provider = "uprobe";
+  ap3->target = "/bin/sh";
+  ap3->address = 1000;
+  auto attach_points3 = std::make_unique<AttachPointList>();
+  attach_points3->emplace_back(std::move(ap1));
+  attach_points3->emplace_back(std::move(ap2));
+  attach_points3->emplace_back(std::move(ap3));
+  Probe uprobe3(std::move(attach_points3), nullptr, nullptr);
   EXPECT_EQ(uprobe3.name(), "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/sh:1000");
 
-  AttachPoint ap4("");
-  ap4.provider = "uprobe";
-  ap4.target = "/bin/sh";
-  ap4.func = "somefunc";
-  ap4.func_offset = 10;
-  AttachPointList attach_points4 = { &ap1, &ap2, &ap3, &ap4 };
-  Probe uprobe4(&attach_points4, nullptr, nullptr);
+  auto ap4 = std::make_unique<AttachPoint>("");
+  ap4->provider = "uprobe";
+  ap4->target = "/bin/sh";
+  ap4->func = "somefunc";
+  ap4->func_offset = 10;
+  auto attach_points4 = std::make_unique<AttachPointList>();
+  attach_points4->emplace_back(std::move(ap1));
+  attach_points4->emplace_back(std::move(ap2));
+  attach_points4->emplace_back(std::move(ap3));
+  attach_points4->emplace_back(std::move(ap4));
+  Probe uprobe4(std::move(attach_points4), nullptr, nullptr);
   EXPECT_EQ(uprobe4.name(), "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/sh:1000,uprobe:/bin/sh:somefunc+10");
 
-  AttachPoint ap5("");
-  ap5.provider = "uprobe";
-  ap5.target = "/bin/sh";
-  ap5.address = 10;
-  AttachPointList attach_points5 = { &ap5 };
-  Probe uprobe5(&attach_points5, nullptr, nullptr);
+  auto ap5 = std::make_unique<AttachPoint>("");
+  ap5->provider = "uprobe";
+  ap5->target = "/bin/sh";
+  ap5->address = 10;
+  auto attach_points5 = std::make_unique<AttachPointList>();
+  attach_points5->emplace_back(std::move(ap5));
+  Probe uprobe5(std::move(attach_points5), nullptr, nullptr);
   EXPECT_EQ(uprobe5.name(), "uprobe:/bin/sh:10");
 
-  AttachPoint ap6("");
-  ap6.provider = "uretprobe";
-  ap6.target = "/bin/sh";
-  ap6.address = 10;
-  AttachPointList attach_points6 = { &ap6 };
-  Probe uprobe6(&attach_points6, nullptr, nullptr);
+  auto ap6 = std::make_unique<AttachPoint>("");
+  ap6->provider = "uretprobe";
+  ap6->target = "/bin/sh";
+  ap6->address = 10;
+  auto attach_points6 = std::make_unique<AttachPointList>();
+  attach_points6->emplace_back(std::move(ap6));
+  Probe uprobe6(std::move(attach_points6), nullptr, nullptr);
   EXPECT_EQ(uprobe6.name(), "uretprobe:/bin/sh:10");
 }
 
 TEST(ast, probe_name_usdt)
 {
-  AttachPoint ap1("");
-  ap1.provider = "usdt";
-  ap1.target = "/bin/sh";
-  ap1.func = "probe1";
-  AttachPointList attach_points1 = { &ap1 };
-  Probe usdt1(&attach_points1, nullptr, nullptr);
+  auto ap1 = std::make_unique<AttachPoint>("");
+  ap1->provider = "usdt";
+  ap1->target = "/bin/sh";
+  ap1->func = "probe1";
+  auto attach_points1 = std::make_unique<AttachPointList>();
+  attach_points1->emplace_back(std::move(ap1));
+  Probe usdt1(std::move(attach_points1), nullptr, nullptr);
   EXPECT_EQ(usdt1.name(), "usdt:/bin/sh:probe1");
 
-  AttachPoint ap2("");
-  ap2.provider = "usdt";
-  ap2.target = "/bin/sh";
-  ap2.func = "probe2";
-  AttachPointList attach_points2 = { &ap1, &ap2 };
-  Probe usdt2(&attach_points2, nullptr, nullptr);
+  auto ap2 = std::make_unique<AttachPoint>("");
+  ap2->provider = "usdt";
+  ap2->target = "/bin/sh";
+  ap2->func = "probe2";
+  auto attach_points2 = std::make_unique<AttachPointList>();
+  attach_points2->emplace_back(std::move(ap1));
+  attach_points2->emplace_back(std::move(ap2));
+  Probe usdt2(std::move(attach_points2), nullptr, nullptr);
   EXPECT_EQ(usdt2.name(), "usdt:/bin/sh:probe1,usdt:/bin/sh:probe2");
 }
 
 TEST(ast, attach_point_name)
 {
-  AttachPoint ap1("");
-  ap1.provider = "kprobe";
-  ap1.func = "sys_read";
-  AttachPoint ap2("");
-  ap2.provider = "kprobe";
-  ap2.func = "sys_thisone";
-  AttachPoint ap3("");
-  ap3.provider = "uprobe";
-  ap3.target = "/bin/sh";
-  ap3.func = "readline";
-  AttachPointList attach_points = { &ap1, &ap2, &ap3 };
-  Probe kprobe(&attach_points, nullptr, nullptr);
-  EXPECT_EQ(ap2.name("sys_thisone"), "kprobe:sys_thisone");
+  auto ap1 = std::make_unique<AttachPoint>("");
+  ap1->provider = "kprobe";
+  ap1->func = "sys_read";
+  auto ap2 = std::make_unique<AttachPoint>("");
+  ap2->provider = "kprobe";
+  ap2->func = "sys_thisone";
+  auto ap3 = std::make_unique<AttachPoint>("");
+  ap3->provider = "uprobe";
+  ap3->target = "/bin/sh";
+  ap3->func = "readline";
+  auto attach_points = std::make_unique<AttachPointList>();
+  attach_points->emplace_back(std::move(ap1));
+  attach_points->emplace_back(std::move(ap2));
+  attach_points->emplace_back(std::move(ap3));
+  Probe kprobe(std::move(attach_points), nullptr, nullptr);
+  EXPECT_EQ(ap2->name("sys_thisone"), "kprobe:sys_thisone");
 
-  Probe uprobe(&attach_points, nullptr, nullptr);
-  EXPECT_EQ(ap3.name("readline"), "uprobe:/bin/sh:readline");
+  Probe uprobe(std::move(attach_points), nullptr, nullptr);
+  EXPECT_EQ(ap3->name("readline"), "uprobe:/bin/sh:readline");
 }
 
 } // namespace ast

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -118,10 +118,11 @@ void check_special_probe(Probe &p, const std::string &attach_point, const std::s
 
 TEST(bpftrace, add_begin_probe)
 {
-  ast::AttachPoint a("");
-  a.provider = "BEGIN";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "BEGIN";
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
   ASSERT_EQ(0, bpftrace.add_probe(probe));
@@ -133,10 +134,11 @@ TEST(bpftrace, add_begin_probe)
 
 TEST(bpftrace, add_end_probe)
 {
-  ast::AttachPoint a("");
-  a.provider = "END";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "END";
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
   ASSERT_EQ(0, bpftrace.add_probe(probe));
@@ -148,11 +150,12 @@ TEST(bpftrace, add_end_probe)
 
 TEST(bpftrace, add_probes_single)
 {
-  ast::AttachPoint a("");
-  a.provider = "kprobe";
-  a.func = "sys_read";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "kprobe";
+  a->func = "sys_read";
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
   ASSERT_EQ(0, bpftrace.add_probe(probe));
@@ -164,14 +167,16 @@ TEST(bpftrace, add_probes_single)
 
 TEST(bpftrace, add_probes_multiple)
 {
-  ast::AttachPoint a1("");
-  a1.provider = "kprobe";
-  a1.func = "sys_read";
-  ast::AttachPoint a2("");
-  a2.provider = "kprobe";
-  a2.func = "sys_write";
-  ast::AttachPointList attach_points = { &a1, &a2 };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a1 = std::make_unique<ast::AttachPoint>("");
+  a1->provider = "kprobe";
+  a1->func = "sys_read";
+  auto a2 = std::make_unique<ast::AttachPoint>("");
+  a2->provider = "kprobe";
+  a2->func = "sys_write";
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a1));
+  attach_points->emplace_back(std::move(a2));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
   ASSERT_EQ(0, bpftrace.add_probe(probe));
@@ -185,18 +190,21 @@ TEST(bpftrace, add_probes_multiple)
 
 TEST(bpftrace, add_probes_wildcard)
 {
-  ast::AttachPoint a1("");
-  a1.provider = "kprobe";
-  a1.func = "sys_read";
-  ast::AttachPoint a2("");
-  a2.provider = "kprobe";
-  a2.func = "my_*";
-  a2.need_expansion = true;
-  ast::AttachPoint a3("");
-  a3.provider = "kprobe";
-  a3.func = "sys_write";
-  ast::AttachPointList attach_points = { &a1, &a2, &a3 };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a1 = std::make_unique<ast::AttachPoint>("");
+  a1->provider = "kprobe";
+  a1->func = "sys_read";
+  auto a2 = std::make_unique<ast::AttachPoint>("");
+  a2->provider = "kprobe";
+  a2->func = "my_*";
+  a2->need_expansion = true;
+  auto a3 = std::make_unique<ast::AttachPoint>("");
+  a3->provider = "kprobe";
+  a3->func = "sys_write";
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a1));
+  attach_points->emplace_back(std::move(a2));
+  attach_points->emplace_back(std::move(a3));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace,
@@ -217,18 +225,21 @@ TEST(bpftrace, add_probes_wildcard)
 
 TEST(bpftrace, add_probes_wildcard_no_matches)
 {
-  ast::AttachPoint a1("");
-  a1.provider = "kprobe";
-  a1.func = "sys_read";
-  ast::AttachPoint a2("");
-  a2.provider = "kprobe";
-  a2.func = "not_here_*";
-  a2.need_expansion = true;
-  ast::AttachPoint a3("");
-  a3.provider = "kprobe";
-  a3.func = "sys_write";
-  ast::AttachPointList attach_points = { &a1, &a2, &a3 };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a1 = std::make_unique<ast::AttachPoint>("");
+  a1->provider = "kprobe";
+  a1->func = "sys_read";
+  auto a2 = std::make_unique<ast::AttachPoint>("");
+  a2->provider = "kprobe";
+  a2->func = "not_here_*";
+  a2->need_expansion = true;
+  auto a3 = std::make_unique<ast::AttachPoint>("");
+  a3->provider = "kprobe";
+  a3->func = "sys_write";
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a1));
+  attach_points->emplace_back(std::move(a2));
+  attach_points->emplace_back(std::move(a3));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace,
@@ -247,11 +258,12 @@ TEST(bpftrace, add_probes_wildcard_no_matches)
 
 TEST(bpftrace, add_probes_kernel_module)
 {
-  ast::AttachPoint a1("");
-  a1.provider = "kprobe";
-  a1.func = "func_in_mod";
-  ast::AttachPointList attach_points = { &a1 };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a1 = std::make_unique<ast::AttachPoint>("");
+  a1->provider = "kprobe";
+  a1->func = "func_in_mod";
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a1));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   ASSERT_EQ(0, bpftrace->add_probe(probe));
@@ -264,12 +276,13 @@ TEST(bpftrace, add_probes_kernel_module)
 
 TEST(bpftrace, add_probes_kernel_module_wildcard)
 {
-  ast::AttachPoint a1("");
-  a1.provider = "kprobe";
-  a1.func = "func_in_mo*";
-  a1.need_expansion = true;
-  ast::AttachPointList attach_points = { &a1 };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a1 = std::make_unique<ast::AttachPoint>("");
+  a1->provider = "kprobe";
+  a1->func = "func_in_mo*";
+  a1->need_expansion = true;
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a1));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace,
@@ -288,12 +301,13 @@ TEST(bpftrace, add_probes_kernel_module_wildcard)
 TEST(bpftrace, add_probes_offset)
 {
   uint64_t offset = 10;
-  ast::AttachPoint a("");
-  a.provider = "kprobe";
-  a.func = "sys_read";
-  a.func_offset = offset;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "kprobe";
+  a->func = "sys_read";
+  a->func_offset = offset;
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
   ASSERT_EQ(0, bpftrace.add_probe(probe));
@@ -307,12 +321,13 @@ TEST(bpftrace, add_probes_offset)
 
 TEST(bpftrace, add_probes_uprobe)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.func = "foo";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "uprobe";
+  a->target = "/bin/sh";
+  a->func = "foo";
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -324,13 +339,14 @@ TEST(bpftrace, add_probes_uprobe)
 
 TEST(bpftrace, add_probes_uprobe_wildcard)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.func = "*open";
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "uprobe";
+  a->target = "/bin/sh";
+  a->func = "*open";
+  a->need_expansion = true;
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/sh")).Times(1);
@@ -346,13 +362,14 @@ TEST(bpftrace, add_probes_uprobe_wildcard)
 
 TEST(bpftrace, add_probes_uprobe_wildcard_file)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/*sh";
-  a.func = "first_open";
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "uprobe";
+  a->target = "/bin/*sh";
+  a->func = "first_open";
+  a->need_expansion = true;
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/*sh")).Times(1);
@@ -370,13 +387,14 @@ TEST(bpftrace, add_probes_uprobe_wildcard_file)
 
 TEST(bpftrace, add_probes_uprobe_wildcard_no_matches)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.func = "foo*";
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "uprobe";
+  a->target = "/bin/sh";
+  a->func = "foo*";
+  a->need_expansion = true;
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/sh")).Times(1);
@@ -388,12 +406,13 @@ TEST(bpftrace, add_probes_uprobe_wildcard_no_matches)
 
 TEST(bpftrace, add_probes_uprobe_string_literal)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.func = "foo*";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "uprobe";
+  a->target = "/bin/sh";
+  a->func = "foo*";
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -405,12 +424,13 @@ TEST(bpftrace, add_probes_uprobe_string_literal)
 
 TEST(bpftrace, add_probes_uprobe_address)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.address = 1024;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "uprobe";
+  a->target = "/bin/sh";
+  a->address = 1024;
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -422,13 +442,14 @@ TEST(bpftrace, add_probes_uprobe_address)
 
 TEST(bpftrace, add_probes_uprobe_string_offset)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.func = "foo";
-  a.func_offset = 10;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "uprobe";
+  a->target = "/bin/sh";
+  a->func = "foo";
+  a->func_offset = 10;
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -442,13 +463,14 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol)
 {
   for (auto &provider : { "uprobe", "uretprobe" })
   {
-    ast::AttachPoint a("");
-    a.provider = provider;
-    a.target = "/bin/sh";
-    a.func = "cpp_mangled";
-    a.need_expansion = true;
-    ast::AttachPointList attach_points = { &a };
-    ast::Probe probe(&attach_points, nullptr, nullptr);
+    auto a = std::make_unique<ast::AttachPoint>("");
+    a->provider = provider;
+    a->target = "/bin/sh";
+    a->func = "cpp_mangled";
+    a->need_expansion = true;
+    auto attach_points = std::make_unique<ast::AttachPointList>();
+    attach_points->emplace_back(std::move(a));
+    ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
     auto bpftrace = get_strict_mock_bpftrace();
     EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/sh")).Times(1);
@@ -466,13 +488,14 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol)
 
 TEST(bpftrace, add_probes_uprobe_cpp_symbol_full)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.func = "cpp_mangled(int)";
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "uprobe";
+  a->target = "/bin/sh";
+  a->func = "cpp_mangled(int)";
+  a->need_expansion = true;
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/sh")).Times(1);
@@ -488,13 +511,14 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol_full)
 
 TEST(bpftrace, add_probes_uprobe_cpp_symbol_wildcard)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.func = "cpp_man*";
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "uprobe";
+  a->target = "/bin/sh";
+  a->func = "cpp_man*";
+  a->need_expansion = true;
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/sh")).Times(1);
@@ -514,14 +538,15 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol_wildcard)
 
 TEST(bpftrace, add_probes_usdt)
 {
-  ast::AttachPoint a("");
-  a.provider = "usdt";
-  a.target = "/bin/sh";
-  a.ns = "prov1";
-  a.func = "mytp";
-  a.usdt.num_locations = 1;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "usdt";
+  a->target = "/bin/sh";
+  a->ns = "prov1";
+  a->func = "mytp";
+  a->usdt.num_locations = 1;
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -535,15 +560,16 @@ TEST(bpftrace, add_probes_usdt)
 
 TEST(bpftrace, add_probes_usdt_wildcard)
 {
-  ast::AttachPoint a("");
-  a.provider = "usdt";
-  a.target = "/bin/*sh";
-  a.ns = "prov*";
-  a.func = "tp*";
-  a.usdt.num_locations = 1;
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "usdt";
+  a->target = "/bin/*sh";
+  a->ns = "prov*";
+  a->func = "tp*";
+  a->usdt.num_locations = 1;
+  a->need_expansion = true;
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, get_symbols_from_usdt(0, "/bin/*sh")).Times(1);
@@ -575,15 +601,16 @@ TEST(bpftrace, add_probes_usdt_wildcard)
 
 TEST(bpftrace, add_probes_usdt_empty_namespace)
 {
-  ast::AttachPoint a("");
-  a.provider = "usdt";
-  a.target = "/bin/sh";
-  a.ns = "";
-  a.func = "tp1";
-  a.usdt.num_locations = 1;
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "usdt";
+  a->target = "/bin/sh";
+  a->ns = "";
+  a->func = "tp1";
+  a->usdt.num_locations = 1;
+  a->need_expansion = true;
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, get_symbols_from_usdt(0, "/bin/sh")).Times(1);
@@ -600,15 +627,16 @@ TEST(bpftrace, add_probes_usdt_empty_namespace)
 
 TEST(bpftrace, add_probes_usdt_empty_namespace_conflict)
 {
-  ast::AttachPoint a("");
-  a.provider = "usdt";
-  a.target = "/bin/sh";
-  a.ns = "";
-  a.func = "tp";
-  a.usdt.num_locations = 1;
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "usdt";
+  a->target = "/bin/sh";
+  a->ns = "";
+  a->func = "tp";
+  a->usdt.num_locations = 1;
+  a->need_expansion = true;
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, get_symbols_from_usdt(0, "/bin/sh")).Times(1);
@@ -618,14 +646,15 @@ TEST(bpftrace, add_probes_usdt_empty_namespace_conflict)
 
 TEST(bpftrace, add_probes_usdt_duplicate_markers)
 {
-  ast::AttachPoint a("");
-  a.provider = "usdt";
-  a.target = "/bin/sh";
-  a.ns = "prov1";
-  a.func = "mytp";
-  a.usdt.num_locations = 3;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "usdt";
+  a->target = "/bin/sh";
+  a->ns = "prov1";
+  a->func = "mytp";
+  a->usdt.num_locations = 3;
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -651,12 +680,13 @@ TEST(bpftrace, add_probes_usdt_duplicate_markers)
 
 TEST(bpftrace, add_probes_tracepoint)
 {
-  ast::AttachPoint a("");
-  a.provider = "tracepoint";
-  a.target = "sched";
-  a.func = "sched_switch";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "tracepoint";
+  a->target = "sched";
+  a->func = "sched_switch";
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -670,13 +700,14 @@ TEST(bpftrace, add_probes_tracepoint)
 
 TEST(bpftrace, add_probes_tracepoint_wildcard)
 {
-  ast::AttachPoint a("");
-  a.provider = "tracepoint";
-  a.target = "sched";
-  a.func = "sched_*";
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "tracepoint";
+  a->target = "sched";
+  a->func = "sched_*";
+  a->need_expansion = true;
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   std::set<std::string> matches = { "sched_one", "sched_two" };
@@ -695,13 +726,14 @@ TEST(bpftrace, add_probes_tracepoint_wildcard)
 
 TEST(bpftrace, add_probes_tracepoint_category_wildcard)
 {
-  ast::AttachPoint a("");
-  a.provider = "tracepoint";
-  a.target = "sched*";
-  a.func = "sched_*";
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "tracepoint";
+  a->target = "sched*";
+  a->func = "sched_*";
+  a->need_expansion = true;
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace,
@@ -726,13 +758,14 @@ TEST(bpftrace, add_probes_tracepoint_category_wildcard)
 
 TEST(bpftrace, add_probes_tracepoint_wildcard_no_matches)
 {
-  ast::AttachPoint a("");
-  a.provider = "tracepoint";
-  a.target = "typo";
-  a.func = "typo_*";
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "tracepoint";
+  a->target = "typo";
+  a->func = "typo_*";
+  a->need_expansion = true;
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace,
@@ -746,12 +779,13 @@ TEST(bpftrace, add_probes_tracepoint_wildcard_no_matches)
 
 TEST(bpftrace, add_probes_profile)
 {
-  ast::AttachPoint a("");
-  a.provider = "profile";
-  a.target = "ms";
-  a.freq = 997;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "profile";
+  a->target = "ms";
+  a->freq = 997;
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -765,12 +799,13 @@ TEST(bpftrace, add_probes_profile)
 
 TEST(bpftrace, add_probes_interval)
 {
-  ast::AttachPoint a("");
-  a.provider = "interval";
-  a.target = "s";
-  a.freq = 1;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "interval";
+  a->target = "s";
+  a->freq = 1;
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -784,12 +819,13 @@ TEST(bpftrace, add_probes_interval)
 
 TEST(bpftrace, add_probes_software)
 {
-  ast::AttachPoint a("");
-  a.provider = "software";
-  a.target = "faults";
-  a.freq = 1000;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "software";
+  a->target = "faults";
+  a->freq = 1000;
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -803,12 +839,13 @@ TEST(bpftrace, add_probes_software)
 
 TEST(bpftrace, add_probes_hardware)
 {
-  ast::AttachPoint a("");
-  a.provider = "hardware";
-  a.target = "cache-references";
-  a.freq = 1000000;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "hardware";
+  a->target = "cache-references";
+  a->freq = 1000000;
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -822,11 +859,12 @@ TEST(bpftrace, add_probes_hardware)
 
 TEST(bpftrace, invalid_provider)
 {
-  ast::AttachPoint a("");
-  a.provider = "lookatme";
-  a.func = "invalid";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "lookatme";
+  a->func = "invalid";
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 
@@ -1053,14 +1091,16 @@ void check_kfunc(Probe &p, ProbeType type, const std::string &name)
 
 TEST_F(bpftrace_btf, add_probes_kfunc)
 {
-  ast::AttachPoint a("");
-  a.provider = "kfunc";
-  a.target = "func_1";
-  ast::AttachPoint b("");
-  b.provider = "kretfunc";
-  b.target = "func_1";
-  ast::AttachPointList attach_points = { &a, &b };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = std::make_unique<ast::AttachPoint>("");
+  a->provider = "kfunc";
+  a->target = "func_1";
+  auto b = std::make_unique<ast::AttachPoint>("");
+  b->provider = "kretfunc";
+  b->target = "func_1";
+  auto attach_points = std::make_unique<ast::AttachPointList>();
+  attach_points->emplace_back(std::move(a));
+  attach_points->emplace_back(std::move(b));
+  ast::Probe probe(std::move(attach_points), nullptr, nullptr);
 
   StrictMock<MockBPFtrace> bpftrace;
 

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -19,11 +19,11 @@ static void parse(const std::string &input, BPFtrace &bpftrace, bool result = tr
   Driver driver(bpftrace);
   ASSERT_EQ(driver.parse_str(extended_input), 0);
 
-  ast::FieldAnalyser fields(driver.root_, bpftrace);
+  ast::FieldAnalyser fields(driver.root_.get(), bpftrace);
   EXPECT_EQ(fields.analyse(), 0);
 
   ClangParser clang;
-  ASSERT_EQ(clang.parse(driver.root_, bpftrace), result);
+  ASSERT_EQ(clang.parse(driver.root_.get(), bpftrace), result);
 }
 
 TEST(clang_parser, integers)

--- a/tests/codegen/call_kstack.cpp
+++ b/tests/codegen/call_kstack.cpp
@@ -26,14 +26,14 @@ TEST(codegen, call_kstack_mapids)
             0);
 
   ClangParser clang;
-  clang.parse(driver.root_, bpftrace);
+  clang.parse(driver.root_.get(), bpftrace);
 
   MockBPFfeature feature;
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace, feature);
+  ast::SemanticAnalyser semantics(driver.root_.get(), bpftrace, feature);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 
-  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  ast::CodegenLLVM codegen(driver.root_.get(), bpftrace);
   codegen.compile();
 
   ASSERT_EQ(FakeMap::next_mapfd_, 7);
@@ -57,14 +57,14 @@ TEST(codegen, call_kstack_modes_mapids)
             0);
 
   ClangParser clang;
-  clang.parse(driver.root_, bpftrace);
+  clang.parse(driver.root_.get(), bpftrace);
 
   MockBPFfeature feature;
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace, feature);
+  ast::SemanticAnalyser semantics(driver.root_.get(), bpftrace, feature);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 
-  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  ast::CodegenLLVM codegen(driver.root_.get(), bpftrace);
   codegen.compile();
 
   ASSERT_EQ(FakeMap::next_mapfd_, 7);

--- a/tests/codegen/call_ustack.cpp
+++ b/tests/codegen/call_ustack.cpp
@@ -26,14 +26,14 @@ TEST(codegen, call_ustack_mapids)
             0);
 
   ClangParser clang;
-  clang.parse(driver.root_, bpftrace);
+  clang.parse(driver.root_.get(), bpftrace);
 
   MockBPFfeature feature;
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace, feature);
+  ast::SemanticAnalyser semantics(driver.root_.get(), bpftrace, feature);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 
-  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  ast::CodegenLLVM codegen(driver.root_.get(), bpftrace);
   codegen.compile();
 
   ASSERT_EQ(FakeMap::next_mapfd_, 7);
@@ -57,14 +57,14 @@ TEST(codegen, call_ustack_modes_mapids)
             0);
 
   ClangParser clang;
-  clang.parse(driver.root_, bpftrace);
+  clang.parse(driver.root_.get(), bpftrace);
 
   MockBPFfeature feature;
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace, feature);
+  ast::SemanticAnalyser semantics(driver.root_.get(), bpftrace, feature);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 
-  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  ast::CodegenLLVM codegen(driver.root_.get(), bpftrace);
   codegen.compile();
 
   ASSERT_EQ(FakeMap::next_mapfd_, 7);

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -372,17 +372,17 @@ static void test(BPFtrace &bpftrace,
   ASSERT_EQ(driver.parse_str(input), 0);
 
   ClangParser clang;
-  clang.parse(driver.root_, bpftrace);
+  clang.parse(driver.root_.get(), bpftrace);
 
   ASSERT_EQ(driver.parse_str(input), 0);
 
   MockBPFfeature feature;
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace, feature);
+  ast::SemanticAnalyser semantics(driver.root_.get(), bpftrace, feature);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 
   std::stringstream out;
-  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  ast::CodegenLLVM codegen(driver.root_.get(), bpftrace);
   codegen.generate_ir();
   codegen.DumpIR(out);
   // Test that generated code compiles cleanly

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -45,10 +45,10 @@ TEST(codegen, populate_sections)
 
   ASSERT_EQ(driver.parse_str("kprobe:foo { 1 } kprobe:bar { 1 }"), 0);
   MockBPFfeature feature;
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace, feature);
+  ast::SemanticAnalyser semantics(driver.root_.get(), bpftrace, feature);
   ASSERT_EQ(semantics.analyse(), 0);
   std::stringstream out;
-  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  ast::CodegenLLVM codegen(driver.root_.get(), bpftrace);
   auto bpforc = codegen.compile();
 
   // Check sections are populated
@@ -71,13 +71,13 @@ TEST(codegen, printf_offsets)
                 "}"),
             0);
   ClangParser clang;
-  clang.parse(driver.root_, bpftrace);
+  clang.parse(driver.root_.get(), bpftrace);
   MockBPFfeature feature;
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace, feature);
+  ast::SemanticAnalyser semantics(driver.root_.get(), bpftrace, feature);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
   std::stringstream out;
-  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  ast::CodegenLLVM codegen(driver.root_.get(), bpftrace);
   codegen.generate_ir();
 
   EXPECT_EQ(bpftrace.printf_args_.size(), 1U);
@@ -116,9 +116,9 @@ TEST(codegen, probe_count)
 
   ASSERT_EQ(driver.parse_str("kprobe:f { 1; } kprobe:d { 1; }"), 0);
   MockBPFfeature feature;
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace, feature);
+  ast::SemanticAnalyser semantics(driver.root_.get(), bpftrace, feature);
   ASSERT_EQ(semantics.analyse(), 0);
-  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  ast::CodegenLLVM codegen(driver.root_.get(), bpftrace);
   codegen.generate_ir();
 }
 } // namespace codegen

--- a/tests/codegen/regression.cpp
+++ b/tests/codegen/regression.cpp
@@ -23,10 +23,10 @@ TEST(codegen, regression_957)
 
   ASSERT_EQ(driver.parse_str("t:sched:sched_one* { cat(\"%s\", probe); }"), 0);
   MockBPFfeature feature;
-  ast::SemanticAnalyser semantics(driver.root_, *bpftrace, feature);
+  ast::SemanticAnalyser semantics(driver.root_.get(), *bpftrace, feature);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
-  ast::CodegenLLVM codegen(driver.root_, *bpftrace);
+  ast::CodegenLLVM codegen(driver.root_.get(), *bpftrace);
   codegen.compile();
 }
 

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -26,18 +26,18 @@ void gen_bytecode(const std::string &input, std::stringstream &out)
 
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.root_, *bpftrace);
+  ast::FieldAnalyser fields(driver.root_.get(), *bpftrace);
   EXPECT_EQ(fields.analyse(), 0);
 
   ClangParser clang;
-  clang.parse(driver.root_, *bpftrace);
+  clang.parse(driver.root_.get(), *bpftrace);
 
   MockBPFfeature feature;
-  ast::SemanticAnalyser semantics(driver.root_, *bpftrace, feature);
+  ast::SemanticAnalyser semantics(driver.root_.get(), *bpftrace, feature);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 
-  ast::CodegenLLVM codegen(driver.root_, *bpftrace);
+  ast::CodegenLLVM codegen(driver.root_.get(), *bpftrace);
   codegen.generate_ir();
   codegen.DumpIR(out);
 }


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

The Bison code creates a lot of objects with the `new` operator. These all end up causing memory leaks, because there is no corresponding call to `delete`. This change resolves this issue by using `std::unique_ptr` to create managed objects that will be destroyed once they are no longer needed.

This is a large commit, but is mostly mechanical changes, no logical change is intended.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
