### PR TITLE
Eliminate duplicate LifetimeStart in CreateAllocaBPFInit, dedupe hoisting code

### DIFF
--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -171,6 +171,14 @@ public:
                        AllocaInst *data,
                        Value *data_len,
                        const location &loc);
+  // moves the insertion point to the start of the function you're inside,
+  // invokes functor, then moves the insertion point back to its original
+  // position. this enables you to emit instructions at the start of your
+  // function. you might want to "hoist" an alloca to make it available to
+  // blocks that do not follow from yours, for example to make $a accessible in
+  // both branches here:
+  // BEGIN { if (nsecs > 0) { $a = 1 } else { $a = 2 } print($a); exit() }
+  void hoist(const std::function<void()> &functor);
   int helper_error_id_ = 0;
 
 private:

--- a/tests/codegen/llvm/basic_while_loop.ll
+++ b/tests/codegen/llvm/basic_while_loop.ll
@@ -14,34 +14,32 @@ entry:
   %1 = bitcast i64* %"$a" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$a"
-  %2 = bitcast i64* %"$a" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 1, i64* %"$a"
   br label %while_cond
 
 while_cond:                                       ; preds = %while_body, %entry
-  %3 = load i64, i64* %"$a"
-  %4 = icmp sle i64 %3, 150
-  %5 = zext i1 %4 to i64
-  %true_cond = icmp ne i64 %5, 0
+  %2 = load i64, i64* %"$a"
+  %3 = icmp sle i64 %2, 150
+  %4 = zext i1 %3 to i64
+  %true_cond = icmp ne i64 %4, 0
   br i1 %true_cond, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %6 = load i64, i64* %"$a"
-  %7 = add i64 %6, 1
-  store i64 %7, i64* %"$a"
-  %8 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %5 = load i64, i64* %"$a"
+  %6 = add i64 %5, 1
+  store i64 %6, i64* %"$a"
+  %7 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   store i64 0, i64* %"@_key"
-  %9 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store i64 %6, i64* %"@_val"
+  %8 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 %5, i64* %"@_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
-  %10 = bitcast i64* %"@_val" to i8*
+  %9 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   br label %while_cond
 
 while_end:                                        ; preds = %while_cond

--- a/tests/codegen/llvm/builtin_ctx_field.ll
+++ b/tests/codegen/llvm/builtin_ctx_field.ll
@@ -24,100 +24,98 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$x"
   %2 = ptrtoint i8* %0 to i64
-  %3 = bitcast i64* %"$x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   store i64 %2, i64* %"$x"
-  %4 = load i64, i64* %"$x"
-  %5 = add i64 %4, 0
-  %6 = inttoptr i64 %5 to i64*
-  %7 = load volatile i64, i64* %6
-  %8 = bitcast i64* %"@a_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %3 = load i64, i64* %"$x"
+  %4 = add i64 %3, 0
+  %5 = inttoptr i64 %4 to i64*
+  %6 = load volatile i64, i64* %5
+  %7 = bitcast i64* %"@a_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   store i64 0, i64* %"@a_key"
-  %9 = bitcast i64* %"@a_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store i64 %7, i64* %"@a_val"
+  %8 = bitcast i64* %"@a_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 %6, i64* %"@a_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@a_key", i64* %"@a_val", i64 0)
-  %10 = bitcast i64* %"@a_val" to i8*
+  %9 = bitcast i64* %"@a_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@a_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@a_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = load i64, i64* %"$x"
-  %13 = add i64 %12, 8
-  %14 = add i64 %13, 0
-  %15 = inttoptr i64 %14 to i16*
-  %16 = load volatile i16, i16* %15
-  %17 = sext i16 %16 to i64
-  %18 = bitcast i64* %"@b_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
+  %11 = load i64, i64* %"$x"
+  %12 = add i64 %11, 8
+  %13 = add i64 %12, 0
+  %14 = inttoptr i64 %13 to i16*
+  %15 = load volatile i16, i16* %14
+  %16 = sext i16 %15 to i64
+  %17 = bitcast i64* %"@b_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
   store i64 0, i64* %"@b_key"
-  %19 = bitcast i64* %"@b_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
-  store i64 %17, i64* %"@b_val"
+  %18 = bitcast i64* %"@b_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
+  store i64 %16, i64* %"@b_val"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem2 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@b_key", i64* %"@b_val", i64 0)
-  %20 = bitcast i64* %"@b_val" to i8*
+  %19 = bitcast i64* %"@b_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  %20 = bitcast i64* %"@b_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  %21 = bitcast i64* %"@b_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
-  %22 = load i64, i64* %"$x"
-  %23 = add i64 %22, 16
-  %24 = add i64 %23, 0
-  %25 = inttoptr i64 %24 to i8*
-  %26 = load volatile i8, i8* %25
-  %27 = sext i8 %26 to i64
-  %28 = bitcast i64* %"@c_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %28)
+  %21 = load i64, i64* %"$x"
+  %22 = add i64 %21, 16
+  %23 = add i64 %22, 0
+  %24 = inttoptr i64 %23 to i8*
+  %25 = load volatile i8, i8* %24
+  %26 = sext i8 %25 to i64
+  %27 = bitcast i64* %"@c_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %27)
   store i64 0, i64* %"@c_key"
-  %29 = bitcast i64* %"@c_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %29)
-  store i64 %27, i64* %"@c_val"
+  %28 = bitcast i64* %"@c_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %28)
+  store i64 %26, i64* %"@c_val"
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
   %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo3, i64* %"@c_key", i64* %"@c_val", i64 0)
-  %30 = bitcast i64* %"@c_val" to i8*
+  %29 = bitcast i64* %"@c_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %29)
+  %30 = bitcast i64* %"@c_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %30)
-  %31 = bitcast i64* %"@c_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %31)
-  %32 = load i64, i64* %"$x"
-  %33 = add i64 %32, 24
-  %34 = inttoptr i64 %33 to i64*
-  %35 = load volatile i64, i64* %34
-  %36 = add i64 %35, 0
+  %31 = load i64, i64* %"$x"
+  %32 = add i64 %31, 24
+  %33 = inttoptr i64 %32 to i64*
+  %34 = load volatile i64, i64* %33
+  %35 = add i64 %34, 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"struct c.c")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct c.c", i32 1, i64 %36)
-  %37 = load i8, i8* %"struct c.c"
-  %38 = sext i8 %37 to i64
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct c.c", i32 1, i64 %35)
+  %36 = load i8, i8* %"struct c.c"
+  %37 = sext i8 %36 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct c.c")
-  %39 = bitcast i64* %"@d_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %39)
+  %38 = bitcast i64* %"@d_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %38)
   store i64 0, i64* %"@d_key"
-  %40 = bitcast i64* %"@d_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %40)
-  store i64 %38, i64* %"@d_val"
+  %39 = bitcast i64* %"@d_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %39)
+  store i64 %37, i64* %"@d_val"
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 4)
   %update_elem6 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo5, i64* %"@d_key", i64* %"@d_val", i64 0)
