### PR TITLE
[bug report] add failing tests that call 2-arg str() in USDT

### DIFF
--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -245,6 +245,24 @@ EXPECT ^1$
 TIMEOUT 5
 BEFORE ./testprogs/usdt_sized_args
 
+NAME "usdt call 2-arg str()"
+RUN bpftrace -e 'usdt:./testprogs/usdt_call_str_2:test:probe1 { printf("<%s>\n", str(arg0, arg1)); exit(); }' -p {{BEFORE_PID}}
+EXPECT ^<hello>$
+TIMEOUT 5
+BEFORE ./testprogs/usdt_call_str_2
+
+NAME "usdt call 2-arg str() with cast"
+RUN bpftrace -e 'usdt:./testprogs/usdt_call_str_2:test:probe1 { printf("<%s>\n", str(arg0, (int32)arg1)); exit(); }' -p {{BEFORE_PID}}
+EXPECT ^<hello>$
+TIMEOUT 5
+BEFORE ./testprogs/usdt_call_str_2
+
+NAME "usdt call 2-arg str() with int"
+RUN bpftrace -e 'usdt:./testprogs/usdt_call_str_2:test:probe2 { printf("<%s>\n", str(arg0, arg1)); exit(); }' -p {{BEFORE_PID}}
+EXPECT ^<hello>$
+TIMEOUT 5
+BEFORE ./testprogs/usdt_call_str_2
+
 # USDT probes can be inlined which creates duplicate identical probes. We must
 # attach to all of them
 NAME "usdt duplicated markers"

--- a/tests/testprogs/usdt_call_str_2.c
+++ b/tests/testprogs/usdt_call_str_2.c
@@ -1,0 +1,23 @@
+#ifdef HAVE_SYSTEMTAP_SYS_SDT_H
+#include <sys/sdt.h>
+#else
+#define DTRACE_PROBE2(a, b, c, d) (void)0
+#endif
+#include <stdlib.h>
+#include <string.h>
+
+int main()
+{
+  const char *s = "hello";
+  size_t s_len = strlen(s);
+  (void)s;
+  (void)s_len;
+
+  while (1)
+  {
+    DTRACE_PROBE2(test, probe1, s, s_len);
+    DTRACE_PROBE2(test, probe2, s, (int)s_len);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
This is rather a bug report with failing tests instead of a patch to fix problems.

## Environment

* Ubuntu 20.04.1 / Kernel 5.4.0-58-generic
* bpftrace 0f7cd742cb2f71426e07d21f27d550e6a12c2387 (latest as of Jan 8 2021)

## Problems

`str(arg0, arg1)` does not work in USDT, where arg0 is `const char*` and arg1 is `size_t` in the target C program.

To be exact, given `const char* s = "..."` and `size_t s_len = strlen(s)` in the C program, emitting an event with `DTRACE_PROBE2(test, probe1, s, s_len)`, and the bpftrace script is something like this:

```
usdt:./testprogs/usdt_call_str_2:test:probe1 {
  printf("<%s>\n", str(arg0, arg1));
  exit();
}
```

It results in `<>`, where it is expected to be `<hello>` (`NAME "usdt call 2-arg str()"
`).  If the second arg is converted to `int` in the C program, it passes (`NAME "usdt call 2-arg str() with int"
`).

Also, `printf("<%s>\n", str(arg0, (int32)arg1));` fails with assertion failure, as the test script includes (`NAME "usdt call 2-arg str() with cast"
`).

## How to reproduce this problem

See the diff in the PR.