### PR TITLE
Ast mem leaks

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -605,5 +605,17 @@ If::If(const If &other) : Statement(other)
 {
 }
 
+AssignVarStatement::AssignVarStatement(const AssignVarStatement &other)
+    : Statement(other)
+{
+  compound = other.compound;
+};
+
+AssignMapStatement::AssignMapStatement(const AssignMapStatement &other)
+    : Statement(other)
+{
+  compound = other.compound;
+};
+
 } // namespace ast
 } // namespace bpftrace

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -43,18 +43,6 @@ MAKE_ACCEPT(Program)
 
 #undef MAKE_ACCEPT
 
-Node::Node() : loc(location())
-{
-}
-
-Node::Node(location loc) : loc(loc)
-{
-}
-
-Expression::Expression(location loc) : Node(loc)
-{
-}
-
 Integer::Integer(long n, location loc) : Expression(loc), n(n)
 {
   is_literal = true;
@@ -105,7 +93,6 @@ Call::Call(const std::string &func, ExpressionList *vargs, location loc)
 {
 }
 
-
 Map::Map(const std::string &ident, location loc)
     : Expression(loc), ident(ident), vargs(nullptr)
 {
@@ -122,13 +109,11 @@ Map::Map(const std::string &ident, ExpressionList *vargs, location loc)
   }
 }
 
-
 Variable::Variable(const std::string &ident, location loc)
     : Expression(loc), ident(ident)
 {
   is_variable = true;
 }
-
 
 Binop::Binop(Expression *left, int op, Expression *right, location loc)
     : Expression(loc), left(left), right(right), op(op)
@@ -194,10 +179,6 @@ Tuple::Tuple(ExpressionList *elems, location loc)
 {
 }
 
-
-Statement::Statement(location loc) : Node(loc)
-{
-}
 
 ExprStatement::ExprStatement(Expression *expr, location loc)
     : Statement(loc), expr(expr)
@@ -386,6 +367,79 @@ int Probe::index() {
 
 void Probe::set_index(int index) {
   index_ = index;
+}
+
+Expression::Expression(const Expression &other) : Node(other)
+{
+  type = other.type;
+  is_literal = other.is_literal;
+  is_variable = other.is_variable;
+  is_map = other.is_map;
+}
+
+Call::Call(const Call &other) : Expression(other)
+{
+  func = other.func;
+}
+
+Binop::Binop(const Binop &other) : Expression(other)
+{
+  op = other.op;
+}
+
+Unop::Unop(const Unop &other) : Expression(other)
+{
+  op = other.op;
+  is_post_op = other.is_post_op;
+}
+
+Map::Map(const Map &other) : Expression(other)
+{
+  ident = other.ident;
+  skip_key_validation = other.skip_key_validation;
+}
+
+FieldAccess::FieldAccess(const FieldAccess &other)
+    : Expression(other), expr(nullptr)
+{
+  field = other.field;
+  index = other.index;
+}
+
+Unroll::Unroll(const Unroll &other) : Statement(other)
+{
+  var = other.var;
+}
+
+Program::Program(const Program &other) : Node(other)
+{
+  c_definitions = other.c_definitions;
+}
+
+Cast::Cast(const Cast &other) : Expression(other)
+{
+  cast_type = other.cast_type;
+  is_pointer = other.is_pointer;
+  is_double_pointer = other.is_double_pointer;
+}
+
+Probe::Probe(const Probe &other) : Node(other)
+{
+  need_expansion = other.need_expansion;
+  need_tp_args_structs = other.need_tp_args_structs;
+  index_ = other.index_;
+}
+
+While::While(const While &other) : Statement(other)
+{
+}
+
+Tuple::Tuple(const Tuple &other) : Expression(other)
+{
+}
+
+If::If(const If &other) : Statement(other)
+{
 }
 
 } // namespace ast

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -43,11 +43,173 @@ MAKE_ACCEPT(Program)
 
 #undef MAKE_ACCEPT
 
+Call::~Call()
+{
+  if (vargs)
+    for (Expression *expr : *vargs)
+      delete expr;
+
+  delete vargs;
+  vargs = nullptr;
+}
+Map::~Map()
+{
+  if (vargs)
+    for (Expression *expr : *vargs)
+      delete expr;
+
+  delete vargs;
+  vargs = nullptr;
+}
+Binop::~Binop()
+{
+  delete left;
+  delete right;
+  left = nullptr;
+  right = nullptr;
+}
+
+Unop::~Unop()
+{
+  delete expr;
+  expr = nullptr;
+}
+
+FieldAccess::~FieldAccess()
+{
+  delete expr;
+  expr = nullptr;
+}
+
+ArrayAccess::~ArrayAccess()
+{
+  delete expr;
+  delete indexpr;
+  expr = nullptr;
+  indexpr = nullptr;
+}
+
+Cast::~Cast()
+{
+  delete expr;
+  expr = nullptr;
+}
+
+Tuple::~Tuple()
+{
+  for (Expression *expr : *elems)
+    delete expr;
+  delete elems;
+}
+
+ExprStatement::~ExprStatement()
+{
+  delete expr;
+  expr = nullptr;
+}
+
+AssignMapStatement::~AssignMapStatement()
+{
+  // In a compound assignment, the expression owns the map so
+  // we shouldn't free
+  if (!compound)
+    delete map;
+  delete expr;
+  map = nullptr;
+  expr = nullptr;
+}
+
+AssignVarStatement::~AssignVarStatement()
+{
+  // In a compound assignment, the expression owns the map so
+  // we shouldn't free
+  if (!compound)
+    delete var;
+  delete expr;
+  var = nullptr;
+  expr = nullptr;
+}
+
+If::~If()
+{
+  delete cond;
+  cond = nullptr;
+
+  if (stmts)
+    for (Statement *s : *stmts)
+      delete s;
+  delete stmts;
+  stmts = nullptr;
+
+  if (else_stmts)
+    for (Statement *s : *else_stmts)
+      delete s;
+  delete else_stmts;
+  else_stmts = nullptr;
+}
+
+Unroll::~Unroll()
+{
+  if (stmts)
+    for (Statement *s : *stmts)
+      delete s;
+  delete stmts;
+  stmts = nullptr;
+}
+Predicate::~Predicate()
+{
+  delete expr;
+  expr = nullptr;
+}
+Ternary::~Ternary()
+{
+  delete cond;
+  delete left;
+  delete right;
+  cond = nullptr;
+  left = nullptr;
+  right = nullptr;
+}
+
+While::~While()
+{
+  delete cond;
+  for (auto *stmt : *stmts)
+    delete stmt;
+  delete stmts;
+}
+
+Probe::~Probe()
+{
+  if (attach_points)
+    for (AttachPoint *ap : *attach_points)
+      delete ap;
+  delete attach_points;
+  attach_points = nullptr;
+
+  delete pred;
+  pred = nullptr;
+
+  if (stmts)
+    for (Statement *s : *stmts)
+      delete s;
+  delete stmts;
+  stmts = nullptr;
+}
+
+Program::~Program()
+{
+  if (probes)
+    for (Probe *p : *probes)
+      delete p;
+  delete probes;
+  probes = nullptr;
+}
+
 Integer::Integer(long n, location loc) : Expression(loc), n(n)
 {
   is_literal = true;
 }
