### PR TITLE
Check exponent value can be expressed in uint64_t

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -112,6 +112,8 @@ and this project adheres to
   - [#1621](https://github.com/iovisor/bpftrace/pull/1621)
 - Only create int type Identifier when it is used in sizeof()
   - [#1622](https://github.com/iovisor/bpftrace/pull/1622)
+- Check exponent value can be expressed in uint64_t
+  - [#1623](https://github.com/iovisor/bpftrace/pull/1623)
 
 #### Tools
 - Hook up execsnoop.bt script onto `execveat` call

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -121,6 +121,7 @@ parallel -N1 "sed -e '/^#\!/d' -e '/\/\*.*/d' -e '/^\s\*.*/d' -e '/\/\/.*/d' -e 
 
 ## Found bugs
 ### AFL
+- [#1623](https://github.com/iovisor/bpftrace/pull/1623)
 - [#1619](https://github.com/iovisor/bpftrace/pull/1619)
 - [#1580](https://github.com/iovisor/bpftrace/pull/1580)
 - [#1573](https://github.com/iovisor/bpftrace/pull/1573)

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -60,7 +60,15 @@ bpftrace|perf           { return Parser::make_STACK_MODE(yytext, loc); }
 {call}                  { return Parser::make_CALL(yytext, loc); }
 {call_and_builtin}      { return Parser::make_CALL_BUILTIN(yytext, loc); }
 {int}                   { return Parser::make_INT(strtoul(yytext, NULL, 0), loc); }
-{exponent}              { return Parser::make_INT(parse_exponent(yytext), loc); }
+{exponent}              {
+                          uint64_t num;
+                          try {
+                            num = parse_exponent(yytext);
+                            return Parser::make_INT(num, loc);
+                          } catch (std::exception const &e) {
+                            driver.error(loc, e.what());
+                          }
+                        }
 {path}                  { return Parser::make_PATH(yytext, loc); }
 {map}                   { return Parser::make_MAP(yytext, loc); }
 {var}                   { return Parser::make_VAR(yytext, loc); }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -5,6 +5,7 @@
 #include <fcntl.h>
 #include <fstream>
 #include <glob.h>
+#include <limits>
 #include <link.h>
 #include <map>
 #include <memory>
@@ -806,6 +807,9 @@ uint64_t parse_exponent(const char *str)
 
   auto exp = strtoll(e_offset + 1, nullptr, 10);
   auto num = base * std::pow(10, exp);
+  uint64_t max = std::numeric_limits<uint64_t>::max();
+  if (num > (double)max)
+    throw std::runtime_error(std::string(str) + " is too big for uint64_t");
   return num;
 }
 

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1659,6 +1659,7 @@ TEST(Parser, scientific_notation)
        "Program\n kprobe:f\n  call: print\n   int: 5000000000\n");
 
   test_parse_failure("k:f { print(5e-9); }");
+  test_parse_failure("k:f { print(1e100); }");
 }
 
 TEST(Parser, while_loop)


### PR DESCRIPTION
Undefined Sanitizer found the following error.

```
sudo ./src/bpftrace -e 'BEGIN {@ = 1e30;}'
/home/ubuntu/work/bpftrace/src/utils.cpp:809:10: runtime error: 1e+30 is outside the range of representable values of type 'unsigned long'
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /home/ubuntu/work/bpftrace/src/utils.cpp:809:10 in
Attaching 1 probe...
^C

@: 0
```

To fix this, in the parse_exponent(), check the exponent value and if
it's bigger than uint64_t'x max value, throw exception. The Lexer then
make an error.

Now it becomes

```
% sudo ./src/bpftrace -e 'BEGIN {@ = 1e30;}'
stdin:1:12-16: ERROR: 1e30 is too big for uint64_t
BEGIN {@ = 1e30;}
           ~~~~
stdin:1:12-17: ERROR: syntax error, unexpected ;
BEGIN {@ = 1e30;}
           ~~~~~
```

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
