### PR TITLE
Array indexing on pointers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,8 @@ and this project adheres to
   - [#1599](https://github.com/iovisor/bpftrace/pull/1599)
 - Printing structures
   - [#1705](https://github.com/iovisor/bpftrace/pull/1705)
+- Array indexing on pointers
+  - [#1739](https://github.com/iovisor/bpftrace/pull/1739)
 
 #### Changed
 - Warn if using `print` on `stats` maps with top and div arguments

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1623,7 +1623,8 @@ void CodegenLLVM::visit(FieldAccess &acc)
 void CodegenLLVM::visit(ArrayAccess &arr)
 {
   SizedType &type = arr.expr->type;
-  auto elem_type = *type.GetElementTy();
+  auto elem_type = type.IsArrayTy() ? *type.GetElementTy()
+                                    : *type.GetPointeeTy();
   size_t elem_size = elem_type.GetSize();
 
   auto scoped_del_expr = accept(arr.expr);

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1385,22 +1385,31 @@ void SemanticAnalyser::visit(ArrayAccess &arr)
   SizedType &indextype = arr.indexpr->type;
 
   if (is_final_pass()) {
-    if (!type.IsArrayTy())
+    if (!type.IsArrayTy() && !type.IsPtrTy())
     {
-      LOG(ERROR, arr.loc, err_)
-          << "The array index operator [] can only be used on arrays, found "
-          << type.type << ".";
+      LOG(ERROR, arr.loc, err_) << "The array index operator [] can only be "
+                                   "used on arrays and pointers, found "
+                                << type.type << ".";
       return;
+    }
+
+    if (type.IsPtrTy() && type.GetPointeeTy()->GetSize() == 0)
+    {
+      LOG(ERROR, arr.loc, err_) << "The array index operator [] cannot be used "
+                                   "on a pointer to an unsized type (void *).";
     }
 
     if (indextype.IsIntTy() && arr.indexpr->is_literal)
     {
-      Integer *index = static_cast<Integer *>(arr.indexpr);
+      if (type.IsArrayTy())
+      {
+        Integer *index = static_cast<Integer *>(arr.indexpr);
 
-      if ((size_t)index->n >= type.GetNumElements())
-        LOG(ERROR, arr.loc, err_)
-            << "the index " << index->n
-            << " is out of bounds for array of size " << type.GetNumElements();
+        if ((size_t)index->n >= type.GetNumElements())
+          LOG(ERROR, arr.loc, err_) << "the index " << index->n
+                                    << " is out of bounds for array of size "
+                                    << type.GetNumElements();
+      }
     }
     else {
       LOG(ERROR, arr.loc, err_) << "The array index operator [] only "
@@ -1408,7 +1417,12 @@ void SemanticAnalyser::visit(ArrayAccess &arr)
     }
   }
 
-  arr.type = type.IsArrayTy() ? *type.GetElementTy() : CreateNone();
+  if (type.IsArrayTy())
+    arr.type = *type.GetElementTy();
+  else if (type.IsPtrTy())
+    arr.type = *type.GetPointeeTy();
+  else
+    arr.type = CreateNone();
   arr.type.is_internal = type.is_internal;
   arr.type.SetAS(type.GetAS());
 }

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -396,7 +396,7 @@ SizedType BTF::get_stype(__u32 id)
     const char *cast = btf_str(btf, t->name_off);
     assert(cast);
     std::string comp = btf_is_struct(t) ? "struct" : "union";
-    stype = CreateRecord(0, comp + " " + cast);
+    stype = CreateRecord(t->size, comp + " " + cast);
   }
   else if (btf_is_ptr(t))
   {

--- a/tests/runtime/array
+++ b/tests/runtime/array
@@ -105,3 +105,33 @@ RUN bpftrace -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:te
 EXPECT @x\[\[\[5,6\],\[7,8\]\]]: 0
 TIMEOUT 5
 AFTER ./testprogs/array_access
+
+NAME array as pointer element access - assign to map
+RUN bpftrace -v -e 'uprobe:./testprogs/array_access:test_array { $a = (int32 *) arg0; @x = $a[0]; exit(); }'
+EXPECT @x: 1
+TIMEOUT 5
+AFTER ./testprogs/array_access
+
+NAME array as pointer element access - assign to var
+RUN bpftrace -v -e 'uprobe:./testprogs/array_access:test_array { $a = (int32 *) arg0; $x = $a[0]; printf("Result: %d\n", $x); exit(); }'
+EXPECT Result: 1
+TIMEOUT 5
+AFTER ./testprogs/array_access
+
+NAME array as pointer access via assignment into var
+RUN bpftrace -v -e 'uprobe:./testprogs/array_access:test_array { $a = (int32 *) arg0; $x = $a[0]; printf("Result: %d\n", $x); exit(); }'
+EXPECT Result: 1
+TIMEOUT 5
+AFTER ./testprogs/array_access
+
+NAME array as pointer element access via assignment into map
+RUN bpftrace -v -e 'uprobe:./testprogs/array_access:test_array { @a[0] = (int32 *) arg0; printf("Result: %d\n", @a[0][0]); exit(); }'
+EXPECT Result: 1
+TIMEOUT 5
+AFTER ./testprogs/array_access
+
+NAME array as pointer element access via assignment into map and var
+RUN bpftrace -v -e 'uprobe:./testprogs/array_access:test_array { @a[0] = (int32 *) arg0; $x = @a[0]; printf("Result: %d\n", $x[0]); exit(); }'
+EXPECT Result: 1
+TIMEOUT 5
+AFTER ./testprogs/array_access

--- a/tests/testprogs/array_access.c
+++ b/tests/testprogs/array_access.c
@@ -8,6 +8,10 @@ struct B
   int y[2][2];
 };
 
+void test_array(int *a __attribute__((unused)))
+{
+}
+
 void test_struct(struct A *a __attribute__((unused)),
                  struct B *b __attribute__((unused)))
 {
@@ -27,4 +31,5 @@ int main(int argc __attribute__((unused)), char ** argv __attribute__((unused)))
   b.y[1][0] = 7;
   b.y[1][1] = 8;
   test_struct(&a, &b);
+  test_array(a.x);
 }


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

Resolves #1717.

The generated codegen is exactly the same as for indexing on arrays. This basically only enables the `[]` operator on pointer type (except for `void *`) in semantic analyser.

This is closely related to #1507 which has not been fully resolved, yet, but since this works the same way as array indexing, it should not be a problem.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
