### PR TITLE
Array improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ and this project adheres to
   - [#1601](https://github.com/iovisor/bpftrace/pull/1601)
 - Disable `str($# + 1)`
   - [#1619](https://github.com/iovisor/bpftrace/issues/1619)
+- Array improvements (support assignment to variables and usage as a map key)
+  - [#1656](https://github.com/iovisor/bpftrace/pull/1656)
 
 #### Changed
 - Warn if using `print` on `stats` maps with top and div arguments

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -445,7 +445,7 @@ void IRBuilderBPF::CreateMapDeleteElem(Value *ctx,
 }
 
 void IRBuilderBPF::CreateProbeRead(Value *ctx,
-                                   AllocaInst *dst,
+                                   Value *dst,
                                    size_t size,
                                    Value *src,
                                    AddrSpace as,
@@ -455,7 +455,7 @@ void IRBuilderBPF::CreateProbeRead(Value *ctx,
 }
 
 void IRBuilderBPF::CreateProbeRead(Value *ctx,
-                                   AllocaInst *dst,
+                                   Value *dst,
                                    llvm::Value *size,
                                    Value *src,
                                    AddrSpace as,

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -183,7 +183,7 @@ AllocaInst *IRBuilderBPF::CreateAllocaBPFInit(const SizedType &stype, const std:
   }
   else
   {
-    CreateStore(getInt64(0), alloca);
+    CreateStore(ConstantInt::get(ty, 0), alloca);
   }
 
   restoreIP(ip);
@@ -220,9 +220,13 @@ llvm::ConstantInt *IRBuilderBPF::GetIntSameSize(uint64_t C, llvm::Value *expr)
 llvm::Type *IRBuilderBPF::GetType(const SizedType &stype)
 {
   llvm::Type *ty;
-  if (stype.IsArray())
+  if (stype.IsByteArray() || stype.IsRecordTy())
   {
     ty = ArrayType::get(getInt8Ty(), stype.GetSize());
+  }
+  else if (stype.IsArrayTy())
+  {
+    ty = ArrayType::get(GetType(*stype.GetElementTy()), stype.GetNumElements());
   }
   else if (stype.IsTupleTy())
   {
@@ -242,10 +246,6 @@ llvm::Type *IRBuilderBPF::GetType(const SizedType &stype)
   else if (stype.IsPtrTy())
   {
     ty = getInt64Ty();
-  }
-  else if (stype.IsRecordTy())
-  {
-    ty = ArrayType::get(getInt8Ty(), stype.GetSize());
   }
   else
   {

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -75,13 +75,13 @@ public:
                            AllocaInst *key,
                            const location &loc);
   void CreateProbeRead(Value *ctx,
-                       AllocaInst *dst,
+                       Value *dst,
                        size_t size,
                        Value *src,
                        AddrSpace as,
                        const location &loc);
   void CreateProbeRead(Value *ctx,
-                       AllocaInst *dst,
+                       Value *dst,
                        llvm::Value *size,
                        Value *src,
                        AddrSpace as,

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -2202,9 +2202,6 @@ void SemanticAnalyser::visit(AssignVarStatement &assignment)
     if (ty == Type::none)
       LOG(ERROR, assignment.expr->loc, err_)
           << "Invalid expression for assignment: " << ty;
-    if (ty == Type::array)
-      LOG(ERROR, assignment.expr->loc, err_)
-          << "Assigning array is not supported (#1057)";
   }
 }
 

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1987,6 +1987,12 @@ void SemanticAnalyser::visit(Tuple &tuple)
     Expression *elem = tuple.elems->at(i);
     elem->accept(*this);
 
+    if (elem->type.IsArrayTy() || elem->type.IsRecordTy())
+    {
+      LOG(ERROR, elem->loc, err_)
+          << elem->type.type << " type not allowed inside a tuple";
+    }
+
     // If elem type is none that means that the tuple contains some
     // invalid cast (e.g., (0, (aaa)0)). In this case, skip the tuple
     // creation. Cast already emits the error.

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1292,9 +1292,6 @@ void SemanticAnalyser::visit(Map &map)
       if (is_final_pass()) {
         if (expr->type.IsNoneTy())
           LOG(ERROR, expr->loc, err_) << "Invalid expression for assignment: ";
-        if (expr->type.IsArrayTy())
-          LOG(ERROR, expr->loc, err_)
-              << "Using array as a map key is not supported (#1052)";
 
         SizedType keytype = expr->type;
         // Skip.IsSigned() when comparing keys to not break existing scripts

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -332,14 +332,8 @@ static SizedType get_sized_type(CXType clang_type)
         return CreateString(size);
       }
 
-      // Only support one-dimensional arrays for now
-      if (elem_type.kind != CXType_ConstantArray)
-      {
-        auto elem_stype = get_sized_type(elem_type);
-        return CreateArray(size, elem_stype);
-      } else {
-        return CreateNone();
-      }
+      auto elem_stype = get_sized_type(elem_type);
+      return CreateArray(size, elem_stype);
     }
     default:
       return CreateNone();

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -118,6 +118,16 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
       ptr << "0x" << std::hex << read_data<int64_t>(data);
       return ptr.str();
     }
+    case Type::array:
+    {
+      std::vector<std::string> elems;
+      for (size_t i = 0; i < arg.GetNumElements(); i++)
+        elems.push_back(argument_value(bpftrace,
+                                       *arg.GetElementTy(),
+                                       (const uint8_t *)data +
+                                           i * arg.GetElementTy()->GetSize()));
+      return "[" + str_join(elems, ",") + "]";
+    }
     default:
       LOG(ERROR) << "invalid mapkey argument type";
   }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -109,16 +109,15 @@ bool SizedType::operator==(const SizedType &t) const
   return IsEqual(t);
 }
 
-bool SizedType::IsArray() const
+bool SizedType::IsByteArray() const
 {
-  return type == Type::array || type == Type::string || type == Type::usym ||
-         type == Type::inet || type == Type::buffer || type == Type::record ||
-         type == Type::timestamp;
+  return type == Type::string || type == Type::usym || type == Type::inet ||
+         type == Type::buffer || type == Type::timestamp;
 }
 
 bool SizedType::IsAggregate() const
 {
-  return IsArray() || IsTupleTy() || IsRecordTy();
+  return IsArrayTy() || IsByteArray() || IsTupleTy() || IsRecordTy();
 }
 
 bool SizedType::IsStack() const
@@ -327,7 +326,8 @@ SizedType CreateStackMode()
 
 SizedType CreateArray(size_t num_elements, const SizedType &element_type)
 {
-  auto ty = SizedType(Type::array, num_elements);
+  size_t size = num_elements * element_type.GetSize();
+  auto ty = SizedType(Type::array, size);
   ty.num_elements_ = num_elements;
   ty.element_type_ = std::make_shared<SizedType>(element_type);
   return ty;

--- a/src/types.h
+++ b/src/types.h
@@ -149,7 +149,7 @@ public:
     ctx_ = true;
   };
 
-  bool IsArray() const;
+  bool IsByteArray() const;
   bool IsAggregate() const;
   bool IsStack() const;
 
@@ -192,7 +192,7 @@ public:
   size_t GetNumElements() const
   {
     assert(IsArrayTy() || IsStringTy());
-    return size_;
+    return IsStringTy() ? size_ : size_ / element_type_->size_;
   };
 
   const std::string GetName() const

--- a/tests/codegen/llvm/args_multiple_tracepoints.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints.ll
@@ -10,26 +10,25 @@ define i64 @"tracepoint:sched:sched_one"(i8*) section "s_tracepoint:sched:sched_
 entry:
   %"@_val" = alloca i64
   %lookup_elem_val = alloca i64
-  %"@_key" = alloca [8 x i8]
+  %"@_key" = alloca i64
   %1 = ptrtoint i8* %0 to i64
   %2 = add i64 %1, 8
   %3 = inttoptr i64 %2 to i64*
   %4 = load volatile i64, i64* %3
-  %5 = bitcast [8 x i8]* %"@_key" to i8*
+  %5 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = bitcast [8 x i8]* %"@_key" to i64*
-  store i64 %4, i64* %6
+  store i64 %4, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* %"@_key")
-  %7 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* %"@_key")
+  %6 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %8 = load i64, i64* %cast
-  store i64 %8, i64* %lookup_elem_val
+  %7 = load i64, i64* %cast
+  store i64 %7, i64* %lookup_elem_val
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
@@ -37,19 +36,19 @@ lookup_failure:                                   ; preds = %entry
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %9 = load i64, i64* %lookup_elem_val
-  %10 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  %12 = add i64 %9, 1
-  store i64 %12, i64* %"@_val"
+  %8 = load i64, i64* %lookup_elem_val
+  %9 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = add i64 %8, 1
+  store i64 %11, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %"@_val", i64 0)
+  %12 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
 
