### PR TITLE
Optimize unknown/incomplete types resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,8 @@ and this project adheres to
   - [#1554](https://github.com/iovisor/bpftrace/pull/1554)
 - Add -q option for quiet
   - [#1616](https://github.com/iovisor/bpftrace/pull/1616)
+- Optimize unknown/incomplete types resolution
+  - [#1571](https://github.com/iovisor/bpftrace/pull/1571)
 
 #### Deprecated
 

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -589,7 +589,7 @@ Cast::Cast(const Cast &other) : Expression(other)
 Probe::Probe(const Probe &other) : Node(other)
 {
   need_expansion = other.need_expansion;
-  need_tp_args_structs = other.need_tp_args_structs;
+  tp_args_structs_level = other.tp_args_structs_level;
   index_ = other.index_;
 }
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -528,7 +528,8 @@ public:
 
   std::string name() const;
   bool need_expansion = false;        // must build a BPF program per wildcard match
-  bool need_tp_args_structs = false;  // must import struct for tracepoints
+  int tp_args_structs_level = -1;     // number of levels of structs that must
+                                      // be imported/resolved for tracepoints
 
   int index();
   void set_index(int index);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -164,6 +164,7 @@ public:
   uint64_t max_probes_ = 512;
   uint64_t log_size_ = 1000000;
   uint64_t perf_rb_pages_ = 64;
+  uint64_t max_type_res_iterations = 0;
   bool demangle_cpp_symbols_ = true;
   bool resolve_user_symbols_ = true;
   bool cache_user_symbols_ = true;

--- a/src/clang_parser.h
+++ b/src/clang_parser.h
@@ -24,12 +24,10 @@ private:
   bool visit_children(CXCursor &cursor, BPFtrace &bpftrace);
   /*
    * The user might have written some struct definitions that rely on types
-   * supplied by BTF data. Also, some types may be defined by typedefs that are
-   * in non-included headers, which causes problems to clang.
+   * supplied by BTF data.
    *
    * This method will pull out any forward-declared / incomplete struct
-   * and typedef definitions and return the types (in string form) of
-   * the unresolved types.
+   * definitions and return the types (in string form) of the unresolved types.
    *
    * Note that this method does not report "errors". This is because the user
    * could have typo'd and actually referenced a non-existent type. Put
@@ -38,8 +36,16 @@ private:
   std::unordered_set<std::string> get_incomplete_types(
       const std::string &input,
       std::vector<CXUnsavedFile> &unsaved_files,
-      const std::vector<const char *> &args,
-      const std::unordered_set<std::string> &complete_types);
+      const std::vector<const char *> &args);
+
+  /*
+   * Collect names of types defined by typedefs that are in non-included
+   * headers as they may pose problems for clang parser.
+   */
+  std::unordered_set<std::string> get_unknown_typedefs(
+      const std::string &input,
+      std::vector<CXUnsavedFile> &unsaved_files,
+      const std::vector<const char *> &args);
 
   static std::optional<std::string> get_unknown_type(
       const std::string &diagnostic_msg);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -621,6 +621,10 @@ int main(int argc, char *argv[])
   if (!get_uint64_env_var("BPFTRACE_PERF_RB_PAGES", bpftrace.perf_rb_pages_))
     return 1;
 
+  if (!get_uint64_env_var("BPFTRACE_MAX_TYPE_RES_ITERATIONS",
+                          bpftrace.max_type_res_iterations))
+    return 1;
+
   if (const char* env_p = std::getenv("BPFTRACE_CAT_BYTES_MAX"))
   {
     uint64_t proposed;

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -70,7 +70,7 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
             }
           }
 
-          if (!probe->need_tp_args_structs)
+          if (probe->tp_args_structs_level <= 0)
             continue;
 
           for (size_t i = 0; i < glob_result.gl_pathc; ++i) {
@@ -119,7 +119,7 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
             return false;
           }
 
-          if (!probe->need_tp_args_structs)
+          if (probe->tp_args_structs_level <= 0)
             continue;
 
           // Check to avoid adding the same struct more than once to definitions

--- a/src/tracepoint_format_parser.h
+++ b/src/tracepoint_format_parser.h
@@ -15,9 +15,15 @@ class TracepointArgsVisitor : public ASTVisitor
 public:
   void visit(Builtin &builtin) override
   {
-    if (builtin.ident == "args")
-      probe_->need_tp_args_structs = true;
+    if (builtin.ident == "args" && probe_->tp_args_structs_level == -1)
+      probe_->tp_args_structs_level = 0;
   };
+  void visit(FieldAccess &acc) override
+  {
+    acc.expr->accept(*this);
+    if (probe_->tp_args_structs_level >= 0)
+      probe_->tp_args_structs_level++;
+  }
   void visit(Probe &probe) override {
     probe_ = &probe;
     ASTVisitor::visit(probe);

--- a/tests/runtime/btf
+++ b/tests/runtime/btf
@@ -10,6 +10,12 @@ EXPECT Attaching 1 probe...
 TIMEOUT 5
 REQUIRES_FEATURE btf
 
+NAME tracepoint_nested_pointer_type_resolution
+RUN bpftrace --btf -e 'tracepoint:napi:napi_poll { args->napi->dev->name; exit(); }'
+EXPECT Attaching 1 probe...
+TIMEOUT 5
+REQUIRES_FEATURE btf
+
 NAME enum_value_reference
 RUN bpftrace -v --btf -e 'BEGIN { printf("%d\n", sizeof(BTF_VAR_STATIC)); exit(); }'
 EXPECT ^8$


### PR DESCRIPTION
Following the discussion in [#1485](https://github.com/iovisor/bpftrace/pull/1485#discussion_r506187878), I implemented a fix that will speed up the resolution of incomplete types and unknown typedefs. The main goal is to limit the number of iterations of type resolution.

The proposed solution is:

- Since incomplete types mostly occur for tracepoints, the number of iterations is given by the number of nested field accesses in tracepoint probes. This will allow to handle, e.g.:
```
src/bpftrace -e 't:napi:napi_poll { printf("%s\n", args->napi->dev->name); }' -b
```
which needs at least 2 iterations.

- Unknown typedefs (see #1485 for details) must be resolved completely, since they will make the Clang parser fail, even if the types are not used in the program. Usually, no more than 3 iterations are needed.
An example that needs 3 iterations:
```
src/bpftrace -e 't:syscalls:sys_enter_* { @[args->__syscall_nr] = count(); } i:ms:1 { exit(); }' -b
```

Still, there may be cases that I missed which require more iterations but in such case, bpftrace will fail with "unknown type" error and the user will have to include appropriate headers.

Any thoughts on this approach? Ideas when this could not work?

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
