### PR TITLE
logging: Don't insert a newline after debug prefix

### DIFF
--- a/src/log.cpp
+++ b/src/log.cpp
@@ -200,7 +200,7 @@ LogStream::~LogStream()
   {
     std::string prefix = "";
     if (type_ == LogType::DEBUG)
-      prefix = "[" + log_file_ + ":" + std::to_string(log_line_) + "]\n";
+      prefix = "[" + log_file_ + ":" + std::to_string(log_line_) + "] ";
     sink_.take_input(type_, loc_, out_, prefix + buf_.str());
   }
 }

--- a/tests/log.cpp
+++ b/tests/log.cpp
@@ -17,7 +17,7 @@ TEST(LogStream, basic)
   // clang-format off
   LOG(DEBUG, ss) << content_1; std::string file = __FILE__; int line = __LINE__;
   // clang-format on
-  std::string prefix = "[" + file + ":" + std::to_string(line) + "]\n";
+  std::string prefix = "[" + file + ":" + std::to_string(line) + "] ";
   EXPECT_EQ(ss.str(), "DEBUG: " + prefix + content_1 + "\n");
   ss.str({});
 


### PR DESCRIPTION
Newline is strange. Log lines should be on one line.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
