### PR TITLE
Ast mem leaks

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -43,18 +43,6 @@ MAKE_ACCEPT(Program)
 
 #undef MAKE_ACCEPT
 
-Node::Node() : loc(location())
-{
-}
-
-Node::Node(location loc) : loc(loc)
-{
-}
-
-Expression::Expression(location loc) : Node(loc)
-{
-}
-
 Integer::Integer(long n, location loc) : Expression(loc), n(n)
 {
   is_literal = true;
@@ -105,7 +93,6 @@ Call::Call(const std::string &func, ExpressionList *vargs, location loc)
 {
 }
 
-
 Map::Map(const std::string &ident, location loc)
     : Expression(loc), ident(ident), vargs(nullptr)
 {
@@ -122,13 +109,11 @@ Map::Map(const std::string &ident, ExpressionList *vargs, location loc)
   }
 }
 
-
 Variable::Variable(const std::string &ident, location loc)
     : Expression(loc), ident(ident)
 {
   is_variable = true;
 }
-
 
 Binop::Binop(Expression *left, int op, Expression *right, location loc)
     : Expression(loc), left(left), right(right), op(op)
@@ -194,10 +179,6 @@ Tuple::Tuple(ExpressionList *elems, location loc)
 {
 }
 
-
-Statement::Statement(location loc) : Node(loc)
-{
-}
 
 ExprStatement::ExprStatement(Expression *expr, location loc)
     : Statement(loc), expr(expr)
@@ -386,6 +367,81 @@ int Probe::index() {
 
 void Probe::set_index(int index) {
   index_ = index;
+}
+
+Expression::Expression(const Expression &other) : Node(other)
+{
+  type = other.type;
+  is_literal = other.is_literal;
+  is_variable = other.is_variable;
+  is_map = other.is_map;
+}
+
+Call::Call(const Call &other) : Expression(other)
+{
+  func = other.func;
+}
+
+Binop::Binop(const Binop &other) : Expression(other)
+{
+  left = nullptr;
+  right = nullptr;
+  op = other.op;
+}
+
+Unop::Unop(const Unop &other) : Expression(other)
+{
+  op = other.op;
+  is_post_op = op;
+}
+
+Map::Map(const Map &other) : Expression(other)
+{
+  ident = other.ident;
+  skip_key_validation = true;
+}
+
+FieldAccess::FieldAccess(const FieldAccess &other)
+    : Expression(other), expr(nullptr)
+{
+  field = other.field;
+  index = other.index;
+}
+
+Unroll::Unroll(const Unroll &other) : Statement(other)
+{
+  var = other.var;
+}
+
+Program::Program(const Program &other) : Node(other)
+{
+  c_definitions = other.c_definitions;
+}
+
+Cast::Cast(const Cast &other) : Expression(other)
+{
+  cast_type = other.cast_type;
+  is_pointer = other.is_pointer;
+  is_double_pointer = other.is_double_pointer;
+}
+
+Probe::Probe(const Probe &other) : Node(other)
+{
+  need_expansion = other.need_expansion;
+  need_tp_args_structs = other.need_tp_args_structs;
+  index_ = other.index_;
+}
+
+While::While(const While &other) : Statement(other)
+{
+}
+
+Tuple::Tuple(const Tuple &other) : Expression(other)
+{
+}
+
+If::If(const If &other) : Statement(other)
+{
 }
 
 } // namespace ast

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -185,22 +185,23 @@ ExprStatement::ExprStatement(Expression *expr, location loc)
 {
 }
 
-
-AssignMapStatement::AssignMapStatement(Map *map, Expression *expr, location loc)
-    : Statement(loc), map(map), expr(expr)
+AssignMapStatement::AssignMapStatement(Map *map,
+                                       Expression *expr,
+                                       bool compound,
+                                       location loc)
+    : Statement(loc), map(map), expr(expr), compound(compound)
 {
   expr->map = map;
 };
 
-
 AssignVarStatement::AssignVarStatement(Variable *var,
                                        Expression *expr,
+                                       bool compound,
                                        location loc)
-    : Statement(loc), var(var), expr(expr)
+    : Statement(loc), var(var), expr(expr), compound(compound)
 {
   expr->var = var;
 }
-
 
 Predicate::Predicate(Expression *expr, location loc) : Node(loc), expr(expr)
 {

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -16,6 +16,12 @@ class Visitor;
 
 #define DEFINE_ACCEPT void accept(Visitor &v) override;
 
+#define DEFINE_CLONE(T)                                                        \
+  T *clone()                                                                   \
+  {                                                                            \
+    return new T(*this);                                                       \
+  };
+
 class Node {
 public:
   Node() = default;
@@ -50,73 +56,99 @@ using ExpressionList = std::vector<Expression *>;
 
 class Integer : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(Integer)
+
   explicit Integer(long n, location loc);
-  Integer(const Integer &other) = default;
+
   long n;
 
-  DEFINE_ACCEPT
+private:
+  Integer(const Integer &other) = default;
 };
 
 class PositionalParameter : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(PositionalParameter)
+
   explicit PositionalParameter(PositionalParameterType ptype,
                                long n,
                                location loc);
-  PositionalParameter(const PositionalParameter &other) = default;
+  ~PositionalParameter() = default;
 
   PositionalParameterType ptype;
   long n;
   bool is_in_str = false;
 
-  DEFINE_ACCEPT
+private:
+  PositionalParameter(const PositionalParameter &other) = default;
 };
 
 class String : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(String)
+
   explicit String(const std::string &str, location loc);
-  String(const String &other) = default;
+  ~String() = default;
 
   std::string str;
 
-  DEFINE_ACCEPT
+private:
+  String(const String &other) = default;
 };
 
 class StackMode : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(StackMode)
+
   explicit StackMode(const std::string &mode, location loc);
-  StackMode(const StackMode &other) = default;
+  ~StackMode() = default;
 
   std::string mode;
 
-  DEFINE_ACCEPT
+private:
+  StackMode(const StackMode &other) = default;
 };
 
 class Identifier : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(Identifier)
+
   explicit Identifier(const std::string &ident, location loc);
-  Identifier(const Identifier &other) = default;
+  ~Identifier() = default;
 
   std::string ident;
 
-  DEFINE_ACCEPT
+private:
+  Identifier(const Identifier &other) = default;
 };
 
 class Builtin : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(Builtin)
+
   explicit Builtin(const std::string &ident, location loc);
-  Builtin(const Builtin &other) = default;
+  ~Builtin() = default;
 
   std::string ident;
   int probe_id;
 
-  DEFINE_ACCEPT
+private:
+  Builtin(const Builtin &other) = default;
 };
 
 class Call : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(Call)
+
   explicit Call(const std::string &func, location loc);
   Call(const std::string &func, ExpressionList *vargs, location loc);
-  Call(const Call &other);
   ~Call()
   {
     if (vargs)
@@ -130,14 +162,17 @@ public:
   std::string func;
   ExpressionList *vargs;
 
-  DEFINE_ACCEPT
+private:
+  Call(const Call &other);
 };
 
 class Map : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(Map)
