### PR TITLE
Use LLVM demangler to avoid crash while processing very long mangled names

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -3,7 +3,6 @@
 #include <cstdio>
 #include <cstring>
 #include <ctime>
-#include <cxxabi.h>
 #include <fstream>
 #include <glob.h>
 #include <iomanip>
@@ -27,6 +26,8 @@
 
 #include <bcc/bcc_syms.h>
 #include <bcc/perf_reader.h>
+
+#include <llvm/Demangle/Demangle.h>
 
 #include "ast/async_event_types.h"
 #include "attached_probe.h"
@@ -88,7 +89,7 @@ std::set<std::string> find_wildcard_matches_internal(
                         : "";
       if (symbol_has_cpp_mangled_signature(fun_line))
       {
-        char *demangled_name = abi::__cxa_demangle(
+        char *demangled_name = llvm::itaniumDemangle(
             fun_line.c_str(), nullptr, nullptr, nullptr);
         if (demangled_name)
         {
@@ -447,7 +448,7 @@ std::set<std::string> BPFtrace::find_symbol_matches(
     {
       if (symbol_has_cpp_mangled_signature(line_func))
       {
-        char *demangled_name = abi::__cxa_demangle(
+        char *demangled_name = llvm::itaniumDemangle(
             line_func.c_str(), nullptr, nullptr, nullptr);
         if (demangled_name)
         {


### PR DESCRIPTION
bpftrace uses __cxa_demangle() from libstdc++ when looking for C++ symbols matching the uprobe specification. However there is a known stack overflow issue in the gcc 7.x runtime, see https://gcc.gnu.org/bugzilla/show_bug.cgi?id=87335

Although the bug report mentions fuzzed inputs, we're hitting the same issue on a real production binary which has mangled symbols over 1700 characters long (!).
```
# bpftrace -e 'uprobe:/proc/2585100/exe:main {}' 
Segmentation fault (core dumped)
```
Crash stack from gdb:
```
Program terminated with signal SIGSEGV, Segmentation fault.
#0  0x00007f54c7e1fcde in d_demangle_callback.constprop () from /usr/local/fbcode/platform007/lib/libstdc++.so.6
(gdb) bt
#0  0x00007f54c7e1fcde in d_demangle_callback.constprop () from /usr/local/fbcode/platform007/lib/libstdc++.so.6
#1  0x00007f54c7e23090 in __cxa_demangle () from /usr/local/fbcode/platform007/lib/libstdc++.so.6
#2  0x00000000004b5cee in bpftrace::BPFtrace::find_symbol_matches[abi:cxx11](bpftrace::ast::AttachPoint const&) const ()
#3  0x00000000004bcd38 in bpftrace::BPFtrace::add_probe(bpftrace::ast::Probe&) ()
#4  0x0000000000a66420 in bpftrace::ast::CodegenLLVM::visit(bpftrace::ast::Probe&) ()
#5  0x0000000000a55f15 in bpftrace::ast::CodegenLLVM::accept(bpftrace::ast::Node*) ()
#6  0x0000000000a561b6 in bpftrace::ast::CodegenLLVM::visit(bpftrace::ast::Program&) ()
#7  0x0000000000a55f15 in bpftrace::ast::CodegenLLVM::accept(bpftrace::ast::Node*) ()
#8  0x0000000000a56240 in bpftrace::ast::CodegenLLVM::generate_ir() ()
#9  0x0000000000424dca in main ()
```
Unfortunately the bug is only fixed in gcc 9.x.

I found that LLVM has a drop-in replacement for __cxa_demangle() in https://llvm.org/doxygen/Demangle_8h_source.html
Luckily with this alternate implementation the demangling works even for very long symbols, without crashing:
```
# /tmp/bpftrace -e 'uprobe:/proc/2585100/exe:main {}' 
Attaching 1 probe...
^C

#
```

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md` -> no language changes
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md` -> trivial change
- [ ] The new behaviour is covered by tests -> hard to test without uploading a 7GB binary to the tests directory :-/ suggestions welcome