-  %41 = bitcast i64* %"@d_val" to i8*
+  %40 = bitcast i64* %"@d_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %40)
+  %41 = bitcast i64* %"@d_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %41)
-  %42 = bitcast i64* %"@d_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %42)
-  %43 = load i64, i64* %"$x"
-  %44 = add i64 %43, 32
-  %45 = bitcast [4 x i8]* %"struct x.e" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %45)
-  %46 = inttoptr i64 %44 to [4 x i8]*
-  %47 = bitcast [4 x i8]* %"struct x.e" to i8*
-  %48 = bitcast [4 x i8]* %46 to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %47, i8* align 1 %48, i64 4, i1 true)
-  %49 = bitcast i64* %"@e_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %49)
+  %42 = load i64, i64* %"$x"
+  %43 = add i64 %42, 32
+  %44 = bitcast [4 x i8]* %"struct x.e" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %44)
+  %45 = inttoptr i64 %43 to [4 x i8]*
+  %46 = bitcast [4 x i8]* %"struct x.e" to i8*
+  %47 = bitcast [4 x i8]* %45 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %46, i8* align 1 %47, i64 4, i1 true)
+  %48 = bitcast i64* %"@e_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %48)
   store i64 0, i64* %"@e_key"
   %pseudo7 = call i64 @llvm.bpf.pseudo(i64 1, i64 5)
   %update_elem8 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [4 x i8]*, i64)*)(i64 %pseudo7, i64* %"@e_key", [4 x i8]* %"struct x.e", i64 0)
-  %50 = bitcast i64* %"@e_key" to i8*
+  %49 = bitcast i64* %"@e_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %49)
+  %50 = bitcast [4 x i8]* %"struct x.e" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %50)
-  %51 = bitcast [4 x i8]* %"struct x.e" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %51)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_buf_implicit_size.ll
+++ b/tests/codegen/llvm/call_buf_implicit_size.ll
@@ -16,28 +16,26 @@ entry:
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$foo"
-  %2 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 0, i64* %"$foo"
-  %3 = bitcast %buffer_16_t* %buffer to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = getelementptr %buffer_16_t, %buffer_16_t* %buffer, i32 0, i32 0
-  store i8 16, i8* %4
-  %5 = getelementptr %buffer_16_t, %buffer_16_t* %buffer, i32 0, i32 1
-  %6 = bitcast [16 x i8]* %5 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 16, i1 false)
-  %7 = load i64, i64* %"$foo"
-  %8 = add i64 %7, 0
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* %5, i32 16, i64 %8)
-  %9 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %2 = bitcast %buffer_16_t* %buffer to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  %3 = getelementptr %buffer_16_t, %buffer_16_t* %buffer, i32 0, i32 0
+  store i8 16, i8* %3
+  %4 = getelementptr %buffer_16_t, %buffer_16_t* %buffer, i32 0, i32 1
+  %5 = bitcast [16 x i8]* %4 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %5, i8 0, i64 16, i1 false)
+  %6 = load i64, i64* %"$foo"
+  %7 = add i64 %6, 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* %4, i32 16, i64 %7)
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %buffer_16_t*, i64)*)(i64 %pseudo, i64* %"@x_key", %buffer_16_t* %buffer, i64 0)
-  %10 = bitcast i64* %"@x_key" to i8*
+  %9 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast %buffer_16_t* %buffer to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast %buffer_16_t* %buffer to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_macaddr.ll
+++ b/tests/codegen/llvm/call_macaddr.ll
@@ -14,18 +14,16 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast [6 x i8]* %macaddr to i8*
   call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 6, i1 false)
-  %3 = bitcast [6 x i8]* %macaddr to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([6 x i8]*, i32, i64)*)([6 x i8]* %macaddr, i32 6, i64 0)
-  %4 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  %3 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [6 x i8]*, i64)*)(i64 %pseudo, i64* %"@x_key", [6 x i8]* %macaddr, i64 0)
-  %5 = bitcast i64* %"@x_key" to i8*
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  %5 = bitcast [6 x i8]* %macaddr to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast [6 x i8]* %macaddr to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_printf.ll
+++ b/tests/codegen/llvm/call_printf.ll
@@ -20,38 +20,36 @@ entry:
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
-  %4 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"$foo"
+  %4 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   %5 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 24, i1 false)
-  %7 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %7
-  %8 = load i64, i64* %"$foo"
-  %9 = add i64 %8, 0
+  call void @llvm.memset.p0i8.i64(i8* align 1 %5, i8 0, i64 24, i1 false)
+  %6 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
+  store i64 0, i64* %6
+  %7 = load i64, i64* %"$foo"
+  %8 = add i64 %7, 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"struct Foo.c")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.c", i32 1, i64 %9)
-  %10 = load i8, i8* %"struct Foo.c"
-  %11 = sext i8 %10 to i64
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.c", i32 1, i64 %8)
+  %9 = load i8, i8* %"struct Foo.c"
+  %10 = sext i8 %9 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct Foo.c")
-  %12 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %11, i64* %12
-  %13 = load i64, i64* %"$foo"
-  %14 = add i64 %13, 8
-  %15 = bitcast i64* %"struct Foo.l" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.l", i32 8, i64 %14)
-  %16 = load i64, i64* %"struct Foo.l"
-  %17 = bitcast i64* %"struct Foo.l" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
-  %18 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 2
-  store i64 %16, i64* %18
+  %11 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
+  store i64 %10, i64* %11
+  %12 = load i64, i64* %"$foo"
+  %13 = add i64 %12, 8
+  %14 = bitcast i64* %"struct Foo.l" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.l", i32 8, i64 %13)
+  %15 = load i64, i64* %"struct Foo.l"
+  %16 = bitcast i64* %"struct Foo.l" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 2
+  store i64 %15, i64* %17
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 24)
-  %19 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  %18 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_printf_LLVM-10.ll
+++ b/tests/codegen/llvm/call_printf_LLVM-10.ll
@@ -20,38 +20,36 @@ entry:
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
-  %4 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"$foo"
+  %4 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   %5 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 24, i1 false)
-  %7 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %7
-  %8 = load i64, i64* %"$foo"
-  %9 = add i64 %8, 0
+  call void @llvm.memset.p0i8.i64(i8* align 1 %5, i8 0, i64 24, i1 false)
+  %6 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
+  store i64 0, i64* %6
+  %7 = load i64, i64* %"$foo"
+  %8 = add i64 %7, 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"struct Foo.c")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.c", i32 1, i64 %9)
-  %10 = load i8, i8* %"struct Foo.c"
-  %11 = sext i8 %10 to i64
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.c", i32 1, i64 %8)
+  %9 = load i8, i8* %"struct Foo.c"
+  %10 = sext i8 %9 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct Foo.c")
-  %12 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %11, i64* %12
-  %13 = load i64, i64* %"$foo"
-  %14 = add i64 %13, 8
-  %15 = bitcast i64* %"struct Foo.l" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.l", i32 8, i64 %14)
-  %16 = load i64, i64* %"struct Foo.l"
-  %17 = bitcast i64* %"struct Foo.l" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
-  %18 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 2
-  store i64 %16, i64* %18
+  %11 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
+  store i64 %10, i64* %11
+  %12 = load i64, i64* %"$foo"
+  %13 = add i64 %12, 8
+  %14 = bitcast i64* %"struct Foo.l" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.l", i32 8, i64 %13)
+  %15 = load i64, i64* %"struct Foo.l"
+  %16 = bitcast i64* %"struct Foo.l" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 2
+  store i64 %15, i64* %17
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 24)
-  %19 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  %18 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/if_else_variable.ll
+++ b/tests/codegen/llvm/if_else_variable.ll
@@ -23,25 +23,23 @@ entry:
   br i1 %true_cond, label %if_body, label %else_body
 
 if_body:                                          ; preds = %entry