@@ -63,26 +62,25 @@ define i64 @"tracepoint:sched:sched_two"(i8*) section "s_tracepoint:sched:sched_
 entry:
   %"@_val" = alloca i64
   %lookup_elem_val = alloca i64
-  %"@_key" = alloca [8 x i8]
+  %"@_key" = alloca i64
   %1 = ptrtoint i8* %0 to i64
   %2 = add i64 %1, 16
   %3 = inttoptr i64 %2 to i64*
   %4 = load volatile i64, i64* %3
-  %5 = bitcast [8 x i8]* %"@_key" to i8*
+  %5 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = bitcast [8 x i8]* %"@_key" to i64*
-  store i64 %4, i64* %6
+  store i64 %4, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* %"@_key")
-  %7 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* %"@_key")
+  %6 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %8 = load i64, i64* %cast
-  store i64 %8, i64* %lookup_elem_val
+  %7 = load i64, i64* %cast
+  store i64 %7, i64* %lookup_elem_val
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
@@ -90,19 +88,19 @@ lookup_failure:                                   ; preds = %entry
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %9 = load i64, i64* %lookup_elem_val
-  %10 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  %12 = add i64 %9, 1
-  store i64 %12, i64* %"@_val"
+  %8 = load i64, i64* %lookup_elem_val
+  %9 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = add i64 %8, 1
+  store i64 %11, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %"@_val", i64 0)
+  %12 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/args_multiple_tracepoints_category_wild.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints_category_wild.ll
@@ -10,26 +10,25 @@ define i64 @"tracepoint:sched:sched_one"(i8*) section "s_tracepoint:sched:sched_
 entry:
   %"@_val" = alloca i64
   %lookup_elem_val = alloca i64
-  %"@_key" = alloca [8 x i8]
+  %"@_key" = alloca i64
   %1 = ptrtoint i8* %0 to i64
   %2 = add i64 %1, 8
   %3 = inttoptr i64 %2 to i64*
   %4 = load volatile i64, i64* %3
-  %5 = bitcast [8 x i8]* %"@_key" to i8*
+  %5 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = bitcast [8 x i8]* %"@_key" to i64*
-  store i64 %4, i64* %6
+  store i64 %4, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* %"@_key")
-  %7 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* %"@_key")
+  %6 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %8 = load i64, i64* %cast
-  store i64 %8, i64* %lookup_elem_val
+  %7 = load i64, i64* %cast
+  store i64 %7, i64* %lookup_elem_val
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
@@ -37,19 +36,19 @@ lookup_failure:                                   ; preds = %entry
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %9 = load i64, i64* %lookup_elem_val
-  %10 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  %12 = add i64 %9, 1
-  store i64 %12, i64* %"@_val"
+  %8 = load i64, i64* %lookup_elem_val
+  %9 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = add i64 %8, 1
+  store i64 %11, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %"@_val", i64 0)
+  %12 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
 
@@ -63,26 +62,25 @@ define i64 @"tracepoint:sched:sched_two"(i8*) section "s_tracepoint:sched:sched_
 entry:
   %"@_val" = alloca i64
   %lookup_elem_val = alloca i64
-  %"@_key" = alloca [8 x i8]
+  %"@_key" = alloca i64
   %1 = ptrtoint i8* %0 to i64
   %2 = add i64 %1, 16
   %3 = inttoptr i64 %2 to i64*
   %4 = load volatile i64, i64* %3
