### PR TITLE
Fix inconsistency in documentation

### DIFF
--- a/tools/tcpaccept_example.txt
+++ b/tools/tcpaccept_example.txt
@@ -8,14 +8,14 @@ addresses changed to protect the innocent):
 # ./tcpaccept.bt
 Tracing tcp accepts. Hit Ctrl-C to end.
 TIME     PID     COMM           RADDR          RPORT LADDR          LPORT BL
-00:34:19 3949061 nginx          10.228.22.228  44226 10.229.20.169  8080  0/128
+00:34:19 3949061 nginx          10.228.22.228  44226 10.229.20.169  8088  0/128
 00:34:19 3951399 ruby           127.0.0.1      52422 127.0.0.1      8000  0/128
 00:34:19 3949062 nginx          10.228.23.128  35408 10.229.20.169  8080  0/128
 
 
-This output shows three connections, an IPv4 connections to PID 1463622, a "redis-server"
-process listening on port 6379, and one IPv6 connection to a "thread.rb" process
-listening on port 8000. The remote address and port are also printed, and the accept queue
+This output shows three connections, an IPv4 connections to PID 3949061, a "ruby"
+process listening on port 8000, and one connection to a "nginx" process
+listening on port 8080. The remote address and port are also printed, and the accept queue
 current size as well as maximum size are shown.
 
 The overhead of this tool should be negligible, since it is only tracing the

--- a/tools/tcpaccept_example.txt
+++ b/tools/tcpaccept_example.txt
@@ -13,7 +13,7 @@ TIME     PID     COMM           RADDR          RPORT LADDR          LPORT BL
 00:34:19 3949062 nginx          10.228.23.128  35408 10.229.20.169  8080  0/128
 
 
-This output shows three connections, an IPv4 connections to PID 3949061, a "ruby"
+This output shows three connections, an IPv4 connections to PID 3951399, a "ruby"
 process listening on port 8000, and one connection to a "nginx" process
 listening on port 8080. The remote address and port are also printed, and the accept queue
 current size as well as maximum size are shown.

--- a/tools/tcpconnect_example.txt
+++ b/tools/tcpconnect_example.txt
@@ -13,7 +13,7 @@ TIME     PID      COMM             SADDR          SPORT  DADDR          DPORT
 
 
 This output shows three connections, one from a "agent" process, one from
-"curl", and one from "redis-cli". The output details shows the IP version, source
+"curl", and one from "nginx". The output details shows the IP version, source
 address, source socket port, destination address, and destination port. This traces attempted
 connections: these may have failed.
 


### PR DESCRIPTION
In some tool explanation files the description text did not match with the shown example output.


##### Checklist (irrelevant)

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