-
 
 String::String(const std::string &str, location loc) : Expression(loc), str(str)
 {

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -185,22 +185,23 @@ ExprStatement::ExprStatement(Expression *expr, location loc)
 {
 }
 
-
-AssignMapStatement::AssignMapStatement(Map *map, Expression *expr, location loc)
-    : Statement(loc), map(map), expr(expr)
+AssignMapStatement::AssignMapStatement(Map *map,
+                                       Expression *expr,
+                                       bool compound,
+                                       location loc)
+    : Statement(loc), map(map), expr(expr), compound(compound)
 {
   expr->map = map;
 };
 
-
 AssignVarStatement::AssignVarStatement(Variable *var,
                                        Expression *expr,
+                                       bool compound,
                                        location loc)
-    : Statement(loc), var(var), expr(expr)
+    : Statement(loc), var(var), expr(expr), compound(compound)
 {
   expr->var = var;
 }
-
 
 Predicate::Predicate(Expression *expr, location loc) : Node(loc), expr(expr)
 {

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -18,9 +18,11 @@ class Visitor;
 
 class Node {
 public:
-  Node();
-  Node(location loc);
+  Node() = default;
+  Node(location loc) : loc(loc){};
+  Node(const Node &other) = default;
   virtual ~Node() = default;
+
   virtual void accept(Visitor &v) = 0;
   location loc;
 };
@@ -29,7 +31,10 @@ class Map;
 class Variable;
 class Expression : public Node {
 public:
-  Expression(location loc);
+  Expression() = default;
+  Expression(location loc) : Node(loc){};
+  Expression(const Expression &other);
+
   SizedType type;
   Map *key_for_map = nullptr;
   Map *map = nullptr; // Only set when this expression is assigned to a map
@@ -43,6 +48,7 @@ using ExpressionList = std::vector<Expression *>;
 class Integer : public Expression {
 public:
   explicit Integer(long n, location loc);
+  Integer(const Integer &other) = default;
   long n;
 
   DEFINE_ACCEPT
@@ -53,6 +59,8 @@ public:
   explicit PositionalParameter(PositionalParameterType ptype,
                                long n,
                                location loc);
+  PositionalParameter(const PositionalParameter &other) = default;
+
   PositionalParameterType ptype;
   long n;
   bool is_in_str = false;
@@ -63,6 +71,8 @@ public:
 class String : public Expression {
 public:
   explicit String(const std::string &str, location loc);
+  String(const String &other) = default;
+
   std::string str;
 
   DEFINE_ACCEPT
@@ -71,6 +81,8 @@ public:
 class StackMode : public Expression {
 public:
   explicit StackMode(const std::string &mode, location loc);
+  StackMode(const StackMode &other) = default;
+
   std::string mode;
 
   DEFINE_ACCEPT
@@ -79,6 +91,8 @@ public:
 class Identifier : public Expression {
 public:
   explicit Identifier(const std::string &ident, location loc);
+  Identifier(const Identifier &other) = default;
+
   std::string ident;
 
   DEFINE_ACCEPT
@@ -87,6 +101,8 @@ public:
 class Builtin : public Expression {
 public:
   explicit Builtin(const std::string &ident, location loc);
+  Builtin(const Builtin &other) = default;
+
   std::string ident;
   int probe_id;
 
@@ -97,8 +113,10 @@ class Call : public Expression {
 public:
   explicit Call(const std::string &func, location loc);
   Call(const std::string &func, ExpressionList *vargs, location loc);
+  Call(const Call &other);
+
   std::string func;
-  ExpressionList *vargs;
+  ExpressionList *vargs = nullptr;
 
   DEFINE_ACCEPT
 };
@@ -107,8 +125,10 @@ class Map : public Expression {
 public:
   explicit Map(const std::string &ident, location loc);
   Map(const std::string &ident, ExpressionList *vargs, location loc);
+  Map(const Map &other);
+
   std::string ident;
-  ExpressionList *vargs;
+  ExpressionList *vargs = nullptr;
   bool skip_key_validation = false;
 
   DEFINE_ACCEPT
@@ -117,6 +137,8 @@ public:
 class Variable : public Expression {
 public:
   explicit Variable(const std::string &ident, location loc);
+  Variable(const Variable &other) = default;
+
   std::string ident;
 
   DEFINE_ACCEPT
@@ -125,7 +147,9 @@ public:
 class Binop : public Expression {
 public:
   Binop(Expression *left, int op, Expression *right, location loc);
-  Expression *left, *right;
+  Binop(const Binop &other);
+
+  Expression *left = nullptr, *right = nullptr;
   int op;
 
   DEFINE_ACCEPT
@@ -138,7 +162,9 @@ public:
        Expression *expr,
        bool is_post_op = false,
        location loc = location());
-  Expression *expr;
+  Unop(const Unop &other);
+
+  Expression *expr = nullptr;
   int op;
   bool is_post_op;
 
@@ -150,7 +176,9 @@ public:
   FieldAccess(Expression *expr, const std::string &field);
   FieldAccess(Expression *expr, const std::string &field, location loc);
   FieldAccess(Expression *expr, ssize_t index, location loc);
-  Expression *expr;
+  FieldAccess(const FieldAccess &other);
+
+  Expression *expr = nullptr;
   std::string field;
   ssize_t index = -1;
 
@@ -161,8 +189,10 @@ class ArrayAccess : public Expression {
 public:
   ArrayAccess(Expression *expr, Expression *indexpr);
   ArrayAccess(Expression *expr, Expression *indexpr, location loc);
-  Expression *expr;
-  Expression *indexpr;
+  ArrayAccess(const ArrayAccess &other) : Expression(other){};
+
+  Expression *expr = nullptr;
+  Expression *indexpr = nullptr;
 
   DEFINE_ACCEPT
 };
@@ -178,10 +208,12 @@ public:
        bool is_double_pointer,
        Expression *expr,
        location loc);
+  Cast(const Cast &other);
+
   std::string cast_type;
   bool is_pointer;
   bool is_double_pointer;
-  Expression *expr;
+  Expression *expr = nullptr;
 
   DEFINE_ACCEPT
 };
@@ -190,7 +222,9 @@ class Tuple : public Expression
 {
 public:
   Tuple(ExpressionList *elems, location loc);
-  ExpressionList *elems;
+  Tuple(const Tuple &other);
+
+  ExpressionList *elems = nullptr;
 
   DEFINE_ACCEPT
 };
@@ -198,14 +232,18 @@ public:
 class Statement : public Node {
 public:
   Statement() = default;
-  Statement(location loc);
+  Statement(location loc) : Node(loc){};
+  Statement(const Statement &other) = default;
 };
+
 using StatementList = std::vector<Statement *>;
 
 class ExprStatement : public Statement {
 public:
   explicit ExprStatement(Expression *expr, location loc);
-  Expression *expr;
+  ExprStatement(const ExprStatement &other) : Statement(other){};
+
+  Expression *expr = nullptr;
 
   DEFINE_ACCEPT
 };
@@ -213,8 +251,10 @@ public:
 class AssignMapStatement : public Statement {
 public:
   AssignMapStatement(Map *map, Expression *expr, location loc = location());
-  Map *map;
-  Expression *expr;
+  AssignMapStatement(const AssignMapStatement &other) : Statement(other){};
+
+  Map *map = nullptr;
+  Expression *expr = nullptr;
 
   DEFINE_ACCEPT
 };
@@ -223,8 +263,10 @@ class AssignVarStatement : public Statement {
 public:
   AssignVarStatement(Variable *var, Expression *expr);
   AssignVarStatement(Variable *var, Expression *expr, location loc);
-  Variable *var;
-  Expression *expr;
+  AssignVarStatement(const AssignVarStatement &other) : Statement(other){};
+
+  Variable *var = nullptr;
+  Expression *expr = nullptr;
 
   DEFINE_ACCEPT
 };
@@ -233,7 +275,9 @@ class If : public Statement {
 public:
   If(Expression *cond, StatementList *stmts);
   If(Expression *cond, StatementList *stmts, StatementList *else_stmts);
-  Expression *cond;
+  If(const If &other);
+
+  Expression *cond = nullptr;
   StatementList *stmts = nullptr;
   StatementList *else_stmts = nullptr;
 
@@ -243,9 +287,11 @@ public:
 class Unroll : public Statement {
 public:
   Unroll(Expression *expr, StatementList *stmts, location loc);
+  Unroll(const Unroll &other);
+
   long int var = 0;
-  Expression *expr;
-  StatementList *stmts;
+  Expression *expr = nullptr;
+  StatementList *stmts = nullptr;
 
   DEFINE_ACCEPT
 };
@@ -253,12 +299,12 @@ public:
 class Jump : public Statement
 {
 public:
-  Jump(int ident, location loc = location()) : loc(loc), ident(ident)
+  Jump(int ident, location loc = location()) : Statement(loc), ident(ident)
   {
   }
+  Jump(const Jump &other) = default;
 
-  location loc;
-  int ident;
+  int ident = 0;
 
   DEFINE_ACCEPT
 };
@@ -266,16 +312,21 @@ public:
 class Predicate : public Node {
 public:
   explicit Predicate(Expression *expr, location loc);
-  Expression *expr;
+  Predicate(const Predicate &other) : Node(other){};
+
+  Expression *expr = nullptr;
 
   DEFINE_ACCEPT
 };
 
 class Ternary : public Expression {
 public:
-  Ternary(Expression *cond, Expression *left, Expression *right);
   Ternary(Expression *cond, Expression *left, Expression *right, location loc);
-  Expression *cond, *left, *right;
+  Ternary(const Ternary &other) : Expression(other){};
+
+  Expression *cond = nullptr;
+  Expression *left = nullptr;
+  Expression *right = nullptr;
 
   DEFINE_ACCEPT
 };
@@ -284,12 +335,13 @@ class While : public Statement
 {
 public:
   While(Expression *cond, StatementList *stmts, location loc)
-      : cond(cond), stmts(stmts), loc(loc)
+      : Statement(loc), cond(cond), stmts(stmts)
   {
   }
-  Expression *cond;
+  While(const While &other);
+
+  Expression *cond = nullptr;
   StatementList *stmts = nullptr;
-  location loc;
 
   DEFINE_ACCEPT
 };
@@ -297,6 +349,7 @@ public:
 class AttachPoint : public Node {
 public:
   explicit AttachPoint(const std::string &raw_input, location loc = location());
+  AttachPoint(const AttachPoint &other) = default;
 
   // Raw, unparsed input from user, eg. kprobe:vfs_read
   std::string raw_input;
@@ -328,10 +381,11 @@ using AttachPointList = std::vector<AttachPoint *>;
 class Probe : public Node {
 public:
   Probe(AttachPointList *attach_points, Predicate *pred, StatementList *stmts);
+  Probe(const Probe &other);
 
-  AttachPointList *attach_points;
-  Predicate *pred;
-  StatementList *stmts;
+  AttachPointList *attach_points = nullptr;
+  Predicate *pred = nullptr;
+  StatementList *stmts = nullptr;
 
   DEFINE_ACCEPT
   std::string name() const;
@@ -348,6 +402,8 @@ using ProbeList = std::vector<Probe *>;
 class Program : public Node {
 public:
   Program(const std::string &c_definitions, ProbeList *probes);
+  Program(const Program &other);
+
   std::string c_definitions;
   ProbeList *probes;
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -24,6 +24,7 @@ public:
   virtual ~Node() = default;
 
   virtual void accept(Visitor &v) = 0;
+
   location loc;
 };
 
@@ -34,6 +35,8 @@ public:
   Expression() = default;
   Expression(location loc) : Node(loc){};
   Expression(const Expression &other);
+  // NB: do not free any of non-owned pointers we store
+  virtual ~Expression() = default;
 
   SizedType type;
   Map *key_for_map = nullptr;
@@ -114,6 +117,15 @@ public:
   explicit Call(const std::string &func, location loc);
   Call(const std::string &func, ExpressionList *vargs, location loc);
   Call(const Call &other);
+  ~Call()
+  {
+    if (vargs)
+      for (Expression *expr : *vargs)
+        delete expr;
+
+    delete vargs;
+    vargs = nullptr;
+  }
 
   std::string func;
   ExpressionList *vargs = nullptr;
@@ -126,6 +138,15 @@ public:
   explicit Map(const std::string &ident, location loc);
   Map(const std::string &ident, ExpressionList *vargs, location loc);
   Map(const Map &other);
+  ~Map()
+  {
+    if (vargs)
+      for (Expression *expr : *vargs)
+        delete expr;
+
+    delete vargs;
+    vargs = nullptr;
+  }
 
   std::string ident;
   ExpressionList *vargs = nullptr;
@@ -149,7 +170,16 @@ public:
   Binop(Expression *left, int op, Expression *right, location loc);
   Binop(const Binop &other);
 
-  Expression *left = nullptr, *right = nullptr;
+  ~Binop()
+  {
+    delete left;
+    delete right;
+    left = nullptr;
+    right = nullptr;
+  }
+
+  Expression *left = nullptr;
+  Expression *right = nullptr;
   int op;
 
   DEFINE_ACCEPT
@@ -164,6 +194,12 @@ public:
        location loc = location());
   Unop(const Unop &other);
 
+  ~Unop()
+  {
+    delete expr;
+    expr = nullptr;
+  }
+
   Expression *expr = nullptr;
   int op;
   bool is_post_op;
@@ -177,6 +213,11 @@ public:
   FieldAccess(Expression *expr, const std::string &field, location loc);
   FieldAccess(Expression *expr, ssize_t index, location loc);
   FieldAccess(const FieldAccess &other);
+  ~FieldAccess()
+  {
+    delete expr;
+    expr = nullptr;
+  }
 
   Expression *expr = nullptr;
   std::string field;
@@ -190,10 +231,16 @@ public:
   ArrayAccess(Expression *expr, Expression *indexpr);
   ArrayAccess(Expression *expr, Expression *indexpr, location loc);
   ArrayAccess(const ArrayAccess &other) : Expression(other){};
+  ~ArrayAccess()
+  {
+    delete expr;
+    delete indexpr;
+    expr = nullptr;
+    indexpr = nullptr;
+  }
 
   Expression *expr = nullptr;
   Expression *indexpr = nullptr;
-
   DEFINE_ACCEPT
 };
 
@@ -209,6 +256,11 @@ public:
        Expression *expr,
        location loc);
   Cast(const Cast &other);
+  ~Cast()
+  {
+    delete expr;
+    expr = nullptr;
+  }
 
   std::string cast_type;
   bool is_pointer;
@@ -223,6 +275,12 @@ class Tuple : public Expression
 public:
   Tuple(ExpressionList *elems, location loc);
   Tuple(const Tuple &other);
+  ~Tuple()
+  {
+    for (Expression *expr : *elems)
+      delete expr;
+    delete elems;
+  }
 
   ExpressionList *elems = nullptr;
 
@@ -242,6 +300,11 @@ class ExprStatement : public Statement {
 public:
   explicit ExprStatement(Expression *expr, location loc);
   ExprStatement(const ExprStatement &other) : Statement(other){};
+  ~ExprStatement()
+  {
+    delete expr;
+    expr = nullptr;
+  }
 
   Expression *expr = nullptr;
 
@@ -252,6 +315,13 @@ class AssignMapStatement : public Statement {
 public:
   AssignMapStatement(Map *map, Expression *expr, location loc = location());
   AssignMapStatement(const AssignMapStatement &other) : Statement(other){};
+  ~AssignMapStatement()
+  {
+    delete map;
+    delete expr;
+    map = nullptr;
+    expr = nullptr;
+  }
 
   Map *map = nullptr;
   Expression *expr = nullptr;
@@ -264,6 +334,13 @@ public:
   AssignVarStatement(Variable *var, Expression *expr);
   AssignVarStatement(Variable *var, Expression *expr, location loc);
   AssignVarStatement(const AssignVarStatement &other) : Statement(other){};
+  ~AssignVarStatement()
+  {
+    delete var;
+    delete expr;
+    var = nullptr;
+    expr = nullptr;
+  }
 
   Variable *var = nullptr;
   Expression *expr = nullptr;
@@ -276,6 +353,23 @@ public:
   If(Expression *cond, StatementList *stmts);
   If(Expression *cond, StatementList *stmts, StatementList *else_stmts);
   If(const If &other);
+  ~If()
+  {
+    delete cond;
+    cond = nullptr;
+
+    if (stmts)
+      for (Statement *s : *stmts)
+        delete s;
+    delete stmts;
+    stmts = nullptr;
+
+    if (else_stmts)
+      for (Statement *s : *else_stmts)
+        delete s;
+    delete else_stmts;
+    else_stmts = nullptr;
+  }
 
   Expression *cond = nullptr;
   StatementList *stmts = nullptr;
@@ -288,6 +382,14 @@ class Unroll : public Statement {
 public:
   Unroll(Expression *expr, StatementList *stmts, location loc);
   Unroll(const Unroll &other);
+  ~Unroll()
+  {
+    if (stmts)
+      for (Statement *s : *stmts)
+        delete s;
+    delete stmts;
+    stmts = nullptr;
+  }
 
   long int var = 0;
   Expression *expr = nullptr;
@@ -303,6 +405,7 @@ public:
   {
   }
   Jump(const Jump &other) = default;
+  ~Jump() = default;
 
   int ident = 0;
 
@@ -313,6 +416,11 @@ class Predicate : public Node {
 public:
   explicit Predicate(Expression *expr, location loc);
   Predicate(const Predicate &other) : Node(other){};
+  ~Predicate()
+  {
+    delete expr;
+    expr = nullptr;
+  }
 
   Expression *expr = nullptr;
 
@@ -323,6 +431,15 @@ class Ternary : public Expression {
 public:
   Ternary(Expression *cond, Expression *left, Expression *right, location loc);
   Ternary(const Ternary &other) : Expression(other){};
+  ~Ternary()
+  {
+    delete cond;
+    delete left;
+    delete right;
+    cond = nullptr;
+    left = nullptr;
+    right = nullptr;
+  }
 
   Expression *cond = nullptr;
   Expression *left = nullptr;
@@ -339,6 +456,13 @@ public:
   {
   }
   While(const While &other);
+  ~While()
+  {
+    delete cond;
+    for (auto *stmt : *stmts)
+      delete stmt;
+    delete stmts;
+  }
 
   Expression *cond = nullptr;
   StatementList *stmts = nullptr;
@@ -350,6 +474,7 @@ class AttachPoint : public Node {
 public:
   explicit AttachPoint(const std::string &raw_input, location loc = location());
   AttachPoint(const AttachPoint &other) = default;
+  ~AttachPoint() = default;
 
   // Raw, unparsed input from user, eg. kprobe:vfs_read
   std::string raw_input;
@@ -382,6 +507,23 @@ class Probe : public Node {
 public:
   Probe(AttachPointList *attach_points, Predicate *pred, StatementList *stmts);
   Probe(const Probe &other);
+  ~Probe()
+  {
+    if (attach_points)
+      for (AttachPoint *ap : *attach_points)
+        delete ap;
+    delete attach_points;
+    attach_points = nullptr;
+
+    delete pred;
+    pred = nullptr;
+
+    if (stmts)
+      for (Statement *s : *stmts)
+        delete s;
+    delete stmts;
+    stmts = nullptr;
+  }
 
   AttachPointList *attach_points = nullptr;
   Predicate *pred = nullptr;
@@ -404,8 +546,17 @@ public:
   Program(const std::string &c_definitions, ProbeList *probes);
   Program(const Program &other);
 
+  ~Program()
+  {
+    if (probes)
+      for (Probe *p : *probes)
+        delete p;
+    delete probes;
+    probes = nullptr;
+  }
+
   std::string c_definitions;
-  ProbeList *probes;
+  ProbeList *probes = nullptr;
 
   DEFINE_ACCEPT
 };

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -16,6 +16,16 @@ class Visitor;
 
 #define DEFINE_ACCEPT void accept(Visitor &v) override;
 
+/**
+ * Copy the node but leave all it's child members uninitialized, effecitvely
+ * turning it into a leaf node
+ */
+#define DEFINE_LEAFCOPY(T)                                                     \
+  T *leafcopy()                                                                \
+  {                                                                            \
+    return new T(*this);                                                       \
+  };
+
 class Node {
 public:
   Node() = default;
@@ -50,73 +60,99 @@ using ExpressionList = std::vector<Expression *>;
 
 class Integer : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(Integer)
+
   explicit Integer(long n, location loc);
-  Integer(const Integer &other) = default;
+
   long n;
 
-  DEFINE_ACCEPT
+private:
+  Integer(const Integer &other) = default;
 };
 
 class PositionalParameter : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(PositionalParameter)
+
   explicit PositionalParameter(PositionalParameterType ptype,
                                long n,
                                location loc);
-  PositionalParameter(const PositionalParameter &other) = default;
+  ~PositionalParameter() = default;
 
   PositionalParameterType ptype;
   long n;
   bool is_in_str = false;
 
-  DEFINE_ACCEPT
+private:
+  PositionalParameter(const PositionalParameter &other) = default;
 };
 
 class String : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(String)
+
   explicit String(const std::string &str, location loc);
-  String(const String &other) = default;
+  ~String() = default;
 
   std::string str;
 
-  DEFINE_ACCEPT
+private:
+  String(const String &other) = default;
 };
 
 class StackMode : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(StackMode)
+
   explicit StackMode(const std::string &mode, location loc);
-  StackMode(const StackMode &other) = default;
+  ~StackMode() = default;
 
   std::string mode;
 
-  DEFINE_ACCEPT
+private:
+  StackMode(const StackMode &other) = default;
 };
 
 class Identifier : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(Identifier)
+
   explicit Identifier(const std::string &ident, location loc);
-  Identifier(const Identifier &other) = default;
+  ~Identifier() = default;
 
   std::string ident;
 
-  DEFINE_ACCEPT
+private:
+  Identifier(const Identifier &other) = default;
 };
 
 class Builtin : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(Builtin)
+
   explicit Builtin(const std::string &ident, location loc);
-  Builtin(const Builtin &other) = default;
+  ~Builtin() = default;
 
   std::string ident;
   int probe_id;
 
-  DEFINE_ACCEPT
+private:
+  Builtin(const Builtin &other) = default;
 };
 
 class Call : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(Call)
+
   explicit Call(const std::string &func, location loc);
   Call(const std::string &func, ExpressionList *vargs, location loc);
-  Call(const Call &other);
   ~Call()
   {
     if (vargs)
@@ -130,14 +166,17 @@ public:
   std::string func;
   ExpressionList *vargs = nullptr;
 
-  DEFINE_ACCEPT
+private:
+  Call(const Call &other);
 };
 
 class Map : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(Map)
+
   explicit Map(const std::string &ident, location loc);
   Map(const std::string &ident, ExpressionList *vargs, location loc);
-  Map(const Map &other);
   ~Map()
   {
     if (vargs)
@@ -152,23 +191,30 @@ public:
   ExpressionList *vargs = nullptr;
   bool skip_key_validation = false;
 
-  DEFINE_ACCEPT
+private:
+  Map(const Map &other);
 };
 
 class Variable : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(Variable)
+
   explicit Variable(const std::string &ident, location loc);
-  Variable(const Variable &other) = default;
+  ~Variable() = default;
 
   std::string ident;
 
-  DEFINE_ACCEPT
+private:
+  Variable(const Variable &other) = default;
 };
 
 class Binop : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(Binop)
+
   Binop(Expression *left, int op, Expression *right, location loc);
-  Binop(const Binop &other);
 
   ~Binop()
   {
@@ -182,17 +228,20 @@ public:
   Expression *right = nullptr;
   int op;
 
-  DEFINE_ACCEPT
+private:
+  Binop(const Binop &other);
 };
 
 class Unop : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(Unop)
+
   Unop(int op, Expression *expr, location loc = location());
   Unop(int op,
        Expression *expr,
        bool is_post_op = false,
        location loc = location());
-  Unop(const Unop &other);
 
   ~Unop()
   {
@@ -204,15 +253,18 @@ public:
   int op;
   bool is_post_op;
 
-  DEFINE_ACCEPT
+private:
+  Unop(const Unop &other);
 };
 
 class FieldAccess : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(FieldAccess)
+
   FieldAccess(Expression *expr, const std::string &field);
   FieldAccess(Expression *expr, const std::string &field, location loc);
   FieldAccess(Expression *expr, ssize_t index, location loc);
-  FieldAccess(const FieldAccess &other);
   ~FieldAccess()
   {
     delete expr;
@@ -223,14 +275,17 @@ public:
   std::string field;
   ssize_t index = -1;
 
-  DEFINE_ACCEPT
+private:
+  FieldAccess(const FieldAccess &other);
 };
 
 class ArrayAccess : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(ArrayAccess)
+
   ArrayAccess(Expression *expr, Expression *indexpr);
   ArrayAccess(Expression *expr, Expression *indexpr, location loc);
-  ArrayAccess(const ArrayAccess &other) : Expression(other){};
   ~ArrayAccess()
   {
     delete expr;
@@ -241,11 +296,16 @@ public:
 
   Expression *expr = nullptr;
   Expression *indexpr = nullptr;
-  DEFINE_ACCEPT
+
+private:
+  ArrayAccess(const ArrayAccess &other) : Expression(other){};
 };
 
 class Cast : public Expression {
 public:
+  DEFINE_LEAFCOPY(Cast)
+  DEFINE_ACCEPT
+
   Cast(const std::string &type,
        bool is_pointer,
        bool is_double_pointer,
@@ -255,7 +315,6 @@ public:
        bool is_double_pointer,
        Expression *expr,
        location loc);
-  Cast(const Cast &other);
   ~Cast()
   {
     delete expr;
@@ -267,14 +326,17 @@ public:
   bool is_double_pointer;
   Expression *expr = nullptr;
 
-  DEFINE_ACCEPT
+private:
+  Cast(const Cast &other);
 };
 
 class Tuple : public Expression
 {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(Tuple)
+
   Tuple(ExpressionList *elems, location loc);
-  Tuple(const Tuple &other);
   ~Tuple()
   {
     for (Expression *expr : *elems)
@@ -284,7 +346,8 @@ public:
 
   ExpressionList *elems = nullptr;
 
-  DEFINE_ACCEPT
+private:
+  Tuple(const Tuple &other);
 };
 
 class Statement : public Node {
@@ -298,8 +361,10 @@ using StatementList = std::vector<Statement *>;
 
 class ExprStatement : public Statement {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(ExprStatement)
+
   explicit ExprStatement(Expression *expr, location loc);
-  ExprStatement(const ExprStatement &other) : Statement(other){};
   ~ExprStatement()
   {
     delete expr;
@@ -308,16 +373,19 @@ public:
 
   Expression *expr = nullptr;
 
-  DEFINE_ACCEPT
+private:
+  ExprStatement(const ExprStatement &other) : Statement(other){};
 };
 
 class AssignMapStatement : public Statement {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(AssignMapStatement)
+
   AssignMapStatement(Map *map,
                      Expression *expr,
                      bool compound = false,
                      location loc = location());
-  AssignMapStatement(const AssignMapStatement &other) : Statement(other){};
   ~AssignMapStatement()
   {
     // In a compound assignment, the expression owns the map so
@@ -333,16 +401,19 @@ public:
   Expression *expr = nullptr;
   bool compound;
 
-  DEFINE_ACCEPT
+private:
+  AssignMapStatement(const AssignMapStatement &other) : Statement(other){};
 };
 
 class AssignVarStatement : public Statement {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(AssignVarStatement)
+
   AssignVarStatement(Variable *var,
                      Expression *expr,
                      bool compound = false,
                      location loc = location());
-  AssignVarStatement(const AssignVarStatement &other) : Statement(other){};
   ~AssignVarStatement()
   {
     // In a compound assignment, the expression owns the map so
@@ -358,14 +429,17 @@ public:
   Expression *expr = nullptr;
   bool compound;
 
-  DEFINE_ACCEPT
+private:
+  AssignVarStatement(const AssignVarStatement &other) : Statement(other){};
 };
 
 class If : public Statement {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(If)
+
   If(Expression *cond, StatementList *stmts);
   If(Expression *cond, StatementList *stmts, StatementList *else_stmts);
-  If(const If &other);
   ~If()
   {
     delete cond;
@@ -388,13 +462,16 @@ public:
   StatementList *stmts = nullptr;
   StatementList *else_stmts = nullptr;
 
-  DEFINE_ACCEPT
+private:
+  If(const If &other);
 };
 
 class Unroll : public Statement {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(Unroll)
+
   Unroll(Expression *expr, StatementList *stmts, location loc);
-  Unroll(const Unroll &other);
   ~Unroll()
   {
     if (stmts)
@@ -408,27 +485,33 @@ public:
   Expression *expr = nullptr;
   StatementList *stmts = nullptr;
 
-  DEFINE_ACCEPT
+private:
+  Unroll(const Unroll &other);
 };
 
 class Jump : public Statement
 {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(Jump)
+
   Jump(int ident, location loc = location()) : Statement(loc), ident(ident)
   {
   }
-  Jump(const Jump &other) = default;
   ~Jump() = default;
 
   int ident = 0;
 
-  DEFINE_ACCEPT
+private:
+  Jump(const Jump &other) = default;
 };
 
 class Predicate : public Node {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(Predicate)
+
   explicit Predicate(Expression *expr, location loc);
-  Predicate(const Predicate &other) : Node(other){};
   ~Predicate()
   {
     delete expr;
@@ -437,13 +520,16 @@ public:
 
   Expression *expr = nullptr;
 
-  DEFINE_ACCEPT
+private:
+  Predicate(const Predicate &other) : Node(other){};
 };
 
 class Ternary : public Expression {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(Ternary)
+
   Ternary(Expression *cond, Expression *left, Expression *right, location loc);
-  Ternary(const Ternary &other) : Expression(other){};
   ~Ternary()
   {
     delete cond;
@@ -457,18 +543,18 @@ public:
   Expression *cond = nullptr;
   Expression *left = nullptr;
   Expression *right = nullptr;
-
-  DEFINE_ACCEPT
 };
 
 class While : public Statement
 {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(While)
+
   While(Expression *cond, StatementList *stmts, location loc)
       : Statement(loc), cond(cond), stmts(stmts)
   {
   }
-  While(const While &other);
   ~While()
   {
     delete cond;
@@ -480,13 +566,16 @@ public:
   Expression *cond = nullptr;
   StatementList *stmts = nullptr;
 
-  DEFINE_ACCEPT
+private:
+  While(const While &other);
 };
 
 class AttachPoint : public Node {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(AttachPoint)
+
   explicit AttachPoint(const std::string &raw_input, location loc = location());
-  AttachPoint(const AttachPoint &other) = default;
   ~AttachPoint() = default;
 
   // Raw, unparsed input from user, eg. kprobe:vfs_read
@@ -504,22 +593,26 @@ public:
   uint64_t address = 0;
   uint64_t func_offset = 0;
 
-  DEFINE_ACCEPT
   std::string name(const std::string &attach_point) const;
   std::string name(const std::string &attach_target,
                    const std::string &attach_point) const;
 
   int index(std::string name);
   void set_index(std::string name, int index);
+
 private:
+  AttachPoint(const AttachPoint &other) = default;
+
   std::map<std::string, int> index_;
 };
 using AttachPointList = std::vector<AttachPoint *>;
 
 class Probe : public Node {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(Probe)
+
   Probe(AttachPointList *attach_points, Predicate *pred, StatementList *stmts);
-  Probe(const Probe &other);
   ~Probe()
   {
     if (attach_points)
@@ -542,22 +635,25 @@ public:
   Predicate *pred = nullptr;
   StatementList *stmts = nullptr;
 
-  DEFINE_ACCEPT
   std::string name() const;
   bool need_expansion = false;        // must build a BPF program per wildcard match
   bool need_tp_args_structs = false;  // must import struct for tracepoints
 
   int index();
   void set_index(int index);
+
 private:
+  Probe(const Probe &other);
   int index_ = 0;
 };
 using ProbeList = std::vector<Probe *>;
 
 class Program : public Node {
 public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(Program)
+
   Program(const std::string &c_definitions, ProbeList *probes);
-  Program(const Program &other);
 
   ~Program()
   {
@@ -571,7 +667,8 @@ public:
   std::string c_definitions;
   ProbeList *probes = nullptr;
 
-  DEFINE_ACCEPT
+private:
+  Program(const Program &other);
 };
 
 std::string opstr(Binop &binop);

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -359,7 +359,7 @@ public:
   bool compound;
 
 private:
-  AssignMapStatement(const AssignMapStatement &other) : Statement(other){};
+  AssignMapStatement(const AssignMapStatement &other);
 };
 
 class AssignVarStatement : public Statement {
@@ -378,7 +378,7 @@ public:
   bool compound;
 
 private:
-  AssignVarStatement(const AssignVarStatement &other) : Statement(other){};
+  AssignVarStatement(const AssignVarStatement &other);
 };
 
 class If : public Statement {

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -313,11 +313,17 @@ public:
 
 class AssignMapStatement : public Statement {
 public:
-  AssignMapStatement(Map *map, Expression *expr, location loc = location());
+  AssignMapStatement(Map *map,
+                     Expression *expr,
+                     bool compound = false,
+                     location loc = location());
   AssignMapStatement(const AssignMapStatement &other) : Statement(other){};
   ~AssignMapStatement()
   {
-    delete map;
+    // In a compound assignment, the expression owns the map so
+    // we shouldn't free
+    if (!compound)
+      delete map;
     delete expr;
     map = nullptr;
     expr = nullptr;
@@ -325,18 +331,24 @@ public:
 
   Map *map = nullptr;
   Expression *expr = nullptr;
+  bool compound;
 
   DEFINE_ACCEPT
 };
 
 class AssignVarStatement : public Statement {
 public:
-  AssignVarStatement(Variable *var, Expression *expr);
-  AssignVarStatement(Variable *var, Expression *expr, location loc);
+  AssignVarStatement(Variable *var,
+                     Expression *expr,
+                     bool compound = false,
+                     location loc = location());
   AssignVarStatement(const AssignVarStatement &other) : Statement(other){};
   ~AssignVarStatement()
   {
-    delete var;
+    // In a compound assignment, the expression owns the map so
+    // we shouldn't free
+    if (!compound)
+      delete var;
     delete expr;
     var = nullptr;
     expr = nullptr;
@@ -344,6 +356,7 @@ public:
 
   Variable *var = nullptr;
   Expression *expr = nullptr;
+  bool compound;
 
   DEFINE_ACCEPT
 };

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -31,6 +31,11 @@ public:
   Node() = default;
   Node(location loc) : loc(loc){};
   Node(const Node &other) = default;
+
+  Node &operator=(const Node &) = delete;
+  Node(Node &&) = delete;
+  Node &operator=(Node &&) = delete;
+
   virtual ~Node() = default;
 
   virtual void accept(Visitor &v) = 0;
@@ -45,6 +50,11 @@ public:
   Expression() = default;
   Expression(location loc) : Node(loc){};
   Expression(const Expression &other);
+
+  Expression &operator=(const Expression &) = delete;
+  Expression(Expression &&) = delete;
+  Expression &operator=(Expression &&) = delete;
+
   // NB: do not free any of non-owned pointers we store
   virtual ~Expression() = default;
 
@@ -310,6 +320,11 @@ public:
   Statement() = default;
   Statement(location loc) : Node(loc){};
   Statement(const Statement &other) = default;
+  ~Statement() = default;
+
+  Statement &operator=(const Statement &) = delete;
+  Statement(Statement &&) = delete;
+  Statement &operator=(Statement &&) = delete;
 };
 
 using StatementList = std::vector<Statement *>;

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -153,15 +153,7 @@ public:
 
   explicit Call(const std::string &func, location loc);
   Call(const std::string &func, ExpressionList *vargs, location loc);
-  ~Call()
-  {
-    if (vargs)
-      for (Expression *expr : *vargs)
-        delete expr;
-
-    delete vargs;
-    vargs = nullptr;
-  }
+  ~Call();
 
   std::string func;
   ExpressionList *vargs = nullptr;
@@ -177,15 +169,7 @@ public:
 
   explicit Map(const std::string &ident, location loc);
   Map(const std::string &ident, ExpressionList *vargs, location loc);
-  ~Map()
-  {
-    if (vargs)
-      for (Expression *expr : *vargs)
-        delete expr;
-
-    delete vargs;
-    vargs = nullptr;
-  }
+  ~Map();
 
   std::string ident;
   ExpressionList *vargs = nullptr;
@@ -216,13 +200,7 @@ public:
 
   Binop(Expression *left, int op, Expression *right, location loc);
 
-  ~Binop()
-  {
-    delete left;
-    delete right;
-    left = nullptr;
-    right = nullptr;
-  }
+  ~Binop();
 
   Expression *left = nullptr;
   Expression *right = nullptr;
@@ -243,11 +221,7 @@ public:
        bool is_post_op = false,
        location loc = location());
 
-  ~Unop()
-  {
-    delete expr;
-    expr = nullptr;
-  }
+  ~Unop();
 
   Expression *expr = nullptr;
   int op;
@@ -265,11 +239,7 @@ public:
   FieldAccess(Expression *expr, const std::string &field);
   FieldAccess(Expression *expr, const std::string &field, location loc);
   FieldAccess(Expression *expr, ssize_t index, location loc);
-  ~FieldAccess()
-  {
-    delete expr;
-    expr = nullptr;
-  }
+  ~FieldAccess();
 
   Expression *expr = nullptr;
   std::string field;
@@ -286,13 +256,7 @@ public:
 
   ArrayAccess(Expression *expr, Expression *indexpr);
   ArrayAccess(Expression *expr, Expression *indexpr, location loc);
-  ~ArrayAccess()
-  {
-    delete expr;
-    delete indexpr;
-    expr = nullptr;
-    indexpr = nullptr;
-  }
+  ~ArrayAccess();
 
   Expression *expr = nullptr;
   Expression *indexpr = nullptr;
@@ -315,11 +279,7 @@ public:
        bool is_double_pointer,
        Expression *expr,
        location loc);
-  ~Cast()
-  {
-    delete expr;
-    expr = nullptr;
-  }
+  ~Cast();
 
   std::string cast_type;
   bool is_pointer;
@@ -337,12 +297,7 @@ public:
   DEFINE_LEAFCOPY(Tuple)
 
   Tuple(ExpressionList *elems, location loc);
-  ~Tuple()
-  {
-    for (Expression *expr : *elems)
-      delete expr;
-    delete elems;
-  }
+  ~Tuple();
 
   ExpressionList *elems = nullptr;
 
@@ -365,11 +320,7 @@ public:
   DEFINE_LEAFCOPY(ExprStatement)
 
   explicit ExprStatement(Expression *expr, location loc);
-  ~ExprStatement()
-  {
-    delete expr;
-    expr = nullptr;
-  }
+  ~ExprStatement();
 
   Expression *expr = nullptr;
 
@@ -386,16 +337,7 @@ public:
                      Expression *expr,
                      bool compound = false,
                      location loc = location());
-  ~AssignMapStatement()
-  {
-    // In a compound assignment, the expression owns the map so
-    // we shouldn't free
-    if (!compound)
-      delete map;
-    delete expr;
-    map = nullptr;
-    expr = nullptr;
-  }
+  ~AssignMapStatement();
 
   Map *map = nullptr;
   Expression *expr = nullptr;
@@ -414,16 +356,7 @@ public:
                      Expression *expr,
                      bool compound = false,
                      location loc = location());
-  ~AssignVarStatement()
-  {
-    // In a compound assignment, the expression owns the map so
-    // we shouldn't free
-    if (!compound)
-      delete var;
-    delete expr;
-    var = nullptr;
-    expr = nullptr;
-  }
+  ~AssignVarStatement();
 
   Variable *var = nullptr;
   Expression *expr = nullptr;
@@ -440,23 +373,7 @@ public:
 
   If(Expression *cond, StatementList *stmts);
   If(Expression *cond, StatementList *stmts, StatementList *else_stmts);
-  ~If()
-  {
-    delete cond;
-    cond = nullptr;
-
-    if (stmts)
-      for (Statement *s : *stmts)
-        delete s;
-    delete stmts;
-    stmts = nullptr;
-
-    if (else_stmts)
-      for (Statement *s : *else_stmts)
-        delete s;
-    delete else_stmts;
-    else_stmts = nullptr;
-  }
+  ~If();
 
   Expression *cond = nullptr;
   StatementList *stmts = nullptr;
@@ -472,14 +389,7 @@ public:
   DEFINE_LEAFCOPY(Unroll)
 
   Unroll(Expression *expr, StatementList *stmts, location loc);
-  ~Unroll()
-  {
-    if (stmts)
-      for (Statement *s : *stmts)
-        delete s;
-    delete stmts;
-    stmts = nullptr;
-  }
+  ~Unroll();
 
   long int var = 0;
   Expression *expr = nullptr;
@@ -512,11 +422,7 @@ public:
   DEFINE_LEAFCOPY(Predicate)
 
   explicit Predicate(Expression *expr, location loc);
-  ~Predicate()
-  {
-    delete expr;
-    expr = nullptr;
-  }
+  ~Predicate();
 
   Expression *expr = nullptr;
 
@@ -530,15 +436,7 @@ public:
   DEFINE_LEAFCOPY(Ternary)
 
   Ternary(Expression *cond, Expression *left, Expression *right, location loc);
-  ~Ternary()
-  {
-    delete cond;
-    delete left;
-    delete right;
-    cond = nullptr;
-    left = nullptr;
-    right = nullptr;
-  }
+  ~Ternary();
 
   Expression *cond = nullptr;
   Expression *left = nullptr;
@@ -555,13 +453,7 @@ public:
       : Statement(loc), cond(cond), stmts(stmts)
   {
   }
-  ~While()
-  {
-    delete cond;
-    for (auto *stmt : *stmts)
-      delete stmt;
-    delete stmts;
-  }
+  ~While();
 
   Expression *cond = nullptr;
   StatementList *stmts = nullptr;
@@ -613,23 +505,7 @@ public:
   DEFINE_LEAFCOPY(Probe)
 
   Probe(AttachPointList *attach_points, Predicate *pred, StatementList *stmts);
-  ~Probe()
-  {
-    if (attach_points)
-      for (AttachPoint *ap : *attach_points)
-        delete ap;
-    delete attach_points;
-    attach_points = nullptr;
-
-    delete pred;
-    pred = nullptr;
-
-    if (stmts)
-      for (Statement *s : *stmts)
-        delete s;
-    delete stmts;
-    stmts = nullptr;
-  }
+  ~Probe();
 
   AttachPointList *attach_points = nullptr;
   Predicate *pred = nullptr;
@@ -655,14 +531,7 @@ public:
 
   Program(const std::string &c_definitions, ProbeList *probes);
 
-  ~Program()
-  {
-    if (probes)
-      for (Probe *p : *probes)
-        delete p;
-    delete probes;
-    probes = nullptr;
-  }
+  ~Program();
 
   std::string c_definitions;
   ProbeList *probes = nullptr;

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -13,13 +13,11 @@ namespace bpftrace {
 
 Driver::Driver(BPFtrace &bpftrace, std::ostream &o) : bpftrace_(bpftrace), out_(o)
 {
-  yylex_init(&scanner_);
-  parser_ = std::make_unique<Parser>(*this, scanner_);
 }
 
 Driver::~Driver()
 {
-  yylex_destroy(scanner_);
+  delete root_;
 }
 
 void Driver::source(std::string filename, std::string script)
@@ -36,10 +34,20 @@ int Driver::parse_str(std::string script)
 
 int Driver::parse()
 {
+  // Ensure we free memory allocated the previous parse if we parse
+  // more than once
+  delete root_;
+  root_ = nullptr;
+
   // Reset source location info on every pass
   loc.initialize();
-  yy_scan_string(Log::get().get_source().c_str(), scanner_);
-  parser_->parse();
+
+  yyscan_t scanner;
+  yylex_init(&scanner);
+  Parser parser(*this, scanner);
+  yy_scan_string(Log::get().get_source().c_str(), scanner);
+  parser.parse();
+  yylex_destroy(scanner);
 
   ast::AttachPointParser ap_parser(root_, bpftrace_, out_);
   if (ap_parser.parse())

--- a/src/driver.h
+++ b/src/driver.h
@@ -25,14 +25,12 @@ public:
   void error(std::ostream &, const location &, const std::string &);
   void error(const location &l, const std::string &m);
   void error(const std::string &m);
-  ast::Program *root_{ nullptr };
+  ast::Program *root_ = nullptr;
 
   BPFtrace &bpftrace_;
 
 private:
-  std::unique_ptr<Parser> parser_;
   std::ostream &out_;
-  yyscan_t scanner_;
   bool failed_ = false;
 };
 

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -265,31 +265,31 @@ block_or_if : block        { $$ = $1; }
 stmt : expr                { $$ = new ast::ExprStatement($1, @1); }
      | compound_assignment { $$ = $1; }
      | jump_stmt           { $$ = $1; }
-     | map "=" expr        { $$ = new ast::AssignMapStatement($1, $3, @2); }
-     | var "=" expr        { $$ = new ast::AssignVarStatement($1, $3, @2); }
+     | map "=" expr        { $$ = new ast::AssignMapStatement($1, $3, false, @2); }
+     | var "=" expr        { $$ = new ast::AssignVarStatement($1, $3, false, @2); }
      | tuple_assignment
      ;
 
-compound_assignment : map LEFTASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::LEFT,  $3, @2), @$); }
-                    | var LEFTASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::LEFT,  $3, @2), @$); }
-                    | map RIGHTASSIGN expr { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::RIGHT, $3, @2), @$); }
-                    | var RIGHTASSIGN expr { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::RIGHT, $3, @2), @$); }
-                    | map PLUSASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::PLUS,  $3, @2), @$); }
-                    | var PLUSASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::PLUS,  $3, @2), @$); }
-                    | map MINUSASSIGN expr { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MINUS, $3, @2), @$); }
-                    | var MINUSASSIGN expr { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MINUS, $3, @2), @$); }
-                    | map MULASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MUL,   $3, @2), @$); }
-                    | var MULASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MUL,   $3, @2), @$); }
-                    | map DIVASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::DIV,   $3, @2), @$); }
-                    | var DIVASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::DIV,   $3, @2), @$); }
-                    | map MODASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MOD,   $3, @2), @$); }
-                    | var MODASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MOD,   $3, @2), @$); }
-                    | map BANDASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BAND,  $3, @2), @$); }
-                    | var BANDASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BAND,  $3, @2), @$); }
-                    | map BORASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BOR,   $3, @2), @$); }
-                    | var BORASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BOR,   $3, @2), @$); }
-                    | map BXORASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BXOR,  $3, @2), @$); }
-                    | var BXORASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BXOR,  $3, @2), @$); }
+compound_assignment : map LEFTASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::LEFT,  $3, @2), true, @$); }
+                    | var LEFTASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::LEFT,  $3, @2), true, @$); }
+                    | map RIGHTASSIGN expr { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::RIGHT, $3, @2), true, @$); }
+                    | var RIGHTASSIGN expr { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::RIGHT, $3, @2), true, @$); }
+                    | map PLUSASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::PLUS,  $3, @2), true, @$); }
+                    | var PLUSASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::PLUS,  $3, @2), true, @$); }
+                    | map MINUSASSIGN expr { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MINUS, $3, @2), true, @$); }
+                    | var MINUSASSIGN expr { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MINUS, $3, @2), true, @$); }
+                    | map MULASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MUL,   $3, @2), true, @$); }
+                    | var MULASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MUL,   $3, @2), true, @$); }
+                    | map DIVASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::DIV,   $3, @2), true, @$); }
+                    | var DIVASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::DIV,   $3, @2), true, @$); }
+                    | map MODASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MOD,   $3, @2), true, @$); }
+                    | var MODASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MOD,   $3, @2), true, @$); }
+                    | map BANDASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BAND,  $3, @2), true, @$); }
+                    | var BANDASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BAND,  $3, @2), true, @$); }
+                    | map BORASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BOR,   $3, @2), true, @$); }
+                    | var BORASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BOR,   $3, @2), true, @$); }
+                    | map BXORASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BXOR,  $3, @2), true, @$); }
+                    | var BXORASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BXOR,  $3, @2), true, @$); }
                     ;
 
 tuple_assignment : expr DOT INT "=" expr { error(@1 + @5, "Tuples are immutable once created. Consider creating a new tuple and assigning it instead."); YYERROR; }

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -9,136 +9,149 @@ using bpftrace::ast::AttachPoint;
 using bpftrace::ast::AttachPointList;
 using bpftrace::ast::Probe;
 
