### PR TITLE
Remove bpftrace.next_probe_id

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -275,11 +275,9 @@ void CodegenLLVM::visit(Builtin &builtin)
     auto begin = bpftrace_.probe_ids_.begin();
     auto end = bpftrace_.probe_ids_.end();
     auto found = std::find(begin, end, probefull_);
+    builtin.probe_id = std::distance(begin, found);
     if (found == end) {
       bpftrace_.probe_ids_.push_back(probefull_);
-      builtin.probe_id = bpftrace_.next_probe_id();
-    } else {
-      builtin.probe_id = std::distance(begin, found);
     }
     expr_ = b_.getInt64(builtin.probe_id);
   }

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -113,9 +113,6 @@ public:
   int clear_map(IMap &map);
   int zero_map(IMap &map);
   int print_map(IMap &map, uint32_t top, uint32_t div);
-  inline int next_probe_id() {
-    return next_probe_id_++;
-  };
   std::string get_stack(uint64_t stackidpid, bool ustack, StackType stack_type, int indent=0);
   std::string resolve_buf(char *buf, size_t size);
   std::string resolve_ksym(uintptr_t addr, bool show_offset=false);
@@ -217,7 +214,6 @@ private:
   int ncpus_;
   int online_cpus_;
   std::vector<std::string> params_;
-  int next_probe_id_ = 0;
 
   std::vector<std::unique_ptr<void, void (*)(void *)>> open_perf_buffers_;
 


### PR DESCRIPTION
The member function 'bpftrace.next_probe_id' is only used to assign new IDs
to probe names. However, this is redundant. Probe IDs are taken from
their location in the vector 'bpftrace.probe_ids_'. This change modifies the
code to take new IDs from the same behaviour.

There are no language, user-visible, or behaviour changes. This is a minor
code improvement.

##### Checklist

- [N/A] Language changes are updated in `docs/reference_guide.md` 
- [N/A] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [N/A] The new behaviour is covered by tests
