### PR TITLE
Support small integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ and this project adheres to
   - [#1530](https://github.com/iovisor/bpftrace/pull/1530)
 - Fix pointer arithmetic for positional parameters
   - [#1514](https://github.com/iovisor/bpftrace/pull/1514)
+- Printing of small integers with `printf`
+  - [#1531](https://github.com/iovisor/bpftrace/pull/1531)
 
 #### Tools
 - Hook up execsnoop.bt script onto `execveat` call

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -112,6 +112,10 @@ private:
   Function *createLog2Function();
   Function *createLinearFunction();
 
+  void binop_string(Binop &binop);
+  void binop_buf(Binop &binop);
+  void binop_int(Binop &binop);
+
   Node *root_;
   LLVMContext context_;
   std::unique_ptr<Module> module_;

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -107,8 +107,11 @@ private:
                      bool expansion);
   [[nodiscard]] ScopedExprDeleter accept(Node *node);
 
+  void compareStructure(SizedType &our_type, llvm::Type *llvm_type);
+
   Function *createLog2Function();
   Function *createLinearFunction();
+
   Node *root_;
   LLVMContext context_;
   std::unique_ptr<Module> module_;

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -223,14 +223,15 @@ llvm::Type *IRBuilderBPF::GetType(const SizedType &stype)
     std::vector<llvm::Type *> llvm_elems;
     std::ostringstream ty_name;
 
-    for (const auto &elemtype : stype.tuple_elems)
+    for (const auto &elem : stype.GetFields())
     {
+      auto &elemtype = elem.type;
       llvm_elems.emplace_back(GetType(elemtype));
       ty_name << elemtype << "_";
     }
     ty_name << "_tuple_t";
 
-    ty = GetStructType(ty_name.str(), llvm_elems, true);
+    ty = GetStructType(ty_name.str(), llvm_elems, false);
   }
   else if (stype.IsPtrTy())
   {

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -241,6 +241,33 @@ llvm::Type *IRBuilderBPF::GetType(const SizedType &stype)
   {
     ty = ArrayType::get(getInt8Ty(), stype.size);
   }
+  else if (stype.IsIntTy())
+  {
+    switch (stype.GetIntBitWidth())
+    {
+      case 128:
+        ty = getInt128Ty();
+        break;
+      case 64:
+        ty = getInt64Ty();
+        break;
+      case 32:
+        ty = getInt32Ty();
+        break;
+      case 16:
+        ty = getInt16Ty();
+        break;
+      case 8:
+        ty = getInt8Ty();
+        break;
+      case 1:
+        ty = getInt1Ty();
+        break;
+      default:
+        LOG(FATAL) << stype.GetIntBitWidth()
+                   << " is not a valid type size for GetType";
+    }
+  }
   else
   {
     switch (stype.size)

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1636,17 +1636,17 @@ void SemanticAnalyser::visit(FieldAccess &acc)
       return;
     }
 
-    bool valid_idx = static_cast<size_t>(acc.index) < type.tuple_elems.size();
+    bool valid_idx = static_cast<size_t>(acc.index) < type.GetFields().size();
 
     // We may not have inferred the full type of the tuple yet in early passes
     // so wait until the final pass.
     if (!valid_idx && is_final_pass())
       LOG(ERROR, acc.loc, err_)
           << "Invalid tuple index: " << acc.index << ". Found "
-          << type.tuple_elems.size() << " elements in tuple.";
+          << type.GetFields().size() << " elements in tuple.";
 
     if (valid_idx)
-      acc.type = type.tuple_elems[acc.index];
+      acc.type = type.GetField(acc.index).type;
 
     return;
   }
@@ -1765,22 +1765,16 @@ void SemanticAnalyser::visit(Cast &cast)
 
 void SemanticAnalyser::visit(Tuple &tuple)
 {
-  auto &type = tuple.type;
-  size_t total_size = 0;
-
-  type.tuple_elems.clear();
-
+  std::vector<SizedType> elements;
   for (size_t i = 0; i < tuple.elems->size(); ++i)
   {
     Expression *elem = tuple.elems->at(i);
     elem->accept(*this);
 
-    type.tuple_elems.emplace_back(elem->type);
-    total_size += elem->type.size;
+    elements.emplace_back(elem->type);
   }
 
-  type.type = Type::tuple;
-  type.size = total_size;
+  tuple.type = CreateTuple(elements);
 }
 
 void SemanticAnalyser::visit(ExprStatement &expr)

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1450,7 +1450,7 @@ void SemanticAnalyser::visit(Unop &unop)
     }
     else if (type.IsIntTy())
     {
-      unop.type = CreateInteger(8 * type.size, type.IsSigned());
+      unop.type = CreateUInt64();
     }
   }
   else if (unop.op == Parser::token::LNOT) {

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -107,6 +107,7 @@ private:
   std::map<std::string, ExpressionList> map_args_;
   std::map<std::string, SizedType> ap_args_;
   std::unordered_set<StackType> needs_stackid_maps_;
+
   uint32_t loop_depth_ = 0;
   bool needs_join_map_ = false;
   bool needs_elapsed_map_ = false;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -718,28 +718,59 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(const std::vec
     switch (arg.type.type)
     {
       case Type::integer:
-        switch (arg.type.size)
+        if (arg.type.IsSigned())
         {
-          case 8:
-            arg_values.push_back(std::make_unique<PrintableInt>(
-                *reinterpret_cast<uint64_t *>(arg_data + arg.offset)));
-            break;
-          case 4:
-            arg_values.push_back(std::make_unique<PrintableInt>(
-                *reinterpret_cast<uint32_t *>(arg_data + arg.offset)));
-            break;
-          case 2:
-            arg_values.push_back(std::make_unique<PrintableInt>(
-                *reinterpret_cast<uint16_t *>(arg_data + arg.offset)));
-            break;
-          case 1:
-            arg_values.push_back(std::make_unique<PrintableInt>(
-                *reinterpret_cast<uint8_t *>(arg_data + arg.offset)));
-            break;
-          default:
-            LOG(FATAL) << "get_arg_values: invalid integer size. 8, 4, 2 and "
-                          "byte supported. "
-                       << arg.type.size << "provided";
+          int64_t val = 0;
+          switch (arg.type.GetIntBitWidth())
+          {
+            case 64:
+              val = *reinterpret_cast<int64_t *>(arg_data + arg.offset);
+              break;
+            case 32:
+              val = *reinterpret_cast<int32_t *>(arg_data + arg.offset);
+              break;
+            case 16:
+              val = *reinterpret_cast<int16_t *>(arg_data + arg.offset);
+              break;
+            case 8:
+              val = *reinterpret_cast<int8_t *>(arg_data + arg.offset);
+              break;
+            case 1:
+              val = *reinterpret_cast<int8_t *>(arg_data + arg.offset);
+              break;
+            default:
+              LOG(FATAL) << "get_arg_values: invalid integer size. 8, 4, 2 and "
+                            "byte supported. "
+                         << arg.type.size << "provided";
+          }
+          arg_values.push_back(std::make_unique<PrintableSInt>(val));
+        }
+        else
+        {
+          uint64_t val = 0;
+          switch (arg.type.GetIntBitWidth())
+          {
+            case 64:
+              val = *reinterpret_cast<uint64_t *>(arg_data + arg.offset);
+              break;
+            case 32:
+              val = *reinterpret_cast<uint32_t *>(arg_data + arg.offset);
+              break;
+            case 16:
+              val = *reinterpret_cast<uint16_t *>(arg_data + arg.offset);
+              break;
+            case 8:
+              val = *reinterpret_cast<uint8_t *>(arg_data + arg.offset);
+              break;
+            case 1:
+              val = *reinterpret_cast<uint8_t *>(arg_data + arg.offset);
+              break;
+            default:
+              LOG(FATAL) << "get_arg_values: invalid integer size. 8, 4, 2 and "
+                            "byte supported. "
+                         << arg.type.size << "provided";
+          }
+          arg_values.push_back(std::make_unique<PrintableInt>(val));
         }
         break;
       case Type::string:

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1346,6 +1346,38 @@ std::string BPFtrace::map_value_to_str(const SizedType &stype,
   }
   else if (stype.IsCountTy())
     return std::to_string(reduce_value<uint64_t>(value, nvalues) / div);
+  else if (stype.IsIntTy())
+  {
+    auto sign = stype.IsSigned();
+    switch (stype.GetIntBitWidth())
+    {
+      // clang-format off
+      case 64:
+        if (sign)
+          return std::to_string(
+            reduce_value<int64_t>(value, nvalues) / (int64_t)div);
+        return std::to_string(reduce_value<uint64_t>(value, nvalues) / div);
+      case 32:
+        if (sign)
+          return std::to_string(
+            reduce_value<int32_t>(value, nvalues) / (int32_t)div);
+        return std::to_string(reduce_value<uint32_t>(value, nvalues) / div);
+      case 16:
+        if (sign)
+          return std::to_string(
+            reduce_value<int16_t>(value, nvalues) / (int16_t)div);
+        return std::to_string(reduce_value<uint16_t>(value, nvalues) / div);
+      case 8:
+        if (sign)
+          return std::to_string(
+            reduce_value<int8_t>(value, nvalues) / (int8_t)div);
+        return std::to_string(reduce_value<uint8_t>(value, nvalues) / div);
+        // clang-format on
+    }
+    LOG(FATAL) << "map_value_to_str: Invalid int bitwidth: "
+               << stype.GetIntBitWidth() << "provided";
+    // lgtm[cpp/missing-return]
+  }
   else if (stype.IsSumTy() || stype.IsIntTy())
   {
     if (stype.IsSigned())

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1373,9 +1373,10 @@ std::string BPFtrace::map_value_to_str(const SizedType &stype,
             reduce_value<int8_t>(value, nvalues) / (int8_t)div);
         return std::to_string(reduce_value<uint8_t>(value, nvalues) / div);
         // clang-format on
+      default:
+        LOG(FATAL) << "map_value_to_str: Invalid int bitwidth: "
+                   << stype.GetIntBitWidth() << "provided";
     }
-    LOG(FATAL) << "map_value_to_str: Invalid int bitwidth: "
-               << stype.GetIntBitWidth() << "provided";
     // lgtm[cpp/missing-return]
   }
   else if (stype.IsSumTy() || stype.IsIntTy())

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -346,13 +346,15 @@ std::string TextOutput::tuple_to_str(BPFtrace &bpftrace,
                                      const std::vector<uint8_t> &value) const
 {
   bool first = true;
-  size_t offset = 0;
   std::string ret;
 
   ret += '(';
 
-  for (const SizedType &elemtype : ty.tuple_elems)
+  for (const auto &elem : ty.GetFields())
   {
+    auto &elemtype = elem.type;
+    auto offset = elem.offset;
+
     if (first)
       first = false;
     else
@@ -682,13 +684,15 @@ std::string JsonOutput::tuple_to_str(BPFtrace &bpftrace,
                                      const std::vector<uint8_t> &value) const
 {
   bool first = true;
-  size_t offset = 0;
   std::string ret;
 
   ret += '[';
 
-  for (const SizedType &elemtype : ty.tuple_elems)
+  for (const auto &elem : ty.GetFields())
   {
+    auto &elemtype = elem.type;
+    auto offset = elem.offset;
+
     if (first)
       first = false;
     else
@@ -710,8 +714,6 @@ std::string JsonOutput::tuple_to_str(BPFtrace &bpftrace,
       if (is_quoted_type(elemtype))
         ret += '"';
     }
-
-    offset += elemtype.size;
   }
 
   ret += ']';

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -84,4 +84,9 @@ uint64_t PrintableInt::value()
   return value_;
 }
 
+uint64_t PrintableSInt::value()
+{
+  return value_;
+}
+
 } // namespace bpftrace

--- a/src/printf.h
+++ b/src/printf.h
@@ -64,4 +64,16 @@ private:
   uint64_t value_;
 };
 
+class PrintableSInt : public virtual IPrintable
+{
+public:
+  PrintableSInt(int64_t value) : value_((uint64_t)(value))
+  {
+  }
+  uint64_t value();
+
+private:
+  int64_t value_;
+};
+
 } // namespace bpftrace

--- a/src/struct.cpp
+++ b/src/struct.cpp
@@ -1,4 +1,5 @@
 #include "struct.h"
+#include <iomanip>
 
 namespace bpftrace {
 
@@ -10,6 +11,69 @@ bool Bitfield::operator==(const Bitfield &other) const {
 
 bool Bitfield::operator!=(const Bitfield &other) const {
   return !(*this == other);
+}
+
+std::unique_ptr<Tuple> Tuple::Create(std::vector<SizedType> fields)
+{
+  // See llvm::StructLayout::StructLayout source
+  std::unique_ptr<Tuple> tuple(new Tuple);
+  ssize_t offset = 0;
+  ssize_t struct_align = 1;
+
+  for (auto &field : fields)
+  {
+    auto align = field.GetAlignment();
+    struct_align = std::max(align, struct_align);
+    auto size = field.size;
+
+    auto padding = (align - (offset % align)) % align;
+    if (padding)
+      tuple->padded = true;
+    offset += padding;
+
+    tuple->fields.push_back(Field{
+        .type = field,
+        .offset = offset,
+        .is_bitfield = false,
+        .bitfield = Bitfield{},
+    });
+
+    offset += size;
+  }
+
+  auto padding = (struct_align - (offset % struct_align)) % struct_align;
+
+  tuple->size = offset + padding;
+  tuple->align = struct_align;
+
+  return tuple;
+}
+
+void Tuple::Dump(std::ostream &os)
+{
+  os << "tuple {" << std::endl;
+
+  auto pad = [](int size) -> std::string {
+    return "__pad[" + std::to_string(size) + "]";
+  };
+
+  auto prefix = [](int offset, std::ostream &os) -> std::ostream & {
+    os << " " << std::setfill(' ') << std::setw(3) << offset << " | ";
+    return os;
+  };
+
+  ssize_t offset = 0;
+  for (const auto &field : fields)
+  {
+    auto delta = field.offset - offset;
+    if (delta)
+    {
+      prefix(offset, os) << pad(delta) << std::endl;
+    }
+    prefix(offset + delta, os) << field.type << std::endl;
+    offset = field.offset + field.type.size;
+  }
+  os << "} sizeof: [" << size << "]" << std::endl;
 }
 
 } // namespace bpftrace

--- a/src/struct.h
+++ b/src/struct.h
@@ -21,13 +21,14 @@ struct Bitfield
 struct Field
 {
   SizedType type;
-  int offset;
+  ssize_t offset;
 
   bool is_bitfield;
   Bitfield bitfield;
 };
 
 using FieldsMap = std::map<std::string, Field>;
+using TupleFields = std::vector<Field>;
 
 struct Struct
 {
@@ -35,4 +36,16 @@ struct Struct
   FieldsMap fields;
 };
 
+struct Tuple
+{
+  size_t size; // in bytes
+  int align;   // in bytes
+  bool padded = false;
+  TupleFields fields;
+
+  static std::unique_ptr<Tuple> Create(std::vector<SizedType> fields);
+  void Dump(std::ostream &os);
+};
+
+std::ostream &operator<<(std::ostream &os, const TupleFields &t);
 } // namespace bpftrace

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 
 #include "log.h"
+#include "struct.h"
 #include "types.h"
 
 namespace bpftrace {
@@ -52,10 +53,10 @@ std::ostream &operator<<(std::ostream &os, const SizedType &type)
   else if (type.IsTupleTy())
   {
     os << "(";
-    size_t n = type.tuple_elems.size();
+    size_t n = type.GetFieldCount();
     for (size_t i = 0; i < n; ++i)
     {
-      os << type.tuple_elems[i];
+      os << type.GetField(i).type;
       if (i != n - 1)
         os << ",";
     }
@@ -435,9 +436,59 @@ SizedType CreateTimestamp()
   return SizedType(Type::timestamp, 16);
 }
 
+SizedType CreateTuple(std::vector<SizedType> fields)
+{
+  auto s = SizedType(Type::tuple, 0);
+  s.tuple_fields = Tuple::Create(fields);
+  s.size = s.tuple_fields->size;
+  return s;
+}
+
 bool SizedType::IsSigned(void) const
 {
   return is_signed_;
+}
+
+std::vector<Field> &SizedType::GetFields() const
+{
+  assert(IsTupleTy());
+  return tuple_fields->fields;
+}
+
+Field &SizedType::GetField(ssize_t n) const
+{
+  assert(IsTupleTy());
+  if (n >= GetFieldCount())
+    throw std::runtime_error("Getfield(): out of bound");
+  return tuple_fields->fields[n];
+}
+
+ssize_t SizedType::GetFieldCount() const
+{
+  assert(IsTupleTy());
+  return tuple_fields->fields.size();
+}
+
+void SizedType::DumpStructure(std::ostream &os)
+{
+  assert(IsTupleTy());
+  return tuple_fields->Dump(os);
+}
+
+ssize_t SizedType::GetAlignment() const
+{
+  if (IsStringTy())
+    return 1;
+
+  if (IsTupleTy())
+    return tuple_fields->align;
+
+  if (size <= 2)
+    return size;
+  else if (size <= 4)
+    return 4;
+  else
+    return 8;
 }
 
 } // namespace bpftrace

--- a/src/types.h
+++ b/src/types.h
@@ -74,6 +74,9 @@ struct StackType
   }
 };
 
