### PR TITLE
Fix listing / tracing usdt probes in shared libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -132,6 +132,8 @@ and this project adheres to
   - [#1639](https://github.com/iovisor/bpftrace/pull/1639)
 - Add workaround for too deep or long macros
   - [#1650](https://github.com/iovisor/bpftrace/pull/1650)
+- Fix attaching to usdt probes in shared libraries
+  - [#1600](https://github.com/iovisor/bpftrace/pull/1600)
 
 #### Tools
 - Hook up execsnoop.bt script onto `execveat` call

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,12 @@ if(HAVE_BFD_DISASM)
   set(BFD_DISASM_SRC ${CMAKE_SOURCE_DIR}/src/bfd-disasm.cpp)
 endif()
 
+if (STATIC_LIBC)
+  # STATIC_LIBC will set linker flags to -static. We don't want this for
+  # testprogs linking, so we clear the flags.
+  unset(CMAKE_EXE_LINKER_FLAGS)
+endif()
+
 # Regenerate codegen_includes.cpp whenever anything in the tests/codegen
 # directory changes
 file(GLOB_RECURSE CODEGEN_SOURCES codegen/*.cpp codegen/*.h)
@@ -139,6 +145,9 @@ if (STATIC_LINKING)
   if(EMBED_LLVM OR EMBED_CLANG)
     set_target_properties(bpftrace_test PROPERTIES LINK_FLAGS "${EMBEDDED_LINK_FLAGS}")
   endif()
+  if(STATIC_LIBC)
+    set_target_properties(bpftrace_test PROPERTIES LINK_FLAGS "-static")
+  endif()
 
   # These are not part of the static libbcc so have to be added separate
   target_link_libraries(bpftrace_test ${LIBBCC_BPF_LIBRARY_STATIC})
@@ -210,10 +219,14 @@ foreach(testprog ${testprogs})
   if(HAVE_SYSTEMTAP_SYS_SDT_H)
     target_compile_definitions(${bin_name} PRIVATE HAVE_SYSTEMTAP_SYS_SDT_H)
   endif(HAVE_SYSTEMTAP_SYS_SDT_H)
-  set_target_properties( ${bin_name} PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testprogs/ COMPILE_FLAGS "-g -O0" LINK_FLAGS "-no-pie")
+  set_target_properties(${bin_name} PROPERTIES LINK_SEARCH_START_STATIC FALSE LINK_SEARCH_END_STATIC FALSE RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testprogs/ COMPILE_FLAGS "-g -O0" LINK_FLAGS "-no-pie")
   list(APPEND compiled_testprogs ${CMAKE_CURRENT_BINARY_DIR}/testprogs/${bin_name})
 endforeach()
 add_custom_target(testprogs DEPENDS ${compiled_testprogs})
+
+target_include_directories(usdt_lib PUBLIC ${CMAKE_SOURCE_DIR}/tests/testlibs/)
+target_compile_options(usdt_lib PRIVATE -fPIC)
+target_link_libraries(usdt_lib usdt_tp)
 
 # Similarly compile all test libs
 file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testlibs/)
@@ -223,6 +236,9 @@ foreach(testlib_source ${testlibs})
   get_filename_component(testlib_name ${testlib_source} NAME_WE)
   add_library(${testlib_name} SHARED ${testlib_source})
   set_target_properties(${testlib_name} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testlibs/ COMPILE_FLAGS "-g -O0")
+  if(HAVE_SYSTEMTAP_SYS_SDT_H)
+    target_compile_definitions(${testlib_name} PRIVATE HAVE_SYSTEMTAP_SYS_SDT_H)
+  endif(HAVE_SYSTEMTAP_SYS_SDT_H)
   # clear the executable bit
   add_custom_command(TARGET ${testlib_name}
     POST_BUILD

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -11,6 +11,13 @@ TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 
+NAME "usdt probes - lists linked library probes by pid"
+RUN bpftrace -l 'usdt:*' -p $(pidof usdt_lib)
+EXPECT libusdt_tp.so:tracetestlib:lib_probe_1
+TIMEOUT 5
+BEFORE ./testprogs/usdt_lib
+REQUIRES ./testprogs/usdt_lib should_not_skip
+
 NAME "usdt probes - filter probes by file on provider"
 RUN bpftrace -l 'usdt:./testprogs/usdt_test:tracetest2:*'
 EXPECT usdt:./testprogs/usdt_test:tracetest2:testprobe2
@@ -61,6 +68,13 @@ EXPECT here
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 TIMEOUT 5
+
+NAME "usdt probes - attach to fully specified library probe by pid"
+RUN bpftrace -e 'usdt:./testlibs/libusdt_tp.so:tracetestlib:lib_probe_1 { printf("here\n" ); exit(); }' -p $(pidof usdt_lib)
+BEFORE ./testprogs/usdt_lib
+EXPECT here
+TIMEOUT 5
+REQUIRES ./testprogs/usdt_lib should_not_skip
 
 NAME "usdt probes - all probes by wildcard and file"
 RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("here\n" ); exit(); }'

--- a/tests/testlibs/usdt_tp.c
+++ b/tests/testlibs/usdt_tp.c
@@ -1,0 +1,19 @@
+#ifdef HAVE_SYSTEMTAP_SYS_SDT_H
+#include <sys/sdt.h>
+#else
+#define DTRACE_PROBE2(a, b, c, d) (void)0
+#endif
+#include "usdt_tp.h"
+#include <stdio.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+long myclock()
+{
+  struct timeval tv;
+  gettimeofday(&tv, NULL);
+  DTRACE_PROBE2(tracetestlib, lib_probe_1, tv.tv_sec, "Hello world");
+  DTRACE_PROBE2(tracetestlib, lib_probe_1, tv.tv_sec, "Hello world2");
+  DTRACE_PROBE2(tracetestlib2, lib_probe_2, tv.tv_sec, "Hello world3");
+  return tv.tv_sec;
+}

--- a/tests/testlibs/usdt_tp.h
+++ b/tests/testlibs/usdt_tp.h
@@ -1,0 +1,4 @@
+#ifndef _USDTLIBX_H_
+#define _USDTLIBX_H_
+extern long myclock();
+#endif

--- a/tests/testprogs/usdt_lib.c
+++ b/tests/testprogs/usdt_lib.c
@@ -1,0 +1,20 @@
+#include "usdt_tp.h"
+#include <stdio.h>
+
+int main(int argc, char **argv __attribute__((unused)))
+{
+  if (argc > 1)
+  // If we don't have Systemtap headers, we should skip USDT tests. Returning 1
+  // can be used as validation in the REQUIRE
+#ifndef HAVE_SYSTEMTAP_SYS_SDT_H
+    return 1;
+#else
+    return 0;
+#endif
+
+  while (1)
+  {
+    myclock();
+  }
+  return 0;
+}


### PR DESCRIPTION
#### Issue

Listing or tracing a usdt probes contained in a linked shared libs doesn't work.

```
# bpftrace -e 'usdt:./tests/testlibs/libusdt_tp.so:tracetestlib:lib_probe_1 { printf("hit\n");}' -p 21488
No probes to attach
```

#### Cause
During `read_probes_from_pid` in `ustd.cpp` we collect usdt probes from bcc and we maintain a cache of paths --> providers --> tracepoints
https://github.com/iovisor/bpftrace/blob/80d2d3c3144b8c74b84e12a72b6b34004229c2cb/src/usdt.cpp#L23-L29

In the scenario above the cache looks something like:
```
usdt_provider_cache = {
	"/proc/43133/root/bcc-build/bpftrace/build/tests/testlibs/libusdt_tp.so": {
		"testlibprovider": [tracepoint1, ...]
	}
}
```
Later in `USDTHelper::probes_for_pid` we get given a pid and try to perform a lookup based on the pid exe path.
https://github.com/iovisor/bpftrace/blob/80d2d3c3144b8c74b84e12a72b6b34004229c2cb/src/usdt.cpp#L78-L85

In this case it tries to look for `/proc/43133/root/bcc-build/bpftrace/build-mine/tests/testprogs/usdt_lib` in the cache, however only `/proc/43133/root/bcc-build/bpftrace/build/tests/testlibs/libusdt_tp.so` exists, and so it fails to find the probe.


#### Fix

The fix is when we iterate the probes given by bcc, we populate another separate map, that maps the paths for each pid found by bcc. So rather than trying to compute the path to look for in the cache using the pid's exe (https://github.com/iovisor/bpftrace/blob/80d2d3c3144b8c74b84e12a72b6b34004229c2cb/src/usdt.cpp#L78-L80) we instead can get the paths for the pid by indexing `usdt_pid_to_paths_cache[pid]`. This way we don't risk a cache miss due to different paths found by bcc / computed by bpftrace.

##### Checklist

- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
