### PR TITLE
build: bump bcc in embedded build

### DIFF
--- a/docker/Dockerfile.ubuntu-glibc
+++ b/docker/Dockerfile.ubuntu-glibc
@@ -5,7 +5,7 @@ ARG BASE
 ARG LLVM_VERSION="8"
 ARG CMAKE_VER="3.16"
 ARG CMAKE_BUILD="2"
-ARG bcc_ref="v0.12.0"
+ARG bcc_ref="v0.19.0"
 ARG bcc_org="iovisor"
 
 ENV LLVM_VERSION=$LLVM_VERSION


### PR DESCRIPTION
The embedded build currently uses a packaged LLVM to build bcc and our
own build to link bpftrace against. For the LLVM12 based build (#1751) I
want to use the our own build but for LLVM 12 support we need at least
bcc 0.19.0.