-  %5 = bitcast i64* %"$s" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
   store i64 10, i64* %"$s"
   br label %if_end
 
 if_end:                                           ; preds = %else_body, %if_body
+  %5 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
   %6 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %7 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %7, i8 0, i64 16, i1 false)
-  %8 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %8
-  %9 = load i64, i64* %"$s"
-  %10 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %9, i64* %10
+  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 16, i1 false)
+  %7 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
+  store i64 0, i64* %7
+  %8 = load i64, i64* %"$s"
+  %9 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
+  store i64 %8, i64* %9
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 16)
-  %11 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %10 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 
 else_body:                                        ; preds = %entry

--- a/tests/codegen/llvm/if_variable.ll
+++ b/tests/codegen/llvm/if_variable.ll
@@ -23,25 +23,23 @@ entry:
   br i1 %true_cond, label %if_body, label %if_end
 
 if_body:                                          ; preds = %entry
-  %5 = bitcast i64* %"$s" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
   store i64 10, i64* %"$s"
   br label %if_end
 
 if_end:                                           ; preds = %if_body, %entry
+  %5 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
   %6 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %7 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %7, i8 0, i64 16, i1 false)
-  %8 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %8
-  %9 = load i64, i64* %"$s"
-  %10 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %9, i64* %10
+  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 16, i1 false)
+  %7 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
+  store i64 0, i64* %7
+  %8 = load i64, i64* %"$s"
+  %9 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
+  store i64 %8, i64* %9
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 16)
-  %11 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %10 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/logical_and_or_different_type.ll
+++ b/tests/codegen/llvm/logical_and_or_different_type.ll
@@ -26,27 +26,25 @@ entry:
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
-  %4 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"$foo"
+  %4 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   %5 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 40, i1 false)
-  %7 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %7
-  %8 = bitcast i64* %"&&_result" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %9 = load i64, i64* %"$foo"
-  %10 = add i64 %9, 0
-  %11 = bitcast i32* %"struct Foo.m" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  %probe_read_user = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.m", i32 4, i64 %10)
-  %12 = load i32, i32* %"struct Foo.m"
-  %13 = sext i32 %12 to i64
-  %14 = bitcast i32* %"struct Foo.m" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %lhs_true_cond = icmp ne i64 %13, 0
+  call void @llvm.memset.p0i8.i64(i8* align 1 %5, i8 0, i64 40, i1 false)
+  %6 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
+  store i64 0, i64* %6
+  %7 = bitcast i64* %"&&_result" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %8 = load i64, i64* %"$foo"
+  %9 = add i64 %8, 0
+  %10 = bitcast i32* %"struct Foo.m" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %probe_read_user = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.m", i32 4, i64 %9)
+  %11 = load i32, i32* %"struct Foo.m"
+  %12 = sext i32 %11 to i64
+  %13 = bitcast i32* %"struct Foo.m" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %lhs_true_cond = icmp ne i64 %12, 0
   br i1 %lhs_true_cond, label %"&&_lhs_true", label %"&&_false"
 
 "&&_lhs_true":                                    ; preds = %entry
@@ -61,24 +59,24 @@ entry:
   br label %"&&_merge"
 
 "&&_merge":                                       ; preds = %"&&_false", %"&&_true"
-  %15 = load i64, i64* %"&&_result"
-  %16 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %15, i64* %16
-  %17 = bitcast i64* %"&&_result5" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
+  %14 = load i64, i64* %"&&_result"
+  %15 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
+  store i64 %14, i64* %15
+  %16 = bitcast i64* %"&&_result5" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
   br i1 true, label %"&&_lhs_true1", label %"&&_false3"
 
 "&&_lhs_true1":                                   ; preds = %"&&_merge"
-  %18 = load i64, i64* %"$foo"
-  %19 = add i64 %18, 0
-  %20 = bitcast i32* %"struct Foo.m6" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %20)
-  %probe_read_user7 = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.m6", i32 4, i64 %19)
-  %21 = load i32, i32* %"struct Foo.m6"
-  %22 = sext i32 %21 to i64
-  %23 = bitcast i32* %"struct Foo.m6" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
-  %rhs_true_cond = icmp ne i64 %22, 0
+  %17 = load i64, i64* %"$foo"
+  %18 = add i64 %17, 0
+  %19 = bitcast i32* %"struct Foo.m6" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
+  %probe_read_user7 = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.m6", i32 4, i64 %18)
+  %20 = load i32, i32* %"struct Foo.m6"
+  %21 = sext i32 %20 to i64
+  %22 = bitcast i32* %"struct Foo.m6" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
+  %rhs_true_cond = icmp ne i64 %21, 0
   br i1 %rhs_true_cond, label %"&&_true2", label %"&&_false3"
 
 "&&_true2":                                       ; preds = %"&&_lhs_true1"
@@ -90,21 +88,21 @@ entry:
   br label %"&&_merge4"
 
 "&&_merge4":                                      ; preds = %"&&_false3", %"&&_true2"
-  %24 = load i64, i64* %"&&_result5"
-  %25 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 2
-  store i64 %24, i64* %25
-  %26 = bitcast i64* %"||_result" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %26)
-  %27 = load i64, i64* %"$foo"
-  %28 = add i64 %27, 0
-  %29 = bitcast i32* %"struct Foo.m8" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %29)
-  %probe_read_user9 = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.m8", i32 4, i64 %28)
-  %30 = load i32, i32* %"struct Foo.m8"
-  %31 = sext i32 %30 to i64
-  %32 = bitcast i32* %"struct Foo.m8" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %32)
-  %lhs_true_cond10 = icmp ne i64 %31, 0
+  %23 = load i64, i64* %"&&_result5"
+  %24 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 2
+  store i64 %23, i64* %24
+  %25 = bitcast i64* %"||_result" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %25)
+  %26 = load i64, i64* %"$foo"
+  %27 = add i64 %26, 0
+  %28 = bitcast i32* %"struct Foo.m8" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %28)
+  %probe_read_user9 = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.m8", i32 4, i64 %27)
+  %29 = load i32, i32* %"struct Foo.m8"
+  %30 = sext i32 %29 to i64
+  %31 = bitcast i32* %"struct Foo.m8" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %31)
+  %lhs_true_cond10 = icmp ne i64 %30, 0
   br i1 %lhs_true_cond10, label %"||_true", label %"||_lhs_false"
 
 "||_lhs_false":                                   ; preds = %"&&_merge4"
@@ -119,24 +117,24 @@ entry:
   br label %"||_merge"
 
 "||_merge":                                       ; preds = %"||_true", %"||_false"
-  %33 = load i64, i64* %"||_result"
-  %34 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 3
-  store i64 %33, i64* %34
-  %35 = bitcast i64* %"||_result15" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %35)
+  %32 = load i64, i64* %"||_result"
+  %33 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 3
+  store i64 %32, i64* %33
+  %34 = bitcast i64* %"||_result15" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %34)
   br i1 false, label %"||_true13", label %"||_lhs_false11"
 
 "||_lhs_false11":                                 ; preds = %"||_merge"
