### PR TITLE
kheader: Do not unpack kheaders if system has BTF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,8 @@ and this project adheres to
   - [#1549](https://github.com/iovisor/bpftrace/pull/1549)
 - Improve codegen for structs and arrays
   - [#1705](https://github.com/iovisor/bpftrace/pull/1705)
+- Do not unpack in-kernel headers if system has BTF
+  - [#1740](https://github.com/iovisor/bpftrace/pull/1740)
 
 #### Deprecated
 

--- a/src/fuzz_main.cpp
+++ b/src/fuzz_main.cpp
@@ -136,7 +136,7 @@ int fuzz_main(const char* data, size_t sz)
     struct utsname utsname;
     uname(&utsname);
     std::string ksrc, kobj;
-    auto kdirs = get_kernel_dirs(utsname);
+    auto kdirs = get_kernel_dirs(utsname, !bpftrace.features_->has_btf());
     ksrc = std::get<0>(kdirs);
     kobj = std::get<1>(kdirs);
 

--- a/src/fuzz_main.cpp
+++ b/src/fuzz_main.cpp
@@ -17,7 +17,6 @@
 #include <unistd.h>
 
 #include "ast/callback_visitor.h"
-#include "bpffeature.h"
 #include "bpforc.h"
 #include "bpftrace.h"
 #include "clang_parser.h"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -733,7 +733,7 @@ int main(int argc, char *argv[])
     struct utsname utsname;
     uname(&utsname);
     std::string ksrc, kobj;
-    auto kdirs = get_kernel_dirs(utsname);
+    auto kdirs = get_kernel_dirs(utsname, !bpftrace.feature_->has_btf());
     ksrc = std::get<0>(kdirs);
     kobj = std::get<1>(kdirs);
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -419,17 +419,20 @@ std::tuple<std::string, std::string> get_kernel_dirs(const struct utsname& utsna
   if (!is_dir(kobj)) {
     kobj = "";
   }
-  if (ksrc == "" && kobj == "") {
+  if (ksrc.empty() && kobj.empty())
+  {
     const auto kheaders_tar_xz_path = unpack_kheaders_tar_xz(utsname);
     if (kheaders_tar_xz_path.size() > 0) {
       return std::make_tuple(kheaders_tar_xz_path, kheaders_tar_xz_path);
     }
     return std::make_tuple("", "");
   }
-  if (ksrc == "") {
+  if (ksrc.empty())
+  {
     ksrc = kobj;
   }
-  else if (kobj == "") {
+  else if (kobj.empty())
+  {
     kobj = ksrc;
   }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -398,7 +398,9 @@ namespace {
 //
 // {"", ""} is returned if no trace of kernel headers was found at all.
 // Both ksrc and kobj are guaranteed to be != "", if at least some trace of kernel sources was found.
-std::tuple<std::string, std::string> get_kernel_dirs(const struct utsname& utsname)
+std::tuple<std::string, std::string> get_kernel_dirs(
+    const struct utsname &utsname,
+    bool unpack_kheaders)
 {
 #ifdef KERNEL_HEADERS_DIR
   return {KERNEL_HEADERS_DIR, KERNEL_HEADERS_DIR};
@@ -421,9 +423,11 @@ std::tuple<std::string, std::string> get_kernel_dirs(const struct utsname& utsna
   }
   if (ksrc.empty() && kobj.empty())
   {
-    const auto kheaders_tar_xz_path = unpack_kheaders_tar_xz(utsname);
-    if (kheaders_tar_xz_path.size() > 0) {
-      return std::make_tuple(kheaders_tar_xz_path, kheaders_tar_xz_path);
+    if (unpack_kheaders)
+    {
+      const auto kheaders_tar_xz_path = unpack_kheaders_tar_xz(utsname);
+      if (kheaders_tar_xz_path.size() > 0)
+        return std::make_tuple(kheaders_tar_xz_path, kheaders_tar_xz_path);
     }
     return std::make_tuple("", "");
   }

--- a/src/utils.h
+++ b/src/utils.h
@@ -142,7 +142,8 @@ std::vector<int> get_online_cpus();
 std::vector<int> get_possible_cpus();
 bool is_dir(const std::string &path);
 std::tuple<std::string, std::string> get_kernel_dirs(
-    const struct utsname &utsname);
+    const struct utsname &utsname,
+    bool unpack_kheaders);
 std::vector<std::string> get_kernel_cflags(const char *uname_machine,
                                            const std::string &ksrc,
                                            const std::string &kobj);


### PR DESCRIPTION
There's no need for kernel headers if the system has BTF. Unpacking
in-kernel headers is extra work for no gain.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
