### PR TITLE
Support old C++ compilers that don't have <filesystem>

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -3,7 +3,6 @@
 #include <cmath>
 #include <cstring>
 #include <fcntl.h>
-#include <filesystem>
 #include <fstream>
 #include <glob.h>
 #include <link.h>
@@ -26,6 +25,16 @@
 #include <elf.h>
 
 #include <linux/version.h>
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace std_filesystem = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace std_filesystem = std::experimental::filesystem;
+#else
+#error "neither <filesystem> nor <experimental/filesystem> are present"
+#endif
 
 namespace {
 
@@ -915,8 +924,8 @@ uint32_t kernel_version(int attempt)
 
 std::string abs_path(const std::string &rel_path)
 {
-  auto p = std::filesystem::path(rel_path);
-  return std::filesystem::canonical(std::filesystem::absolute(p)).string();
+  auto p = std_filesystem::path(rel_path);
+  return std_filesystem::canonical(std_filesystem::absolute(p)).string();
 }
 
 } // namespace bpftrace


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

Old C++ compilers such as g++ 7.x doesn't have `<filesystem>`, but they sometimes
have `<experimental/filesystem>` instead.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
