### PR TITLE
Fix LNOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@ and this project adheres to
   - [#1565](https://github.com/iovisor/bpftrace/pull/1565)
 - Error if Positional Params num is zero
   - [#1568](https://github.com/iovisor/bpftrace/issues/1568)
+- Fix LNOT
+  - [#1570](https://github.com/iovisor/bpftrace/pull/1570)
 
 #### Tools
 - Hook up execsnoop.bt script onto `execveat` call

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1594,7 +1594,19 @@ void SemanticAnalyser::visit(Unop &unop)
     }
   }
   else if (unop.op == Parser::token::LNOT) {
-    unop.type = CreateUInt(type.size);
+    // CreateUInt() abort if a size is invalid, so check the size here
+    if (!(type.size == 0 || type.size == 1 || type.size == 2 ||
+          type.size == 4 || type.size == 8))
+    {
+      LOG(ERROR, unop.loc, err_)
+          << "The " << opstr(unop)
+          << " operator can not be used on expressions of type '" << type
+          << "'";
+    }
+    else
+    {
+      unop.type = CreateUInt(8 * type.size);
+    }
   }
   else {
     unop.type = CreateInteger(64, type.IsSigned());

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -917,6 +917,15 @@ TEST(semantic_analyser, unop_not)
   test("kprobe:f { ~\"0\"; }", 10);
 }
 
+TEST(semantic_analyser, unop_lnot)
+{
+  test("kprobe:f { !0; }", 0);
+  test("kprobe:f { !(int32)0; }", 0);
+  test("struct X { int n; } kprobe:f { $x = (struct X*)0; !$x; }", 10);
+  test("struct X { int n; } kprobe:f { $x = (struct X)0; !$x; }", 10);
+  test("kprobe:f { !\"0\"; }", 1);
+}
+
 TEST(semantic_analyser, unop_increment_decrement)
 {
   test("kprobe:f { $x = 0; $x++; }", 0);


### PR DESCRIPTION
CreateUint() expects bit size, not byte size. This fixes the following
error.

```
% sudo ./src/bpftrace -e 'BEGIN { !(int32)0 }'
bpftrace: /home/ubuntu/work/bpftrace/src/types.cpp:251: bpftrace::SizedType bpftrace::CreateInteger(size_t, bool): Assertion `bits == 0 || bits == 8 || bits == 16 || bits == 32 || bits == 64' failed.
zsh: abort      sudo ./src/bpftrace -e 'BEGIN { !(int32)0 }'
```

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
