### PR TITLE
lang: Add support for pointer to pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,8 @@ and this project adheres to
   - [#1504](https://github.com/iovisor/bpftrace/pull/1504)
 - Support watchpoint for kernel space address
   - [#1552](https://github.com/iovisor/bpftrace/pull/1552)
+- Support for pointer to pointer
+  - [#1557](https://github.com/iovisor/bpftrace/pull/1557)
 
 #### Changed
 - Warn if using `print` on `stats` maps with top and div arguments

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -248,16 +248,27 @@ void ArrayAccess::accept(Visitor &v) {
   v.visit(*this);
 }
 
-Cast::Cast(const std::string &type, bool is_pointer, Expression *expr)
-    : cast_type(type), is_pointer(is_pointer), expr(expr)
+Cast::Cast(const std::string &type,
+           bool is_pointer,
+           bool is_double_pointer,
+           Expression *expr)
+    : cast_type(type),
+      is_pointer(is_pointer),
+      is_double_pointer(is_double_pointer),
+      expr(expr)
 {
 }
 
 Cast::Cast(const std::string &type,
            bool is_pointer,
+           bool is_double_pointer,
            Expression *expr,
            location loc)
-    : Expression(loc), cast_type(type), is_pointer(is_pointer), expr(expr)
+    : Expression(loc),
+      cast_type(type),
+      is_pointer(is_pointer),
+      is_double_pointer(is_double_pointer),
+      expr(expr)
 {
 }
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -178,13 +178,18 @@ public:
 
 class Cast : public Expression {
 public:
-  Cast(const std::string &type, bool is_pointer, Expression *expr);
   Cast(const std::string &type,
        bool is_pointer,
+       bool is_double_pointer,
+       Expression *expr);
+  Cast(const std::string &type,
+       bool is_pointer,
+       bool is_double_pointer,
        Expression *expr,
        location loc);
   std::string cast_type;
   bool is_pointer;
+  bool is_double_pointer;
   Expression *expr;
 
   void accept(Visitor &v) override;

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1306,10 +1306,11 @@ void CodegenLLVM::visit(Unop &unop)
     {
       case bpftrace::Parser::token::MUL:
       {
-        if (unop.type.IsIntegerTy())
+        if (unop.type.IsIntegerTy() || unop.type.IsPtrTy())
         {
           auto *et = type.GetPointeeTy();
-          int size = et->GetIntBitWidth() / 8;
+          // Pointer always 64 bits wide
+          int size = unop.type.IsIntegerTy() ? et->GetIntBitWidth() / 8 : 8;
           AllocaInst *dst = b_.CreateAllocaBPF(*et, "deref");
           b_.CreateProbeRead(ctx_, dst, size, expr_, type.GetAS(), unop.loc);
           expr_ = b_.CreateIntCast(b_.CreateLoad(dst),

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1252,7 +1252,7 @@ void SemanticAnalyser::visit(Map &map)
       if (expr->type.IsIntTy() && expr->type.size < 8)
       {
         std::string type = expr->type.IsSigned() ? "int64" : "uint64";
-        Expression * cast = new ast::Cast(type, false, expr);
+        Expression *cast = new ast::Cast(type, false, false, expr);
         cast->accept(*this);
         map.vargs->at(i) = cast;
         expr = cast;
@@ -1873,6 +1873,9 @@ void SemanticAnalyser::visit(Cast &cast)
         LOG(ERROR, cast.loc, err_)
             << "Integer pointer casts are not supported for type: ctx";
       }
+
+      if (cast.is_double_pointer)
+        cast.type = CreatePointer(cast.type);
     }
     else
     {
@@ -1903,7 +1906,12 @@ void SemanticAnalyser::visit(Cast &cast)
 
   cast_size = bpftrace_.structs_[cast.cast_type].size;
   if (cast.is_pointer)
+  {
     cast.type = CreatePointer(CreateRecord(cast_size, cast.cast_type));
+
+    if (cast.is_double_pointer)
+      cast.type = CreatePointer(cast.type);
+  }
   else
     cast.type = CreateRecord(cast_size, cast.cast_type);
   cast.type.SetAS(cast.expr->type.GetAS());

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -333,8 +333,9 @@ expr : int                                      { $$ = $1; }
      | expr DOT INT                             { $$ = new ast::FieldAccess($1, $3, @3); }
      | expr PTR ident                           { $$ = new ast::FieldAccess(new ast::Unop(token::MUL, $1, @2), $3, @$); }
      | expr "[" expr "]"                        { $$ = new ast::ArrayAccess($1, $3, @2 + @4); }
-     | "(" IDENT ")" expr %prec CAST            { $$ = new ast::Cast($2, false, $4, @1 + @3); }
-     | "(" IDENT MUL ")" expr %prec CAST        { $$ = new ast::Cast($2, true, $5, @1 + @4); }
+     | "(" IDENT ")" expr %prec CAST            { $$ = new ast::Cast($2, false, false, $4, @1 + @3); }
+     | "(" IDENT MUL ")" expr %prec CAST        { $$ = new ast::Cast($2, true, false, $5, @1 + @4); }
+     | "(" IDENT MUL MUL ")" expr %prec CAST    { $$ = new ast::Cast($2, true, true, $6, @1 + @5); }
      | "(" expr "," vargs ")"                   {
                                                   auto args = new ast::ExpressionList;
                                                   args->emplace_back($2);

--- a/tests/codegen/llvm/ptr_to_ptr.ll
+++ b/tests/codegen/llvm/ptr_to_ptr.ll
@@ -1,0 +1,63 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%printf_t = type { i64, i64 }
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
+entry:
+  %deref1 = alloca i32
+  %deref = alloca i64
+  %printf_args = alloca %printf_t
+  %"$pp" = alloca i64
+  %1 = bitcast i64* %"$pp" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 0, i64* %"$pp"
+  %2 = bitcast i64* %"$pp" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"$pp"
+  %3 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  %4 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 16, i1 false)
+  %5 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
+  store i64 0, i64* %5
+  %6 = load i64, i64* %"$pp"
+  %7 = bitcast i64* %deref to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* %deref, i32 8, i64 %6)
+  %8 = load i64, i64* %deref
+  %9 = bitcast i64* %deref to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i32* %deref1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %probe_read2 = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* %deref1, i32 4, i64 %8)
+  %11 = load i32, i32* %deref1
+  %12 = sext i32 %11 to i64
+  %13 = bitcast i32* %deref1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
+  store i64 %12, i64* %14
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 %get_cpu_id, %printf_t* %printf_args, i64 16)
+  %15 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/ptr_to_ptr.cpp
+++ b/tests/codegen/ptr_to_ptr.cpp
@@ -1,0 +1,16 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, ptr_to_ptr)
+{
+  test(R"PROG(kprobe:f { $pp = (int32 **)0; printf("%d\n", **$pp); })PROG",
+
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/runtime/complex_types
+++ b/tests/runtime/complex_types
@@ -2,3 +2,8 @@ NAME struct-array
 RUN bpftrace runtime/scripts/struct_array.bt -c ./testprogs/struct_array
 EXPECT 100 102 104 106 108 -- 0 2 4 6 8 -- 100 98 96 94 92
 TIMEOUT 5
+
+NAME pointer_to_pointer
+RUN bpftrace -e 'struct Foo { int a; char b[10]; } uprobe:./testprogs/ptr_to_ptr:function { $pp = (struct Foo **)arg0; printf("%d\n", (*$pp)->a); }' -c ./testprogs/ptr_to_ptr
+EXPECT 123
+TIMEOUT 5

--- a/tests/testprogs/ptr_to_ptr.c
+++ b/tests/testprogs/ptr_to_ptr.c
@@ -1,0 +1,19 @@
+struct Foo
+{
+  int a;
+  char b[10];
+};
+
+int function(struct Foo **f)
+{
+  return (*f)->a;
+}
+
+int main(int argc __attribute__((unused)), char **argv __attribute__((unused)))
+{
+  struct Foo foo1 = { .a = 123, .b = "hello" };
+  struct Foo *foo2 = &foo1;
+  function(&foo2);
+
+  return 0;
+}


### PR DESCRIPTION
Previously, you could not do something like:
```
$pp = (char **) arg0;
print(**$pp);
```

Instead, you had to do something like:
```
$p = *arg0;
$val = *((char *)$p);
print($val);
```

Notice how in the second example we had to load a pointer as
an integer, then cast it back to a pointer and dereference again.

The first example is better because it's more clear what's going
on.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
