### PR TITLE
NFC: Normalize member variable names

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -41,10 +41,10 @@ void SemanticAnalyser::visit(Integer &integer)
 void SemanticAnalyser::visit(PositionalParameter &param)
 {
   param.type = CreateInt64();
-  if (is_in_str)
+  if (is_in_str_)
   {
     param.is_in_str = true;
-    has_pos_param = true;
+    has_pos_param_ = true;
   }
   switch (param.ptype)
   {
@@ -398,7 +398,7 @@ void SemanticAnalyser::visit(Call &call)
   func_setter scope_bound_func_setter{ *this, call.func };
 
   if (call.func == "str")
-    is_in_str = true;
+    is_in_str_ = true;
 
   if (call.vargs) {
     for (Expression *expr : *call.vargs) {
@@ -536,7 +536,7 @@ void SemanticAnalyser::visit(Call &call)
             << "argument (" << t << " provided)";
       }
       call.type = CreateString(bpftrace_.strlen_);
-      if (has_pos_param)
+      if (has_pos_param_)
       {
         if (dynamic_cast<PositionalParameter *>(arg))
           call.is_literal = true;
@@ -551,7 +551,7 @@ void SemanticAnalyser::visit(Call &call)
                 << call.func << "() only accepts positional parameters"
                 << " directly or with a single constant offset added";
           }
-          has_pos_param = false;
+          has_pos_param_ = false;
         }
       }
 
@@ -559,7 +559,7 @@ void SemanticAnalyser::visit(Call &call)
         check_arg(call, Type::integer, 1, false);
       }
     }
-    is_in_str = false;
+    is_in_str_ = false;
   }
   else if (call.func == "buf")
   {
@@ -1361,7 +1361,7 @@ void SemanticAnalyser::visit(Binop &binop)
         }
       }
 
-      if (is_in_str)
+      if (is_in_str_)
       {
         // Check if one of the operands is a positional parameter
         // The other one should be a constant offset

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -114,8 +114,8 @@ private:
   bool has_begin_probe_ = false;
   bool has_end_probe_ = false;
   bool has_child_ = false;
-  bool is_in_str = false;
-  bool has_pos_param = false;
+  bool is_in_str_ = false;
+  bool has_pos_param_ = false;
 };
 
 } // namespace ast


### PR DESCRIPTION
Most of the codebase uses the `_` suffix for private member variables.
The rest of the member variables in SemanticAnalyser follow this
convention too.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
