### PR TITLE
Glob memleak

### DIFF
--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -71,7 +71,10 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
           }
 
           if (probe->tp_args_structs_level <= 0)
+          {
+            globfree(&glob_result);
             continue;
+          }
 
           for (size_t i = 0; i < glob_result.gl_pathc; ++i) {
             std::string filename(glob_result.gl_pathv[i]);


### PR DESCRIPTION
This fixes a glob memory leak. We short circuit the loop but don't clean up the glob object. This is only triggered for scripts that have a wildcard tracepoint and  `need_tp_args_structs == false`.

As the whole function was a bit long and hard to read with all the nesting I've split it into parts.