### PR TITLE
Fix single arg wildcard probe listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
 #### Removed
 
 #### Fixed
+- Fix single arg wildcard probe listing
+  - [#1775](https://github.com/iovisor/bpftrace/pull/1775)
 
 #### Tools
 

--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -475,8 +475,12 @@ AttachPointParser::State AttachPointParser::usdt_parser()
 
 AttachPointParser::State AttachPointParser::tracepoint_parser()
 {
-  if (parts_.size() == 2 && parts_.at(1) == "*")
-    parts_.push_back("*");
+  // Help with `bpftrace -l 'tracepoint:*foo*'` listing -- wildcard the
+  // tracepoint category b/c user is most likely to be looking for the event
+  // name
+  if (parts_.size() == 2 && has_wildcard(parts_.at(1)))
+    parts_.insert(parts_.begin() + 1, "*");
+
   if (parts_.size() != 3)
   {
     if (ap_->ignore_invalid)

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -33,3 +33,9 @@ NAME c_array_indexing
 RUN bpftrace -v -e 'struct Foo { int a; uint8_t b[10]; } uprobe:testprogs/uprobe_test:function2 { $foo = (struct Foo *)arg0; printf("%c %c %c %c %c\n", $foo->b[0], $foo->b[1], $foo->b[2], $foo->b[3], $foo->b[4]) }' -c ./testprogs/uprobe_test
 EXPECT h e l l o
 TIMEOUT 5
+
+# https://github.com/iovisor/bpftrace/issues/1773
+NAME single_arg_wildcard_listing
+RUN bpftrace -l "*do_nanosleep*"
+EXPECT kprobe:do_nanosleep
+TIMEOUT 1

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -39,3 +39,8 @@ NAME single_arg_wildcard_listing
 RUN bpftrace -l "*do_nanosleep*"
 EXPECT kprobe:do_nanosleep
 TIMEOUT 1
+
+NAME single_arg_wildcard_listing_tracepoint
+RUN bpftrace -l "*sched_switch*"
+EXPECT tracepoint:sched:sched_switch
+TIMEOUT 1


### PR DESCRIPTION
We regressed on single arg wildcard probe listings. eg.

```
# bpftrace -l '*sleep*'
```

We should support this b/c the docs have said we support this.
Even `bpftrace --help` shows the above example.

This fixes #1773.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
