### PR TITLE
Small int prep work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,8 @@ and this project adheres to
   - [#1573](https://github.com/iovisor/bpftrace/pull/1573)
 - Fix a possible integer overflow
   - [#1580](https://github.com/iovisor/bpftrace/pull/1580)
+- Printing of small integers with `printf`
+  - [#1532](https://github.com/iovisor/bpftrace/pull/1532)
 
 #### Tools
 - Hook up execsnoop.bt script onto `execveat` call

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -2618,6 +2618,10 @@ void CodegenLLVM::createFormatStringCall(Call &call, int &id, CallArgs &call_arg
     Value *offset = b_.CreateGEP(fmt_args, {b_.getInt32(0), b_.getInt32(i)});
     if (needMemcpy(arg.type))
       b_.CREATE_MEMCPY(offset, expr_, arg.type.GetSize(), 1);
+    else if (arg.type.IsIntegerTy() && arg.type.GetSize() < 8)
+      b_.CreateStore(
+          b_.CreateIntCast(expr_, b_.getInt64Ty(), arg.type.IsSigned()),
+          offset);
     else
       b_.CreateStore(expr_, offset);
   }

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -89,7 +89,7 @@ void CodegenLLVM::visit(PositionalParameter &param)
 
 void CodegenLLVM::visit(String &string)
 {
-  string.str.resize(string.type.size-1);
+  string.str.resize(string.type.GetSize() - 1);
   Constant *const_str = ConstantDataArray::getString(module_->getContext(), string.str, true);
   AllocaInst *buf = b_.CreateAllocaBPF(string.type, "str");
   b_.CreateStore(const_str, buf);
@@ -191,8 +191,8 @@ void CodegenLLVM::visit(Builtin &builtin)
   {
     AllocaInst *buf = b_.CreateAllocaBPF(builtin.type, "comm");
     // initializing memory needed for older kernels:
-    b_.CREATE_MEMSET(buf, b_.getInt8(0), builtin.type.size, 1);
-    b_.CreateGetCurrentComm(ctx_, buf, builtin.type.size, builtin.loc);
+    b_.CREATE_MEMSET(buf, b_.getInt8(0), builtin.type.GetSize(), 1);
+    b_.CreateGetCurrentComm(ctx_, buf, builtin.type.GetSize(), builtin.loc);
     expr_ = buf;
     expr_deleter_ = [this, buf]() { b_.CreateLifetimeEnd(buf); };
   }
@@ -561,7 +561,7 @@ void CodegenLLVM::visit(Call &call)
     {
       auto &arg = *call.vargs->at(0);
       fixed_buffer_length = arg.type.GetNumElements() *
-                            arg.type.GetElementTy()->size;
+                            arg.type.GetElementTy()->GetSize();
       length = b_.getInt8(fixed_buffer_length);
     }
 
@@ -737,7 +737,7 @@ void CodegenLLVM::visit(Call &call)
     auto inet = call.vargs->at(0);
     if (call.vargs->size() == 1)
     {
-      if (inet->type.IsIntegerTy() || inet->type.size == 4)
+      if (inet->type.IsIntegerTy() || inet->type.GetSize() == 4)
       {
         af_type = b_.getInt64(AF_INET);
       }
@@ -762,7 +762,7 @@ void CodegenLLVM::visit(Call &call)
     {
       b_.CreateProbeRead(ctx_,
                          static_cast<AllocaInst *>(inet_offset),
-                         inet->type.size,
+                         inet->type.GetSize(),
                          expr_,
                          inet->type.GetAS(),
                          call.loc);
@@ -947,7 +947,7 @@ void CodegenLLVM::visit(Call &call)
   }
   else if (call.func == "sizeof")
   {
-    expr_ = b_.getInt64(call.vargs->at(0)->type.size);
+    expr_ = b_.getInt64(call.vargs->at(0)->type.GetSize());
   }
   else if (call.func == "strncmp") {
     uint64_t size = static_cast<Integer *>(call.vargs->at(2))->n;
@@ -1074,7 +1074,8 @@ void CodegenLLVM::binop_string(Binop &binop)
     auto scoped_del_left = accept(binop.left);
     Value *left_string = expr_;
 
-    size_t len = std::min(binop.left->type.size, binop.right->type.size);
+    size_t len = std::min(binop.left->type.GetSize(),
+                          binop.right->type.GetSize());
     expr_ = b_.CreateStrncmp(ctx_,
                              left_string,
                              left_as,
@@ -1108,7 +1109,8 @@ void CodegenLLVM::binop_buf(Binop &binop)
   Value *left_string = expr_;
   auto left_as = binop.left->type.GetAS();
 
-  size_t len = std::min(binop.left->type.size, binop.right->type.size);
+  size_t len = std::min(binop.left->type.GetSize(),
+                        binop.right->type.GetSize());
   expr_ = b_.CreateStrncmp(ctx_,
                            left_string,
                            left_as,
@@ -1425,12 +1427,12 @@ void CodegenLLVM::visit(Ternary &ternary)
     // copy selected string via CreateMemCpy
     b_.SetInsertPoint(left_block);
     auto scoped_del_left = accept(ternary.left);
-    b_.CREATE_MEMCPY(buf, expr_, ternary.type.size, 1);
+    b_.CREATE_MEMCPY(buf, expr_, ternary.type.GetSize(), 1);
     b_.CreateBr(done);
 
     b_.SetInsertPoint(right_block);
     auto scoped_del_right = accept(ternary.right);
-    b_.CREATE_MEMCPY(buf, expr_, ternary.type.size, 1);
+    b_.CREATE_MEMCPY(buf, expr_, ternary.type.GetSize(), 1);
     b_.CreateBr(done);
 
     b_.SetInsertPoint(done);
@@ -1520,7 +1522,7 @@ void CodegenLLVM::visit(FieldAccess &acc)
       AllocaInst *dst = b_.CreateAllocaBPF(field.type,
                                            "internal_" + type.GetName() + "." +
                                                acc.field);
-      b_.CREATE_MEMCPY(dst, src, field.type.size, 1);
+      b_.CREATE_MEMCPY(dst, src, field.type.GetSize(), 1);
       expr_ = dst;
       expr_deleter_ = [this, dst]() { b_.CreateLifetimeEnd(dst); };
     }
@@ -1581,13 +1583,13 @@ void CodegenLLVM::visit(FieldAccess &acc)
         b_.CREATE_MEMCPY_VOLATILE(dst,
                                   b_.CreateIntToPtr(src,
                                                     field_ty->getPointerTo()),
-                                  field.type.size,
+                                  field.type.GetSize(),
                                   1);
       }
       else
       {
         b_.CreateProbeRead(
-            ctx_, dst, field.type.size, src, type.GetAS(), acc.loc);
+            ctx_, dst, field.type.GetSize(), src, type.GetAS(), acc.loc);
       }
       expr_ = dst;
       expr_deleter_ = [this, dst]() { b_.CreateLifetimeEnd(dst); };
@@ -1603,7 +1605,7 @@ void CodegenLLVM::visit(FieldAccess &acc)
         AllocaInst *dst = b_.CreateAllocaBPF(field.type,
                                              type.GetName() + "." + acc.field);
         // memset so verifier doesn't complain about reading uninitialized stack
-        b_.CREATE_MEMSET(dst, b_.getInt8(0), field.type.size, 1);
+        b_.CREATE_MEMSET(dst, b_.getInt8(0), field.type.GetSize(), 1);
         b_.CreateProbeRead(
             ctx_, dst, field.bitfield.read_bytes, src, type.GetAS(), acc.loc);
         raw = b_.CreateLoad(dst);
@@ -1646,7 +1648,7 @@ void CodegenLLVM::visit(FieldAccess &acc)
       AllocaInst *dst = b_.CreateAllocaBPF(field.type,
                                            type.GetName() + "." + acc.field);
       b_.CreateProbeRead(
-          ctx_, dst, field.type.size, src, type.GetAS(), acc.loc);
+          ctx_, dst, field.type.GetSize(), src, type.GetAS(), acc.loc);
       expr_ = b_.CreateIntCast(b_.CreateLoad(dst),
                                b_.getInt64Ty(),
                                field.type.IsSigned());
@@ -1659,7 +1661,7 @@ void CodegenLLVM::visit(ArrayAccess &arr)
 {
   Value *array, *index, *offset;
   SizedType &type = arr.expr->type;
-  size_t element_size = type.GetElementTy()->size;
+  size_t element_size = type.GetElementTy()->GetSize();
 
   auto scoped_del_expr = accept(arr.expr);
   array = expr_;
@@ -1704,8 +1706,10 @@ void CodegenLLVM::visit(Cast &cast)
   auto scoped_del = accept(cast.expr);
   if (cast.type.IsIntTy())
   {
-    expr_ = b_.CreateIntCast(
-        expr_, b_.getIntNTy(8 * cast.type.size), cast.type.IsSigned(), "cast");
+    expr_ = b_.CreateIntCast(expr_,
+                             b_.getIntNTy(8 * cast.type.GetSize()),
+                             cast.type.IsSigned(),
+                             "cast");
   }
 }
 
@@ -1720,7 +1724,7 @@ void CodegenLLVM::compareStructure(SizedType &our_type, llvm::Type *llvm_type)
   // But offset is only used for printing, so we can recover
   // from that by storing the correct offset.
   //
-  size_t our_size = our_type.size;
+  size_t our_size = our_type.GetSize();
   size_t llvm_size = layout_.getTypeAllocSize(llvm_type);
 
   if (llvm_size != our_size)
@@ -1766,7 +1770,7 @@ void CodegenLLVM::visit(Tuple &tuple)
     Value *dst = b_.CreateGEP(buf, { b_.getInt32(0), b_.getInt32(i) });
 
     if (shouldBeOnStackAlready(elem->type))
-      b_.CREATE_MEMCPY(dst, expr_, elem->type.size, 1);
+      b_.CREATE_MEMCPY(dst, expr_, elem->type.GetSize(), 1);
     else
       b_.CreateStore(expr_, dst);
   }
@@ -1809,7 +1813,7 @@ void CodegenLLVM::visit(AssignMapStatement &assignment)
       AllocaInst *dst = b_.CreateAllocaBPF(map.type, map.ident + "_val");
       b_.CreateProbeRead(ctx_,
                          dst,
-                         map.type.size,
+                         map.type.GetSize(),
                          expr,
                          assignment.expr->type.GetAS(),
                          assignment.loc);
@@ -1857,7 +1861,7 @@ void CodegenLLVM::visit(AssignVarStatement &assignment)
 
   if (needMemcpy(var.type))
   {
-    b_.CREATE_MEMCPY(variables_[var.ident], expr_, var.type.size, 1);
+    b_.CREATE_MEMCPY(variables_[var.ident], expr_, var.type.GetSize(), 1);
   }
   else
   {
@@ -2253,7 +2257,7 @@ AllocaInst *CodegenLLVM::getMapKey(Map &map)
       }
       else
       {
-        key = b_.CreateAllocaBPF(expr->type.size, map.ident + "_key");
+        key = b_.CreateAllocaBPF(expr->type.GetSize(), map.ident + "_key");
         b_.CreateStore(
             b_.CreateIntCast(expr_, b_.getInt64Ty(), expr->type.IsSigned()),
             b_.CreatePointerCast(key, expr_->getType()->getPointerTo()));
@@ -2265,7 +2269,7 @@ AllocaInst *CodegenLLVM::getMapKey(Map &map)
       size_t size = 0;
       for (Expression *expr : *map.vargs)
       {
-        size += expr->type.size;
+        size += expr->type.GetSize();
       }
       key = b_.CreateAllocaBPF(size, map.ident + "_key");
 
@@ -2278,7 +2282,7 @@ AllocaInst *CodegenLLVM::getMapKey(Map &map)
             key, { b_.getInt64(0), b_.getInt64(offset) });
 
         if (shouldBeOnStackAlready(expr->type))
-          b_.CREATE_MEMCPY(offset_val, expr_, expr->type.size, 1);
+          b_.CREATE_MEMCPY(offset_val, expr_, expr->type.GetSize(), 1);
         else
         {
           // promote map key to 64-bit:
@@ -2287,7 +2291,7 @@ AllocaInst *CodegenLLVM::getMapKey(Map &map)
               b_.CreatePointerCast(offset_val,
                                    expr_->getType()->getPointerTo()));
         }
-        offset += expr->type.size;
+        offset += expr->type.GetSize();
       }
     }
   }