-  %5 = bitcast [8 x i8]* %"@_key" to i8*
+  %5 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = bitcast [8 x i8]* %"@_key" to i64*
-  store i64 %4, i64* %6
+  store i64 %4, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* %"@_key")
-  %7 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* %"@_key")
+  %6 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %8 = load i64, i64* %cast
-  store i64 %8, i64* %lookup_elem_val
+  %7 = load i64, i64* %cast
+  store i64 %7, i64* %lookup_elem_val
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
@@ -90,19 +88,19 @@ lookup_failure:                                   ; preds = %entry
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %9 = load i64, i64* %lookup_elem_val
-  %10 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  %12 = add i64 %9, 1
-  store i64 %12, i64* %"@_val"
+  %8 = load i64, i64* %lookup_elem_val
+  %9 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = add i64 %8, 1
+  store i64 %11, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %"@_val", i64 0)
+  %12 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
 
@@ -110,26 +108,25 @@ define i64 @"tracepoint:sched_extra:sched_extra"(i8*) section "s_tracepoint:sche
 entry:
   %"@_val" = alloca i64
   %lookup_elem_val = alloca i64
-  %"@_key" = alloca [8 x i8]
+  %"@_key" = alloca i64
   %1 = ptrtoint i8* %0 to i64
   %2 = add i64 %1, 24
   %3 = inttoptr i64 %2 to i64*
   %4 = load volatile i64, i64* %3
-  %5 = bitcast [8 x i8]* %"@_key" to i8*
+  %5 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = bitcast [8 x i8]* %"@_key" to i64*
-  store i64 %4, i64* %6
+  store i64 %4, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* %"@_key")
-  %7 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* %"@_key")
+  %6 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %8 = load i64, i64* %cast
-  store i64 %8, i64* %lookup_elem_val
+  %7 = load i64, i64* %cast
+  store i64 %7, i64* %lookup_elem_val
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
@@ -137,19 +134,19 @@ lookup_failure:                                   ; preds = %entry
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %9 = load i64, i64* %lookup_elem_val
-  %10 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  %12 = add i64 %9, 1
-  store i64 %12, i64* %"@_val"
+  %8 = load i64, i64* %lookup_elem_val
+  %9 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = add i64 %8, 1
+  store i64 %11, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %"@_val", i64 0)
+  %12 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/args_multiple_tracepoints_wild.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints_wild.ll
@@ -10,26 +10,25 @@ define i64 @"tracepoint:sched:sched_one"(i8*) section "s_tracepoint:sched:sched_
 entry:
   %"@_val" = alloca i64
   %lookup_elem_val = alloca i64
-  %"@_key" = alloca [8 x i8]
+  %"@_key" = alloca i64
   %1 = ptrtoint i8* %0 to i64
   %2 = add i64 %1, 8
   %3 = inttoptr i64 %2 to i64*
   %4 = load volatile i64, i64* %3
-  %5 = bitcast [8 x i8]* %"@_key" to i8*
+  %5 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = bitcast [8 x i8]* %"@_key" to i64*
-  store i64 %4, i64* %6
+  store i64 %4, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* %"@_key")
-  %7 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* %"@_key")
+  %6 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %8 = load i64, i64* %cast
-  store i64 %8, i64* %lookup_elem_val
+  %7 = load i64, i64* %cast
+  store i64 %7, i64* %lookup_elem_val
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
@@ -37,19 +36,19 @@ lookup_failure:                                   ; preds = %entry
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %9 = load i64, i64* %lookup_elem_val
-  %10 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  %12 = add i64 %9, 1
-  store i64 %12, i64* %"@_val"
+  %8 = load i64, i64* %lookup_elem_val
+  %9 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = add i64 %8, 1
+  store i64 %11, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %"@_val", i64 0)
+  %12 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
 
@@ -63,26 +62,25 @@ define i64 @"tracepoint:sched:sched_two"(i8*) section "s_tracepoint:sched:sched_
 entry:
   %"@_val" = alloca i64
   %lookup_elem_val = alloca i64
-  %"@_key" = alloca [8 x i8]
+  %"@_key" = alloca i64
   %1 = ptrtoint i8* %0 to i64
   %2 = add i64 %1, 16
   %3 = inttoptr i64 %2 to i64*
   %4 = load volatile i64, i64* %3
-  %5 = bitcast [8 x i8]* %"@_key" to i8*
+  %5 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = bitcast [8 x i8]* %"@_key" to i64*
-  store i64 %4, i64* %6
+  store i64 %4, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* %"@_key")
-  %7 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* %"@_key")
+  %6 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %8 = load i64, i64* %cast
-  store i64 %8, i64* %lookup_elem_val
+  %7 = load i64, i64* %cast
+  store i64 %7, i64* %lookup_elem_val
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
@@ -90,19 +88,19 @@ lookup_failure:                                   ; preds = %entry
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %9 = load i64, i64* %lookup_elem_val
-  %10 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  %12 = add i64 %9, 1
-  store i64 %12, i64* %"@_val"
+  %8 = load i64, i64* %lookup_elem_val
+  %9 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = add i64 %8, 1
+  store i64 %11, i64* %"@_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo1, [8 x i8]* %"@_key", i64* %"@_val", i64 0)
-  %13 = bitcast [8 x i8]* %"@_key" to i8*
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %"@_val", i64 0)
+  %12 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/map_assign_array.ll
+++ b/tests/codegen/llvm/map_assign_array.ll
@@ -13,59 +13,57 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i32 0, i32* %"$var"
   %lookup_elem_val = alloca [4 x i32]
-  %"@x_key1" = alloca [8 x i8]
+  %"@x_key1" = alloca i64
   %"@x_val" = alloca [4 x i32]
-  %"@x_key" = alloca [8 x i8]
+  %"@x_key" = alloca i64
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
   %4 = add i64 %arg0, 0
