### PR TITLE
Assign correct stack_type to map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ and this project adheres to
   - [#1530](https://github.com/iovisor/bpftrace/pull/1530)
 - Fix pointer arithmetic for positional parameters
   - [#1514](https://github.com/iovisor/bpftrace/pull/1514)
+- SEGV when using perf format for stacks
+  - [#1524](https://github.com/iovisor/bpftrace/pull/1524)
 
 #### Tools
 - Hook up execsnoop.bt script onto `execveat` call

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -9,7 +9,7 @@ EXPECT value: 100ms100
 TIMEOUT 5
 
 NAME printf_llu
-RUN bpftrace -e 'BEGIN { @start = nsecs; } i:s:1 { printf("Elapsed time: %llus\n", (nsecs - @start)/1000000000); clear(@start); exit();}'  
+RUN bpftrace -e 'BEGIN { @start = nsecs; } i:s:1 { printf("Elapsed time: %llus\n", (nsecs - @start)/1000000000); clear(@start); exit();}'
 EXPECT Elapsed time: 1s
 TIMEOUT 5
 
@@ -154,6 +154,13 @@ RUN bpftrace -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n%s\n", kstack()
 EXPECT SUCCESS kstack
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8
+
+NAME kstack perf mode
+RUN bpftrace -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n", kstack(perf, 1)); exit(); }'
+EXPECT SUCCESS kstack
+TIMEOUT 5
+AFTER ./testprogs/syscall nanosleep  1e8
+
 
 NAME ustack
 RUN bpftrace -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n%s\n", ustack(), ustack(1)); exit(); }'

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -767,28 +767,28 @@ TEST(semantic_analyser, call_stack)
   test("kprobe:f { ustack(perf, 3) }", 0);
 
   // Wrong arguments
-  test("kprobe:f { kstack(3, perf) }", 10);
-  test("kprobe:f { ustack(3, perf) }", 10);
+  test("kprobe:f { kstack(3, perf) }", 1);
+  test("kprobe:f { ustack(3, perf) }", 1);
   test("kprobe:f { kstack(perf, 3, 4) }", 1);
   test("kprobe:f { ustack(perf, 3, 4) }", 1);
   test("kprobe:f { kstack(bob) }", 1);
   test("kprobe:f { ustack(bob) }", 1);
-  test("kprobe:f { kstack(\"str\") }", 10);
-  test("kprobe:f { ustack(\"str\") }", 10);
-  test("kprobe:f { kstack(perf, \"str\") }", 10);
-  test("kprobe:f { ustack(perf, \"str\") }", 10);
-  test("kprobe:f { kstack(\"str\", 3) }", 10);
-  test("kprobe:f { ustack(\"str\", 3) }", 10);
+  test("kprobe:f { kstack(\"str\") }", 1);
+  test("kprobe:f { ustack(\"str\") }", 1);
+  test("kprobe:f { kstack(perf, \"str\") }", 1);
+  test("kprobe:f { ustack(perf, \"str\") }", 1);
+  test("kprobe:f { kstack(\"str\", 3) }", 1);
+  test("kprobe:f { ustack(\"str\", 3) }", 1);
 
   // Non-literals
-  test("kprobe:f { @x = perf; kstack(@x) }", 10);
-  test("kprobe:f { @x = perf; ustack(@x) }", 10);
-  test("kprobe:f { @x = perf; kstack(@x, 3) }", 10);
-  test("kprobe:f { @x = perf; ustack(@x, 3) }", 10);
-  test("kprobe:f { @x = 3; kstack(@x) }", 10);
-  test("kprobe:f { @x = 3; ustack(@x) }", 10);
-  test("kprobe:f { @x = 3; kstack(perf, @x) }", 10);
-  test("kprobe:f { @x = 3; ustack(perf, @x) }", 10);
+  test("kprobe:f { @x = perf; kstack(@x) }", 1);
+  test("kprobe:f { @x = perf; ustack(@x) }", 1);
+  test("kprobe:f { @x = perf; kstack(@x, 3) }", 1);
+  test("kprobe:f { @x = perf; ustack(@x, 3) }", 1);
+  test("kprobe:f { @x = 3; kstack(@x) }", 1);
+  test("kprobe:f { @x = 3; ustack(@x) }", 1);
+  test("kprobe:f { @x = 3; kstack(perf, @x) }", 1);
+  test("kprobe:f { @x = 3; ustack(perf, @x) }", 1);
 }
 
 TEST(semantic_analyser, map_reassignment)


### PR DESCRIPTION
The type of a map gets determined the first time something gets assigned
to it. As the arguments to `kstack/ustack` only get evaluated in the
last pass the map will be created with the default stack type, not the
one specified by the user.
Due to the way stacks work, with the hidden stack map and the user map
that holds the stack id, this only shows up when trying to print the
map. The type associated with the user map has the correct stack type,
but the original map has the default. This eventually leads to a SEGV.

Simple repro:

```
'i:s:1 { $a=10; @=kstack(perf); exit(); }'
```

```
Thread 1 "bpftrace" received signal SIGSEGV, Segmentation fault.
0x000000000046475a in bpftrace::BPFtrace::get_stack[abi:cxx11](...)
1680	  int err = bpf_lookup_elem(maps[stack_type].value()->mapfd_,
(gdb) p stack_type
$1 = {limit = 127, mode = bpftrace::StackMode::bpftrace}`
```

As this call expects literals we don't have to worry about variables and
thing that might be evaluated later, so we can just remove the
`is_final_pass()` check.

This fixes #1523

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
