### PR TITLE
Fix the kprobe:vfs_open example for newer Kernel versions

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -436,7 +436,7 @@ being executed.
 
 ```
 # bpftrace --include linux/path.h --include linux/dcache.h \
-    -e 'kprobe:vfs_open { printf("open path: %s\n", str(((path *)arg0)->dentry->d_name.name)); }'
+    -e 'kprobe:vfs_open { printf("open path: %s\n", str(((struct path *)arg0)->dentry->d_name.name)); }'
 Attaching 1 probe...
 open path: .com.google.Chrome.ASsbu2
 open path: .com.google.Chrome.gimc10


### PR DESCRIPTION
Just a small adjustment to make the `kprobe:vfs_open` example work again with a current kernel.
```bash
kmille@linbox:tmp uname -a
Linux linbox 5.11.2-arch1-1 #1 SMP PREEMPT Fri, 26 Feb 2021 18:26:41 +0000 x86_64 GNU/Linux
kmille@linbox:tmp sudo bpftrace mypbraceprogram.bpf
mypbraceprogram.bpf:6:31-44: ERROR: Unknown struct/union: 'path'
    printf("open path: %s\n", str(((path *)arg0)->dentry->d_name.name));
                              ~~~~~~~~~~~~~
kmille@linbox:tmp vim mypbraceprogram.bpf
kmille@linbox:tmp sudo bpftrace mypbraceprogram.bpf
Attaching 1 probe...
open path: cmdline
open path: cmdline
^C
```

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
