### PR TITLE
Do not check string size for printf()'s format string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to
   - [#1486](https://github.com/iovisor/bpftrace/pull/1486)
 - Switch `nsecs` to `ktime_get_boot_ns`
   - [#1475](https://github.com/iovisor/bpftrace/pull/1475)
+- Do not check size of the format string of `printf`
+  - [#1538](https://github.com/iovisor/bpftrace/pull/1538)
 
 #### Deprecated
 

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -76,6 +76,14 @@ void SemanticAnalyser::visit(PositionalParameter &param)
 
 void SemanticAnalyser::visit(String &string)
 {
+  // Skip check for printf()'s format string (1st argument) and create the string
+  // with the original size. This is because format string is not part of bpf byte code.
+  if (func_ == "printf" && func_arg_idx_ == 0)
+  {
+    string.type = CreateString(string.str.size());
+    return;
+  }
+
   if (!is_compile_time_func(func_) && string.str.size() > STRING_SIZE - 1)
   {
     LOG(ERROR, string.loc, err_) << "String is too long (over " << STRING_SIZE
@@ -388,6 +396,7 @@ void SemanticAnalyser::visit(Call &call)
     ~func_setter()
     {
       analyser_.func_ = old_func_;
+      analyser_.func_arg_idx_ = -1;
     }
 
   private:
@@ -401,7 +410,11 @@ void SemanticAnalyser::visit(Call &call)
     is_in_str = true;
 
   if (call.vargs) {
-    for (Expression *expr : *call.vargs) {
+    for (size_t i = 0; i < call.vargs->size(); ++i)
+    {
+      auto &expr = (*call.vargs)[i];
+      func_arg_idx_ = i;
+
       expr->accept(*this);
     }
   }

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -76,8 +76,9 @@ void SemanticAnalyser::visit(PositionalParameter &param)
 
 void SemanticAnalyser::visit(String &string)
 {
-  // Skip check for printf()'s format string (1st argument) and create the string
-  // with the original size. This is because format string is not part of bpf byte code.
+  // Skip check for printf()'s format string (1st argument) and create the
+  // string with the original size. This is because format string is not part of
+  // bpf byte code.
   if (func_ == "printf" && func_arg_idx_ == 0)
   {
     string.type = CreateString(string.str.size());

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -101,11 +101,9 @@ private:
 
   Probe *probe_;
 
-  // Temporarily record the function currently being visited by this
-  // SemanticAnalyser.
+  // Holds the function currently being visited by this SemanticAnalyser.
   std::string func_;
-  // Temporarily record the function argument index currently being visited by
-  // this SemanticAnalyser.
+  // Holds the function argument index currently being visited by this SemanticAnalyser.
   int func_arg_idx_ = -1;
 
   std::map<std::string, SizedType> variable_val_;

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -101,10 +101,11 @@ private:
 
   Probe *probe_;
 
-  // Temporarily record the function currently being visited by this SemanticAnalyser.
-  std::string func_;
-  // Temporarily record the function argument index currently being visited by this
+  // Temporarily record the function currently being visited by this
   // SemanticAnalyser.
+  std::string func_;
+  // Temporarily record the function argument index currently being visited by
+  // this SemanticAnalyser.
   int func_arg_idx_ = -1;
 
   std::map<std::string, SizedType> variable_val_;

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -100,7 +100,13 @@ private:
   void accept_statements(StatementList *stmts);
 
   Probe *probe_;
+
+  // Temporarily record the function currently being visited by this SemanticAnalyser.
   std::string func_;
+  // Temporarily record the function argument index currently being visited by this
+  // SemanticAnalyser.
+  int func_arg_idx_ = -1;
+
   std::map<std::string, SizedType> variable_val_;
   std::map<std::string, SizedType> map_val_;
   std::map<std::string, MapKey> map_key_;


### PR DESCRIPTION
And create String with its original size, without truncation.

This allows having longer format string in printf() statement,
and does not affect existing functionality.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
