### PR TITLE
add support for watchpoint on kernel space address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to
   - [#1542](https://github.com/iovisor/bpftrace/pull/1542)
 - Set addrspace info for various builtins
   - [#1504](https://github.com/iovisor/bpftrace/pull/1504)
+- Support watchpoint for kernel space address
+  - [#1552](https://github.com/iovisor/bpftrace/pull/1552)
 
 #### Changed
 - Warn if using `print` on `stats` maps with top and div arguments

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -59,7 +59,7 @@ bpftrace|perf           { return Parser::make_STACK_MODE(yytext, loc); }
 {builtin}               { return Parser::make_BUILTIN(yytext, loc); }
 {call}                  { return Parser::make_CALL(yytext, loc); }
 {call_and_builtin}      { return Parser::make_CALL_BUILTIN(yytext, loc); }
-{int}                   { return Parser::make_INT(strtoll(yytext, NULL, 0), loc); }
+{int}                   { return Parser::make_INT(strtoul(yytext, NULL, 0), loc); }
 {exponent}              { return Parser::make_INT(parse_exponent(yytext), loc); }
 {path}                  { return Parser::make_PATH(yytext, loc); }
 {map}                   { return Parser::make_MAP(yytext, loc); }

--- a/tests/runtime/watchpoint
+++ b/tests/runtime/watchpoint
@@ -2,3 +2,9 @@ NAME watchpoint - absolute address
 RUN bpftrace -v -e 'watchpoint::0x10000000:8:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint
 EXPECT hit!
 TIMEOUT 5
+
+NAME kwatchpoint - knl absolute address
+RUN bpftrace -v -e "watchpoint::0x$(awk '$3 == "jiffies" {print $1}' /proc/kallsyms):4:w { printf(\"hit\n\"); exit(); }"
+EXPECT hit
+TIMEOUT 5
+REQUIRES awk '$3 == "jiffies" {got=1} END {exit !got}' /proc/kallsyms


### PR DESCRIPTION
##### Description

Add support for watchpoint on absolute kernel space address, so the following command can run correctly:

```
# bpftrace -e "watchpoint::0x$(awk '$3 == "jiffies" {print $1}' /proc/kallsyms):8:w {@[kstack] = count();}"
Attaching 1 probe...   
^C
@[
    do_timer+12
    tick_do_update_jiffies64.part.22+89
    tick_sched_do_timer+103
    tick_sched_timer+39
    __hrtimer_run_queues+256
    hrtimer_interrupt+256
    smp_apic_timer_interrupt+106
    apic_timer_interrupt+15
    cpuidle_enter_state+188
    cpuidle_enter+41
    do_idle+536
    cpu_startup_entry+25
    start_secondary+355
    secondary_startup_64+164
]: 319
```

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
