### PR TITLE
tracepoint: Support __data_loc fields in tracepoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to
   - [#1499](https://github.com/iovisor/bpftrace/pull/1499)
 - Positional parameters: support numbers as strings and params as string literals
   - [#1514](https://github.com/iovisor/bpftrace/pull/1514)
+- Support for tracepoint __data_loc fields
+  - [#1542](https://github.com/iovisor/bpftrace/pull/1542)
 
 #### Changed
 - Warn if using `print` on `stats` maps with top and div arguments
@@ -44,6 +46,8 @@ and this project adheres to
   - [#1486](https://github.com/iovisor/bpftrace/pull/1486)
 - Switch `nsecs` to `ktime_get_boot_ns`
   - [#1475](https://github.com/iovisor/bpftrace/pull/1475)
+- Tracepoint __data_loc fields are renamed from `args->data_loc_name` to `args->name`
+  - [#1542](https://github.com/iovisor/bpftrace/pull/1542)
 
 #### Deprecated
 

--- a/src/struct.h
+++ b/src/struct.h
@@ -25,6 +25,14 @@ struct Field
 
   bool is_bitfield;
   Bitfield bitfield;
+
+  // Used for tracepoint __data_loc's
+  //
+  // If true, this field is a 32 bit integer whose value encodes information on
+  // where to find the actual data. The first 2 bytes is the size of the data.
+  // The last 2 bytes is the offset from the start of the tracepoint struct
+  // where the data begins.
+  bool is_data_loc = false;
 };
 
 using FieldsMap = std::map<std::string, Field>;

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -205,7 +205,6 @@ std::string TracepointFormatParser::parse_field(const std::string &line,
   if (field_type.find("__data_loc") != std::string::npos)
   {
     field_type = "int";
-    field_name = "data_loc_" + field_name;
   }
 
   // Only adjust field types for non-arrays

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -204,7 +204,10 @@ std::string TracepointFormatParser::parse_field(const std::string &line,
 
   if (field_type.find("__data_loc") != std::string::npos)
   {
-    field_type = "int";
+    // Note that the type here (ie `int`) does not matter. Later during parse
+    // time the parser will rewrite this field type to a u64 so that it can
+    // hold the pointer to the actual location of the data.
+    field_type = R"_(__attribute__((annotate("tp_data_loc"))) int)_";
   }
 
   // Only adjust field types for non-arrays

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -124,6 +124,12 @@ RUN bpftrace -v -e 'tracepoint:syscalls:sys_*_nanosleep { printf("hit "); }' -c 
 EXPECT hit hit
 TIMEOUT 5
 
+# Test that we get at least two characters out
+NAME tracepoint_data_loc
+RUN bpftrace -v -e 'tracepoint:irq:irq_handler_entry { print(str(args->name)) }'
+EXPECT ..+
+TIMEOUT 5
+
 NAME profile
 RUN bpftrace -v -e 'profile:hz:599 { @[tid] = count(); exit();}'
 EXPECT \@\[[0-9]*\]\:\s[0-9]

--- a/tests/tracepoint_format_parser.cpp
+++ b/tests/tracepoint_format_parser.cpp
@@ -90,10 +90,10 @@ TEST(tracepoint_format_parser, data_loc)
   std::string input = "	field:__data_loc char[] msg;	offset:8;	size:4;	signed:1;";
 
   std::string expected =
-    "struct _tracepoint_syscalls_sys_enter_read\n"
-    "{\n"
-    "  int data_loc_msg;\n"
-    "};\n";
+      "struct _tracepoint_syscalls_sys_enter_read\n"
+      "{\n"
+      "  __attribute__((annotate(\"tp_data_loc\"))) int msg;\n"
+      "};\n";
 
   std::istringstream format_file(input);
 


### PR DESCRIPTION
This PR teaches bpftrace to read `__data_loc` arguments from tracepoints.

Note that this PR causes a minor compatibility break where fields previously
named `args->data_loc_name` are now named `args->name`.

This closes #385 . This supercedes #770 .

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