+
   explicit Map(const std::string &ident, location loc);
   Map(const std::string &ident, ExpressionList *vargs, location loc);
-  Map(const Map &other);
   ~Map()
   {
     if (vargs)
@@ -152,23 +187,30 @@ public:
   ExpressionList *vargs = nullptr;
   bool skip_key_validation = false;
 
-  DEFINE_ACCEPT
+private:
+  Map(const Map &other);
 };
 
 class Variable : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(Variable)
+
   explicit Variable(const std::string &ident, location loc);
-  Variable(const Variable &other) = default;
+  ~Variable() = default;
 
   std::string ident;
 
-  DEFINE_ACCEPT
+private:
+  Variable(const Variable &other) = default;
 };
 
 class Binop : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(Binop)
+
   Binop(Expression *left, int op, Expression *right, location loc);
-  Binop(const Binop &other);
 
   ~Binop()
   {
@@ -182,17 +224,20 @@ public:
   Expression *right = nullptr;
   int op;
 
-  DEFINE_ACCEPT
+private:
+  Binop(const Binop &other);
 };
 
 class Unop : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(Unop)
+
   Unop(int op, Expression *expr, location loc = location());
   Unop(int op,
        Expression *expr,
        bool is_post_op = false,
        location loc = location());
-  Unop(const Unop &other);
 
   ~Unop()
   {
@@ -204,15 +249,18 @@ public:
   int op;
   bool is_post_op;
 
-  DEFINE_ACCEPT
+private:
+  Unop(const Unop &other);
 };
 
 class FieldAccess : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(FieldAccess)
+
   FieldAccess(Expression *expr, const std::string &field);
   FieldAccess(Expression *expr, const std::string &field, location loc);
   FieldAccess(Expression *expr, ssize_t index, location loc);
-  FieldAccess(const FieldAccess &other);
   ~FieldAccess()
   {
     delete expr;
@@ -223,14 +271,17 @@ public:
   std::string field;
   ssize_t index = -1;
 
-  DEFINE_ACCEPT
+private:
+  FieldAccess(const FieldAccess &other);
 };
 
 class ArrayAccess : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(ArrayAccess)
+
   ArrayAccess(Expression *expr, Expression *indexpr);
   ArrayAccess(Expression *expr, Expression *indexpr, location loc);
