### PR TITLE
build: Remove unnecessary cmake for tests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,10 +1,4 @@
 add_compile_options("-Wno-undef")
-add_compile_options("-Wno-switch-default")
-add_compile_options("-Wno-switch-enum")
-
-if(HAVE_BFD_DISASM)
-  set(BFD_DISASM_SRC ${CMAKE_SOURCE_DIR}/src/bfd-disasm.cpp)
-endif()
 
 if (STATIC_LIBC)
   # STATIC_LIBC will set linker flags to -static. We don't want this for


### PR DESCRIPTION
The gcc man page states:
```
Most of these have both positive and negative forms;
the negative form of -ffoo is -fno-foo.  This manual documents
only one of these two forms, whichever one is not the default.
```

Which leads me to believe that:

* -Wno-switch-default is the default setting
* -Wno-switch-enum is also the default setting

and both can be removed. Removing both does not generate any new
warnings on a clean build for me.

-Wno-undef is needed for gtest to build correctly.

The HAVE_BFD_DISASM is no longer necessary in tests/ after
7c40e2a3 ("build: Share core bpftrace code with test binary")

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