-  %36 = load i64, i64* %"$foo"
-  %37 = add i64 %36, 0
-  %38 = bitcast i32* %"struct Foo.m16" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %38)
-  %probe_read_user17 = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.m16", i32 4, i64 %37)
-  %39 = load i32, i32* %"struct Foo.m16"
-  %40 = sext i32 %39 to i64
-  %41 = bitcast i32* %"struct Foo.m16" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %41)
-  %rhs_true_cond18 = icmp ne i64 %40, 0
+  %35 = load i64, i64* %"$foo"
+  %36 = add i64 %35, 0
+  %37 = bitcast i32* %"struct Foo.m16" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %37)
+  %probe_read_user17 = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.m16", i32 4, i64 %36)
+  %38 = load i32, i32* %"struct Foo.m16"
+  %39 = sext i32 %38 to i64
+  %40 = bitcast i32* %"struct Foo.m16" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %40)
+  %rhs_true_cond18 = icmp ne i64 %39, 0
   br i1 %rhs_true_cond18, label %"||_true13", label %"||_false12"
 
 "||_false12":                                     ; preds = %"||_lhs_false11"
@@ -148,13 +146,13 @@ entry:
   br label %"||_merge14"
 
 "||_merge14":                                     ; preds = %"||_true13", %"||_false12"
-  %42 = load i64, i64* %"||_result15"
-  %43 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 4
-  store i64 %42, i64* %43
+  %41 = load i64, i64* %"||_result15"
+  %42 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 4
+  store i64 %41, i64* %42
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 40)
-  %44 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %44)
+  %43 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %43)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/map_assign_array.ll
+++ b/tests/codegen/llvm/map_assign_array.ll
@@ -59,8 +59,6 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   %15 = load volatile i32, i32* %14
   %16 = bitcast [4 x i32]* %lookup_elem_val to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = bitcast i32* %"$var" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
   store i32 %15, i32* %"$var"
   ret i64 0
 }

--- a/tests/codegen/llvm/nested_while_loop.ll
+++ b/tests/codegen/llvm/nested_while_loop.ll
@@ -19,45 +19,41 @@ entry:
   %2 = bitcast i64* %"$i" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 0, i64* %"$i"
-  %3 = bitcast i64* %"$i" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   store i64 1, i64* %"$i"
   br label %while_cond
 
 while_cond:                                       ; preds = %while_end3, %entry
-  %4 = load i64, i64* %"$i"
-  %5 = icmp sle i64 %4, 100
-  %6 = zext i1 %5 to i64
-  %true_cond = icmp ne i64 %6, 0
+  %3 = load i64, i64* %"$i"
+  %4 = icmp sle i64 %3, 100
+  %5 = zext i1 %4 to i64
+  %true_cond = icmp ne i64 %5, 0
   br i1 %true_cond, label %while_body, label %while_end
 
 while_body:                                       ; preds = %while_cond
-  %7 = bitcast i64* %"$j" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   store i64 0, i64* %"$j"
-  %8 = load i64, i64* %"$i"
-  %9 = add i64 %8, 1
-  store i64 %9, i64* %"$i"
+  %6 = load i64, i64* %"$i"
+  %7 = add i64 %6, 1
+  store i64 %7, i64* %"$i"
   br label %while_cond1
 
 while_end:                                        ; preds = %while_cond
   ret i64 0
 
 while_cond1:                                      ; preds = %lookup_merge, %while_body
-  %10 = load i64, i64* %"$j"
-  %11 = icmp sle i64 %10, 100
-  %12 = zext i1 %11 to i64
-  %true_cond4 = icmp ne i64 %12, 0
+  %8 = load i64, i64* %"$j"
+  %9 = icmp sle i64 %8, 100
+  %10 = zext i1 %9 to i64
+  %true_cond4 = icmp ne i64 %10, 0
   br i1 %true_cond4, label %while_body2, label %while_end3
 
 while_body2:                                      ; preds = %while_cond1
-  %13 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %11 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   store i64 0, i64* %"@_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* %"@_key")
-  %14 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  %12 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
@@ -66,8 +62,8 @@ while_end3:                                       ; preds = %while_cond1
 
 lookup_success:                                   ; preds = %while_body2
   %cast = bitcast i8* %lookup_elem to i64*
-  %15 = load i64, i64* %cast
-  store i64 %15, i64* %lookup_elem_val
+  %13 = load i64, i64* %cast
+  store i64 %13, i64* %lookup_elem_val
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %while_body2
@@ -75,22 +71,22 @@ lookup_failure:                                   ; preds = %while_body2
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %16 = load i64, i64* %lookup_elem_val
-  %17 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
-  %18 = bitcast i64* %"@_newval" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
-  %19 = add i64 %16, 1
-  store i64 %19, i64* %"@_newval"
+  %14 = load i64, i64* %lookup_elem_val
+  %15 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %16 = bitcast i64* %"@_newval" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
+  %17 = add i64 %14, 1
+  store i64 %17, i64* %"@_newval"
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo5, i64* %"@_key", i64* %"@_newval", i64 0)
-  %20 = bitcast i64* %"@_newval" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  %21 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
-  %22 = load i64, i64* %"$j"
-  %23 = add i64 %22, 1
-  store i64 %23, i64* %"$j"
+  %18 = bitcast i64* %"@_newval" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  %19 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  %20 = load i64, i64* %"$j"
+  %21 = add i64 %20, 1
+  store i64 %21, i64* %"$j"
   br label %while_cond1
 }
 

--- a/tests/codegen/llvm/ptr_to_ptr.ll
+++ b/tests/codegen/llvm/ptr_to_ptr.ll
@@ -17,35 +17,33 @@ entry:
   %1 = bitcast i64* %"$pp" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$pp"
