### PR TITLE
Add llvm11 build support for 0.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,18 @@ jobs:
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size
           BASE: bionic
+        - NAME: LLVM 11 Debug
+          TYPE: Debug
+          LLVM_VERSION: 11
+          RUN_ALL_TESTS: 1
+          RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size
+          BASE: bionic
+        - NAME: LLVM 11 Release
+          TYPE: Release
+          LLVM_VERSION: 11
+          RUN_ALL_TESTS: 1
+          RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size
+          BASE: bionic
     steps:
     - uses: actions/checkout@v2
     - name: Build docker container

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.2] 2020-10-28
+
+Add LLVM11 build support
+
 ## [0.11.1] 2020-09-22
 
 Bug fix release for the [Docker build](https://quay.io/repository/iovisor/bpftrace)

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -201,10 +201,25 @@ llvm::Type *IRBuilderBPF::GetType(const SizedType &stype)
   return ty;
 }
 
+CallInst *IRBuilderBPF::createCall(Value *callee,
+                                   ArrayRef<Value *> args,
+                                   const Twine &Name)
+{
+#if LLVM_VERSION_MAJOR >= 11
+  auto *calleePtrType = cast<PointerType>(callee->getType());
+  auto *calleeType = cast<FunctionType>(calleePtrType->getElementType());
+  return CreateCall(calleeType, callee, args, Name);
+#else
+  return CreateCall(callee, args, Name);
+#endif
+}
+
 CallInst *IRBuilderBPF::CreateBpfPseudoCall(int mapfd)
 {
   Function *pseudo_func = module_.getFunction("llvm.bpf.pseudo");
-  return CreateCall(pseudo_func, {getInt64(BPF_PSEUDO_MAP_FD), getInt64(mapfd)}, "pseudo");
+  return createCall(pseudo_func,
+                    { getInt64(BPF_PSEUDO_MAP_FD), getInt64(mapfd) },
+                    "pseudo");
 }
 
 CallInst *IRBuilderBPF::CreateBpfPseudoCall(Map &map)
@@ -227,7 +242,7 @@ CallInst *IRBuilderBPF::createMapLookup(int mapfd, AllocaInst *key)
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_map_lookup_elem),
       lookup_func_ptr_type);
-  return CreateCall(lookup_func, { map_ptr, key }, "lookup_elem");
+  return createCall(lookup_func, { map_ptr, key }, "lookup_elem");
 }
 
 CallInst *IRBuilderBPF::CreateGetJoinMap(Value *ctx, const location &loc)
@@ -325,7 +340,7 @@ void IRBuilderBPF::CreateMapUpdateElem(Value *ctx,
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_map_update_elem),
       update_func_ptr_type);
-  CallInst *call = CreateCall(update_func,
+  CallInst *call = createCall(update_func,
                               { map_ptr, key, val, flags },
                               "update_elem");
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_map_update_elem, loc);
@@ -349,7 +364,7 @@ void IRBuilderBPF::CreateMapDeleteElem(Value *ctx,
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_map_delete_elem),
       delete_func_ptr_type);
-  CallInst *call = CreateCall(delete_func, { map_ptr, key }, "delete_elem");
+  CallInst *call = createCall(delete_func, { map_ptr, key }, "delete_elem");
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_map_delete_elem, loc);
 }
 
@@ -378,7 +393,7 @@ void IRBuilderBPF::CreateProbeRead(Value *ctx,
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_probe_read),
       proberead_func_ptr_type);
-  CallInst *call = CreateCall(proberead_func, { dst, size, src }, "probe_read");
+  CallInst *call = createCall(proberead_func, { dst, size, src }, "probe_read");
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_probe_read, loc);
 }
 
