### PR TITLE
semantics: Remove extraneous values in async args

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -974,7 +974,8 @@ void SemanticAnalyser::visit(Call &call)
               << "Non-map print() only takes 1 argument, " << call.vargs->size()
               << " found";
 
-        bpftrace_.non_map_print_args_.emplace_back(arg.type);
+        if (is_final_pass())
+          bpftrace_.non_map_print_args_.emplace_back(arg.type);
       }
       else
       {


### PR DESCRIPTION
We really only need to fill `non_map_print_args_` in the final pass.
Filling it on each pass doesn't hurt (b/c indicies 0..N, where N is the
number of non-map print() calls are accurate, but N..M is all unused
values, where M is non_map_print_args_.size())  but is wasteful.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