-  %2 = bitcast i64* %"$pp" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 0, i64* %"$pp"
+  %2 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   %3 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 16, i1 false)
-  %5 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %5
-  %6 = load i64, i64* %"$pp"
-  %7 = bitcast i64* %deref to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* %deref, i32 8, i64 %6)
-  %8 = load i64, i64* %deref
-  %9 = bitcast i64* %deref to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i32* %deref1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  %probe_read2 = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* %deref1, i32 4, i64 %8)
-  %11 = load i32, i32* %deref1
-  %12 = sext i32 %11 to i64
-  %13 = bitcast i32* %deref1 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %12, i64* %14
+  call void @llvm.memset.p0i8.i64(i8* align 1 %3, i8 0, i64 16, i1 false)
+  %4 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
+  store i64 0, i64* %4
+  %5 = load i64, i64* %"$pp"
+  %6 = bitcast i64* %deref to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* %deref, i32 8, i64 %5)
+  %7 = load i64, i64* %deref
+  %8 = bitcast i64* %deref to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast i32* %deref1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %probe_read2 = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* %deref1, i32 4, i64 %7)
+  %10 = load i32, i32* %deref1
+  %11 = sext i32 %10 to i64
+  %12 = bitcast i32* %deref1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
+  store i64 %11, i64* %13
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 16)
-  %15 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %14 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_char_1.ll
+++ b/tests/codegen/llvm/struct_char_1.ll
@@ -18,28 +18,26 @@ entry:
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
-  %4 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"$foo"
-  %5 = load i64, i64* %"$foo"
-  %6 = add i64 %5, 0
+  %4 = load i64, i64* %"$foo"
+  %5 = add i64 %4, 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"struct Foo.x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.x", i32 1, i64 %6)
-  %7 = load i8, i8* %"struct Foo.x"
-  %8 = sext i8 %7 to i64
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.x", i32 1, i64 %5)
+  %6 = load i8, i8* %"struct Foo.x"
+  %7 = sext i8 %6 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct Foo.x")
-  %9 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 0, i64* %"@x_key"
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  store i64 %8, i64* %"@x_val"
+  %9 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i64 %7, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %11 = bitcast i64* %"@x_val" to i8*
+  %10 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_char_2.ll
+++ b/tests/codegen/llvm/struct_char_2.ll
@@ -18,28 +18,26 @@ entry:
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
-  %4 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"$foo"
-  %5 = load i64, i64* %"$foo"
-  %6 = add i64 %5, 0
+  %4 = load i64, i64* %"$foo"
+  %5 = add i64 %4, 0
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"struct Foo.x")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.x", i32 1, i64 %6)
-  %7 = load i8, i8* %"struct Foo.x"
-  %8 = sext i8 %7 to i64
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.x", i32 1, i64 %5)
+  %6 = load i8, i8* %"struct Foo.x"
+  %7 = sext i8 %6 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct Foo.x")
-  %9 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 0, i64* %"@x_key"
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  store i64 %8, i64* %"@x_val"
+  %9 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i64 %7, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %11 = bitcast i64* %"@x_val" to i8*
+  %10 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_integer_ptr_1.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_1.ll
@@ -19,36 +19,34 @@ entry:
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
-  %4 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"$foo"
-  %5 = load i64, i64* %"$foo"
-  %6 = add i64 %5, 0
-  %7 = bitcast i64* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.x", i32 8, i64 %6)
-  %8 = load i64, i64* %"struct Foo.x"
-  %9 = bitcast i64* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i32* %deref to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %8)
-  %11 = load i32, i32* %deref
-  %12 = sext i32 %11 to i64
-  %13 = bitcast i32* %deref to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  %4 = load i64, i64* %"$foo"
+  %5 = add i64 %4, 0
+  %6 = bitcast i64* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.x", i32 8, i64 %5)
+  %7 = load i64, i64* %"struct Foo.x"
+  %8 = bitcast i64* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast i32* %deref to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %7)
+  %10 = load i32, i32* %deref
+  %11 = sext i32 %10 to i64
+  %12 = bitcast i32* %deref to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
   store i64 0, i64* %"@x_key"
-  %15 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
-  store i64 %12, i64* %"@x_val"
+  %14 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  store i64 %11, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %16 = bitcast i64* %"@x_val" to i8*
+  %15 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %16 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_integer_ptr_2.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_2.ll
@@ -19,36 +19,34 @@ entry:
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
-  %4 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"$foo"
-  %5 = load i64, i64* %"$foo"
-  %6 = add i64 %5, 0
-  %7 = bitcast i64* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.x", i32 8, i64 %6)
-  %8 = load i64, i64* %"struct Foo.x"
-  %9 = bitcast i64* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i32* %deref to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %8)
-  %11 = load i32, i32* %deref
-  %12 = sext i32 %11 to i64
-  %13 = bitcast i32* %deref to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  %4 = load i64, i64* %"$foo"
+  %5 = add i64 %4, 0
+  %6 = bitcast i64* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.x", i32 8, i64 %5)
+  %7 = load i64, i64* %"struct Foo.x"
+  %8 = bitcast i64* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast i32* %deref to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %7)
+  %10 = load i32, i32* %deref
+  %11 = sext i32 %10 to i64
+  %12 = bitcast i32* %deref to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
   store i64 0, i64* %"@x_key"
-  %15 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
-  store i64 %12, i64* %"@x_val"
+  %14 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  store i64 %11, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %16 = bitcast i64* %"@x_val" to i8*
+  %15 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %16 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_integers_1.ll
+++ b/tests/codegen/llvm/struct_integers_1.ll
@@ -18,30 +18,28 @@ entry:
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
-  %4 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"$foo"
-  %5 = load i64, i64* %"$foo"
-  %6 = add i64 %5, 0
-  %7 = bitcast i32* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.x", i32 4, i64 %6)
-  %8 = load i32, i32* %"struct Foo.x"
-  %9 = sext i32 %8 to i64
-  %10 = bitcast i32* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %4 = load i64, i64* %"$foo"
+  %5 = add i64 %4, 0
+  %6 = bitcast i32* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.x", i32 4, i64 %5)
+  %7 = load i32, i32* %"struct Foo.x"
+  %8 = sext i32 %7 to i64
+  %9 = bitcast i32* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 0, i64* %"@x_key"
-  %12 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  store i64 %9, i64* %"@x_val"
+  %11 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i64 %8, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %13 = bitcast i64* %"@x_val" to i8*
+  %12 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_integers_2.ll
+++ b/tests/codegen/llvm/struct_integers_2.ll
@@ -18,30 +18,28 @@ entry:
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
-  %4 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"$foo"
-  %5 = load i64, i64* %"$foo"
-  %6 = add i64 %5, 0
-  %7 = bitcast i32* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.x", i32 4, i64 %6)
-  %8 = load i32, i32* %"struct Foo.x"
-  %9 = sext i32 %8 to i64
-  %10 = bitcast i32* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %4 = load i64, i64* %"$foo"
+  %5 = add i64 %4, 0
+  %6 = bitcast i32* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.x", i32 4, i64 %5)
+  %7 = load i32, i32* %"struct Foo.x"
+  %8 = sext i32 %7 to i64
+  %9 = bitcast i32* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 0, i64* %"@x_key"
-  %12 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  store i64 %9, i64* %"@x_val"
+  %11 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i64 %8, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %13 = bitcast i64* %"@x_val" to i8*
+  %12 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_long_1.ll
+++ b/tests/codegen/llvm/struct_long_1.ll
@@ -18,29 +18,27 @@ entry:
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
-  %4 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"$foo"
-  %5 = load i64, i64* %"$foo"
-  %6 = add i64 %5, 0
-  %7 = bitcast i64* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.x", i32 8, i64 %6)
-  %8 = load i64, i64* %"struct Foo.x"
-  %9 = bitcast i64* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %4 = load i64, i64* %"$foo"
+  %5 = add i64 %4, 0
+  %6 = bitcast i64* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.x", i32 8, i64 %5)
+  %7 = load i64, i64* %"struct Foo.x"
+  %8 = bitcast i64* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 0, i64* %"@x_key"
-  %11 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  store i64 %8, i64* %"@x_val"
+  %10 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i64 %7, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %12 = bitcast i64* %"@x_val" to i8*
+  %11 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_long_2.ll
+++ b/tests/codegen/llvm/struct_long_2.ll
@@ -18,29 +18,27 @@ entry:
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
-  %4 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"$foo"
-  %5 = load i64, i64* %"$foo"
-  %6 = add i64 %5, 0
-  %7 = bitcast i64* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.x", i32 8, i64 %6)
-  %8 = load i64, i64* %"struct Foo.x"
-  %9 = bitcast i64* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %4 = load i64, i64* %"$foo"
+  %5 = add i64 %4, 0
+  %6 = bitcast i64* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.x", i32 8, i64 %5)
+  %7 = load i64, i64* %"struct Foo.x"
+  %8 = bitcast i64* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 0, i64* %"@x_key"
-  %11 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  store i64 %8, i64* %"@x_val"
+  %10 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i64 %7, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %12 = bitcast i64* %"@x_val" to i8*
+  %11 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_nested_struct_anon_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_1.ll
@@ -18,31 +18,29 @@ entry:
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
-  %4 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"$foo"
-  %5 = load i64, i64* %"$foo"
+  %4 = load i64, i64* %"$foo"
+  %5 = add i64 %4, 0
   %6 = add i64 %5, 0
