### PR TITLE
usdt: Plug memory leak

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -869,13 +869,14 @@ std::vector<std::unique_ptr<AttachedProbe>> BPFtrace::attach_usdt_probe(
   if (::glob("/proc/[0-9]*/maps", GLOB_NOSORT, nullptr, &globbuf))
     throw std::runtime_error("failed to glob");
 
-  const char *p;
+  char *p;
   if (!(p = realpath(probe.path.c_str(), nullptr)))
   {
     LOG(ERROR) << "Failed to resolve " << probe.path;
     return ret;
   }
   std::string resolved(p);
+  free(p);
 
   for (size_t i = 0; i < globbuf.gl_pathc; ++i)
   {


### PR DESCRIPTION
The returned pointer from realpath() needs to be freed.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
