### PR TITLE
semantic: block conversion of integer into struct

### DIFF
--- a/tests/codegen/builtin_ctx_field.cpp
+++ b/tests/codegen/builtin_ctx_field.cpp
@@ -6,11 +6,30 @@ namespace codegen {
 
 TEST(codegen, builtin_ctx_field)
 {
-  std::string structs = "struct c {char c} struct x { long a; short b[4]; "
-                        "struct c c; struct c *d; char e[4]}";
-  test(structs + "kprobe:f { $x = (struct x*)ctx; @a = $x->a; @b = $x->b[0]; "
-                 "@c = $x->c.c; @d = $x->d->c; @e = $x->e;}",
-       NAME);
+  std::string prog = R"END(
+struct c {
+  char c;
+};
+
+struct x {
+  long a;
+  short b[4];
+  struct c c;
+  struct c *d;
+  char e[4]
+};
+
+kprobe:f {
+  $x = (struct x*)ctx;
+  @a = $x->a;
+  @b = $x->b[0];
+  @c = $x->c.c;
+  @d = $x->d->c;
+  @e = $x->e;
+}
+)END";
+
+  test(prog, NAME);
 }
 
 } // namespace codegen

--- a/tests/codegen/call_printf.cpp
+++ b/tests/codegen/call_printf.cpp
@@ -6,7 +6,7 @@ namespace codegen {
 
 TEST(codegen, call_printf)
 {
-  test("struct Foo { char c; long l; } kprobe:f { $foo = (struct Foo*)0; "
+  test("struct Foo { char c; long l; } kprobe:f { $foo = (struct Foo*)arg0; "
        "printf(\"%c %lu\\n\", $foo->c, $foo->l) }",
 
        NAME);

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -67,7 +67,7 @@ TEST(codegen, printf_offsets)
                 "struct Foo { char c; int i; char str[10]; }\n"
                 "kprobe:f\n"
                 "{\n"
-                "  $foo = (struct Foo*)0;\n"
+                "  $foo = (struct Foo*)arg0;\n"
                 "  printf(\"%c %u %s %p\\n\", $foo->c, $foo->i, $foo->str, 0)\n"
                 "}"),
             0);

--- a/tests/codegen/llvm/call_printf.ll
+++ b/tests/codegen/llvm/call_printf.ll
@@ -17,39 +17,42 @@ entry:
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$foo"
-  %2 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 0, i64* %"$foo"
-  %3 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 24, i1 false)
-  %5 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %5
-  %6 = load i64, i64* %"$foo"
-  %7 = add i64 %6, 0
+  %2 = bitcast i8* %0 to i64*
+  %3 = getelementptr i64, i64* %2, i64 14
+  %arg0 = load volatile i64, i64* %3
+  %4 = bitcast i64* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 %arg0, i64* %"$foo"
+  %5 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 24, i1 false)
+  %7 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
+  store i64 0, i64* %7
+  %8 = load i64, i64* %"$foo"
+  %9 = add i64 %8, 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"struct Foo.c")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.c", i32 1, i64 %7)
-  %8 = load i8, i8* %"struct Foo.c"
-  %9 = sext i8 %8 to i64
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.c", i32 1, i64 %9)
+  %10 = load i8, i8* %"struct Foo.c"
+  %11 = sext i8 %10 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct Foo.c")
-  %10 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %9, i64* %10
-  %11 = load i64, i64* %"$foo"
-  %12 = add i64 %11, 8
-  %13 = bitcast i64* %"struct Foo.l" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.l", i32 8, i64 %12)
-  %14 = load i64, i64* %"struct Foo.l"
+  %12 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
+  store i64 %11, i64* %12
+  %13 = load i64, i64* %"$foo"
+  %14 = add i64 %13, 8
   %15 = bitcast i64* %"struct Foo.l" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
-  %16 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 2
-  store i64 %14, i64* %16
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.l", i32 8, i64 %14)
+  %16 = load i64, i64* %"struct Foo.l"
+  %17 = bitcast i64* %"struct Foo.l" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %18 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 2
+  store i64 %16, i64* %18
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* %printf_args, i64 24)
-  %17 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %19 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_printf_LLVM-10.ll
+++ b/tests/codegen/llvm/call_printf_LLVM-10.ll
@@ -17,39 +17,42 @@ entry:
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$foo"
-  %2 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 0, i64* %"$foo"
-  %3 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 24, i1 false)
-  %5 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %5
-  %6 = load i64, i64* %"$foo"
-  %7 = add i64 %6, 0
+  %2 = bitcast i8* %0 to i64*
+  %3 = getelementptr i64, i64* %2, i64 14
+  %arg0 = load volatile i64, i64* %3
+  %4 = bitcast i64* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 %arg0, i64* %"$foo"
+  %5 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 24, i1 false)
+  %7 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
+  store i64 0, i64* %7
+  %8 = load i64, i64* %"$foo"
+  %9 = add i64 %8, 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"struct Foo.c")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.c", i32 1, i64 %7)
-  %8 = load i8, i8* %"struct Foo.c"
-  %9 = sext i8 %8 to i64
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.c", i32 1, i64 %9)
+  %10 = load i8, i8* %"struct Foo.c"
+  %11 = sext i8 %10 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct Foo.c")
-  %10 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %9, i64* %10
-  %11 = load i64, i64* %"$foo"
-  %12 = add i64 %11, 8
-  %13 = bitcast i64* %"struct Foo.l" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.l", i32 8, i64 %12)
-  %14 = load i64, i64* %"struct Foo.l"
+  %12 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
+  store i64 %11, i64* %12
+  %13 = load i64, i64* %"$foo"
+  %14 = add i64 %13, 8
   %15 = bitcast i64* %"struct Foo.l" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
-  %16 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 2
-  store i64 %14, i64* %16
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.l", i32 8, i64 %14)
+  %16 = load i64, i64* %"struct Foo.l"
+  %17 = bitcast i64* %"struct Foo.l" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %18 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 2
+  store i64 %16, i64* %18
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* %printf_args, i64 24)
-  %17 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %19 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/logical_and_or_different_type.ll
+++ b/tests/codegen/llvm/logical_and_or_different_type.ll
@@ -24,28 +24,31 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast [4 x i8]* %"$foo" to i8*
   call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 4, i1 false)
