### PR TITLE
Remove the --btf option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -248,6 +248,8 @@ Bug fix release for the [Docker build](https://quay.io/repository/iovisor/bpftra
 
 - Drop LLVM 5 support
   - [#1215](https://github.com/iovisor/bpftrace/issues/1215)
+- Remove the --btf option
+  - [#1669](https://github.com/iovisor/bpftrace/pull/1669)
 
 #### Fixed
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -141,7 +141,6 @@ OPTIONS:
     -B MODE        output buffering mode ('line', 'full', or 'none')
     -d             debug info dry run
     -dd            verbose debug info dry run
-    -b             force BTF (BPF type format) processing
     -e 'program'   execute this program
     -h             show this help message
     -I DIR         add the specified DIR to the search path for include files.
@@ -2744,7 +2743,7 @@ Attaching 1 probe...
 Attaching 1 probe...
 8
 
-# bpftrace --btf -e 'BEGIN { printf("%d\n", sizeof(struct task_struct)); }'
+# bpftrace -e 'BEGIN { printf("%d\n", sizeof(struct task_struct)); }'
 Attaching 1 probe...
 13120
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -108,6 +108,7 @@ discussion to other files in /docs, the /tools/\*\_examples.txt files, or blog p
     - [1. `printf()`: Per-Event Output](#1-printf-per-event-output)
     - [2. `interval`: Interval Output](#2-interval-interval-output)
     - [3. `hist()`, `printf()`: Histogram Printing](#3-hist-print-histogram-printing)
+- [BTF Support](#btf-support)
 - [Advanced Tools](#advanced-tools)
 - [Errors](#errors)
 
@@ -980,13 +981,7 @@ open path: interrupts
 [...]
 ```
 
-Requirements for using BTF:
-
-- Linux 4.18+ with `CONFIG_DEBUG_INFO_BTF=y`
-    - Building requires dwarves with pahole v1.13+
-- bpftrace v0.9.3+ with BTF support (built with libbpf v0.0.4+)
-
-See [kernel documentation](https://www.kernel.org/doc/html/latest/bpf/btf.html) for more information on BTF.
+See [BTF Support](#btf-support) for more details.
 
 Examples in situ:
 [(kprobe) search /tools](https://github.com/iovisor/bpftrace/search?q=kprobe%3A+path%3Atools&type=Code)
@@ -3288,6 +3283,25 @@ Histograms can also be printed on-demand, using the `print()` function. Eg:
 
 [...]
 ```
+
+# BTF Support
+
+If kernel has BTF, kernel types are automatically available and there is no need to include additional headers
+to use them.
+
+Requirements for using BTF:
+
+- Linux 4.18+ with `CONFIG_DEBUG_INFO_BTF=y`
+    - Building requires dwarves with pahole v1.13+
+- bpftrace v0.9.3+ with BTF support (built with libbpf v0.0.4+)
+
+See [kernel documentation](https://www.kernel.org/doc/html/latest/bpf/btf.html) for more information on BTF.
+
+Beware that BTF types are not available to a bpftrace program if it contains a user-defined type that
+redefines some BTF type. Here, "user-defined types" are also types introduced via included headers.
+Therefore, if you include a kernel header in your bpftrace program, it is very likely that it will define some
+kernel type and that BTF won't be available to your program (and you'll have to define/include all necessary
+types manually).
 
 # Advanced Tools
 

--- a/man/man8/bpftrace.8
+++ b/man/man8/bpftrace.8
@@ -55,10 +55,6 @@ See \fBPROBE TYPES\fR and \fBBUILTINS (variables/functions)\fR for the bpftrace 
 The buffering mode to be used for output ('full', 'none').
 .
 .TP
-\fB\-b | --btf\fR
-Force BTF data processing if it's available. By default it's enabled only if the user does not specify any types/includes.
-.
-.TP
 \fB\-c CMD\fR
 Helper to run CMD. Equivalent to manually running CMD and then giving passing the PID to -p. This is useful to ensure
 you've traced at least the duration CMD's execution.

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -169,7 +169,6 @@ public:
   bool resolve_user_symbols_ = true;
   bool cache_user_symbols_ = true;
   bool safe_mode_ = true;
-  bool force_btf_ = false;
   bool has_usdt_ = false;
   bool usdt_file_activation_ = false;
   int helper_check_level_ = 0;

--- a/src/clang_parser.h
+++ b/src/clang_parser.h
@@ -56,6 +56,7 @@ private:
       const std::string &diagnostic_msg);
 
   CXUnsavedFile get_btf_generated_header(BPFtrace &bpftrace);
+  CXUnsavedFile get_empty_btf_generated_header();
 
   std::string input;
   std::vector<const char *> args;
@@ -94,6 +95,9 @@ private:
     CXCursor get_translation_unit_cursor();
 
     const std::vector<std::string> &get_error_messages();
+
+    bool has_redefinition_error();
+    bool has_unknown_type_error();
 
   private:
     CXIndex index;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -61,7 +61,6 @@ void usage()
   std::cerr << "    -o file        redirect bpftrace output to file" << std::endl;
   std::cerr << "    -d             debug info dry run" << std::endl;
   std::cerr << "    -dd            verbose debug info dry run" << std::endl;
-  std::cerr << "    -b             force BTF (BPF type format) processing" << std::endl;
   std::cerr << "    -e 'program'   execute this program" << std::endl;
   std::cerr << "    -h, --help     show this help message" << std::endl;
   std::cerr << "    -I DIR         add the directory to the include search path" << std::endl;
@@ -275,7 +274,6 @@ int main(int argc, char *argv[])
   std::string cmd_str;
   bool listing = false;
   bool safe_mode = true;
-  bool force_btf = false;
   bool usdt_file_activation = false;
   int helper_check_level = 0;
   TestMode test_mode = TestMode::UNSET;
@@ -382,7 +380,6 @@ int main(int argc, char *argv[])
         safe_mode = false;
         break;
       case 'b':
-        force_btf = true;
         break;
       case 'h':
         usage();
@@ -466,7 +463,6 @@ int main(int argc, char *argv[])
 
   bpftrace.usdt_file_activation_ = usdt_file_activation;
   bpftrace.safe_mode_ = safe_mode;
-  bpftrace.force_btf_ = force_btf;
   bpftrace.helper_check_level_ = helper_check_level;
   bpftrace.boottime_ = get_boottime();
 

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -217,11 +217,8 @@ std::string TracepointFormatParser::parse_field(const std::string &line,
   if (field_name.find("[") == std::string::npos)
     field_type = adjust_integer_types(field_type, size);
 
-  // With --btf on, we try not to use any header files, including
-  // <linux/types.h>. That means we must request all the types we need
-  // from BTF. Note we don't need to gate this on --btf because the
-  // expensive type reslution is already gated on --btf (adding to a set
-  // is cheap).
+  // If BTF is available, we try not to use any header files, including
+  // <linux/types.h> and request all the types we need from BTF.
   bpftrace.btf_set_.emplace(field_type);
 
   return extra + "  " + field_type + " " + field_name + ";\n";

--- a/tests/runtime/btf
+++ b/tests/runtime/btf
@@ -1,23 +1,35 @@
 NAME user_supplied_c_def_using_btf
-RUN bpftrace -v --btf -e 'struct foo { struct task_struct t; } BEGIN { exit(); }'
+RUN bpftrace -v -e 'struct foo { struct task_struct t; } BEGIN { exit(); }'
 EXPECT Attaching 1 probe...
 TIMEOUT 5
 REQUIRES_FEATURE btf
 
 NAME tracepoint_pointer_type_resolution
-RUN bpftrace -v --btf -e 'tracepoint:syscalls:sys_enter_nanosleep { args->rqtp->tv_sec; exit(); }'
+RUN bpftrace -v -e 'tracepoint:syscalls:sys_enter_nanosleep { args->rqtp->tv_sec; exit(); }'
 EXPECT Attaching 1 probe...
 TIMEOUT 5
 REQUIRES_FEATURE btf
 
 NAME tracepoint_nested_pointer_type_resolution
-RUN bpftrace --btf -e 'tracepoint:napi:napi_poll { args->napi->dev->name; exit(); }'
+RUN bpftrace -e 'tracepoint:napi:napi_poll { args->napi->dev->name; exit(); }'
 EXPECT Attaching 1 probe...
 TIMEOUT 5
 REQUIRES_FEATURE btf
 
 NAME enum_value_reference
-RUN bpftrace -v --btf -e 'BEGIN { printf("%d\n", sizeof(BTF_VAR_STATIC)); exit(); }'
+RUN bpftrace -v -e 'BEGIN { printf("%d\n", sizeof(BTF_VAR_STATIC)); exit(); }'
 EXPECT ^8$
+TIMEOUT 5
+REQUIRES_FEATURE btf
+
+NAME redefine_btf_type
+RUN bpftrace -v -e 'struct task_struct { int x; } BEGIN { printf("%d\n", curtask->x); }'
+EXPECT -?[0-9][0-9]*
+TIMEOUT 5
+REQUIRES_FEATURE btf
+
+NAME redefine_btf_type_missing_def
+RUN bpftrace -v -e 'struct task_struct { struct thread_info x; } BEGIN { printf("%d\n", curtask->x.status); }'
+EXPECT error:.*'struct thread_info'
 TIMEOUT 5
 REQUIRES_FEATURE btf

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -194,7 +194,7 @@ EXPECT ^8 8$
 TIMEOUT 5
 
 NAME sizeof_btf
-RUN bpftrace --btf -e 'BEGIN { printf("size=%d\n", sizeof(struct task_struct)); exit(); }'
+RUN bpftrace -e 'BEGIN { printf("size=%d\n", sizeof(struct task_struct)); exit(); }'
 EXPECT ^size=
 TIMEOUT 5
 REQUIRES_FEATURE btf


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

This is an improved version of #1506, which caused type redefinition conflicts for some cases. Now, all the examples mentioned in the old PR should work.

BTF is parsed automatically if it is available and if the user didn't define any type (either via user definitions or via includes) that would redefine some type from BTF.

I think that this also closes #1588. It would seem nicer to allow the user to redefine a part of the types and take the rest from BTF, but I believe that could cause some unexpected behaviour (see [this comment](https://github.com/iovisor/bpftrace/issues/1588#issuecomment-721069928) for details).

The only problem of this implementation is that it checks for redefinitions by running the Clang parser and then checking the error messages. This is not a nice solution, but I haven't been able to find a better one, yet. If you have any ideas, please bring them in.

Also, I'm not sure if this solves the problem from #1511, as `linux/types.h` will be used when BTF is not and that may cause redefinition errors with `sys/types.h`. It shouldn't be hard to resolve this in a way similar to this PR, but I haven't been able to come with a reproducer.

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
