### PR TITLE
Attach binary/tools to release

### DIFF
--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -32,7 +32,7 @@ See https://semver.org/ .
 
 ## Tagging a release
 
-You must do 3 things to formally release a version:
+You must do these things to formally release a version:
 
 1. Mark the release in the CHANGELOG by replacing the `## Unreleased` header
    with `## [VERSION] date`.
@@ -42,3 +42,9 @@ You must do 3 things to formally release a version:
    as "commits"), then "Draft a new release". The tag version and release title
    should be the same and in `vX.Y.Z` format. The tag description should
    be the same as what you added to `CHANGELOG.md`.
+1. Attach a tar of the tools to the release.
+1. Once the release tag pipeline has finished, extract the bpftrace binary from
+   the release build on and attach it to the release.
+  -  `docker run -v
+$(pwd):/output quay.io/iovisor/bpftrace:vXX.YY.ZZ /bin/bash -c "cp
+/usr/bin/bpftrace /output"`


### PR DESCRIPTION
Makes it easier for users to get started and run bpftrace (on most
platforms at least, due to glibc dep).

