### PR TITLE
Fix a possible integer overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,8 @@ and this project adheres to
   - [#1572](https://github.com/iovisor/bpftrace/pull/1572)
 - Check string comparison size
   - [#1573](https://github.com/iovisor/bpftrace/pull/1573)
+- Fix a possible integer overflow
+  - [#1580](https://github.com/iovisor/bpftrace/pull/1580)
 
 #### Tools
 - Hook up execsnoop.bt script onto `execveat` call

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -221,8 +221,19 @@ static bool getBitfield(CXCursor c, Bitfield &bitfield)
 
   size_t bitfield_offset = clang_Cursor_getOffsetOfField(c) % 8;
   size_t bitfield_bitwidth = clang_getFieldDeclBitWidth(c);
+  size_t bitfield_bitdidth_max = sizeof(uint64_t) * 8;
 
-  bitfield.mask = (1 << bitfield_bitwidth) - 1;
+  if (bitfield_bitwidth > bitfield_bitdidth_max)
+  {
+    LOG(WARNING) << "bitfiled bitwidth " << bitfield_bitwidth
+                 << "is not supporeted."
+                 << " Use bitwidth " << bitfield_bitdidth_max;
+    bitfield_bitwidth = bitfield_bitdidth_max;
+  }
+  if (bitfield_bitwidth == bitfield_bitdidth_max)
+    bitfield.mask = std::numeric_limits<uint64_t>::max();
+  else
+    bitfield.mask = (1ULL << bitfield_bitwidth) - 1;
   bitfield.access_rshift = bitfield_offset;
   // Round up to nearest byte
   bitfield.read_bytes = (bitfield_offset + bitfield_bitwidth + 7) / 8;

--- a/src/struct.h
+++ b/src/struct.h
@@ -15,7 +15,7 @@ struct Bitfield
   // Then rshift the resulting value by `access_rshift` to get field value
   size_t access_rshift;
   // Then logical AND `mask` to mask out everything but this bitfield
-  size_t mask;
+  uint64_t mask;
 };
 
 struct Field


### PR DESCRIPTION
When I tried to use UndefinedSanitizer (by
CXXFLAGS="-fsanitize=undefined"), I found the following error.

```
% sudo ./src/bpftrace -e 'BEGIN{curtask}'
/home/ubuntu/work/bpftrace_master/src/clang_parser.cpp:225:22: runtime error: shift exponent 64 is too large for 32-bit type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/ubuntu/work/bpftrace_master/src/clang_parser.cpp:225:22 in
/home/ubuntu/work/bpftrace_master/src/clang_parser.cpp:225:44: runtime error: signed integer overflow: -2147483648 - 1 cannot be represented in type 'int'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/ubuntu/work/bpftrace_master/src/clang_parser.cpp:225:44 in
```

It warned about integer overflows. This patch fixes this.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