-  %3 = bitcast [4 x i8]* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [4 x i8]* %"$foo" to i8*
-  %5 = bitcast i64 0 to i8 addrspace(64)*
-  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %4, i8 addrspace(64)* align 1 %5, i64 4, i1 false)
-  %6 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %7 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %7, i8 0, i64 40, i1 false)
-  %8 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %8
-  %9 = bitcast i64* %"&&_result" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %10 = add [4 x i8]* %"$foo", i64 0
-  %11 = bitcast i32* %"struct Foo.m" to i8*
+  %3 = bitcast i8* %0 to i64*
+  %4 = getelementptr i64, i64* %3, i64 14
+  %arg0 = load volatile i64, i64* %4
+  %5 = bitcast [4 x i8]* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast [4 x i8]* %"$foo" to i8*
+  %7 = bitcast i64 %arg0 to i8 addrspace(64)*
+  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %6, i8 addrspace(64)* align 1 %7, i64 4, i1 false)
+  %8 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %9 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %9, i8 0, i64 40, i1 false)
+  %10 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
+  store i64 0, i64* %10
+  %11 = bitcast i64* %"&&_result" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  %probe_read_user = call i64 inttoptr (i64 112 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m", i32 4, [4 x i8]* %10)
-  %12 = load i32, i32* %"struct Foo.m"
-  %13 = sext i32 %12 to i64
-  %14 = bitcast i32* %"struct Foo.m" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %lhs_true_cond = icmp ne i64 %13, 0
+  %12 = add [4 x i8]* %"$foo", i64 0
+  %13 = bitcast i32* %"struct Foo.m" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %probe_read_user = call i64 inttoptr (i64 112 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m", i32 4, [4 x i8]* %12)
+  %14 = load i32, i32* %"struct Foo.m"
+  %15 = sext i32 %14 to i64
+  %16 = bitcast i32* %"struct Foo.m" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %lhs_true_cond = icmp ne i64 %15, 0
   br i1 %lhs_true_cond, label %"&&_lhs_true", label %"&&_false"
 
 "&&_lhs_true":                                    ; preds = %entry
@@ -60,23 +63,23 @@ entry:
   br label %"&&_merge"
 
 "&&_merge":                                       ; preds = %"&&_false", %"&&_true"
-  %15 = load i64, i64* %"&&_result"
-  %16 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %15, i64* %16
-  %17 = bitcast i64* %"&&_result5" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
+  %17 = load i64, i64* %"&&_result"
+  %18 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
+  store i64 %17, i64* %18
+  %19 = bitcast i64* %"&&_result5" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
   br i1 true, label %"&&_lhs_true1", label %"&&_false3"
 
 "&&_lhs_true1":                                   ; preds = %"&&_merge"
-  %18 = add [4 x i8]* %"$foo", i64 0
-  %19 = bitcast i32* %"struct Foo.m6" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
-  %probe_read_user7 = call i64 inttoptr (i64 112 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m6", i32 4, [4 x i8]* %18)
-  %20 = load i32, i32* %"struct Foo.m6"
-  %21 = sext i32 %20 to i64
-  %22 = bitcast i32* %"struct Foo.m6" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
-  %rhs_true_cond = icmp ne i64 %21, 0
+  %20 = add [4 x i8]* %"$foo", i64 0
+  %21 = bitcast i32* %"struct Foo.m6" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21)
+  %probe_read_user7 = call i64 inttoptr (i64 112 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m6", i32 4, [4 x i8]* %20)
+  %22 = load i32, i32* %"struct Foo.m6"
+  %23 = sext i32 %22 to i64
+  %24 = bitcast i32* %"struct Foo.m6" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
+  %rhs_true_cond = icmp ne i64 %23, 0
   br i1 %rhs_true_cond, label %"&&_true2", label %"&&_false3"
 
 "&&_true2":                                       ; preds = %"&&_lhs_true1"
@@ -88,20 +91,20 @@ entry:
   br label %"&&_merge4"
 
 "&&_merge4":                                      ; preds = %"&&_false3", %"&&_true2"
-  %23 = load i64, i64* %"&&_result5"
-  %24 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 2
-  store i64 %23, i64* %24
-  %25 = bitcast i64* %"||_result" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %25)
-  %26 = add [4 x i8]* %"$foo", i64 0
-  %27 = bitcast i32* %"struct Foo.m8" to i8*
+  %25 = load i64, i64* %"&&_result5"
+  %26 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 2
+  store i64 %25, i64* %26
+  %27 = bitcast i64* %"||_result" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %27)
-  %probe_read_user9 = call i64 inttoptr (i64 112 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m8", i32 4, [4 x i8]* %26)
-  %28 = load i32, i32* %"struct Foo.m8"
-  %29 = sext i32 %28 to i64
-  %30 = bitcast i32* %"struct Foo.m8" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %30)
-  %lhs_true_cond10 = icmp ne i64 %29, 0
+  %28 = add [4 x i8]* %"$foo", i64 0
+  %29 = bitcast i32* %"struct Foo.m8" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %29)
+  %probe_read_user9 = call i64 inttoptr (i64 112 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m8", i32 4, [4 x i8]* %28)
+  %30 = load i32, i32* %"struct Foo.m8"
+  %31 = sext i32 %30 to i64
+  %32 = bitcast i32* %"struct Foo.m8" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %32)
+  %lhs_true_cond10 = icmp ne i64 %31, 0
   br i1 %lhs_true_cond10, label %"||_true", label %"||_lhs_false"
 
 "||_lhs_false":                                   ; preds = %"&&_merge4"
@@ -116,23 +119,23 @@ entry:
   br label %"||_merge"
 
 "||_merge":                                       ; preds = %"||_true", %"||_false"
-  %31 = load i64, i64* %"||_result"
-  %32 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 3
-  store i64 %31, i64* %32
-  %33 = bitcast i64* %"||_result15" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %33)
+  %33 = load i64, i64* %"||_result"
+  %34 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 3
+  store i64 %33, i64* %34
+  %35 = bitcast i64* %"||_result15" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %35)
   br i1 false, label %"||_true13", label %"||_lhs_false11"
 
 "||_lhs_false11":                                 ; preds = %"||_merge"
-  %34 = add [4 x i8]* %"$foo", i64 0
-  %35 = bitcast i32* %"struct Foo.m16" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %35)
-  %probe_read_user17 = call i64 inttoptr (i64 112 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m16", i32 4, [4 x i8]* %34)
-  %36 = load i32, i32* %"struct Foo.m16"
-  %37 = sext i32 %36 to i64
-  %38 = bitcast i32* %"struct Foo.m16" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %38)
-  %rhs_true_cond18 = icmp ne i64 %37, 0
+  %36 = add [4 x i8]* %"$foo", i64 0
+  %37 = bitcast i32* %"struct Foo.m16" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %37)
+  %probe_read_user17 = call i64 inttoptr (i64 112 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.m16", i32 4, [4 x i8]* %36)
+  %38 = load i32, i32* %"struct Foo.m16"
+  %39 = sext i32 %38 to i64
+  %40 = bitcast i32* %"struct Foo.m16" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %40)
+  %rhs_true_cond18 = icmp ne i64 %39, 0
   br i1 %rhs_true_cond18, label %"||_true13", label %"||_false12"
 
 "||_false12":                                     ; preds = %"||_lhs_false11"
@@ -144,14 +147,14 @@ entry:
   br label %"||_merge14"
 
 "||_merge14":                                     ; preds = %"||_true13", %"||_false12"
-  %39 = load i64, i64* %"||_result15"
-  %40 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 4
-  store i64 %39, i64* %40
+  %41 = load i64, i64* %"||_result15"
+  %42 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 4
+  store i64 %41, i64* %42
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* %printf_args, i64 40)
-  %41 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %41)
+  %43 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %43)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_char_1.ll
+++ b/tests/codegen/llvm/struct_char_1.ll
@@ -16,29 +16,32 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast [1 x i8]* %"$foo" to i8*
   call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 1, i1 false)
-  %3 = bitcast [1 x i8]* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [1 x i8]* %"$foo" to i8*
-  %5 = bitcast i64 0 to i8 addrspace(64)*
-  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %4, i8 addrspace(64)* align 1 %5, i64 1, i1 false)
-  %6 = add [1 x i8]* %"$foo", i64 0
+  %3 = bitcast i8* %0 to i64*
+  %4 = getelementptr i64, i64* %3, i64 14
+  %arg0 = load volatile i64, i64* %4
+  %5 = bitcast [1 x i8]* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast [1 x i8]* %"$foo" to i8*
+  %7 = bitcast i64 %arg0 to i8 addrspace(64)*
+  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %6, i8 addrspace(64)* align 1 %7, i64 1, i1 false)
+  %8 = add [1 x i8]* %"$foo", i64 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"struct Foo.x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, [1 x i8]*)*)(i8* %"struct Foo.x", i32 1, [1 x i8]* %6)
-  %7 = load i8, i8* %"struct Foo.x"
-  %8 = sext i8 %7 to i64
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, [1 x i8]*)*)(i8* %"struct Foo.x", i32 1, [1 x i8]* %8)
+  %9 = load i8, i8* %"struct Foo.x"
+  %10 = sext i8 %9 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct Foo.x")
-  %9 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %11 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   store i64 0, i64* %"@x_key"
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  store i64 %8, i64* %"@x_val"
+  %12 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  store i64 %10, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %11 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_char_2.ll
+++ b/tests/codegen/llvm/struct_char_2.ll
@@ -15,28 +15,31 @@ entry:
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$foo"
-  %2 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 0, i64* %"$foo"
-  %3 = load i64, i64* %"$foo"
-  %4 = add i64 %3, 0
+  %2 = bitcast i8* %0 to i64*
+  %3 = getelementptr i64, i64* %2, i64 14
+  %arg0 = load volatile i64, i64* %3
+  %4 = bitcast i64* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 %arg0, i64* %"$foo"
+  %5 = load i64, i64* %"$foo"
+  %6 = add i64 %5, 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"struct Foo.x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.x", i32 1, i64 %4)
-  %5 = load i8, i8* %"struct Foo.x"
-  %6 = sext i8 %5 to i64
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.x", i32 1, i64 %6)
+  %7 = load i8, i8* %"struct Foo.x"
+  %8 = sext i8 %7 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct Foo.x")
-  %7 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %9 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 0, i64* %"@x_key"
-  %8 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  store i64 %6, i64* %"@x_val"
+  %10 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i64 %8, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %9 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_integer_ptr_1.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_1.ll
@@ -17,37 +17,40 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast [8 x i8]* %"$foo" to i8*
   call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 8, i1 false)