-  ArrayAccess(const ArrayAccess &other) : Expression(other){};
   ~ArrayAccess()
   {
     delete expr;
@@ -241,11 +292,16 @@ public:
 
   Expression *expr = nullptr;
   Expression *indexpr = nullptr;
-  DEFINE_ACCEPT
+
+private:
+  ArrayAccess(const ArrayAccess &other) : Expression(other){};
 };
 
 class Cast : public Expression {
 public:
+  DEFINE_CLONE(Cast)
+  DEFINE_ACCEPT
+
   Cast(const std::string &type,
        bool is_pointer,
        bool is_double_pointer,
@@ -255,7 +311,6 @@ public:
        bool is_double_pointer,
        Expression *expr,
        location loc);
-  Cast(const Cast &other);
   ~Cast()
   {
     delete expr;
@@ -267,14 +322,17 @@ public:
   bool is_double_pointer;
   Expression *expr = nullptr;
 
-  DEFINE_ACCEPT
+private:
+  Cast(const Cast &other);
 };
 
 class Tuple : public Expression
 {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(Tuple)
+
   Tuple(ExpressionList *elems, location loc);
-  Tuple(const Tuple &other);
   ~Tuple()
   {
     for (Expression *expr : *elems)
@@ -284,7 +342,8 @@ public:
 
   ExpressionList *elems = nullptr;
 
-  DEFINE_ACCEPT
+private:
+  Tuple(const Tuple &other);
 };
 
 class Statement : public Node {
@@ -298,8 +357,10 @@ using StatementList = std::vector<Statement *>;
 
 class ExprStatement : public Statement {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(ExprStatement)
+
   explicit ExprStatement(Expression *expr, location loc);
-  ExprStatement(const ExprStatement &other) : Statement(other){};
   ~ExprStatement()
   {
     delete expr;
@@ -308,16 +369,19 @@ public:
 
   Expression *expr = nullptr;
 
-  DEFINE_ACCEPT
+private:
+  ExprStatement(const ExprStatement &other) : Statement(other){};
 };
 
 class AssignMapStatement : public Statement {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(AssignMapStatement)
+
   AssignMapStatement(Map *map,
                      Expression *expr,
                      bool compound = false,
                      location loc = location());
-  AssignMapStatement(const AssignMapStatement &other) : Statement(other){};
   ~AssignMapStatement()
   {
     // In a compound assignment, the expression owns the map so
@@ -333,16 +397,19 @@ public:
   Expression *expr = nullptr;
   bool compound;
 
-  DEFINE_ACCEPT
+private:
+  AssignMapStatement(const AssignMapStatement &other) : Statement(other){};
 };
 
 class AssignVarStatement : public Statement {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(AssignVarStatement)
+
   AssignVarStatement(Variable *var,
                      Expression *expr,
                      bool compound = false,
                      location loc = location());
-  AssignVarStatement(const AssignVarStatement &other) : Statement(other){};
   ~AssignVarStatement()
   {
     // In a compound assignment, the expression owns the map so
@@ -358,14 +425,17 @@ public:
   Expression *expr = nullptr;
   bool compound;
 
-  DEFINE_ACCEPT
+private:
+  AssignVarStatement(const AssignVarStatement &other) : Statement(other){};
 };
 
 class If : public Statement {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(If)
+
   If(Expression *cond, StatementList *stmts);
   If(Expression *cond, StatementList *stmts, StatementList *else_stmts);
-  If(const If &other);
   ~If()
   {
     delete cond;
@@ -388,13 +458,16 @@ public:
   StatementList *stmts = nullptr;
   StatementList *else_stmts = nullptr;
 
-  DEFINE_ACCEPT
+private:
+  If(const If &other);
 };
 
 class Unroll : public Statement {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(Unroll)
+
   Unroll(Expression *expr, StatementList *stmts, location loc);
-  Unroll(const Unroll &other);
   ~Unroll()
   {
     if (stmts)
@@ -408,27 +481,33 @@ public:
   Expression *expr = nullptr;
   StatementList *stmts = nullptr;
 
-  DEFINE_ACCEPT
+private:
+  Unroll(const Unroll &other);
 };
 
 class Jump : public Statement
 {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(Jump)
+
   Jump(int ident, location loc = location()) : Statement(loc), ident(ident)
   {
   }
-  Jump(const Jump &other) = default;
   ~Jump() = default;
 
   int ident = 0;
 
-  DEFINE_ACCEPT
+private:
+  Jump(const Jump &other) = default;
 };
 
 class Predicate : public Node {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(Predicate)
+
   explicit Predicate(Expression *expr, location loc);
-  Predicate(const Predicate &other) : Node(other){};
   ~Predicate()
   {
     delete expr;
@@ -437,13 +516,16 @@ public:
 
   Expression *expr = nullptr;
 
-  DEFINE_ACCEPT
+private:
+  Predicate(const Predicate &other) : Node(other){};
 };
 
 class Ternary : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(Ternary)
+
   Ternary(Expression *cond, Expression *left, Expression *right, location loc);
-  Ternary(const Ternary &other) : Expression(other){};
   ~Ternary()
   {
     delete cond;
@@ -457,18 +539,18 @@ public:
   Expression *cond = nullptr;
   Expression *left = nullptr;
   Expression *right = nullptr;
-
-  DEFINE_ACCEPT
 };
 
 class While : public Statement
 {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(While)
+
   While(Expression *cond, StatementList *stmts, location loc)
       : Statement(loc), cond(cond), stmts(stmts)
   {
   }
-  While(const While &other);
   ~While()
   {
     delete cond;
@@ -480,13 +562,16 @@ public:
   Expression *cond = nullptr;
   StatementList *stmts = nullptr;
 
-  DEFINE_ACCEPT
+private:
+  While(const While &other);
 };
 
 class AttachPoint : public Node {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(AttachPoint)
+
   explicit AttachPoint(const std::string &raw_input, location loc = location());
-  AttachPoint(const AttachPoint &other) = default;
   ~AttachPoint() = default;
 
   // Raw, unparsed input from user, eg. kprobe:vfs_read
@@ -504,22 +589,26 @@ public:
   uint64_t address = 0;
   uint64_t func_offset = 0;
 
-  DEFINE_ACCEPT
   std::string name(const std::string &attach_point) const;
   std::string name(const std::string &attach_target,
                    const std::string &attach_point) const;
 
   int index(std::string name);
   void set_index(std::string name, int index);
+
 private:
+  AttachPoint(const AttachPoint &other) = default;
+
   std::map<std::string, int> index_;
 };
 using AttachPointList = std::vector<AttachPoint *>;
 
 class Probe : public Node {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(Probe)
+
   Probe(AttachPointList *attach_points, Predicate *pred, StatementList *stmts);
-  Probe(const Probe &other);
   ~Probe()
   {
     if (attach_points)
@@ -542,22 +631,25 @@ public:
   Predicate *pred = nullptr;
   StatementList *stmts = nullptr;
 
-  DEFINE_ACCEPT
   std::string name() const;
   bool need_expansion = false;        // must build a BPF program per wildcard match
   bool need_tp_args_structs = false;  // must import struct for tracepoints
 
   int index();
   void set_index(int index);
+
 private:
+  Probe(const Probe &other);
   int index_ = 0;
 };
 using ProbeList = std::vector<Probe *>;
 
 class Program : public Node {
 public:
+  DEFINE_ACCEPT
+  DEFINE_CLONE(Program)
+
   Program(const std::string &c_definitions, ProbeList *probes);
-  Program(const Program &other);
 
   ~Program()
   {
@@ -571,7 +663,8 @@ public:
   std::string c_definitions;
   ProbeList *probes = nullptr;
 
-  DEFINE_ACCEPT
+private:
+  Program(const Program &other);
 };
 
 std::string opstr(Binop &binop);

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -313,11 +313,17 @@ public:
 
 class AssignMapStatement : public Statement {
 public:
-  AssignMapStatement(Map *map, Expression *expr, location loc = location());
+  AssignMapStatement(Map *map,
+                     Expression *expr,
+                     bool compound = false,
+                     location loc = location());
   AssignMapStatement(const AssignMapStatement &other) : Statement(other){};
   ~AssignMapStatement()
   {
-    delete map;
+    // In a compound assignment, the expression owns the map so
+    // we shouldn't free
+    if (!compound)
+      delete map;
     delete expr;
     map = nullptr;
     expr = nullptr;
@@ -325,18 +331,24 @@ public:
 
   Map *map = nullptr;
   Expression *expr = nullptr;
+  bool compound;
 
   DEFINE_ACCEPT
 };
 
 class AssignVarStatement : public Statement {
 public:
-  AssignVarStatement(Variable *var, Expression *expr);
-  AssignVarStatement(Variable *var, Expression *expr, location loc);
+  AssignVarStatement(Variable *var,
+                     Expression *expr,
+                     bool compound = false,
+                     location loc = location());
   AssignVarStatement(const AssignVarStatement &other) : Statement(other){};
   ~AssignVarStatement()
   {
-    delete var;
+    // In a compound assignment, the expression owns the map so
+    // we shouldn't free
+    if (!compound)
+      delete var;
     delete expr;
     var = nullptr;
     expr = nullptr;
@@ -344,6 +356,7 @@ public:
 
   Variable *var = nullptr;
   Expression *expr = nullptr;
+  bool compound;
 
   DEFINE_ACCEPT
 };

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -13,13 +13,11 @@ namespace bpftrace {
 
 Driver::Driver(BPFtrace &bpftrace, std::ostream &o) : bpftrace_(bpftrace), out_(o)
 {
-  yylex_init(&scanner_);
-  parser_ = std::make_unique<Parser>(*this, scanner_);
 }
 
 Driver::~Driver()
 {
-  yylex_destroy(scanner_);
+  delete root_;
 }
 
 void Driver::source(std::string filename, std::string script)
@@ -36,10 +34,20 @@ int Driver::parse_str(std::string script)
 
 int Driver::parse()
 {
+  // Ensure we free memory allocated the previous parse if we parse
+  // more than once
+  delete root_;
+  root_ = nullptr;
+
   // Reset source location info on every pass
   loc.initialize();
-  yy_scan_string(Log::get().get_source().c_str(), scanner_);
-  parser_->parse();
+
+  yyscan_t scanner;
+  yylex_init(&scanner);
+  Parser parser(*this, scanner);
+  yy_scan_string(Log::get().get_source().c_str(), scanner);
+  parser.parse();
+  yylex_destroy(scanner);
 
   ast::AttachPointParser ap_parser(root_, bpftrace_, out_);
   if (ap_parser.parse())

--- a/src/driver.h
+++ b/src/driver.h
@@ -25,14 +25,12 @@ public:
   void error(std::ostream &, const location &, const std::string &);
   void error(const location &l, const std::string &m);
   void error(const std::string &m);
-  ast::Program *root_{ nullptr };
+  ast::Program *root_ = nullptr;
 
   BPFtrace &bpftrace_;
 
 private:
-  std::unique_ptr<Parser> parser_;
   std::ostream &out_;
-  yyscan_t scanner_;
   bool failed_ = false;
 };
 

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -265,31 +265,31 @@ block_or_if : block        { $$ = $1; }
 stmt : expr                { $$ = new ast::ExprStatement($1, @1); }
      | compound_assignment { $$ = $1; }
      | jump_stmt           { $$ = $1; }
-     | map "=" expr        { $$ = new ast::AssignMapStatement($1, $3, @2); }
-     | var "=" expr        { $$ = new ast::AssignVarStatement($1, $3, @2); }
+     | map "=" expr        { $$ = new ast::AssignMapStatement($1, $3, false, @2); }
+     | var "=" expr        { $$ = new ast::AssignVarStatement($1, $3, false, @2); }
      | tuple_assignment
      ;
 
-compound_assignment : map LEFTASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::LEFT,  $3, @2), @$); }
-                    | var LEFTASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::LEFT,  $3, @2), @$); }
-                    | map RIGHTASSIGN expr { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::RIGHT, $3, @2), @$); }
-                    | var RIGHTASSIGN expr { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::RIGHT, $3, @2), @$); }
-                    | map PLUSASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::PLUS,  $3, @2), @$); }
-                    | var PLUSASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::PLUS,  $3, @2), @$); }
-                    | map MINUSASSIGN expr { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MINUS, $3, @2), @$); }
-                    | var MINUSASSIGN expr { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MINUS, $3, @2), @$); }
-                    | map MULASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MUL,   $3, @2), @$); }
-                    | var MULASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MUL,   $3, @2), @$); }
-                    | map DIVASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::DIV,   $3, @2), @$); }
-                    | var DIVASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::DIV,   $3, @2), @$); }
-                    | map MODASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MOD,   $3, @2), @$); }
-                    | var MODASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MOD,   $3, @2), @$); }
-                    | map BANDASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BAND,  $3, @2), @$); }
-                    | var BANDASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BAND,  $3, @2), @$); }
-                    | map BORASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BOR,   $3, @2), @$); }
-                    | var BORASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BOR,   $3, @2), @$); }
-                    | map BXORASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BXOR,  $3, @2), @$); }
-                    | var BXORASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BXOR,  $3, @2), @$); }
+compound_assignment : map LEFTASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::LEFT,  $3, @2), true, @$); }
+                    | var LEFTASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::LEFT,  $3, @2), true, @$); }
+                    | map RIGHTASSIGN expr { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::RIGHT, $3, @2), true, @$); }
+                    | var RIGHTASSIGN expr { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::RIGHT, $3, @2), true, @$); }
+                    | map PLUSASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::PLUS,  $3, @2), true, @$); }
+                    | var PLUSASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::PLUS,  $3, @2), true, @$); }
+                    | map MINUSASSIGN expr { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MINUS, $3, @2), true, @$); }
+                    | var MINUSASSIGN expr { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MINUS, $3, @2), true, @$); }
+                    | map MULASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MUL,   $3, @2), true, @$); }
+                    | var MULASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MUL,   $3, @2), true, @$); }
+                    | map DIVASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::DIV,   $3, @2), true, @$); }
+                    | var DIVASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::DIV,   $3, @2), true, @$); }
+                    | map MODASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MOD,   $3, @2), true, @$); }
+                    | var MODASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MOD,   $3, @2), true, @$); }
+                    | map BANDASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BAND,  $3, @2), true, @$); }
+                    | var BANDASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BAND,  $3, @2), true, @$); }
+                    | map BORASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BOR,   $3, @2), true, @$); }
+                    | var BORASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BOR,   $3, @2), true, @$); }
+                    | map BXORASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BXOR,  $3, @2), true, @$); }
+                    | var BXORASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BXOR,  $3, @2), true, @$); }
                     ;
 
 tuple_assignment : expr DOT INT "=" expr { error(@1 + @5, "Tuples are immutable once created. Consider creating a new tuple and assigning it instead."); YYERROR; }

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -13,7 +13,7 @@ static AttachPointList *APL(std::vector<AttachPoint *> list)
 {
   auto apl = new AttachPointList();
   for (auto l : list)
-    apl->push_back(new AttachPoint(*l));
+    apl->push_back(l->clone());
   return apl;
 }
 
