### PR TITLE
Prevent crash with /proc path canonicalization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -114,6 +114,8 @@ and this project adheres to
   - [#1622](https://github.com/iovisor/bpftrace/pull/1622)
 - Check exponent value can be expressed in uint64_t
   - [#1623](https://github.com/iovisor/bpftrace/pull/1623)
+- Fix tracing of usdt probes across namespaces
+  - [#1637](https://github.com/iovisor/bpftrace/pull/1637)
 
 #### Tools
 - Hook up execsnoop.bt script onto `execveat` call

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -87,6 +87,17 @@ static void symlink_test_binary(const std::string& destination)
   }
 }
 
+static std::string get_working_path()
+{
+  char cwd_path[PATH_MAX];
+  if (::getcwd(cwd_path, PATH_MAX) == nullptr)
+  {
+    throw std::runtime_error(
+        "getting current working directory for tests failed");
+  }
+  return std::string(cwd_path);
+}
+
 TEST(utils, resolve_binary_path)
 {
   std::string path = "/tmp/bpftrace-test-utils-XXXXXX";
@@ -129,6 +140,35 @@ TEST(utils, parse_exponent)
   EXPECT_EQ(parse_exponent((const char*)"010e010"), 1e11);
 
   EXPECT_EQ(parse_exponent((const char*)"2a9"), 2ULL);
+}
+
+TEST(utils, abs_path)
+{
+  std::string path = "/tmp/bpftrace-test-utils-XXXXXX";
+  std::string rel_file = "bpftrace-test-utils-abs-path";
+  if (::mkdtemp(&path[0]) == nullptr)
+  {
+    throw std::runtime_error("creating temporary path for tests failed");
+  }
+
+  int fd;
+  fd = open((path + "/somefile").c_str(), O_CREAT, S_IRUSR);
+  close(fd);
+  fd = open(rel_file.c_str(), O_CREAT, S_IRUSR);
+  close(fd);
+
+  // Translates absolute path with '../..'
+  EXPECT_EQ(abs_path(path + "/../.." + path + "/somefile"), path + "/somefile");
+  // Translates relative path with './'
+  EXPECT_EQ(abs_path("./" + rel_file), get_working_path() + "/" + rel_file);
+
+  // /proc/<pid>/root path returned as is (and doesn't throw)
+  EXPECT_NO_THROW(
+      abs_path(std::string("/proc/1/root/usr/local/bin/usdt_test.so")));
+  EXPECT_EQ(abs_path(std::string("/proc/1/root/usr/local/bin/usdt_test.so")),
+            std::string("/proc/1/root/usr/local/bin/usdt_test.so"));
+
+  remove(rel_file.c_str());
 }
 
 } // namespace utils


### PR DESCRIPTION
#### Issue

Attempting to trace an executable (with either namespace relative, or /proc rooted path) that is in a different mount namespace than the one bpftrace is running in fails.

```
# bpftrace -e 'usdt:/proc/92493/root/home/usdt_test:tracetest:testprobe { printf("hit\n")}' -p 92493
ERROR: failed to write elf: filesystem error: cannot canonicalize: No such file or directory [/proc/92493/root/home/usdt_test] [/bcc-build/bpftrace/build]

# bpftrace -e 'usdt:/home/usdt_test:tracetest:testprobe { printf("hit\n")}' -p 92493
ERROR: failed to write elf: filesystem error: cannot canonicalize: No such file or directory [/proc/92493/root/home/usdt_test] [/bcc-build/bpftrace/build]
```

#### Cause
The reason is attempting to perform `filesystem::canonical('/proc/<pid>/root/usr/bin/..')` to a proc path of a pid that is in a different mount namespace fails with `No such file or directory`. (it looks like canonical() [does an lstat](https://gist.github.com/xdrop/0c98611c28115e653d737ad7c006a18e#file-strace-bpftrace-1-L839) on the current root instead and doesn't find the file there)


#### Call stack
The call originates from `abs_path`, and this is the call stack before it blows up:
```
* thread #1, name = 'bpftrace', stop reason = breakpoint 1.1
  * frame #0: 0x000055555565dd52 bpftrace`bpftrace::abs_path(rel_path="p~\xb9UUU"...) at utils.cpp:927
    frame #1: 0x00005555555c2ed6 bpftrace`_ZNK8bpftrace8BPFtrace21find_wildcard_matchesB5cxx11ERKNS_3ast11AttachPointE(this=0x00007fffffffe120, attach_point=0x0000555555b80bf0) at bpftrace.cpp:406
    frame #2: 0x000055555569250e bpftrace`bpftrace::ast::CodegenLLVM::visit(this=0x00007fffffffdd60, probe=0x0000555555b11fb0) at codegen_llvm.cpp:2139
    frame #3: 0x0000555555676ff8 bpftrace`bpftrace::ast::Probe::accept(this=0x0000555555b11fb0, v=0x00007fffffffdd60) at ast.cpp:41
    frame #4: 0x00005555556987a5 bpftrace`bpftrace::ast::CodegenLLVM::accept(this=0x00007fffffffdd60, node=0x0000555555b11fb0) at codegen_llvm.cpp:2819
    frame #5: 0x0000555555692e52 bpftrace`bpftrace::ast::CodegenLLVM::visit(this=0x00007fffffffdd60, program=0x00007fffe4015fd0) at codegen_llvm.cpp:2228
    frame #6: 0x000055555567702c bpftrace`bpftrace::ast::Program::accept(this=0x00007fffe4015fd0, v=0x00007fffffffdd60) at ast.cpp:42
    frame #7: 0x00005555556987a5 bpftrace`bpftrace::ast::CodegenLLVM::accept(this=0x00007fffffffdd60, node=0x00007fffe4015fd0) at codegen_llvm.cpp:2819
    frame #8: 0x000055555569808b bpftrace`bpftrace::ast::CodegenLLVM::generate_ir(this=0x00007fffffffdd60) at codegen_llvm.cpp:2723
    frame #9: 0x0000555555668fc8 bpftrace`main(argc=5, argv=0x00007fffffffe688) at main.cpp:787
    frame #10: 0x00007fffed11dbf7 libc.so.6`__libc_start_main(main=(bpftrace`main at main.cpp:272), argc=5, argv=0x00007fffffffe688, init=<unavailable>, fini=<unavailable>, rtld_fini=<unavailable>, stack_end=0x00007fffffffe678) at libc-start.c:310
    frame #11: 0x0000555555579aaa bpftrace`_start + 42
```

#### Fix

The fix is to give up trying to canonicalize `/proc` based baths. That of course means something like tracing `/proc/92493/root/home/../home/usdt_test` will not work (it doesn't event work now anyway), but I don't see a strong use case for trying to support canonicalization of /proc based paths.

##### Checklist

- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