-  %5 = bitcast [8 x i8]* %"@x_key" to i8*
+  %5 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = bitcast [8 x i8]* %"@x_key" to i64*
-  store i64 0, i64* %6
-  %7 = bitcast [4 x i32]* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i64 0, i64* %"@x_key"
+  %6 = bitcast [4 x i32]* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([4 x i32]*, i32, i64)*)([4 x i32]* %"@x_val", i32 16, i64 %4)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, [4 x i32]*, i64)*)(i64 %pseudo, [8 x i8]* %"@x_key", [4 x i32]* %"@x_val", i64 0)
-  %8 = bitcast [8 x i8]* %"@x_key" to i8*
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [4 x i32]*, i64)*)(i64 %pseudo, i64* %"@x_key", [4 x i32]* %"@x_val", i64 0)
+  %7 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %8 = bitcast [4 x i32]* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast [4 x i32]* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast [8 x i8]* %"@x_key1" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  %11 = bitcast [8 x i8]* %"@x_key1" to i64*
-  store i64 0, i64* %11
+  %9 = bitcast i64* %"@x_key1" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i64 0, i64* %"@x_key1"
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo2, [8 x i8]* %"@x_key1")
-  %12 = bitcast [4 x i32]* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo2, i64* %"@x_key1")
+  %10 = bitcast [4 x i32]* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %13 = bitcast [4 x i32]* %lookup_elem_val to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %13, i8* align 1 %lookup_elem, i64 16, i1 false)
+  %11 = bitcast [4 x i32]* %lookup_elem_val to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %11, i8* align 1 %lookup_elem, i64 16, i1 false)
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  %14 = bitcast [4 x i32]* %lookup_elem_val to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %14, i8 0, i64 16, i1 false)
+  %12 = bitcast [4 x i32]* %lookup_elem_val to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %12, i8 0, i64 16, i1 false)
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %15 = bitcast [8 x i8]* %"@x_key1" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
-  %16 = ptrtoint [4 x i32]* %lookup_elem_val to i64
-  %17 = add i64 %16, 0
-  %18 = inttoptr i64 %17 to i32*
-  %19 = load volatile i32, i32* %18
-  %20 = bitcast [4 x i32]* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  %21 = bitcast i32* %"$var" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21)
-  store i32 %19, i32* %"$var"
+  %13 = bitcast i64* %"@x_key1" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = ptrtoint [4 x i32]* %lookup_elem_val to i64
+  %15 = add i64 %14, 0
+  %16 = inttoptr i64 %15 to i32*
+  %17 = load volatile i32, i32* %16
+  %18 = bitcast [4 x i32]* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  %19 = bitcast i32* %"$var" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
+  store i32 %17, i32* %"$var"
   ret i64 0
 }
 

--- a/tests/codegen/llvm/map_assign_array.ll
+++ b/tests/codegen/llvm/map_assign_array.ll
@@ -1,0 +1,85 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
+entry:
+  %"$var" = alloca i32
+  %1 = bitcast i32* %"$var" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i32 0, i32* %"$var"
+  %lookup_elem_val = alloca [4 x i32]
+  %"@x_key1" = alloca [8 x i8]
+  %"@x_val" = alloca [4 x i32]
+  %"@x_key" = alloca [8 x i8]
+  %2 = bitcast i8* %0 to i64*
+  %3 = getelementptr i64, i64* %2, i64 14
+  %arg0 = load volatile i64, i64* %3
+  %4 = add i64 %arg0, 0
+  %5 = bitcast [8 x i8]* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast [8 x i8]* %"@x_key" to i64*
+  store i64 0, i64* %6
+  %7 = bitcast [4 x i32]* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([4 x i32]*, i32, i64)*)([4 x i32]* %"@x_val", i32 16, i64 %4)
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, [4 x i32]*, i64)*)(i64 %pseudo, [8 x i8]* %"@x_key", [4 x i32]* %"@x_val", i64 0)
+  %8 = bitcast [8 x i8]* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast [4 x i32]* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast [8 x i8]* %"@x_key1" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = bitcast [8 x i8]* %"@x_key1" to i64*
+  store i64 0, i64* %11
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo2, [8 x i8]* %"@x_key1")
+  %12 = bitcast [4 x i32]* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %13 = bitcast [4 x i32]* %lookup_elem_val to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %13, i8* align 1 %lookup_elem, i64 16, i1 false)
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  %14 = bitcast [4 x i32]* %lookup_elem_val to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %14, i8 0, i64 16, i1 false)
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %15 = bitcast [8 x i8]* %"@x_key1" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %16 = ptrtoint [4 x i32]* %lookup_elem_val to i64
+  %17 = add i64 %16, 0
+  %18 = inttoptr i64 %17 to i32*
+  %19 = load volatile i32, i32* %18
+  %20 = bitcast [4 x i32]* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
+  %21 = bitcast i32* %"$var" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21)
+  store i32 %19, i32* %"$var"
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/map_key_array.ll
+++ b/tests/codegen/llvm/map_key_array.ll
@@ -1,0 +1,39 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
+entry:
+  %"@x_val" = alloca i64
+  %"@x_key" = alloca [4 x i32]
+  %1 = bitcast i8* %0 to i64*
+  %2 = getelementptr i64, i64* %1, i64 14
+  %arg0 = load volatile i64, i64* %2
+  %3 = add i64 %arg0, 0
+  %4 = bitcast [4 x i32]* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([4 x i32]*, i32, i64)*)([4 x i32]* %"@x_key", i32 16, i64 %3)
+  %5 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i64 44, i64* %"@x_val"
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [4 x i32]*, i64*, i64)*)(i64 %pseudo, [4 x i32]* %"@x_key", i64* %"@x_val", i64 0)
+  %6 = bitcast [4 x i32]* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/map_key_probe.ll
+++ b/tests/codegen/llvm/map_key_probe.ll
@@ -9,24 +9,23 @@ declare i64 @llvm.bpf.pseudo(i64, i64) #0
 define i64 @"tracepoint:sched:sched_one"(i8*) section "s_tracepoint:sched:sched_one_1" {
 entry:
   %"@x_val" = alloca i64
-  %"@x_key1" = alloca [8 x i8]
+  %"@x_key1" = alloca i64
   %lookup_elem_val = alloca i64
-  %"@x_key" = alloca [8 x i8]
-  %1 = bitcast [8 x i8]* %"@x_key" to i8*
+  %"@x_key" = alloca i64
+  %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast [8 x i8]* %"@x_key" to i64*
-  store i64 0, i64* %2
+  store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* %"@x_key")
-  %3 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* %"@x_key")
+  %2 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %4 = load i64, i64* %cast
-  store i64 %4, i64* %lookup_elem_val
+  %3 = load i64, i64* %cast
+  store i64 %3, i64* %lookup_elem_val
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
@@ -34,25 +33,24 @@ lookup_failure:                                   ; preds = %entry
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %5 = load i64, i64* %lookup_elem_val
-  %6 = bitcast i64* %lookup_elem_val to i8*
+  %4 = load i64, i64* %lookup_elem_val
+  %5 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast [8 x i8]* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = add i64 %5, 1
-  %9 = bitcast [8 x i8]* %"@x_key1" to i8*
+  %7 = add i64 %4, 1
+  %8 = bitcast i64* %"@x_key1" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 0, i64* %"@x_key1"
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %10 = bitcast [8 x i8]* %"@x_key1" to i64*
-  store i64 0, i64* %10
-  %11 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  store i64 %8, i64* %"@x_val"
+  store i64 %7, i64* %"@x_val"
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo2, [8 x i8]* %"@x_key1", i64* %"@x_val", i64 0)
-  %12 = bitcast [8 x i8]* %"@x_key1" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@x_key1", i64* %"@x_val", i64 0)
+  %10 = bitcast i64* %"@x_key1" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   ret i64 0
 }
 
