### PR TITLE
semantic_analyser: Fix state leak between str() processing

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -41,7 +41,7 @@ void SemanticAnalyser::visit(Integer &integer)
 void SemanticAnalyser::visit(PositionalParameter &param)
 {
   param.type = CreateInt64();
-  if (is_in_str_)
+  if (func_ == "str")
   {
     param.is_in_str = true;
     has_pos_param_ = true;
@@ -397,9 +397,6 @@ void SemanticAnalyser::visit(Call &call)
 
   func_setter scope_bound_func_setter{ *this, call.func };
 
-  if (call.func == "str")
-    is_in_str_ = true;
-
   if (call.vargs) {
     for (Expression *expr : *call.vargs) {
       expr->accept(*this);
@@ -558,7 +555,6 @@ void SemanticAnalyser::visit(Call &call)
         check_arg(call, Type::integer, 1, false);
       }
     }
-    is_in_str_ = false;
     has_pos_param_ = false;
   }
   else if (call.func == "buf")
@@ -1361,7 +1357,7 @@ void SemanticAnalyser::visit(Binop &binop)
         }
       }
 
-      if (is_in_str_)
+      if (func_ == "str")
       {
         // Check if one of the operands is a positional parameter
         // The other one should be a constant offset

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -551,7 +551,6 @@ void SemanticAnalyser::visit(Call &call)
                 << call.func << "() only accepts positional parameters"
                 << " directly or with a single constant offset added";
           }
-          has_pos_param_ = false;
         }
       }
 
@@ -560,6 +559,7 @@ void SemanticAnalyser::visit(Call &call)
       }
     }
     is_in_str_ = false;
+    has_pos_param_ = false;
   }
   else if (call.func == "buf")
   {

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -114,7 +114,6 @@ private:
   bool has_begin_probe_ = false;
   bool has_end_probe_ = false;
   bool has_child_ = false;
-  bool is_in_str_ = false;
   bool has_pos_param_ = false;
 };
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -589,6 +589,15 @@ TEST(semantic_analyser, call_str_2_expr)
   test("kprobe:f { @x = str(arg0, arg1); }", 0);
 }
 
+TEST(semantic_analyser, call_str_state_leak_regression_test)
+{
+  // Previously, the semantic analyser would leak state in the first str()
+  // call. This would make the semantic analyser think it's still processing
+  // a positional parameter in the second str() call causing confusing error
+  // messages.
+  test(R"PROG(kprobe:f { $x = str($1) == "asdf"; $y = str(arg0) })PROG", 0);
+}
+
 TEST(semantic_analyser, call_buf)
 {
   test("kprobe:f { buf(arg0, 1); }", 0);


### PR DESCRIPTION
Before, if the semantic analyser encountered a str() call on a
positional parameter, it would leak state into following `str()` calls
and still think it was processing a positional parameter.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
