### PR TITLE
Delete driver.root_ when failing parse

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -49,9 +49,18 @@ int Driver::parse()
   parser.parse();
   yylex_destroy(scanner);
 
-  ast::AttachPointParser ap_parser(root_, bpftrace_, out_);
-  if (ap_parser.parse())
-    failed_ = true;
+  if (!failed_)
+  {
+    ast::AttachPointParser ap_parser(root_, bpftrace_, out_);
+    if (ap_parser.parse())
+      failed_ = true;
+  }
+
+  if (failed_)
+  {
+    delete root_;
+    root_ = nullptr;
+  }
 
   // Keep track of errors thrown ourselves, since the result of
   // parser_->parse() doesn't take scanner errors into account,


### PR DESCRIPTION
First I created this to try to fix https://github.com/iovisor/bpftrace/pull/1650#issuecomment-733232881, but this does not fix it. However, I accidentally realized that this solves #1634 since it does not try to parse attachpoint when failing the first parse. I think this patch does not have bad side effects. So to fix 1634 I created this PR.

Closes #1634

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
