### PR TITLE
scripts: Add script to update codegen tests

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -62,7 +62,7 @@ shift 2
 [[ $EMBED_LLVM  == "ON" ]] && with_timeout make embedded_llvm "$@"
 [[ $EMBED_CLANG == "ON" ]] && with_timeout make embedded_clang "$@"
 [[ $DEPS_ONLY == "ON" ]] && exit 0
-make "$@"
+make "$@" -j $(nproc)
 
 if [ $RUN_TESTS = 1 ]; then
   if [ "$RUN_ALL_TESTS" = "1" ]; then

--- a/scripts/update_codegen_tests.sh
+++ b/scripts/update_codegen_tests.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+# Updates codegen tests' expected LLVM IR
+#
+
+set -eu
+
+# Change dir to project root
+cd "$(dirname "${BASH_SOURCE[0]}")"
+cd ..
+
+# Build docker image
+pushd docker
+docker build                  \
+  --network host              \
+  --build-arg LLVM_VERSION=8  \
+  -t bpftrace-builder-bionic  \
+  -f Dockerfile.bionic        \
+  .
+popd
+
+# Update IR
+docker run                                \
+  --network host                          \
+  --rm                                    \
+  -it                                     \
+  -v $(pwd):$(pwd)                        \
+  -e BPFTRACE_UPDATE_TESTS=1              \
+  -e TEST_ARGS="--gtest_filter=codegen.*" \
+  bpftrace-builder-bionic "$(pwd)/build-codegen-update" Debug "$@"

--- a/tests/README.md
+++ b/tests/README.md
@@ -37,8 +37,12 @@ automatically, else it will fall back to rewriting.
 
 #### Updating
 
-If the test is run with `BPFTRACE_UPDATE_TESTS=1` the `test` helper will update
-the IR instead of running the tests.
+Run `./scripts/update_codegen_tests.sh` after making codegen changes up update
+the expected LLVM IR.
+
+Alternatively (if you need more control over which tests are updated), if the
+test is run with `BPFTRACE_UPDATE_TESTS=1` the `test` helper will update the IR
+instead of running the tests.
 
 ## Runtime tests
 


### PR DESCRIPTION
This script helps update codegen changes. Basically all it does is
compile bpftrace against LLVM 8 and run bpftrace_test with the right
invocation.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