@@ -65,24 +63,23 @@ declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
 define i64 @"tracepoint:sched:sched_two"(i8*) section "s_tracepoint:sched:sched_two_2" {
 entry:
   %"@x_val" = alloca i64
-  %"@x_key1" = alloca [8 x i8]
+  %"@x_key1" = alloca i64
   %lookup_elem_val = alloca i64
-  %"@x_key" = alloca [8 x i8]
-  %1 = bitcast [8 x i8]* %"@x_key" to i8*
+  %"@x_key" = alloca i64
+  %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast [8 x i8]* %"@x_key" to i64*
-  store i64 1, i64* %2
+  store i64 1, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, [8 x i8]*)*)(i64 %pseudo, [8 x i8]* %"@x_key")
-  %3 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* %"@x_key")
+  %2 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %4 = load i64, i64* %cast
-  store i64 %4, i64* %lookup_elem_val
+  %3 = load i64, i64* %cast
+  store i64 %3, i64* %lookup_elem_val
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
@@ -90,25 +87,24 @@ lookup_failure:                                   ; preds = %entry
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %5 = load i64, i64* %lookup_elem_val
-  %6 = bitcast i64* %lookup_elem_val to i8*
+  %4 = load i64, i64* %lookup_elem_val
+  %5 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast [8 x i8]* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = add i64 %5, 1
-  %9 = bitcast [8 x i8]* %"@x_key1" to i8*
+  %7 = add i64 %4, 1
+  %8 = bitcast i64* %"@x_key1" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 1, i64* %"@x_key1"
+  %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %10 = bitcast [8 x i8]* %"@x_key1" to i64*
-  store i64 1, i64* %10
-  %11 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  store i64 %8, i64* %"@x_val"
+  store i64 %7, i64* %"@x_val"
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [8 x i8]*, i64*, i64)*)(i64 %pseudo2, [8 x i8]* %"@x_key1", i64* %"@x_val", i64 0)
-  %12 = bitcast [8 x i8]* %"@x_key1" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@x_key1", i64* %"@x_val", i64 0)
+  %10 = bitcast i64* %"@x_key1" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/nested_array_struct.ll
+++ b/tests/codegen/llvm/nested_array_struct.ll
@@ -1,0 +1,96 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
+entry:
+  %"@_val" = alloca i64
+  %"@_key" = alloca i64
+  %lookup_elem_val = alloca [2 x [2 x [4 x i8]]]
+  %"@bar_key1" = alloca i64
+  %"@bar_val" = alloca [2 x [2 x [4 x i8]]]
+  %"@bar_key" = alloca i64
+  %1 = bitcast i8* %0 to i64*
+  %2 = getelementptr i64, i64* %1, i64 14
+  %arg0 = load volatile i64, i64* %2
+  %3 = add i64 %arg0, 0
+  %4 = bitcast i64* %"@bar_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 42, i64* %"@bar_key"
+  %5 = bitcast [2 x [2 x [4 x i8]]]* %"@bar_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([2 x [2 x [4 x i8]]]*, i32, i64)*)([2 x [2 x [4 x i8]]]* %"@bar_val", i32 16, i64 %3)
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [2 x [2 x [4 x i8]]]*, i64)*)(i64 %pseudo, i64* %"@bar_key", [2 x [2 x [4 x i8]]]* %"@bar_val", i64 0)
+  %6 = bitcast i64* %"@bar_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast [2 x [2 x [4 x i8]]]* %"@bar_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %8 = bitcast i64* %"@bar_key1" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 42, i64* %"@bar_key1"
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo2, i64* %"@bar_key1")
+  %9 = bitcast [2 x [2 x [4 x i8]]]* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %10 = bitcast [2 x [2 x [4 x i8]]]* %lookup_elem_val to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %10, i8* align 1 %lookup_elem, i64 16, i1 false)
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  %11 = bitcast [2 x [2 x [4 x i8]]]* %lookup_elem_val to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 16, i1 false)
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %12 = bitcast i64* %"@bar_key1" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = ptrtoint [2 x [2 x [4 x i8]]]* %lookup_elem_val to i64
+  %14 = add i64 %13, 0
+  %15 = inttoptr i64 %14 to [2 x [4 x i8]]*
+  %16 = bitcast [2 x [2 x [4 x i8]]]* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = ptrtoint [2 x [4 x i8]]* %15 to i64
+  %18 = add i64 %17, 4
+  %19 = inttoptr i64 %18 to [4 x i8]*
+  %20 = getelementptr [4 x i8], [4 x i8]* %19, i64 0, i64 0
+  %21 = bitcast i8* %20 to i32*
+  %22 = load i32, i32* %21
+  %23 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
+  store i64 0, i64* %"@_key"
+  %24 = sext i32 %22 to i64
+  %25 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %25)
+  store i64 %24, i64* %"@_val"
+  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo3, i64* %"@_key", i64* %"@_val", i64 0)
+  %26 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %26)
+  %27 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %27)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* nocapture writeonly, i8* nocapture readonly, i64, i1) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly, i8, i64, i1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/llvm/struct_save_nested.ll
+++ b/tests/codegen/llvm/struct_save_nested.ll
@@ -104,22 +104,23 @@ lookup_merge10:                                   ; preds = %lookup_failure9, %l
   %27 = bitcast [16 x i8]* %lookup_elem_val11 to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %27)
   %28 = getelementptr [8 x i8], [8 x i8]* %"internal_struct Foo.bar13", i64 0, i64 0
