### PR TITLE
1263: use filesystem; get_pid_exe

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -151,19 +151,23 @@ bool get_uint64_env_var(const std::string &str, uint64_t &dest)
 
 std::string get_pid_exe(pid_t pid)
 {
-  char proc_path[512];
-  char exe_path[4096];
-  int res;
+  std::error_code ec;
+  std_filesystem::path proc_path{ "/proc" };
+  proc_path /= std::to_string(pid);
+  proc_path /= "exe";
 
-  sprintf(proc_path, "/proc/%d/exe", pid);
-  res = readlink(proc_path, exe_path, sizeof(exe_path));
-  if (res == -1)
+  if (!std_filesystem::exists(proc_path, ec) ||
+      !std_filesystem::is_symlink(proc_path, ec))
     return "";
-  if (res >= static_cast<int>(sizeof(exe_path))) {
-    throw std::runtime_error("executable path exceeded maximum supported size of 4096 characters");
+
+  std::string exe_path = std_filesystem::read_symlink(proc_path).string();
+
+  if (exe_path.length() >= 4096)
+  {
+    throw std::runtime_error(
+        "executable path exceeded maximum supported size of 4096 characters");
   }
-  exe_path[res] = '\0';
-  return std::string(exe_path);
+  return exe_path;
 }
 
 bool has_wildcard(const std::string &str)


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests

@fbs #1263 small update in utils::get_pid_exe; using filesystem's path instead of `sprintf`, all tests passed, and it's backward compatible