### PR TITLE
Remove warnings from test:

### DIFF
--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -740,8 +740,8 @@ TEST(clang_parser, struct_qualifiers)
 TEST(clang_parser, redefined_types)
 {
   BPFtrace bpftrace;
-  parse("struct a {int a}; struct a {int a};", bpftrace, false);
-  parse("struct a {int a}; struct a {int a; short b;};", bpftrace, false);
+  parse("struct a {int a;}; struct a {int a;};", bpftrace, false);
+  parse("struct a {int a;}; struct a {int a; short b;};", bpftrace, false);
 }
 
 TEST(clang_parser, data_loc_annotation)


### PR DESCRIPTION
Reduces

```
[ RUN      ] clang_parser.redefined_types
definitions.h:2:16: warning: expected ';' at end of declaration list
definitions.h:3:8: error: redefinition of 'a'
definitions.h:2:8: note: previous definition is here
definitions.h:3:16: warning: expected ';' at end of declaration list
ERROR: Try running with --btf to force BTF processing or include headers with missing type definitions
ERROR: Try running with --btf to force BTF processing or include headers with missing type definitions
definitions.h:2:16: warning: expected ';' at end of declaration list
definitions.h:3:8: error: redefinition of 'a'
definitions.h:2:8: note: previous definition is here
```

Into

```
definitions.h:3:8: error: redefinition of 'a'
definitions.h:2:8: note: previous definition is here
ERROR: Try running with --btf to force BTF processing or include headers with missing type definitions
definitions.h:3:8: error: redefinition of 'a'
definitions.h:2:8: note: previous definition is here
ERROR: Try running with --btf to force BTF processing or include headers with missing type definitions
```

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