-  %7 = add i64 %6, 0
-  %8 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Foo::(anonymous at definitions.h:2:14).x", i32 4, i64 %7)
-  %9 = load i32, i32* %"struct Foo::(anonymous at definitions.h:2:14).x"
-  %10 = sext i32 %9 to i64
-  %11 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %7 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Foo::(anonymous at definitions.h:2:14).x", i32 4, i64 %6)
+  %8 = load i32, i32* %"struct Foo::(anonymous at definitions.h:2:14).x"
+  %9 = sext i32 %8 to i64
+  %10 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   store i64 0, i64* %"@x_key"
-  %13 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  store i64 %10, i64* %"@x_val"
+  %12 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  store i64 %9, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %14 = bitcast i64* %"@x_val" to i8*
+  %13 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_nested_struct_anon_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_2.ll
@@ -18,31 +18,29 @@ entry:
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
-  %4 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"$foo"
-  %5 = load i64, i64* %"$foo"
+  %4 = load i64, i64* %"$foo"
+  %5 = add i64 %4, 0
   %6 = add i64 %5, 0
-  %7 = add i64 %6, 0
-  %8 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Foo::(anonymous at definitions.h:2:14).x", i32 4, i64 %7)
-  %9 = load i32, i32* %"struct Foo::(anonymous at definitions.h:2:14).x"
-  %10 = sext i32 %9 to i64
-  %11 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %7 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Foo::(anonymous at definitions.h:2:14).x", i32 4, i64 %6)
+  %8 = load i32, i32* %"struct Foo::(anonymous at definitions.h:2:14).x"
+  %9 = sext i32 %8 to i64
+  %10 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   store i64 0, i64* %"@x_key"
-  %13 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  store i64 %10, i64* %"@x_val"
+  %12 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  store i64 %9, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %14 = bitcast i64* %"@x_val" to i8*
+  %13 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_nested_struct_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_1.ll
@@ -18,31 +18,29 @@ entry:
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
-  %4 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"$foo"
-  %5 = load i64, i64* %"$foo"
+  %4 = load i64, i64* %"$foo"
+  %5 = add i64 %4, 0
   %6 = add i64 %5, 0
-  %7 = add i64 %6, 0
-  %8 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %7)
-  %9 = load i32, i32* %"struct Bar.x"
-  %10 = sext i32 %9 to i64
-  %11 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %7 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %6)
+  %8 = load i32, i32* %"struct Bar.x"
+  %9 = sext i32 %8 to i64
+  %10 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   store i64 0, i64* %"@x_key"
-  %13 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  store i64 %10, i64* %"@x_val"
+  %12 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  store i64 %9, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %14 = bitcast i64* %"@x_val" to i8*
+  %13 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_nested_struct_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_2.ll
@@ -18,31 +18,29 @@ entry:
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
-  %4 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"$foo"
-  %5 = load i64, i64* %"$foo"
+  %4 = load i64, i64* %"$foo"
+  %5 = add i64 %4, 0
   %6 = add i64 %5, 0
-  %7 = add i64 %6, 0
-  %8 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %7)
-  %9 = load i32, i32* %"struct Bar.x"
-  %10 = sext i32 %9 to i64
-  %11 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %7 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %6)
+  %8 = load i32, i32* %"struct Bar.x"
+  %9 = sext i32 %8 to i64
+  %10 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   store i64 0, i64* %"@x_key"
-  %13 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  store i64 %10, i64* %"@x_val"
+  %12 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  store i64 %9, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %14 = bitcast i64* %"@x_val" to i8*
+  %13 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
@@ -19,37 +19,35 @@ entry:
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
-  %4 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"$foo"
-  %5 = load i64, i64* %"$foo"
-  %6 = add i64 %5, 0
-  %7 = bitcast i64* %"struct Foo.bar" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.bar", i32 8, i64 %6)
-  %8 = load i64, i64* %"struct Foo.bar"
-  %9 = bitcast i64* %"struct Foo.bar" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = add i64 %8, 0
-  %11 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %10)
-  %12 = load i32, i32* %"struct Bar.x"
-  %13 = sext i32 %12 to i64
-  %14 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  %4 = load i64, i64* %"$foo"
+  %5 = add i64 %4, 0
+  %6 = bitcast i64* %"struct Foo.bar" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.bar", i32 8, i64 %5)
+  %7 = load i64, i64* %"struct Foo.bar"
+  %8 = bitcast i64* %"struct Foo.bar" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = add i64 %7, 0
+  %10 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %9)
+  %11 = load i32, i32* %"struct Bar.x"
+  %12 = sext i32 %11 to i64
+  %13 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
   store i64 0, i64* %"@x_key"
-  %16 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
-  store i64 %13, i64* %"@x_val"
+  %15 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  store i64 %12, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %17 = bitcast i64* %"@x_val" to i8*
+  %16 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
-  %18 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
@@ -19,37 +19,35 @@ entry:
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
-  %4 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"$foo"
-  %5 = load i64, i64* %"$foo"
-  %6 = add i64 %5, 0
-  %7 = bitcast i64* %"struct Foo.bar" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.bar", i32 8, i64 %6)
-  %8 = load i64, i64* %"struct Foo.bar"
-  %9 = bitcast i64* %"struct Foo.bar" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = add i64 %8, 0
-  %11 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %10)
-  %12 = load i32, i32* %"struct Bar.x"
-  %13 = sext i32 %12 to i64
-  %14 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  %4 = load i64, i64* %"$foo"
+  %5 = add i64 %4, 0
+  %6 = bitcast i64* %"struct Foo.bar" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.bar", i32 8, i64 %5)
+  %7 = load i64, i64* %"struct Foo.bar"
+  %8 = bitcast i64* %"struct Foo.bar" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = add i64 %7, 0
+  %10 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %9)
+  %11 = load i32, i32* %"struct Bar.x"
+  %12 = sext i32 %11 to i64
+  %13 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
   store i64 0, i64* %"@x_key"