-  %3 = bitcast [8 x i8]* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [8 x i8]* %"$foo" to i8*
-  %5 = bitcast i64 0 to i8 addrspace(64)*
-  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %4, i8 addrspace(64)* align 1 %5, i64 8, i1 false)
-  %6 = add [8 x i8]* %"$foo", i64 0
-  %7 = bitcast i64* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, [8 x i8]*)*)(i64* %"struct Foo.x", i32 8, [8 x i8]* %6)
-  %8 = load i64, i64* %"struct Foo.x"
+  %3 = bitcast i8* %0 to i64*
+  %4 = getelementptr i64, i64* %3, i64 14
+  %arg0 = load volatile i64, i64* %4
+  %5 = bitcast [8 x i8]* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast [8 x i8]* %"$foo" to i8*
+  %7 = bitcast i64 %arg0 to i8 addrspace(64)*
+  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %6, i8 addrspace(64)* align 1 %7, i64 8, i1 false)
+  %8 = add [8 x i8]* %"$foo", i64 0
   %9 = bitcast i64* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i32* %deref to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %8)
-  %11 = load i32, i32* %deref
-  %12 = sext i32 %11 to i64
-  %13 = bitcast i32* %deref to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, [8 x i8]*)*)(i64* %"struct Foo.x", i32 8, [8 x i8]* %8)
+  %10 = load i64, i64* %"struct Foo.x"
+  %11 = bitcast i64* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i32* %deref to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %10)
+  %13 = load i32, i32* %deref
+  %14 = sext i32 %13 to i64
+  %15 = bitcast i32* %deref to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %16 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
   store i64 0, i64* %"@x_key"
-  %15 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
-  store i64 %12, i64* %"@x_val"
+  %17 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
+  store i64 %14, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %16 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %18 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  %19 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_integer_ptr_2.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_2.ll
@@ -16,36 +16,39 @@ entry:
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$foo"
-  %2 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 0, i64* %"$foo"
-  %3 = load i64, i64* %"$foo"
-  %4 = add i64 %3, 0
-  %5 = bitcast i64* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.x", i32 8, i64 %4)
-  %6 = load i64, i64* %"struct Foo.x"
+  %2 = bitcast i8* %0 to i64*
+  %3 = getelementptr i64, i64* %2, i64 14
+  %arg0 = load volatile i64, i64* %3
+  %4 = bitcast i64* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 %arg0, i64* %"$foo"
+  %5 = load i64, i64* %"$foo"
+  %6 = add i64 %5, 0
   %7 = bitcast i64* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i32* %deref to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %6)
-  %9 = load i32, i32* %deref
-  %10 = sext i32 %9 to i64
-  %11 = bitcast i32* %deref to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.x", i32 8, i64 %6)
+  %8 = load i64, i64* %"struct Foo.x"
+  %9 = bitcast i64* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i32* %deref to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %8)
+  %11 = load i32, i32* %deref
+  %12 = sext i32 %11 to i64
+  %13 = bitcast i32* %deref to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
   store i64 0, i64* %"@x_key"
-  %13 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  store i64 %10, i64* %"@x_val"
+  %15 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  store i64 %12, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %14 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %16 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_integers_1.ll
+++ b/tests/codegen/llvm/struct_integers_1.ll
@@ -16,31 +16,34 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast [4 x i8]* %"$foo" to i8*
   call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 4, i1 false)
-  %3 = bitcast [4 x i8]* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [4 x i8]* %"$foo" to i8*
-  %5 = bitcast i64 0 to i8 addrspace(64)*
-  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %4, i8 addrspace(64)* align 1 %5, i64 4, i1 false)
-  %6 = add [4 x i8]* %"$foo", i64 0
-  %7 = bitcast i32* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.x", i32 4, [4 x i8]* %6)
-  %8 = load i32, i32* %"struct Foo.x"
-  %9 = sext i32 %8 to i64
-  %10 = bitcast i32* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %3 = bitcast i8* %0 to i64*
+  %4 = getelementptr i64, i64* %3, i64 14
+  %arg0 = load volatile i64, i64* %4
+  %5 = bitcast [4 x i8]* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast [4 x i8]* %"$foo" to i8*
+  %7 = bitcast i64 %arg0 to i8 addrspace(64)*
+  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %6, i8 addrspace(64)* align 1 %7, i64 4, i1 false)
+  %8 = add [4 x i8]* %"$foo", i64 0
+  %9 = bitcast i32* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo.x", i32 4, [4 x i8]* %8)
+  %10 = load i32, i32* %"struct Foo.x"
+  %11 = sext i32 %10 to i64
+  %12 = bitcast i32* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
   store i64 0, i64* %"@x_key"
-  %12 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  store i64 %9, i64* %"@x_val"
+  %14 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  store i64 %11, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %13 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %16 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_integers_2.ll
+++ b/tests/codegen/llvm/struct_integers_2.ll
@@ -15,30 +15,33 @@ entry:
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$foo"
-  %2 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 0, i64* %"$foo"
-  %3 = load i64, i64* %"$foo"
-  %4 = add i64 %3, 0
-  %5 = bitcast i32* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.x", i32 4, i64 %4)
-  %6 = load i32, i32* %"struct Foo.x"
-  %7 = sext i32 %6 to i64
-  %8 = bitcast i32* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %2 = bitcast i8* %0 to i64*
+  %3 = getelementptr i64, i64* %2, i64 14
+  %arg0 = load volatile i64, i64* %3
+  %4 = bitcast i64* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 %arg0, i64* %"$foo"
+  %5 = load i64, i64* %"$foo"
+  %6 = add i64 %5, 0
+  %7 = bitcast i32* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.x", i32 4, i64 %6)
+  %8 = load i32, i32* %"struct Foo.x"
+  %9 = sext i32 %8 to i64
+  %10 = bitcast i32* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   store i64 0, i64* %"@x_key"
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  store i64 %7, i64* %"@x_val"
+  %12 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  store i64 %9, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %11 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_long_1.ll
+++ b/tests/codegen/llvm/struct_long_1.ll
@@ -16,30 +16,33 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast [8 x i8]* %"$foo" to i8*
   call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 8, i1 false)
-  %3 = bitcast [8 x i8]* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [8 x i8]* %"$foo" to i8*
-  %5 = bitcast i64 0 to i8 addrspace(64)*
-  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %4, i8 addrspace(64)* align 1 %5, i64 8, i1 false)
-  %6 = add [8 x i8]* %"$foo", i64 0
-  %7 = bitcast i64* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, [8 x i8]*)*)(i64* %"struct Foo.x", i32 8, [8 x i8]* %6)
-  %8 = load i64, i64* %"struct Foo.x"
+  %3 = bitcast i8* %0 to i64*
+  %4 = getelementptr i64, i64* %3, i64 14
+  %arg0 = load volatile i64, i64* %4
+  %5 = bitcast [8 x i8]* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast [8 x i8]* %"$foo" to i8*
+  %7 = bitcast i64 %arg0 to i8 addrspace(64)*
+  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %6, i8 addrspace(64)* align 1 %7, i64 8, i1 false)
+  %8 = add [8 x i8]* %"$foo", i64 0
   %9 = bitcast i64* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, [8 x i8]*)*)(i64* %"struct Foo.x", i32 8, [8 x i8]* %8)
+  %10 = load i64, i64* %"struct Foo.x"
+  %11 = bitcast i64* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
   store i64 0, i64* %"@x_key"
-  %11 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  store i64 %8, i64* %"@x_val"
+  %13 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  store i64 %10, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %12 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_long_2.ll
+++ b/tests/codegen/llvm/struct_long_2.ll
@@ -15,29 +15,32 @@ entry:
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$foo"
-  %2 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 0, i64* %"$foo"
-  %3 = load i64, i64* %"$foo"
-  %4 = add i64 %3, 0
-  %5 = bitcast i64* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.x", i32 8, i64 %4)
-  %6 = load i64, i64* %"struct Foo.x"
+  %2 = bitcast i8* %0 to i64*
+  %3 = getelementptr i64, i64* %2, i64 14
+  %arg0 = load volatile i64, i64* %3
+  %4 = bitcast i64* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 %arg0, i64* %"$foo"
+  %5 = load i64, i64* %"$foo"
+  %6 = add i64 %5, 0
   %7 = bitcast i64* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.x", i32 8, i64 %6)
+  %8 = load i64, i64* %"struct Foo.x"
+  %9 = bitcast i64* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 0, i64* %"@x_key"
-  %9 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store i64 %6, i64* %"@x_val"
+  %11 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i64 %8, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_nested_struct_anon_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_1.ll
@@ -16,32 +16,35 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast [4 x i8]* %"$foo" to i8*
   call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 4, i1 false)
