### PR TITLE
Add DISK field to biosnoop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 ## Unreleased
 
 #### Added
+- Add disk field to biosnoop
+  - [#1660](https://github.com/iovisor/bpftrace/pull/1660)
 - Add path builtin
   - [#1492](https://github.com/iovisor/bpftrace/pull/1492)
 - Allow wildcards for tracepoint categories

--- a/tools/biosnoop.bt
+++ b/tools/biosnoop.bt
@@ -13,7 +13,7 @@
 
 BEGIN
 {
-	printf("%-12s %-16s %-16s %-6s %7s\n", "TIME(ms)", "DISK", "COMM", "PID", "LAT(ms)");
+	printf("%-12s %-7s %-16s %-6s %7s\n", "TIME(ms)", "DISK", "COMM", "PID", "LAT(ms)");
 }
 
 kprobe:blk_account_io_start
@@ -29,7 +29,7 @@ kprobe:blk_account_io_done
 
 {
 	$now = nsecs;
-	printf("%-12u %-16s %-16s %-6d %7d\n",
+	printf("%-12u %-7s %-16s %-6d %7d\n",
 	    elapsed / 1000000, @disk[arg0], @iocomm[arg0], @iopid[arg0],
 	    ($now - @start[arg0]) / 1000000);
 

--- a/tools/biosnoop.bt
+++ b/tools/biosnoop.bt
@@ -1,9 +1,10 @@
 #!/usr/bin/env bpftrace
+#include <linux/blkdev.h>
 /*
  * biosnoop.bt   Block I/O tracing tool, showing per I/O latency.
  *               For Linux, uses bpftrace, eBPF.
  *
- * TODO: switch to block tracepoints. Add device, offset, and size columns.
+ * TODO: switch to block tracepoints. Add offset and size columns.
  *
  * This is a bpftrace version of the bcc tool of the same name.
  *
@@ -12,7 +13,7 @@
 
 BEGIN
 {
-	printf("%-12s %-16s %-6s %7s\n", "TIME(ms)", "COMM", "PID", "LAT(ms)");
+	printf("%-12s %-16s %-16s %-6s %7s\n", "TIME(ms)", "DISK", "COMM", "PID", "LAT(ms)");
 }
 
 kprobe:blk_account_io_start
@@ -20,19 +21,22 @@ kprobe:blk_account_io_start
 	@start[arg0] = nsecs;
 	@iopid[arg0] = pid;
 	@iocomm[arg0] = comm;
+	@disk[arg0] = ((struct request *)arg0)->rq_disk->disk_name;
 }
 
 kprobe:blk_account_io_done
 /@start[arg0] != 0 && @iopid[arg0] != 0 && @iocomm[arg0] != ""/
+
 {
 	$now = nsecs;
-	printf("%-12u %-16s %-6d %7d\n",
-	    elapsed / 1e6, @iocomm[arg0], @iopid[arg0],
-	    ($now - @start[arg0]) / 1e6);
+	printf("%-12u %-16s %-16s %-6d %7d\n",
+	    elapsed / 1000000, @disk[arg0], @iocomm[arg0], @iopid[arg0],
+	    ($now - @start[arg0]) / 1000000);
 
 	delete(@start[arg0]);
 	delete(@iopid[arg0]);
 	delete(@iocomm[arg0]);
+	delete(@disk[arg0]);
 }
 
 END
@@ -40,4 +44,5 @@ END
 	clear(@start);
 	clear(@iopid);
 	clear(@iocomm);
+	clear(@disk);
 }

--- a/tools/biosnoop.bt
+++ b/tools/biosnoop.bt
@@ -30,8 +30,8 @@ kprobe:blk_account_io_done
 {
 	$now = nsecs;
 	printf("%-12u %-7s %-16s %-6d %7d\n",
-	    elapsed / 1000000, @disk[arg0], @iocomm[arg0], @iopid[arg0],
-	    ($now - @start[arg0]) / 1000000);
+	    elapsed / 1e6, @disk[arg0], @iocomm[arg0], @iopid[arg0],
+	    ($now - @start[arg0]) / 1e6);
 
 	delete(@start[arg0]);
 	delete(@iopid[arg0]);

--- a/tools/biosnoop_example.txt
+++ b/tools/biosnoop_example.txt
@@ -6,25 +6,25 @@ that was on-CPU at the time of queue insert) and the latency of the I/O:
 
 # ./biosnoop.bt
 Attaching 4 probes...
-TIME(ms)     COMM             PID    LAT(ms)
-611          bash             4179        10
-611          cksum            4179         0
-627          cksum            4179        15
-641          cksum            4179        13
-644          cksum            4179         3
-658          cksum            4179        13
-673          cksum            4179        14
-686          cksum            4179        13
-701          cksum            4179        14
-710          cksum            4179         8
-717          cksum            4179         6
-728          cksum            4179        10
-735          cksum            4179         6
-751          cksum            4179        10
-758          cksum            4179        17
-783          cksum            4179        12
-796          cksum            4179        25
-802          cksum            4179        32
+TIME(ms)     DISK             COMM             PID    LAT(ms)
+611          nvme0n1          bash             4179        10
+611          nvme0n1          cksum            4179         0
+627          nvme0n1          cksum            4179        15
+641          nvme0n1          cksum            4179        13
+644          nvme0n1          cksum            4179         3
+658          nvme0n1          cksum            4179        13
+673          nvme0n1          cksum            4179        14
+686          nvme0n1          cksum            4179        13
+701          nvme0n1          cksum            4179        14
+710          nvme0n1          cksum            4179         8
+717          nvme0n1          cksum            4179         6
+728          nvme0n1          cksum            4179        10
+735          nvme0n1          cksum            4179         6
+751          nvme0n1          cksum            4179        10
+758          nvme0n1          cksum            4179        17
+783          nvme0n1          cksum            4179        12
+796          nvme0n1          cksum            4179        25
+802          nvme0n1          cksum            4179        32
 [...]
 
 This output shows the cksum process was issuing block I/O, which were
@@ -37,9 +37,9 @@ An example of some background flushing:
 
 # ./biosnoop.bt
 Attaching 4 probes...
-TIME(ms)     COMM             PID    LAT(ms)
-2966         jbd2/nvme0n1-8   615          0
-2967         jbd2/nvme0n1-8   615          0
+TIME(ms)     DISK             COMM             PID    LAT(ms)
+2966         nvme0n1          jbd2/nvme0n1-8   615          0
+2967         nvme0n1          jbd2/nvme0n1-8   615          0
 [...]
 
 


### PR DESCRIPTION
Add disk field to biosnoop.

I tried to also add `req->part->part_no` but I felt I was not getting what I expected on it when writing to certain partitions. 

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [X] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
