### PR TITLE
Fix segfault in probe listing

### DIFF
--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -581,7 +581,9 @@ std::map<std::string, std::vector<std::string>> BTF::get_params(
     _Pragma("GCC diagnostic push")
         _Pragma("GCC diagnostic ignored \"-Wmissing-field-initializers\"")
 
-            DECLARE_LIBBPF_OPTS(btf_dump_emit_type_decl_opts, decl_opts, 0);
+            DECLARE_LIBBPF_OPTS(btf_dump_emit_type_decl_opts,
+                                decl_opts,
+                                .field_name = "");
 
     _Pragma("GCC diagnostic pop")
 

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -49,6 +49,12 @@ EXPECT kfunc
 REQUIRES_FEATURE btf
 TIMEOUT 1
 
+NAME it lists kfunc params
+RUN bpftrace -lv "kfunc:*" | grep kfunc
+EXPECT \s+[a-zA-Z_\*\s]+
+REQUIRES_FEATURE btf
+TIMEOUT 1
+
 NAME it lists kprobes with regex filter
 RUN bpftrace -l "kprobe:*"
 EXPECT kprobe:


### PR DESCRIPTION
Fixes #1754 

The problem was introduced by commit c261cdbc94f6d232c1944cc484e63b5039ce665f which set `btf_dump_emit_type_decl_opts.field_name` to `NULL`, which caused a segfault when later dereferenced in libbpf.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
