### PR TITLE
bpftrace: Fix list probes by pids tests

### DIFF
--- a/tests/runtime/engine/utils.py
+++ b/tests/runtime/engine/utils.py
@@ -161,13 +161,16 @@ class Utils(object):
                     # a test program needs to accept arguments. It covers the
                     # current simple calls with no arguments
                     child_name = os.path.basename(test.before.split()[-1])
-                    while subprocess.call(["pidof", child_name], stdout=dn, stderr=dn) != 0:
+                    while subprocess.call(["pidof", "-s", child_name], stdout=dn, stderr=dn) != 0:
                         time.sleep(0.1)
                         waited+=0.1
                         if waited > test.timeout:
                             raise TimeoutError('Timed out waiting for BEFORE %s ', test.before)
 
             bpf_call = Utils.prepare_bpf_call(test)
+            if test.before:
+                childpid = subprocess.Popen(["pidof", "-s", child_name], stdout=subprocess.PIPE, universal_newlines=True).communicate()[0].strip()
+                bpf_call = re.sub("{{BEFORE_PID}}", str(childpid), bpf_call)
             env = {'test': test.name}
             env.update(test.env)
             p = subprocess.Popen(

--- a/tests/runtime/uprobe
+++ b/tests/runtime/uprobe
@@ -24,25 +24,25 @@ EXPECT uprobe:./testprogs/uprobe_test:function1
 TIMEOUT 5
 
 NAME "uprobes - list probes by pid"
-RUN bpftrace -l -p $(pidof uprobe_test) | grep -e '^uprobe'
+RUN bpftrace -l -p {{BEFORE_PID}} | grep -e '^uprobe'
 EXPECT uprobe:.*/testprogs/uprobe_test:function1
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME "uprobes - list probes by pid; uprobes only"
-RUN bpftrace -l 'uprobe:*' -p $(pidof uprobe_test)
+RUN bpftrace -l 'uprobe:*' -p {{BEFORE_PID}}
 EXPECT uprobe:.*/testprogs/uprobe_test:function1
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME "uprobes - list probes by pid in separate mount namespace"
-RUN bpftrace -l -p $(pidof uprobe_test) | grep -e '^uprobe'
+RUN bpftrace -l -p {{BEFORE_PID}} | grep -e '^uprobe'
 EXPECT uprobe:.*/bpftrace-unshare-mountns-test/uprobe_test:function1
 TIMEOUT 5
 BEFORE ./testprogs/mountns_wrapper uprobe_test
 
 NAME "uprobes - attach to probe for executable in separate mount namespace"
-RUN bpftrace -e 'uprobe:/tmp/bpftrace-unshare-mountns-test/uprobe_test:function1 { printf("here\n" ); exit(); }' -p $(pidof uprobe_test)
+RUN bpftrace -e 'uprobe:/tmp/bpftrace-unshare-mountns-test/uprobe_test:function1 { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT Attaching 1 probe...
 TIMEOUT 5
 BEFORE ./testprogs/mountns_wrapper uprobe_test

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -5,7 +5,7 @@ TIMEOUT 5
 REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - list probes by pid"
-RUN bpftrace -l 'usdt:*' -p $(pidof usdt_test)
+RUN bpftrace -l 'usdt:*' -p {{BEFORE_PID}}
 EXPECT usdt_test:tracetest:testprobe
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
@@ -18,7 +18,7 @@ TIMEOUT 5
 REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - filter probes by pid on provider"
-RUN bpftrace -l 'usdt:*:tracetest2:*' -p $(pidof usdt_test)
+RUN bpftrace -l 'usdt:*:tracetest2:*' -p {{BEFORE_PID}}
 EXPECT usdt_test:tracetest2:testprobe2
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
@@ -37,7 +37,7 @@ TIMEOUT 5
 REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - filter probes by pid and wildcard probe name"
-RUN bpftrace -l 'usdt:*:tracetest:test*' -p $(pidof usdt_test)
+RUN bpftrace -l 'usdt:*:tracetest:test*' -p {{BEFORE_PID}}
 EXPECT usdt_test:tracetest:testprobe2
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
@@ -56,7 +56,7 @@ EXPECT here
 TIMEOUT 5
 
 NAME "usdt probes - attach to fully specified probe by pid"
-RUN bpftrace -e 'usdt::tracetest:testprobe { printf("here\n" ); exit(); }' -p $(pidof usdt_test)
+RUN bpftrace -e 'usdt::tracetest:testprobe { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT here
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
@@ -83,7 +83,7 @@ TIMEOUT 5
 #  - Fix https://github.com/iovisor/bpftrace/issues/565#issuecomment-496731112
 #    and https://github.com/iovisor/bpftrace/issues/688
 NAME "usdt probes - all probes by wildcard and pid"
-RUN bpftrace -e 'usdt:* { printf("here\n" ); exit(); }' -p $(pidof usdt_test)
+RUN bpftrace -e 'usdt:* { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT Attaching 3 probes...
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
@@ -120,7 +120,7 @@ EXPECT Attaching 9 probes...
 TIMEOUT 5
 
 NAME "usdt probes - attach to probe on multiple providers by wildcard and pid"
-RUN bpftrace -e 'usdt:::*probe2 { printf("here\n" ); exit(); }' -p $(pidof usdt_test)
+RUN bpftrace -e 'usdt:::*probe2 { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT Attaching 2 probes...
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
@@ -143,7 +143,7 @@ REQUIRES bash -c "exit 1"
 # we should:
 #  - Skip if bcc doesn't support multiple probes with the same name
 NAME "usdt probes - attach to probe with args by pid"
-RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("%s\n", str(arg1) ); exit(); }' -p $(pidof usdt_test)
+RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("%s\n", str(arg1) ); exit(); }' -p {{BEFORE_PID}}
 EXPECT Hello world
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
@@ -163,14 +163,14 @@ EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe
 TIMEOUT 5
 
 NAME "usdt probes - attach to probe with probe builtin and args by pid"
-RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }' -p $(pidof usdt_test)
+RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }' -p {{BEFORE_PID}}
 EXPECT usdt_test:tracetest:testprobe
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - attach to probe with semaphore"
-RUN bpftrace -e 'usdt::tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }' -p $(pidof usdt_semaphore_test)
+RUN bpftrace -e 'usdt::tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }' -p {{BEFORE_PID}}
 EXPECT tracetest_testprobe_semaphore: [1-9]
 TIMEOUT 5
 BEFORE ./testprogs/usdt_semaphore_test
@@ -217,7 +217,7 @@ BEFORE ./testprogs/usdt_semaphore_test & ./testprogs/usdt_semaphore_test
 REQUIRES ./testprogs/usdt_semaphore_test should_not_skip
 
 NAME "usdt probes - list probes by pid in separate mountns"
-RUN bpftrace -l 'usdt:*' -p $(pidof usdt_test)
+RUN bpftrace -l 'usdt:*' -p {{BEFORE_PID}}
 EXPECT usdt:.*/tmp/bpftrace-unshare-mountns-test/usdt_test:tracetest:testprobe
 TIMEOUT 5
 BEFORE ./testprogs/mountns_wrapper usdt_test
@@ -226,21 +226,21 @@ BEFORE ./testprogs/mountns_wrapper usdt_test
 # This test relies on the latest version of bcc (expected to be released as 0.13.0)
 # Once we build against this version with USDT fixes, we should re-enable this test.
 NAME "usdt probes - attach to fully specified probe by pid in separate mountns"
-RUN bpftrace -e 'usdt:/tmp/bpftrace-unshare-mountns-test/usdt_test:tracetest:testprobe { printf("here\n" ); exit(); }' -p $(pidof usdt_test)
+RUN bpftrace -e 'usdt:/tmp/bpftrace-unshare-mountns-test/usdt_test:tracetest:testprobe { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT here
 TIMEOUT 5
 BEFORE ./testprogs/mountns_wrapper usdt_test
 REQUIRES bash -c "exit 1"
 
 NAME "usdt quoted probe name"
-RUN bpftrace -e 'usdt:./testprogs/usdt_quoted_probe:test:"\"probe1\"" { printf("%d\n", arg0); exit(); }' -p $(pidof usdt_quoted_probe)
+RUN bpftrace -e 'usdt:./testprogs/usdt_quoted_probe:test:"\"probe1\"" { printf("%d\n", arg0); exit(); }' -p {{BEFORE_PID}}
 EXPECT 1
 TIMEOUT 5
 BEFORE ./testprogs/usdt_quoted_probe
 REQUIRES ./testprogs/usdt_quoted_probe should_not_skip
 
 NAME "usdt sized arguments"
-RUN bpftrace -e 'usdt:./testprogs/usdt_sized_args:test:probe2 { printf("%ld\n", arg0); exit(); }' -p $(pidof usdt_sized_args)
+RUN bpftrace -e 'usdt:./testprogs/usdt_sized_args:test:probe2 { printf("%ld\n", arg0); exit(); }' -p {{BEFORE_PID}}
 EXPECT ^1$
 TIMEOUT 5
 BEFORE ./testprogs/usdt_sized_args


### PR DESCRIPTION
List by pid fails on Fedora 33, as two pids are returned for
uprobe_test, usdt_test.

root      173886  173874  0 10:12 ?        00:00:00 [uprobe_test] \<defunct\>
root      173896  173874  0 10:12 ?        00:00:00 ./testprogs/uprobe_test

pidof uprobe_test returns : 173896 173886

I could see these two pids in x86 as well. However, on s390x, pidof sometimes returns 2 pids, which result in failure

This results in Usage error for listing usecase, as getopt_long expects
just one pid in -p.

Fix this by returning just one pid. pidof -s seems to return the latest
pid. i.e testprogs/uprobe_test.
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
