### PR TITLE
Move BTF verbose messages to debug messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,6 +56,8 @@ and this project adheres to
   - [#1553](https://github.com/iovisor/bpftrace/pull/1553)
 - Improve tuple assignment error message
   - [#1563](https://github.com/iovisor/bpftrace/pull/1563)
+- Remove "BTF: using data from ..." message when using -v flag
+  - [#1554](https://github.com/iovisor/bpftrace/pull/1554)
 
 #### Deprecated
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -300,7 +300,6 @@ If BTF is available, it is also possible to list struct/union/emum definitions. 
 
 ```
 # bpftrace -lv "struct path"
-BTF: using data from /sys/kernel/btf/vmlinux
 struct path {
         struct vfsmount *mnt;
         struct dentry *dentry;

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -115,7 +115,7 @@ static struct btf *btf_open(const struct vmlinux_location *locs)
 
     if (err)
     {
-      if (bt_verbose)
+      if (bt_debug != DebugLevel::kNone)
       {
         char err_buf[256];
 
@@ -126,7 +126,7 @@ static struct btf *btf_open(const struct vmlinux_location *locs)
       continue;
     }
 
-    if (bt_verbose)
+    if (bt_debug != DebugLevel::kNone)
     {
       std::cerr << "BTF: using data from " << path << std::endl;
     }


### PR DESCRIPTION
Before, you'd get:
```
$ sudo ./build/src/bpftrace -lv "kfunc:hrtimers_dead_cpu"
BTF: using data from /sys/kernel/btf/vmlinux
kfunc:hrtimers_dead_cpu
    unsigned int scpu;
    int retval;
```

The first message is kind of ugly and not very actionable or informative
for users. Better to move it to debug where bpftrace developers might
actually make use of the information.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