@@ -51,7 +51,7 @@ TEST(ast, probe_name_kprobe)
   Probe kprobe1(attach_points1, nullptr, nullptr);
   EXPECT_EQ(kprobe1.name(), "kprobe:sys_read");
 
-  auto ap2_copy1 = new AttachPoint(*ap2);
+  auto ap2_copy1 = ap2->clone();
   auto attach_points2 = APL({ ap1, ap2 });
   Probe kprobe2(attach_points2, nullptr, nullptr);
   EXPECT_EQ(kprobe2.name(), "kprobe:sys_read,kprobe:sys_write");

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -9,136 +9,149 @@ using bpftrace::ast::AttachPoint;
 using bpftrace::ast::AttachPointList;
 using bpftrace::ast::Probe;
 
+static AttachPointList *APL(std::vector<AttachPoint *> list)
+{
+  auto apl = new AttachPointList();
+  for (auto l : list)
+    apl->push_back(new AttachPoint(*l));
+  return apl;
+}
+
 TEST(ast, probe_name_special)
 {
-  AttachPoint ap1("");
-  ap1.provider = "BEGIN";
-  AttachPointList attach_points1 = { &ap1 };
-  Probe begin(&attach_points1, nullptr, nullptr);
+  auto ap1 = new AttachPoint("");
+  ap1->provider = "BEGIN";
+  auto attach_points1 = APL({ ap1 });
+  Probe begin(attach_points1, nullptr, nullptr);
   EXPECT_EQ(begin.name(), "BEGIN");
 
-  AttachPoint ap2("");
-  ap2.provider = "END";
-  AttachPointList attach_points2 = { &ap2 };
-  Probe end(&attach_points2, nullptr, nullptr);
+  auto ap2 = new AttachPoint("");
+  ap2->provider = "END";
+  auto attach_points2 = APL({ ap2 });
+  Probe end(attach_points2, nullptr, nullptr);
   EXPECT_EQ(end.name(), "END");
 }
 
 TEST(ast, probe_name_kprobe)
 {
-  AttachPoint ap1("");
-  ap1.provider = "kprobe";
-  ap1.func = "sys_read";
-  AttachPointList attach_points1 = { &ap1 };
-  Probe kprobe1(&attach_points1, nullptr, nullptr);
+  auto ap1 = new AttachPoint("");
+  ap1->provider = "kprobe";
+  ap1->func = "sys_read";
+
+  auto ap2 = new AttachPoint("");
+  ap2->provider = "kprobe";
+  ap2->func = "sys_write";
+
+  auto ap3 = new AttachPoint("");
+  ap3->provider = "kprobe";
+  ap3->func = "sys_read";
+  ap3->func_offset = 10;
+
+  auto attach_points1 = APL({ ap1 });
+  Probe kprobe1(attach_points1, nullptr, nullptr);
   EXPECT_EQ(kprobe1.name(), "kprobe:sys_read");
 
-  AttachPoint ap2("");
-  ap2.provider = "kprobe";
-  ap2.func = "sys_write";
-  AttachPointList attach_points2 = { &ap1, &ap2 };
-  Probe kprobe2(&attach_points2, nullptr, nullptr);
+  auto ap2_copy1 = new AttachPoint(*ap2);
+  auto attach_points2 = APL({ ap1, ap2 });
+  Probe kprobe2(attach_points2, nullptr, nullptr);
   EXPECT_EQ(kprobe2.name(), "kprobe:sys_read,kprobe:sys_write");
 
-  AttachPoint ap3("");
-  ap3.provider = "kprobe";
-  ap3.func = "sys_read";
-  ap3.func_offset = 10;
-  AttachPointList attach_points3 = { &ap1, &ap2, &ap3 };
-  Probe kprobe3(&attach_points3, nullptr, nullptr);
+  auto attach_points3 = APL({ ap1, ap2_copy1, ap3 });
+  Probe kprobe3(attach_points3, nullptr, nullptr);
   EXPECT_EQ(kprobe3.name(),
             "kprobe:sys_read,kprobe:sys_write,kprobe:sys_read+10");
 }
 
 TEST(ast, probe_name_uprobe)
 {
-  AttachPoint ap1("");
-  ap1.provider = "uprobe";
-  ap1.target = "/bin/sh";
-  ap1.func = "readline";
-  AttachPointList attach_points1 = { &ap1 };
-  Probe uprobe1(&attach_points1, nullptr, nullptr);
+  auto ap1 = new AttachPoint("");
+  ap1->provider = "uprobe";
+  ap1->target = "/bin/sh";
+  ap1->func = "readline";
+  auto attach_points1 = APL({ ap1 });
+  Probe uprobe1(attach_points1, nullptr, nullptr);
   EXPECT_EQ(uprobe1.name(), "uprobe:/bin/sh:readline");
 
-  AttachPoint ap2("");
-  ap2.provider = "uprobe";
-  ap2.target = "/bin/sh";
-  ap2.func = "somefunc";
-  AttachPointList attach_points2 = { &ap1, &ap2 };
-  Probe uprobe2(&attach_points2, nullptr, nullptr);
+  auto ap2 = new AttachPoint("");
+  ap2->provider = "uprobe";
+  ap2->target = "/bin/sh";
+  ap2->func = "somefunc";
+  auto attach_points2 = APL({ ap1, ap2 });
+  Probe uprobe2(attach_points2, nullptr, nullptr);
   EXPECT_EQ(uprobe2.name(), "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc");
 
-  AttachPoint ap3("");
-  ap3.provider = "uprobe";
-  ap3.target = "/bin/sh";
-  ap3.address = 1000;
-  AttachPointList attach_points3 = { &ap1, &ap2, &ap3 };
-  Probe uprobe3(&attach_points3, nullptr, nullptr);
+  auto ap3 = new AttachPoint("");
+  ap3->provider = "uprobe";
+  ap3->target = "/bin/sh";
+  ap3->address = 1000;
+  auto attach_points3 = APL({ ap1, ap2, ap3 });
+  Probe uprobe3(attach_points3, nullptr, nullptr);
   EXPECT_EQ(uprobe3.name(), "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/sh:1000");
 
-  AttachPoint ap4("");
-  ap4.provider = "uprobe";
-  ap4.target = "/bin/sh";
-  ap4.func = "somefunc";
-  ap4.func_offset = 10;
-  AttachPointList attach_points4 = { &ap1, &ap2, &ap3, &ap4 };
-  Probe uprobe4(&attach_points4, nullptr, nullptr);
+  auto ap4 = new AttachPoint("");
+  ap4->provider = "uprobe";
+  ap4->target = "/bin/sh";
+  ap4->func = "somefunc";
+  ap4->func_offset = 10;
+  auto attach_points4 = APL({ ap1, ap2, ap3, ap4 });
+  Probe uprobe4(attach_points4, nullptr, nullptr);
   EXPECT_EQ(uprobe4.name(), "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/sh:1000,uprobe:/bin/sh:somefunc+10");
 
-  AttachPoint ap5("");
-  ap5.provider = "uprobe";
-  ap5.target = "/bin/sh";
-  ap5.address = 10;
-  AttachPointList attach_points5 = { &ap5 };
-  Probe uprobe5(&attach_points5, nullptr, nullptr);
+  auto ap5 = new AttachPoint("");
+  ap5->provider = "uprobe";
+  ap5->target = "/bin/sh";
+  ap5->address = 10;
+  auto attach_points5 = APL({ ap5 });
+  Probe uprobe5(attach_points5, nullptr, nullptr);
   EXPECT_EQ(uprobe5.name(), "uprobe:/bin/sh:10");
 
-  AttachPoint ap6("");
-  ap6.provider = "uretprobe";
-  ap6.target = "/bin/sh";
-  ap6.address = 10;
-  AttachPointList attach_points6 = { &ap6 };
-  Probe uprobe6(&attach_points6, nullptr, nullptr);
+  auto ap6 = new AttachPoint("");
+  ap6->provider = "uretprobe";
+  ap6->target = "/bin/sh";
+  ap6->address = 10;
+  auto attach_points6 = APL({ ap6 });
+  Probe uprobe6(attach_points6, nullptr, nullptr);
   EXPECT_EQ(uprobe6.name(), "uretprobe:/bin/sh:10");
 }
 
 TEST(ast, probe_name_usdt)
 {
-  AttachPoint ap1("");
-  ap1.provider = "usdt";
-  ap1.target = "/bin/sh";
-  ap1.func = "probe1";
-  AttachPointList attach_points1 = { &ap1 };
-  Probe usdt1(&attach_points1, nullptr, nullptr);
+  auto ap1 = new AttachPoint("");
+  ap1->provider = "usdt";
+  ap1->target = "/bin/sh";
+  ap1->func = "probe1";
+  auto attach_points1 = APL({ ap1 });
+  Probe usdt1(attach_points1, nullptr, nullptr);
   EXPECT_EQ(usdt1.name(), "usdt:/bin/sh:probe1");
 
-  AttachPoint ap2("");
-  ap2.provider = "usdt";
-  ap2.target = "/bin/sh";
-  ap2.func = "probe2";
-  AttachPointList attach_points2 = { &ap1, &ap2 };
-  Probe usdt2(&attach_points2, nullptr, nullptr);
+  auto ap2 = new AttachPoint("");
+  ap2->provider = "usdt";
+  ap2->target = "/bin/sh";
+  ap2->func = "probe2";
+  auto attach_points2 = APL({ ap1, ap2 });
+  Probe usdt2(attach_points2, nullptr, nullptr);
   EXPECT_EQ(usdt2.name(), "usdt:/bin/sh:probe1,usdt:/bin/sh:probe2");
 }
 
 TEST(ast, attach_point_name)
 {
-  AttachPoint ap1("");
-  ap1.provider = "kprobe";
-  ap1.func = "sys_read";
-  AttachPoint ap2("");
-  ap2.provider = "kprobe";
-  ap2.func = "sys_thisone";
-  AttachPoint ap3("");
-  ap3.provider = "uprobe";
-  ap3.target = "/bin/sh";
-  ap3.func = "readline";
-  AttachPointList attach_points = { &ap1, &ap2, &ap3 };
-  Probe kprobe(&attach_points, nullptr, nullptr);
-  EXPECT_EQ(ap2.name("sys_thisone"), "kprobe:sys_thisone");
+  auto ap1 = new AttachPoint("");
+  ap1->provider = "kprobe";
+  ap1->func = "sys_read";
+  auto ap2 = new AttachPoint("");
+  ap2->provider = "kprobe";
+  ap2->func = "sys_thisone";
+  auto ap3 = new AttachPoint("");
+  ap3->provider = "uprobe";
+  ap3->target = "/bin/sh";
+  ap3->func = "readline";
+  auto attach_points = APL({ ap1, ap2, ap3 });
+  Probe kprobe(attach_points, nullptr, nullptr);
+  EXPECT_EQ(ap2->name("sys_thisone"), "kprobe:sys_thisone");
 
-  Probe uprobe(&attach_points, nullptr, nullptr);
-  EXPECT_EQ(ap3.name("readline"), "uprobe:/bin/sh:readline");
+  attach_points = APL({ ap1, ap2, ap3 });
+  Probe uprobe(attach_points, nullptr, nullptr);
+  EXPECT_EQ(ap3->name("readline"), "uprobe:/bin/sh:readline");
 }
 
 } // namespace ast

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -1,9 +1,10 @@
 #include <cstring>
 
