### PR TITLE
Error if using negative length in str() and buf()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,6 +108,8 @@ and this project adheres to
   - [#1532](https://github.com/iovisor/bpftrace/pull/1532)
 - Fix bitfield access for big endian
   - [#1628](https://github.com/iovisor/bpftrace/pull/1628)
+- Error if using negative length in str() and buf()
+  - [#1621](https://github.com/iovisor/bpftrace/pull/1621)
 
 #### Tools
 - Hook up execsnoop.bt script onto `execveat` call

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -120,6 +120,7 @@ parallel -N1 "sed -e '/^#\!/d' -e '/\/\*.*/d' -e '/^\s\*.*/d' -e '/\/\/.*/d' -e 
 ```
 
 ## Found bugs
+### AFL
 - [#1619](https://github.com/iovisor/bpftrace/pull/1619)
 - [#1580](https://github.com/iovisor/bpftrace/pull/1580)
 - [#1573](https://github.com/iovisor/bpftrace/pull/1573)
@@ -135,3 +136,6 @@ parallel -N1 "sed -e '/^#\!/d' -e '/\/\*.*/d' -e '/^\s\*.*/d' -e '/\/\/.*/d' -e 
 - [#1221](https://github.com/iovisor/bpftrace/pull/1221)
 - [#1210](https://github.com/iovisor/bpftrace/pull/1210)
 - [#1205](https://github.com/iovisor/bpftrace/pull/1205)
+
+### libFuzzer
+- [#1621](https://github.com/iovisor/bpftrace/pull/1621)

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -604,6 +604,17 @@ void SemanticAnalyser::visit(Call &call)
         }
       }
 
+      if (call.vargs->size() == 2)
+      {
+        auto &size_arg = *call.vargs->at(1);
+        long value = static_cast<Integer &>(size_arg).n;
+        if (value < 0)
+        {
+          LOG(ERROR, call.loc, err_)
+              << call.func << "cannot use negative length (" << value << ")";
+        }
+      }
+
       // Required for cases like strncmp(str($1), str(2), 4))
       call.type.SetAS(t.GetAS());
       if (is_final_pass() && call.vargs->size() > 1) {
@@ -645,7 +656,15 @@ void SemanticAnalyser::visit(Call &call)
 
       auto &size_arg = *call.vargs->at(1);
       if (size_arg.is_literal)
-        buffer_size = static_cast<Integer &>(size_arg).n;
+      {
+        long value = static_cast<Integer &>(size_arg).n;
+        if (value < 0)
+        {
+          LOG(ERROR, call.loc, err_)
+              << call.func << "cannot use negative length (" << value << ")";
+        }
+        buffer_size = value;
+      }
     }
 
     if (buffer_size > max_buffer_size)

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -579,6 +579,7 @@ TEST(semantic_analyser, call_str)
 TEST(semantic_analyser, call_str_2_lit)
 {
   test("kprobe:f { str(arg0, 3); }", 0);
+  test("kprobe:f { str(arg0, -3); }", 1);
   test("kprobe:f { @x = str(arg0, 3); }", 0);
   test("kprobe:f { str(arg0, \"hello\"); }", 10);
 }
@@ -601,6 +602,7 @@ TEST(semantic_analyser, call_str_state_leak_regression_test)
 TEST(semantic_analyser, call_buf)
 {
   test("kprobe:f { buf(arg0, 1); }", 0);
+  test("kprobe:f { buf(arg0, -1); }", 1);
   test("kprobe:f { @x = buf(arg0, 1); }", 0);
   test("kprobe:f { $x = buf(arg0, 1); }", 0);
   test("kprobe:f { buf(); }", 1);


### PR DESCRIPTION
This disables a negative length in `str()` and `buf`(), such as `buf("aaa", -1)`.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
