### PR TITLE
Disable memory watchpoint tests s390x

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1465,7 +1465,8 @@ Examples in situ:
 
 ## 14. `watchpoint`: Memory watchpoints
 
-**WARNING**: this feature is experimental and may be subject to interface changes.
+**WARNING**: this feature is experimental and may be subject to interface changes. Memory watchpoints are
+also architecture dependant
 
 Syntax:
 

--- a/tests/runtime/watchpoint
+++ b/tests/runtime/watchpoint
@@ -1,10 +1,12 @@
 NAME watchpoint - absolute address
 RUN bpftrace -v -e 'watchpoint::0x10000000:8:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint
 EXPECT hit!
+ARCH aarch64|ppc64|ppc64le|x86_64
 TIMEOUT 5
 
 NAME kwatchpoint - knl absolute address
 RUN bpftrace -v -e "watchpoint::0x$(awk '$3 == "jiffies" {print $1}' /proc/kallsyms):4:w { printf(\"hit\n\"); exit(); }"
 EXPECT hit
+ARCH aarch64|ppc64|ppc64le|x86_64
 TIMEOUT 5
 REQUIRES awk '$3 == "jiffies" {got=1} END {exit !got}' /proc/kallsyms


### PR DESCRIPTION
Memory watchpoints are not yet implemented for s390x. Hence disable the tests for s390x.

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