-  %16 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
-  store i64 %13, i64* %"@x_val"
+  %15 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  store i64 %12, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %17 = bitcast i64* %"@x_val" to i8*
+  %16 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
-  %18 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_short_1.ll
+++ b/tests/codegen/llvm/struct_short_1.ll
@@ -18,30 +18,28 @@ entry:
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
-  %4 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"$foo"
-  %5 = load i64, i64* %"$foo"
-  %6 = add i64 %5, 0
-  %7 = bitcast i16* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i16*, i32, i64)*)(i16* %"struct Foo.x", i32 2, i64 %6)
-  %8 = load i16, i16* %"struct Foo.x"
-  %9 = sext i16 %8 to i64
-  %10 = bitcast i16* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %4 = load i64, i64* %"$foo"
+  %5 = add i64 %4, 0
+  %6 = bitcast i16* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i16*, i32, i64)*)(i16* %"struct Foo.x", i32 2, i64 %5)
+  %7 = load i16, i16* %"struct Foo.x"
+  %8 = sext i16 %7 to i64
+  %9 = bitcast i16* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 0, i64* %"@x_key"
-  %12 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  store i64 %9, i64* %"@x_val"
+  %11 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i64 %8, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %13 = bitcast i64* %"@x_val" to i8*
+  %12 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_short_2.ll
+++ b/tests/codegen/llvm/struct_short_2.ll
@@ -18,30 +18,28 @@ entry:
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
-  %4 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"$foo"
-  %5 = load i64, i64* %"$foo"
-  %6 = add i64 %5, 0
-  %7 = bitcast i16* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i16*, i32, i64)*)(i16* %"struct Foo.x", i32 2, i64 %6)
-  %8 = load i16, i16* %"struct Foo.x"
-  %9 = sext i16 %8 to i64
-  %10 = bitcast i16* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %4 = load i64, i64* %"$foo"
+  %5 = add i64 %4, 0
+  %6 = bitcast i16* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i16*, i32, i64)*)(i16* %"struct Foo.x", i32 2, i64 %5)
+  %7 = load i16, i16* %"struct Foo.x"
+  %8 = sext i16 %7 to i64
+  %9 = bitcast i16* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 0, i64* %"@x_key"
-  %12 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  store i64 %9, i64* %"@x_val"
+  %11 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i64 %8, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %13 = bitcast i64* %"@x_val" to i8*
+  %12 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_string_array_1.ll
+++ b/tests/codegen/llvm/struct_string_array_1.ll
@@ -17,23 +17,21 @@ entry:
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
-  %4 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"$foo"
-  %5 = load i64, i64* %"$foo"
-  %6 = add i64 %5, 0
-  %7 = bitcast [32 x i8]* %"struct Foo.str" to i8*
+  %4 = load i64, i64* %"$foo"
+  %5 = add i64 %4, 0
+  %6 = bitcast [32 x i8]* %"struct Foo.str" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([32 x i8]*, i32, i64)*)([32 x i8]* %"struct Foo.str", i32 32, i64 %5)
+  %7 = bitcast i64* %"@mystr_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([32 x i8]*, i32, i64)*)([32 x i8]* %"struct Foo.str", i32 32, i64 %6)
-  %8 = bitcast i64* %"@mystr_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 0, i64* %"@mystr_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [32 x i8]*, i64)*)(i64 %pseudo, i64* %"@mystr_key", [32 x i8]* %"struct Foo.str", i64 0)
-  %9 = bitcast i64* %"@mystr_key" to i8*
+  %8 = bitcast i64* %"@mystr_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast [32 x i8]* %"struct Foo.str" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast [32 x i8]* %"struct Foo.str" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_string_array_2.ll
+++ b/tests/codegen/llvm/struct_string_array_2.ll
@@ -17,23 +17,21 @@ entry:
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
-  %4 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"$foo"
-  %5 = load i64, i64* %"$foo"
-  %6 = add i64 %5, 0
-  %7 = bitcast [32 x i8]* %"struct Foo.str" to i8*
+  %4 = load i64, i64* %"$foo"
+  %5 = add i64 %4, 0
+  %6 = bitcast [32 x i8]* %"struct Foo.str" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([32 x i8]*, i32, i64)*)([32 x i8]* %"struct Foo.str", i32 32, i64 %5)
+  %7 = bitcast i64* %"@mystr_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([32 x i8]*, i32, i64)*)([32 x i8]* %"struct Foo.str", i32 32, i64 %6)
-  %8 = bitcast i64* %"@mystr_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 0, i64* %"@mystr_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [32 x i8]*, i64)*)(i64 %pseudo, i64* %"@mystr_key", [32 x i8]* %"struct Foo.str", i64 0)
-  %9 = bitcast i64* %"@mystr_key" to i8*
+  %8 = bitcast i64* %"@mystr_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast [32 x i8]* %"struct Foo.str" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast [32 x i8]* %"struct Foo.str" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_string_ptr.ll
+++ b/tests/codegen/llvm/struct_string_ptr.ll
@@ -19,40 +19,38 @@ entry:
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
-  %4 = bitcast i64* %"$foo" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 %arg0, i64* %"$foo"
+  %4 = bitcast i64* %strlen to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   %5 = bitcast i64* %strlen to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %strlen to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 8, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* align 1 %5, i8 0, i64 8, i1 false)
   store i64 64, i64* %strlen
+  %6 = bitcast [64 x i8]* %str to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   %7 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %8 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %8, i8 0, i64 64, i1 false)
-  %9 = load i64, i64* %"$foo"
-  %10 = add i64 %9, 0
-  %11 = bitcast i64* %"struct Foo.str" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.str", i32 8, i64 %10)
-  %12 = load i64, i64* %"struct Foo.str"
-  %13 = bitcast i64* %"struct Foo.str" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = load i64, i64* %strlen
-  %15 = trunc i64 %14 to i32
-  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %15, i64 %12)
-  %16 = bitcast i64* %strlen to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = bitcast i64* %"@mystr_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
+  call void @llvm.memset.p0i8.i64(i8* align 1 %7, i8 0, i64 64, i1 false)
+  %8 = load i64, i64* %"$foo"
+  %9 = add i64 %8, 0
+  %10 = bitcast i64* %"struct Foo.str" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.str", i32 8, i64 %9)
+  %11 = load i64, i64* %"struct Foo.str"
+  %12 = bitcast i64* %"struct Foo.str" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = load i64, i64* %strlen
+  %14 = trunc i64 %13 to i32
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 ([64 x i8]*, i32, i64)*)([64 x i8]* %str, i32 %14, i64 %11)
+  %15 = bitcast i64* %strlen to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %16 = bitcast i64* %"@mystr_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
   store i64 0, i64* %"@mystr_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* %"@mystr_key", [64 x i8]* %str, i64 0)
-  %18 = bitcast i64* %"@mystr_key" to i8*
+  %17 = bitcast i64* %"@mystr_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %18 = bitcast [64 x i8]* %str to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
-  %19 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/variable.ll
+++ b/tests/codegen/llvm/variable.ll
@@ -22,26 +22,24 @@ entry:
   call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 16, i1 false)
   %get_comm = call i64 inttoptr (i64 16 to i64 ([16 x i8]*, i64)*)([16 x i8]* %comm, i64 16)
   %5 = bitcast [16 x i8]* %"$var" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = bitcast [16 x i8]* %"$var" to i8*
+  %6 = bitcast [16 x i8]* %comm to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %5, i8* align 1 %6, i64 16, i1 false)
   %7 = bitcast [16 x i8]* %comm to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %6, i8* align 1 %7, i64 16, i1 false)
