### PR TITLE
tests/childproc: resume SIGHUP to SIG_DFL before test

### DIFF
--- a/tests/child.cpp
+++ b/tests/child.cpp
@@ -110,6 +110,7 @@ TEST(childproc, destructor_destroy_child)
 
 TEST(childproc, child_kill_before_exec)
 {
+  signal(SIGHUP, SIG_DFL);
   auto child = getChild(TEST_BIN_SLOW);
 
   EXPECT_EQ(kill(child->pid(), SIGHUP), 0);


### PR DESCRIPTION
since SIGHUP could be set SIG_IGN in parent process,
test will get failed, so resume SIGHUP before test.

Signed-off-by: Chunmei Xu <xuchunmei@linux.alibaba.com>

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
