### PR TITLE
Rename `BPFTRACE_KERNEL_SOURCE` to `BPFTRACE_KERNEL_HEADERS`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ and this project adheres to
   - [#1542](https://github.com/iovisor/bpftrace/pull/1542)
 - Change a part of the message of '-v' output
   - [#1553](https://github.com/iovisor/bpftrace/pull/1553)
+- Rename `BPFTRACE_KERNEL_SOURCE` to `BPFTRACE_KERNEL_HEADERS`
+  - [#1561](https://github.com/iovisor/bpftrace/pull/1561)
 
 #### Deprecated
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -3272,4 +3272,4 @@ bpftrace requires kernel headers for certain features, which are searched for by
 /lib/modules/$(uname -r)
 ```
 
-The default search directory can be overridden using the environment variable `BPFTRACE_KERNEL_SOURCE`.
+The default search directory can be overridden using the environment variable `BPFTRACE_KERNEL_HEADERS`.

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -83,6 +83,7 @@ void usage()
   std::cerr << "    BPFTRACE_CACHE_USER_SYMBOLS [default: auto] enable user symbol cache" << std::endl;
   std::cerr << "    BPFTRACE_VMLINUX            [default: none] vmlinux path used for kernel symbol resolution" << std::endl;
   std::cerr << "    BPFTRACE_BTF                [default: none] BTF file" << std::endl;
+  std::cerr << "    BPFTRACE_KERNEL_HEADERS     [default: none] kernel headers search directory" << std::endl;
   std::cerr << std::endl;
   std::cerr << "EXAMPLES:" << std::endl;
   std::cerr << "bpftrace -l '*sleep*'" << std::endl;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -401,7 +401,10 @@ std::tuple<std::string, std::string> get_kernel_dirs(const struct utsname& utsna
   return {KERNEL_HEADERS_DIR, KERNEL_HEADERS_DIR};
 #endif
 
-  const char *kpath_env = ::getenv("BPFTRACE_KERNEL_SOURCE");
+  const char *kpath_env = ::getenv("BPFTRACE_KERNEL_HEADERS");
+  if (!kpath_env)
+    kpath_env = ::getenv("BPFTRACE_KERNEL_SOURCE");
+
   if (kpath_env)
     return std::make_tuple(kpath_env, kpath_env);
 


### PR DESCRIPTION
As we need headers not the actual source the new name better reflects
it's purpose. To avoid breaking existing scripts the old name is still
supported as fallback.

```
$ BPFTRACE_KERNEL_HEADERS=/tmp bpftrace -e 'k:f {}'
fatal error: '/tmp/include/linux/kconfig.h' file not found

$ BPFTRACE_KERNEL_SOURCE=/tmp bpftrace -e 'k:f {}'
fatal error: '/tmp/include/linux/kconfig.h' file not found
```

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
