### PR TITLE
Support clear() and delete() on a count()-based map without key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,8 @@ and this project adheres to
   - [#1658](https://github.com/iovisor/bpftrace/pull/1658)
 - Don't create a tuple if an element size if zero
   - [#1653](https://github.com/iovisor/bpftrace/pull/1653)
+- Support clear() and delete() on a count()-based map without a key
+  - [#1639](https://github.com/iovisor/bpftrace/pull/1639)
 
 #### Tools
 - Hook up execsnoop.bt script onto `execveat` call

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1266,6 +1266,9 @@ int BPFtrace::print_maps()
 // clear a map
 int BPFtrace::clear_map(IMap &map)
 {
+  if (!map.is_clearable())
+    return zero_map(map);
+
   std::vector<uint8_t> old_key;
   try
   {

--- a/src/imap.h
+++ b/src/imap.h
@@ -27,6 +27,11 @@ public:
     return map_type_ == BPF_MAP_TYPE_PERCPU_HASH ||
            map_type_ == BPF_MAP_TYPE_PERCPU_ARRAY;
   }
+  bool is_clearable() const
+  {
+    return map_type_ != BPF_MAP_TYPE_ARRAY &&
+           map_type_ != BPF_MAP_TYPE_PERCPU_ARRAY;
+  }
 
   // unique id of this map. Used by (bpf) runtime to reference
   // this map

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -136,6 +136,16 @@ RUN bpftrace -e "$(echo '#define _UNDERSCORE 314'; echo 'BEGIN { printf("%d\\n",
 EXPECT 314
 TIMEOUT 1
 
+NAME clear map
+RUN bpftrace -e 'BEGIN { @ = 1; @a[1] = 1; clear(@); clear(@a); printf("ok\n"); exit(); }'
+EXPECT ok
+TIMEOUT 1
+
+NAME clear count-map
+RUN bpftrace -e 'BEGIN { @ = count(); @a[1] = count(); clear(@); clear(@a); exit(); }'
+EXPECT @: 0
+TIMEOUT 1
+
 NAME increment/decrement map
 RUN bpftrace -e 'BEGIN { @x = 10; printf("%d", @x++); printf(" %d", ++@x); printf(" %d", @x--); printf(" %d\n", --@x); delete(@x); exit(); }'
 EXPECT 10 12 12 10

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -146,6 +146,16 @@ RUN bpftrace -e 'BEGIN { @ = count(); @a[1] = count(); clear(@); clear(@a); exit
 EXPECT @: 0
 TIMEOUT 1
 
+NAME delete map
+RUN bpftrace -e 'BEGIN { @ = 1; @a[1] = 1; delete(@); delete(@a[1]); printf("ok\n"); exit(); }'
+EXPECT ok
+TIMEOUT 1
+
+NAME delete count-map
+RUN bpftrace -e 'BEGIN { @ = count(); @a[1] = count(); delete(@); delete(@a[1]); exit(); }'
+EXPECT @: 0
+TIMEOUT 1
+
 NAME increment/decrement map
 RUN bpftrace -e 'BEGIN { @x = 10; printf("%d", @x++); printf(" %d", ++@x); printf(" %d", @x--); printf(" %d\n", --@x); delete(@x); exit(); }'
 EXPECT 10 12 12 10


### PR DESCRIPTION
439a6bc changes so that count()-based map with no arguments uses
BPF_MAP_TYPE_PERCPU_ARRAY for the performance. The problem is crear()
uses bpf_map_delete_elem(), but ARRAY-typed maps cannot be deleted.
To solve this, suggested by fbs in #1350 (comment),
use zero() internally in clear() if a map type is array.

Like clear(), delete() also does not work for count()-based map (please
see the previous commit message for the details.) To fix this, instead
calling bpf_map_delete_elem() when delete(), call bpf_mpa_updat_elem()
and update the map value with zero.

Closes #1350 

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
