### PR TITLE
Fix llvm errors of PositonalParameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,8 @@ and this project adheres to
   - [#1514](https://github.com/iovisor/bpftrace/pull/1514)
 - SEGV when using perf format for stacks
   - [#1524](https://github.com/iovisor/bpftrace/pull/1524)
+- Fix llvm errors of PositonalParameter
+  - [#1565](https://github.com/iovisor/bpftrace/pull/1565)
 
 #### Tools
 - Hook up execsnoop.bt script onto `execveat` call

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -76,7 +76,7 @@ void CodegenLLVM::visit(PositionalParameter &param)
           AllocaInst *buf = b_.CreateAllocaBPF(ArrayType::get(b_.getInt8Ty(), pstr.length() + 1), "str");
           b_.CREATE_MEMSET(buf, b_.getInt8(0), pstr.length() + 1, 1);
           b_.CreateStore(const_str, buf);
-          expr_ = buf;
+          expr_ = b_.CreatePtrToInt(buf, b_.getInt64Ty());
           expr_deleter_ = [this, buf]() { b_.CreateLifetimeEnd(buf); };
         }
       }

--- a/tests/codegen/llvm/optional_positional_parameter.ll
+++ b/tests/codegen/llvm/optional_positional_parameter.ll
@@ -40,22 +40,23 @@ entry:
   %10 = bitcast [1 x i8]* %str1 to i8*
   call void @llvm.memset.p0i8.i64(i8* align 1 %10, i8 0, i64 1, i1 false)
   store [1 x i8] zeroinitializer, [1 x i8]* %str1
-  %11 = load i64, i64* %strlen
-  %12 = trunc i64 %11 to i32
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, [1 x i8]*)*)([64 x i8]* %str, i32 %12, [1 x i8]* %str1)
-  %13 = bitcast i64* %strlen to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast [1 x i8]* %str1 to i8*
+  %11 = ptrtoint [1 x i8]* %str1 to i64
+  %12 = load i64, i64* %strlen
+  %13 = trunc i64 %12 to i32
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %13, i64 %11)
+  %14 = bitcast i64* %strlen to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  %15 = bitcast [1 x i8]* %str1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %16 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
   store i64 0, i64* %"@y_key"
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem3 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo2, i64* %"@y_key", [64 x i8]* %str, i64 0)
-  %16 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = bitcast [64 x i8]* %str to i8*
+  %17 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %18 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
   ret i64 0
 }
 


### PR DESCRIPTION
The first commit fixes the error reported by AddressSanitizer. As of the second commit, I didn't encounter a specific problem but I think it is a correct fix. Please see each commit message for the details.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
