### PR TITLE
Ast cleanup

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -7,6 +7,7 @@ add_library(ast
   printer.cpp
   semantic_analyser.cpp
   callback_visitor.cpp
+  visitors.cpp
 )
 
 target_include_directories(ast PUBLIC ${CMAKE_SOURCE_DIR}/src)

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -1,6 +1,7 @@
 #include "ast.h"
 #include "log.h"
 #include "parser.tab.hh"
+#include "visitors.h"
 #include <iostream>
 
 namespace bpftrace {

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -7,6 +7,42 @@
 namespace bpftrace {
 namespace ast {
 
+#define MAKE_ACCEPT(Ty)                                                        \
+  void Ty::accept(Visitor &v)                                                  \
+  {                                                                            \
+    v.visit(*this);                                                            \
+  };
+
+MAKE_ACCEPT(Integer)
+MAKE_ACCEPT(String)
+MAKE_ACCEPT(StackMode)
+MAKE_ACCEPT(Builtin)
+MAKE_ACCEPT(Identifier)
+MAKE_ACCEPT(PositionalParameter)
+MAKE_ACCEPT(Call)
+MAKE_ACCEPT(Map)
+MAKE_ACCEPT(Variable)
+MAKE_ACCEPT(Binop)
+MAKE_ACCEPT(Unop)
+MAKE_ACCEPT(Ternary)
+MAKE_ACCEPT(FieldAccess)
+MAKE_ACCEPT(ArrayAccess)
+MAKE_ACCEPT(Cast)
+MAKE_ACCEPT(Tuple)
+MAKE_ACCEPT(ExprStatement)
+MAKE_ACCEPT(AssignMapStatement)
+MAKE_ACCEPT(AssignVarStatement)
+MAKE_ACCEPT(Predicate)
+MAKE_ACCEPT(AttachPoint)
+MAKE_ACCEPT(If)
+MAKE_ACCEPT(Unroll)
+MAKE_ACCEPT(While)
+MAKE_ACCEPT(Jump)
+MAKE_ACCEPT(Probe)
+MAKE_ACCEPT(Program)
+
+#undef MAKE_ACCEPT
+
 Node::Node() : loc(location())
 {
 }
@@ -24,18 +60,12 @@ Integer::Integer(long n, location loc) : Expression(loc), n(n)
   is_literal = true;
 }
 
-void Integer::accept(Visitor &v) {
-  v.visit(*this);
-}
 
 String::String(const std::string &str, location loc) : Expression(loc), str(str)
 {
   is_literal = true;
 }
 
-void String::accept(Visitor &v) {
-  v.visit(*this);
-}
 
 StackMode::StackMode(const std::string &mode, location loc)
     : Expression(loc), mode(mode)
@@ -43,27 +73,18 @@ StackMode::StackMode(const std::string &mode, location loc)
   is_literal = true;
 }
 
-void StackMode::accept(Visitor &v) {
-  v.visit(*this);
-}
 
 Builtin::Builtin(const std::string &ident, location loc)
     : Expression(loc), ident(is_deprecated(ident))
 {
 }
 
-void Builtin::accept(Visitor &v) {
-  v.visit(*this);
-}
 
 Identifier::Identifier(const std::string &ident, location loc)
     : Expression(loc), ident(ident)
 {
 }
 
-void Identifier::accept(Visitor &v) {
-  v.visit(*this);
-}
 
 PositionalParameter::PositionalParameter(PositionalParameterType ptype,
                                          long n,
@@ -73,9 +94,6 @@ PositionalParameter::PositionalParameter(PositionalParameterType ptype,
   is_literal = true;
 }
 
-void PositionalParameter::accept(Visitor &v) {
-  v.visit(*this);
-}
 
 Call::Call(const std::string &func, location loc)
     : Expression(loc), func(is_deprecated(func)), vargs(nullptr)
@@ -87,9 +105,6 @@ Call::Call(const std::string &func, ExpressionList *vargs, location loc)
 {
 }
 
-void Call::accept(Visitor &v) {
-  v.visit(*this);
-}
 
 Map::Map(const std::string &ident, location loc)
     : Expression(loc), ident(ident), vargs(nullptr)
@@ -107,9 +122,6 @@ Map::Map(const std::string &ident, ExpressionList *vargs, location loc)
   }
 }
 
-void Map::accept(Visitor &v) {
-  v.visit(*this);
-}
 
 Variable::Variable(const std::string &ident, location loc)
     : Expression(loc), ident(ident)
@@ -117,18 +129,12 @@ Variable::Variable(const std::string &ident, location loc)
   is_variable = true;
 }
 
-void Variable::accept(Visitor &v) {
-  v.visit(*this);
-}
 
 Binop::Binop(Expression *left, int op, Expression *right, location loc)
     : Expression(loc), left(left), right(right), op(op)
 {
 }
 
-void Binop::accept(Visitor &v) {
-  v.visit(*this);
-}
 
 Unop::Unop(int op, Expression *expr, location loc)
     : Expression(loc), expr(expr), op(op), is_post_op(false)
@@ -140,9 +146,6 @@ Unop::Unop(int op, Expression *expr, bool is_post_op, location loc)
 {
 }
 
