### PR TITLE
Fix attaching to multiple usdt probe locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,6 +136,8 @@ and this project adheres to
   - [#1650](https://github.com/iovisor/bpftrace/pull/1650)
 - Fix attaching to usdt probes in shared libraries
   - [#1600](https://github.com/iovisor/bpftrace/pull/1600)
+- Fix attaching to multiple usdt probe locations with the same label
+  - [#1681](https://github.com/iovisor/bpftrace/pull/1681)
 
 #### Tools
 - Hook up execsnoop.bt script onto `execveat` call

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -857,7 +857,8 @@ void AttachedProbe::attach_usdt(int pid, BPFfeature &feature)
   probe_.path = u->path;
 
   err = bcc_usdt_get_location(
-      ctx, probe_.ns.c_str(), probe_.attach_point.c_str(), 0, &loc);
+      ctx, probe_.ns.c_str(), probe_.attach_point.c_str(),
+      probe_.usdt_location_idx, &loc);
   if (err)
     throw std::runtime_error("Error finding location for probe: " +
                              probe_.name);

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -856,9 +856,11 @@ void AttachedProbe::attach_usdt(int pid, BPFfeature &feature)
     throw std::runtime_error("Failed to find usdt probe: " + eventname());
   probe_.path = u->path;
 
-  err = bcc_usdt_get_location(
-      ctx, probe_.ns.c_str(), probe_.attach_point.c_str(),
-      probe_.usdt_location_idx, &loc);
+  err = bcc_usdt_get_location(ctx,
+                              probe_.ns.c_str(),
+                              probe_.attach_point.c_str(),
+                              probe_.usdt_location_idx,
+                              &loc);
   if (err)
     throw std::runtime_error("Error finding location for probe: " +
                              probe_.name);

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -262,8 +262,8 @@ BEFORE ./testprogs/usdt_sized_args
 # USDT probes can be inlined which creates duplicate identical probes. We must
 # attach to all of them
 NAME "usdt duplicated markers"
-RUN bpftrace -e 'usdt:./testprogs/usdt_inlined:tracetest:testprobe { exit(); }' -c ./testprogs/usdt_inlined
-EXPECT Attaching 2 probes
+RUN bpftrace -e 'usdt:./testprogs/usdt_inlined:tracetest:testprobe { printf("%d\n", arg1); @a += 1; if (@a >= 2) {exit();} }' -c ./testprogs/usdt_inlined
+EXPECT Attaching 2 probes.*\s999\s*100
 TIMEOUT 1
 REQUIRES ./testprogs/usdt_inlined should_not_skip
 

--- a/tests/testprogs/usdt_inlined.c
+++ b/tests/testprogs/usdt_inlined.c
@@ -12,7 +12,7 @@ __attribute__((always_inline)) inline static void myclock(int probe_num)
   // Volatile forces reading directly from the stack so that
   // the probe's argument is not saved as a constant value.
   volatile int on_stack = probe_num;
-  (void) on_stack;
+  (void)on_stack;
   struct timeval tv;
   gettimeofday(&tv, NULL);
   DTRACE_PROBE2(tracetest, testprobe, tv.tv_sec, on_stack);

--- a/tests/testprogs/usdt_inlined.c
+++ b/tests/testprogs/usdt_inlined.c
@@ -7,23 +7,27 @@
 #include <sys/time.h>
 #include <unistd.h>
 
-__attribute__((always_inline)) inline static void myclock()
+__attribute__((always_inline)) inline static void myclock(int probe_num)
 {
+  // Volatile forces reading directly from the stack so that
+  // the probe's argument is not saved as a constant value.
+  volatile int on_stack = probe_num;
+  (void) on_stack;
   struct timeval tv;
   gettimeofday(&tv, NULL);
-  DTRACE_PROBE2(tracetest, testprobe, tv.tv_sec, "Hello world");
+  DTRACE_PROBE2(tracetest, testprobe, tv.tv_sec, on_stack);
 }
 
 static void mywrapper()
 {
-  myclock();
+  myclock(100);
 }
 
 static void loop()
 {
   while (1)
   {
-    myclock();
+    myclock(999);
     mywrapper();
     sleep(1);
   }


### PR DESCRIPTION
Fixes a bug where all usdt BPF programs were attached to the first probe point
location when there are multiple locations of the same probe (inlining
etc).
Also, modifies the existing test to test the correct probes are installed.


Here is a minimal test example to show this behaviour:
```
// test-probe-loc.c
#include <sys/sdt.h>
int main() {
   DTRACE_PROBE1(test, probe, 1); // probe 1
}
int unused() {
   DTRACE_PROBE1(test, probe, 2); // probe 2
}
```
```
# gcc test-probe-loc.c -o test-probe-loc
# bpftool -e 'usdt:./test:test:probe { printf("%d\n", arg0); }' -c ./test-probe-loc
# tplist-bpfcc -vv -l ./test-probe-loc
b'test':b'probe' [sema 0x0]
  location #1 b'./test-probe-loc' 0x1131
    argument #1 4 signed   bytes @ 1
  location #2 b'./test-probe-loc' 0x1141
    argument #1 4 signed   bytes @ 2
```

Without the fix, ```probe 1``` is hit twice (but with different BPF programs running, hence both 1 and 2 are printed). _Or it might never get called depending on the order that probe locations are listed in test-probe-loc._
```
# bpftrace_v.11.4 -e 'usdt:./test-probe-loc:test:probe { printf("%d\n", arg0); }' -c ./test-probe-loc
Attaching 2 probes...
1
2
```

With the fix, ```probe 1``` is only called once with the correct BPF program
```
# bpftrace_master -e 'usdt:./test-probe-loc:test:probe { printf("%d\n", arg0); }' -c ./test-probe-loc
Attaching 2 probes...
1
```

