### PR TITLE
Update kernel options list to support kprobes

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,6 +41,9 @@ CONFIG_BPF_JIT=y
 CONFIG_HAVE_EBPF_JIT=y
 CONFIG_BPF_EVENTS=y
 CONFIG_FTRACE_SYSCALLS=y
+CONFIG_FUNCTION_TRACER=y
+CONFIG_HAVE_DYNAMIC_FTRACE=y
+CONFIG_DYNAMIC_FTRACE=y
 ```
 
 This can be verified by running the `check_kernel_features` script from the


### PR DESCRIPTION

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

To use kprobes, bpftrace looks up `/sys/kernel/tracing/available_filter_functions` which is not available otherwise without these options.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
