### PR TITLE
Use unsigned in bitfield_test.c

### DIFF
--- a/tests/testprogs/bitfield_test.c
+++ b/tests/testprogs/bitfield_test.c
@@ -9,8 +9,8 @@ struct Foo
 
 struct Bar
 {
-  short a : 4, b : 8, c : 3, d : 1;
-  int e : 9, f : 15, g : 1, h : 2, i : 5;
+  unsigned short a : 4, b : 8, c : 3, d : 1;
+  unsigned int e : 9, f : 15, g : 1, h : 2, i : 5;
 };
 
 __attribute__((noinline)) unsigned int func(struct Foo *foo)


### PR DESCRIPTION
This suppresses the following clang warnings

```
/disk/work/bpftrace/tests/testprogs/bitfield_test.c:36:9: warning: implicit truncation from 'int' to bit-field changes value from 217 to -39 [-Wbitfield-constant-conversion]
  bar.b = 217;
        ^ ~~~
[...]
```


##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
