### PR TITLE
release v0.11.1

### DIFF
--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -207,7 +207,7 @@ jobs:
     - name: Authenticate with docker registry
       if: >
         matrix.env['TYPE'] == 'Release' &&
-        github.ref == 'refs/heads/master' &&
+        (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) &&
         github.repository == 'iovisor/bpftrace'
       env:
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
@@ -216,7 +216,7 @@ jobs:
     - name: Package docker image and push to quay.io
       if: >
         matrix.env['TYPE'] == 'Release' &&
-        github.ref == 'refs/heads/master' &&
+        (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) &&
         github.repository == 'iovisor/bpftrace'
       run: >
         ./docker/scripts/push.sh

--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -193,7 +193,7 @@ jobs:
         -e EMBED_BINUTILS=${EMBED_BINUTILS}
         --entrypoint /bin/bash
         bpftrace-embedded-${{ matrix.env['BASE'] }}
-        -c "strip --keep-symbol BEGIN_trigger $(pwd)/build-embedded/src/bpftrace"
+        -c "strip --keep-symbol BEGIN_trigger --keep-symbol END_trigger $(pwd)/build-embedded/src/bpftrace"
 
     - uses: actions/upload-artifact@v1
       with:

--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -121,21 +121,79 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Build docker container
-      run: |
-        docker build -t bpftrace-embedded-${{ matrix.env['BASE'] }} -f docker/Dockerfile.${{ matrix.env['DISTRO'] }} --build-arg bcc_ref=${{ matrix.env['BCC_REF'] }} --build-arg BASE=${{ matrix.env['BASE'] }} --build-arg ALPINE_VERSION=${{ matrix.env['ALPINE_VERSION'] }} docker/
+      run: >
+        docker build
+        -t bpftrace-embedded-${{ matrix.env['BASE'] }}
+        -f docker/Dockerfile.${{ matrix.env['DISTRO'] }}
+        --build-arg bcc_ref=${{ matrix.env['BCC_REF'] }}
+        --build-arg BASE=${{ matrix.env['BASE'] }}
+        --build-arg ALPINE_VERSION=${{ matrix.env['ALPINE_VERSION'] }}
+        docker/
     - name: bpftrace embedded build
       env: ${{ matrix.env }}
-      run: |
-        docker run --privileged -v $(pwd):$(pwd) -w $(pwd) -v /sys/kernel/debug:/sys/kernel/debug:rw -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -e STATIC_LINKING=${STATIC_LINKING} -e STATIC_LIBC=${STATIC_LIBC} -e EMBED_LLVM=${EMBED_LLVM} -e EMBED_CLANG=${EMBED_CLANG} -e EMBED_BCC=${EMBED_BCC} -e EMBED_LIBELF=${EMBED_LIBELF} -e EMBED_LIBCLANG_ONLY=${EMBED_LIBCLANG_ONLY} -e EMBED_BINUTILS=${EMBED_BINUTILS} -e RUN_ALL_TESTS=${RUN_ALL_TESTS} -e CMAKE_EXTRA_FLAGS="${CMAKE_EXTRA_FLAGS}" -e TEST_GROUPS_DISABLE="${TEST_GROUPS_DISABLE}" -e RUNTIME_TEST_DISABLE="${RUNTIME_TEST_DISABLE}" bpftrace-embedded-${{ matrix.env['BASE'] }} $(pwd)/build-embedded ${TYPE} -j`nproc`
+      run: >
+        docker run --privileged
+        -v $(pwd):$(pwd)
+        -w $(pwd)
+        -v /sys/kernel/debug:/sys/kernel/debug:rw
+        -v /lib/modules:/lib/modules:ro
+        -v /usr/src:/usr/src:ro
+        -e STATIC_LINKING=${STATIC_LINKING}
+        -e STATIC_LIBC=${STATIC_LIBC}
+        -e EMBED_LLVM=${EMBED_LLVM}
+        -e EMBED_CLANG=${EMBED_CLANG}
+        -e EMBED_BCC=${EMBED_BCC}
+        -e EMBED_LIBELF=${EMBED_LIBELF}
+        -e EMBED_LIBCLANG_ONLY=${EMBED_LIBCLANG_ONLY}
+        -e EMBED_BINUTILS=${EMBED_BINUTILS}
+        -e RUN_ALL_TESTS=${RUN_ALL_TESTS}
+        -e CMAKE_EXTRA_FLAGS="${CMAKE_EXTRA_FLAGS}"
+        -e TEST_GROUPS_DISABLE="${TEST_GROUPS_DISABLE}"
+        -e RUNTIME_TEST_DISABLE="${RUNTIME_TEST_DISABLE}"
+        bpftrace-embedded-${{ matrix.env['BASE'] }}
+        $(pwd)/build-embedded ${TYPE}
+        -j`nproc`
     - name: Check linked libs
       env: ${{ matrix.env }}
