### PR TITLE
info: Display full llvm version

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -131,7 +131,8 @@ static int info()
   std::cerr << std::endl
             << "Build" << std::endl
             << "  version: " << BPFTRACE_VERSION << std::endl
-            << "  LLVM: " << LLVM_VERSION_MAJOR << std::endl
+            << "  LLVM: " << LLVM_VERSION_MAJOR << "." << LLVM_VERSION_MINOR
+            << "." << LLVM_VERSION_PATCH << std::endl
             << "  foreach_sym: "
 #ifdef HAVE_BCC_ELF_FOREACH_SYM
             << "yes" << std::endl


### PR DESCRIPTION
Useful when debugging. Sometimes llvm enums like `CXCursorKind` can gain
elements between patch bumps.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
