### PR TITLE
types: (hacky) fix sizedtype memleak with shared_ptr

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -328,7 +328,7 @@ SizedType CreateArray(size_t num_elements, const SizedType &element_type)
 {
   auto ty = SizedType(Type::array, num_elements);
   ty.num_elements_ = num_elements;
-  ty.element_type_ = new SizedType(element_type);
+  ty.element_type_ = std::make_shared<SizedType>(element_type);
   return ty;
 }
 
@@ -336,7 +336,7 @@ SizedType CreatePointer(const SizedType &pointee_type, AddrSpace as)
 {
   // Pointer itself is always an uint64
   auto ty = SizedType(Type::pointer, 8);
-  ty.element_type_ = new SizedType(pointee_type);
+  ty.element_type_ = std::make_shared<SizedType>(pointee_type);
   ty.SetAS(as);
   return ty;
 }

--- a/src/types.h
+++ b/src/types.h
@@ -101,8 +101,8 @@ public:
 private:
   size_t size_; // in bytes
   bool is_signed_ = false;
-  SizedType *element_type_ = nullptr; // for "container" and pointer
-                                      // (like) types
+  std::shared_ptr<SizedType> element_type_; // for "container" and pointer
+                                            // (like) types
   size_t num_elements_;               // for array like types
   std::string name_; // name of this type, for named types like struct
   bool ctx_ = false; // Is bpf program context
@@ -204,13 +204,13 @@ public:
   const SizedType *GetElementTy() const
   {
     assert(IsArrayTy());
-    return element_type_;
+    return element_type_.get();
   }
 
   const SizedType *GetPointeeTy() const
   {
     assert(IsPtrTy());
-    return element_type_;
+    return element_type_.get();
   }
 
   bool IsBoolTy() const


### PR DESCRIPTION
Switching to shared_pointers is a bit of a hack and not really doing
proper memory management. We're still risk accidentally modifying the
object we're pointing too and changing the containing type of an
array/pointer. But it shouldn't be any worse than it is now an it
reduces the amount of leaks significantly, which make using the ASAN
output a lot easier.


