### PR TITLE
bpftrace: Fix intptrcast test for big endian

### DIFF
--- a/tests/runtime/intptrcast
+++ b/tests/runtime/intptrcast
@@ -28,7 +28,7 @@ AFTER ./testprogs/intptrcast
 
 NAME Sum casted value
 RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r15")+160)); exit();}'
-EXPECT ^@: 4077
+EXPECT ^@: 4660
 TIMEOUT 5
 ARCH s390x
 AFTER ./testprogs/intptrcast
@@ -63,7 +63,7 @@ AFTER ./testprogs/intptrcast
 
 NAME Casting ints
 RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("r15")+160); printf("%d\n", $a); exit();}'
-EXPECT 4077
+EXPECT 4660
 TIMEOUT 5
 ARCH s390x
 AFTER ./testprogs/intptrcast

--- a/tests/testprogs/intptrcast.c
+++ b/tests/testprogs/intptrcast.c
@@ -3,7 +3,7 @@ int fn(short p1,
        short p3,
        short p4,
        short p5,
-       short p6,
+       unsigned long p6,
        short p7,
        short p8,
        short p9)
@@ -12,6 +12,14 @@ int fn(short p1,
 }
 
 int main() {
-  fn(0x123, 0x456, 0x789, 0xabc, 0xdef, 0xfed, 0xcba, 0xcba, 0xcba);
+  fn(0x123,
+     0x456,
+     0x789,
+     0xabc,
+     0xdef,
+     0x1234567887654321,
+     0xcba,
+     0xcba,
+     0xcba);
   return 0;
 }


### PR DESCRIPTION
In C:
```
int main()
{
        unsigned long i = 4077;
        /* Result is 0 for big endian */
        /* Result is 4077 for little endian */
        printf("%x\n", \*(uint16_t \*)&i);
        unsigned long c = 0x1234567887654321;
        /* Result is 0x1234 for big endian */
        /* Result is 0x4321 for little endian */
        printf("%x\n", *(int16_t *)&c);
}
```
Hence change the testcase to include the following behaviour for big
endian system.

Thanks

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x ] The new behaviour is covered by tests