-  %3 = bitcast [4 x i8]* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [4 x i8]* %"$foo" to i8*
-  %5 = bitcast i64 0 to i8 addrspace(64)*
-  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %4, i8 addrspace(64)* align 1 %5, i64 4, i1 false)
-  %6 = add [4 x i8]* %"$foo", i64 0
-  %7 = add [4 x i8]* %6, i64 0
-  %8 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo::(anonymous at definitions.h:2:14).x", i32 4, [4 x i8]* %7)
-  %9 = load i32, i32* %"struct Foo::(anonymous at definitions.h:2:14).x"
-  %10 = sext i32 %9 to i64
-  %11 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %3 = bitcast i8* %0 to i64*
+  %4 = getelementptr i64, i64* %3, i64 14
+  %arg0 = load volatile i64, i64* %4
+  %5 = bitcast [4 x i8]* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast [4 x i8]* %"$foo" to i8*
+  %7 = bitcast i64 %arg0 to i8 addrspace(64)*
+  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %6, i8 addrspace(64)* align 1 %7, i64 4, i1 false)
+  %8 = add [4 x i8]* %"$foo", i64 0
+  %9 = add [4 x i8]* %8, i64 0
+  %10 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Foo::(anonymous at definitions.h:2:14).x", i32 4, [4 x i8]* %9)
+  %11 = load i32, i32* %"struct Foo::(anonymous at definitions.h:2:14).x"
+  %12 = sext i32 %11 to i64
+  %13 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
   store i64 0, i64* %"@x_key"
-  %13 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  store i64 %10, i64* %"@x_val"
+  %15 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  store i64 %12, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %14 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %16 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_nested_struct_anon_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_2.ll
@@ -15,31 +15,34 @@ entry:
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$foo"
-  %2 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 0, i64* %"$foo"
-  %3 = load i64, i64* %"$foo"
-  %4 = add i64 %3, 0
-  %5 = add i64 %4, 0
-  %6 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Foo::(anonymous at definitions.h:2:14).x", i32 4, i64 %5)
-  %7 = load i32, i32* %"struct Foo::(anonymous at definitions.h:2:14).x"
-  %8 = sext i32 %7 to i64
-  %9 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %2 = bitcast i8* %0 to i64*
+  %3 = getelementptr i64, i64* %2, i64 14
+  %arg0 = load volatile i64, i64* %3
+  %4 = bitcast i64* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 %arg0, i64* %"$foo"
+  %5 = load i64, i64* %"$foo"
+  %6 = add i64 %5, 0
+  %7 = add i64 %6, 0
+  %8 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Foo::(anonymous at definitions.h:2:14).x", i32 4, i64 %7)
+  %9 = load i32, i32* %"struct Foo::(anonymous at definitions.h:2:14).x"
+  %10 = sext i32 %9 to i64
+  %11 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
   store i64 0, i64* %"@x_key"
-  %11 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  store i64 %8, i64* %"@x_val"
+  %13 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  store i64 %10, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %12 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_nested_struct_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_1.ll
@@ -16,32 +16,35 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast [4 x i8]* %"$foo" to i8*
   call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 4, i1 false)
-  %3 = bitcast [4 x i8]* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [4 x i8]* %"$foo" to i8*
-  %5 = bitcast i64 0 to i8 addrspace(64)*
-  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %4, i8 addrspace(64)* align 1 %5, i64 4, i1 false)
-  %6 = add [4 x i8]* %"$foo", i64 0
-  %7 = add [4 x i8]* %6, i64 0
-  %8 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Bar.x", i32 4, [4 x i8]* %7)
-  %9 = load i32, i32* %"struct Bar.x"
-  %10 = sext i32 %9 to i64
-  %11 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %3 = bitcast i8* %0 to i64*
+  %4 = getelementptr i64, i64* %3, i64 14
+  %arg0 = load volatile i64, i64* %4
+  %5 = bitcast [4 x i8]* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast [4 x i8]* %"$foo" to i8*
+  %7 = bitcast i64 %arg0 to i8 addrspace(64)*
+  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %6, i8 addrspace(64)* align 1 %7, i64 4, i1 false)
+  %8 = add [4 x i8]* %"$foo", i64 0
+  %9 = add [4 x i8]* %8, i64 0
+  %10 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, [4 x i8]*)*)(i32* %"struct Bar.x", i32 4, [4 x i8]* %9)
+  %11 = load i32, i32* %"struct Bar.x"
+  %12 = sext i32 %11 to i64
+  %13 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
   store i64 0, i64* %"@x_key"
-  %13 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  store i64 %10, i64* %"@x_val"
+  %15 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  store i64 %12, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %14 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %16 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_nested_struct_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_2.ll
@@ -15,31 +15,34 @@ entry:
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$foo"
-  %2 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 0, i64* %"$foo"
-  %3 = load i64, i64* %"$foo"
-  %4 = add i64 %3, 0
-  %5 = add i64 %4, 0
-  %6 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %5)
-  %7 = load i32, i32* %"struct Bar.x"
-  %8 = sext i32 %7 to i64
-  %9 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %2 = bitcast i8* %0 to i64*
+  %3 = getelementptr i64, i64* %2, i64 14
+  %arg0 = load volatile i64, i64* %3
+  %4 = bitcast i64* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 %arg0, i64* %"$foo"
+  %5 = load i64, i64* %"$foo"
+  %6 = add i64 %5, 0
+  %7 = add i64 %6, 0
+  %8 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %7)
+  %9 = load i32, i32* %"struct Bar.x"
+  %10 = sext i32 %9 to i64
+  %11 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
   store i64 0, i64* %"@x_key"
-  %11 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  store i64 %8, i64* %"@x_val"
+  %13 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  store i64 %10, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %12 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
@@ -17,38 +17,41 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast [8 x i8]* %"$foo" to i8*
   call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 8, i1 false)
-  %3 = bitcast [8 x i8]* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [8 x i8]* %"$foo" to i8*
-  %5 = bitcast i64 0 to i8 addrspace(64)*
-  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %4, i8 addrspace(64)* align 1 %5, i64 8, i1 false)
-  %6 = add [8 x i8]* %"$foo", i64 0
-  %7 = bitcast i64* %"struct Foo.bar" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, [8 x i8]*)*)(i64* %"struct Foo.bar", i32 8, [8 x i8]* %6)
-  %8 = load i64, i64* %"struct Foo.bar"
+  %3 = bitcast i8* %0 to i64*
+  %4 = getelementptr i64, i64* %3, i64 14
+  %arg0 = load volatile i64, i64* %4
+  %5 = bitcast [8 x i8]* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast [8 x i8]* %"$foo" to i8*
+  %7 = bitcast i64 %arg0 to i8 addrspace(64)*
+  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %6, i8 addrspace(64)* align 1 %7, i64 8, i1 false)
+  %8 = add [8 x i8]* %"$foo", i64 0
   %9 = bitcast i64* %"struct Foo.bar" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = add i64 %8, 0
-  %11 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %10)
-  %12 = load i32, i32* %"struct Bar.x"
-  %13 = sext i32 %12 to i64
-  %14 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, [8 x i8]*)*)(i64* %"struct Foo.bar", i32 8, [8 x i8]* %8)
+  %10 = load i64, i64* %"struct Foo.bar"
+  %11 = bitcast i64* %"struct Foo.bar" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = add i64 %10, 0
+  %13 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %12)
+  %14 = load i32, i32* %"struct Bar.x"
+  %15 = sext i32 %14 to i64
+  %16 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
   store i64 0, i64* %"@x_key"
-  %16 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
-  store i64 %13, i64* %"@x_val"
+  %18 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
+  store i64 %15, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %17 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
-  %18 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  %19 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  %20 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
@@ -16,37 +16,40 @@ entry:
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$foo"
-  %2 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 0, i64* %"$foo"
-  %3 = load i64, i64* %"$foo"
-  %4 = add i64 %3, 0
-  %5 = bitcast i64* %"struct Foo.bar" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.bar", i32 8, i64 %4)
-  %6 = load i64, i64* %"struct Foo.bar"
+  %2 = bitcast i8* %0 to i64*
+  %3 = getelementptr i64, i64* %2, i64 14
+  %arg0 = load volatile i64, i64* %3
+  %4 = bitcast i64* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 %arg0, i64* %"$foo"
+  %5 = load i64, i64* %"$foo"
+  %6 = add i64 %5, 0
   %7 = bitcast i64* %"struct Foo.bar" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = add i64 %6, 0
