### PR TITLE
Add 'elapsed' to man page

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1618,7 +1618,7 @@ And as you can see in above example it's also possible to access function argume
 - `uid` - User ID
 - `gid` - Group ID
 - `nsecs` - Nanosecond timestamp
-- `elapsed` - Nanosecond timestamp since bpftrace initialization
+- `elapsed` - Nanoseconds since bpftrace initialization
 - `cpu` - Processor ID
 - `comm` - Process name
 - `kstack` - Kernel stack trace

--- a/man/man8/bpftrace.8
+++ b/man/man8/bpftrace.8
@@ -263,6 +263,10 @@ Group ID
 Nanosecond timestamp
 .
 .TP
+\fBelapsed\fR
+Nanoseconds since bpftrace initialization
+.
+.TP
 \fBcpu\fR
 Processor ID
 .


### PR DESCRIPTION
Include 'elapsed' in the list of builtin variables documented in
bpftrace.8. Also clarify that the variable is not a timestamp but rather
the number of nanoseconds elapsed since bpftrace was initialized.
