### PR TITLE
bpftrace: Fix bitfield access for Big endian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -106,6 +106,8 @@ and this project adheres to
   - [#1580](https://github.com/iovisor/bpftrace/pull/1580)
 - Printing of small integers with `printf`
   - [#1532](https://github.com/iovisor/bpftrace/pull/1532)
+- Fix bitfield access for big endian
+  - [#1628](https://github.com/iovisor/bpftrace/pull/1628)
 
 #### Tools
 - Hook up execsnoop.bt script onto `execveat` call

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1611,7 +1611,14 @@ void CodegenLLVM::visit(FieldAccess &acc)
         raw = b_.CreateLoad(dst);
         b_.CreateLifetimeEnd(dst);
       }
-      Value *shifted = b_.CreateLShr(raw, field.bitfield.access_rshift);
+      size_t rshiftbits;
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+      rshiftbits = field.bitfield.access_rshift;
+#else
+      rshiftbits = (field.type.GetSize() - field.bitfield.read_bytes) * 8;
+      rshiftbits += field.bitfield.access_rshift;
+#endif
+      Value *shifted = b_.CreateLShr(raw, rshiftbits);
       Value *masked = b_.CreateAnd(shifted, field.bitfield.mask);
       expr_ = masked;
     }

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -234,9 +234,14 @@ static bool getBitfield(CXCursor c, Bitfield &bitfield)
     bitfield.mask = std::numeric_limits<uint64_t>::max();
   else
     bitfield.mask = (1ULL << bitfield_bitwidth) - 1;
-  bitfield.access_rshift = bitfield_offset;
   // Round up to nearest byte
   bitfield.read_bytes = (bitfield_offset + bitfield_bitwidth + 7) / 8;
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+  bitfield.access_rshift = bitfield_offset;
+#else
+  bitfield.access_rshift = (bitfield.read_bytes * 8 - bitfield_offset -
+                            bitfield_bitwidth);
+#endif
 
   return true;
 }

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -195,6 +195,12 @@ EXPECT 1 2 5 0 65535
 TIMEOUT 5
 AFTER ./testprogs/bitfield_test
 
+NAME bitfield_access_2
+RUN bpftrace -v -e 'struct Bar { short a:4, b:8, c:3, d:1; int e:9, f:15, g:1, h:2, i:5 } uprobe:./testprogs/bitfield_test:func2 { $bar = (struct Bar *)arg0; printf("%d %d %d %d %d", $bar->a, $bar->b, $bar->c, $bar->d, $bar->e); printf(" %d %d %d %d", $bar->f, $bar->g, $bar->h, $bar->i); exit()}'
+EXPECT 1 217 5 1 500 31117 1 2 27
+TIMEOUT 5
+AFTER ./testprogs/bitfield_test
+
 NAME exit exits immediately
 RUN bpftrace -e 'i:ms:100 { @++; exit(); @++ }'
 EXPECT @: 1

--- a/tests/testprogs/bitfield_test.c
+++ b/tests/testprogs/bitfield_test.c
@@ -7,20 +7,40 @@ struct Foo
                e:16;
 };
 
+struct Bar
+{
+  short a : 4, b : 8, c : 3, d : 1;
+  int e : 9, f : 15, g : 1, h : 2, i : 5;
+};
+
 __attribute__((noinline)) unsigned int func(struct Foo *foo)
 {
   return foo->b;
+}
+__attribute__((noinline)) short func2(struct Bar *bar)
+{
+  return bar->b;
 }
 
 int main()
 {
   struct Foo foo;
+  struct Bar bar;
   foo.a = 1;
   foo.b = 2;
   foo.c = 5;
   foo.d = 0;
   foo.e = 65535;
   func(&foo);
-
+  bar.a = 1;
+  bar.b = 217;
+  bar.c = 5;
+  bar.d = 1;
+  bar.e = 500;
+  bar.f = 31117;
+  bar.g = 1;
+  bar.h = 2;
+  bar.i = 27;
+  func2(&bar);
   return 0;
 }


### PR DESCRIPTION
This resolves bitfield access for big endian systems. 
Also added testcases to cover few more cases.

Thanks

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x ] The new behaviour is covered by tests
