### PR TITLE
bpforc.h: Include <optional> header

### DIFF
--- a/src/bpforc.h
+++ b/src/bpforc.h
@@ -22,6 +22,8 @@
 #include <llvm/ExecutionEngine/Orc/JITTargetMachineBuilder.h>
 #endif
 
+#include <optional>
+
 namespace bpftrace {
 
 const std::string LLVMTargetTriple = "bpf-pc-linux";


### PR DESCRIPTION
This is required since this header had std::optional<std::tuple<uint8_t *, uintptr_t>>

Fixes buiild errors with clang-12 with gcc11-runtime

Signed-off-by: Khem Raj <raj.khem@gmail.com>

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
