### PR TITLE
clang-parser: Remove extraneous redefinition check

### DIFF
--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -435,26 +435,14 @@ bool ClangParser::visit_children(CXCursor &cursor, BPFtrace &bpftrace)
           Bitfield bitfield;
           bool is_bitfield = getBitfield(c, bitfield);
 
-          // Warn if we already have the struct member defined and is
-          // different type and keep the current definition in place.
-          if (structs.count(ptypestr) != 0 &&
-              structs[ptypestr].fields.count(ident)    != 0 &&
-              structs[ptypestr].fields[ident].offset   != offset &&
-              structs[ptypestr].fields[ident].type     != get_sized_type(type) &&
-              structs[ptypestr].fields[ident].is_bitfield && is_bitfield &&
-              structs[ptypestr].fields[ident].bitfield != bitfield &&
-              structs[ptypestr].size                   != ptypesize)
-          {
-            LOG(WARNING) << "type mismatch for " << ptypestr << "::" << ident;
-          }
-          else
-          {
-            structs[ptypestr].fields[ident].offset = offset;
-            structs[ptypestr].fields[ident].type = get_sized_type(type);
-            structs[ptypestr].fields[ident].is_bitfield = is_bitfield;
-            structs[ptypestr].fields[ident].bitfield = bitfield;
-            structs[ptypestr].size = ptypesize;
-          }
+          // No need to worry about redefined types b/c we should have already
+          // checked clang diagnostics. The diagnostics will tell us if we have
+          // duplicated types.
+          structs[ptypestr].fields[ident].offset = offset;
+          structs[ptypestr].fields[ident].type = get_sized_type(type);
+          structs[ptypestr].fields[ident].is_bitfield = is_bitfield;
+          structs[ptypestr].fields[ident].bitfield = bitfield;
+          structs[ptypestr].size = ptypesize;
         }
 
         return CXChildVisit_Recurse;

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -737,6 +737,13 @@ TEST(clang_parser, struct_qualifiers)
   EXPECT_EQ(SB.fields["a2"].type.GetName(), "struct a");
 }
 
+TEST(clang_parser, redefined_types)
+{
+  BPFtrace bpftrace;
+  parse("struct a {int a}; struct a {int a};", bpftrace, false);
+  parse("struct a {int a}; struct a {int a; short b;};", bpftrace, false);
+}
+
 } // namespace clang_parser
 } // namespace test
 } // namespace bpftrace


### PR DESCRIPTION
We already check for redefinition errors (among other things) at
`handler.check_diagnostics(..)`. The diagnostic check occurs before we
walk the AST. The removed check is done while walking the AST.

Furthermore, the removed redefinition check is wrong. I don't think the
boolean operators are correct (most of the `&&`s should be `||`s).
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
