### PR TITLE
tests: runtime: Print test output on a single line

### DIFF
--- a/tests/runtime/engine/utils.py
+++ b/tests/runtime/engine/utils.py
@@ -229,5 +229,5 @@ class Utils(object):
             print(fail("[  FAILED  ] ") + "%s.%s" % (test.suite, test.name))
             print('\tCommand: ' + bpf_call)
             print('\tExpected: ' + test.expect)
-            print('\tFound: ' + output)
+            print('\tFound: ' + output.encode("unicode_escape").decode("utf-8"))
             return Utils.FAIL


### PR DESCRIPTION
It's kind of hard to glance at the output when it spans multiple lines.
I think it's much clearer when it's all escaped and on one line. Just
like how gtest does its output.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
