### PR TITLE
bpftrace: Correct ntop tests for BE and add more tests

### DIFF
--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -193,6 +193,13 @@ TIMEOUT 5
 NAME ntop static ip
 RUN bpftrace -v -e 'i:ms:100 { printf("IP: %s, %s, %s, %s\n", ntop(1), ntop(0x0100007f), ntop(0xffff0000), ntop(0x0000ffff)); exit() }'
 EXPECT IP: 1.0.0.0, 127.0.0.1, 0.0.255.255, 255.255.0.0
+ARCH x86_64|aarch64|ppc64le
+TIMEOUT 5
+
+NAME ntop static ip
+RUN bpftrace -v -e 'i:ms:100 { printf("IP: %s, %s, %s, %s\n", ntop(0x01000000), ntop(0x7f000001), ntop(0x0000ffff), ntop(0xffff0000)); exit() }'
+EXPECT IP: 1.0.0.0, 127.0.0.1, 0.0.255.255, 255.255.0.0
+ARCH s390x|ppc64
 TIMEOUT 5
 
 NAME usym


### PR DESCRIPTION
- Ideally ntop should take the arguments in network byte order. However,
ntop function is normally used in tcp_connect or so, which already
provides the address in network byte order. Hence just adjust the
testcase.

Signed-off-by: Sumanth Korikkar <sumanthk@linux.ibm.com>

Thanks

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