@@ -413,7 +428,7 @@ CallInst *IRBuilderBPF::CreateProbeReadStr(Value *ctx,
 {
   assert(ctx && ctx->getType() == getInt8PtrTy());
   Constant *fn = createProbeReadStrFn(dst->getType(), src->getType());
-  CallInst *call = CreateCall(fn,
+  CallInst *call = createCall(fn,
                               { dst, getInt32(size), src },
                               "probe_read_str");
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_probe_read_str, loc);
@@ -434,7 +449,7 @@ CallInst *IRBuilderBPF::CreateProbeReadStr(Value *ctx,
   auto *size_i32 = CreateIntCast(size, getInt32Ty(), false);
 
   Constant *fn = createProbeReadStrFn(dst->getType(), src->getType());
-  CallInst *call = CreateCall(fn, { dst, size_i32, src }, "probe_read_str");
+  CallInst *call = createCall(fn, { dst, size_i32, src }, "probe_read_str");
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_probe_read_str, loc);
   return call;
 }
@@ -717,7 +732,7 @@ CallInst *IRBuilderBPF::CreateGetNs()
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_ktime_get_ns),
       gettime_func_ptr_type);
-  return CreateCall(gettime_func, {}, "get_ns");
+  return createCall(gettime_func, {}, "get_ns");
 }
 
 CallInst *IRBuilderBPF::CreateGetPidTgid()
@@ -730,7 +745,7 @@ CallInst *IRBuilderBPF::CreateGetPidTgid()
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_get_current_pid_tgid),
       getpidtgid_func_ptr_type);
-  return CreateCall(getpidtgid_func, {}, "get_pid_tgid");
+  return createCall(getpidtgid_func, {}, "get_pid_tgid");
 }
 
 CallInst *IRBuilderBPF::CreateGetCurrentCgroupId()
@@ -744,7 +759,7 @@ CallInst *IRBuilderBPF::CreateGetCurrentCgroupId()
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_get_current_cgroup_id),
       getcgroupid_func_ptr_type);
-  return CreateCall(getcgroupid_func, {}, "get_cgroup_id");
+  return createCall(getcgroupid_func, {}, "get_cgroup_id");
 }
 
 CallInst *IRBuilderBPF::CreateGetUidGid()
@@ -757,7 +772,7 @@ CallInst *IRBuilderBPF::CreateGetUidGid()
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_get_current_uid_gid),
       getuidgid_func_ptr_type);
-  return CreateCall(getuidgid_func, {}, "get_uid_gid");
+  return createCall(getuidgid_func, {}, "get_uid_gid");
 }
 
 CallInst *IRBuilderBPF::CreateGetCpuId()
@@ -770,7 +785,7 @@ CallInst *IRBuilderBPF::CreateGetCpuId()
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_get_smp_processor_id),
       getcpuid_func_ptr_type);
-  return CreateCall(getcpuid_func, {}, "get_cpu_id");
+  return createCall(getcpuid_func, {}, "get_cpu_id");
 }
 
 CallInst *IRBuilderBPF::CreateGetCurrentTask()
@@ -783,7 +798,7 @@ CallInst *IRBuilderBPF::CreateGetCurrentTask()
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_get_current_task),
       getcurtask_func_ptr_type);
-  return CreateCall(getcurtask_func, {}, "get_cur_task");
+  return createCall(getcurtask_func, {}, "get_cur_task");
 }
 
 CallInst *IRBuilderBPF::CreateGetRandom()
@@ -796,7 +811,7 @@ CallInst *IRBuilderBPF::CreateGetRandom()
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_get_prandom_u32),
       getrandom_func_ptr_type);
-  return CreateCall(getrandom_func, {}, "get_random");
+  return createCall(getrandom_func, {}, "get_random");
 }
 
 CallInst *IRBuilderBPF::CreateGetStackId(Value *ctx,
@@ -826,7 +841,7 @@ CallInst *IRBuilderBPF::CreateGetStackId(Value *ctx,
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_get_stackid),
       getstackid_func_ptr_type);
-  CallInst *call = CreateCall(getstackid_func,
+  CallInst *call = createCall(getstackid_func,
                               { ctx, map_ptr, flags_val },
                               "get_stackid");
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_get_stackid, loc);
@@ -852,7 +867,7 @@ void IRBuilderBPF::CreateGetCurrentComm(Value *ctx,
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_get_current_comm),
       getcomm_func_ptr_type);