-  %8 = bitcast [16 x i8]* %comm to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 0, i64* %"@x_key"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [16 x i8]*, i64)*)(i64 %pseudo, i64* %"@x_key", [16 x i8]* %"$var", i64 0)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %9 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 0, i64* %"@y_key"
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem2 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [16 x i8]*, i64)*)(i64 %pseudo1, i64* %"@y_key", [16 x i8]* %"$var", i64 0)
-  %12 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %11 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/variable_assign_array.ll
+++ b/tests/codegen/llvm/variable_assign_array.ll
@@ -19,30 +19,28 @@ entry:
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3
   %4 = add i64 %arg0, 0
-  %5 = bitcast i64* %"$var" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
   store i64 %4, i64* %"$var"
-  %6 = load i64, i64* %"$var"
-  %7 = add i64 %6, 0
-  %8 = bitcast i32* %array_access to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %array_access, i32 4, i64 %7)
-  %9 = load i32, i32* %array_access
-  %10 = sext i32 %9 to i64
-  %11 = bitcast i32* %array_access to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %5 = load i64, i64* %"$var"
+  %6 = add i64 %5, 0
+  %7 = bitcast i32* %array_access to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %array_access, i32 4, i64 %6)
+  %8 = load i32, i32* %array_access
+  %9 = sext i32 %8 to i64
+  %10 = bitcast i32* %array_access to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   store i64 0, i64* %"@x_key"
-  %13 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  store i64 %10, i64* %"@x_val"
+  %12 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  store i64 %9, i64* %"@x_val"
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %14 = bitcast i64* %"@x_val" to i8*
+  %13 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/variable_increment_decrement.ll
+++ b/tests/codegen/llvm/variable_increment_decrement.ll
@@ -21,69 +21,67 @@ entry:
   %1 = bitcast i64* %"$x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$x"
-  %2 = bitcast i64* %"$x" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 10, i64* %"$x"
+  %2 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   %3 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  %4 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 16, i1 false)
-  %5 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %5
-  %6 = load i64, i64* %"$x"
-  %7 = add i64 %6, 1
-  store i64 %7, i64* %"$x"
-  %8 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %6, i64* %8
+  call void @llvm.memset.p0i8.i64(i8* align 1 %3, i8 0, i64 16, i1 false)
+  %4 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
+  store i64 0, i64* %4
+  %5 = load i64, i64* %"$x"
+  %6 = add i64 %5, 1
+  store i64 %6, i64* %"$x"
+  %7 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
+  store i64 %5, i64* %7
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 16)
-  %9 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %8 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast %printf_t.0* %printf_args1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   %10 = bitcast %printf_t.0* %printf_args1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  %11 = bitcast %printf_t.0* %printf_args1 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 16, i1 false)
-  %12 = getelementptr %printf_t.0, %printf_t.0* %printf_args1, i32 0, i32 0
-  store i64 1, i64* %12
-  %13 = load i64, i64* %"$x"
-  %14 = add i64 %13, 1
-  store i64 %14, i64* %"$x"
-  %15 = getelementptr %printf_t.0, %printf_t.0* %printf_args1, i32 0, i32 1
-  store i64 %14, i64* %15
+  call void @llvm.memset.p0i8.i64(i8* align 1 %10, i8 0, i64 16, i1 false)
+  %11 = getelementptr %printf_t.0, %printf_t.0* %printf_args1, i32 0, i32 0
+  store i64 1, i64* %11
+  %12 = load i64, i64* %"$x"
+  %13 = add i64 %12, 1
+  store i64 %13, i64* %"$x"
+  %14 = getelementptr %printf_t.0, %printf_t.0* %printf_args1, i32 0, i32 1
+  store i64 %13, i64* %14
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %perf_event_output3 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.0*, i64)*)(i8* %0, i64 %pseudo2, i64 4294967295, %printf_t.0* %printf_args1, i64 16)
-  %16 = bitcast %printf_t.0* %printf_args1 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %15 = bitcast %printf_t.0* %printf_args1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %16 = bitcast %printf_t.1* %printf_args4 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
   %17 = bitcast %printf_t.1* %printf_args4 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
-  %18 = bitcast %printf_t.1* %printf_args4 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %18, i8 0, i64 16, i1 false)
-  %19 = getelementptr %printf_t.1, %printf_t.1* %printf_args4, i32 0, i32 0
-  store i64 2, i64* %19
-  %20 = load i64, i64* %"$x"
-  %21 = sub i64 %20, 1
-  store i64 %21, i64* %"$x"
-  %22 = getelementptr %printf_t.1, %printf_t.1* %printf_args4, i32 0, i32 1
-  store i64 %20, i64* %22
+  call void @llvm.memset.p0i8.i64(i8* align 1 %17, i8 0, i64 16, i1 false)
+  %18 = getelementptr %printf_t.1, %printf_t.1* %printf_args4, i32 0, i32 0
+  store i64 2, i64* %18
+  %19 = load i64, i64* %"$x"
+  %20 = sub i64 %19, 1
+  store i64 %20, i64* %"$x"
+  %21 = getelementptr %printf_t.1, %printf_t.1* %printf_args4, i32 0, i32 1
+  store i64 %19, i64* %21
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %perf_event_output6 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.1*, i64)*)(i8* %0, i64 %pseudo5, i64 4294967295, %printf_t.1* %printf_args4, i64 16)
-  %23 = bitcast %printf_t.1* %printf_args4 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
+  %22 = bitcast %printf_t.1* %printf_args4 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
+  %23 = bitcast %printf_t.2* %printf_args7 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
   %24 = bitcast %printf_t.2* %printf_args7 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %24)
-  %25 = bitcast %printf_t.2* %printf_args7 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %25, i8 0, i64 16, i1 false)
-  %26 = getelementptr %printf_t.2, %printf_t.2* %printf_args7, i32 0, i32 0
-  store i64 3, i64* %26
-  %27 = load i64, i64* %"$x"
-  %28 = sub i64 %27, 1
-  store i64 %28, i64* %"$x"
-  %29 = getelementptr %printf_t.2, %printf_t.2* %printf_args7, i32 0, i32 1
-  store i64 %28, i64* %29
+  call void @llvm.memset.p0i8.i64(i8* align 1 %24, i8 0, i64 16, i1 false)
+  %25 = getelementptr %printf_t.2, %printf_t.2* %printf_args7, i32 0, i32 0
+  store i64 3, i64* %25
+  %26 = load i64, i64* %"$x"
+  %27 = sub i64 %26, 1
+  store i64 %27, i64* %"$x"
+  %28 = getelementptr %printf_t.2, %printf_t.2* %printf_args7, i32 0, i32 1
+  store i64 %27, i64* %28
   %pseudo8 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %perf_event_output9 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.2*, i64)*)(i8* %0, i64 %pseudo8, i64 4294967295, %printf_t.2* %printf_args7, i64 16)
-  %30 = bitcast %printf_t.2* %printf_args7 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %30)
+  %29 = bitcast %printf_t.2* %printf_args7 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %29)
   ret i64 0
 }
 


### PR DESCRIPTION
Resolves https://github.com/iovisor/bpftrace/issues/1787

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
  - No language changes
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
  - Though this affects codegen, it eliminates a tautology, so BPF bytecode expected to be equivalent.
- [x] The new behaviour is covered by tests
  - No new behaviour