-  %9 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %8)
-  %10 = load i32, i32* %"struct Bar.x"
-  %11 = sext i32 %10 to i64
-  %12 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.bar", i32 8, i64 %6)
+  %8 = load i64, i64* %"struct Foo.bar"
+  %9 = bitcast i64* %"struct Foo.bar" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = add i64 %8, 0
+  %11 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %10)
+  %12 = load i32, i32* %"struct Bar.x"
+  %13 = sext i32 %12 to i64
+  %14 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
   store i64 0, i64* %"@x_key"
-  %14 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
-  store i64 %11, i64* %"@x_val"
+  %16 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
+  store i64 %13, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %15 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
-  %16 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %18 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_save_1.ll
+++ b/tests/codegen/llvm/struct_save_1.ll
@@ -10,18 +10,21 @@ define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %"@foo_val" = alloca [12 x i8]
   %"@foo_key" = alloca i64
-  %1 = bitcast i64* %"@foo_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  %1 = bitcast i8* %0 to i64*
+  %2 = getelementptr i64, i64* %1, i64 14
+  %arg0 = load volatile i64, i64* %2
+  %3 = bitcast i64* %"@foo_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   store i64 0, i64* %"@foo_key"
-  %2 = bitcast [12 x i8]* %"@foo_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([12 x i8]*, i32, i64)*)([12 x i8]* %"@foo_val", i32 12, i64 0)
+  %4 = bitcast [12 x i8]* %"@foo_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([12 x i8]*, i32, i64)*)([12 x i8]* %"@foo_val", i32 12, i64 %arg0)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [12 x i8]*, i64)*)(i64 %pseudo, i64* %"@foo_key", [12 x i8]* %"@foo_val", i64 0)
-  %3 = bitcast i64* %"@foo_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [12 x i8]* %"@foo_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  %5 = bitcast i64* %"@foo_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = bitcast [12 x i8]* %"@foo_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_save_2.ll
+++ b/tests/codegen/llvm/struct_save_2.ll
@@ -10,18 +10,21 @@ define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
 entry:
   %"@foo_val" = alloca [12 x i8]
   %"@foo_key" = alloca i64
-  %1 = bitcast i64* %"@foo_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  %1 = bitcast i8* %0 to i64*
+  %2 = getelementptr i64, i64* %1, i64 14
+  %arg0 = load volatile i64, i64* %2
+  %3 = bitcast i64* %"@foo_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   store i64 0, i64* %"@foo_key"
-  %2 = bitcast [12 x i8]* %"@foo_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([12 x i8]*, i32, i64)*)([12 x i8]* %"@foo_val", i32 12, i64 0)
+  %4 = bitcast [12 x i8]* %"@foo_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([12 x i8]*, i32, i64)*)([12 x i8]* %"@foo_val", i32 12, i64 %arg0)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [12 x i8]*, i64)*)(i64 %pseudo, i64* %"@foo_key", [12 x i8]* %"@foo_val", i64 0)
-  %3 = bitcast i64* %"@foo_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [12 x i8]* %"@foo_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  %5 = bitcast i64* %"@foo_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = bitcast [12 x i8]* %"@foo_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_save_nested.ll
+++ b/tests/codegen/llvm/struct_save_nested.ll
@@ -19,104 +19,107 @@ entry:
   %"@foo_key1" = alloca i64
   %"@foo_val" = alloca [16 x i8]
   %"@foo_key" = alloca i64
-  %1 = bitcast i64* %"@foo_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  %1 = bitcast i8* %0 to i64*
+  %2 = getelementptr i64, i64* %1, i64 14
+  %arg0 = load volatile i64, i64* %2
+  %3 = bitcast i64* %"@foo_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   store i64 0, i64* %"@foo_key"
-  %2 = bitcast [16 x i8]* %"@foo_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* %"@foo_val", i32 16, i64 0)
+  %4 = bitcast [16 x i8]* %"@foo_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* %"@foo_val", i32 16, i64 %arg0)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [16 x i8]*, i64)*)(i64 %pseudo, i64* %"@foo_key", [16 x i8]* %"@foo_val", i64 0)
-  %3 = bitcast i64* %"@foo_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [16 x i8]* %"@foo_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
-  %5 = bitcast i64* %"@foo_key1" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %5 = bitcast i64* %"@foo_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = bitcast [16 x i8]* %"@foo_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast i64* %"@foo_key1" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   store i64 0, i64* %"@foo_key1"
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo2, i64* %"@foo_key1")
-  %6 = bitcast [16 x i8]* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %8 = bitcast [16 x i8]* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %7 = bitcast [16 x i8]* %lookup_elem_val to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %7, i8* align 1 %lookup_elem, i64 16, i1 false)
+  %9 = bitcast [16 x i8]* %lookup_elem_val to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %9, i8* align 1 %lookup_elem, i64 16, i1 false)
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  %8 = bitcast [16 x i8]* %lookup_elem_val to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %8, i8 0, i64 16, i1 false)
+  %10 = bitcast [16 x i8]* %lookup_elem_val to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %10, i8 0, i64 16, i1 false)
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %9 = bitcast i64* %"@foo_key1" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = getelementptr [16 x i8], [16 x i8]* %lookup_elem_val, i64 0, i64 4
-  %11 = bitcast [8 x i8]* %"internal_struct Foo.bar" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  %12 = bitcast [8 x i8]* %"internal_struct Foo.bar" to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %12, i8* align 1 %10, i64 8, i1 false)
-  %13 = bitcast [16 x i8]* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@bar_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  %11 = bitcast i64* %"@foo_key1" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = getelementptr [16 x i8], [16 x i8]* %lookup_elem_val, i64 0, i64 4
+  %13 = bitcast [8 x i8]* %"internal_struct Foo.bar" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %14 = bitcast [8 x i8]* %"internal_struct Foo.bar" to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %14, i8* align 1 %12, i64 8, i1 false)
+  %15 = bitcast [16 x i8]* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %16 = bitcast i64* %"@bar_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
   store i64 0, i64* %"@bar_key"
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [8 x i8]*, i64)*)(i64 %pseudo3, i64* %"@bar_key", [8 x i8]* %"internal_struct Foo.bar", i64 0)
-  %15 = bitcast i64* %"@bar_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
-  %16 = bitcast [8 x i8]* %"internal_struct Foo.bar" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = bitcast i64* %"@foo_key5" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
+  %17 = bitcast i64* %"@bar_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %18 = bitcast [8 x i8]* %"internal_struct Foo.bar" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  %19 = bitcast i64* %"@foo_key5" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
   store i64 0, i64* %"@foo_key5"
   %pseudo6 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %lookup_elem7 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo6, i64* %"@foo_key5")
-  %18 = bitcast [16 x i8]* %lookup_elem_val11 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
+  %20 = bitcast [16 x i8]* %lookup_elem_val11 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %20)
   %map_lookup_cond12 = icmp ne i8* %lookup_elem7, null
   br i1 %map_lookup_cond12, label %lookup_success8, label %lookup_failure9
 
 lookup_success8:                                  ; preds = %lookup_merge
-  %19 = bitcast [16 x i8]* %lookup_elem_val11 to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %19, i8* align 1 %lookup_elem7, i64 16, i1 false)
+  %21 = bitcast [16 x i8]* %lookup_elem_val11 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %21, i8* align 1 %lookup_elem7, i64 16, i1 false)
   br label %lookup_merge10
 
 lookup_failure9:                                  ; preds = %lookup_merge
-  %20 = bitcast [16 x i8]* %lookup_elem_val11 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %20, i8 0, i64 16, i1 false)
+  %22 = bitcast [16 x i8]* %lookup_elem_val11 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %22, i8 0, i64 16, i1 false)
   br label %lookup_merge10
 
 lookup_merge10:                                   ; preds = %lookup_failure9, %lookup_success8