+static AttachPointList *APL(std::vector<AttachPoint *> list)
+{
+  auto apl = new AttachPointList();
+  for (auto l : list)
+    apl->push_back(new AttachPoint(*l));
+  return apl;
+}
+
 TEST(ast, probe_name_special)
 {
-  AttachPoint ap1("");
-  ap1.provider = "BEGIN";
-  AttachPointList attach_points1 = { &ap1 };
-  Probe begin(&attach_points1, nullptr, nullptr);
+  auto ap1 = new AttachPoint("");
+  ap1->provider = "BEGIN";
+  auto attach_points1 = APL({ ap1 });
+  Probe begin(attach_points1, nullptr, nullptr);
   EXPECT_EQ(begin.name(), "BEGIN");
 
-  AttachPoint ap2("");
-  ap2.provider = "END";
-  AttachPointList attach_points2 = { &ap2 };
-  Probe end(&attach_points2, nullptr, nullptr);
+  auto ap2 = new AttachPoint("");
+  ap2->provider = "END";
+  auto attach_points2 = APL({ ap2 });
+  Probe end(attach_points2, nullptr, nullptr);
   EXPECT_EQ(end.name(), "END");
 }
 
 TEST(ast, probe_name_kprobe)
 {
-  AttachPoint ap1("");
-  ap1.provider = "kprobe";
-  ap1.func = "sys_read";
-  AttachPointList attach_points1 = { &ap1 };
-  Probe kprobe1(&attach_points1, nullptr, nullptr);
+  auto ap1 = new AttachPoint("");
+  ap1->provider = "kprobe";
+  ap1->func = "sys_read";
+
+  auto ap2 = new AttachPoint("");
+  ap2->provider = "kprobe";
+  ap2->func = "sys_write";
+
+  auto ap3 = new AttachPoint("");
+  ap3->provider = "kprobe";
+  ap3->func = "sys_read";
+  ap3->func_offset = 10;
+
+  auto attach_points1 = APL({ ap1 });
+  Probe kprobe1(attach_points1, nullptr, nullptr);
   EXPECT_EQ(kprobe1.name(), "kprobe:sys_read");
 
-  AttachPoint ap2("");
-  ap2.provider = "kprobe";
-  ap2.func = "sys_write";
-  AttachPointList attach_points2 = { &ap1, &ap2 };
-  Probe kprobe2(&attach_points2, nullptr, nullptr);
+  auto ap2_copy1 = new AttachPoint(*ap2);
+  auto attach_points2 = APL({ ap1, ap2 });
+  Probe kprobe2(attach_points2, nullptr, nullptr);
   EXPECT_EQ(kprobe2.name(), "kprobe:sys_read,kprobe:sys_write");
 
-  AttachPoint ap3("");
-  ap3.provider = "kprobe";
-  ap3.func = "sys_read";
-  ap3.func_offset = 10;
-  AttachPointList attach_points3 = { &ap1, &ap2, &ap3 };
-  Probe kprobe3(&attach_points3, nullptr, nullptr);
+  auto attach_points3 = APL({ ap1, ap2_copy1, ap3 });
+  Probe kprobe3(attach_points3, nullptr, nullptr);
   EXPECT_EQ(kprobe3.name(),
             "kprobe:sys_read,kprobe:sys_write,kprobe:sys_read+10");
 }
 
 TEST(ast, probe_name_uprobe)
 {
-  AttachPoint ap1("");
-  ap1.provider = "uprobe";
-  ap1.target = "/bin/sh";
-  ap1.func = "readline";
-  AttachPointList attach_points1 = { &ap1 };
-  Probe uprobe1(&attach_points1, nullptr, nullptr);
+  auto ap1 = new AttachPoint("");
+  ap1->provider = "uprobe";
+  ap1->target = "/bin/sh";
+  ap1->func = "readline";
+  auto attach_points1 = APL({ ap1 });
+  Probe uprobe1(attach_points1, nullptr, nullptr);
   EXPECT_EQ(uprobe1.name(), "uprobe:/bin/sh:readline");
 
-  AttachPoint ap2("");
-  ap2.provider = "uprobe";
-  ap2.target = "/bin/sh";
-  ap2.func = "somefunc";
-  AttachPointList attach_points2 = { &ap1, &ap2 };
-  Probe uprobe2(&attach_points2, nullptr, nullptr);
+  auto ap2 = new AttachPoint("");
+  ap2->provider = "uprobe";
+  ap2->target = "/bin/sh";
+  ap2->func = "somefunc";
+  auto attach_points2 = APL({ ap1, ap2 });
+  Probe uprobe2(attach_points2, nullptr, nullptr);
   EXPECT_EQ(uprobe2.name(), "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc");
 
-  AttachPoint ap3("");
-  ap3.provider = "uprobe";
-  ap3.target = "/bin/sh";
-  ap3.address = 1000;
-  AttachPointList attach_points3 = { &ap1, &ap2, &ap3 };
-  Probe uprobe3(&attach_points3, nullptr, nullptr);
+  auto ap3 = new AttachPoint("");
+  ap3->provider = "uprobe";
+  ap3->target = "/bin/sh";
+  ap3->address = 1000;
+  auto attach_points3 = APL({ ap1, ap2, ap3 });
+  Probe uprobe3(attach_points3, nullptr, nullptr);
   EXPECT_EQ(uprobe3.name(), "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/sh:1000");
 
-  AttachPoint ap4("");
-  ap4.provider = "uprobe";
-  ap4.target = "/bin/sh";
-  ap4.func = "somefunc";
-  ap4.func_offset = 10;
-  AttachPointList attach_points4 = { &ap1, &ap2, &ap3, &ap4 };
-  Probe uprobe4(&attach_points4, nullptr, nullptr);
+  auto ap4 = new AttachPoint("");
+  ap4->provider = "uprobe";
+  ap4->target = "/bin/sh";
+  ap4->func = "somefunc";
+  ap4->func_offset = 10;
+  auto attach_points4 = APL({ ap1, ap2, ap3, ap4 });
+  Probe uprobe4(attach_points4, nullptr, nullptr);
   EXPECT_EQ(uprobe4.name(), "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/sh:1000,uprobe:/bin/sh:somefunc+10");
 
-  AttachPoint ap5("");
-  ap5.provider = "uprobe";
-  ap5.target = "/bin/sh";
-  ap5.address = 10;
-  AttachPointList attach_points5 = { &ap5 };
-  Probe uprobe5(&attach_points5, nullptr, nullptr);
+  auto ap5 = new AttachPoint("");
+  ap5->provider = "uprobe";
+  ap5->target = "/bin/sh";
+  ap5->address = 10;
+  auto attach_points5 = APL({ ap5 });
+  Probe uprobe5(attach_points5, nullptr, nullptr);
   EXPECT_EQ(uprobe5.name(), "uprobe:/bin/sh:10");
 
-  AttachPoint ap6("");
-  ap6.provider = "uretprobe";
-  ap6.target = "/bin/sh";
-  ap6.address = 10;
-  AttachPointList attach_points6 = { &ap6 };
-  Probe uprobe6(&attach_points6, nullptr, nullptr);
+  auto ap6 = new AttachPoint("");
+  ap6->provider = "uretprobe";
+  ap6->target = "/bin/sh";
+  ap6->address = 10;
+  auto attach_points6 = APL({ ap6 });
+  Probe uprobe6(attach_points6, nullptr, nullptr);
   EXPECT_EQ(uprobe6.name(), "uretprobe:/bin/sh:10");
 }
 
 TEST(ast, probe_name_usdt)
 {
-  AttachPoint ap1("");
-  ap1.provider = "usdt";
-  ap1.target = "/bin/sh";
-  ap1.func = "probe1";
-  AttachPointList attach_points1 = { &ap1 };
-  Probe usdt1(&attach_points1, nullptr, nullptr);
+  auto ap1 = new AttachPoint("");
+  ap1->provider = "usdt";
+  ap1->target = "/bin/sh";
+  ap1->func = "probe1";
+  auto attach_points1 = APL({ ap1 });
+  Probe usdt1(attach_points1, nullptr, nullptr);
   EXPECT_EQ(usdt1.name(), "usdt:/bin/sh:probe1");
 
-  AttachPoint ap2("");
-  ap2.provider = "usdt";
-  ap2.target = "/bin/sh";
-  ap2.func = "probe2";
-  AttachPointList attach_points2 = { &ap1, &ap2 };
-  Probe usdt2(&attach_points2, nullptr, nullptr);
+  auto ap2 = new AttachPoint("");
+  ap2->provider = "usdt";
+  ap2->target = "/bin/sh";
+  ap2->func = "probe2";
+  auto attach_points2 = APL({ ap1, ap2 });
+  Probe usdt2(attach_points2, nullptr, nullptr);
   EXPECT_EQ(usdt2.name(), "usdt:/bin/sh:probe1,usdt:/bin/sh:probe2");
 }
 
 TEST(ast, attach_point_name)
 {
-  AttachPoint ap1("");
-  ap1.provider = "kprobe";
-  ap1.func = "sys_read";
-  AttachPoint ap2("");
-  ap2.provider = "kprobe";
-  ap2.func = "sys_thisone";
-  AttachPoint ap3("");
-  ap3.provider = "uprobe";
-  ap3.target = "/bin/sh";
-  ap3.func = "readline";
-  AttachPointList attach_points = { &ap1, &ap2, &ap3 };
-  Probe kprobe(&attach_points, nullptr, nullptr);
-  EXPECT_EQ(ap2.name("sys_thisone"), "kprobe:sys_thisone");
+  auto ap1 = new AttachPoint("");
+  ap1->provider = "kprobe";
+  ap1->func = "sys_read";
+  auto ap2 = new AttachPoint("");
+  ap2->provider = "kprobe";
+  ap2->func = "sys_thisone";
+  auto ap3 = new AttachPoint("");
+  ap3->provider = "uprobe";
+  ap3->target = "/bin/sh";
+  ap3->func = "readline";
+  auto attach_points = APL({ ap1, ap2, ap3 });
+  Probe kprobe(attach_points, nullptr, nullptr);
+  EXPECT_EQ(ap2->name("sys_thisone"), "kprobe:sys_thisone");
 
-  Probe uprobe(&attach_points, nullptr, nullptr);
-  EXPECT_EQ(ap3.name("readline"), "uprobe:/bin/sh:readline");
+  attach_points = APL({ ap1, ap2, ap3 });
+  Probe uprobe(attach_points, nullptr, nullptr);
+  EXPECT_EQ(ap3->name("readline"), "uprobe:/bin/sh:readline");
 }
 
 } // namespace ast

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -13,7 +13,7 @@ static AttachPointList *APL(std::vector<AttachPoint *> list)
 {
   auto apl = new AttachPointList();
   for (auto l : list)
-    apl->push_back(new AttachPoint(*l));
+    apl->push_back(l->leafcopy());
   return apl;
 }
 
