### PR TITLE
Don't create a tuple if an element size if zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -126,6 +126,8 @@ and this project adheres to
   - [#1645](https://github.com/iovisor/bpftrace/pull/1645)
 - Fix invalid size crash when using strftime() inside a tuple
   - [#1658](https://github.com/iovisor/bpftrace/pull/1658)
+- Don't create a tuple if an element size if zero
+  - [#1653](https://github.com/iovisor/bpftrace/pull/1653)
 
 #### Tools
 - Hook up execsnoop.bt script onto `execveat` call

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -162,5 +162,6 @@ parallel -N1 "sed -e '/^#\!/d' -e '/\/\*.*/d' -e '/^\s\*.*/d' -e '/\/\/.*/d' -e 
 - [#1205](https://github.com/iovisor/bpftrace/pull/1205)
 
 ### libFuzzer
+- [#1653](https://github.com/iovisor/bpftrace/pull/1653)
 - [#1621](https://github.com/iovisor/bpftrace/pull/1621)
 - [#1622](https://github.com/iovisor/bpftrace/pull/1622)

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1991,7 +1991,7 @@ void SemanticAnalyser::visit(Tuple &tuple)
     // If elem type is none that means that the tuple contains some
     // invalid cast (e.g., (0, (aaa)0)). In this case, skip the tuple
     // creation. Cast already emits the error.
-    if (elem->type.IsNoneTy())
+    if (elem->type.IsNoneTy() || elem->type.GetSize() == 0)
       return;
     elements.emplace_back(elem->type);
   }

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1906,6 +1906,7 @@ TEST(semantic_analyser, tuple)
   test(R"_(BEGIN { @t = (1, 2); @t = 5; })_", 1);
   test(R"_(BEGIN { @t = (1, count()) })_", 1);
   test(R"_(BEGIN { @t = (1, (aaa)0) })_", 1);
+  test(R"_(BEGIN { @t = (1, !(aaa)0) })_", 1);
 }
 
 TEST(semantic_analyser, tuple_indexing)


### PR DESCRIPTION
I though #1572 fixes the issue of invalid tuple creation, but there is
another issue. libfuzzer found the following:

```
% sudo ./src/bpftrace -e 'BEGIN { (1, !(int1)1); }'
/disk/work/bpftrace2/src/struct.cpp:29:37: runtime error: division by zero
SUMMARY: UndefinedBehaviorSanitizer: undefined-behavior /disk/work/bpftrace2/src/struct.cpp:29:37 in
AddressSanitizer:DEADLYSIGNAL
=================================================================
==46777==ERROR: AddressSanitizer: FPE on unknown address 0x00000000b6b9 (pc 0x0000009aa53c bp 0x7fffffff68d0 sp 0x7fffffff64a0 T0)
    #0 0x9aa53c in bpftrace::Tuple::Create(std::vector<bpftrace::SizedType, std::allocator<bpftrace::SizedType> >) /disk/work/bpftrace2/src/struct.cpp:29:37
    #1 0x9cb00a in bpftrace::CreateTuple(std::vector<bpftrace::SizedType, std::allocator<bpftrace::SizedType> > const&) /disk/work/bpftrace2/src/types.cpp:443:20
    #2 0xc9dd2c in bpftrace::ast::SemanticAnalyser::visit(bpftrace::ast::Tuple&) /disk/work/bpftrace2/src/ast/semantic_analyser.cpp:1994:16
    #3 0xa8048b in bpftrace::ast::Tuple::accept(bpftrace::ast::Visitor&) /disk/work/bpftrace2/src/ast/ast.cpp:31:1
    #4 0xc9e116 in bpftrace::ast::SemanticAnalyser::visit(bpftrace::ast::ExprStatement&) /disk/work/bpftrace2/src/ast/semantic_analyser.cpp:1999:14
    #5 0xa805eb in bpftrace::ast::ExprStatement::accept(bpftrace::ast::Visitor&) /disk/work/bpftrace2/src/ast/ast.cpp:32:1
    #6 0xcbb643 in bpftrace::ast::SemanticAnalyser::visit(bpftrace::ast::Probe&) /disk/work/bpftrace2/src/ast/semantic_analyser.cpp:2473:11
    #7 0xa8124b in bpftrace::ast::Probe::accept(bpftrace::ast::Visitor&) /disk/work/bpftrace2/src/ast/ast.cpp:41:1
    #8 0xcbb97d in bpftrace::ast::SemanticAnalyser::visit(bpftrace::ast::Program&) /disk/work/bpftrace2/src/ast/semantic_analyser.cpp:2481:12
    #9 0xa813ab in bpftrace::ast::Program::accept(bpftrace::ast::Visitor&) /disk/work/bpftrace2/src/ast/ast.cpp:42:1
    #10 0xcbbda0 in bpftrace::ast::SemanticAnalyser::analyse() /disk/work/bpftrace2/src/ast/semantic_analyser.cpp:2490:12
    #11 0xa474fa in main /disk/work/bpftrace2/src/main.cpp:738:19
    #12 0x7fffed57e0b2 in __libc_start_main /build/glibc-ZN95T4/glibc-2.31/csu/../csu/libc-start.c:308:16
    #13 0x4fe68d in _start (/disk/work/bpftrace2/build/src/bpftrace+0x4fe68d)

AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: FPE /disk/work/bpftrace2/src/struct.cpp:29:37 in bpftrace::Tuple::Create(std::vector<bpftrace::SizedType, std::allocator<bpftrace::SizedType> >)
==46777==ABORTING
```

In this case, `elem->type` is `int` because of `!`, but its size is zero
and that causes the problem. To fix issue, don't create tuple if an
elemenet size is zero.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
