### PR TITLE
tuples: Treat Type::timestamp as an array 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -124,6 +124,8 @@ and this project adheres to
   - [#1646](https://github.com/iovisor/bpftrace/pull/1646)
 - Fix several undefined behavior
   - [#1645](https://github.com/iovisor/bpftrace/pull/1645)
+- Fix invalid size crash when using strftime() inside a tuple
+  - [#1658](https://github.com/iovisor/bpftrace/pull/1658)
 
 #### Tools
 - Hook up execsnoop.bt script onto `execveat` call

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -112,7 +112,8 @@ bool SizedType::operator==(const SizedType &t) const
 bool SizedType::IsArray() const
 {
   return type == Type::array || type == Type::string || type == Type::usym ||
-         type == Type::inet || type == Type::buffer || type == Type::record;
+         type == Type::inet || type == Type::buffer || type == Type::record ||
+         type == Type::timestamp;
 }
 
 bool SizedType::IsAggregate() const

--- a/tests/codegen/llvm/call_strftime.ll
+++ b/tests/codegen/llvm/call_strftime.ll
@@ -4,7 +4,7 @@ target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
 %strftime_t = type <{ i64, i64 }>
-%printf_t = type { i64, i128 }
+%printf_t = type { i64, [16 x i8] }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64, i64) #0
@@ -27,7 +27,7 @@ entry:
   %6 = getelementptr %strftime_t, %strftime_t* %strftime_args, i64 0, i32 1
   store i64 %get_ns, i64* %6
   %7 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  %8 = bitcast i128* %7 to i8*
+  %8 = bitcast [16 x i8]* %7 to i8*
   %9 = bitcast %strftime_t* %strftime_args to i8*
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %8, i8* align 1 %9, i64 16, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)

--- a/tests/codegen/llvm/call_strftime_LLVM-10.ll
+++ b/tests/codegen/llvm/call_strftime_LLVM-10.ll
@@ -4,7 +4,7 @@ target datalayout = "e-m:e-p:64:64-i64:64-n32:64-S128"
 target triple = "bpf-pc-linux"
 
 %strftime_t = type <{ i64, i64 }>
-%printf_t = type { i64, i128 }
+%printf_t = type { i64, [16 x i8] }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -27,7 +27,7 @@ entry:
   %6 = getelementptr %strftime_t, %strftime_t* %strftime_args, i64 0, i32 1
   store i64 %get_ns, i64* %6
   %7 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  %8 = bitcast i128* %7 to i8*
+  %8 = bitcast [16 x i8]* %7 to i8*
   %9 = bitcast %strftime_t* %strftime_args to i8*
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %8, i8* align 1 %9, i64 16, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)

--- a/tests/runtime/tuples
+++ b/tests/runtime/tuples
@@ -59,3 +59,8 @@ NAME tuple print
 RUN bpftrace -e 'BEGIN { @ = (1, 2, "string", (4, 5)); exit(); }'
 EXPECT ^@: \(1, 2, string, \(4, 5\)\)$
 TIMEOUT 5
+
+NAME tuple strftime type is packed
+RUN bpftrace -e 'BEGIN { @ = (nsecs, strftime("%M:%S", nsecs)); exit(); }'
+EXPECT ^@: \(\d+, \d+:\d+\)$
+TIMEOUT 5


### PR DESCRIPTION
Previously, we were seeing issues like:

```
$ sudo bpftrace -e 'BEGIN {@a[pid]=(nsecs, strftime("%M:%S", nsecs)); }'
FATAL: BUG: Struct size mismatch: expected: 24, real: 32
Aborted (core dumped)
```
on certain LLVM versions. The issue most likely has to do with padding
and whether LLVM considers the 16 byte type as a single 128 bit integer
or two 64 bit integers. If considered as a single 128 bit integer, then
the padded struct size is indeed 32 bytes. If as two 64 bit integers,
then 24 bytes is correct.

Instead of trying to fight with LLVM on this, mark Type::timestamp as an
array so that codegen will tell LLVM that Type::timestamp types are an
array of 16 8-bit integers. This effectively packs the type. We know
this is safe to do b/c Type::timestamp types are accessed from userspace
as two 64-bit integers anyways (see `AsyncEvent::Strftime`) which is
naturally packed on both 32-bit and 64-bit machines.

Note that this is also how Type::Usym is implemented.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
