### PR TITLE
1263: bpf feature; removed stat

### DIFF
--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -4,13 +4,11 @@
 #endif
 #include <bpffeature.h>
 #include <cstddef>
-#include <cstdio>
-#include <fcntl.h>
 #include <fstream>
-#include <sys/stat.h>
 #include <unistd.h>
 
 #include "btf.h"
+#include "filesystem_wrapper.h"
 #include "probe_matcher.h"
 #include "utils.h"
 
@@ -321,10 +319,9 @@ bool BPFfeature::has_uprobe_refcnt()
     return *has_uprobe_refcnt_;
 
 #ifdef LIBBCC_ATTACH_UPROBE_SEVEN_ARGS_SIGNATURE
-  struct stat sb;
-  has_uprobe_refcnt_ =
-      ::stat("/sys/bus/event_source/devices/uprobe/format/ref_ctr_offset",
-             &sb) == 0;
+  std::error_code ec;
+  has_uprobe_refcnt_ = std_filesystem::exists(
+      "/sys/bus/event_source/devices/uprobe/format/ref_ctr_offset", ec);
 #else
   has_uprobe_refcnt_ = false;
 #endif // LIBBCC_ATTACH_UPROBE_SEVEN_ARGS_SIGNATURE

--- a/src/filesystem_wrapper.h
+++ b/src/filesystem_wrapper.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace std_filesystem = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace std_filesystem = std::experimental::filesystem;
+#else
+#error "neither <filesystem> nor <experimental/filesystem> are present"
+#endif

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -13,10 +13,10 @@
 #include <sstream>
 #include <string>
 #include <sys/auxv.h>
-#include <sys/stat.h>
 #include <tuple>
 #include <unistd.h>
 
+#include "filesystem_wrapper.h"
 #include "log.h"
 #include "probe_matcher.h"
 #include "utils.h"
@@ -26,16 +26,6 @@
 #include <elf.h>
 
 #include <linux/version.h>
-
-#if __has_include(<filesystem>)
-#include <filesystem>
-namespace std_filesystem = std::filesystem;
-#elif __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
-namespace std_filesystem = std::experimental::filesystem;
-#else
-#error "neither <filesystem> nor <experimental/filesystem> are present"
-#endif
 
 namespace {
 


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests

#1263 
@fbs @danobi 
- removed `stat` from bpf feature
- add file_wrapper for loading std filesystem