### PR TITLE
log: Don't include bpftrace.h

### DIFF
--- a/src/log.h
+++ b/src/log.h
@@ -1,11 +1,12 @@
 #pragma once
 
+#include <cassert>
 #include <iostream>
 #include <optional>
 #include <sstream>
 #include <unordered_map>
 
-#include "bpftrace.h"
+#include "location.hh"
 
 namespace bpftrace {
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -17,6 +17,7 @@
 #include <tuple>
 #include <unistd.h>
 
+#include "bpftrace.h"
 #include "log.h"
 #include "probe_matcher.h"
 #include "utils.h"


### PR DESCRIPTION
If log.h includes bpftrace.h, then you cannot use LOG macros in
bpftrace.h (which can be useful). Logging should work from absolutely
anywhere.

log.h does not need to include bpftrace.h anyways. location.hh is
enough.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
