### PR TITLE
src/attached_probe: fix wrong setting of vmlinux_location.raw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ and this project adheres to
   - [#1457](https://github.com/iovisor/bpftrace/pull/1457)
 - Fix type resolution for struct field access via variables
   - [#1450](https://github.com/iovisor/bpftrace/pull/1450)
+- Fix wrong setting of vmlinux_location.raw when offset kprobe used
+  - [#1530](https://github.com/iovisor/bpftrace/pull/1530)
 
 #### Tools
 - Hook up execsnoop.bt script onto `execveat` call

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -505,7 +505,7 @@ void AttachedProbe::resolve_offset_kprobe(bool safe_mode)
   sym.name = symbol;
   const struct vmlinux_location *locs = vmlinux_locs;
   struct vmlinux_location locs_env[] = {
-    { nullptr, true },
+    { nullptr, false },
     { nullptr, false },
   };
   char *env_path = std::getenv("BPFTRACE_VMLINUX");


### PR DESCRIPTION
find_vmlinux() will skip checking if vmlinux_location.raw is true, and
thus the wrong setting of vmlinux_location.raw in
resolve_offset_kprobe() will always cause the following error when
BPFTRACE_VMLINUX env exists:

"ERROR: Could not resolve symbol XXXXX. Use BPFTRACE_VMLINUX
env variable to specify vmlinux path. Compile bpftrace with
ALLOW_UNSAFE_PROBE option to force skip the check."

Signed-off-by: Jeffle Xu <jefflexu@linux.alibaba.com>

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