+struct Tuple;
+struct Field;
+
 class SizedType
 {
 public:
@@ -93,8 +96,6 @@ public:
   bool is_tparg = false;
   bool is_kfarg = false;
   int kfarg_idx = -1;
-  // Only valid if `type == Type::tuple`
-  std::vector<SizedType> tuple_elems;
 
 private:
   bool is_signed_ = false;
@@ -106,7 +107,26 @@ private:
   AddrSpace as_ = AddrSpace::none;
   ssize_t size_bits; // size in bits for integer types
 
+  std::shared_ptr<Tuple> tuple_fields; // tuple fields
+
 public:
+  /**
+     Tuple accessors
+  */
+  std::vector<Field> &GetFields() const;
+  Field &GetField(ssize_t n) const;
+  ssize_t GetFieldCount() const;
+
+  /**
+     Required alignment for this type
+   */
+  ssize_t GetAlignment() const;
+
+  /**
+     Dump the underlying structure for debug purposes
+  */
+  void DumpStructure(std::ostream &os);
+
   AddrSpace GetAS() const
   {
     return as_;
@@ -300,6 +320,7 @@ public:
   friend SizedType CreatePointer(const SizedType &pointee_type, AddrSpace as);
   friend SizedType CreateRecord(size_t size, const std::string &name);
   friend SizedType CreateInteger(size_t bits, bool is_signed);
+  friend SizedType CreateTuple(std::vector<SizedType> fields);
 };
 // Type helpers
 
@@ -325,6 +346,8 @@ SizedType CreatePointer(const SizedType &pointee_type,
    size in bytes
  */
 SizedType CreateRecord(size_t size, const std::string &name);
+
+SizedType CreateTuple(std::vector<SizedType> fields);
 
 SizedType CreateStackMode();
 SizedType CreateStack(bool kernel, StackType st = StackType());

--- a/tests/codegen-validator.sh
+++ b/tests/codegen-validator.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ## Don't add to this
-IGNORE="(_LLVM|printf|(logical_and_or_different_type|struct_char_1|struct_integer_ptr_1|struct_integers_1|struct_long_1|struct_nested_struct_anon_1|struct_nested_struct_named_1|struct_nested_struct_ptr_named_1|struct_save_nested|struct_short_1|struct_string_array_1).ll)"
+IGNORE="(LLVM)"
 EXIT=0
 
 LLVM=$(command -v llvm-as-7)

--- a/tests/codegen/llvm/call_print_composit.ll
+++ b/tests/codegen/llvm/call_print_composit.ll
@@ -4,7 +4,7 @@ target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
 %print_tuple_72_t = type <{ i64, i64, [72 x i8] }>
-%"int64_string[64]__tuple_t" = type <{ i64, [64 x i8] }>
+%"int64_string[64]__tuple_t" = type { i64, [64 x i8] }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
@@ -16,36 +16,38 @@ entry:
   %tuple = alloca %"int64_string[64]__tuple_t"
   %1 = bitcast %"int64_string[64]__tuple_t"* %tuple to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = getelementptr %"int64_string[64]__tuple_t", %"int64_string[64]__tuple_t"* %tuple, i32 0, i32 0
-  store i64 1, i64* %2
-  %3 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  %2 = bitcast %"int64_string[64]__tuple_t"* %tuple to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 72, i1 false)
+  %3 = getelementptr %"int64_string[64]__tuple_t", %"int64_string[64]__tuple_t"* %tuple, i32 0, i32 0
+  store i64 1, i64* %3
+  %4 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store [64 x i8] c"abc\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str
-  %4 = getelementptr %"int64_string[64]__tuple_t", %"int64_string[64]__tuple_t"* %tuple, i32 0, i32 1
-  %5 = bitcast [64 x i8]* %4 to i8*
-  %6 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %5, i8* align 1 %6, i64 64, i1 false)
+  %5 = getelementptr %"int64_string[64]__tuple_t", %"int64_string[64]__tuple_t"* %tuple, i32 0, i32 1
+  %6 = bitcast [64 x i8]* %5 to i8*
   %7 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast %print_tuple_72_t* %print_tuple_72_t to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %9 = getelementptr %print_tuple_72_t, %print_tuple_72_t* %print_tuple_72_t, i64 0, i32 0