@@ -2307,7 +2311,7 @@ AllocaInst *CodegenLLVM::getHistMapKey(Map &map, Value *log2)
     size_t size = 8; // Extra space for the bucket value
     for (Expression *expr : *map.vargs)
     {
-      size += expr->type.size;
+      size += expr->type.GetSize();
     }
     key = b_.CreateAllocaBPF(size, map.ident + "_key");
 
@@ -2316,10 +2320,10 @@ AllocaInst *CodegenLLVM::getHistMapKey(Map &map, Value *log2)
       auto scoped_del = accept(expr);
       Value *offset_val = b_.CreateGEP(key, {b_.getInt64(0), b_.getInt64(offset)});
       if (shouldBeOnStackAlready(expr->type))
-        b_.CREATE_MEMCPY(offset_val, expr_, expr->type.size, 1);
+        b_.CREATE_MEMCPY(offset_val, expr_, expr->type.GetSize(), 1);
       else
         b_.CreateStore(expr_, offset_val);
-      offset += expr->type.size;
+      offset += expr->type.GetSize();
     }
     Value *offset_val = b_.CreateGEP(key, {b_.getInt64(0), b_.getInt64(offset)});
     b_.CreateStore(log2, offset_val);
@@ -2613,7 +2617,7 @@ void CodegenLLVM::createFormatStringCall(Call &call, int &id, CallArgs &call_arg
     auto scoped_del = accept(&arg);
     Value *offset = b_.CreateGEP(fmt_args, {b_.getInt32(0), b_.getInt32(i)});
     if (needMemcpy(arg.type))
-      b_.CREATE_MEMCPY(offset, expr_, arg.type.size, 1);
+      b_.CREATE_MEMCPY(offset, expr_, arg.type.GetSize(), 1);
     else
       b_.CreateStore(expr_, offset);
   }
