### PR TITLE
Fix usdt_sized_args for Big endian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@ and this project adheres to
   - [#1524](https://github.com/iovisor/bpftrace/pull/1524)
 - Fix llvm errors of PositonalParameter
   - [#1565](https://github.com/iovisor/bpftrace/pull/1565)
+- Fix usdt sized args usecase
+  - [#1566](https://github.com/iovisor/bpftrace/pull/1566)
 
 #### Tools
 - Hook up execsnoop.bt script onto `execveat` call

--- a/tests/codegen/llvm/usdt1.ll
+++ b/tests/codegen/llvm/usdt1.ll
@@ -1,0 +1,40 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+define i64 @"usdt:./testprogs/usdt_sized_args:test:probe2_loc0"(i8*) section "s_usdt:./testprogs/usdt_sized_args:test:probe2_loc0_1" {
+entry:
+  %"$x" = alloca i64
+  %1 = bitcast i64* %"$x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 0, i64* %"$x"
+  %arg0 = alloca i32
+  %load_register = getelementptr i8, i8* %0, i64 32
+  %2 = bitcast i32* %arg0 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  %3 = bitcast i8* %load_register to i64*
+  %4 = load i64, i64* %3
+  %5 = add i64 %4, -8
+  %probe_read_user = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %arg0, i32 4, i64 %5)
+  %6 = load i32, i32* %arg0
+  %7 = zext i32 %6 to i64
+  %8 = bitcast i32* %arg0 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast i64* %"$x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i64 %7, i64* %"$x"
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/usdt2.ll
+++ b/tests/codegen/llvm/usdt2.ll
@@ -1,0 +1,63 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+define i64 @"usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe_loc0"(i8*) section "s_usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe_loc0_1" {
+entry:
+  %"$x" = alloca [64 x i8]
+  %1 = bitcast [64 x i8]* %"$x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  %2 = bitcast [64 x i8]* %"$x" to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 64, i1 false)
+  %arg1 = alloca i64
+  %str = alloca [64 x i8]
+  %strlen = alloca i64
+  %3 = bitcast i64* %strlen to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  %4 = bitcast i64* %strlen to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 8, i1 false)
+  store i64 64, i64* %strlen
+  %5 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 64, i1 false)
+  %load_register = getelementptr i8, i8* %0, i64 96
+  %7 = bitcast i64* %arg1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %8 = bitcast i8* %load_register to i64*
+  %9 = load i64, i64* %8
+  %10 = bitcast i64* %arg1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = load i64, i64* %strlen
+  %12 = trunc i64 %11 to i32
+  %probe_read_user_str = call i64 inttoptr (i64 114 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %12, i64 %9)
+  %13 = bitcast i64* %strlen to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast [64 x i8]* %"$x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  %15 = bitcast [64 x i8]* %"$x" to i8*
+  %16 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %15, i8* align 1 %16, i64 64, i1 false)
+  %17 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64 immarg, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1 immarg) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64 immarg, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1 immarg) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/usdt_args.cpp
+++ b/tests/codegen/usdt_args.cpp
@@ -1,0 +1,21 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, usdt1)
+{
+  test("usdt:./testprogs/usdt_sized_args:test:probe2 {  $x = arg0; }", NAME);
+}
+
+TEST(codegen, usdt2)
+{
+  test("usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { $x = "
+       "str(arg1); }",
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace


### PR DESCRIPTION
Test : usdt_sized_args

0: (bf) r6 = r1
1: (b7) r1 = 0
2: (7b) *(u64 *)(r10 -24) = r1
3: (79) r3 = *(u64 *)(r6 +112)
4: (7b) *(u64 *)(r10 -8) = r1   <-----
5: (07) r3 += 168
6: (bf) r1 = r10
7: (07) r1 += -8
8: (b7) r2 = 4 <-----
9: (85) call bpf_probe_read_user#-62440
(...)

Results hex - 00 00 00 01 00 00 00 00 in BE. -> 4294967296.

Fix this by first loading only abs_size.  Then casting it to 8 bytes.
which results in 00 00 00 00 00 00 00 01 for BE. -> 1

Fixed bpf log:
0: (bf) r6 = r1
1: (b7) r1 = 0
2: (7b) *(u64 *)(r10 -24) = r1
last_idx 2 first_idx 0
regs=2 stack=0 before 1: (b7) r1 = 0
3: (79) r3 = *(u64 *)(r6 +32)
4: (07) r3 += -8
5: (bf) r1 = r10
6: (07) r1 += -8
7: (b7) r2 = 4
8: (85) call bpf_probe_read_user#112
last_idx 8 first_idx 0
regs=4 stack=0 before 7: (b7) r2 = 4
9: (61) r1 = *(u32 *)(r10 -8)  <----- 
10: (7b) *(u64 *)(r10 -16) = r1 <-----


<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
