### PR TITLE
Remove join type

### DIFF
--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -2748,11 +2748,9 @@ int SemanticAnalyser::create_maps_impl(void)
   {
     // join uses map storage as we'd like to process data larger than can fit on
     // the BPF stack.
-    std::string map_ident = "join";
-    SizedType type = CreateJoin(bpftrace_.join_argnum_,
-                                bpftrace_.join_argsize_);
-    MapKey key;
-    auto map = std::make_unique<T>(map_ident, type, key, 1);
+    int value_size = 8 + 8 + bpftrace_.join_argnum_ * bpftrace_.join_argsize_;
+    auto map = std::make_unique<T>(
+        "join", BPF_MAP_TYPE_PERCPU_ARRAY, 4, value_size, 1, 0);
     failed_maps += is_invalid_map(map->mapfd_);
     bpftrace_.maps.Set(MapManager::Type::Join, std::move(map));
   }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -71,12 +71,6 @@ Map::Map(const std::string &name,
   {
     map_type_ = BPF_MAP_TYPE_PERCPU_HASH;
   }
-  else if (type.IsJoinTy())
-  {
-    map_type_ = BPF_MAP_TYPE_PERCPU_ARRAY;
-    max_entries = 1;
-    key_size = 4;
-  }
   else
     map_type_ = BPF_MAP_TYPE_HASH;
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -166,7 +166,6 @@ std::string typestr(Type t)
     case Type::string:   return "string";   break;
     case Type::ksym:     return "ksym";     break;
     case Type::usym:     return "usym";     break;
-    case Type::join:     return "join";     break;
     case Type::probe:    return "probe";    break;
     case Type::username: return "username"; break;
     case Type::inet:     return "inet";     break;
@@ -435,11 +434,6 @@ SizedType CreateUSym()
 SizedType CreateKSym()
 {
   return SizedType(Type::ksym, 8);
-}
-
-SizedType CreateJoin(size_t argnum, size_t argsize)
-{
-  return SizedType(Type::join, 8 + 8 + argnum * argsize);
 }
 
 SizedType CreateBuffer(size_t size)

--- a/src/types.h
+++ b/src/types.h
@@ -36,7 +36,6 @@ enum class Type
   string,
   ksym,
   usym,
-  join,
   probe,
   username,
   inet,
@@ -285,11 +284,6 @@ public:
   {
     return type == Type::usym;
   };
-
-  bool IsJoinTy(void) const
-  {
-    return type == Type::join;
-  };
   bool IsProbeTy(void) const
   {
     return type == Type::probe;
@@ -389,7 +383,6 @@ SizedType CreateLhist();
 SizedType CreateHist();
 SizedType CreateUSym();
 SizedType CreateKSym();
-SizedType CreateJoin(size_t argnum, size_t argsize);
 SizedType CreateBuffer(size_t size);
 SizedType CreateTimestamp();
 SizedType CreateMacAddress();


### PR DESCRIPTION
join() does not return a value, so there was never any way that another function in the AST would consume join()'s output as an argument.

I recall from one of the "big string" pull requests (which had tried to introduce a "fmtstr" type to describe a scratch map just like the one join() uses) that it was desirable for _fewer_ types to exist, to limit the number of types for which each function had to implement support.

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
  - No language changes
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
  - No user-visible changes
- [x] The new behaviour is covered by tests
  - No new behaviour. ran `join()` example from reference guide; it has not regressed. AST still prints fine with `-dd`.