### PR TITLE
Release v0.12.0

### DIFF
--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -53,21 +53,6 @@ jobs:
           BASE: bionic
           DISTRO: ubuntu-glibc
         - TYPE: Release
-          NAME: vanilla_llvm12+clang+glibc2.27
-          LLVM_VERSION: 12
-          STATIC_LINKING: ON
-          STATIC_LIBC: OFF
-          EMBED_LLVM: ON
-          EMBED_CLANG: ON
-          EMBED_LIBCLANG_ONLY: OFF
-          EMBED_BCC: OFF
-          EMBED_LIBELF: OFF
-          EMBED_BINUTILS: OFF
-          RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size
-          BASE: bionic
-          DISTRO: ubuntu-glibc
-        - TYPE: Release
           NAME: vanilla_llvm+clang+glibc2.27_edge
           EDGE: ON
           BCC_REF: master

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## Unreleased
 
+## [0.12.0] 2021-04-01
+
 #### Added
 - Add path builtin
   - [#1492](https://github.com/iovisor/bpftrace/pull/1492)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ project(bpftrace)
 
 # bpftrace version number components.
 set(bpftrace_VERSION_MAJOR 0)
-set(bpftrace_VERSION_MINOR 11)
-set(bpftrace_VERSION_PATCH 4)
+set(bpftrace_VERSION_MINOR 12)
+set(bpftrace_VERSION_PATCH 0)
 
 include(GNUInstallDirs)
 

--- a/docker/scripts/push.sh
+++ b/docker/scripts/push.sh
@@ -5,7 +5,7 @@ set -e
 # You must run login.sh before running this script.
 
 DEFAULT_DOCKER_REPO="quay.io"
-DEFAULT_RELEASE_TARGET="vanilla_llvm12+clang+glibc2.27"
+DEFAULT_RELEASE_TARGET="vanilla_llvm+clang+glibc2.27"
 
 # Currently only support pushing to quay.io
 DOCKER_REPO=${DEFAULT_DOCKER_REPO}


### PR DESCRIPTION
The LLVM 12 embedded build seems doomed for now (binary is 100M+ and has issues on exit). We can always do a 0.12.1 release once we've fixed the issues.
