### PR TITLE
Provide better error message when assigning to tuple element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,8 @@ and this project adheres to
   - [#1542](https://github.com/iovisor/bpftrace/pull/1542)
 - Change a part of the message of '-v' output
   - [#1553](https://github.com/iovisor/bpftrace/pull/1553)
+- Improve tuple assignment error message
+  - [#1563](https://github.com/iovisor/bpftrace/pull/1563)
 
 #### Deprecated
 

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -265,6 +265,7 @@ stmt : expr                { $$ = new ast::ExprStatement($1); }
      | jump_stmt           { $$ = $1; }
      | map "=" expr        { $$ = new ast::AssignMapStatement($1, $3, @2); }
      | var "=" expr        { $$ = new ast::AssignVarStatement($1, $3, @2); }
+     | tuple_assignment
      ;
 
 compound_assignment : map LEFTASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::LEFT,  $3, @2)); }
@@ -288,6 +289,8 @@ compound_assignment : map LEFTASSIGN expr  { $$ = new ast::AssignMapStatement($1
                     | map BXORASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BXOR,  $3, @2)); }
                     | var BXORASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BXOR,  $3, @2)); }
                     ;
+
+tuple_assignment : expr DOT INT "=" expr { error(@1 + @5, "Tuples are immutable once created. Consider creating a new tuple and assigning it instead."); YYERROR; }
 
 int : MINUS INT    { $$ = new ast::Integer(-1 * $2, @$); }
     | INT          { $$ = new ast::Integer($1, @$); }

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1663,6 +1663,20 @@ TEST(Parser, while_loop)
 )PROG");
 }
 
+TEST(Parser, tuple_assignment_error)
+{
+  BPFtrace bpftrace;
+  std::stringstream out;
+  Driver driver(bpftrace, out);
+  EXPECT_EQ(driver.parse_str("i:s:1 { @x = (1, 2); $x.1 = 1; }"), 1);
+  std::string expected =
+      R"(stdin:1:22-30: ERROR: Tuples are immutable once created. Consider creating a new tuple and assigning it instead.
+i:s:1 { @x = (1, 2); $x.1 = 1; }
+                     ~~~~~~~~
+)";
+  EXPECT_EQ(out.str(), expected);
+}
+
 } // namespace parser
 } // namespace test
 } // namespace bpftrace

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1663,7 +1663,7 @@ TEST(Parser, while_loop)
 )PROG");
 }
 
-TEST(Parser, tuple_assignment_error)
+TEST(Parser, tuple_assignment_error_message)
 {
   BPFtrace bpftrace;
   std::stringstream out;
@@ -1675,6 +1675,16 @@ i:s:1 { @x = (1, 2); $x.1 = 1; }
                      ~~~~~~~~
 )";
   EXPECT_EQ(out.str(), expected);
+}
+
+TEST(Parser, tuple_assignment_error)
+{
+  test_parse_failure("i:s:1 { (1, 0) = 0 }");
+  test_parse_failure("i:s:1 { ((1, 0), 3).0.0 = 3 }");
+  test_parse_failure("i:s:1 { ((1, 0), 3).0 = (0, 1) }");
+  test_parse_failure("i:s:1 { (1, \"two\", (3, 4)).5 = \"six\"; }");
+  test_parse_failure("i:s:1 { $a = 1; $a.2 = 3 }");
+  test_parse_failure("i:s:1 { 0.1 = 1.0 }");
 }
 
 } // namespace parser


### PR DESCRIPTION
##### Description

This change addresses the second part of #1560 by adding an explicit error message when assigning to a tuple element:

```
./src/bpftrace -e 'i:s:1 { $x = (1, 2); $x.1 = 1; }'
stdin:1:22-30: ERROR: Tuples are immutable. Consider creating a new tuple and assigning it instead.
i:s:1 { $x = (1, 2); $x.1 = 1; }
                     ~~~~~~~~
```

I went with the approach of making this a parse-time error for simplicity. I ran all the unit tests and verified that the number of shift-reduce conflicts haven't changed after implementing this.

An alternative approach is to allow tuple assignment to parse successfully, and then make tuple assignment error later during semantic analysis. This would be a little more complex, but would also provide a better error message (since it can disambiguate between assigning to tuples vs. assigning to maps). Let me know if this approach is preferable.

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
