### PR TITLE
Check a call function is available for a probe type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,8 @@ and this project adheres to
   - [#1623](https://github.com/iovisor/bpftrace/pull/1623)
 - Fix tracing of usdt probes across namespaces
   - [#1637](https://github.com/iovisor/bpftrace/pull/1637)
+- Disable reg() for kfunc 
+  - [#1646](https://github.com/iovisor/bpftrace/pull/1646)
 
 #### Tools
 - Hook up execsnoop.bt script onto `execveat` call

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -79,6 +79,7 @@ private:
                  bool want_literal = false,
                  bool fail = true);
   bool check_symbol(const Call &call, int arg_num);
+  bool check_available(const Call &call, ProbeType type);
 
   void check_stack_call(Call &call, bool kernel);
 

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -79,7 +79,7 @@ private:
                  bool want_literal = false,
                  bool fail = true);
   bool check_symbol(const Call &call, int arg_num);
-  bool check_available(const Call &call, ProbeType type);
+  bool check_available(const Call &call, const AttachPoint &ap);
 
   void check_stack_call(Call &call, bool kernel);
 

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -40,7 +40,7 @@ public:
     {
       return -1;
     }
-    else if (name[0] > 'A' && name[0] < 'z')
+    else if (name[0] >= 'A' && name[0] <= 'z')
     {
       sym->address = 12345;
       sym->size = 4;

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2042,6 +2042,11 @@ TEST_F(semantic_analyser_btf, kfunc)
   // func_* have different args, one of them
   // is used in probe code, we can't continue -> FAIL
   test("kfunc:func_* { $x = args->foo1; }", 0, true, false, 1);
+  // reg() is not available in kfunc
+#ifdef ARCH_X86_64
+  test("kfunc:func_1 { reg(\"ip\") }", 1);
+  test("kretfunc:func_1 { reg(\"ip\") }", 1);
+#endif
 }
 
 TEST_F(semantic_analyser_btf, short_name)


### PR DESCRIPTION
Some call functions (e.g., `reg()`) is not available for some probe types. To check this, add `check_available(call, type)` function. This function returns true if the call is available for that type. Also, disable `reg()` in k(ret)func using this function. Previously that is mistakenly allowed and resulted in invalid BPF codes.


##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