+#include "bpftrace.h"
+#include "driver.h"
+#include "mocks.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "bpftrace.h"
-#include "mocks.h"
 
 namespace bpftrace {
 namespace test {
@@ -29,6 +30,42 @@ void check_kprobe(Probe &p,
   EXPECT_EQ(orig_name, p.orig_name);
   EXPECT_EQ(kprobe_name(attach_point, func_offset), p.name);
   EXPECT_EQ(func_offset, p.func_offset);
+}
+
+static auto make_probe(std::vector<ast::AttachPoint *> elems)
+{
+  auto apl = new ast::AttachPointList(elems);
+  return new ast::Probe(apl, nullptr, nullptr);
+}
+
+static auto make_usdt_probe(const std::string &target,
+                            const std::string &ns,
+                            const std::string &func,
+                            bool need_expansion = false,
+                            int locations = 0)
+{
+  auto a = new ast::AttachPoint("");
+  a->provider = "usdt";
+  a->target = target;
+  a->ns = ns;
+  a->func = func;
+  a->need_expansion = need_expansion;
+  a->usdt.num_locations = locations;
+  return make_probe({ a });
+}
+
+static auto parse_probe(const std::string &str)
+{
+  StrictMock<MockBPFtrace> b;
+  Driver d(b);
+
+  if (d.parse_str(str))
+  {
+    throw std::runtime_error("Parser failed");
+  }
+  auto probe = d.root_->probes->front();
+  d.root_->probes->clear();
+  return probe;
 }
 
 static const std::string uprobe_name(const std::string &path,
@@ -118,13 +155,10 @@ void check_special_probe(Probe &p, const std::string &attach_point, const std::s
 
 TEST(bpftrace, add_begin_probe)
 {
-  ast::AttachPoint a("");
-  a.provider = "BEGIN";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  ast::Probe *probe = parse_probe("BEGIN{}");
 
   StrictMock<MockBPFtrace> bpftrace;
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(0U, bpftrace.get_probes().size());
   ASSERT_EQ(1U, bpftrace.get_special_probes().size());
 
@@ -133,13 +167,10 @@ TEST(bpftrace, add_begin_probe)
 
 TEST(bpftrace, add_end_probe)
 {
-  ast::AttachPoint a("");
-  a.provider = "END";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  ast::Probe *probe = parse_probe("END{}");
 
   StrictMock<MockBPFtrace> bpftrace;
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(0U, bpftrace.get_probes().size());
   ASSERT_EQ(1U, bpftrace.get_special_probes().size());
 
@@ -148,14 +179,9 @@ TEST(bpftrace, add_end_probe)
 
 TEST(bpftrace, add_probes_single)
 {
-  ast::AttachPoint a("");
-  a.provider = "kprobe";
-  a.func = "sys_read";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  ast::Probe *probe = parse_probe("kprobe:sys_read {}");
   StrictMock<MockBPFtrace> bpftrace;
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
 
@@ -164,17 +190,9 @@ TEST(bpftrace, add_probes_single)
 
 TEST(bpftrace, add_probes_multiple)
 {
-  ast::AttachPoint a1("");
-  a1.provider = "kprobe";
-  a1.func = "sys_read";
-  ast::AttachPoint a2("");
-  a2.provider = "kprobe";
-  a2.func = "sys_write";
-  ast::AttachPointList attach_points = { &a1, &a2 };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  ast::Probe *probe = parse_probe("kprobe:sys_read,kprobe:sys_write{}");
   StrictMock<MockBPFtrace> bpftrace;
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(2U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
 
@@ -185,18 +203,8 @@ TEST(bpftrace, add_probes_multiple)
 
 TEST(bpftrace, add_probes_wildcard)
 {
-  ast::AttachPoint a1("");
-  a1.provider = "kprobe";
-  a1.func = "sys_read";
-  ast::AttachPoint a2("");
-  a2.provider = "kprobe";
-  a2.func = "my_*";
-  a2.need_expansion = true;
-  ast::AttachPoint a3("");
-  a3.provider = "kprobe";
-  a3.func = "sys_write";
-  ast::AttachPointList attach_points = { &a1, &a2, &a3 };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  ast::Probe *probe = parse_probe(
+      "kprobe:sys_read,kprobe:my_*,kprobe:sys_write{}");
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace,
@@ -204,7 +212,7 @@ TEST(bpftrace, add_probes_wildcard)
         "/sys/kernel/debug/tracing/available_filter_functions"))
     .Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(4U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 
@@ -217,18 +225,8 @@ TEST(bpftrace, add_probes_wildcard)
 
 TEST(bpftrace, add_probes_wildcard_no_matches)
 {
-  ast::AttachPoint a1("");
-  a1.provider = "kprobe";
-  a1.func = "sys_read";
-  ast::AttachPoint a2("");
-  a2.provider = "kprobe";
-  a2.func = "not_here_*";
-  a2.need_expansion = true;
-  ast::AttachPoint a3("");
-  a3.provider = "kprobe";
-  a3.func = "sys_write";
-  ast::AttachPointList attach_points = { &a1, &a2, &a3 };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  ast::Probe *probe = parse_probe(
+      "kprobe:sys_read,kprobe:not_here_*,kprobe:sys_write{}");
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace,
@@ -236,7 +234,7 @@ TEST(bpftrace, add_probes_wildcard_no_matches)
         "/sys/kernel/debug/tracing/available_filter_functions"))
     .Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(2U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 
@@ -247,14 +245,10 @@ TEST(bpftrace, add_probes_wildcard_no_matches)
 
 TEST(bpftrace, add_probes_kernel_module)
 {
-  ast::AttachPoint a1("");
-  a1.provider = "kprobe";
-  a1.func = "func_in_mod";
-  ast::AttachPointList attach_points = { &a1 };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  ast::Probe *probe = parse_probe("kprobe:func_in_mod{}");
 
   auto bpftrace = get_strict_mock_bpftrace();
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(1U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 
@@ -264,20 +258,14 @@ TEST(bpftrace, add_probes_kernel_module)
 
 TEST(bpftrace, add_probes_kernel_module_wildcard)
 {
-  ast::AttachPoint a1("");
-  a1.provider = "kprobe";
-  a1.func = "func_in_mo*";
-  a1.need_expansion = true;
-  ast::AttachPointList attach_points = { &a1 };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  ast::Probe *probe = parse_probe("kprobe:func_in_mo*{}");
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace,
               get_symbols_from_file(
                   "/sys/kernel/debug/tracing/available_filter_functions"))
       .Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(1U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 
@@ -287,16 +275,10 @@ TEST(bpftrace, add_probes_kernel_module_wildcard)
 
 TEST(bpftrace, add_probes_offset)
 {
-  uint64_t offset = 10;
-  ast::AttachPoint a("");
-  a.provider = "kprobe";
-  a.func = "sys_read";
-  a.func_offset = offset;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  auto offset = 10;
+  ast::Probe *probe = parse_probe("kprobe:sys_read+10{}");
   StrictMock<MockBPFtrace> bpftrace;
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
 
@@ -307,16 +289,10 @@ TEST(bpftrace, add_probes_offset)
 
 TEST(bpftrace, add_probes_uprobe)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.func = "foo";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
   StrictMock<MockBPFtrace> bpftrace;
+  ast::Probe *probe = parse_probe("uprobe:/bin/sh:foo {}");
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
   check_uprobe(bpftrace.get_probes().at(0), "/bin/sh", "foo", "uprobe:/bin/sh:foo");
@@ -324,18 +300,12 @@ TEST(bpftrace, add_probes_uprobe)
 
 TEST(bpftrace, add_probes_uprobe_wildcard)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.func = "*open";
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  ast::Probe *probe = parse_probe("uprobe:/bin/sh:*open {}");
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/sh")).Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(2U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 
@@ -346,18 +316,11 @@ TEST(bpftrace, add_probes_uprobe_wildcard)
 
 TEST(bpftrace, add_probes_uprobe_wildcard_file)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/*sh";
-  a.func = "first_open";
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  ast::Probe *probe = parse_probe("uprobe:/bin/*sh:first_open {}");
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/*sh")).Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(2U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 
@@ -370,34 +333,26 @@ TEST(bpftrace, add_probes_uprobe_wildcard_file)
 
 TEST(bpftrace, add_probes_uprobe_wildcard_no_matches)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.func = "foo*";
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  ast::Probe *probe = parse_probe("uprobe:/bin/sh:foo* {}");
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/sh")).Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(0U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 }
 
 TEST(bpftrace, add_probes_uprobe_string_literal)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.func = "foo*";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = new ast::AttachPoint("");
+  a->provider = "uprobe";
+  a->target = "/bin/sh";
+  a->func = "foo*";
 
+  auto probe = make_probe({ a });
   StrictMock<MockBPFtrace> bpftrace;
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
   check_uprobe(bpftrace.get_probes().at(0), "/bin/sh", "foo*", "uprobe:/bin/sh:foo*");
@@ -405,16 +360,10 @@ TEST(bpftrace, add_probes_uprobe_string_literal)
 
 TEST(bpftrace, add_probes_uprobe_address)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.address = 1024;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  ast::Probe *probe = parse_probe("uprobe:/bin/sh:1024 {}");
   StrictMock<MockBPFtrace> bpftrace;
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
   check_uprobe(bpftrace.get_probes().at(0), "/bin/sh", "", "uprobe:/bin/sh:1024", 1024);
@@ -422,17 +371,10 @@ TEST(bpftrace, add_probes_uprobe_address)
 
 TEST(bpftrace, add_probes_uprobe_string_offset)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.func = "foo";
-  a.func_offset = 10;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  ast::Probe *probe = parse_probe("uprobe:/bin/sh:foo+10{}");
   StrictMock<MockBPFtrace> bpftrace;
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
   check_uprobe(bpftrace.get_probes().at(0), "/bin/sh", "foo", "uprobe:/bin/sh:foo+10", 0, 10);
@@ -442,18 +384,14 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol)
 {
   for (auto &provider : { "uprobe", "uretprobe" })
   {
-    ast::AttachPoint a("");
-    a.provider = provider;
-    a.target = "/bin/sh";
-    a.func = "cpp_mangled";
-    a.need_expansion = true;
-    ast::AttachPointList attach_points = { &a };
-    ast::Probe probe(&attach_points, nullptr, nullptr);
+    std::stringstream prog;
+    prog << provider << ":/bin/sh:cpp_mangled{}";
+    ast::Probe *probe = parse_probe(prog.str());
 
     auto bpftrace = get_strict_mock_bpftrace();
     EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/sh")).Times(1);
 
-    ASSERT_EQ(0, bpftrace->add_probe(probe));
+    ASSERT_EQ(0, bpftrace->add_probe(*probe));
     ASSERT_EQ(2U, bpftrace->get_probes().size());
     ASSERT_EQ(0U, bpftrace->get_special_probes().size());
     auto orig_name = std::string(provider) + ":/bin/sh:cpp_mangled";
@@ -466,18 +404,12 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol)
 
 TEST(bpftrace, add_probes_uprobe_cpp_symbol_full)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.func = "cpp_mangled(int)";
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto probe = parse_probe("uprobe:/bin/sh:\"cpp_mangled(int)\"{}");
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/sh")).Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(1U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
   check_uprobe(bpftrace->get_probes().at(0),
@@ -488,18 +420,12 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol_full)
 
 TEST(bpftrace, add_probes_uprobe_cpp_symbol_wildcard)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.func = "cpp_man*";
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto probe = parse_probe("uprobe:/bin/sh:cpp_man*{}");
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/sh")).Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(2U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
   check_uprobe(bpftrace->get_probes().at(0),
@@ -514,18 +440,12 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol_wildcard)
 
 TEST(bpftrace, add_probes_usdt)
 {
-  ast::AttachPoint a("");
-  a.provider = "usdt";
-  a.target = "/bin/sh";
-  a.ns = "prov1";
-  a.func = "mytp";
-  a.usdt.num_locations = 1;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto probe = parse_probe("usdt:/bin/sh:prov1:mytp{}");
+  probe->attach_points->front()->usdt.num_locations = 1;
 
   StrictMock<MockBPFtrace> bpftrace;
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
   check_usdt(bpftrace.get_probes().at(0),
@@ -535,20 +455,11 @@ TEST(bpftrace, add_probes_usdt)
 
 TEST(bpftrace, add_probes_usdt_wildcard)
 {
-  ast::AttachPoint a("");
-  a.provider = "usdt";
-  a.target = "/bin/*sh";
-  a.ns = "prov*";
-  a.func = "tp*";
-  a.usdt.num_locations = 1;
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  auto probe = make_usdt_probe("/bin/*sh", "prov*", "tp*", true, 1);
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, get_symbols_from_usdt(0, "/bin/*sh")).Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(4U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
   check_usdt(bpftrace->get_probes().at(0),
@@ -575,20 +486,12 @@ TEST(bpftrace, add_probes_usdt_wildcard)
 
 TEST(bpftrace, add_probes_usdt_empty_namespace)
 {
-  ast::AttachPoint a("");
-  a.provider = "usdt";
-  a.target = "/bin/sh";
-  a.ns = "";
-  a.func = "tp1";
-  a.usdt.num_locations = 1;
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto probe = make_usdt_probe("/bin/sh", "", "tp1", true, 1);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, get_symbols_from_usdt(0, "/bin/sh")).Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(1U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
   check_usdt(bpftrace->get_probes().at(0),
@@ -600,36 +503,20 @@ TEST(bpftrace, add_probes_usdt_empty_namespace)
 
 TEST(bpftrace, add_probes_usdt_empty_namespace_conflict)
 {
-  ast::AttachPoint a("");
-  a.provider = "usdt";
-  a.target = "/bin/sh";
-  a.ns = "";
-  a.func = "tp";
-  a.usdt.num_locations = 1;
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  auto probe = make_usdt_probe("/bin/sh", "", "tp", true, 1);
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, get_symbols_from_usdt(0, "/bin/sh")).Times(1);
 
-  ASSERT_EQ(1, bpftrace->add_probe(probe));
+  ASSERT_EQ(1, bpftrace->add_probe(*probe));
 }
 
 TEST(bpftrace, add_probes_usdt_duplicate_markers)
 {
-  ast::AttachPoint a("");
-  a.provider = "usdt";
-  a.target = "/bin/sh";
-  a.ns = "prov1";
-  a.func = "mytp";
-  a.usdt.num_locations = 3;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto probe = make_usdt_probe("/bin/sh", "prov1", "mytp", false, 3);
 
   StrictMock<MockBPFtrace> bpftrace;
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(3U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
   check_usdt(bpftrace.get_probes().at(0),
@@ -651,16 +538,10 @@ TEST(bpftrace, add_probes_usdt_duplicate_markers)
 
 TEST(bpftrace, add_probes_tracepoint)
 {
-  ast::AttachPoint a("");
-  a.provider = "tracepoint";
-  a.target = "sched";
-  a.func = "sched_switch";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  auto probe = parse_probe(("tracepoint:sched:sched_switch {}"));
   StrictMock<MockBPFtrace> bpftrace;
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
 
@@ -670,21 +551,14 @@ TEST(bpftrace, add_probes_tracepoint)
 
 TEST(bpftrace, add_probes_tracepoint_wildcard)
 {
-  ast::AttachPoint a("");
-  a.provider = "tracepoint";
-  a.target = "sched";
-  a.func = "sched_*";
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  auto probe = parse_probe(("tracepoint:sched:sched_* {}"));
   auto bpftrace = get_strict_mock_bpftrace();
   std::set<std::string> matches = { "sched_one", "sched_two" };
   EXPECT_CALL(*bpftrace,
       get_symbols_from_file("/sys/kernel/debug/tracing/available_events"))
     .Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(2U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 
@@ -695,21 +569,14 @@ TEST(bpftrace, add_probes_tracepoint_wildcard)
 
 TEST(bpftrace, add_probes_tracepoint_category_wildcard)
 {
-  ast::AttachPoint a("");
-  a.provider = "tracepoint";
-  a.target = "sched*";
-  a.func = "sched_*";
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  auto probe = parse_probe(("tracepoint:sched*:sched_* {}"));
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace,
               get_symbols_from_file(
                   "/sys/kernel/debug/tracing/available_events"))
       .Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(3U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 
@@ -726,6 +593,8 @@ TEST(bpftrace, add_probes_tracepoint_category_wildcard)
 
 TEST(bpftrace, add_probes_tracepoint_wildcard_no_matches)
 {
+  auto probe = parse_probe("tracepoint:type:typo_* {}");
+  /*
   ast::AttachPoint a("");
   a.provider = "tracepoint";
   a.target = "typo";
@@ -733,29 +602,32 @@ TEST(bpftrace, add_probes_tracepoint_wildcard_no_matches)
   a.need_expansion = true;
   ast::AttachPointList attach_points = { &a };
   ast::Probe probe(&attach_points, nullptr, nullptr);
-
+*/
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace,
       get_symbols_from_file("/sys/kernel/debug/tracing/available_events"))
     .Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(0U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 }
 
 TEST(bpftrace, add_probes_profile)
 {
+  /*
   ast::AttachPoint a("");
   a.provider = "profile";
   a.target = "ms";
   a.freq = 997;
   ast::AttachPointList attach_points = { &a };
   ast::Probe probe(&attach_points, nullptr, nullptr);
+  */
+  auto probe = parse_probe("profile:ms:997 {}");
 
   StrictMock<MockBPFtrace> bpftrace;
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
 
@@ -765,16 +637,17 @@ TEST(bpftrace, add_probes_profile)
 
 TEST(bpftrace, add_probes_interval)
 {
-  ast::AttachPoint a("");
-  a.provider = "interval";
-  a.target = "s";
-  a.freq = 1;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  // ast::AttachPoint a("");
+  // a.provider = "interval";
+  // a.target = "s";
+  // a.freq = 1;
+  // ast::AttachPointList attach_points = { &a };
+  // ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto probe = parse_probe("i:s:1 {}");
 
   StrictMock<MockBPFtrace> bpftrace;
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
 
@@ -784,16 +657,17 @@ TEST(bpftrace, add_probes_interval)
 
 TEST(bpftrace, add_probes_software)
 {
-  ast::AttachPoint a("");
-  a.provider = "software";
-  a.target = "faults";
-  a.freq = 1000;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  // ast::AttachPoint a("");
+  // a.provider = "software";
+  // a.target = "faults";
+  // a.freq = 1000;
+  // ast::AttachPointList attach_points = { &a };
+  // ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto probe = parse_probe("software:faults:1000 {}");
 
   StrictMock<MockBPFtrace> bpftrace;
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
 
@@ -803,16 +677,17 @@ TEST(bpftrace, add_probes_software)
 
 TEST(bpftrace, add_probes_hardware)
 {
-  ast::AttachPoint a("");
-  a.provider = "hardware";
-  a.target = "cache-references";
-  a.freq = 1000000;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  // ast::AttachPoint a("");
+  // a.provider = "hardware";
+  // a.target = "cache-references";
+  // a.freq = 1000000;
+  // ast::AttachPointList attach_points = { &a };
+  // ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto probe = parse_probe("hardware:cache-references:1000000 {}");
 
   StrictMock<MockBPFtrace> bpftrace;
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
 
@@ -822,15 +697,14 @@ TEST(bpftrace, add_probes_hardware)
 
 TEST(bpftrace, invalid_provider)
 {
-  ast::AttachPoint a("");
-  a.provider = "lookatme";
-  a.func = "invalid";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = new ast::AttachPoint("");
+  a->provider = "lookatme";
+  a->func = "invalid";
+  auto probe = make_probe({ a });
 
   StrictMock<MockBPFtrace> bpftrace;
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
 }
 
 std::pair<std::vector<uint8_t>, std::vector<uint8_t>> key_value_pair_int(std::vector<uint64_t> key, int val)


### PR DESCRIPTION
Also split from #1607 

These fix some of the memory leaks we have, mostly a rebase of #1055. 

To avoid memory leaks and ownership issue this also defines shallow copy constructors for each node and marks them as private. This makes  it impossible to accidentally copy the object and have two objects point to the same  memory, which can lead to double frees. If you really want a shallow copy you can use the `copy()` method. A deep copy is possible, but not implemented as I didn't need it.


##### Checklist
 
- [x] The new behaviour is covered by tests
