### PR TITLE
bpftrace: Fix build error

### DIFF
--- a/src/arch/arch.h
+++ b/src/arch/arch.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <stdexcept>
 #include <string>
 #include <vector>
 

--- a/tests/runtime/watchpoint
+++ b/tests/runtime/watchpoint
@@ -14,12 +14,14 @@ REQUIRES awk '$3 == "jiffies" {got=1} END {exit !got}' /proc/kallsyms
 NAME function_arg_addr
 RUN bpftrace -v -e 'watchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint_func
 EXPECT hit!
+ARCH aarch64|x86_64
 TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME async_function_arg_addr
 RUN bpftrace -v -e 'asyncwatchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint_func
 EXPECT hit!
+ARCH aarch64|x86_64
 TIMEOUT 5
 REQUIRES_FEATURE signal
 
@@ -27,35 +29,41 @@ NAME function_arg_addr_process_flag
 RUN bpftrace -v -e 'watchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }' -p $(pidof watchpoint_func)
 BEFORE ./testprogs/watchpoint_func
 EXPECT hit!
+ARCH aarch64|x86_64
 TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME many_function_probes
 RUN bpftrace -e 'watchpoint:increment+arg0:4:w { printf("hit!\n") }' -c ./testprogs/watchpoint_func_many_probes
 EXPECT You are out of watchpoint registers
+ARCH aarch64|x86_64
 TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME unwatch
 RUN bpftrace runtime/scripts/watchpoint_unwatch.bt -c ./testprogs/watchpoint_unwatch
 EXPECT count=1
+ARCH aarch64|x86_64
 TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME function_multiattach
 RUN bpftrace -v runtime/scripts/watchpoint_multiattach.bt -c ./testprogs/watchpoint_func_wildcard
 EXPECT count=3
+ARCH aarch64|x86_64
 TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME wildcarded_function
 RUN bpftrace -v -e 'watchpoint:increment_*+arg0:4:w { printf("hit!\n") }' -c ./testprogs/watchpoint_func_wildcard
 EXPECT You are out of watchpoint registers
+ARCH aarch64|x86_64
 TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME unique_probe_bodies
 RUN bpftrace -v -e 'watchpoint:increment_*+arg0:4:w { printf("%s!\n", probe) }' -c ./testprogs/watchpoint_func_wildcard
 EXPECT .*increment_0:4:w!
+ARCH aarch64|x86_64
 TIMEOUT 5
 REQUIRES_FEATURE signal


### PR DESCRIPTION
Add required header to avoid build errors.

The compilation fails for s390x and probably powerpc as well.

Fixes: 290dadea ("watchpoint: Permit specifying function+function_arg
XOR absolute address")

Signed-off-by: Sumanth Korikkar <sumanthk@linux.ibm.com>

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
