### PR TITLE
Fix invalid cast handling in tuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ and this project adheres to
   - [#1568](https://github.com/iovisor/bpftrace/issues/1568)
 - Fix LNOT
   - [#1570](https://github.com/iovisor/bpftrace/pull/1570)
+- Fix invalid cast handling in tuple
+  - [#1572](https://github.com/iovisor/bpftrace/pull/1572)
 
 #### Tools
 - Hook up execsnoop.bt script onto `execveat` call

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1946,6 +1946,11 @@ void SemanticAnalyser::visit(Tuple &tuple)
     Expression *elem = tuple.elems->at(i);
     elem->accept(*this);
 
+    // If elem type is none that means that the tuple contains some
+    // invalid cast (e.g., (0, (aaa)0)). In this case, skip the tuple
+    // creation. Cast already emits the error.
+    if (elem->type.IsNoneTy())
+      return;
     elements.emplace_back(elem->type);
   }
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1836,6 +1836,7 @@ TEST(semantic_analyser, tuple)
   test(R"_(BEGIN { @t = (1, 2); @t = (4, "other"); })_", 10);
   test(R"_(BEGIN { @t = (1, 2); @t = 5; })_", 1);
   test(R"_(BEGIN { @t = (1, count()) })_", 1);
+  test(R"_(BEGIN { @t = (1, (aaa)0) })_", 1);
 }
 
 TEST(semantic_analyser, tuple_indexing)


### PR DESCRIPTION
If the tuple contains a invalid cast, it causes floating
point exception. For example:

```
% ./src/bpftrace -e 'BEGIN { (0, (aaa)0); }'
AddressSanitizer:DEADLYSIGNAL
=================================================================
==50713==ERROR: AddressSanitizer: FPE on unknown address 0x00000000c619 (pc 0x0000007c2c84 bp 0x7ffef9ec7030 sp 0x7ffef9ec6cc0 T0)
    #0 0x7c2c84 in bpftrace::Tuple::Create(std::vector<bpftrace::SizedType, std::allocator<bpftrace::SizedType> >) /home/ubuntu/work/bpftrace/bpftrace/src/struct.cpp:29:37
    #1 0x7d7706 in bpftrace::CreateTuple(std::vector<bpftrace::SizedType, std::allocator<bpftrace::SizedType> > const&) /home/ubuntu/work/bpftrace/bpftrace/src/types.cpp:442:20
    #2 0x88ff89 in bpftrace::ast::SemanticAnalyser::visit(bpftrace::ast::Tuple&) /home/ubuntu/work/bpftrace/bpftrace/src/ast/semantic_analyser.cpp:1932:16
[...]
```

The reason is the type of a invalid cast becomes none, and its size is
zero. CreateTuple() does not support it. To fix the problem, when
visiting Tuple, check an element type and if the type is none, skip the
tuple creation. An error is already emited by Cast. Now the error is

```
% sudo ./src/bpftrace -e 'BEGIN { (0, (aaa)0); }'
[sudo] password for ubuntu:
stdin:1:13-18: ERROR: Unknown struct/union: 'aaa'
BEGIN { (0, (aaa)0); }
            ~~~~~
```

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