@@ -51,7 +51,7 @@ TEST(ast, probe_name_kprobe)
   Probe kprobe1(attach_points1, nullptr, nullptr);
   EXPECT_EQ(kprobe1.name(), "kprobe:sys_read");
 
-  auto ap2_copy1 = new AttachPoint(*ap2);
+  auto ap2_copy1 = ap2->leafcopy();
   auto attach_points2 = APL({ ap1, ap2 });
   Probe kprobe2(attach_points2, nullptr, nullptr);
   EXPECT_EQ(kprobe2.name(), "kprobe:sys_read,kprobe:sys_write");

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -1,9 +1,10 @@
 #include <cstring>
 
+#include "bpftrace.h"
+#include "driver.h"
+#include "mocks.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
-#include "bpftrace.h"
-#include "mocks.h"
 
 namespace bpftrace {
 namespace test {
@@ -29,6 +30,42 @@ void check_kprobe(Probe &p,
   EXPECT_EQ(orig_name, p.orig_name);
   EXPECT_EQ(kprobe_name(attach_point, func_offset), p.name);
   EXPECT_EQ(func_offset, p.func_offset);
+}
+
+static auto make_probe(std::vector<ast::AttachPoint *> elems)
+{
+  auto apl = new ast::AttachPointList(elems);
+  return new ast::Probe(apl, nullptr, nullptr);
+}
+
+static auto make_usdt_probe(const std::string &target,
+                            const std::string &ns,
+                            const std::string &func,
+                            bool need_expansion = false,
+                            int locations = 0)
+{
+  auto a = new ast::AttachPoint("");
+  a->provider = "usdt";
+  a->target = target;
+  a->ns = ns;
+  a->func = func;
+  a->need_expansion = need_expansion;
+  a->usdt.num_locations = locations;
+  return make_probe({ a });
+}
+
+static auto parse_probe(const std::string &str)
+{
+  StrictMock<MockBPFtrace> b;
+  Driver d(b);
+
+  if (d.parse_str(str))
+  {
+    throw std::runtime_error("Parser failed");
+  }
+  auto probe = d.root_->probes->front();
+  d.root_->probes->clear();
+  return probe;
 }
 
 static const std::string uprobe_name(const std::string &path,
@@ -118,13 +155,10 @@ void check_special_probe(Probe &p, const std::string &attach_point, const std::s
 
 TEST(bpftrace, add_begin_probe)
 {
-  ast::AttachPoint a("");
-  a.provider = "BEGIN";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  ast::Probe *probe = parse_probe("BEGIN{}");
 
   StrictMock<MockBPFtrace> bpftrace;
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(0U, bpftrace.get_probes().size());
   ASSERT_EQ(1U, bpftrace.get_special_probes().size());
 
@@ -133,13 +167,10 @@ TEST(bpftrace, add_begin_probe)
 
 TEST(bpftrace, add_end_probe)
 {
-  ast::AttachPoint a("");
-  a.provider = "END";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  ast::Probe *probe = parse_probe("END{}");
 
   StrictMock<MockBPFtrace> bpftrace;
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(0U, bpftrace.get_probes().size());
   ASSERT_EQ(1U, bpftrace.get_special_probes().size());
 
@@ -148,14 +179,9 @@ TEST(bpftrace, add_end_probe)
 
 TEST(bpftrace, add_probes_single)
 {
-  ast::AttachPoint a("");
-  a.provider = "kprobe";
-  a.func = "sys_read";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  ast::Probe *probe = parse_probe("kprobe:sys_read {}");
   StrictMock<MockBPFtrace> bpftrace;
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
 
@@ -164,17 +190,9 @@ TEST(bpftrace, add_probes_single)
 
 TEST(bpftrace, add_probes_multiple)
 {
-  ast::AttachPoint a1("");
-  a1.provider = "kprobe";
-  a1.func = "sys_read";
-  ast::AttachPoint a2("");
-  a2.provider = "kprobe";
-  a2.func = "sys_write";
-  ast::AttachPointList attach_points = { &a1, &a2 };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  ast::Probe *probe = parse_probe("kprobe:sys_read,kprobe:sys_write{}");
   StrictMock<MockBPFtrace> bpftrace;
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(2U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
 
@@ -185,18 +203,8 @@ TEST(bpftrace, add_probes_multiple)
 
 TEST(bpftrace, add_probes_wildcard)
 {
-  ast::AttachPoint a1("");
-  a1.provider = "kprobe";
-  a1.func = "sys_read";
-  ast::AttachPoint a2("");
-  a2.provider = "kprobe";
-  a2.func = "my_*";
-  a2.need_expansion = true;
-  ast::AttachPoint a3("");
-  a3.provider = "kprobe";
-  a3.func = "sys_write";
-  ast::AttachPointList attach_points = { &a1, &a2, &a3 };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  ast::Probe *probe = parse_probe(
+      "kprobe:sys_read,kprobe:my_*,kprobe:sys_write{}");
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace,
@@ -204,7 +212,7 @@ TEST(bpftrace, add_probes_wildcard)
         "/sys/kernel/debug/tracing/available_filter_functions"))
     .Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(4U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 
@@ -217,18 +225,8 @@ TEST(bpftrace, add_probes_wildcard)
 
 TEST(bpftrace, add_probes_wildcard_no_matches)
 {
-  ast::AttachPoint a1("");
-  a1.provider = "kprobe";
-  a1.func = "sys_read";
-  ast::AttachPoint a2("");
-  a2.provider = "kprobe";
-  a2.func = "not_here_*";
-  a2.need_expansion = true;
-  ast::AttachPoint a3("");
-  a3.provider = "kprobe";
-  a3.func = "sys_write";
-  ast::AttachPointList attach_points = { &a1, &a2, &a3 };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  ast::Probe *probe = parse_probe(
+      "kprobe:sys_read,kprobe:not_here_*,kprobe:sys_write{}");
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace,
@@ -236,7 +234,7 @@ TEST(bpftrace, add_probes_wildcard_no_matches)
         "/sys/kernel/debug/tracing/available_filter_functions"))
     .Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(2U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 
@@ -247,14 +245,10 @@ TEST(bpftrace, add_probes_wildcard_no_matches)
 
 TEST(bpftrace, add_probes_kernel_module)
 {
-  ast::AttachPoint a1("");
-  a1.provider = "kprobe";
-  a1.func = "func_in_mod";
-  ast::AttachPointList attach_points = { &a1 };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  ast::Probe *probe = parse_probe("kprobe:func_in_mod{}");
 
   auto bpftrace = get_strict_mock_bpftrace();
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(1U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 
@@ -264,20 +258,14 @@ TEST(bpftrace, add_probes_kernel_module)
 
 TEST(bpftrace, add_probes_kernel_module_wildcard)
 {
-  ast::AttachPoint a1("");
-  a1.provider = "kprobe";
-  a1.func = "func_in_mo*";
-  a1.need_expansion = true;
-  ast::AttachPointList attach_points = { &a1 };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  ast::Probe *probe = parse_probe("kprobe:func_in_mo*{}");
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace,
               get_symbols_from_file(
                   "/sys/kernel/debug/tracing/available_filter_functions"))
       .Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(1U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 
@@ -287,16 +275,10 @@ TEST(bpftrace, add_probes_kernel_module_wildcard)
 
 TEST(bpftrace, add_probes_offset)
 {
-  uint64_t offset = 10;
-  ast::AttachPoint a("");
-  a.provider = "kprobe";
-  a.func = "sys_read";
-  a.func_offset = offset;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  auto offset = 10;
+  ast::Probe *probe = parse_probe("kprobe:sys_read+10{}");
   StrictMock<MockBPFtrace> bpftrace;
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
 
@@ -307,16 +289,10 @@ TEST(bpftrace, add_probes_offset)
 
 TEST(bpftrace, add_probes_uprobe)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.func = "foo";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
   StrictMock<MockBPFtrace> bpftrace;
+  ast::Probe *probe = parse_probe("uprobe:/bin/sh:foo {}");
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
   check_uprobe(bpftrace.get_probes().at(0), "/bin/sh", "foo", "uprobe:/bin/sh:foo");
@@ -324,18 +300,12 @@ TEST(bpftrace, add_probes_uprobe)
 
 TEST(bpftrace, add_probes_uprobe_wildcard)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.func = "*open";
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  ast::Probe *probe = parse_probe("uprobe:/bin/sh:*open {}");
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/sh")).Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(2U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 
@@ -346,18 +316,11 @@ TEST(bpftrace, add_probes_uprobe_wildcard)
 
 TEST(bpftrace, add_probes_uprobe_wildcard_file)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/*sh";
-  a.func = "first_open";
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  ast::Probe *probe = parse_probe("uprobe:/bin/*sh:first_open {}");
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/*sh")).Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(2U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 
@@ -370,34 +333,26 @@ TEST(bpftrace, add_probes_uprobe_wildcard_file)
 
 TEST(bpftrace, add_probes_uprobe_wildcard_no_matches)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.func = "foo*";
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  ast::Probe *probe = parse_probe("uprobe:/bin/sh:foo* {}");
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/sh")).Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(0U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 }
 
 TEST(bpftrace, add_probes_uprobe_string_literal)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.func = "foo*";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = new ast::AttachPoint("");
+  a->provider = "uprobe";
+  a->target = "/bin/sh";
+  a->func = "foo*";
 
+  auto probe = make_probe({ a });
   StrictMock<MockBPFtrace> bpftrace;
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
   check_uprobe(bpftrace.get_probes().at(0), "/bin/sh", "foo*", "uprobe:/bin/sh:foo*");
@@ -405,16 +360,10 @@ TEST(bpftrace, add_probes_uprobe_string_literal)
 
 TEST(bpftrace, add_probes_uprobe_address)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.address = 1024;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  ast::Probe *probe = parse_probe("uprobe:/bin/sh:1024 {}");
   StrictMock<MockBPFtrace> bpftrace;
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
   check_uprobe(bpftrace.get_probes().at(0), "/bin/sh", "", "uprobe:/bin/sh:1024", 1024);
@@ -422,17 +371,10 @@ TEST(bpftrace, add_probes_uprobe_address)
 
 TEST(bpftrace, add_probes_uprobe_string_offset)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.func = "foo";
-  a.func_offset = 10;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  ast::Probe *probe = parse_probe("uprobe:/bin/sh:foo+10{}");
   StrictMock<MockBPFtrace> bpftrace;
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
   check_uprobe(bpftrace.get_probes().at(0), "/bin/sh", "foo", "uprobe:/bin/sh:foo+10", 0, 10);
@@ -442,18 +384,14 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol)
 {
   for (auto &provider : { "uprobe", "uretprobe" })
   {
-    ast::AttachPoint a("");
-    a.provider = provider;
-    a.target = "/bin/sh";
-    a.func = "cpp_mangled";
-    a.need_expansion = true;
-    ast::AttachPointList attach_points = { &a };
-    ast::Probe probe(&attach_points, nullptr, nullptr);
+    std::stringstream prog;
+    prog << provider << ":/bin/sh:cpp_mangled{}";
+    ast::Probe *probe = parse_probe(prog.str());
 
     auto bpftrace = get_strict_mock_bpftrace();
     EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/sh")).Times(1);
 
-    ASSERT_EQ(0, bpftrace->add_probe(probe));
+    ASSERT_EQ(0, bpftrace->add_probe(*probe));
     ASSERT_EQ(2U, bpftrace->get_probes().size());
     ASSERT_EQ(0U, bpftrace->get_special_probes().size());
     auto orig_name = std::string(provider) + ":/bin/sh:cpp_mangled";
@@ -466,18 +404,12 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol)
 
 TEST(bpftrace, add_probes_uprobe_cpp_symbol_full)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.func = "cpp_mangled(int)";
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto probe = parse_probe("uprobe:/bin/sh:\"cpp_mangled(int)\"{}");
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/sh")).Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(1U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
   check_uprobe(bpftrace->get_probes().at(0),
@@ -488,18 +420,12 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol_full)
 
 TEST(bpftrace, add_probes_uprobe_cpp_symbol_wildcard)
 {
-  ast::AttachPoint a("");
-  a.provider = "uprobe";
-  a.target = "/bin/sh";
-  a.func = "cpp_man*";
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto probe = parse_probe("uprobe:/bin/sh:cpp_man*{}");
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, extract_func_symbols_from_path("/bin/sh")).Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(2U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
   check_uprobe(bpftrace->get_probes().at(0),
@@ -514,18 +440,12 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol_wildcard)
 
 TEST(bpftrace, add_probes_usdt)
 {
-  ast::AttachPoint a("");
-  a.provider = "usdt";
-  a.target = "/bin/sh";
-  a.ns = "prov1";
-  a.func = "mytp";
-  a.usdt.num_locations = 1;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto probe = parse_probe("usdt:/bin/sh:prov1:mytp{}");
+  probe->attach_points->front()->usdt.num_locations = 1;
 
   StrictMock<MockBPFtrace> bpftrace;
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
   check_usdt(bpftrace.get_probes().at(0),
@@ -535,20 +455,11 @@ TEST(bpftrace, add_probes_usdt)
 
 TEST(bpftrace, add_probes_usdt_wildcard)
 {
-  ast::AttachPoint a("");
-  a.provider = "usdt";
-  a.target = "/bin/*sh";
-  a.ns = "prov*";
-  a.func = "tp*";
-  a.usdt.num_locations = 1;
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  auto probe = make_usdt_probe("/bin/*sh", "prov*", "tp*", true, 1);
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, get_symbols_from_usdt(0, "/bin/*sh")).Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(4U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
   check_usdt(bpftrace->get_probes().at(0),
@@ -575,20 +486,12 @@ TEST(bpftrace, add_probes_usdt_wildcard)
 
 TEST(bpftrace, add_probes_usdt_empty_namespace)
 {
-  ast::AttachPoint a("");
-  a.provider = "usdt";
-  a.target = "/bin/sh";
-  a.ns = "";
-  a.func = "tp1";
-  a.usdt.num_locations = 1;
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto probe = make_usdt_probe("/bin/sh", "", "tp1", true, 1);
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, get_symbols_from_usdt(0, "/bin/sh")).Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(1U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
   check_usdt(bpftrace->get_probes().at(0),
@@ -600,36 +503,20 @@ TEST(bpftrace, add_probes_usdt_empty_namespace)
 
 TEST(bpftrace, add_probes_usdt_empty_namespace_conflict)
 {
-  ast::AttachPoint a("");
-  a.provider = "usdt";
-  a.target = "/bin/sh";
-  a.ns = "";
-  a.func = "tp";
-  a.usdt.num_locations = 1;
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  auto probe = make_usdt_probe("/bin/sh", "", "tp", true, 1);
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace, get_symbols_from_usdt(0, "/bin/sh")).Times(1);
 
-  ASSERT_EQ(1, bpftrace->add_probe(probe));
+  ASSERT_EQ(1, bpftrace->add_probe(*probe));
 }
 
 TEST(bpftrace, add_probes_usdt_duplicate_markers)
 {
-  ast::AttachPoint a("");
-  a.provider = "usdt";
-  a.target = "/bin/sh";
-  a.ns = "prov1";
-  a.func = "mytp";
-  a.usdt.num_locations = 3;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto probe = make_usdt_probe("/bin/sh", "prov1", "mytp", false, 3);
 
   StrictMock<MockBPFtrace> bpftrace;
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(3U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
   check_usdt(bpftrace.get_probes().at(0),
@@ -651,16 +538,10 @@ TEST(bpftrace, add_probes_usdt_duplicate_markers)
 
 TEST(bpftrace, add_probes_tracepoint)
 {
-  ast::AttachPoint a("");
-  a.provider = "tracepoint";
-  a.target = "sched";
-  a.func = "sched_switch";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  auto probe = parse_probe(("tracepoint:sched:sched_switch {}"));
   StrictMock<MockBPFtrace> bpftrace;
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
 
@@ -670,21 +551,14 @@ TEST(bpftrace, add_probes_tracepoint)
 
 TEST(bpftrace, add_probes_tracepoint_wildcard)
 {
-  ast::AttachPoint a("");
-  a.provider = "tracepoint";
-  a.target = "sched";
-  a.func = "sched_*";
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  auto probe = parse_probe(("tracepoint:sched:sched_* {}"));
   auto bpftrace = get_strict_mock_bpftrace();
   std::set<std::string> matches = { "sched_one", "sched_two" };
   EXPECT_CALL(*bpftrace,
       get_symbols_from_file("/sys/kernel/debug/tracing/available_events"))
     .Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(2U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 
@@ -695,21 +569,14 @@ TEST(bpftrace, add_probes_tracepoint_wildcard)
 
 TEST(bpftrace, add_probes_tracepoint_category_wildcard)
 {
-  ast::AttachPoint a("");
-  a.provider = "tracepoint";
-  a.target = "sched*";
-  a.func = "sched_*";
-  a.need_expansion = true;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
-
+  auto probe = parse_probe(("tracepoint:sched*:sched_* {}"));
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace,
               get_symbols_from_file(
                   "/sys/kernel/debug/tracing/available_events"))
       .Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(3U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 
@@ -726,6 +593,8 @@ TEST(bpftrace, add_probes_tracepoint_category_wildcard)
 
 TEST(bpftrace, add_probes_tracepoint_wildcard_no_matches)
 {
+  auto probe = parse_probe("tracepoint:type:typo_* {}");
+  /*
   ast::AttachPoint a("");
   a.provider = "tracepoint";
   a.target = "typo";
@@ -733,29 +602,32 @@ TEST(bpftrace, add_probes_tracepoint_wildcard_no_matches)
   a.need_expansion = true;
   ast::AttachPointList attach_points = { &a };
   ast::Probe probe(&attach_points, nullptr, nullptr);
-
+*/
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace,
       get_symbols_from_file("/sys/kernel/debug/tracing/available_events"))
     .Times(1);
 
-  ASSERT_EQ(0, bpftrace->add_probe(probe));
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(0U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 }
 
 TEST(bpftrace, add_probes_profile)
 {
+  /*
   ast::AttachPoint a("");
   a.provider = "profile";
   a.target = "ms";
   a.freq = 997;
   ast::AttachPointList attach_points = { &a };
   ast::Probe probe(&attach_points, nullptr, nullptr);
+  */
+  auto probe = parse_probe("profile:ms:997 {}");
 
   StrictMock<MockBPFtrace> bpftrace;
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
 
@@ -765,16 +637,17 @@ TEST(bpftrace, add_probes_profile)
 
 TEST(bpftrace, add_probes_interval)
 {
-  ast::AttachPoint a("");
-  a.provider = "interval";
-  a.target = "s";
-  a.freq = 1;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  // ast::AttachPoint a("");
+  // a.provider = "interval";
+  // a.target = "s";
+  // a.freq = 1;
+  // ast::AttachPointList attach_points = { &a };
+  // ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto probe = parse_probe("i:s:1 {}");
 
   StrictMock<MockBPFtrace> bpftrace;
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
 
@@ -784,16 +657,17 @@ TEST(bpftrace, add_probes_interval)
 
 TEST(bpftrace, add_probes_software)
 {
-  ast::AttachPoint a("");
-  a.provider = "software";
-  a.target = "faults";
-  a.freq = 1000;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  // ast::AttachPoint a("");
+  // a.provider = "software";
+  // a.target = "faults";
+  // a.freq = 1000;
+  // ast::AttachPointList attach_points = { &a };
+  // ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto probe = parse_probe("software:faults:1000 {}");
 
   StrictMock<MockBPFtrace> bpftrace;
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
 
@@ -803,16 +677,17 @@ TEST(bpftrace, add_probes_software)
 
 TEST(bpftrace, add_probes_hardware)
 {
-  ast::AttachPoint a("");
-  a.provider = "hardware";
-  a.target = "cache-references";
-  a.freq = 1000000;
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  // ast::AttachPoint a("");
+  // a.provider = "hardware";
+  // a.target = "cache-references";
+  // a.freq = 1000000;
+  // ast::AttachPointList attach_points = { &a };
+  // ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto probe = parse_probe("hardware:cache-references:1000000 {}");
 
   StrictMock<MockBPFtrace> bpftrace;
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
 
@@ -822,15 +697,14 @@ TEST(bpftrace, add_probes_hardware)
 
 TEST(bpftrace, invalid_provider)
 {
-  ast::AttachPoint a("");
-  a.provider = "lookatme";
-  a.func = "invalid";
-  ast::AttachPointList attach_points = { &a };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  auto a = new ast::AttachPoint("");
+  a->provider = "lookatme";
+  a->func = "invalid";
+  auto probe = make_probe({ a });
 
   StrictMock<MockBPFtrace> bpftrace;
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
 }
 
 std::pair<std::vector<uint8_t>, std::vector<uint8_t>> key_value_pair_int(std::vector<uint64_t> key, int val)
@@ -1053,18 +927,11 @@ void check_kfunc(Probe &p, ProbeType type, const std::string &name)
 
 TEST_F(bpftrace_btf, add_probes_kfunc)
 {
-  ast::AttachPoint a("");
-  a.provider = "kfunc";
-  a.target = "func_1";
-  ast::AttachPoint b("");
-  b.provider = "kretfunc";
-  b.target = "func_1";
-  ast::AttachPointList attach_points = { &a, &b };
-  ast::Probe probe(&attach_points, nullptr, nullptr);
+  ast::Probe *probe = parse_probe("kfunc:func_1,kretfunc:func_1 {}");
 
   StrictMock<MockBPFtrace> bpftrace;
 
-  ASSERT_EQ(0, bpftrace.add_probe(probe));
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(2U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
 


### PR DESCRIPTION
 #1627 was accidentally merged

----

These fix some of the memory leaks we have, mostly a rebase of #1055.

To avoid memory leaks and ownership issue this also defines shallow copy constructors for each node and marks them as private. This makes it impossible to accidentally copy the object and have two objects point to the same memory, which can lead to double frees. If you really want a shallow copy you can use the copy() method. A deep copy is possible, but not implemented as I didn't need it.


