### PR TITLE
tests/semantic: Add architecture specific testcase support

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -120,6 +120,18 @@ if(LIBBCC_ATTACH_UPROBE_SEVEN_ARGS_SIGNATURE)
   target_compile_definitions(bpftrace_test PRIVATE LIBBCC_ATTACH_UPROBE_SEVEN_ARGS_SIGNATURE)
 endif(LIBBCC_ATTACH_UPROBE_SEVEN_ARGS_SIGNATURE)
 
+if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
+  target_compile_definitions(bpftrace_test PRIVATE ARCH_AARCH64)
+elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64" OR
+       CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64le")
+  target_compile_definitions(bpftrace_test PRIVATE ARCH_PPC64)
+elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "s390" OR
+       CMAKE_SYSTEM_PROCESSOR STREQUAL "s390x")
+  target_compile_definitions(bpftrace_test PRIVATE ARCH_S390)
+elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+  target_compile_definitions(bpftrace_test PRIVATE ARCH_X86_64)
+endif()
+
 target_link_libraries(bpftrace_test arch ast parser resources)
 
 target_link_libraries(bpftrace_test ${LIBBCC_LIBRARIES})

--- a/tests/codegen/call_reg.cpp
+++ b/tests/codegen/call_reg.cpp
@@ -4,12 +4,14 @@ namespace bpftrace {
 namespace test {
 namespace codegen {
 
+#ifdef ARCH_X86_64
 TEST(codegen, call_reg) // Identical to builtin_func apart from variable names
 {
   test("kprobe:f { @x = reg(\"ip\") }",
 
        NAME);
 }
+#endif
 
 } // namespace codegen
 } // namespace test

--- a/tests/codegen/intptrcast_assign_var.cpp
+++ b/tests/codegen/intptrcast_assign_var.cpp
@@ -4,10 +4,12 @@ namespace bpftrace {
 namespace test {
 namespace codegen {
 
+#ifdef ARCH_X86_64
 TEST(codegen, intptrcast_assign_var)
 {
   test("kretprobe:f { @=*(int8*)(reg(\"bp\")-1) }", NAME);
 }
+#endif
 
 } // namespace codegen
 } // namespace test

--- a/tests/codegen/intptrcast_call.cpp
+++ b/tests/codegen/intptrcast_call.cpp
@@ -4,11 +4,13 @@ namespace bpftrace {
 namespace test {
 namespace codegen {
 
+#ifdef ARCH_X86_64
 TEST(codegen, intptrcast_call)
 {
   // Casting should work inside a call
   test("kretprobe:f { @=sum(*(int8*)(reg(\"bp\")-1)) }", NAME);
 }
+#endif
 
 } // namespace codegen
 } // namespace test

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -198,7 +198,9 @@ TEST(semantic_analyser, builtin_functions)
   test("kprobe:f { kaddr(\"sym\") }", 0);
   test("kprobe:f { ntop(0xffff) }", 0);
   test("kprobe:f { ntop(2, 0xffff) }", 0);
+#ifdef ARCH_X86_64
   test("kprobe:f { reg(\"ip\") }", 0);
+#endif
   test("kprobe:f { kstack(1) }", 0);
   test("kprobe:f { ustack(1) }", 0);
   test("kprobe:f { cat(\"/proc/uptime\") }", 0);
@@ -728,8 +730,10 @@ TEST(semantic_analyser, call_cgroupid)
 
 TEST(semantic_analyser, call_reg)
 {
+#ifdef ARCH_X86_64
   test("kprobe:f { reg(\"ip\"); }", 0);
   test("kprobe:f { @x = reg(\"ip\"); }", 0);
+#endif
   test("kprobe:f { reg(\"blah\"); }", 1);
   test("kprobe:f { reg(); }", 1);
   test("kprobe:f { reg(123); }", 1);


### PR DESCRIPTION
commit 48d405133160 ("bpftrace: Add architecture specific testcase
support") added architecture specific support for runtime tests.
Still there are architecture specific testcases in semantic_analyser,
where 'ip' register is hard coded in semantic_analyser.call_reg and
semantic_analyser.builtin_functions.

These testcases are all c/c++ files and thus we need conditional compiling.

Signed-off-by: Jeffle Xu <jefflexu@linux.alibaba.com>

#1137 had ever noted that some architecture specific test cases are hard coded, and thus will fail in some architectures not supported.

- some runtime-test had been fixed by  commit 48d405133160 ("bpftrace: Add architecture specific testcase support")
- opensnoop/statsnoop in tools-parsing-test had been fixed by commit 330953c11190c23a12f98d374d1b5eb6d7aad1fe ("fix build failed on aarch64")

This patch is supposed to fix the failure in semantic_analyser.builtin_functions, semantic_analyser.call_reg.


##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
