### PR TITLE
tools: handle renamed lookup_fast function in dcsnoop

### DIFF
--- a/tools/dcsnoop.bt
+++ b/tools/dcsnoop.bt
@@ -32,7 +32,8 @@ BEGIN
 }
 
 // comment out this block to avoid showing hits:
-kprobe:lookup_fast
+kprobe:lookup_fast,
+kprobe:lookup_fast.constprop.*
 {
 	$nd = (struct nameidata *)arg0;
 	printf("%-8d %-6d %-16s R %s\n", elapsed / 1e6, pid, comm,


### PR DESCRIPTION
The lookup_fast function can be rename lookup_fast.constprop.x by gcc
constant propagation optimization and that breaks dcsnoop. Let's look
for both name.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