-  store i64 30007, i64* %9
-  %10 = getelementptr %print_tuple_72_t, %print_tuple_72_t* %print_tuple_72_t, i64 0, i32 1
-  store i64 0, i64* %10
-  %11 = getelementptr %print_tuple_72_t, %print_tuple_72_t* %print_tuple_72_t, i32 0, i32 2
-  %12 = bitcast [72 x i8]* %11 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %12, i8 0, i64 72, i1 false)
-  %13 = bitcast [72 x i8]* %11 to i8*
-  %14 = bitcast %"int64_string[64]__tuple_t"* %tuple to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %13, i8* align 1 %14, i64 72, i1 false)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %6, i8* align 1 %7, i64 64, i1 false)
+  %8 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast %print_tuple_72_t* %print_tuple_72_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %10 = getelementptr %print_tuple_72_t, %print_tuple_72_t* %print_tuple_72_t, i64 0, i32 0
+  store i64 30007, i64* %10
+  %11 = getelementptr %print_tuple_72_t, %print_tuple_72_t* %print_tuple_72_t, i64 0, i32 1
+  store i64 0, i64* %11
+  %12 = getelementptr %print_tuple_72_t, %print_tuple_72_t* %print_tuple_72_t, i32 0, i32 2
+  %13 = bitcast [72 x i8]* %12 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %13, i8 0, i64 72, i1 false)
+  %14 = bitcast [72 x i8]* %12 to i8*
+  %15 = bitcast %"int64_string[64]__tuple_t"* %tuple to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %14, i8* align 1 %15, i64 72, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %print_tuple_72_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %print_tuple_72_t* %print_tuple_72_t, i64 88)
-  %15 = bitcast %print_tuple_72_t* %print_tuple_72_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
-  %16 = bitcast %"int64_string[64]__tuple_t"* %tuple to i8*
+  %16 = bitcast %print_tuple_72_t* %print_tuple_72_t to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = bitcast %"int64_string[64]__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
   ret i64 0
 }
 
