### PR TITLE
[RFC] Add --no-headers option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to
   - [#1499](https://github.com/iovisor/bpftrace/pull/1499)
 - Positional parameters: support numbers as strings and params as string literals
   - [#1514](https://github.com/iovisor/bpftrace/pull/1514)
+- Add --no-headers flag
+  - [#1545](https://github.com/iovisor/bpftrace/pull/1545)
 
 #### Changed
 - Warn if using `print` on `stats` maps with top and div arguments

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -165,6 +165,7 @@ public:
   bool force_btf_ = false;
   bool has_usdt_ = false;
   bool usdt_file_activation_ = false;
+  bool no_headers_ = false;
   int helper_check_level_ = 0;
   std::optional<struct timespec> boottime_;
 

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -595,10 +595,12 @@ bool ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<s
 
   bool process_btf = program->c_definitions.empty() ||
                      (bpftrace.force_btf_ && bpftrace.btf_.has_data());
+  if (bpftrace.no_headers_)
+    process_btf = false;
 
   // We set these args early because some systems may not have <linux/types.h>
   // (containers) and fully rely on BTF.
-  if (process_btf)
+  if (process_btf || bpftrace.no_headers_)
   {
     // Prevent BTF generated header from redefining stuff found
     // in <linux/types.h>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -58,6 +58,7 @@ void usage()
   std::cerr << "    -h, --help     show this help message" << std::endl;
   std::cerr << "    -I DIR         add the directory to the include search path" << std::endl;
   std::cerr << "    --include FILE add an #include file before preprocessing" << std::endl;
+  std::cerr << "    --no-headers   do not include any BTF or system supplied headers" << std::endl;
   std::cerr << "    -l [search]    list probes" << std::endl;
   std::cerr << "    -p PID         enable USDT probes on PID" << std::endl;
   std::cerr << "    -c 'CMD'       run CMD and enable USDT probes on resulting process" << std::endl;
@@ -261,13 +262,14 @@ int main(int argc, char *argv[])
   bool listing = false;
   bool safe_mode = true;
   bool force_btf = false;
+  bool no_headers = false;
   bool usdt_file_activation = false;
   int helper_check_level = 0;
   std::string script, search, file_name, output_file, output_format, output_elf;
   OutputBufferConfig obc = OutputBufferConfig::UNSET;
   int c;
 
-  const char* const short_options = "dbB:f:e:hlp:vc:Vo:I:k";
+  const char* const short_options = "dbB:f:e:hlp:vc:Vo:I:kn";
   option long_options[] = {
     option{ "help", no_argument, nullptr, 'h' },
     option{ "version", no_argument, nullptr, 'V' },
@@ -275,6 +277,7 @@ int main(int argc, char *argv[])
     option{ "unsafe", no_argument, nullptr, 'u' },
     option{ "btf", no_argument, nullptr, 'b' },
     option{ "include", required_argument, nullptr, '#' },
+    option{ "no-headers", no_argument, nullptr, 1999 },
     option{ "info", no_argument, nullptr, 2000 },
     option{ "emit-elf", required_argument, nullptr, 2001 },
     option{ "no-warnings", no_argument, nullptr, 2002 },
@@ -287,6 +290,9 @@ int main(int argc, char *argv[])
   {
     switch (c)
     {
+      case 1999: // --no-headers
+        no_headers = true;
+        break;
       case 2000: // --info
         if (is_root())
           return info();
@@ -433,6 +439,7 @@ int main(int argc, char *argv[])
   BPFtrace bpftrace(std::move(output));
   Driver driver(bpftrace);
 
+  bpftrace.no_headers_ = no_headers;
   bpftrace.usdt_file_activation_ = usdt_file_activation;
   bpftrace.safe_mode_ = safe_mode;
   bpftrace.force_btf_ = force_btf;


### PR DESCRIPTION
This option disables all processing of system supplied or BTF supplied
header files. When used, the user can be sure whatever header files they
include will not cause redefinition errors.

This closes #1511 .

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