-      run: |
-        docker run --privileged -v $(pwd):$(pwd) -w $(pwd) -v /sys/kernel/debug:/sys/kernel/debug:rw -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -e STATIC_LINKING=${STATIC_LINKING} -e STATIC_LIBC=${STATIC_LIBC} -e EMBED_LLVM=${EMBED_LLVM} -e EMBED_CLANG=${EMBED_CLANG} -e EMBED_BCC=${EMBED_BCC} -e EMBED_LIBELF=${EMBED_LIBELF} -e EMBED_LIBCLANG_ONLY=${EMBED_LIBCLANG_ONLY} -e EMBED_BINUTILS=${EMBED_BINUTILS} --entrypoint /bin/bash bpftrace-embedded-${{ matrix.env['BASE'] }} -c "[[ -f $(pwd)/build-embedded/src/bpftrace ]] && ! readelf --dynamic $(pwd)/build-embedded/src/bpftrace | grep NEEDED | grep -v 'libm\|libc\|ld-linux\|libpthread\|libdl'"
+      run: >
+        docker run --privileged
+        -v $(pwd):$(pwd)
+        -w $(pwd)
+        -v /sys/kernel/debug:/sys/kernel/debug:rw
+        -v /lib/modules:/lib/modules:ro
+        -v /usr/src:/usr/src:ro
+        -e STATIC_LINKING=${STATIC_LINKING}
+        -e STATIC_LIBC=${STATIC_LIBC}
+        -e EMBED_LLVM=${EMBED_LLVM}
+        -e EMBED_CLANG=${EMBED_CLANG}
+        -e EMBED_BCC=${EMBED_BCC}
+        -e EMBED_LIBELF=${EMBED_LIBELF}
+        -e EMBED_LIBCLANG_ONLY=${EMBED_LIBCLANG_ONLY}
+        -e EMBED_BINUTILS=${EMBED_BINUTILS}
+        --entrypoint /bin/bash
+        bpftrace-embedded-${{ matrix.env['BASE'] }}
+        -c "[[ -f $(pwd)/build-embedded/src/bpftrace ]] && ! readelf --dynamic $(pwd)/build-embedded/src/bpftrace | grep NEEDED | grep -v 'libm\|libc\|ld-linux\|libpthread\|libdl'"
     - name: Strip artifacts
       env: ${{ matrix.env }}
       if: matrix.env['TYPE'] == 'Release'
