### PR TITLE
embedded: Fix llvm 9+ builds

### DIFF
--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -176,6 +176,7 @@ jobs:
         -v /sys/kernel/debug:/sys/kernel/debug:rw
         -v /lib/modules:/lib/modules:ro
         -v /usr/src:/usr/src:ro
+        -e LLVM_VERSION=${LLVM_VERSION}
         -e STATIC_LINKING=${STATIC_LINKING}
         -e STATIC_LIBC=${STATIC_LIBC}
         -e EMBED_LLVM=${EMBED_LLVM}
@@ -200,6 +201,7 @@ jobs:
         -v /sys/kernel/debug:/sys/kernel/debug:rw
         -v /lib/modules:/lib/modules:ro
         -v /usr/src:/usr/src:ro
+        -e LLVM_VERSION=${LLVM_VERSION}
         -e STATIC_LINKING=${STATIC_LINKING}
         -e STATIC_LIBC=${STATIC_LIBC}
         -e EMBED_LLVM=${EMBED_LLVM}
@@ -221,6 +223,7 @@ jobs:
         -v /sys/kernel/debug:/sys/kernel/debug:rw
         -v /lib/modules:/lib/modules:ro
         -v /usr/src:/usr/src:ro
+        -e LLVM_VERSION=${LLVM_VERSION}
         -e STATIC_LINKING=${STATIC_LINKING}
         -e STATIC_LIBC=${STATIC_LIBC}
         -e EMBED_LLVM=${EMBED_LLVM}

--- a/cmake/embed/embed_llvm.cmake
+++ b/cmake/embed/embed_llvm.cmake
@@ -48,7 +48,6 @@ set(LLVM_LIBRARY_TARGETS
     LLVMBitReader
     LLVMBitWriter
     LLVMBPFAsmParser
-    LLVMBPFAsmPrinter
     LLVMBPFCodeGen
     LLVMBPFDesc
     LLVMBPFDisassembler
@@ -102,6 +101,16 @@ set(LLVM_LIBRARY_TARGETS
     LLVMXRay
     LLVMSupport
     )
+
+if(LLVM_MAJOR_VERSION STREQUAL "7" OR LLVM_MAJOR_VERSION STREQUAL "8")
+  # https://github.com/llvm/llvm-project/commit/48803aa65c96857fb4245cd0d74a6b422d8f8ff6
+  # removed BPFAsmPrinter as an independent target for LLVM 9+
+  #
+  # NB: This target must be placed before `LLVMBPFDesc` so the linker does not
+  # discard the symbols from `LLVMBPFDesc` that `LLVMBPFAsmPrinter` requires.
+  # Link order matters.
+  list(PREPEND LLVM_LIBRARY_TARGETS "LLVMBPFAsmPrinter")
+endif()
 
 # These build flags are based off of Alpine, Debian and Gentoo packages
 # optimized for compatibility and reducing build targets


### PR DESCRIPTION
Seems llvm build exposes less targets starting at llvm 9.0.1.

This commit removes redundant llvm bpf targets -- the removed targets
should already be present inside libLLVMBPFCodeGen.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