@@ -53,13 +55,13 @@ entry:
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
 
 ; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+
+; Function Attrs: argmemonly nounwind
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
-
-; Function Attrs: argmemonly nounwind
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/tuple.ll
+++ b/tests/codegen/llvm/tuple.ll
@@ -3,7 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
-%"int64_int64_string[64]__tuple_t" = type <{ i64, i64, [64 x i8] }>
+%"int64_int64_string[64]__tuple_t" = type { i64, i64, [64 x i8] }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
@@ -15,33 +15,38 @@ entry:
   %tuple = alloca %"int64_int64_string[64]__tuple_t"
   %1 = bitcast %"int64_int64_string[64]__tuple_t"* %tuple to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = getelementptr %"int64_int64_string[64]__tuple_t", %"int64_int64_string[64]__tuple_t"* %tuple, i32 0, i32 0
-  store i64 1, i64* %2
-  %3 = getelementptr %"int64_int64_string[64]__tuple_t", %"int64_int64_string[64]__tuple_t"* %tuple, i32 0, i32 1
-  store i64 2, i64* %3
-  %4 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  %2 = bitcast %"int64_int64_string[64]__tuple_t"* %tuple to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 80, i1 false)
+  %3 = getelementptr %"int64_int64_string[64]__tuple_t", %"int64_int64_string[64]__tuple_t"* %tuple, i32 0, i32 0
+  store i64 1, i64* %3
+  %4 = getelementptr %"int64_int64_string[64]__tuple_t", %"int64_int64_string[64]__tuple_t"* %tuple, i32 0, i32 1
+  store i64 2, i64* %4
+  %5 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
   store [64 x i8] c"str\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str