-  %21 = bitcast i64* %"@foo_key5" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
-  %22 = getelementptr [16 x i8], [16 x i8]* %lookup_elem_val11, i64 0, i64 4
-  %23 = bitcast [8 x i8]* %"internal_struct Foo.bar13" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
-  %24 = bitcast [8 x i8]* %"internal_struct Foo.bar13" to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %24, i8* align 1 %22, i64 8, i1 false)
-  %25 = bitcast [16 x i8]* %lookup_elem_val11 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %25)
-  %26 = getelementptr [8 x i8], [8 x i8]* %"internal_struct Foo.bar13", i64 0, i64 0
-  %27 = load i32, i8* %26
-  %28 = bitcast [8 x i8]* %"internal_struct Foo.bar13" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %28)
-  %29 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %29)
-  store i64 0, i64* %"@x_key"
-  %30 = sext i32 %27 to i64
-  %31 = bitcast i64* %"@x_val" to i8*
+  %23 = bitcast i64* %"@foo_key5" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
+  %24 = getelementptr [16 x i8], [16 x i8]* %lookup_elem_val11, i64 0, i64 4
+  %25 = bitcast [8 x i8]* %"internal_struct Foo.bar13" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %25)
+  %26 = bitcast [8 x i8]* %"internal_struct Foo.bar13" to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %26, i8* align 1 %24, i64 8, i1 false)
+  %27 = bitcast [16 x i8]* %lookup_elem_val11 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %27)
+  %28 = getelementptr [8 x i8], [8 x i8]* %"internal_struct Foo.bar13", i64 0, i64 0
+  %29 = load i32, i8* %28
+  %30 = bitcast [8 x i8]* %"internal_struct Foo.bar13" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %30)
+  %31 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %31)
-  store i64 %30, i64* %"@x_val"
+  store i64 0, i64* %"@x_key"
+  %32 = sext i32 %29 to i64
+  %33 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %33)
+  store i64 %32, i64* %"@x_val"
   %pseudo14 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
   %update_elem15 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo14, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %32 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %32)
-  %33 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %33)
+  %34 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %34)
+  %35 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %35)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_save_string.ll
+++ b/tests/codegen/llvm/struct_save_string.ll
@@ -13,51 +13,54 @@ entry:
   %"@foo_key1" = alloca i64
   %"@foo_val" = alloca [32 x i8]
   %"@foo_key" = alloca i64
-  %1 = bitcast i64* %"@foo_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  %1 = bitcast i8* %0 to i64*
+  %2 = getelementptr i64, i64* %1, i64 14
+  %arg0 = load volatile i64, i64* %2
+  %3 = bitcast i64* %"@foo_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   store i64 0, i64* %"@foo_key"
-  %2 = bitcast [32 x i8]* %"@foo_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([32 x i8]*, i32, i64)*)([32 x i8]* %"@foo_val", i32 32, i64 0)
+  %4 = bitcast [32 x i8]* %"@foo_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([32 x i8]*, i32, i64)*)([32 x i8]* %"@foo_val", i32 32, i64 %arg0)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [32 x i8]*, i64)*)(i64 %pseudo, i64* %"@foo_key", [32 x i8]* %"@foo_val", i64 0)
-  %3 = bitcast i64* %"@foo_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [32 x i8]* %"@foo_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
-  %5 = bitcast i64* %"@foo_key1" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %5 = bitcast i64* %"@foo_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = bitcast [32 x i8]* %"@foo_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast i64* %"@foo_key1" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   store i64 0, i64* %"@foo_key1"
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo2, i64* %"@foo_key1")
-  %6 = bitcast [32 x i8]* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %8 = bitcast [32 x i8]* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %7 = bitcast [32 x i8]* %lookup_elem_val to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %7, i8* align 1 %lookup_elem, i64 32, i1 false)
+  %9 = bitcast [32 x i8]* %lookup_elem_val to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %9, i8* align 1 %lookup_elem, i64 32, i1 false)
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  %8 = bitcast [32 x i8]* %lookup_elem_val to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %8, i8 0, i64 32, i1 false)
+  %10 = bitcast [32 x i8]* %lookup_elem_val to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %10, i8 0, i64 32, i1 false)
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %9 = bitcast i64* %"@foo_key1" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = getelementptr [32 x i8], [32 x i8]* %lookup_elem_val, i64 0, i64 0
-  %11 = bitcast i64* %"@str_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %11 = bitcast i64* %"@foo_key1" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = getelementptr [32 x i8], [32 x i8]* %lookup_elem_val, i64 0, i64 0
+  %13 = bitcast i64* %"@str_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
   store i64 0, i64* %"@str_key"
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
-  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i8*, i64)*)(i64 %pseudo3, i64* %"@str_key", i8* %10, i64 0)
-  %12 = bitcast i64* %"@str_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast [32 x i8]* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i8*, i64)*)(i64 %pseudo3, i64* %"@str_key", i8* %12, i64 0)
+  %14 = bitcast i64* %"@str_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = bitcast [32 x i8]* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_short_1.ll
+++ b/tests/codegen/llvm/struct_short_1.ll
@@ -16,31 +16,34 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast [2 x i8]* %"$foo" to i8*
   call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 2, i1 false)
-  %3 = bitcast [2 x i8]* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [2 x i8]* %"$foo" to i8*
-  %5 = bitcast i64 0 to i8 addrspace(64)*
-  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %4, i8 addrspace(64)* align 1 %5, i64 2, i1 false)
-  %6 = add [2 x i8]* %"$foo", i64 0
-  %7 = bitcast i16* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i16*, i32, [2 x i8]*)*)(i16* %"struct Foo.x", i32 2, [2 x i8]* %6)
-  %8 = load i16, i16* %"struct Foo.x"
-  %9 = sext i16 %8 to i64
-  %10 = bitcast i16* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %3 = bitcast i8* %0 to i64*
+  %4 = getelementptr i64, i64* %3, i64 14
+  %arg0 = load volatile i64, i64* %4
+  %5 = bitcast [2 x i8]* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast [2 x i8]* %"$foo" to i8*
+  %7 = bitcast i64 %arg0 to i8 addrspace(64)*
+  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %6, i8 addrspace(64)* align 1 %7, i64 2, i1 false)
+  %8 = add [2 x i8]* %"$foo", i64 0
+  %9 = bitcast i16* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i16*, i32, [2 x i8]*)*)(i16* %"struct Foo.x", i32 2, [2 x i8]* %8)
+  %10 = load i16, i16* %"struct Foo.x"
+  %11 = sext i16 %10 to i64
+  %12 = bitcast i16* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
   store i64 0, i64* %"@x_key"
-  %12 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  store i64 %9, i64* %"@x_val"
+  %14 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  store i64 %11, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %13 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %16 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_short_2.ll
+++ b/tests/codegen/llvm/struct_short_2.ll
@@ -15,30 +15,33 @@ entry:
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$foo"
-  %2 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 0, i64* %"$foo"
-  %3 = load i64, i64* %"$foo"
-  %4 = add i64 %3, 0
-  %5 = bitcast i16* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i16*, i32, i64)*)(i16* %"struct Foo.x", i32 2, i64 %4)
-  %6 = load i16, i16* %"struct Foo.x"
-  %7 = sext i16 %6 to i64
-  %8 = bitcast i16* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %2 = bitcast i8* %0 to i64*
+  %3 = getelementptr i64, i64* %2, i64 14
+  %arg0 = load volatile i64, i64* %3
+  %4 = bitcast i64* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 %arg0, i64* %"$foo"
+  %5 = load i64, i64* %"$foo"
+  %6 = add i64 %5, 0
+  %7 = bitcast i16* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i16*, i32, i64)*)(i16* %"struct Foo.x", i32 2, i64 %6)
+  %8 = load i16, i16* %"struct Foo.x"
+  %9 = sext i16 %8 to i64
+  %10 = bitcast i16* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   store i64 0, i64* %"@x_key"
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  store i64 %7, i64* %"@x_val"
+  %12 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  store i64 %9, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %11 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_string_array_1.ll
+++ b/tests/codegen/llvm/struct_string_array_1.ll
@@ -15,24 +15,27 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast [32 x i8]* %"$foo" to i8*
   call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 32, i1 false)