-  %29 = load i32, i8* %28
-  %30 = bitcast [8 x i8]* %"internal_struct Foo.bar13" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %30)
-  %31 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %31)
+  %29 = bitcast i8* %28 to i32*
+  %30 = load i32, i32* %29
+  %31 = bitcast [8 x i8]* %"internal_struct Foo.bar13" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %31)
+  %32 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %32)
   store i64 0, i64* %"@x_key"
-  %32 = sext i32 %29 to i64
-  %33 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %33)
-  store i64 %32, i64* %"@x_val"
+  %33 = sext i32 %30 to i64
+  %34 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %34)
+  store i64 %33, i64* %"@x_val"
   %pseudo14 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
   %update_elem15 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo14, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %34 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %34)
-  %35 = bitcast i64* %"@x_val" to i8*
+  %35 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %35)
+  %36 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %36)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/variable_assign_array.ll
+++ b/tests/codegen/llvm/variable_assign_array.ll
@@ -1,0 +1,56 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64, i64) #0
+
+define i64 @"kprobe:f"(i8*) section "s_kprobe:f_1" {
+entry:
+  %"@x_val" = alloca i64
+  %"@x_key" = alloca i64
+  %array_access = alloca i32
+  %"$var" = alloca i64
+  %1 = bitcast i64* %"$var" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 0, i64* %"$var"
+  %2 = bitcast i8* %0 to i64*
+  %3 = getelementptr i64, i64* %2, i64 14
+  %arg0 = load volatile i64, i64* %3
+  %4 = add i64 %arg0, 0
+  %5 = bitcast i64* %"$var" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i64 %4, i64* %"$var"
+  %6 = load i64, i64* %"$var"
+  %7 = add i64 %6, 0
+  %8 = bitcast i32* %array_access to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %array_access, i32 4, i64 %7)
+  %9 = load i32, i32* %array_access
+  %10 = zext i32 %9 to i64
+  %11 = bitcast i32* %array_access to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  store i64 0, i64* %"@x_key"
+  %13 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  store i64 %10, i64* %"@x_val"
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
+  %14 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.start.p0i8(i64, i8* nocapture) #1
+
+; Function Attrs: argmemonly nounwind
+declare void @llvm.lifetime.end.p0i8(i64, i8* nocapture) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nounwind }

--- a/tests/codegen/map_assign_array.cpp
+++ b/tests/codegen/map_assign_array.cpp
@@ -1,0 +1,21 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, map_assign_array)
+{
+  test("struct Foo { int arr[4]; }"
+       "kprobe:f"
+       "{"
+       "  @x[0] = ((struct Foo *)arg0)->arr;"
+       "  $var = @x[0][0]; "
+       "}",
+
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/map_key_array.cpp
+++ b/tests/codegen/map_key_array.cpp
@@ -1,0 +1,20 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, map_key_array)
+{
+  test("struct Foo { int arr[4]; }"
+       "kprobe:f"
+       "{"
+       "  @x[((struct Foo *)arg0)->arr] = 44;"
+       "}",
+
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/nested_array_struct.cpp
+++ b/tests/codegen/nested_array_struct.cpp
@@ -1,0 +1,21 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, nested_array_struct)
+{
+  test("struct Bar { int x; } struct Foo { struct Bar bar[2][2]; }"
+       "kprobe:f"
+       "{"
+       "  @bar[42] = ((struct Foo *)arg0)->bar;"
+       "  @ = @bar[42][0][1].x;"
+       "}",
+
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/variable_assign_array.cpp
+++ b/tests/codegen/variable_assign_array.cpp
@@ -1,0 +1,21 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, variable_assign_array)
+{
+  test("struct Foo { int arr[4]; }"
+       "kprobe:f"
+       "{"
+       "  $var = ((struct Foo *)arg0)->arr;"
+       "  @x = $var[0]; "
+       "}",
+
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/runtime/array
+++ b/tests/runtime/array
@@ -1,17 +1,23 @@
 NAME array element access - assign to map
-RUN bpftrace -v -e 'struct MyStruct { int y[4]; } uprobe:./testprogs/array_access:test_struct { $s = (struct MyStruct *) arg0; @x = $s->y[0]; exit(); }'
+RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; @x = $a->x[0]; exit(); }'
 EXPECT @x: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array element access - assign to var
-RUN bpftrace -v -e 'struct MyStruct { int y[4]; } uprobe:./testprogs/array_access:test_struct { $s = (struct MyStruct *) arg0; $x = $s->y[0]; printf("Result: %d\n", $x); exit(); }'
+RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a->x[0]; printf("Result: %d\n", $x); exit(); }'
 EXPECT Result: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array element access - out of bounds
-RUN bpftrace -v -e 'struct MyStruct { int y[4]; } uprobe:./testprogs/array_access:test_struct { $s = (struct MyStruct *) arg0; $x = $s->y[5]; printf("%d\n", $x); exit(); }'
+RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a->x[5]; printf("%d\n", $x); exit(); }'
 EXPECT the index 5 is out of bounds for array of size 4
+TIMEOUT 5
+AFTER ./testprogs/array_access
+
+NAME array element access via assignment into var
+RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = ((struct A *) arg0)->x; $x = $a[0]; printf("Result: %d\n", $x); exit(); }'
+EXPECT Result: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access

--- a/tests/runtime/array
+++ b/tests/runtime/array
@@ -57,3 +57,45 @@ RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_
 EXPECT @x\[\[1,2,3,4\]\]: 0
 TIMEOUT 5
 AFTER ./testprogs/array_access
+
+NAME multi-dimensional array element access
+RUN bpftrace -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $x = ((struct B *) arg1)->y[1][0]; printf("Result: %d\n", $x); exit(); }'
+EXPECT Result: 7
+TIMEOUT 5
+AFTER ./testprogs/array_access
+
+NAME multi-dimensional array element access via assignment into var
+RUN bpftrace -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $b = ((struct B *) arg1)->y; $y = $b[1][0]; printf("Result: %d\n", $y); exit(); }'
+EXPECT Result: 7
+TIMEOUT 5
+AFTER ./testprogs/array_access
+
+NAME multi-dimensional array element access via assignment into map
+RUN bpftrace -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b[0] = ((struct B *) arg1)->y; printf("Result: %d\n", @b[0][1][0]); exit(); }'
+EXPECT Result: 7
+TIMEOUT 5
+AFTER ./testprogs/array_access
+
+NAME multi-dimensional array element access via assignment into map and var
+RUN bpftrace -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b[0] = ((struct B *) arg1)->y; $x = @b[0]; printf("Result: %d\n", $x[1][0]); exit(); }'
+EXPECT Result: 7
+TIMEOUT 5
+AFTER ./testprogs/array_access
+
+NAME multi-dimensional array assignment into map
+RUN bpftrace -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b = ((struct B *) arg1)->y; exit(); }'
+EXPECT @b: \[\[5,6\],\[7,8\]\]
+TIMEOUT 5
+AFTER ./testprogs/array_access
+
+NAME multi-dimensional array as a map key
+RUN bpftrace -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @x[((struct B *) arg1)->y] = 0; exit(); }'
+EXPECT @x\[\[\[5,6\],\[7,8\]\]]: 0
+TIMEOUT 5
+AFTER ./testprogs/array_access
+
+NAME multi-dimensional array as a map key assigned from another map
+RUN bpftrace -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b = ((struct B *) arg1)->y; @x[@b] = 0; exit(); }'
+EXPECT @x\[\[\[5,6\],\[7,8\]\]]: 0
+TIMEOUT 5
+AFTER ./testprogs/array_access

