### PR TITLE
Only create int type Identifier when it is used in sizeof()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -110,6 +110,8 @@ and this project adheres to
   - [#1628](https://github.com/iovisor/bpftrace/pull/1628)
 - Error if using negative length in str() and buf()
   - [#1621](https://github.com/iovisor/bpftrace/pull/1621)
+- Only create int type Identifier when it is used in sizeof()
+  - [#1622](https://github.com/iovisor/bpftrace/pull/1622)
 
 #### Tools
 - Hook up execsnoop.bt script onto `execveat` call

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -139,3 +139,4 @@ parallel -N1 "sed -e '/^#\!/d' -e '/\/\*.*/d' -e '/^\s\*.*/d' -e '/\/\/.*/d' -e 
 
 ### libFuzzer
 - [#1621](https://github.com/iovisor/bpftrace/pull/1621)
+- [#1622](https://github.com/iovisor/bpftrace/pull/1622)

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -113,7 +113,7 @@ void SemanticAnalyser::visit(Identifier &identifier)
     identifier.type = CreateRecord(bpftrace_.structs_[identifier.ident].size,
                                    identifier.ident);
   }
-  else if (getIntcasts().count(identifier.ident) != 0)
+  else if (func_ == "sizeof" && getIntcasts().count(identifier.ident) != 0)
   {
     identifier.type = CreateInt(
         std::get<0>(getIntcasts().at(identifier.ident)));

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1997,6 +1997,12 @@ TEST(semantic_analyser, call_path)
   test("END { $k = path( 1 ) }", 1);
 }
 
+TEST(semantic_analyser, int_ident)
+{
+  test("BEGIN { sizeof(int32) }", 0);
+  test("BEGIN { print(int32) }", 1);
+}
+
 #ifdef HAVE_LIBBPF_BTF_DUMP
 
 #include "btf_common.h"


### PR DESCRIPTION
Currently, `int8`, `in16`, ... etc are considered as a identifier when used other than sizeof. This disabled it , and fixed the following error:

```
sudo ./src/bpftrace -e 'BEGIN { print(int32); }'
FATAL: unknown identifier "int32"
zsh: abort sudo ./src/bpftrace -e 'BEGIN { print(int32); }'
```
##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