-  %3 = bitcast [32 x i8]* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [32 x i8]* %"$foo" to i8*
-  %5 = bitcast i64 0 to i8 addrspace(64)*
-  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %4, i8 addrspace(64)* align 1 %5, i64 32, i1 false)
-  %6 = add [32 x i8]* %"$foo", i64 0
-  %7 = bitcast [32 x i8]* %"struct Foo.str" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([32 x i8]*, i32, [32 x i8]*)*)([32 x i8]* %"struct Foo.str", i32 32, [32 x i8]* %6)
-  %8 = bitcast i64* %"@mystr_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %3 = bitcast i8* %0 to i64*
+  %4 = getelementptr i64, i64* %3, i64 14
+  %arg0 = load volatile i64, i64* %4
+  %5 = bitcast [32 x i8]* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast [32 x i8]* %"$foo" to i8*
+  %7 = bitcast i64 %arg0 to i8 addrspace(64)*
+  call void @llvm.memcpy.p0i8.p64i8.i64(i8* align 1 %6, i8 addrspace(64)* align 1 %7, i64 32, i1 false)
+  %8 = add [32 x i8]* %"$foo", i64 0
+  %9 = bitcast [32 x i8]* %"struct Foo.str" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([32 x i8]*, i32, [32 x i8]*)*)([32 x i8]* %"struct Foo.str", i32 32, [32 x i8]* %8)
+  %10 = bitcast i64* %"@mystr_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 0, i64* %"@mystr_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [32 x i8]*, i64)*)(i64 %pseudo, i64* %"@mystr_key", [32 x i8]* %"struct Foo.str", i64 0)
-  %9 = bitcast i64* %"@mystr_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast [32 x i8]* %"struct Foo.str" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@mystr_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast [32 x i8]* %"struct Foo.str" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_string_array_2.ll
+++ b/tests/codegen/llvm/struct_string_array_2.ll
@@ -14,23 +14,26 @@ entry:
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$foo"
-  %2 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 0, i64* %"$foo"
-  %3 = load i64, i64* %"$foo"
-  %4 = add i64 %3, 0
-  %5 = bitcast [32 x i8]* %"struct Foo.str" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([32 x i8]*, i32, i64)*)([32 x i8]* %"struct Foo.str", i32 32, i64 %4)
-  %6 = bitcast i64* %"@mystr_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %2 = bitcast i8* %0 to i64*
+  %3 = getelementptr i64, i64* %2, i64 14
+  %arg0 = load volatile i64, i64* %3
+  %4 = bitcast i64* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 %arg0, i64* %"$foo"
+  %5 = load i64, i64* %"$foo"
+  %6 = add i64 %5, 0
+  %7 = bitcast [32 x i8]* %"struct Foo.str" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([32 x i8]*, i32, i64)*)([32 x i8]* %"struct Foo.str", i32 32, i64 %6)
+  %8 = bitcast i64* %"@mystr_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 0, i64* %"@mystr_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [32 x i8]*, i64)*)(i64 %pseudo, i64* %"@mystr_key", [32 x i8]* %"struct Foo.str", i64 0)
-  %7 = bitcast i64* %"@mystr_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast [32 x i8]* %"struct Foo.str" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast i64* %"@mystr_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast [32 x i8]* %"struct Foo.str" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_string_ptr.ll
+++ b/tests/codegen/llvm/struct_string_ptr.ll
@@ -16,40 +16,43 @@ entry:
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$foo"
-  %2 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 0, i64* %"$foo"
-  %3 = bitcast i64* %strlen to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %strlen to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 8, i1 false)
-  store i64 64, i64* %strlen
-  %5 = bitcast [64 x i8]* %str to i8*
+  %2 = bitcast i8* %0 to i64*
+  %3 = getelementptr i64, i64* %2, i64 14
+  %arg0 = load volatile i64, i64* %3
+  %4 = bitcast i64* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 %arg0, i64* %"$foo"
+  %5 = bitcast i64* %strlen to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 64, i1 false)
-  %7 = load i64, i64* %"$foo"
-  %8 = add i64 %7, 0
-  %9 = bitcast i64* %"struct Foo.str" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.str", i32 8, i64 %8)
-  %10 = load i64, i64* %"struct Foo.str"
+  %6 = bitcast i64* %strlen to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 8, i1 false)
+  store i64 64, i64* %strlen
+  %7 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %8 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %8, i8 0, i64 64, i1 false)
+  %9 = load i64, i64* %"$foo"
+  %10 = add i64 %9, 0
   %11 = bitcast i64* %"struct Foo.str" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = load i64, i64* %strlen
-  %13 = trunc i64 %12 to i32
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %13, i64 %10)
-  %14 = bitcast i64* %strlen to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@mystr_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.str", i32 8, i64 %10)
+  %12 = load i64, i64* %"struct Foo.str"
+  %13 = bitcast i64* %"struct Foo.str" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = load i64, i64* %strlen
+  %15 = trunc i64 %14 to i32
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %15, i64 %12)
+  %16 = bitcast i64* %strlen to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = bitcast i64* %"@mystr_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
   store i64 0, i64* %"@mystr_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* %"@mystr_key", [64 x i8]* %str, i64 0)
-  %16 = bitcast i64* %"@mystr_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %18 = bitcast i64* %"@mystr_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  %19 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
   ret i64 0
 }
 