@@ -2673,9 +2677,9 @@ void CodegenLLVM::createPrintNonMapCall(Call &call, int &id)
   auto &arg = *call.vargs->at(0);
   auto scoped_del = accept(&arg);
 
-  auto elements = AsyncEvent::PrintNonMap().asLLVMType(b_, arg.type.size);
+  auto elements = AsyncEvent::PrintNonMap().asLLVMType(b_, arg.type.GetSize());
   std::ostringstream struct_name;
-  struct_name << call.func << "_" << arg.type.type << "_" << arg.type.size
+  struct_name << call.func << "_" << arg.type.type << "_" << arg.type.GetSize()
               << "_t";
   StructType *print_struct = b_.GetStructType(struct_name.str(),
                                               elements,
@@ -2693,9 +2697,9 @@ void CodegenLLVM::createPrintNonMapCall(Call &call, int &id)
 
   // Store content
   Value *content_offset = b_.CreateGEP(buf, { b_.getInt32(0), b_.getInt32(2) });
-  b_.CREATE_MEMSET(content_offset, b_.getInt8(0), arg.type.size, 1);
+  b_.CREATE_MEMSET(content_offset, b_.getInt8(0), arg.type.GetSize(), 1);
   if (needMemcpy(arg.type))
-    b_.CREATE_MEMCPY(content_offset, expr_, arg.type.size, 1);
+    b_.CREATE_MEMCPY(content_offset, expr_, arg.type.GetSize(), 1);
   else
   {
     auto ptr = b_.CreatePointerCast(content_offset,

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -179,7 +179,7 @@ AllocaInst *IRBuilderBPF::CreateAllocaBPFInit(const SizedType &stype, const std:
 
   if (needMemcpy(stype))
   {
-    CREATE_MEMSET(alloca, getInt8(0), stype.size, 1);
+    CREATE_MEMSET(alloca, getInt8(0), stype.GetSize(), 1);
   }
   else
   {
@@ -222,7 +222,7 @@ llvm::Type *IRBuilderBPF::GetType(const SizedType &stype)
   llvm::Type *ty;
   if (stype.IsArray())
   {
-    ty = ArrayType::get(getInt8Ty(), stype.size);
+    ty = ArrayType::get(getInt8Ty(), stype.GetSize());
   }
   else if (stype.IsTupleTy())
   {
@@ -245,11 +245,11 @@ llvm::Type *IRBuilderBPF::GetType(const SizedType &stype)
   }
   else if (stype.IsRecordTy())
   {
-    ty = ArrayType::get(getInt8Ty(), stype.size);
+    ty = ArrayType::get(getInt8Ty(), stype.GetSize());
   }
   else
   {
-    switch (stype.size)
+    switch (stype.GetSize())
     {
       case 16:
         ty = getInt128Ty();
@@ -267,7 +267,8 @@ llvm::Type *IRBuilderBPF::GetType(const SizedType &stype)
         ty = getInt8Ty();
         break;
       default:
-        LOG(FATAL) << stype.size << " is not a valid type size for GetType";
+        LOG(FATAL) << stype.GetSize()
+                   << " is not a valid type size for GetType";
     }
   }
   return ty;
@@ -362,7 +363,7 @@ Value *IRBuilderBPF::CreateMapLookupElem(Value *ctx,
 
   SetInsertPoint(lookup_success_block);
   if (needMemcpy(type))
-    CREATE_MEMCPY(value, call, type.size, 1);
+    CREATE_MEMCPY(value, call, type.GetSize(), 1);
   else
   {
     assert(value->getType()->isPointerTy() &&
@@ -375,7 +376,7 @@ Value *IRBuilderBPF::CreateMapLookupElem(Value *ctx,
 
   SetInsertPoint(lookup_failure_block);
   if (needMemcpy(type))
-    CREATE_MEMSET(value, getInt8(0), type.size, 1);
+    CREATE_MEMSET(value, getInt8(0), type.GetSize(), 1);
   else
     CreateStore(getInt64(0), value);
   CreateHelperError(ctx, getInt32(0), libbpf::BPF_FUNC_map_lookup_elem, loc);

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1605,7 +1605,7 @@ void SemanticAnalyser::visit(Unop &unop)
     }
     else if (type.IsIntTy())
     {
-      unop.type = CreateInteger(8 * type.size, type.IsSigned());
+      unop.type = CreateUInt64();
     }
   }
   else if (unop.op == Parser::token::LNOT) {

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -853,7 +853,9 @@ void SemanticAnalyser::visit(Call &call)
         for (auto iter = call.vargs->begin() + 1; iter != call.vargs->end();
              iter++)
         {
-          auto ty = (*iter)->type;
+          // NOTE: modifying the type will break the resizing that happens
+          // in the codegen. We have to copy the type here to avoid modification
+          SizedType ty = (*iter)->type;
           // Promote to 64-bit if it's not an aggregate type
           if (!ty.IsAggregate() && !ty.IsTimestampTy())
             ty.SetSize(8);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -590,7 +590,7 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
     const SizedType &ty = bpftrace->non_map_print_args_.at(print->print_id);
 
     std::vector<uint8_t> bytes;
-    for (size_t i = 0; i < ty.size; ++i)
+    for (size_t i = 0; i < ty.GetSize(); ++i)
       bytes.emplace_back(reinterpret_cast<uint8_t>(print->content[i]));
 
     bpftrace->out_->value(*bpftrace, ty, bytes);
@@ -718,7 +718,7 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(const std::vec
     switch (arg.type.type)
     {
       case Type::integer:
-        switch (arg.type.size)
+        switch (arg.type.GetSize())
         {
           case 8:
             arg_values.push_back(std::make_unique<PrintableInt>(
@@ -739,14 +739,14 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(const std::vec
           default:
             LOG(FATAL) << "get_arg_values: invalid integer size. 8, 4, 2 and "
                           "byte supported. "
-                       << arg.type.size << "provided";
+                       << arg.type.GetSize() << "provided";
         }
         break;
       case Type::string:
       {
         auto p = reinterpret_cast<char *>(arg_data + arg.offset);
         arg_values.push_back(std::make_unique<PrintableString>(
-            std::string(p, strnlen(p, arg.type.size))));
+            std::string(p, strnlen(p, arg.type.GetSize()))));
         break;
       }
       case Type::buffer:
@@ -1299,7 +1299,7 @@ int BPFtrace::zero_map(IMap &map)
     old_key = key;
   }
 
-  int value_size = map.type_.size * nvalues;
+  int value_size = map.type_.GetSize() * nvalues;
   std::vector<uint8_t> zero(value_size, 0);
   for (auto &key : keys)
   {
@@ -1343,7 +1343,7 @@ std::string BPFtrace::map_value_to_str(const SizedType &stype,
   else if (stype.IsStringTy())
   {
     auto p = reinterpret_cast<const char *>(value.data());
-    return std::string(p, strnlen(p, stype.size));
+    return std::string(p, strnlen(p, stype.GetSize()));
   }
   else if (stype.IsCountTy())
     return std::to_string(reduce_value<uint64_t>(value, nvalues) / div);
@@ -1428,7 +1428,7 @@ int BPFtrace::print_map(IMap &map, uint32_t top, uint32_t div)
 
   while (bpf_get_next_key(map.mapfd_, old_key.data(), key.data()) == 0)
   {
-    int value_size = map.type_.size;
+    int value_size = map.type_.GetSize();
     value_size *= nvalues;
     auto value = std::vector<uint8_t>(value_size);
     int err = bpf_lookup_elem(map.mapfd_, key.data(), value.data());
@@ -1515,7 +1515,7 @@ int BPFtrace::print_map_hist(IMap &map, uint32_t top, uint32_t div)
     for (size_t i=0; i<map.key_.size(); i++)
       key_prefix.at(i) = key.at(i);
 
-    int value_size = map.type_.size * nvalues;
+    int value_size = map.type_.GetSize() * nvalues;
     auto value = std::vector<uint8_t>(value_size);
     int err = bpf_lookup_elem(map.mapfd_, key.data(), value.data());
     if (err == -1)
@@ -1594,7 +1594,7 @@ int BPFtrace::print_map_stats(IMap &map, uint32_t top, uint32_t div)
     for (size_t i=0; i<map.key_.size(); i++)
       key_prefix.at(i) = key.at(i);
 
-    int value_size = map.type_.size * nvalues;
+    int value_size = map.type_.GetSize() * nvalues;
     auto value = std::vector<uint8_t>(value_size);
     int err = bpf_lookup_elem(map.mapfd_, key.data(), value.data());
     if (err == -1)
@@ -1700,7 +1700,7 @@ std::vector<uint8_t> BPFtrace::find_empty_key(IMap &map, size_t size) const
   if (size == 0) size = 8;
   auto key = std::vector<uint8_t>(size);
   uint32_t nvalues = map.is_per_cpu_type() ? ncpus_ : 1;
-  int value_size = map.type_.size * nvalues;
+  int value_size = map.type_.GetSize() * nvalues;
   auto value = std::vector<uint8_t>(value_size);
 
   if (bpf_lookup_elem(map.mapfd_, key.data(), value.data()))
@@ -2126,7 +2126,7 @@ void BPFtrace::sort_by_key(std::vector<SizedType> key_args,
   int arg_offset = 0;
   for (auto arg : key_args)
   {
-    arg_offset += arg.size;
+    arg_offset += arg.GetSize();
   }
 
   // Sort the key arguments in reverse order so the results are sorted by
@@ -2134,11 +2134,11 @@ void BPFtrace::sort_by_key(std::vector<SizedType> key_args,
   for (size_t i=key_args.size(); i-- > 0; )
   {
     auto arg = key_args.at(i);
-    arg_offset -= arg.size;
+    arg_offset -= arg.GetSize();
 
     if (arg.IsIntTy())
     {
-      if (arg.size == 8)
+      if (arg.GetSize() == 8)
       {
         std::stable_sort(
             values_by_key.begin(), values_by_key.end(), [&](auto &a, auto &b) {
@@ -2147,7 +2147,7 @@ void BPFtrace::sort_by_key(std::vector<SizedType> key_args,
               return va < vb;
             });
       }
-      else if (arg.size == 4)
+      else if (arg.GetSize() == 4)
       {
         std::stable_sort(
             values_by_key.begin(), values_by_key.end(), [&](auto &a, auto &b) {
@@ -2159,7 +2159,7 @@ void BPFtrace::sort_by_key(std::vector<SizedType> key_args,
       else
       {
         LOG(FATAL) << "invalid integer argument size. 4 or 8  expected, but "
-                   << arg.size << " provided";
+                   << arg.GetSize() << " provided";
       }
 
     }
@@ -2169,7 +2169,7 @@ void BPFtrace::sort_by_key(std::vector<SizedType> key_args,
           values_by_key.begin(), values_by_key.end(), [&](auto &a, auto &b) {
             return strncmp((const char *)(a.first.data() + arg_offset),
                            (const char *)(b.first.data() + arg_offset),
-                           arg.size) < 0;
+                           arg.GetSize()) < 0;
           });
     }
 

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -59,7 +59,7 @@ Map::Map(const std::string &name, const SizedType &type, const MapKey &key, int 
   else
     map_type_ = BPF_MAP_TYPE_HASH;
 
-  int value_size = type.size;
+  int value_size = type.GetSize();
   int flags = 0;
   mapfd_ = create_map(map_type_, name.c_str(), key_size, value_size, max_entries, flags);
   if (mapfd_ < 0)

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -17,7 +17,7 @@ size_t MapKey::size() const
 {
   size_t size = 0;
   for (auto &arg : args_)
-    size += arg.size;
+    size += arg.GetSize();
   return size;
 }
 
@@ -43,7 +43,7 @@ std::vector<std::string> MapKey::argument_value_list(BPFtrace &bpftrace,
   for (const SizedType &arg : args_)
   {
     list.push_back(argument_value(bpftrace, arg, &data[offset]));
-    offset += arg.size;
+    offset += arg.GetSize();
   }
   return list;
 }
@@ -65,7 +65,7 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
   switch (arg.type)
   {
     case Type::integer:
-      switch (arg.size)
+      switch (arg.GetSize())
       {
         case 1:
           return std::to_string(read_data<int8_t>(data));
@@ -105,12 +105,12 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
     case Type::string:
     {
       auto p = static_cast<const char *>(data);
-      return std::string(p, strnlen(p, arg.size));
+      return std::string(p, strnlen(p, arg.GetSize()));
     }
     case Type::buffer:
     {
       auto p = static_cast<const char *>(data) + 1;
-      return hex_format_buffer(p, arg.size - 1);
+      return hex_format_buffer(p, arg.GetSize() - 1);
     }
     case Type::pointer:
     {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -361,14 +361,15 @@ std::string TextOutput::tuple_to_str(BPFtrace &bpftrace,
       ret += ", ";
 
     std::vector<uint8_t> elem_value(value.begin() + offset,
-                                    value.begin() + offset + elemtype.size);
+                                    value.begin() + offset +
+                                        elemtype.GetSize());
 
     if (elemtype.type == Type::tuple)
       ret += tuple_to_str(bpftrace, elemtype, elem_value);
     else
       ret += bpftrace.map_value_to_str(elemtype, elem_value, false, 1);
 
-    offset += elemtype.size;
+    offset += elemtype.GetSize();
   }
 
   ret += ')';
@@ -699,7 +700,8 @@ std::string JsonOutput::tuple_to_str(BPFtrace &bpftrace,
       ret += ',';
 
     std::vector<uint8_t> elem_value(value.begin() + offset,
-                                    value.begin() + offset + elemtype.size);
+                                    value.begin() + offset +
+                                        elemtype.GetSize());
 
     if (elemtype.type == Type::tuple)
       ret += tuple_to_str(bpftrace, elemtype, elem_value);

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -69,19 +69,23 @@ std::string verify_format_string(const std::string &fmt, std::vector<Field> args
   return "";
 }
 
-uint64_t PrintableString::value()
+int PrintableString::print(char *buf, size_t size, const char *fmt)
 {
-  return (uint64_t)value_.c_str();
+  return snprintf(buf, size, fmt, value_.c_str());
 }
 
-uint64_t PrintableCString::value()
+int PrintableCString::print(char *buf, size_t size, const char *fmt)
 {
-  return (uint64_t)value_;
+  return snprintf(buf, size, fmt, value_);
 }
 
-uint64_t PrintableInt::value()
+int PrintableInt::print(char *buf, size_t size, const char *fmt)
 {
-  return value_;
+  return snprintf(buf, size, fmt, value_);
 }
 
+int PrintableSInt::print(char *buf, size_t size, const char *fmt)
+{
+  return snprintf(buf, size, fmt, value_);
+}
 } // namespace bpftrace

--- a/src/printf.h
+++ b/src/printf.h
@@ -31,14 +31,14 @@ class IPrintable
 {
 public:
   virtual ~IPrintable() { };
-  virtual uint64_t value() = 0;
+  virtual int print(char* buf, size_t size, const char* fmt) = 0;
 };
 
 class PrintableString : public virtual IPrintable
 {
 public:
   PrintableString(std::string value) : value_(std::move(value)) { }
-  uint64_t value();
+  int print(char* buf, size_t size, const char* fmt) override;
 
 private:
   std::string value_;
@@ -48,7 +48,7 @@ class PrintableCString : public virtual IPrintable
 {
 public:
   PrintableCString(char* value) : value_(value) { }
-  uint64_t value();
+  int print(char* buf, size_t size, const char* fmt) override;
 
 private:
   char* value_;
@@ -58,10 +58,22 @@ class PrintableInt : public virtual IPrintable
 {
 public:
   PrintableInt(uint64_t value) : value_(value) { }
-  uint64_t value();
+  int print(char* buf, size_t size, const char* fmt) override;
 
 private:
   uint64_t value_;
+};
+
+class PrintableSInt : public virtual IPrintable
+{
+public:
+  PrintableSInt(int64_t value) : value_(value)
+  {
+  }
+  int print(char* buf, size_t size, const char* fmt) override;
+
+private:
+  int64_t value_;
 };
 
 } // namespace bpftrace

--- a/src/struct.cpp
+++ b/src/struct.cpp
@@ -24,7 +24,7 @@ std::unique_ptr<Tuple> Tuple::Create(std::vector<SizedType> fields)
   {
     auto align = field.GetAlignment();
     struct_align = std::max(align, struct_align);
-    auto size = field.size;
+    auto size = field.GetSize();
 
     auto padding = (align - (offset % align)) % align;
     if (padding)
@@ -71,7 +71,7 @@ void Tuple::Dump(std::ostream &os)
       prefix(offset, os) << pad(delta) << std::endl;
     }
     prefix(offset + delta, os) << field.type << std::endl;
-    offset = field.offset + field.type.size;
+    offset = field.offset + field.type.GetSize();
   }
   os << "} sizeof: [" << size << "]" << std::endl;
 }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -40,7 +40,7 @@ std::ostream &operator<<(std::ostream &os, const SizedType &type)
   }
   else if (type.IsIntTy())
   {
-    os << (type.is_signed_ ? "" : "unsigned ") << "int" << 8 * type.size;
+    os << (type.is_signed_ ? "" : "unsigned ") << "int" << 8 * type.GetSize();
   }
   else if (type.IsArrayTy())
   {
@@ -48,7 +48,7 @@ std::ostream &operator<<(std::ostream &os, const SizedType &type)
   }
   else if (type.IsStringTy() || type.IsBufferTy())
   {
-    os << type.type << "[" << type.size << "]";
+    os << type.type << "[" << type.GetSize() << "]";
   }
   else if (type.IsTupleTy())
   {
@@ -90,12 +90,13 @@ bool SizedType::IsEqual(const SizedType &t) const
     return false;
 
   if (IsRecordTy())
-    return t.GetName() == GetName() && t.size == size;
+    return t.GetName() == GetName() && t.GetSize() == GetSize();
 
   if (IsPtrTy())
     return *t.GetPointeeTy() == *GetPointeeTy();
 
-  return type == t.type && size == t.size && is_signed_ == t.is_signed_;
+  return type == t.type && GetSize() == t.GetSize() &&
+         is_signed_ == t.is_signed_;
 }
 
 bool SizedType::operator!=(const SizedType &t) const
@@ -440,7 +441,7 @@ SizedType CreateTuple(const std::vector<SizedType> &fields)
 {
   auto s = SizedType(Type::tuple, 0);
   s.tuple_fields = Tuple::Create(fields);
-  s.size = s.tuple_fields->size;
+  s.size_ = s.tuple_fields->size;
   return s;
 }
 
@@ -483,9 +484,9 @@ ssize_t SizedType::GetAlignment() const
   if (IsTupleTy())
     return tuple_fields->align;
 
-  if (size <= 2)
-    return size;
-  else if (size <= 4)
+  if (GetSize() <= 2)
+    return GetSize();
+  else if (GetSize() <= 4)
     return 4;
   else
     return 8;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -249,7 +249,7 @@ SizedType CreateInteger(size_t bits, bool is_signed)
   assert(bits == 0 || bits == 1 || bits == 8 || bits == 16 || bits == 32 ||
          bits == 64);
   auto t = SizedType(Type::integer, bits / 8, is_signed);
-  t.size_bits = bits;
+  t.size_bits_ = bits;
   return t;
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -80,17 +80,18 @@ struct Field;
 class SizedType
 {
 public:
-  SizedType() : type(Type::none), size(0) { }
-  SizedType(Type type, size_t size_, bool is_signed)
-      : type(type), size(size_), is_signed_(is_signed)
+  SizedType() : type(Type::none), size_(0)
   {
   }
-  SizedType(Type type, size_t size_) : type(type), size(size_)
+  SizedType(Type type, size_t size_, bool is_signed)
+      : type(type), size_(size_), is_signed_(is_signed)
+  {
+  }
+  SizedType(Type type, size_t size_) : type(type), size_(size_)
   {
   }
 
   Type type;
-  size_t size;                 // in bytes
   StackType stack_type;
   bool is_internal = false;
   bool is_tparg = false;
@@ -98,6 +99,7 @@ public:
   int kfarg_idx = -1;
 
 private:
+  size_t size_; // in bytes
   bool is_signed_ = false;
   SizedType *element_type_ = nullptr; // for "container" and pointer
                                       // (like) types
@@ -165,6 +167,22 @@ public:
 
   bool IsSigned(void) const;
 
+  size_t GetSize() const
+  {
+    return size_;
+  }
+
+  void SetSize(size_t size)
+  {
+    size_ = size;
+    if (IsIntTy())
+    {
+      assert(size == 0 || size == 1 || size == 8 || size == 16 || size == 32 ||
+             size == 64);
+      size_bits_ = size * 8;
+    }
+  }
+
   size_t GetIntBitWidth() const
   {
     assert(IsIntTy());
@@ -174,7 +192,7 @@ public:
   size_t GetNumElements() const
   {
     assert(IsArrayTy() || IsStringTy());
-    return size;
+    return size_;
   };
 
   const std::string GetName() const

--- a/src/types.h
+++ b/src/types.h
@@ -105,7 +105,7 @@ private:
   std::string name_; // name of this type, for named types like struct
   bool ctx_ = false; // Is bpf program context
   AddrSpace as_ = AddrSpace::none;
-  ssize_t size_bits; // size in bits for integer types
+  ssize_t size_bits_; // size in bits for integer types
 
   std::shared_ptr<Tuple> tuple_fields; // tuple fields
 
@@ -168,7 +168,7 @@ public:
   size_t GetIntBitWidth() const
   {
     assert(IsIntTy());
-    return size_bits;
+    return size_bits_;
   };
 
   size_t GetNumElements() const
@@ -197,7 +197,7 @@ public:
 
   bool IsBoolTy() const
   {
-    return type == Type::integer && size_bits == 1;
+    return type == Type::integer && size_bits_ == 1;
   };
   bool IsPtrTy() const
   {

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -43,15 +43,15 @@ TEST(clang_parser, integers)
   ASSERT_EQ(structs["struct Foo"].fields.count("z"), 1U);
 
   EXPECT_EQ(structs["struct Foo"].fields["x"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["x"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["x"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Foo"].fields["x"].offset, 0);
 
   EXPECT_EQ(structs["struct Foo"].fields["y"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["y"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["y"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Foo"].fields["y"].offset, 4);
 
   EXPECT_EQ(structs["struct Foo"].fields["z"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["z"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["z"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Foo"].fields["z"].offset, 8);
 }
 
@@ -73,19 +73,19 @@ TEST(clang_parser, c_union)
   ASSERT_EQ(structs["union Foo"].fields.count("l"), 1U);
 
   EXPECT_EQ(structs["union Foo"].fields["c"].type.type, Type::integer);
-  EXPECT_EQ(structs["union Foo"].fields["c"].type.size, 1U);
+  EXPECT_EQ(structs["union Foo"].fields["c"].type.GetSize(), 1U);
   EXPECT_EQ(structs["union Foo"].fields["c"].offset, 0);
 
   EXPECT_EQ(structs["union Foo"].fields["s"].type.type, Type::integer);
-  EXPECT_EQ(structs["union Foo"].fields["s"].type.size, 2U);
+  EXPECT_EQ(structs["union Foo"].fields["s"].type.GetSize(), 2U);
   EXPECT_EQ(structs["union Foo"].fields["s"].offset, 0);
 
   EXPECT_EQ(structs["union Foo"].fields["i"].type.type, Type::integer);
-  EXPECT_EQ(structs["union Foo"].fields["i"].type.size, 4U);
+  EXPECT_EQ(structs["union Foo"].fields["i"].type.GetSize(), 4U);
   EXPECT_EQ(structs["union Foo"].fields["i"].offset, 0);
 
   EXPECT_EQ(structs["union Foo"].fields["l"].type.type, Type::integer);
-  EXPECT_EQ(structs["union Foo"].fields["l"].type.size, 8U);
+  EXPECT_EQ(structs["union Foo"].fields["l"].type.GetSize(), 8U);
   EXPECT_EQ(structs["union Foo"].fields["l"].offset, 0);
 }
 
@@ -104,7 +104,7 @@ TEST(clang_parser, c_enum)
   ASSERT_EQ(structs["struct Foo"].fields.count("e"), 1U);
 
   EXPECT_EQ(structs["struct Foo"].fields["e"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["e"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["e"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Foo"].fields["e"].offset, 0);
 }
 
@@ -165,7 +165,7 @@ TEST(clang_parser, string_array)
   ASSERT_EQ(structs["struct Foo"].fields.count("str"), 1U);
 
   EXPECT_EQ(structs["struct Foo"].fields["str"].type.type, Type::string);
-  EXPECT_EQ(structs["struct Foo"].fields["str"].type.size, 32U);
+  EXPECT_EQ(structs["struct Foo"].fields["str"].type.GetSize(), 32U);
   EXPECT_EQ(structs["struct Foo"].fields["str"].offset, 0);
 }
 
@@ -187,7 +187,7 @@ TEST(clang_parser, nested_struct_named)
   auto &bar = structs["struct Foo"].fields["bar"];
   EXPECT_TRUE(bar.type.IsRecordTy());
   EXPECT_EQ(bar.type.GetName(), "struct Bar");
-  EXPECT_EQ(bar.type.size, 4U);
+  EXPECT_EQ(bar.type.GetSize(), 4U);
   EXPECT_EQ(bar.offset, 0);
 }
 
@@ -210,7 +210,7 @@ TEST(clang_parser, nested_struct_ptr_named)
   EXPECT_TRUE(bar.type.IsPtrTy());
   EXPECT_TRUE(bar.type.GetPointeeTy()->IsRecordTy());
   EXPECT_EQ(bar.type.GetPointeeTy()->GetName(), "struct Bar");
-  EXPECT_EQ(bar.type.GetPointeeTy()->size, sizeof(int));
+  EXPECT_EQ(bar.type.GetPointeeTy()->GetSize(), sizeof(int));
   EXPECT_EQ(bar.offset, 0);
 }
 
@@ -240,7 +240,7 @@ TEST(clang_parser, nested_struct_no_type)
   ASSERT_EQ(structs[bar].fields.count("x"), 1U);
 
   EXPECT_EQ(structs[bar].fields["x"].type.type, Type::integer);
-  EXPECT_EQ(structs[bar].fields["x"].type.size, 4U);
+  EXPECT_EQ(structs[bar].fields["x"].type.GetSize(), 4U);
   EXPECT_EQ(structs[bar].fields["x"].offset, 0);
 
   EXPECT_EQ(structs[baz].size, 4);
@@ -248,18 +248,18 @@ TEST(clang_parser, nested_struct_no_type)
   ASSERT_EQ(structs[baz].fields.count("y"), 1U);
 
   EXPECT_EQ(structs[baz].fields["y"].type.type, Type::integer);
-  EXPECT_EQ(structs[baz].fields["y"].type.size, 4U);
+  EXPECT_EQ(structs[baz].fields["y"].type.GetSize(), 4U);
   EXPECT_EQ(structs[baz].fields["y"].offset, 0);
 
   {
     auto &bar = structs["struct Foo"].fields["bar"];
     EXPECT_TRUE(bar.type.IsRecordTy());
-    EXPECT_EQ(bar.type.size, sizeof(int));
+    EXPECT_EQ(bar.type.GetSize(), sizeof(int));
     EXPECT_EQ(bar.offset, 0);
 
     auto &baz = structs["struct Foo"].fields["baz"];
     EXPECT_TRUE(baz.type.IsRecordTy());
-    EXPECT_EQ(baz.type.size, sizeof(int));
+    EXPECT_EQ(baz.type.GetSize(), sizeof(int));
     EXPECT_EQ(baz.offset, 4);
   }
 }
@@ -288,13 +288,13 @@ TEST(clang_parser, nested_struct_unnamed_fields)
   ASSERT_EQ(structs["struct Foo"].fields.count("a"), 1U);
 
   EXPECT_EQ(structs["struct Foo"].fields["x"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["x"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["x"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Foo"].fields["x"].offset, 0);
   EXPECT_EQ(structs["struct Foo"].fields["y"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["y"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["y"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Foo"].fields["y"].offset, 4);
   EXPECT_EQ(structs["struct Foo"].fields["a"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["a"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Foo"].fields["a"].offset, 8);
 
 
@@ -303,7 +303,7 @@ TEST(clang_parser, nested_struct_unnamed_fields)
   EXPECT_EQ(structs["struct Bar"].fields.count("z"), 1U);
 
   EXPECT_EQ(structs["struct Bar"].fields["z"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Bar"].fields["z"].type.size, 4U);
+  EXPECT_EQ(structs["struct Bar"].fields["z"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Bar"].fields["z"].offset, 0);
 }
 
@@ -336,23 +336,23 @@ TEST(clang_parser, nested_struct_anon_union_struct)
   ASSERT_EQ(structs["struct Foo"].fields.count("z"), 1U);
 
   EXPECT_EQ(structs["struct Foo"].fields["_xy"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["_xy"].type.size, 8U);
+  EXPECT_EQ(structs["struct Foo"].fields["_xy"].type.GetSize(), 8U);
   EXPECT_EQ(structs["struct Foo"].fields["_xy"].offset, 0);
 
   EXPECT_EQ(structs["struct Foo"].fields["x"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["x"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["x"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Foo"].fields["x"].offset, 0);
 
   EXPECT_EQ(structs["struct Foo"].fields["y"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["y"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["y"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Foo"].fields["y"].offset, 4);
 
   EXPECT_EQ(structs["struct Foo"].fields["a"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["a"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Foo"].fields["a"].offset, 8);
 
   EXPECT_EQ(structs["struct Foo"].fields["z"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["z"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["z"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Foo"].fields["z"].offset, 12);
 }
 
@@ -373,7 +373,7 @@ TEST(clang_parser, bitfields)
   ASSERT_EQ(structs["struct Foo"].fields.count("c"), 1U);
 
   EXPECT_EQ(structs["struct Foo"].fields["a"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["a"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Foo"].fields["a"].offset, 0);
   EXPECT_TRUE(structs["struct Foo"].fields["a"].is_bitfield);
   EXPECT_EQ(structs["struct Foo"].fields["a"].bitfield.read_bytes, 0x1U);
@@ -381,7 +381,7 @@ TEST(clang_parser, bitfields)
   EXPECT_EQ(structs["struct Foo"].fields["a"].bitfield.mask, 0xFFU);
 
   EXPECT_EQ(structs["struct Foo"].fields["b"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["b"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["b"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Foo"].fields["b"].offset, 1);
   EXPECT_TRUE(structs["struct Foo"].fields["b"].is_bitfield);
   EXPECT_EQ(structs["struct Foo"].fields["b"].bitfield.read_bytes, 0x1U);
@@ -389,7 +389,7 @@ TEST(clang_parser, bitfields)
   EXPECT_EQ(structs["struct Foo"].fields["b"].bitfield.mask, 0xFFU);
 
   EXPECT_EQ(structs["struct Foo"].fields["c"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["c"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["c"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Foo"].fields["c"].offset, 2);
   EXPECT_TRUE(structs["struct Foo"].fields["c"].is_bitfield);
   EXPECT_EQ(structs["struct Foo"].fields["c"].bitfield.read_bytes, 0x2U);
@@ -416,7 +416,7 @@ TEST(clang_parser, bitfields_uneven_fields)
   ASSERT_EQ(structs["struct Foo"].fields.count("e"), 1U);
 
   EXPECT_EQ(structs["struct Foo"].fields["a"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["a"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Foo"].fields["a"].offset, 0);
   EXPECT_TRUE(structs["struct Foo"].fields["a"].is_bitfield);
   EXPECT_EQ(structs["struct Foo"].fields["a"].bitfield.read_bytes, 1U);
@@ -424,7 +424,7 @@ TEST(clang_parser, bitfields_uneven_fields)
   EXPECT_EQ(structs["struct Foo"].fields["a"].bitfield.mask, 0x1U);
 
   EXPECT_EQ(structs["struct Foo"].fields["b"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["b"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["b"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Foo"].fields["b"].offset, 0);
   EXPECT_TRUE(structs["struct Foo"].fields["b"].is_bitfield);
   EXPECT_EQ(structs["struct Foo"].fields["b"].bitfield.read_bytes, 1U);
@@ -432,7 +432,7 @@ TEST(clang_parser, bitfields_uneven_fields)
   EXPECT_EQ(structs["struct Foo"].fields["b"].bitfield.mask, 0x1U);
 
   EXPECT_EQ(structs["struct Foo"].fields["c"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["c"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["c"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Foo"].fields["c"].offset, 0);
   EXPECT_TRUE(structs["struct Foo"].fields["c"].is_bitfield);
   EXPECT_EQ(structs["struct Foo"].fields["c"].bitfield.read_bytes, 1U);
@@ -440,7 +440,7 @@ TEST(clang_parser, bitfields_uneven_fields)
   EXPECT_EQ(structs["struct Foo"].fields["c"].bitfield.mask, 0x7U);
 
   EXPECT_EQ(structs["struct Foo"].fields["d"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["d"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["d"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Foo"].fields["d"].offset, 0);
   EXPECT_TRUE(structs["struct Foo"].fields["d"].is_bitfield);
   EXPECT_EQ(structs["struct Foo"].fields["d"].bitfield.read_bytes, 4U);
@@ -448,7 +448,7 @@ TEST(clang_parser, bitfields_uneven_fields)
   EXPECT_EQ(structs["struct Foo"].fields["d"].bitfield.mask, 0xFFFFFU);
 
   EXPECT_EQ(structs["struct Foo"].fields["e"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["e"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["e"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Foo"].fields["e"].offset, 3);
   EXPECT_TRUE(structs["struct Foo"].fields["e"].is_bitfield);
   EXPECT_EQ(structs["struct Foo"].fields["e"].bitfield.read_bytes, 1U);
@@ -474,7 +474,7 @@ TEST(clang_parser, bitfields_with_padding)
   ASSERT_EQ(structs["struct Foo"].fields.count("end"), 1U);
 
   EXPECT_EQ(structs["struct Foo"].fields["a"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["a"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["a"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Foo"].fields["a"].offset, 4);
   EXPECT_TRUE(structs["struct Foo"].fields["a"].is_bitfield);
   EXPECT_EQ(structs["struct Foo"].fields["a"].bitfield.read_bytes, 4U);
@@ -482,7 +482,7 @@ TEST(clang_parser, bitfields_with_padding)
   EXPECT_EQ(structs["struct Foo"].fields["a"].bitfield.mask, 0xFFFFFFFU);
 
   EXPECT_EQ(structs["struct Foo"].fields["b"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["b"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo"].fields["b"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Foo"].fields["b"].offset, 7);
   EXPECT_TRUE(structs["struct Foo"].fields["b"].is_bitfield);
   EXPECT_EQ(structs["struct Foo"].fields["b"].bitfield.read_bytes, 1U);
@@ -507,15 +507,15 @@ TEST(clang_parser, builtin_headers)
   ASSERT_EQ(structs["struct Foo"].fields.count("z"), 1U);
 
   EXPECT_EQ(structs["struct Foo"].fields["x"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["x"].type.size, 8U);
+  EXPECT_EQ(structs["struct Foo"].fields["x"].type.GetSize(), 8U);
   EXPECT_EQ(structs["struct Foo"].fields["x"].offset, 0);
 
   EXPECT_EQ(structs["struct Foo"].fields["y"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["y"].type.size, 8U);
+  EXPECT_EQ(structs["struct Foo"].fields["y"].type.GetSize(), 8U);
   EXPECT_EQ(structs["struct Foo"].fields["y"].offset, 8);
 
   EXPECT_EQ(structs["struct Foo"].fields["z"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["z"].type.size, 8U);
+  EXPECT_EQ(structs["struct Foo"].fields["z"].type.GetSize(), 8U);
   EXPECT_EQ(structs["struct Foo"].fields["z"].offset, 16);
 }
 
@@ -572,15 +572,15 @@ TEST_F(clang_parser_btf, btf)
   ASSERT_EQ(structs["struct Foo1"].fields.count("c"), 1U);
 
   EXPECT_EQ(structs["struct Foo1"].fields["a"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo1"].fields["a"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo1"].fields["a"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Foo1"].fields["a"].offset, 0);
 
   EXPECT_EQ(structs["struct Foo1"].fields["b"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo1"].fields["b"].type.size, 1U);
+  EXPECT_EQ(structs["struct Foo1"].fields["b"].type.GetSize(), 1U);
   EXPECT_EQ(structs["struct Foo1"].fields["b"].offset, 4);
 
   EXPECT_EQ(structs["struct Foo1"].fields["c"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo1"].fields["c"].type.size, 8U);
+  EXPECT_EQ(structs["struct Foo1"].fields["c"].type.GetSize(), 8U);
   EXPECT_EQ(structs["struct Foo1"].fields["c"].offset, 8);
 
   EXPECT_EQ(structs["struct Foo2"].size, 24);
@@ -590,15 +590,15 @@ TEST_F(clang_parser_btf, btf)
   ASSERT_EQ(structs["struct Foo2"].fields.count("g"), 1U);
 
   EXPECT_EQ(structs["struct Foo2"].fields["a"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo2"].fields["a"].type.size, 4U);
+  EXPECT_EQ(structs["struct Foo2"].fields["a"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct Foo2"].fields["a"].offset, 0);
 
   EXPECT_EQ(structs["struct Foo2"].fields["f"].type.type, Type::record);
-  EXPECT_EQ(structs["struct Foo2"].fields["f"].type.size, 16U);
+  EXPECT_EQ(structs["struct Foo2"].fields["f"].type.GetSize(), 16U);
   EXPECT_EQ(structs["struct Foo2"].fields["f"].offset, 8);
 
   EXPECT_EQ(structs["struct Foo2"].fields["g"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo2"].fields["g"].type.size, 1U);
+  EXPECT_EQ(structs["struct Foo2"].fields["g"].type.GetSize(), 1U);
   EXPECT_EQ(structs["struct Foo2"].fields["g"].offset, 8);
 
   EXPECT_EQ(structs["struct Foo3"].size, 16);
@@ -673,7 +673,7 @@ TEST(clang_parser, btf_unresolved_typedef)
   ASSERT_EQ(structs["struct Foo"].fields.count("x"), 1U);
 
   EXPECT_EQ(structs["struct Foo"].fields["x"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct Foo"].fields["x"].type.size, 8U);
+  EXPECT_EQ(structs["struct Foo"].fields["x"].type.GetSize(), 8U);
   EXPECT_EQ(structs["struct Foo"].fields["x"].offset, 0);
 }
 #endif // HAVE_LIBBPF_BTF_DUMP
@@ -698,7 +698,7 @@ TEST(clang_parser, struct_typedef)
   ASSERT_EQ(structs["struct max_align_t"].fields.count("x"), 1U);
 
   EXPECT_EQ(structs["struct max_align_t"].fields["x"].type.type, Type::integer);
-  EXPECT_EQ(structs["struct max_align_t"].fields["x"].type.size, 4U);
+  EXPECT_EQ(structs["struct max_align_t"].fields["x"].type.GetSize(), 4U);
   EXPECT_EQ(structs["struct max_align_t"].fields["x"].offset, 0);
 
   // typedef'd struct (defined in __stddef_max_align_t.h builtin header)
@@ -708,12 +708,16 @@ TEST(clang_parser, struct_typedef)
   ASSERT_EQ(structs["max_align_t"].fields.count("__clang_max_align_nonce2"), 1U);
 
   EXPECT_EQ(structs["max_align_t"].fields["__clang_max_align_nonce1"].type.type, Type::integer);
-  EXPECT_EQ(structs["max_align_t"].fields["__clang_max_align_nonce1"].type.size, 8U);
+  EXPECT_EQ(
+      structs["max_align_t"].fields["__clang_max_align_nonce1"].type.GetSize(),
+      8U);
   EXPECT_EQ(structs["max_align_t"].fields["__clang_max_align_nonce1"].offset, 0);
 
   // double are not parsed correctly yet so these fields are junk for now
   EXPECT_EQ(structs["max_align_t"].fields["__clang_max_align_nonce2"].type.type, Type::none);
-  EXPECT_EQ(structs["max_align_t"].fields["__clang_max_align_nonce2"].type.size, 0U);
+  EXPECT_EQ(
+      structs["max_align_t"].fields["__clang_max_align_nonce2"].type.GetSize(),
+      0U);
   EXPECT_EQ(structs["max_align_t"].fields["__clang_max_align_nonce2"].offset, 16);
 }
 

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -94,19 +94,19 @@ TEST(codegen, printf_offsets)
   // Note that scalar types are promoted to 64-bits when put into
   // a perf event buffer
   EXPECT_EQ(args[0].type.type, Type::integer);
-  EXPECT_EQ(args[0].type.size, 8U);
+  EXPECT_EQ(args[0].type.GetSize(), 8U);
   EXPECT_EQ(args[0].offset, 8);
 
   EXPECT_EQ(args[1].type.type, Type::integer);
-  EXPECT_EQ(args[1].type.size, 8U);
+  EXPECT_EQ(args[1].type.GetSize(), 8U);
   EXPECT_EQ(args[1].offset, 16);
 
   EXPECT_EQ(args[2].type.type, Type::string);
-  EXPECT_EQ(args[2].type.size, 10U);
+  EXPECT_EQ(args[2].type.GetSize(), 10U);
   EXPECT_EQ(args[2].offset, 24);
 
   EXPECT_EQ(args[3].type.type, Type::integer);
-  EXPECT_EQ(args[3].type.size, 8U);
+  EXPECT_EQ(args[3].type.GetSize(), 8U);
   EXPECT_EQ(args[3].offset, 40);
 }
 

--- a/tests/runtime/signed_ints
+++ b/tests/runtime/signed_ints
@@ -27,3 +27,8 @@ NAME sum with negative value
 RUN bpftrace -e 'BEGIN { @=sum(10); @=sum(-20); exit(); }'
 EXPECT ^@: -10$
 TIMEOUT 1
+
+NAME mixed values
+RUN bpftrace -e 'BEGIN { printf("%d %d %d %d\n", (int8) -10, -5555, (int16)-123, 100); exit(); }'
+EXPECT ^-10 -5555 -123 100$
+TIMEOUT 5


### PR DESCRIPTION
This is based on #1509, so that will have to land first.

This is some more prep work for #1091. Main things:

- break some `if` nesting in the codegen into separate functions
- treat integer dereference like a `kptr(uint64 *)` as discussed in #1507. E.g. `$x = *123` => `$x = * (uint64*)123;`
- fix a printing bug
- Make the  `SizedType.size` attribute private