-  %5 = getelementptr %"int64_int64_string[64]__tuple_t", %"int64_int64_string[64]__tuple_t"* %tuple, i32 0, i32 2
-  %6 = bitcast [64 x i8]* %5 to i8*
-  %7 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %6, i8* align 1 %7, i64 64, i1 false)
+  %6 = getelementptr %"int64_int64_string[64]__tuple_t", %"int64_int64_string[64]__tuple_t"* %tuple, i32 0, i32 2
+  %7 = bitcast [64 x i8]* %6 to i8*
   %8 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@t_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %7, i8* align 1 %8, i64 64, i1 false)
+  %9 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@t_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 0, i64* %"@t_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %"int64_int64_string[64]__tuple_t"*, i64)*)(i64 %pseudo, i64* %"@t_key", %"int64_int64_string[64]__tuple_t"* %tuple, i64 0)
-  %10 = bitcast i64* %"@t_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast %"int64_int64_string[64]__tuple_t"* %tuple to i8*
+  %11 = bitcast i64* %"@t_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast %"int64_int64_string[64]__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
 
 ; Function Attrs: argmemonly nounwind
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #1

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -162,23 +162,6 @@ EXPECT @: 50
 TIMEOUT 5
 REQUIRES_FEATURE loop
 
-NAME basic tuple
-RUN bpftrace -e 'BEGIN { $v = 99; $t = (0, 1, "str", (5, 6), $v); printf("%d %d %s %d %d %d\n", $t.0, $t.1, $t.2, $t.3.0, $t.3.1, $t.4); exit(); }'
-EXPECT 0 1 str 5 6 99
-TIMEOUT 5
-
-NAME basic tuple map
-RUN bpftrace -e 'BEGIN { $v = 99; @t = (0, 1, "str"); printf("%d %d %s\n", @t.0, @t.1, @t.2); exit(); }'
-EXPECT 0 1 str
-TIMEOUT 5
-
-# Careful with '(' and ')', they are read by the test engine as a regex group,
-# so make sure to escape them.
-NAME tuple print
-RUN bpftrace -e 'BEGIN { @ = (1, 2, "string", (4, 5)); exit(); }'
-EXPECT ^@: \(1, 2, string, \(4, 5\)\)$
-TIMEOUT 5
-
 NAME disable warnings
 RUN bpftrace --no-warnings -e 'BEGIN { @x = stats(10); print(@x, 2); clear(@x); exit();}' 2>&1| grep -c -E "WARNING|invalid option"
 EXPECT ^0$