-void Unop::accept(Visitor &v) {
-  v.visit(*this);
-}
 
 Ternary::Ternary(Expression *cond,
                  Expression *left,
@@ -152,9 +155,6 @@ Ternary::Ternary(Expression *cond,
 {
 }
 
-void Ternary::accept(Visitor &v) {
-  v.visit(*this);
-}
 
 FieldAccess::FieldAccess(Expression *expr,
                          const std::string &field,
@@ -168,18 +168,12 @@ FieldAccess::FieldAccess(Expression *expr, ssize_t index, location loc)
 {
 }
 
-void FieldAccess::accept(Visitor &v) {
-  v.visit(*this);
-}
 
 ArrayAccess::ArrayAccess(Expression *expr, Expression *indexpr, location loc)
     : Expression(loc), expr(expr), indexpr(indexpr)
 {
 }
 
-void ArrayAccess::accept(Visitor &v) {
-  v.visit(*this);
-}
 
 Cast::Cast(const std::string &type,
            bool is_pointer,
@@ -194,19 +188,12 @@ Cast::Cast(const std::string &type,
 {
 }
 
-void Cast::accept(Visitor &v) {
-  v.visit(*this);
-}
 
 Tuple::Tuple(ExpressionList *elems, location loc)
     : Expression(loc), elems(elems)
 {
 }
 
-void Tuple::accept(Visitor &v)
-{
-  v.visit(*this);
-}
 
 Statement::Statement(location loc) : Node(loc)
 {
@@ -217,9 +204,6 @@ ExprStatement::ExprStatement(Expression *expr, location loc)
 {
 }
 
-void ExprStatement::accept(Visitor &v) {
-  v.visit(*this);
-}
 
 AssignMapStatement::AssignMapStatement(Map *map, Expression *expr, location loc)
     : Statement(loc), map(map), expr(expr)
@@ -227,9 +211,6 @@ AssignMapStatement::AssignMapStatement(Map *map, Expression *expr, location loc)
   expr->map = map;
 };
 
-void AssignMapStatement::accept(Visitor &v) {
-  v.visit(*this);
-}
 
 AssignVarStatement::AssignVarStatement(Variable *var,
                                        Expression *expr,
@@ -239,26 +220,17 @@ AssignVarStatement::AssignVarStatement(Variable *var,
   expr->var = var;
 }
 
-void AssignVarStatement::accept(Visitor &v) {
-  v.visit(*this);
-}
 
 Predicate::Predicate(Expression *expr, location loc) : Node(loc), expr(expr)
 {
 }
 
-void Predicate::accept(Visitor &v) {
-  v.visit(*this);
-}
 
 AttachPoint::AttachPoint(const std::string &raw_input, location loc)
     : Node(loc), raw_input(raw_input)
 {
 }
 
-void AttachPoint::accept(Visitor &v) {
-  v.visit(*this);
-}
 
 If::If(Expression *cond, StatementList *stmts) : cond(cond), stmts(stmts)
 {
@@ -269,27 +241,10 @@ If::If(Expression *cond, StatementList *stmts, StatementList *else_stmts)
 {
 }
 
-void If::accept(Visitor &v) {
-  v.visit(*this);
-}
 
 Unroll::Unroll(Expression *expr, StatementList *stmts, location loc)
     : Statement(loc), expr(expr), stmts(stmts)
 {
-}
-
-void Unroll::accept(Visitor &v) {
-  v.visit(*this);
-}
-
-void While::accept(Visitor &v)
-{
-  v.visit(*this);
-}
-
-void Jump::accept(Visitor &v)
-{
-  v.visit(*this);
 }
 
 Probe::Probe(AttachPointList *attach_points,
@@ -299,17 +254,10 @@ Probe::Probe(AttachPointList *attach_points,
 {
 }
 
-void Probe::accept(Visitor &v) {
-  v.visit(*this);
-}
 
 Program::Program(const std::string &c_definitions, ProbeList *probes)
     : c_definitions(c_definitions), probes(probes)
 {
-}
-
-void Program::accept(Visitor &v) {
-  v.visit(*this);
 }
 
 std::string opstr(Jump &jump)

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -15,17 +15,8 @@ Node::Node(location loc) : loc(loc)
 {
 }
 
-Expression::Expression() : Node()
-{
-}
-
 Expression::Expression(location loc) : Node(loc)
 {
-}
-
-Integer::Integer(long n) : n(n)
-{
-  is_literal = true;
 }
 
 Integer::Integer(long n, location loc) : Expression(loc), n(n)
@@ -37,11 +28,6 @@ void Integer::accept(Visitor &v) {
   v.visit(*this);
 }
 
-String::String(const std::string &str) : str(str)
-{
-  is_literal = true;
-}
-
 String::String(const std::string &str, location loc) : Expression(loc), str(str)
 {
   is_literal = true;
@@ -49,11 +35,6 @@ String::String(const std::string &str, location loc) : Expression(loc), str(str)
 
 void String::accept(Visitor &v) {
   v.visit(*this);
-}
-
-StackMode::StackMode(const std::string &mode) : mode(mode)
-{
-  is_literal = true;
 }
 
 StackMode::StackMode(const std::string &mode, location loc)
@@ -66,10 +47,6 @@ void StackMode::accept(Visitor &v) {
   v.visit(*this);
 }
 
-Builtin::Builtin(const std::string &ident) : ident(is_deprecated(ident))
-{
-}
-
 Builtin::Builtin(const std::string &ident, location loc)
     : Expression(loc), ident(is_deprecated(ident))
 {
@@ -79,10 +56,6 @@ void Builtin::accept(Visitor &v) {
   v.visit(*this);
 }
 
-Identifier::Identifier(const std::string &ident) : ident(ident)
-{
-}
-
 Identifier::Identifier(const std::string &ident, location loc)
     : Expression(loc), ident(ident)
 {
@@ -90,12 +63,6 @@ Identifier::Identifier(const std::string &ident, location loc)
 
 void Identifier::accept(Visitor &v) {
   v.visit(*this);
-}
-
-PositionalParameter::PositionalParameter(PositionalParameterType ptype, long n)
-    : ptype(ptype), n(n)
-{
-  is_literal = true;
 }
 
 PositionalParameter::PositionalParameter(PositionalParameterType ptype,
@@ -110,17 +77,8 @@ void PositionalParameter::accept(Visitor &v) {
   v.visit(*this);
 }
 
-Call::Call(const std::string &func) : func(is_deprecated(func)), vargs(nullptr)
-{
-}
-
 Call::Call(const std::string &func, location loc)
     : Expression(loc), func(is_deprecated(func)), vargs(nullptr)
-{
-}
-
-Call::Call(const std::string &func, ExpressionList *vargs)
-    : func(is_deprecated(func)), vargs(vargs)
 {
 }
 
@@ -139,12 +97,6 @@ Map::Map(const std::string &ident, location loc)
   is_map = true;
 }
 
-Map::Map(const std::string &ident, ExpressionList *vargs)
-    : ident(ident), vargs(vargs)
-{
-  is_map = true;
-}
-
 Map::Map(const std::string &ident, ExpressionList *vargs, location loc)
     : Expression(loc), ident(ident), vargs(vargs)
 {
@@ -157,11 +109,6 @@ Map::Map(const std::string &ident, ExpressionList *vargs, location loc)
 
 void Map::accept(Visitor &v) {
   v.visit(*this);
-}
-
-Variable::Variable(const std::string &ident) : ident(ident)
-{
-  is_variable = true;
 }
 
 Variable::Variable(const std::string &ident, location loc)
@@ -197,11 +144,6 @@ void Unop::accept(Visitor &v) {
   v.visit(*this);
 }
 
-Ternary::Ternary(Expression *cond, Expression *left, Expression *right)
-    : cond(cond), left(left), right(right)
-{
-}
-
 Ternary::Ternary(Expression *cond,
                  Expression *left,
                  Expression *right,
@@ -212,11 +154,6 @@ Ternary::Ternary(Expression *cond,
 
 void Ternary::accept(Visitor &v) {
   v.visit(*this);
-}
-
-FieldAccess::FieldAccess(Expression *expr, const std::string &field)
-    : expr(expr), field(field)
-{
 }
 
 FieldAccess::FieldAccess(Expression *expr,
@@ -235,11 +172,6 @@ void FieldAccess::accept(Visitor &v) {
   v.visit(*this);
 }
 
-ArrayAccess::ArrayAccess(Expression *expr, Expression *indexpr)
-    : expr(expr), indexpr(indexpr)
-{
-}
-
 ArrayAccess::ArrayAccess(Expression *expr, Expression *indexpr, location loc)
     : Expression(loc), expr(expr), indexpr(indexpr)
 {
@@ -247,17 +179,6 @@ ArrayAccess::ArrayAccess(Expression *expr, Expression *indexpr, location loc)
 
 void ArrayAccess::accept(Visitor &v) {
   v.visit(*this);
-}
-
-Cast::Cast(const std::string &type,
-           bool is_pointer,
-           bool is_double_pointer,
-           Expression *expr)
-    : cast_type(type),
-      is_pointer(is_pointer),
-      is_double_pointer(is_double_pointer),
-      expr(expr)
-{
 }
 
 Cast::Cast(const std::string &type,
@@ -291,10 +212,6 @@ Statement::Statement(location loc) : Node(loc)
 {
 }
 
-ExprStatement::ExprStatement(Expression *expr) : expr(expr)
-{
-}
-
 ExprStatement::ExprStatement(Expression *expr, location loc)
     : Statement(loc), expr(expr)
 {
@@ -314,12 +231,6 @@ void AssignMapStatement::accept(Visitor &v) {
   v.visit(*this);
 }
 
-AssignVarStatement::AssignVarStatement(Variable *var, Expression *expr)
-    : var(var), expr(expr)
-{
-  expr->var = var;
-}
-
 AssignVarStatement::AssignVarStatement(Variable *var,
                                        Expression *expr,
                                        location loc)
@@ -330,10 +241,6 @@ AssignVarStatement::AssignVarStatement(Variable *var,
 
 void AssignVarStatement::accept(Visitor &v) {
   v.visit(*this);
-}
-
-Predicate::Predicate(Expression *expr) : expr(expr)
-{
 }
 
 Predicate::Predicate(Expression *expr, location loc) : Node(loc), expr(expr)
@@ -375,13 +282,6 @@ void Unroll::accept(Visitor &v) {
   v.visit(*this);
 }
 
-Probe::Probe(AttachPointList *attach_points,
-             Predicate *pred,
-             StatementList *stmts)
-    : attach_points(attach_points), pred(pred), stmts(stmts)
-{
-}
-
 void While::accept(Visitor &v)
 {
   v.visit(*this);
@@ -390,6 +290,13 @@ void While::accept(Visitor &v)
 void Jump::accept(Visitor &v)
 {
   v.visit(*this);
+}
+
+Probe::Probe(AttachPointList *attach_points,
+             Predicate *pred,
+             StatementList *stmts)
+    : attach_points(attach_points), pred(pred), stmts(stmts)
+{
 }
 
 void Probe::accept(Visitor &v) {

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -27,7 +27,6 @@ class Map;
 class Variable;
 class Expression : public Node {
 public:
-  Expression();
   Expression(location loc);
   SizedType type;
   Map *key_for_map = nullptr;
@@ -41,7 +40,6 @@ using ExpressionList = std::vector<Expression *>;
 
 class Integer : public Expression {
 public:
-  explicit Integer(long n);
   explicit Integer(long n, location loc);
   long n;
 
@@ -50,7 +48,6 @@ public:
 
 class PositionalParameter : public Expression {
 public:
-  explicit PositionalParameter(PositionalParameterType ptype, long n);
   explicit PositionalParameter(PositionalParameterType ptype,
                                long n,
                                location loc);
@@ -63,7 +60,6 @@ public:
 
 class String : public Expression {
 public:
-  explicit String(const std::string &str);
   explicit String(const std::string &str, location loc);
   std::string str;
 
@@ -72,7 +68,6 @@ public:
 
 class StackMode : public Expression {
 public:
-  explicit StackMode(const std::string &mode);
   explicit StackMode(const std::string &mode, location loc);
   std::string mode;
 
@@ -81,7 +76,6 @@ public:
 
 class Identifier : public Expression {
 public:
-  explicit Identifier(const std::string &ident);
   explicit Identifier(const std::string &ident, location loc);
   std::string ident;
 
@@ -90,7 +84,6 @@ public:
 
 class Builtin : public Expression {
 public:
-  explicit Builtin(const std::string &ident);
   explicit Builtin(const std::string &ident, location loc);
   std::string ident;
   int probe_id;
@@ -100,9 +93,7 @@ public:
 
 class Call : public Expression {
 public:
-  explicit Call(const std::string &func);
   explicit Call(const std::string &func, location loc);
-  Call(const std::string &func, ExpressionList *vargs);
   Call(const std::string &func, ExpressionList *vargs, location loc);
   std::string func;
   ExpressionList *vargs;
@@ -113,7 +104,6 @@ public:
 class Map : public Expression {
 public:
   explicit Map(const std::string &ident, location loc);
-  Map(const std::string &ident, ExpressionList *vargs);
   Map(const std::string &ident, ExpressionList *vargs, location loc);
   std::string ident;
   ExpressionList *vargs;
@@ -124,7 +114,6 @@ public:
 
 class Variable : public Expression {
 public:
-  explicit Variable(const std::string &ident);
   explicit Variable(const std::string &ident, location loc);
   std::string ident;
 
@@ -213,7 +202,6 @@ using StatementList = std::vector<Statement *>;
 
 class ExprStatement : public Statement {
 public:
-  explicit ExprStatement(Expression *expr);
   explicit ExprStatement(Expression *expr, location loc);
   Expression *expr;
 
@@ -275,7 +263,6 @@ public:
 
 class Predicate : public Node {
 public:
-  explicit Predicate(Expression *expr);
   explicit Predicate(Expression *expr, location loc);
   Expression *expr;
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -14,6 +14,8 @@ namespace ast {
 
 class Visitor;
 
+#define DEFINE_ACCEPT void accept(Visitor &v) override;
+
 class Node {
 public:
   Node();
@@ -43,7 +45,7 @@ public:
   explicit Integer(long n, location loc);
   long n;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class PositionalParameter : public Expression {
@@ -55,7 +57,7 @@ public:
   long n;
   bool is_in_str = false;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class String : public Expression {
@@ -63,7 +65,7 @@ public:
   explicit String(const std::string &str, location loc);
   std::string str;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class StackMode : public Expression {
@@ -71,7 +73,7 @@ public:
   explicit StackMode(const std::string &mode, location loc);
   std::string mode;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class Identifier : public Expression {
@@ -79,7 +81,7 @@ public:
   explicit Identifier(const std::string &ident, location loc);
   std::string ident;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class Builtin : public Expression {
@@ -88,7 +90,7 @@ public:
   std::string ident;
   int probe_id;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class Call : public Expression {
@@ -98,7 +100,7 @@ public:
   std::string func;
   ExpressionList *vargs;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class Map : public Expression {
@@ -109,7 +111,7 @@ public:
   ExpressionList *vargs;
   bool skip_key_validation = false;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class Variable : public Expression {
@@ -117,7 +119,7 @@ public:
   explicit Variable(const std::string &ident, location loc);
   std::string ident;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class Binop : public Expression {
@@ -126,7 +128,7 @@ public:
   Expression *left, *right;
   int op;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class Unop : public Expression {
@@ -140,7 +142,7 @@ public:
   int op;
   bool is_post_op;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class FieldAccess : public Expression {
@@ -152,7 +154,7 @@ public:
   std::string field;
   ssize_t index = -1;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class ArrayAccess : public Expression {
@@ -162,7 +164,7 @@ public:
   Expression *expr;
   Expression *indexpr;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class Cast : public Expression {
@@ -181,7 +183,7 @@ public:
   bool is_double_pointer;
   Expression *expr;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class Tuple : public Expression
@@ -190,7 +192,7 @@ public:
   Tuple(ExpressionList *elems, location loc);
   ExpressionList *elems;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class Statement : public Node {
@@ -205,7 +207,7 @@ public:
   explicit ExprStatement(Expression *expr, location loc);
   Expression *expr;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class AssignMapStatement : public Statement {
@@ -214,7 +216,7 @@ public:
   Map *map;
   Expression *expr;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class AssignVarStatement : public Statement {
@@ -224,7 +226,7 @@ public:
   Variable *var;
   Expression *expr;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class If : public Statement {
@@ -235,7 +237,7 @@ public:
   StatementList *stmts = nullptr;
   StatementList *else_stmts = nullptr;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class Unroll : public Statement {
@@ -245,7 +247,7 @@ public:
   Expression *expr;
   StatementList *stmts;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class Jump : public Statement
@@ -258,7 +260,7 @@ public:
   location loc;
   int ident;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class Predicate : public Node {
@@ -266,7 +268,7 @@ public:
   explicit Predicate(Expression *expr, location loc);
   Expression *expr;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class Ternary : public Expression {
@@ -275,7 +277,7 @@ public:
   Ternary(Expression *cond, Expression *left, Expression *right, location loc);
   Expression *cond, *left, *right;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class While : public Statement
@@ -289,7 +291,7 @@ public:
   StatementList *stmts = nullptr;
   location loc;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 class AttachPoint : public Node {
@@ -311,7 +313,7 @@ public:
   uint64_t address = 0;
   uint64_t func_offset = 0;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
   std::string name(const std::string &attach_point) const;
   std::string name(const std::string &attach_target,
                    const std::string &attach_point) const;
@@ -331,7 +333,7 @@ public:
   Predicate *pred;
   StatementList *stmts;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
   std::string name() const;
   bool need_expansion = false;        // must build a BPF program per wildcard match
   bool need_tp_args_structs = false;  // must import struct for tracepoints
@@ -349,12 +351,14 @@ public:
   std::string c_definitions;
   ProbeList *probes;
 
-  void accept(Visitor &v) override;
+  DEFINE_ACCEPT
 };
 
 std::string opstr(Binop &binop);
 std::string opstr(Unop &unop);
 std::string opstr(Jump &jump);
+
+#undef DEFINE_ACCEPT
 
 } // namespace ast
 } // namespace bpftrace

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -365,38 +365,6 @@ public:
   void accept(Visitor &v) override;
 };
 
-class Visitor {
-public:
-  virtual ~Visitor() = default;
-  virtual void visit(Integer &integer) = 0;
-  virtual void visit(PositionalParameter &integer) = 0;
-  virtual void visit(String &string) = 0;
-  virtual void visit(Builtin &builtin) = 0;
-  virtual void visit(Identifier &identifier) = 0;
-  virtual void visit(StackMode &mode) = 0;
-  virtual void visit(Call &call) = 0;
-  virtual void visit(Map &map) = 0;
-  virtual void visit(Variable &var) = 0;
-  virtual void visit(Binop &binop) = 0;
-  virtual void visit(Unop &unop) = 0;
-  virtual void visit(Ternary &ternary) = 0;
-  virtual void visit(FieldAccess &acc) = 0;
-  virtual void visit(ArrayAccess &arr) = 0;
-  virtual void visit(Cast &cast) = 0;
-  virtual void visit(Tuple &tuple) = 0;
-  virtual void visit(ExprStatement &expr) = 0;
-  virtual void visit(AssignMapStatement &assignment) = 0;
-  virtual void visit(AssignVarStatement &assignment) = 0;
-  virtual void visit(If &if_block) = 0;
-  virtual void visit(Jump &jump) = 0;
-  virtual void visit(Unroll &unroll) = 0;
-  virtual void visit(While &while_block) = 0;
-  virtual void visit(Predicate &pred) = 0;
-  virtual void visit(AttachPoint &ap) = 0;
-  virtual void visit(Probe &probe) = 0;
-  virtual void visit(Program &program) = 0;
-};
-
 std::string opstr(Binop &binop);
 std::string opstr(Unop &unop);
 std::string opstr(Jump &jump);

--- a/src/ast/callback_visitor.h
+++ b/src/ast/callback_visitor.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "ast.h"
+#include "visitors.h"
 #include <functional>
 
 namespace bpftrace {
@@ -8,7 +8,7 @@ namespace ast {
 
 using callback = std::function<void(Node *)>;
 
-class CallbackVisitor : public Visitor
+class CallbackVisitor : public ASTVisitor
 {
 public:
   explicit CallbackVisitor(callback func) : func_(func)

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -20,7 +20,8 @@ using namespace llvm;
 
 using CallArgs = std::vector<std::tuple<std::string, std::vector<Field>>>;
 
-class CodegenLLVM : public Visitor {
+class CodegenLLVM : public ASTVisitor
+{
 public:
   explicit CodegenLLVM(Node *root, BPFtrace &bpftrace);
 
@@ -116,7 +117,7 @@ private:
   void binop_buf(Binop &binop);
   void binop_int(Binop &binop);
 
-  Node *root_;
+  Node *root_ = nullptr;
   LLVMContext context_;
   std::unique_ptr<Module> module_;
   std::unique_ptr<ExecutionEngine> ee_;

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -3,10 +3,10 @@
 #include <iostream>
 #include <ostream>
 
-#include "ast.h"
 #include "bpftrace.h"
 #include "irbuilderbpf.h"
 #include "map.h"
+#include "visitors.h"
 
 #include <llvm/Support/raw_os_ostream.h>
 #include <llvm/ExecutionEngine/MCJIT.h>

--- a/src/ast/field_analyser.h
+++ b/src/ast/field_analyser.h
@@ -1,7 +1,7 @@
 #pragma once
 
-#include "ast.h"
 #include "bpftrace.h"
+#include "visitors.h"
 #include <iostream>
 #include <string>
 #include <unordered_set>

--- a/src/ast/field_analyser.h
+++ b/src/ast/field_analyser.h
@@ -9,45 +9,29 @@
 namespace bpftrace {
 namespace ast {
 
-class FieldAnalyser : public Visitor {
+class FieldAnalyser : public ASTVisitor
+{
 public:
   explicit FieldAnalyser(Node *root,
                          BPFtrace &bpftrace,
                          std::ostream &out = std::cerr)
-      : type_(""),
-        root_(root),
+      : root_(root),
+        type_(""),
         bpftrace_(bpftrace),
         prog_type_(BPF_PROG_TYPE_UNSPEC),
         out_(out)
   { }
 
-  void visit(Integer &integer) override;
-  void visit(PositionalParameter &param) override;
-  void visit(String &string) override;
-  void visit(StackMode &mode) override;
   void visit(Identifier &identifier) override;
   void visit(Builtin &builtin) override;
-  void visit(Call &call) override;
   void visit(Map &map) override;
   void visit(Variable &var) override;
-  void visit(Binop &binop) override;
-  void visit(Unop &unop) override;
-  void visit(Ternary &ternary) override;
   void visit(FieldAccess &acc) override;
-  void visit(ArrayAccess &arr) override;
   void visit(Cast &cast) override;
-  void visit(Tuple &tuple) override;
-  void visit(ExprStatement &expr) override;
   void visit(AssignMapStatement &assignment) override;
   void visit(AssignVarStatement &assignment) override;
-  void visit(If &if_block) override;
-  void visit(Unroll &unroll) override;
-  void visit(While &while_block) override;
-  void visit(Jump &jump) override;
-  void visit(Predicate &pred) override;
   void visit(AttachPoint &ap) override;
   void visit(Probe &probe) override;
-  void visit(Program &program) override;
 
   int analyse();
 
@@ -57,8 +41,8 @@ private:
   bool compare_args(const std::map<std::string, SizedType>& args1,
                     const std::map<std::string, SizedType>& args2);
 
+  Node *root_;
   std::string    type_;
-  Node          *root_;
   BPFtrace      &bpftrace_;
   bpf_prog_type  prog_type_;
   bool           has_builtin_args_;

--- a/src/ast/printer.cpp
+++ b/src/ast/printer.cpp
@@ -9,6 +9,12 @@
 namespace bpftrace {
 namespace ast {
 
+void Printer::print(Node *root)
+{
+  depth_ = 0;
+  Visit(root);
+}
+
 std::string Printer::type(const SizedType &ty)
 {
   std::stringstream buf;

--- a/src/ast/printer.h
+++ b/src/ast/printer.h
@@ -6,12 +6,15 @@
 namespace bpftrace {
 namespace ast {
 
-class Printer : public Visitor {
+class Printer : public ASTVisitor
+{
 public:
   explicit Printer(std::ostream &out, bool print_types = false)
       : out_(out), print_types(print_types)
   {
   }
+
+  void print(Node *root);
 
   void visit(Integer &integer) override;
   void visit(PositionalParameter &param) override;
@@ -46,6 +49,7 @@ public:
 private:
   std::ostream &out_;
   bool print_types = false;
+
   std::string type(const SizedType &ty);
 };
 

--- a/src/ast/printer.h
+++ b/src/ast/printer.h
@@ -1,7 +1,7 @@
 #pragma once
 
+#include "visitors.h"
 #include <ostream>
-#include "ast.h"
 
 namespace bpftrace {
 namespace ast {

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1256,7 +1256,7 @@ void SemanticAnalyser::visit(Map &map)
       if (expr->type.IsIntTy() && expr->type.GetSize() < 8)
       {
         std::string type = expr->type.IsSigned() ? "int64" : "uint64";
-        Expression *cast = new ast::Cast(type, false, false, expr);
+        Expression *cast = new ast::Cast(type, false, false, expr, map.loc);
         cast->accept(*this);
         map.vargs->at(i) = cast;
         expr = cast;

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -13,21 +13,19 @@
 namespace bpftrace {
 namespace ast {
 
-class SemanticAnalyser : public Visitor {
+class SemanticAnalyser : public ASTVisitor
+{
 public:
   explicit SemanticAnalyser(Node *root,
                             BPFtrace &bpftrace,
                             std::ostream &out = std::cerr,
                             bool has_child = true)
-      : root_(root),
-        bpftrace_(bpftrace),
-        out_(out),
-        has_child_(has_child)
+      : root_(root), bpftrace_(bpftrace), out_(out), has_child_(has_child)
   {
   }
 
   explicit SemanticAnalyser(Node *root, BPFtrace &bpftrace, bool has_child)
-      : SemanticAnalyser(root, bpftrace, std::cerr, has_child)
+      : root_(root), bpftrace_(bpftrace), out_(std::cerr), has_child_(has_child)
   {
   }
 
@@ -63,7 +61,7 @@ public:
   int analyse();
 
 private:
-  Node *root_;
+  Node *root_ = nullptr;
   BPFtrace &bpftrace_;
   std::ostream &out_;
   std::ostringstream err_;

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -4,11 +4,11 @@
 #include <sstream>
 #include <unordered_set>
 
-#include "ast.h"
 #include "bpffeature.h"
 #include "bpftrace.h"
 #include "map.h"
 #include "types.h"
+#include "visitors.h"
 
 namespace bpftrace {
 namespace ast {

--- a/src/ast/visitors.cpp
+++ b/src/ast/visitors.cpp
@@ -1,0 +1,188 @@
+#include "visitors.h"
+#include "ast.h"
+
+namespace bpftrace {
+namespace ast {
+
+void ASTVisitor::visit(Integer &integer __attribute__((__unused__)))
+{
+}
+
+void ASTVisitor::visit(PositionalParameter &param __attribute__((__unused__)))
+{
+}
+
+void ASTVisitor::visit(String &string __attribute__((__unused__)))
+{
+}
+
+void ASTVisitor::visit(StackMode &mode __attribute__((__unused__)))
+{
+}
+
+void ASTVisitor::visit(Builtin &builtin __attribute__((__unused__)))
+{
+}
+
+void ASTVisitor::visit(Identifier &identifier __attribute__((__unused__)))
+{
+}
+
+void ASTVisitor::visit(Call &call)
+{
+  if (call.vargs)
+  {
+    for (Expression *expr : *call.vargs)
+    {
+      expr->accept(*this);
+    }
+  }
+}
+
+void ASTVisitor::visit(Map &map)
+{
+  if (map.vargs)
+  {
+    for (Expression *expr : *map.vargs)
+    {
+      expr->accept(*this);
+    }
+  }
+}
+
+void ASTVisitor::visit(Variable &var __attribute__((__unused__)))
+{
+}
+
+void ASTVisitor::visit(Binop &binop)
+{
+  binop.left->accept(*this);
+  binop.right->accept(*this);
+}
+
+void ASTVisitor::visit(Unop &unop)
+{
+  unop.expr->accept(*this);
+}
+
+void ASTVisitor::visit(Ternary &ternary)
+{
+  ternary.cond->accept(*this);
+  ternary.left->accept(*this);
+  ternary.right->accept(*this);
+}
+
+void ASTVisitor::visit(FieldAccess &acc)
+{
+  acc.expr->accept(*this);
+}
+
+void ASTVisitor::visit(ArrayAccess &arr)
+{
+  arr.expr->accept(*this);
+  arr.indexpr->accept(*this);
+}
+
+void ASTVisitor::visit(Cast &cast)
+{
+  cast.expr->accept(*this);
+}
+
+void ASTVisitor::visit(Tuple &tuple)
+{
+  for (Expression *expr : *tuple.elems)
+    expr->accept(*this);
+}
+
+void ASTVisitor::visit(ExprStatement &expr)
+{
+  expr.expr->accept(*this);
+}
+
+void ASTVisitor::visit(AssignMapStatement &assignment)
+{
+  assignment.map->accept(*this);
+  assignment.expr->accept(*this);
+}
+
+void ASTVisitor::visit(AssignVarStatement &assignment)
+{
+  assignment.var->accept(*this);
+  assignment.expr->accept(*this);
+}
+
+void ASTVisitor::visit(If &if_block)
+{
+  if_block.cond->accept(*this);
+
+  for (Statement *stmt : *if_block.stmts)
+  {
+    stmt->accept(*this);
+  }
+
+  if (if_block.else_stmts)
+  {
+    for (Statement *stmt : *if_block.else_stmts)
+    {
+      stmt->accept(*this);
+    }
+  }
+}
+
+void ASTVisitor::visit(Unroll &unroll)
+{
+  unroll.expr->accept(*this);
+  for (Statement *stmt : *unroll.stmts)
+  {
+    stmt->accept(*this);
+  }
+}
+
+void ASTVisitor::visit(While &while_block)
+{
+  while_block.cond->accept(*this);
+
+  for (Statement *stmt : *while_block.stmts)
+  {
+    stmt->accept(*this);
+  }
+}
+
+void ASTVisitor::visit(Jump &jump __attribute__((__unused__)))
+{
+}
+
+void ASTVisitor::visit(Predicate &pred)
+{
+  pred.expr->accept(*this);
+}
+
+void ASTVisitor::visit(AttachPoint &ap __attribute__((__unused__)))
+{
+}
+
+void ASTVisitor::visit(Probe &probe)
+{
+  for (AttachPoint *ap : *probe.attach_points)
+  {
+    ap->accept(*this);
+  }
+
+  if (probe.pred)
+  {
+    probe.pred->accept(*this);
+  }
+  for (Statement *stmt : *probe.stmts)
+  {
+    stmt->accept(*this);
+  }
+}
+
+void ASTVisitor::visit(Program &program)
+{
+  for (Probe *probe : *program.probes)
+    probe->accept(*this);
+}
+
+} // namespace ast
+} // namespace bpftrace

--- a/src/ast/visitors.h
+++ b/src/ast/visitors.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include "ast.h"
+
+namespace bpftrace {
+namespace ast {
+
+class Visitor
+{
+public:
+  virtual ~Visitor() = default;
+  virtual void visit(Integer &integer) = 0;
+  virtual void visit(PositionalParameter &integer) = 0;
+  virtual void visit(String &string) = 0;
+  virtual void visit(Builtin &builtin) = 0;
+  virtual void visit(Identifier &identifier) = 0;
+  virtual void visit(StackMode &mode) = 0;
+  virtual void visit(Call &call) = 0;
+  virtual void visit(Map &map) = 0;
+  virtual void visit(Variable &var) = 0;
+  virtual void visit(Binop &binop) = 0;
+  virtual void visit(Unop &unop) = 0;
+  virtual void visit(Ternary &ternary) = 0;
+  virtual void visit(FieldAccess &acc) = 0;
+  virtual void visit(ArrayAccess &arr) = 0;
+  virtual void visit(Cast &cast) = 0;
+  virtual void visit(Tuple &tuple) = 0;
+  virtual void visit(ExprStatement &expr) = 0;
+  virtual void visit(AssignMapStatement &assignment) = 0;
+  virtual void visit(AssignVarStatement &assignment) = 0;
+  virtual void visit(If &if_block) = 0;
+  virtual void visit(Jump &jump) = 0;
+  virtual void visit(Unroll &unroll) = 0;
+  virtual void visit(While &while_block) = 0;
+  virtual void visit(Predicate &pred) = 0;
+  virtual void visit(AttachPoint &ap) = 0;
+  virtual void visit(Probe &probe) = 0;
+  virtual void visit(Program &program) = 0;
+};
+
+class ASTVisitor : public Visitor
+{
+public:
+  explicit ASTVisitor() = default;
+  ~ASTVisitor() = default;
+
+  ASTVisitor(const ASTVisitor &) = delete;
+  ASTVisitor &operator=(const ASTVisitor &) = delete;
+  ASTVisitor(ASTVisitor &&) = delete;
+  ASTVisitor &operator=(ASTVisitor &&) = delete;
+
+  virtual void Visit(Node *root)
+  {
+    root->accept(*this);
+  };
+
+  void visit(Integer &integer) override;
+  void visit(PositionalParameter &param) override;
+  void visit(String &string) override;
+  void visit(StackMode &mode) override;
+  void visit(Identifier &identifier) override;
+  void visit(Builtin &builtin) override;
+  void visit(Call &call) override;
+  void visit(Map &map) override;
+  void visit(Variable &var) override;
+  void visit(Binop &binop) override;
+  void visit(Unop &unop) override;
+  void visit(Ternary &ternary) override;
+  void visit(FieldAccess &acc) override;
+  void visit(ArrayAccess &arr) override;
+  void visit(Cast &cast) override;
+  void visit(Tuple &tuple) override;
+  void visit(ExprStatement &expr) override;
+  void visit(AssignMapStatement &assignment) override;
+  void visit(AssignVarStatement &assignment) override;
+  void visit(If &if_block) override;
+  void visit(Unroll &unroll) override;
+  void visit(While &while_block) override;
+  void visit(Jump &jump) override;
+  void visit(Predicate &pred) override;
+  void visit(AttachPoint &ap) override;
+  void visit(Probe &probe) override;
+  void visit(Program &program) override;
+};
+
+} // namespace ast
+} // namespace bpftrace

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -680,8 +680,8 @@ int main(int argc, char *argv[])
   {
     std::cout << "\nAST\n";
     std::cout << "-------------------\n";
-    ast::Printer p(std::cout);
-    driver.root_->accept(p);
+    ast::Printer printer(std::cout);
+    printer.print(driver.root_);
     std::cout << std::endl;
   }
 
@@ -735,8 +735,8 @@ int main(int argc, char *argv[])
   {
     std::cout << "\nAST after semantic analysis\n";
     std::cout << "-------------------\n";
-    ast::Printer p(std::cout, true);
-    driver.root_->accept(p);
+    ast::Printer printer(std::cout, true);
+    printer.print(driver.root_);
     std::cout << std::endl;
   }
 

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -262,7 +262,7 @@ block_or_if : block        { $$ = $1; }
             | if_stmt      { $$ = new ast::StatementList; $$->emplace_back($1); }
             ;
 
-stmt : expr                { $$ = new ast::ExprStatement($1); }
+stmt : expr                { $$ = new ast::ExprStatement($1, @1); }
      | compound_assignment { $$ = $1; }
      | jump_stmt           { $$ = $1; }
      | map "=" expr        { $$ = new ast::AssignMapStatement($1, $3, @2); }
@@ -270,26 +270,26 @@ stmt : expr                { $$ = new ast::ExprStatement($1); }
      | tuple_assignment
      ;
 
-compound_assignment : map LEFTASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::LEFT,  $3, @2)); }
-                    | var LEFTASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::LEFT,  $3, @2)); }
-                    | map RIGHTASSIGN expr { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::RIGHT, $3, @2)); }
-                    | var RIGHTASSIGN expr { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::RIGHT, $3, @2)); }
-                    | map PLUSASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::PLUS,  $3, @2)); }
-                    | var PLUSASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::PLUS,  $3, @2)); }
-                    | map MINUSASSIGN expr { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MINUS, $3, @2)); }
-                    | var MINUSASSIGN expr { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MINUS, $3, @2)); }
-                    | map MULASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MUL,   $3, @2)); }
-                    | var MULASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MUL,   $3, @2)); }
-                    | map DIVASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::DIV,   $3, @2)); }
-                    | var DIVASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::DIV,   $3, @2)); }
-                    | map MODASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MOD,   $3, @2)); }
-                    | var MODASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MOD,   $3, @2)); }
-                    | map BANDASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BAND,  $3, @2)); }
-                    | var BANDASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BAND,  $3, @2)); }
-                    | map BORASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BOR,   $3, @2)); }
-                    | var BORASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BOR,   $3, @2)); }
-                    | map BXORASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BXOR,  $3, @2)); }
-                    | var BXORASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BXOR,  $3, @2)); }
+compound_assignment : map LEFTASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::LEFT,  $3, @2), @$); }
+                    | var LEFTASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::LEFT,  $3, @2), @$); }
+                    | map RIGHTASSIGN expr { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::RIGHT, $3, @2), @$); }
+                    | var RIGHTASSIGN expr { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::RIGHT, $3, @2), @$); }
+                    | map PLUSASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::PLUS,  $3, @2), @$); }
+                    | var PLUSASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::PLUS,  $3, @2), @$); }
+                    | map MINUSASSIGN expr { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MINUS, $3, @2), @$); }
+                    | var MINUSASSIGN expr { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MINUS, $3, @2), @$); }
+                    | map MULASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MUL,   $3, @2), @$); }
+                    | var MULASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MUL,   $3, @2), @$); }
+                    | map DIVASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::DIV,   $3, @2), @$); }
+                    | var DIVASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::DIV,   $3, @2), @$); }
+                    | map MODASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MOD,   $3, @2), @$); }
+                    | var MODASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MOD,   $3, @2), @$); }
+                    | map BANDASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BAND,  $3, @2), @$); }
+                    | var BANDASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BAND,  $3, @2), @$); }
+                    | map BORASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BOR,   $3, @2), @$); }
+                    | var BORASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BOR,   $3, @2), @$); }
+                    | map BXORASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BXOR,  $3, @2), @$); }
+                    | var BXORASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BXOR,  $3, @2), @$); }
                     ;
 
 tuple_assignment : expr DOT INT "=" expr { error(@1 + @5, "Tuples are immutable once created. Consider creating a new tuple and assigning it instead."); YYERROR; }

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -31,7 +31,7 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
     program->c_definitions += "#include <linux/types.h>\n";
   for (ast::Probe *probe : probes_with_tracepoint)
   {
-    n.analyse(probe);
+    n.visit(*probe);
 
     for (ast::AttachPoint *ap : *probe->attach_points)
     {

--- a/src/tracepoint_format_parser.h
+++ b/src/tracepoint_format_parser.h
@@ -3,7 +3,7 @@
 #include <istream>
 #include <set>
 
-#include "ast/ast.h"
+#include "ast/visitors.h"
 #include "bpftrace.h"
 
 namespace bpftrace {

--- a/src/tracepoint_format_parser.h
+++ b/src/tracepoint_format_parser.h
@@ -10,123 +10,19 @@ namespace bpftrace {
 
 namespace ast {
 
-class TracepointArgsVisitor : public Visitor
+class TracepointArgsVisitor : public ASTVisitor
 {
 public:
-  ~TracepointArgsVisitor() override { }
-  void visit(__attribute__((unused)) Integer &integer) override { };  // Leaf
-  void visit(__attribute__((unused)) PositionalParameter &integer) override { };  // Leaf
-  void visit(__attribute__((unused)) String &string) override { };  // Leaf
-  void visit(__attribute__((unused)) StackMode &mode) override { };  // Leaf
-  void visit(__attribute__((unused)) Identifier &identifier) override { };  // Leaf
-  void visit(__attribute__((unused)) Jump &jump) override{}; // Leaf
-  void visit(Builtin &builtin) override {  // Leaf
+  void visit(Builtin &builtin) override
+  {
     if (builtin.ident == "args")
       probe_->need_tp_args_structs = true;
-  };  // Leaf
-  void visit(Call &call) override {
-    if (call.vargs) {
-      for (Expression *expr : *call.vargs) {
-        expr->accept(*this);
-      }
-    }
   };
-  void visit(Map &map) override {
-    if (map.vargs) {
-      for (Expression *expr : *map.vargs) {
-        expr->accept(*this);
-      }
-    }
-  };
-  void visit(__attribute__((unused)) Variable &var) override { };  // Leaf
-  void visit(Binop &binop) override {
-    binop.left->accept(*this);
-    binop.right->accept(*this);
-  };
-  void visit(Unop &unop) override {
-    unop.expr->accept(*this);
-  };
-  void visit(Ternary &ternary) override {
-    ternary.cond->accept(*this);
-    ternary.left->accept(*this);
-    ternary.right->accept(*this);
-  };
-  void visit(FieldAccess &acc) override {
-    acc.expr->accept(*this);
-  };
-  void visit(ArrayAccess &acc) override {
-    acc.expr->accept(*this);
-  };
-  void visit(Cast &cast) override {
-    cast.expr->accept(*this);
-  };
-  void visit(Tuple &tuple) override
-  {
-    for (Expression *expr : *tuple.elems)
-      expr->accept(*this);
-  };
-  void visit(ExprStatement &expr) override {
-    expr.expr->accept(*this);
-  };
-  void visit(AssignMapStatement &assignment) override {
-    assignment.map->accept(*this);
-    assignment.expr->accept(*this);
-  };
-  void visit(AssignVarStatement &assignment) override {
-    assignment.expr->accept(*this);
-  };
-  void visit(If &if_block) override {
-    if_block.cond->accept(*this);
-
-    for (Statement *stmt : *if_block.stmts) {
-      stmt->accept(*this);
-    }
-
-    if (if_block.else_stmts) {
-      for (Statement *stmt : *if_block.else_stmts) {
-        stmt->accept(*this);
-      }
-    }
-  };
-  void visit(Unroll &unroll) override {
-    for (Statement *stmt : *unroll.stmts) {
-      stmt->accept(*this);
-    }
-  };
-  void visit(While &while_block) override
-  {
-    while_block.cond->accept(*this);
-
-    for (Statement *stmt : *while_block.stmts)
-    {
-      stmt->accept(*this);
-    }
-  }
-  void visit(Predicate &pred) override {
-    pred.expr->accept(*this);
-  };
-  void visit(__attribute__((unused)) AttachPoint &ap) override { };  // Leaf
   void visit(Probe &probe) override {
     probe_ = &probe;
-    for (AttachPoint *ap : *probe.attach_points) {
-      ap->accept(*this);
-    }
-    if (probe.pred) {
-      probe.pred->accept(*this);
-    }
-    for (Statement *stmt : *probe.stmts) {
-      stmt->accept(*this);
-    }
-  };
-  void visit(Program &program) override {
-    for (Probe *probe : *program.probes)
-      probe->accept(*this);
+    ASTVisitor::visit(probe);
   };
 
-  void analyse(Probe *probe) {
-    probe_ = probe;
-    probe->accept(*this);
-  }
 private:
   Probe *probe_;
 };

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -33,7 +33,7 @@ void test(BPFtrace &bpftrace,
 
   std::ostringstream out;
   Printer printer(out);
-  driver.root_->accept(printer);
+  printer.print(driver.root_);
   EXPECT_EQ(output, out.str());
 }
 


### PR DESCRIPTION
Split from #1607 to make it less huge. This,

- removes constructors that don't have a location. Location is required for error messages, having the old constructors make it possible to forget to specify a location.
- deduplicates some visitor code by implementing a base visitor that just walks the tree and the moving exisiting visitors to that. That way its possible to just override the nodes you want instead of having to duplicate the whole tree.