### PR TITLE
Error if Positional Params num is zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -86,6 +86,8 @@ and this project adheres to
   - [#1524](https://github.com/iovisor/bpftrace/pull/1524)
 - Fix llvm errors of PositonalParameter
   - [#1565](https://github.com/iovisor/bpftrace/pull/1565)
+- Error if Positional Params num is zero
+  - [#1568](https://github.com/iovisor/bpftrace/issues/1568)
 
 #### Tools
 - Hook up execsnoop.bt script onto `execveat` call

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -215,7 +215,9 @@ ternary : expr QUES expr COLON expr { $$ = new ast::Ternary($1, $3, $5, @$); }
 
 param : PARAM      {
                      try {
-                       $$ = new ast::PositionalParameter(PositionalParameterType::positional, std::stol($1.substr(1, $1.size()-1)), @$);
+                       long n = std::stol($1.substr(1, $1.size()-1));
+                       if (n == 0) throw std::exception();
+                       $$ = new ast::PositionalParameter(PositionalParameterType::positional, n, @$);
                      } catch (std::exception const& e) {
                        error(@1, "param " + $1 + " is out of integer range [1, " +
                              std::to_string(std::numeric_limits<long>::max()) + "]");

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -71,6 +71,7 @@ TEST(Parser, builtin_variables)
 TEST(Parser, positional_param)
 {
   test("kprobe:f { $1 }", "Program\n kprobe:f\n  param: $1\n");
+  test_parse_failure("kprobe:f { $0 }");
 }
 
 TEST(Parser, positional_param_count)

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1311,9 +1311,6 @@ TEST(semantic_analyser, positional_parameters)
   bpftrace.add_param("hello");
   bpftrace.add_param("0x123");
 
-  test(bpftrace, "kprobe:f { printf(\"%d\", $0); }", 1);
-  test(bpftrace, "kprobe:f { printf(\"%s\", str($0)); }", 1);
-
   test(bpftrace, "kprobe:f { printf(\"%d\", $1); }", 0);
   test(bpftrace, "kprobe:f { printf(\"%s\", str($1)); }", 0);
 


### PR DESCRIPTION
Positional parameter zero ($0) is invalid. Previously, using $0 causes
std::out_of_range error due to the underflow and confuses users.

```
% sudo ./src/bpftrace -e 'k:$0 {}' vfs_open
terminate called after throwing an instance of 'std::out_of_range'
  what():  vector::_M_range_check: __n (which is 18446744073709551615) >= this->size() (which is 1)
zsh: abort      sudo ./src/bpftrace -e 'k:$0 {}' vfs_open
```

This commit changes this and in the parser check the positional params
num is not zero. This can be also done in the lexical analyzer, but to
print verbose an error message do this in the parser. Now the error message is

```
% sudo ./src/bpftrace -e 'k:$0 {}' vfs_open
stdin:1:1-5: ERROR: param $0 is out of integer range [1, 9223372036854775807]
k:$0 {}
~~~
```

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