-      run: |
-        docker run --privileged -v $(pwd):$(pwd) -w $(pwd) -v /sys/kernel/debug:/sys/kernel/debug:rw -v /lib/modules:/lib/modules:ro -v /usr/src:/usr/src:ro -e STATIC_LINKING=${STATIC_LINKING} -e STATIC_LIBC=${STATIC_LIBC} -e EMBED_LLVM=${EMBED_LLVM} -e EMBED_CLANG=${EMBED_CLANG} -e EMBED_BCC=${EMBED_BCC} -e EMBED_LIBELF=${EMBED_LIBELF} -e EMBED_LIBCLANG_ONLY=${EMBED_LIBCLANG_ONLY} -e EMBED_BINUTILS=${EMBED_BINUTILS} --entrypoint /bin/bash bpftrace-embedded-${{ matrix.env['BASE'] }} -c "strip --keep-symbol BEGIN_trigger $(pwd)/build-embedded/src/bpftrace"
+      run: >
+        docker run --privileged
+        -v $(pwd):$(pwd)
+        -w $(pwd)
+        -v /sys/kernel/debug:/sys/kernel/debug:rw
+        -v /lib/modules:/lib/modules:ro
+        -v /usr/src:/usr/src:ro
+        -e STATIC_LINKING=${STATIC_LINKING}
+        -e STATIC_LIBC=${STATIC_LIBC}
+        -e EMBED_LLVM=${EMBED_LLVM}
+        -e EMBED_CLANG=${EMBED_CLANG}
+        -e EMBED_BCC=${EMBED_BCC}
+        -e EMBED_LIBELF=${EMBED_LIBELF}
+        -e EMBED_LIBCLANG_ONLY=${EMBED_LIBCLANG_ONLY}
+        -e EMBED_BINUTILS=${EMBED_BINUTILS}
+        --entrypoint /bin/bash
+        bpftrace-embedded-${{ matrix.env['BASE'] }}
+        -c "strip --keep-symbol BEGIN_trigger $(pwd)/build-embedded/src/bpftrace"
 
     - uses: actions/upload-artifact@v1
       with:
@@ -147,11 +205,23 @@ jobs:
         path: build-embedded/tests/bpftrace_test
 
     - name: Authenticate with docker registry
-      if: matrix.env['TYPE'] == 'Release' && github.ref == 'refs/heads/master' && github.repository == 'iovisor/bpftrace'
+      if: >
+        matrix.env['TYPE'] == 'Release' &&
+        github.ref == 'refs/heads/master' &&
+        github.repository == 'iovisor/bpftrace'
       env:
         QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
       run: ./docker/scripts/auth.sh ${{ github.repository }}
 
     - name: Package docker image and push to quay.io
-      if: matrix.env['TYPE'] == 'Release' && github.ref == 'refs/heads/master' && github.repository == 'iovisor/bpftrace'
-      run: ./docker/scripts/push.sh ${{ github.repository }} ${{ github.ref }} ${{ github.sha }} ${{ matrix.env['NAME'] }} ${{ matrix.env['EDGE'] }}
+      if: >
+        matrix.env['TYPE'] == 'Release' &&
+        github.ref == 'refs/heads/master' &&
+        github.repository == 'iovisor/bpftrace'
+      run: >
+        ./docker/scripts/push.sh
+        ${{ github.repository }}
+        ${{ github.ref }}
+        ${{ github.sha }}
+        ${{ matrix.env['NAME'] }}
+        ${{ matrix.env['EDGE'] }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.1] 2020-09-22
+
+Bug fix release for the [Docker build](https://quay.io/repository/iovisor/bpftrace)
+
+### Fixed
+
+- Don't strip END_trigger 
+  - [#1513](https://github.com/iovisor/bpftrace/pull/1513)
+
+
 ## [0.11.0] 2020-07-15
 
 ### All Changes

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(bpftrace)
 # bpftrace version number components.
 set(bpftrace_VERSION_MAJOR 0)
 set(bpftrace_VERSION_MINOR 11)
-set(bpftrace_VERSION_PATCH 0)
+set(bpftrace_VERSION_PATCH 1)
 
 include(GNUInstallDirs)
 


### PR DESCRIPTION
Our quay.io builds had two issues:

- END trigger was broken due to binary stripping
- v0.11.0 was never pushed due to a CI issue

To fix that we need a v0.11.1 release with fixes for both. This means that we won't get all the v0.X images we usually have but I don't think anyone uses them. 

See #1522 for details.

The 0.11_release branch is based on the current v0.11.0 tag.  This PR backports the fixes required for the quay.io image into that branch and prepares for the 0.11.1 release.

After this has been merged we need still need to:

- go through the release process, create a v0.11.1 tag etc
- merge the `v0.11.1 release` commit into master, to keep the changelog in sync
