### PR TITLE
usdt: Add support for kernel usdt semaphore activation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to
   - [#1552](https://github.com/iovisor/bpftrace/pull/1552)
 - Support for pointer to pointer
   - [#1557](https://github.com/iovisor/bpftrace/pull/1557)
+- Support for uprobe refcounts
+  - [#1567](https://github.com/iovisor/bpftrace/pull/1567)
 
 #### Changed
 - Warn if using `print` on `stats` maps with top and div arguments

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1267,7 +1267,18 @@ hi
 ^C
 ```
 
-bpftrace also supports USDT semaphores. You may activate semaphores by passing in `-p $PID` or
+bpftrace also supports USDT semaphores. If both your environment and bpftrace
+support uprobe refcounts, then USDT semaphores are automatically activated for
+all processes upon probe attachment (and `--usdt-file-activation` becomes a
+noop). You can check if your system supports uprobe refcounts by running:
+
+```
+# bpftrace --info 2>&1 | grep "uprobe refcount"
+  bcc bpf_attach_uprobe refcount: yes
+  uprobe refcount (depends on Build:bcc bpf_attach_uprobe refcount): yes
+```
+
+If your system does not support uprobe refcounts, you may activate semaphores by passing in `-p $PID` or
 `--usdt-file-activation`. `--usdt-file-activation` looks through `/proc` to find processes that
 have your probe's binary mapped with executable permissions into their address space and then tries
 to attach your probe. Note that file activation occurs only once (during attach time). In other

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -177,14 +177,17 @@ AttachedProbe::AttachedProbe(Probe &probe, std::tuple<uint8_t *, uintptr_t> func
   }
 }
 
-AttachedProbe::AttachedProbe(Probe &probe, std::tuple<uint8_t *, uintptr_t> func, int pid)
-  : probe_(probe), func_(func)
+AttachedProbe::AttachedProbe(Probe &probe,
+                             std::tuple<uint8_t *, uintptr_t> func,
+                             int pid,
+                             BPFfeature &feature)
+    : probe_(probe), func_(func)
 {
   load_prog();
   switch (probe_.type)
   {
     case ProbeType::usdt:
-      attach_usdt(pid);
+      attach_usdt(pid, feature);
       break;
     case ProbeType::watchpoint:
       attach_watchpoint(pid, probe.mode);
@@ -722,7 +725,7 @@ void AttachedProbe::attach_uprobe(bool safe_mode)
   perf_event_fds_.push_back(perf_event_fd);
 }
 
-void AttachedProbe::attach_usdt(int pid)
+void AttachedProbe::attach_usdt(int pid, BPFfeature &feature)
 {
   struct bcc_usdt_location loc = {};
   int err;

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -48,7 +48,10 @@ private:
   int usdt_sem_up_manual(const std::string &fn_name, void *ctx);
   // Increment semaphore count manually with BCC addsem API
   int usdt_sem_up_manual_addsem(int pid, const std::string &fn_name, void *ctx);
-  int usdt_sem_up(int pid, const std::string &fn_name, void *ctx);
+  int usdt_sem_up(BPFfeature &feature,
+                  int pid,
+                  const std::string &fn_name,
+                  void *ctx);
   void attach_usdt(int pid, BPFfeature &feature);
 
   void attach_tracepoint();

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -39,7 +39,18 @@ private:
   void load_prog();
   void attach_kprobe(bool safe_mode);
   void attach_uprobe(bool safe_mode);
+
+  // Note: the following usdt attachment functions will only activate a
+  // semaphore if one exists.
+  //
+  // Increment semaphore count manually with memory hogging API (least
+  // preferrable)
+  int usdt_sem_up_manual(const std::string &fn_name, void *ctx);
+  // Increment semaphore count manually with BCC addsem API
+  int usdt_sem_up_manual_addsem(int pid, const std::string &fn_name, void *ctx);
+  int usdt_sem_up(int pid, const std::string &fn_name, void *ctx);
   void attach_usdt(int pid, BPFfeature &feature);
+
   void attach_tracepoint();
   void attach_profile();
   void attach_interval();

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -5,6 +5,7 @@
 #include <tuple>
 #include <vector>
 
+#include "bpffeature.h"
 #include "types.h"
 
 #include <bcc/libbpf.h>
@@ -21,7 +22,10 @@ public:
   AttachedProbe(Probe &probe,
                 std::tuple<uint8_t *, uintptr_t> func,
                 bool safe_mode);
-  AttachedProbe(Probe &probe, std::tuple<uint8_t *, uintptr_t> func, int pid);
+  AttachedProbe(Probe &probe,
+                std::tuple<uint8_t *, uintptr_t> func,
+                int pid,
+                BPFfeature &feature);
   ~AttachedProbe();
   AttachedProbe(const AttachedProbe &) = delete;
   AttachedProbe &operator=(const AttachedProbe &) = delete;
@@ -35,7 +39,7 @@ private:
   void load_prog();
   void attach_kprobe(bool safe_mode);
   void attach_uprobe(bool safe_mode);
-  void attach_usdt(int pid);
+  void attach_usdt(int pid, BPFfeature &feature);
   void attach_tracepoint();
   void attach_profile();
   void attach_interval();

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -70,6 +70,7 @@ public:
   bool has_btf();
   bool has_map_batch();
   bool has_d_path();
+  bool has_uprobe_refcnt();
 
   std::string report(void);
 
@@ -99,6 +100,7 @@ protected:
   std::optional<bool> has_d_path_;
   std::optional<int> insns_limit_;
   std::optional<bool> has_map_batch_;
+  std::optional<bool> has_uprobe_refcnt_;
 
 private:
   bool detect_map(enum libbpf::bpf_map_type map_type);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -887,7 +887,8 @@ std::vector<std::unique_ptr<AttachedProbe>> BPFtrace::attach_usdt_probe(
 
   if (!(file_activation && probe.path.size()))
   {
-    ret.emplace_back(std::make_unique<AttachedProbe>(probe, func, pid));
+    ret.emplace_back(
+        std::make_unique<AttachedProbe>(probe, func, pid, *feature_));
     return ret;
   }
 
@@ -944,7 +945,7 @@ std::vector<std::unique_ptr<AttachedProbe>> BPFtrace::attach_usdt_probe(
       }
 
       ret.emplace_back(
-          std::make_unique<AttachedProbe>(probe, func, pid_parsed));
+          std::make_unique<AttachedProbe>(probe, func, pid_parsed, *feature_));
       break;
     }
   }
@@ -997,7 +998,7 @@ std::vector<std::unique_ptr<AttachedProbe>> BPFtrace::attach_probe(
     else if (probe.type == ProbeType::watchpoint)
     {
       ret.emplace_back(
-          std::make_unique<AttachedProbe>(probe, func->second, pid));
+          std::make_unique<AttachedProbe>(probe, func->second, pid, *feature_));
       return ret;
     }
     else

--- a/src/usdt.cpp
+++ b/src/usdt.cpp
@@ -27,6 +27,11 @@ static void usdt_probe_each(struct bcc_usdt *usdt_probe)
           .path = usdt_probe->bin_path,
           .provider = usdt_probe->provider,
           .name = usdt_probe->name,
+#ifdef LIBBCC_ATTACH_UPROBE_SEVEN_ARGS_SIGNATURE
+          .semaphore_offset = usdt_probe->semaphore_offset,
+#else
+          .semaphore_offset = 0,
+#endif
           .num_locations = usdt_probe->num_locations,
       });
 }

--- a/src/usdt.h
+++ b/src/usdt.h
@@ -9,6 +9,7 @@ struct usdt_probe_entry
   std::string path;
   std::string provider;
   std::string name;
+  uint64_t semaphore_offset;
   int num_locations;
 };
 

--- a/tests/runtime-tests.sh
+++ b/tests/runtime-tests.sh
@@ -12,4 +12,9 @@ pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1
 BPFTRACE_RUNTIME_TEST_EXECUTABLE=${BPFTRACE_RUNTIME_TEST_EXECUTABLE:-../src/};
 export BPFTRACE_RUNTIME_TEST_EXECUTABLE;
 
+echo "===================="
+echo "bpftrace --info:"
+echo "===================="
+"${BPFTRACE_RUNTIME_TEST_EXECUTABLE}/bpftrace" --info
+
 python3 runtime/engine/main.py $@

--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -98,7 +98,7 @@ class TestParser(object):
             elif item_name == 'ARCH':
                 arch = [x.strip() for x in line.split("|")]
             elif item_name == 'REQUIRES_FEATURE':
-                features = {"loop", "btf", "probe_read_kernel", "dpath"}
+                features = {"loop", "btf", "probe_read_kernel", "dpath", "uprobe_refcount"}
 
                 for f in line.split(" "):
                     f = f.strip()

--- a/tests/runtime/engine/utils.py
+++ b/tests/runtime/engine/utils.py
@@ -101,6 +101,8 @@ class Utils(object):
         bpffeature["probe_read_kernel"] = output.find("probe_read_kernel: yes") != -1
         bpffeature["btf"] = output.find("btf (depends on Build:libbpf): yes") != -1
         bpffeature["dpath"] = output.find("dpath: yes") != -1
+        bpffeature["uprobe_refcount"] = \
+            output.find("uprobe refcount (depends on Build:bcc bpf_attach_uprobe refcount): yes") != -1
         return bpffeature
 
     @staticmethod

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -171,14 +171,14 @@ REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - attach to probe with semaphore"
 RUN bpftrace -e 'usdt::tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }' -p $(pidof usdt_semaphore_test)
-EXPECT tracetest_testprobe_semaphore: 1
+EXPECT tracetest_testprobe_semaphore: [1-9]
 TIMEOUT 5
 BEFORE ./testprogs/usdt_semaphore_test
 REQUIRES ./testprogs/usdt_semaphore_test should_not_skip
 
 NAME "usdt probes - file based semaphore activation"
 RUN bpftrace -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }' --usdt-file-activation
-EXPECT tracetest_testprobe_semaphore: 1
+EXPECT tracetest_testprobe_semaphore: [1-9]
 TIMEOUT 5
 BEFORE ./testprogs/usdt_semaphore_test
 REQUIRES ./testprogs/usdt_semaphore_test should_not_skip
@@ -188,6 +188,26 @@ RUN bpftrace -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { exit
 EXPECT Failed to find processes running
 TIMEOUT 5
 REQUIRES ./testprogs/usdt_semaphore_test should_not_skip
+REQUIRES_FEATURE !uprobe_refcount
+
+# We should be able to attach a probe even without any running processes
+# if the kernel handles the semaphore
+NAME "usdt probes - file based semaphore activation no process, kernel usdt semaphore"
+RUN bpftrace -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { exit(); }' --usdt-file-activation
+EXPECT Attaching 1 probe
+TIMEOUT 5
+REQUIRES ./testprogs/usdt_semaphore_test should_not_skip
+REQUIRES_FEATURE uprobe_refcount
+
+# We should be able to activate a semaphore without specifying a PID or
+# --usdt-file-activation if the kernel handles the semaphore
+NAME "usdt probes - file based semaphore activation"
+RUN bpftrace -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }'
+EXPECT tracetest_testprobe_semaphore: [1-9]
+TIMEOUT 5
+BEFORE ./testprogs/usdt_semaphore_test
+REQUIRES ./testprogs/usdt_semaphore_test should_not_skip
+REQUIRES_FEATURE uprobe_refcount
 
 NAME "usdt probes - file based semaphore activation multi process"
 RUN bpftrace -v runtime/scripts/usdt_file_activation_multiprocess.bt --usdt-file-activation

--- a/tests/testprogs/usdt_semaphore_test.c
+++ b/tests/testprogs/usdt_semaphore_test.c
@@ -33,6 +33,8 @@ main(int argc, char **argv __attribute__((unused))) {
 
   while (1) {
     myclock();
+    // Sleep is necessary to not overflow perf buffer
+    usleep(1000);
   }
   return 0;
 }


### PR DESCRIPTION
This PR adds support for the kernel's uprobe ref count API. If you
pass the kernel an offset to the usdt semaphore while attaching
a uprobe, the kernel will manage the lifetime of the semaphore.

This is better because:
* if bpftrace crashes the semaphore will be deactivated
* the kernel does a much better job implementing
  --usdt-file-activation than we can in userspace (faster and less
  racy)

This is nice because it makes usdt's with semaphore act like a regular
usdt. No need to pass the PID to activate the semaphore.

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