-  CallInst *call = CreateCall(getcomm_func,
+  CallInst *call = createCall(getcomm_func,
                               { buf, getInt64(size) },
                               "get_comm");
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_get_current_comm, loc);
@@ -883,7 +898,9 @@ void IRBuilderBPF::CreatePerfEventOutput(Value *ctx, Value *data, size_t size)
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_perf_event_output),
       perfoutput_func_ptr_type);
-  CreateCall(perfoutput_func, {ctx, map_ptr, flags_val, data, size_val}, "perf_event_output");
+  createCall(perfoutput_func,
+             { ctx, map_ptr, flags_val, data, size_val },
+             "perf_event_output");
 }
 
 void IRBuilderBPF::CreateSignal(Value *ctx, Value *sig, const location &loc)
@@ -899,7 +916,7 @@ void IRBuilderBPF::CreateSignal(Value *ctx, Value *sig, const location &loc)
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_send_signal),
       signal_func_ptr_type);
-  CallInst *call = CreateCall(signal_func, { sig }, "signal");
+  CallInst *call = createCall(signal_func, { sig }, "signal");
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_send_signal, loc);
 }
 
@@ -913,7 +930,7 @@ void IRBuilderBPF::CreateOverrideReturn(Value *ctx, Value *rc)
   Constant *override_func = ConstantExpr::getCast(Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_override_return),
       override_func_ptr_type);
-  CreateCall(override_func, { ctx, rc }, "override");
+  createCall(override_func, { ctx, rc }, "override");
 }
 
 Value *IRBuilderBPF::CreatKFuncArg(Value *ctx,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -80,6 +80,7 @@ public:
   CallInst   *CreateGetRandom();
   CallInst   *CreateGetStackId(Value *ctx, bool ustack, StackType stack_type, const location& loc);
   CallInst   *CreateGetJoinMap(Value *ctx, const location& loc);
+  CallInst   *createCall(Value *callee, ArrayRef<Value *> args, const Twine &Name);
   void        CreateGetCurrentComm(Value *ctx, AllocaInst *buf, size_t size, const location& loc);
   void        CreatePerfEventOutput(Value *ctx, Value *data, size_t size);
   void        CreateSignal(Value *ctx, Value *sig, const location &loc);

--- a/src/bpforc.h
+++ b/src/bpforc.h
@@ -96,9 +96,15 @@ public:
       : TM(TM_),
         Resolver(createLegacyLookupResolver(
             ES,
+#if LLVM_VERSION_MAJOR >= 11
+            [](llvm::StringRef Name __attribute__((unused))) -> JITSymbol {
+              return nullptr;
+            },
+#else
             [](const std::string &Name __attribute__((unused))) -> JITSymbol {
               return nullptr;
             },
+#endif
             [](Error Err) { cantFail(std::move(Err), "lookup failed"); })),
 #if LLVM_VERSION_MAJOR > 8
         ObjectLayer(AcknowledgeORCv1Deprecation,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -16,6 +16,13 @@ add_custom_command(OUTPUT ${CMAKE_BINARY_DIR}/tests/codegen_includes.cpp
     -P ${CMAKE_SOURCE_DIR}/tests/codegen/generate_codegen_includes.cmake
   DEPENDS ${CODEGEN_SOURCES})
 
+if(${LLVM_VERSION} VERSION_LESS 11.0.0)
+  set(CODEGEN_SRC ${CMAKE_BINARY_DIR}/tests/codegen_includes.cpp)
+else()
+  set(CODEGEN_SRC "")
+  message("Disabled codegen test for LLVM >= 11")
+endif()
+
 add_executable(bpftrace_test
   ast.cpp
   bpftrace.cpp
@@ -30,7 +37,7 @@ add_executable(bpftrace_test
   tracepoint_format_parser.cpp
   utils.cpp
 
-  ${CMAKE_BINARY_DIR}/tests/codegen_includes.cpp
+  ${CODEGEN_SRC}
 
   ${CMAKE_SOURCE_DIR}/src/attached_probe.cpp
   ${CMAKE_SOURCE_DIR}/src/bpftrace.cpp


### PR DESCRIPTION
Codegen build for LLVM11 is disabled. Related to #1546

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
