### PR TITLE
syscount.bt: Fix small typo in explanatory comment

### DIFF
--- a/tools/syscount.bt
+++ b/tools/syscount.bt
@@ -1,6 +1,6 @@
 #!/usr/bin/env bpftrace
 /*
- * syscount.bt	Count system callls.
+ * syscount.bt	Count system calls.
  *		For Linux, uses bpftrace, eBPF.
  *
  * This is a bpftrace version of the bcc tool of the same name.


### PR DESCRIPTION
Replace "callls" with "calls".