--- a/tests/runtime/array
+++ b/tests/runtime/array
@@ -21,3 +21,21 @@ RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_
 EXPECT Result: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
+
+NAME array element access via assignment into map
+RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a[0] = ((struct A *) arg0)->x; printf("Result: %d\n", @a[0][0]); exit(); }'
+EXPECT Result: 1
+TIMEOUT 5
+AFTER ./testprogs/array_access
+
+NAME array element access via assignment into map and var
+RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a[0] = ((struct A *) arg0)->x; $x = @a[0]; printf("Result: %d\n", $x[0]); exit(); }'
+EXPECT Result: 1
+TIMEOUT 5
+AFTER ./testprogs/array_access
+
+NAME array assignment into map
+RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a = ((struct A *) arg0)->x; exit(); }'
+EXPECT @a: \[1,2,3,4\]
+TIMEOUT 5
+AFTER ./testprogs/array_access

--- a/tests/runtime/array
+++ b/tests/runtime/array
@@ -39,3 +39,21 @@ RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_
 EXPECT @a: \[1,2,3,4\]
 TIMEOUT 5
 AFTER ./testprogs/array_access
+
+NAME array as a map key
+RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x[((struct A *) arg0)->x] = 0; exit(); }'
+EXPECT @x\[\[1,2,3,4\]\]: 0
+TIMEOUT 5
+AFTER ./testprogs/array_access
+
+NAME array as a part of map multikey
+RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x[((struct A *) arg0)->x, 42] = 0; exit(); }'
+EXPECT @x\[\[1,2,3,4\], 42\]: 0
+TIMEOUT 5
+AFTER ./testprogs/array_access
+
+NAME array as a map key assigned from another map
+RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a = ((struct A *) arg0)->x; @x[@a] = 0; exit(); }'
+EXPECT @x\[\[1,2,3,4\]\]: 0
+TIMEOUT 5
+AFTER ./testprogs/array_access

--- a/tests/runtime/complex_types
+++ b/tests/runtime/complex_types
@@ -1,6 +1,11 @@
 NAME struct-array
 RUN bpftrace runtime/scripts/struct_array.bt -c ./testprogs/struct_array
-EXPECT 100 102 104 106 108 -- 0 2 4 6 8 -- 100 98 96 94 92
+EXPECT 100 101 102 103 104 -- 0 1 2 3 4 -- 100 99 98 97 96
+TIMEOUT 5
+
+NAME struct-array with variables
+RUN bpftrace runtime/scripts/struct_array_vars.bt -c ./testprogs/struct_array
+EXPECT 100 101 102 103 104 -- 0 1 2 3 4 -- 100 99 98 97 96 -- 42
 TIMEOUT 5
 
 NAME pointer_to_pointer

--- a/tests/runtime/scripts/struct_array.bt
+++ b/tests/runtime/scripts/struct_array.bt
@@ -1,6 +1,6 @@
 struct T {
   uint32_t a;
-  uint32_t b;
+  uint32_t b[2];
 };
 
 struct W {
@@ -18,22 +18,22 @@ uprobe:./testprogs/struct_array:clear {
   $c = (struct C *) arg0;
 
   printf("%d ", $c->w[0].a);
+  printf("%d ", $c->w[1].a);
   printf("%d ", $c->w[2].a);
+  printf("%d ", $c->w[3].a);
   printf("%d ", $c->w[4].a);
-  printf("%d ", $c->w[6].a);
-  printf("%d ", $c->w[8].a);
 
   printf("-- ");
   printf("%d ", $c->w[0].t.a);
+  printf("%d ", $c->w[1].t.a);
   printf("%d ", $c->w[2].t.a);
+  printf("%d ", $c->w[3].t.a);
   printf("%d ", $c->w[4].t.a);
-  printf("%d ", $c->w[6].t.a);
-  printf("%d ", $c->w[8].t.a);
 
   printf("-- ");
-  printf("%d ", $c->w[0].t.b);
-  printf("%d ", $c->w[2].t.b);
-  printf("%d ", $c->w[4].t.b);
-  printf("%d ", $c->w[6].t.b);
-  printf("%d\n", $c->w[8].t.b);
+  printf("%d ", $c->w[0].t.b[0]);
+  printf("%d ", $c->w[1].t.b[0]);
+  printf("%d ", $c->w[2].t.b[0]);
+  printf("%d ", $c->w[3].t.b[0]);
+  printf("%d\n", $c->w[4].t.b[0]);
 }

--- a/tests/runtime/scripts/struct_array_vars.bt
+++ b/tests/runtime/scripts/struct_array_vars.bt
@@ -1,0 +1,46 @@
+struct T {
+  uint32_t a;
+  uint32_t b[2];
+};
+
+struct W {
+  uint32_t a;
+  struct T t;
+};
+
+struct C {
+  uint32_t a;
+  void * b;
+  struct W w[5];
+};
+
+uprobe:./testprogs/struct_array:clear {
+  $c = (struct C *) arg0;
+
+  $w = $c->w;
+  @w[0] = $c->w;
+  @[$c->w] = 42;
+
+  printf("%d ", $w[0].a);
+  printf("%d ", $w[1].a);
+  printf("%d ", $w[2].a);
+  printf("%d ", $w[3].a);
+  printf("%d ", $w[4].a);
+
+  printf("-- ");
+  printf("%d ", @w[0][0].t.a);
+  printf("%d ", @w[0][1].t.a);
+  printf("%d ", @w[0][2].t.a);
+  printf("%d ", @w[0][3].t.a);
+  printf("%d ", @w[0][4].t.a);
+
+  printf("-- ");
+  printf("%d ", @w[0][0].t.b[0]);
+  printf("%d ", @w[0][1].t.b[0]);
+  printf("%d ", @w[0][2].t.b[0]);
+  printf("%d ", @w[0][3].t.b[0]);
+  printf("%d ", @w[0][4].t.b[0]);
+
+  printf("-- ");
+  printf("%d ", @[$c->w]);
+}

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -899,6 +899,26 @@ TEST(semantic_analyser, array_in_map)
        1);
 }
 
