### PR TITLE
Replace '@' prefix in map name with 'AT_' when creating map

### DIFF
--- a/src/map.h
+++ b/src/map.h
@@ -30,7 +30,7 @@ public:
   virtual ~Map() override;
 
   int create_map(enum bpf_map_type map_type,
-                 const char *name,
+                 const std::string &name,
                  int key_size,
                  int value_size,
                  int max_entries,


### PR DESCRIPTION
When calling the API function to create the map, e.g., bcc_create_map,
replace the '@' prefix, if it exists, with the string 'AT_'. Otherwise,
map creation with the name fails, and (e.g.,) BCC falls back to
creating the map without a name.

Closes: #1752

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