--- a/tests/codegen/logical_and_or_different_type.cpp
+++ b/tests/codegen/logical_and_or_different_type.cpp
@@ -6,9 +6,13 @@ namespace codegen {
 
 TEST(codegen, logical_and_or_different_type)
 {
-  test("struct Foo { int m; } BEGIN { $foo = (struct Foo)0; printf(\"%d %d %d "
-       "%d\", $foo.m && 0, 1 && $foo.m, $foo.m || 0, 0 || $foo.m); }",
-
+  test("struct Foo { int m; }"
+       "BEGIN"
+       "{"
+       "  $foo = *(struct Foo*)arg0;"
+       "  printf(\"%d %d %d %d\", $foo.m && 0, 1 && $foo.m, $foo.m || 0, 0 || "
+       "$foo.m)"
+       "}",
        NAME);
 }
 

--- a/tests/codegen/struct_char.cpp
+++ b/tests/codegen/struct_char.cpp
@@ -9,7 +9,7 @@ TEST(codegen, struct_char)
   test("struct Foo { char x; }"
        "kprobe:f"
        "{"
-       "  $foo = (struct Foo)0;"
+       "  $foo = *(struct Foo*)arg0;"
        "  @x = $foo.x;"
        "}",
        std::string(NAME) + "_1");
@@ -17,7 +17,7 @@ TEST(codegen, struct_char)
   test("struct Foo { char x; }"
        "kprobe:f"
        "{"
-       "  $foo = (struct Foo*)0;"
+       "  $foo = (struct Foo*)arg0;"
        "  @x = $foo->x;"
        "}",
        std::string(NAME) + "_2");

--- a/tests/codegen/struct_integer_ptr.cpp
+++ b/tests/codegen/struct_integer_ptr.cpp
@@ -9,7 +9,7 @@ TEST(codegen, struct_integer_ptr)
   test("struct Foo { int *x; }"
        "kprobe:f"
        "{"
-       "  $foo = (struct Foo)0;"
+       "  $foo = *(struct Foo*)arg0;"
        "  @x = *$foo.x;"
        "}",
        std::string(NAME) + "_1");
@@ -17,7 +17,7 @@ TEST(codegen, struct_integer_ptr)
   test("struct Foo { int *x; }"
        "kprobe:f"
        "{"
-       "  $foo = (struct Foo*)0;"
+       "  $foo = (struct Foo*)arg0;"
        "  @x = *$foo->x;"
        "}",
        std::string(NAME) + "_2");

--- a/tests/codegen/struct_integers.cpp
+++ b/tests/codegen/struct_integers.cpp
@@ -9,7 +9,7 @@ TEST(codegen, struct_integers)
   test("struct Foo { int x; }"
        "kprobe:f"
        "{"
-       "  $foo = (struct Foo)0;"
+       "  $foo = *(struct Foo*)arg0;"
        "  @x = $foo.x;"
        "}",
        std::string(NAME) + "_1");
@@ -17,7 +17,7 @@ TEST(codegen, struct_integers)
   test("struct Foo { int x; }"
        "kprobe:f"
        "{"
-       "  $foo = (struct Foo*)0;"
+       "  $foo = (struct Foo*)arg0;"
        "  @x = $foo->x;"
        "}",
        std::string(NAME) + "_2");

--- a/tests/codegen/struct_long.cpp
+++ b/tests/codegen/struct_long.cpp
@@ -9,7 +9,7 @@ TEST(codegen, struct_long)
   test("struct Foo { long x; }"
        "kprobe:f"
        "{"
-       "  $foo = (struct Foo)0;"
+       "  $foo = *(struct Foo*)arg0;"
        "  @x = $foo.x;"
        "}",
        std::string(NAME) + "_1");
@@ -17,7 +17,7 @@ TEST(codegen, struct_long)
   test("struct Foo { long x; }"
        "kprobe:f"
        "{"
-       "  $foo = (struct Foo*)0;"
+       "  $foo = (struct Foo*)arg0;"
        "  @x = $foo->x;"
        "}",
        std::string(NAME) + "_2");

--- a/tests/codegen/struct_nested_struct_anon.cpp
+++ b/tests/codegen/struct_nested_struct_anon.cpp
@@ -9,7 +9,7 @@ TEST(codegen, struct_nested_struct_anon)
   test("struct Foo { struct { int x; } bar; }"
        "kprobe:f"
        "{"
-       "  $foo = (struct Foo)0;"
+       "  $foo = *(struct Foo*)arg0;"
        "  @x = $foo.bar.x;"
        "}",
        std::string(NAME) + "_1");
@@ -17,7 +17,7 @@ TEST(codegen, struct_nested_struct_anon)
   test("struct Foo { struct { int x; } bar; }"
        "kprobe:f"
        "{"
-       "  $foo = (struct Foo*)0;"
+       "  $foo = (struct Foo*)arg0;"
        "  @x = $foo->bar.x;"
        "}",
        std::string(NAME) + "_2");

--- a/tests/codegen/struct_nested_struct_named.cpp
+++ b/tests/codegen/struct_nested_struct_named.cpp
@@ -9,7 +9,7 @@ TEST(codegen, struct_nested_struct_named)
   test("struct Bar { int x; } struct Foo { struct Bar bar; }"
        "kprobe:f"
        "{"
-       "  $foo = (struct Foo)0;"
+       "  $foo = *(struct Foo*)arg0;"
        "  @x = $foo.bar.x;"
        "}",
        std::string(NAME) + "_1");
@@ -17,7 +17,7 @@ TEST(codegen, struct_nested_struct_named)
   test("struct Bar { int x; } struct Foo { struct Bar bar; }"
        "kprobe:f"
        "{"
-       "  $foo = (struct Foo*)0;"
+       "  $foo = (struct Foo*)arg0;"
        "  @x = $foo->bar.x;"
        "}",
        std::string(NAME) + "_2");

--- a/tests/codegen/struct_nested_struct_ptr_named.cpp
+++ b/tests/codegen/struct_nested_struct_ptr_named.cpp
@@ -9,7 +9,7 @@ TEST(codegen, struct_nested_struct_ptr_named)
   test("struct Bar { int x; } struct Foo { struct Bar *bar; }"
        "kprobe:f"
        "{"
-       "  $foo = (struct Foo)0;"
+       "  $foo = *(struct Foo*)arg0;"
        "  @x = $foo.bar->x;"
        "}",
        std::string(NAME) + "_1");
@@ -17,7 +17,7 @@ TEST(codegen, struct_nested_struct_ptr_named)
   test("struct Bar { int x; } struct Foo { struct Bar *bar; }"
        "kprobe:f"
        "{"
-       "  $foo = (struct Foo*)0;"
+       "  $foo = (struct Foo*)arg0;"
        "  @x = $foo->bar->x;"
        "}",
        std::string(NAME) + "_2");

--- a/tests/codegen/struct_save.cpp
+++ b/tests/codegen/struct_save.cpp
@@ -9,14 +9,14 @@ TEST(codegen, struct_save)
   test("struct Foo { int x, y, z; }"
        "kprobe:f"
        "{"
-       "  @foo = (struct Foo)0;"
+       "  @foo = *(struct Foo*)arg0;"
        "}",
        std::string(NAME) + "_1");
 
   test("struct Foo { int x, y, z; }"
        "kprobe:f"
        "{"
-       "  @foo = *(struct Foo*)0;"
+       "  @foo = *(struct Foo*)arg0;"
        "}",
        std::string(NAME) + "_2");
 }

--- a/tests/codegen/struct_save_nested.cpp
+++ b/tests/codegen/struct_save_nested.cpp
@@ -9,7 +9,7 @@ TEST(codegen, struct_save_nested)
   test("struct Foo { int m; struct { int x; int y; } bar; int n; }"
        "kprobe:f"
        "{"
-       "  @foo = (struct Foo)0;"
+       "  @foo = *(struct Foo*)arg0;"
        "  @bar = @foo.bar;"
        "  @x = @foo.bar.x;"
        "}",

--- a/tests/codegen/struct_save_string.cpp
+++ b/tests/codegen/struct_save_string.cpp
@@ -9,7 +9,7 @@ TEST(codegen, struct_save_string)
   test("struct Foo { char str[32]; }"
        "kprobe:f"
        "{"
-       "  @foo = (struct Foo)0;"
+       "  @foo = *(struct Foo*)arg0;"
        "  @str = @foo.str;"
        "}",
        NAME);

--- a/tests/codegen/struct_short.cpp
+++ b/tests/codegen/struct_short.cpp
@@ -9,7 +9,7 @@ TEST(codegen, struct_short)
   test("struct Foo { short x; }"
        "kprobe:f"
        "{"
-       "  $foo = (struct Foo)0;"
+       "  $foo = *(struct Foo*)arg0;"
        "  @x = $foo.x;"
        "}",
        std::string(NAME) + "_1");
@@ -17,7 +17,7 @@ TEST(codegen, struct_short)
   test("struct Foo { short x; }"
        "kprobe:f"
        "{"
-       "  $foo = (struct Foo*)0;"
+       "  $foo = (struct Foo*)arg0;"
        "  @x = $foo->x;"
        "}",
        std::string(NAME) + "_2");

--- a/tests/codegen/struct_string_array.cpp
+++ b/tests/codegen/struct_string_array.cpp
@@ -9,7 +9,7 @@ TEST(codegen, struct_string_array)
   test("struct Foo { char str[32]; }"
        "kprobe:f"
        "{"
-       "  $foo = (struct Foo)0;"
+       "  $foo = *(struct Foo*)arg0;"
        "  @mystr = $foo.str;"
        "}",
        std::string(NAME) + "_1");
@@ -17,7 +17,7 @@ TEST(codegen, struct_string_array)
   test("struct Foo { char str[32]; }"
        "kprobe:f"
        "{"
-       "  $foo = (struct Foo*)0;"
+       "  $foo = (struct Foo*)arg0;"
        "  @mystr = $foo->str;"
        "}",
        std::string(NAME) + "_2");

--- a/tests/codegen/struct_string_ptr.cpp
+++ b/tests/codegen/struct_string_ptr.cpp
@@ -9,7 +9,7 @@ TEST(codegen, struct_string_ptr)
   test("struct Foo { char *str; }"
        "kprobe:f"
        "{"
-       "  $foo = (struct Foo*)0;"
+       "  $foo = (struct Foo*)arg0;"
        "  @mystr = str($foo->str);"
        "}",
        NAME);

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -178,7 +178,7 @@ EXPECT ^ERROR: failed to open file '/does/not/exist/file': No such file or direc
 TIMEOUT 5
 
 NAME sizeof
-RUN bpftrace -e 'struct Foo { int x; char c; } BEGIN { $x = 1; printf("%d %d %d %d %d\n", sizeof(struct Foo), sizeof(((struct Foo)0).x), sizeof(((struct Foo)0).c), sizeof(1 == 1), sizeof($x)); exit(); }'
+RUN bpftrace -e 'struct Foo { int x; char c; } BEGIN { $x = 1; printf("%d %d %d %d %d\n", sizeof(struct Foo), sizeof((*(struct Foo*)0).x), sizeof((*(struct Foo*)0).c), sizeof(1 == 1), sizeof($x)); exit(); }'
 EXPECT ^8 4 1 8 8$
 TIMEOUT 5
 

--- a/tests/runtime/signed_ints
+++ b/tests/runtime/signed_ints
@@ -19,7 +19,7 @@ EXPECT @: -22$
 TIMEOUT 1
 
 NAME Comparison should print as 0 or 1
-RUN bpftrace -e 'struct x { uint64_t x; }; BEGIN { $a = ((struct x)0).x; printf("%d %d\n", $a > -1, $a < 1); exit(); }'
+RUN bpftrace -e 'struct x { uint64_t x; }; BEGIN { $a = (*(struct x*)0).x; printf("%d %d\n", $a > -1, $a < 1); exit(); }'
 EXPECT ^0 1$
 TIMEOUT 1
 


### PR DESCRIPTION
The conversion of an integer into a struct doesn't make sense, they're
two completely different types and best cast it leads to an incorrectly
initialized struct.

Currently it causes invalid IR to be emitted, LLVM inserts addrspace
casts to convert between the two, but verifier still rejects the result.

For the language it doesn't make sense either. Structs are not something
you create, you usually load them onto the stack by following a pointer
(e.g. `$foo = * (struct X*) arg0;`). Instead we have tuples for simple
collections.

fixes: #1536