+TEST(semantic_analyser, array_as_map_key)
+{
+  test("struct MyStruct { int x[2]; int y[4]; }"
+       "kprobe:f { @x[((struct MyStruct *)arg0)->x] = 0; }",
+       0);
+
+  test("struct MyStruct { int x[2]; int y[4]; }"
+       "kprobe:f { @x[((struct MyStruct *)arg0)->x, "
+       "              ((struct MyStruct *)arg0)->y] = 0; }",
+       0);
+
+  // Mismatched key types
+  test("struct MyStruct { int x[2]; int y[4]; }"
+       "kprobe:f { "
+       "    @x[((struct MyStruct *)arg0)->x] = 0; "
+       "    @x[((struct MyStruct *)arg0)->y] = 1; "
+       "}",
+       10);
+}
+
 TEST(semantic_analyser, variable_type)
 {
   BPFtrace bpftrace;

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -864,6 +864,14 @@ TEST(semantic_analyser, array_access) {
   auto assignment = static_cast<ast::AssignMapStatement *>(
       driver.root_->probes->at(0)->stmts->at(1));
   EXPECT_EQ(CreateInt64(), assignment->map->type);
+
+  test(driver,
+       "struct MyStruct { int y[4]; } kprobe:f { $s = ((struct MyStruct *) "
+       "arg0)->y; @x = $s[0];}",
+       0);
+  auto array_var_assignment = static_cast<ast::AssignVarStatement *>(
+      driver.root_->probes->at(0)->stmts->at(0));
+  EXPECT_EQ(CreateArray(4, CreateInt32()), array_var_assignment->var->type);
 }
 
 TEST(semantic_analyser, variable_type)

--- a/tests/testprogs/array_access.c
+++ b/tests/testprogs/array_access.c
@@ -3,7 +3,15 @@ struct A
   int x[4];
 };
 
-void test_struct(struct A *a __attribute__((unused))) { }
+struct B
+{
+  int y[2][2];
+};
+
+void test_struct(struct A *a __attribute__((unused)),
+                 struct B *b __attribute__((unused)))
+{
+}
 
 int main(int argc __attribute__((unused)), char ** argv __attribute__((unused)))
 {
@@ -12,5 +20,11 @@ int main(int argc __attribute__((unused)), char ** argv __attribute__((unused)))
   a.x[1] = 2;
   a.x[2] = 3;
   a.x[3] = 4;
-  test_struct(&a);
+
+  struct B b;
+  b.y[0][0] = 5;
+  b.y[0][1] = 6;
+  b.y[1][0] = 7;
+  b.y[1][1] = 8;
+  test_struct(&a, &b);
 }

--- a/tests/testprogs/array_access.c
+++ b/tests/testprogs/array_access.c
@@ -1,13 +1,16 @@
-typedef struct MY_STRUCT{
+struct A
+{
   int x[4];
+};
 
-}mystruct;
-
-void test_struct(mystruct *s __attribute__((unused))) { }
+void test_struct(struct A *a __attribute__((unused))) { }
 
 int main(int argc __attribute__((unused)), char ** argv __attribute__((unused)))
 {
-  mystruct s;
-  s.x[0] = 1;
-  test_struct(&s);
+  struct A a;
+  a.x[0] = 1;
+  a.x[1] = 2;
+  a.x[2] = 3;
+  a.x[3] = 4;
+  test_struct(&a);
 }

--- a/tests/testprogs/struct_array.c
+++ b/tests/testprogs/struct_array.c
@@ -4,7 +4,7 @@
 struct T
 {
   uint32_t a;
-  uint32_t b;
+  uint32_t b[2];
 };
 
 struct W
@@ -17,7 +17,7 @@ struct C
 {
   uint32_t a;
   void* b;
-  struct W w[10];
+  struct W w[5];
 };
 
 void clear(struct C* c)
@@ -34,11 +34,12 @@ int main()
 
   c.a = 0x55555555;
   c.b = (void*)0x55555555;
-  for (int x = 0; x < 10; x++)
+  for (int x = 0; x < 5; x++)
   {
     c.w[x].a = 100 + x;
     c.w[x].t.a = x;
-    c.w[x].t.b = 100 - x;
+    c.w[x].t.b[0] = 100 - x;
+    c.w[x].t.b[1] = 100 - 2 * x;
   }
 
   clear(&c);


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

This improves work with constant arrays. Until now, user could only use `[]` to directly access particular array elements.
This PR adds new possibilities to:
- assign an array to a local variable (resolves #1057)
- assign an array to a map
- use an array as a map key (resolves #1052).

If an array is assigned into a variable, operator `[]` can be later used on that variable to access the array elements.

For local variables, only the pointer to the array is stored. For maps, the array is fully copied into the map (or into the map key) since it may be accessed from another probe where the original array may not exist anymore, or may have a different value. I'm not sure if this is a correct approach, feel free to suggest something better.

The last commit also slightly changes the type of `alloca` for map key - instead of always allocating an array of bytes, it allocates the appropriate type (e.g. `i64` instead of `[8 * i8]` for integer keys). This caused some changes in existing codegens.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
