### PR TITLE
Check string comparison size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,6 +92,8 @@ and this project adheres to
   - [#1570](https://github.com/iovisor/bpftrace/pull/1570)
 - Fix invalid cast handling in tuple
   - [#1572](https://github.com/iovisor/bpftrace/pull/1572)
+- Check string comparison size
+  - [#1573](https://github.com/iovisor/bpftrace/pull/1573)
 
 #### Tools
 - Hook up execsnoop.bt script onto `execveat` call

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1499,6 +1499,21 @@ void SemanticAnalyser::visit(Binop &binop)
           << " operator can not be used on expressions of types " << lhs << ", "
           << rhs;
     }
+    else if (binop.op == Parser::token::EQ &&
+             ((!binop.left->is_literal && binop.right->is_literal) ||
+              (binop.left->is_literal && !binop.right->is_literal)))
+    {
+      auto *lit = binop.left->is_literal ? binop.left : binop.right;
+      auto *str = lit == binop.left ? binop.right : binop.left;
+      auto lit_len = bpftrace_.get_string_literal(lit).size();
+      auto str_len = str->type.GetNumElements();
+      if (lit_len > str_len)
+      {
+        LOG(WARNING, binop.left->loc + binop.loc + binop.right->loc, out_)
+            << "The literal is longer than the variable string (size="
+            << str_len << "), condition will always be false";
+      }
+    }
   }
 
   bool is_signed = lsign && rsign;

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1395,6 +1395,30 @@ TEST(semantic_analyser, signed_int_comparison_warnings)
   test_for_warning("kretprobe:f /retval < 1/ {}", cmp_sign, invert);
 }
 
+TEST(semantic_analyser, string_comparison)
+{
+  test("struct MyStruct {char y[4]; } kprobe:f { $s = (struct MyStruct*)arg0; "
+       "$s->y == \"abc\"}",
+       0);
+  test("struct MyStruct {char y[4]; } kprobe:f { $s = (struct MyStruct*)arg0; "
+       "\"abc\" != $s->y}",
+       0);
+  test("struct MyStruct {char y[4]; } kprobe:f { $s = (struct MyStruct*)arg0; "
+       "\"abc\" == \"abc\"}",
+       0);
+
+  bool invert = true;
+  std::string msg = "the condition is always false";
+  test_for_warning("struct MyStruct {char y[4]; } kprobe:f { $s = (struct "
+                   "MyStruct*)arg0; $s->y == \"long string\"}",
+                   msg,
+                   invert);
+  test_for_warning("struct MyStruct {char y[4]; } kprobe:f { $s = (struct "
+                   "MyStruct*)arg0; \"long string\" != $s->y}",
+                   msg,
+                   invert);
+}
+
 TEST(semantic_analyser, signed_int_arithmetic_warnings)
 {
   // Test type warnings for arithmetic


### PR DESCRIPTION
In the debug build, the following assertion failure occurs:

```
% sudo ./src/bpftrace -e 'BEGIN /comm == "aaaaaaaaaaaaaaaaaaaaaaaaa"/ {}'
bpftrace: /home/ubuntu/work/bpftrace/bpftrace/src/ast/irbuilderbpf.cpp:683: llvm::Value *bpftrace::ast::IRBuilderBPF::CreateStrncmp(llvm::Value *, llvm::Value *, bpftrace::AddrSpace, std::string, uint64_t, const bpftrace::location &, bool): Assertion `valp->getElementType()->isArrayTy() && valp->getElementType()->getArrayNumElements() >= n && valp->getElementType()->getArrayElementType() == getInt8Ty()' failed.
```

The problem part is https://github.com/iovisor/bpftrace/blob/a03b5c4bbb12a25345a2fdec78374963ff936131/src/ast/irbuilderbpf.cpp#L682
and the reason is that the the size of "comm" is 16, but the size of
string literal is bigger than that.

To fix the problem, check the string size in the semantic analyzer and
error if the size of string literal exeeds the that of the other. Now
the above exmaple becomes

```
% sudo ./src/bpftrace -e 'BEGIN /comm == "aaaaaaaaaaaaaaaaaaaaaaaaa"/ {}'
stdin:1:7-43: ERROR: The right string literal has the longer length of the size of the left (16 < 25)
BEGIN /comm == "aaaaaaaaaaaaaaaaaaaaaaaaa"/ {}
      ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests


---------------

I wonder if this could cause a regression. I don't think so, but...