### PR TITLE
Change a part of the message of '-v' output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to
   - [#1475](https://github.com/iovisor/bpftrace/pull/1475)
 - Tracepoint __data_loc fields are renamed from `args->data_loc_name` to `args->name`
   - [#1542](https://github.com/iovisor/bpftrace/pull/1542)
+- Change a part of the message of '-v' output
+  - [#1553](https://github.com/iovisor/bpftrace/pull/1553)
 
 #### Deprecated
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -365,7 +365,7 @@ The `-v` option prints more information about the program as it is run:
 # bpftrace -v -e 'tracepoint:syscalls:sys_enter_nanosleep { printf("%s is sleeping.\n", comm); }'
 Attaching 1 probe...
 
-Bytecode:
+The verifier log:
 0: (bf) r6 = r1
 1: (b7) r1 = 0
 2: (7b) *(u64 *)(r10 -24) = r1
@@ -401,7 +401,7 @@ iscsid is sleeping.
 [...]
 ```
 
-This includes `Bytecode:` and then the eBPF bytecode after it was compiled from the llvm assembly.
+This includes `The verifier log:` and then the log message from the in-kernel vertifier.
 
 ## 7. Preprocessor Options
 

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -657,7 +657,7 @@ void AttachedProbe::load_prog()
       std::cout << std::endl << "Program ID: " << info.id << std::endl;
     }
     std::cout << std::endl
-              << "Bytecode: " << std::endl
+              << "The verifier log: " << std::endl
               << log_buf.get() << std::endl;
   }
 }


### PR DESCRIPTION
Change "Bytecode" to "The verifier log" since a log might not
contain BPF bytecodes.

Closes #1551

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
