### PR TITLE
1263: ast codegen; remove sprintf

### DIFF
--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -576,9 +576,9 @@ void CodegenLLVM::visit(Call &call)
     }
 
     auto elements = AsyncEvent::Buf().asLLVMType(b_, fixed_buffer_length);
-    char dynamic_sized_struct_name[30];
-    sprintf(dynamic_sized_struct_name, "buffer_%ld_t", fixed_buffer_length);
-    StructType *buf_struct = b_.GetStructType(dynamic_sized_struct_name,
+    std::ostringstream dynamic_sized_struct_name;
+    dynamic_sized_struct_name << "buffer_" << fixed_buffer_length << "_t";
+    StructType *buf_struct = b_.GetStructType(dynamic_sized_struct_name.str(),
                                               elements,
                                               false);
     AllocaInst *buf = b_.CreateAllocaBPF(buf_struct, "buffer");


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests

#1263 
@fbs @danobi replaced last sprintf with `ostringstream`