--- a/tests/runtime/signed_ints
+++ b/tests/runtime/signed_ints
@@ -27,3 +27,8 @@ NAME sum with negative value
 RUN bpftrace -e 'BEGIN { @=sum(10); @=sum(-20); exit(); }'
 EXPECT ^@: -10$
 TIMEOUT 1
+
+NAME mixed values
+RUN bpftrace -e 'BEGIN { printf("%d %d %d %d\n", (int8) -10, -5555, (int16)-123, 100); exit(); }'
+EXPECT ^-10 -5555 -123 100$
+TIMEOUT 5

--- a/tests/runtime/tuples
+++ b/tests/runtime/tuples
@@ -1,0 +1,61 @@
+NAME basic tuple
+RUN bpftrace -e 'BEGIN { $v = 99; $t = (0, 1, "str", (5, 6), $v); printf("%d %d %s %d %d %d\n", $t.0, $t.1, $t.2, $t.3.0, $t.3.1, $t.4); exit(); }'
+EXPECT 0 1 str 5 6 99
+TIMEOUT 5
+
+NAME basic tuple map
+RUN bpftrace -e 'BEGIN { $v = 99; @t = (0, 1, "str"); printf("%d %d %s\n", @t.0, @t.1, @t.2); exit(); }'
+EXPECT 0 1 str
+TIMEOUT 5
+
+NAME mixed int tuple map
+RUN bpftrace -e 'BEGIN { @ = ( (int32) -100, (int8) 10, 50 ); exit();}'
+EXPECT @: \(-100, 10, 50\)
+TIMEOUT 5
+
+NAME mixed int tuple map 2
+RUN bpftrace -e 'BEGIN { @ = ( -100, (int8) 10, (int32) 50 ); exit();}'
+EXPECT @: \(-100, 10, 50\)
+TIMEOUT 5
+
+NAME mixed int tuple map 3
+RUN bpftrace -e 'BEGIN { @ = ( -100, (int8) 10, (int32) 50, 100 ); exit();}'
+EXPECT @: \(-100, 10, 50, 100\)
+TIMEOUT 5
+
+NAME complex tuple 1
+RUN bpftrace -e 'BEGIN { print(((int8)-100, (int8) 100, "abcdef", 3, (int32) 1, (int64)-10, (int8)10, (int16)-555)); exit(); }'
+EXPECT \(-100, 100, abcdef, 3, 1, -10, 10, -555\)
+TIMEOUT 5
+
+NAME tuple struct sizing 1
+RUN bpftrace -e 'BEGIN { $t = ((int8) 1, (int64) 1, (int8) 1, (int64) 1); print(sizeof($t)); exit() }'
+EXPECT 32
+TIMEOUT 5
+
+NAME tuple struct sizing 2
+RUN bpftrace -e 'BEGIN { $t = ((int8) 1, (int16) 1, (int32) 1); print(sizeof($t)); exit() }'
+EXPECT 8
+TIMEOUT 5
+
+NAME tuple struct sizing 3
+RUN bpftrace -e 'BEGIN { $t = ((int32) 1, (int16) 1, (int8) 1); print(sizeof($t)); exit() }'
+EXPECT 8
+TIMEOUT 5
+
+NAME complex tuple 4
+RUN bpftrace -e 'BEGIN { $a = ((int8)-100, (int8) 100, "abcdef", 3, (int32) 1, (int64)-10, (int8)10, (int16)-555, "abc"); print(sizeof($a)); exit(); }'
+EXPECT 168
+TIMEOUT 5
+
+NAME nested tuple
+RUN bpftrace -e 'BEGIN{ @ = ((int8)1, ((int8)-20, (int8)30)); exit(); }'
+EXPECT @: \(1, \(-20, 30\)\)
+TIMEOUT 5
+
+# Careful with '(' and ')', they are read by the test engine as a regex group,
+# so make sure to escape them.
+NAME tuple print
+RUN bpftrace -e 'BEGIN { @ = (1, 2, "string", (4, 5)); exit(); }'
+EXPECT ^@: \(1, 2, string, \(4, 5\)\)$
+TIMEOUT 5


### PR DESCRIPTION
This is based on #1532 and #1509 

---

Bpftrace always treated all integers as i64 internally. This isn't necessarily a bad thing, although it does introduce quite a bit of useless casting into the ir, and some wasted bytes (and probably some cpu cycles on 32 bit systems). But the implementation is suboptimal. Instead of doing casts we changed the size of the type (`type.size = 8`). This not only causes invalid IR but it also leads to subtle bugs as this ends up zero extending instead of sign extending values into i64.

This is an attempt to get rid of all the internal i64 promotions and just do conversions where it makes sense. 

The most tricky part is around assignment and comparison. We could follow what C does with its implicit int promotions but that can lead to hard to spot bugs. For now all it does is complain when changing the type of a var (maps are always i64):

```
tcpconnect.bt:49:12-13: WARNING: Implicit conversion of variable: $dport from: unsigned int16 to unsigned int64
    $dport = ($dport >> 8) | (($dport << 8) & 0x00FF00);
           ~
```

I'm still trying to figure out what works well. Opening this as a draft for now to collect some feedback.