### PR TITLE
[RFC] Store printf arguments off-stack (in per-CPU scratch buffer)

### DIFF
--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -113,6 +113,7 @@ struct HelperError
   uint64_t action_id;
   uint64_t error_id;
   int32_t return_value;
+  int8_t is_fatal;
 
   std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b)
   {
@@ -120,6 +121,7 @@ struct HelperError
       b.getInt64Ty(), // asyncid
       b.getInt64Ty(), // error_id
       b.getInt32Ty(), // return value
+      b.getInt8Ty(),  // is_fatal
     };
   }
 } __attribute__((packed));

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -643,25 +643,8 @@ void CodegenLLVM::visit(Call &call)
     AllocaInst *second = b_.CreateAllocaBPF(b_.getInt64Ty(),
                                             call.func + "_second");
     Value *perfdata = b_.CreateGetJoinMap(ctx_, call.loc);
-    Function *parent = b_.GetInsertBlock()->getParent();
-
-    BasicBlock *zero = BasicBlock::Create(module_->getContext(),
-                                          "joinzero",
-                                          parent);
-    BasicBlock *notzero = BasicBlock::Create(module_->getContext(),
-                                             "joinnotzero",
-                                             parent);
-
-    b_.CreateCondBr(b_.CreateICmpNE(perfdata,
-                                    ConstantExpr::getCast(Instruction::IntToPtr,
-                                                          b_.getInt64(0),
-                                                          b_.getInt8PtrTy()),
-                                    "joinzerocond"),
-                    notzero,
-                    zero);
 
     // arg0
-    b_.SetInsertPoint(notzero);
     b_.CreateStore(b_.getInt64(asyncactionint(AsyncAction::join)), perfdata);
     b_.CreateStore(b_.getInt64(join_id_),
                    b_.CreateGEP(perfdata, b_.getInt64(8)));
@@ -697,10 +680,6 @@ void CodegenLLVM::visit(Call &call)
         perfdata,
         8 + 8 + bpftrace_.join_argnum_ * bpftrace_.join_argsize_);
 
-    b_.CreateBr(zero);
-
-    // done
-    b_.SetInsertPoint(zero);
     expr_ = nullptr;
   }
   else if (call.func == "ksym")

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -2686,7 +2686,8 @@ void CodegenLLVM::createFormatStringCall(Call &call, int &id, CallArgs &call_arg
     arg.offset = struct_layout->getElementOffset(i+1); // +1 for the id field
   }
 
-  AllocaInst *fmt_args = b_.CreateAllocaBPF(fmt_struct, call_name + "_args");
+  auto fmt_struct_ptr_ty = PointerType::get(fmt_struct, 0);
+  Value *fmt_args = b_.CreateGetFmtStrMap(ctx_, fmt_struct_ptr_ty, call.loc);
   // as the struct is not packed we need to memset it.
   b_.CREATE_MEMSET(fmt_args, b_.getInt8(0), struct_size, 1);
 
@@ -2710,7 +2711,6 @@ void CodegenLLVM::createFormatStringCall(Call &call, int &id, CallArgs &call_arg
 
   id++;
   b_.CreatePerfEventOutput(ctx_, fmt_args, struct_size);
-  b_.CreateLifetimeEnd(fmt_args);
   expr_ = nullptr;
 }
 

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -2057,7 +2057,13 @@ void CodegenLLVM::generateProbe(Probe &probe,
   func->setSection(
       get_section_name_for_probe(section_name, index, usdt_location_index));
   BasicBlock *entry = BasicBlock::Create(module_->getContext(), "entry", func);
+  BasicBlock *post_hoist = BasicBlock::Create(module_->getContext(),
+                                              "post_hoist",
+                                              func);
+  b_.post_hoist_block_ = post_hoist;
   b_.SetInsertPoint(entry);
+  b_.CreateBr(post_hoist);
+  b_.SetInsertPoint(post_hoist);
 
   // check: do the following 8 lines need to be in the wildcard loop?
   ctx_ = func->arg_begin();

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -13,7 +13,6 @@
 
 #include <llvm/IR/DataLayout.h>
 #include <llvm/IR/Module.h>
-#include <llvm/Transforms/Utils/BasicBlockUtils.h>
 
 namespace libbpf {
 #undef __BPF_FUNC_MAPPER
@@ -379,12 +378,12 @@ CallInst *IRBuilderBPF::CreateGetScratchMap(Value *ctx,
 {
   assert(post_hoist_block_ != nullptr);
   auto ip = saveIP();
-  BasicBlock *get_map = SplitEdge(post_hoist_block_->getSinglePredecessor(),
-                                  post_hoist_block_,
-                                  nullptr,
-                                  nullptr,
-                                  nullptr,
-                                  "validate_map_lookup_" + name);
+  BasicBlock *get_map = SPLIT_EDGE(post_hoist_block_->getSinglePredecessor(),
+                                   post_hoist_block_,
+                                   nullptr,
+                                   nullptr,
+                                   nullptr,
+                                   "validate_map_lookup_" + name);
   // remove the unconditional break to posthoist which SplitEdge gives us,
   // because CreateHelperErrorCond() will emit a conditional break to posthoist
   // instead

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -355,6 +355,18 @@ CallInst *IRBuilderBPF::CreateGetJoinMap(Value *ctx, const location &loc)
                              loc);
 }
 
+CallInst *IRBuilderBPF::CreateGetFmtStrMap(Value *ctx,
+                                           PointerType *printf_struct_ptr_ty,
+                                           const location &loc)
+{
+  return CreateGetScratchMap(
+      ctx,
+      bpftrace_.maps[MapManager::Type::FmtStr].value()->id,
+      "fmtstr",
+      printf_struct_ptr_ty,
+      loc);
+}
+
 CallInst *IRBuilderBPF::CreateGetScratchMap(Value *ctx,
                                             int mapid,
                                             const std::string &name,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -151,13 +151,25 @@ public:
   CallInst   *CreateGetRandom();
   CallInst   *CreateGetStackId(Value *ctx, bool ustack, StackType stack_type, const location& loc);
   CallInst   *CreateGetJoinMap(Value *ctx, const location& loc);
+  CallInst *CreateGetFmtStrMap(Value *ctx,
+                               PointerType *printf_struct_ptr_ty,
+                               const location &loc);
   CallInst   *createCall(Value *callee, ArrayRef<Value *> args, const Twine &Name);
   void        CreateGetCurrentComm(Value *ctx, AllocaInst *buf, size_t size, const location& loc);
   void        CreatePerfEventOutput(Value *ctx, Value *data, size_t size);
   void        CreateSignal(Value *ctx, Value *sig, const location &loc);
   void        CreateOverrideReturn(Value *ctx, Value *rc);
-  void        CreateHelperError(Value *ctx, Value *return_value, libbpf::bpf_func_id func_id, const location& loc);
-  void        CreateHelperErrorCond(Value *ctx, Value *return_value, libbpf::bpf_func_id func_id, const location& loc, bool compare_zero=false);
+  void CreateHelperError(Value *ctx,
+                         Value *return_value,
+                         libbpf::bpf_func_id func_id,
+                         const location &loc,
+                         bool is_fatal = false);
+  void CreateHelperErrorCond(Value *ctx,
+                             Value *return_value,
+                             libbpf::bpf_func_id func_id,
+                             const location &loc,
+                             bool compare_zero = false,
+                             bool require_success = false);
   StructType *GetStructType(std::string name, const std::vector<llvm::Type *> & elements, bool packed = false);
   AllocaInst *CreateUSym(llvm::Value *val);
   Value      *CreatKFuncArg(Value *ctx, SizedType& type, std::string& name);
@@ -190,10 +202,27 @@ private:
                                 Builtin &builtin,
                                 AddrSpace as,
                                 const location &loc);
-  CallInst *createMapLookup(int mapid, Value *key);
+  CallInst *createMapLookup(int mapid,
+                            Value *key,
+                            const std::string &name = "lookup_elem");
+  CallInst *createMapLookup(int mapid,
+                            Value *key,
+                            PointerType *ptr_ty,
+                            const std::string &name = "lookup_elem");
   Constant *createProbeReadStrFn(llvm::Type *dst,
                                  llvm::Type *src,
                                  AddrSpace as);
+  CallInst *CreateGetScratchMap(Value *ctx,
+                                int mapid,
+                                const std::string &name,
+                                const location &loc,
+                                int key = 0);
+  CallInst *CreateGetScratchMap(Value *ctx,
+                                int mapid,
+                                const std::string &name,
+                                PointerType *ptr_ty,
+                                const location &loc,
+                                int key = 0);
   libbpf::bpf_func_id selectProbeReadHelper(AddrSpace as, bool str);
 
   std::map<std::string, StructType *> structs_;

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -168,8 +168,10 @@ public:
                              Value *return_value,
                              libbpf::bpf_func_id func_id,
                              const location &loc,
+                             const std::string &helper_name = "helper",
                              bool compare_zero = false,
-                             bool require_success = false);
+                             bool require_success = false,
+                             llvm::BasicBlock *helper_merge_block = nullptr);
   StructType *GetStructType(std::string name, const std::vector<llvm::Type *> & elements, bool packed = false);
   AllocaInst *CreateUSym(llvm::Value *val);
   Value      *CreatKFuncArg(Value *ctx, SizedType& type, std::string& name);
@@ -192,6 +194,7 @@ public:
   // BEGIN { if (nsecs > 0) { $a = 1 } else { $a = 2 } print($a); exit() }
   void hoist(const std::function<void()> &functor);
   int helper_error_id_ = 0;
+  BasicBlock *post_hoist_block_ = nullptr;
 
 private:
   Module &module_;

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -7,6 +7,7 @@
 
 #include <llvm/Config/llvm-config.h>
 #include <llvm/IR/IRBuilder.h>
+#include <llvm/Transforms/Utils/BasicBlockUtils.h>
 
 #if LLVM_VERSION_MAJOR >= 5 && LLVM_VERSION_MAJOR < 7
 #define CREATE_MEMCPY(dst, src, size, algn)                                    \
@@ -33,6 +34,19 @@
 #else
 #define CREATE_MEMSET(ptr, val, size, align)                                   \
   CreateMemSet((ptr), (val), (size), (align))
+#endif
+
+#if LLVM_VERSION_MAJOR >= 5 && LLVM_VERSION_MAJOR < 8
+#define SPLIT_EDGE(from, to, dt, li, mssau, bbname)                            \
+  SplitEdge((from), (to), (dt), (li))
+#elif LLVM_VERSION_MAJOR >= 8 && LLVM_VERSION_MAJOR < 12
+#define SPLIT_EDGE(from, to, dt, li, mssau, bbname)                            \
+  SplitEdge((from), (to), (dt), (li), (mssau))
+#elif LLVM_VERSION_MAJOR >= 12
+#define SPLIT_EDGE(from, to, dt, li, mssau, bbname)                            \
+  SplitEdge((from), (to), (dt), (li), (mssau), (bbname))
+#else
+#error Unsupported LLVM version
 #endif
 
 namespace bpftrace {

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -134,10 +134,12 @@ private:
   bool needs_join_map_ = false;
   bool needs_elapsed_map_ = false;
   bool needs_data_map_ = false;
+  bool needs_fmtstr_map_ = false;
   bool has_begin_probe_ = false;
   bool has_end_probe_ = false;
   bool has_child_ = false;
   bool has_pos_param_ = false;
+  size_t max_fmtstr_args_size_ = 0;
 };
 
 Pass CreateSemanticPass();

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -294,6 +294,8 @@ std::string to_string(MapManager::Type t)
       return "elapsed";
     case MapManager::Type::SeqPrintfData:
       return "seq_printf_data";
+    case MapManager::Type::FmtStr:
+      return "fmtstr";
   }
   return {}; // unreached
 }

--- a/src/mapmanager.h
+++ b/src/mapmanager.h
@@ -60,6 +60,7 @@ public:
     Join,
     Elapsed,
     SeqPrintfData,
+    FmtStr,
   };
 
   void Set(Type t, std::unique_ptr<IMap> map);

--- a/src/utils.h
+++ b/src/utils.h
@@ -215,6 +215,12 @@ inline std::string &trim(std::string &s)
   return ltrim(rtrim(s));
 }
 
+// rounds up to nearest factor of `alignment`
+inline size_t align_to(size_t proposed, size_t alignment)
+{
+  return (proposed + alignment - 1) / alignment * alignment;
+};
+
 template <typename T>
 T read_data(const void *src)
 {

--- a/tests/codegen/llvm/args_multiple_tracepoints.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints.ll
@@ -11,6 +11,9 @@ entry:
   %"@_val" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = ptrtoint i8* %0 to i64
   %2 = add i64 %1, 8
   %3 = inttoptr i64 %2 to i64*
@@ -25,13 +28,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %7 = load i64, i64* %cast, align 8
   store i64 %7, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
@@ -63,6 +66,9 @@ entry:
   %"@_val" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = ptrtoint i8* %0 to i64
   %2 = add i64 %1, 16
   %3 = inttoptr i64 %2 to i64*
@@ -77,13 +83,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %7 = load i64, i64* %cast, align 8
   store i64 %7, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 

--- a/tests/codegen/llvm/args_multiple_tracepoints_category_wild.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints_category_wild.ll
@@ -11,6 +11,9 @@ entry:
   %"@_val" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = ptrtoint i8* %0 to i64
   %2 = add i64 %1, 8
   %3 = inttoptr i64 %2 to i64*
@@ -25,13 +28,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %7 = load i64, i64* %cast, align 8
   store i64 %7, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
@@ -63,6 +66,9 @@ entry:
   %"@_val" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = ptrtoint i8* %0 to i64
   %2 = add i64 %1, 16
   %3 = inttoptr i64 %2 to i64*
@@ -77,13 +83,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %7 = load i64, i64* %cast, align 8
   store i64 %7, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
@@ -109,6 +115,9 @@ entry:
   %"@_val" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = ptrtoint i8* %0 to i64
   %2 = add i64 %1, 24
   %3 = inttoptr i64 %2 to i64*
@@ -123,13 +132,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %7 = load i64, i64* %cast, align 8
   store i64 %7, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 

--- a/tests/codegen/llvm/args_multiple_tracepoints_wild.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints_wild.ll
@@ -11,6 +11,9 @@ entry:
   %"@_val" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = ptrtoint i8* %0 to i64
   %2 = add i64 %1, 8
   %3 = inttoptr i64 %2 to i64*
@@ -25,13 +28,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %7 = load i64, i64* %cast, align 8
   store i64 %7, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
@@ -63,6 +66,9 @@ entry:
   %"@_val" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = ptrtoint i8* %0 to i64
   %2 = add i64 %1, 16
   %3 = inttoptr i64 %2 to i64*
@@ -77,13 +83,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %7 = load i64, i64* %cast, align 8
   store i64 %7, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 

--- a/tests/codegen/llvm/basic_while_loop.ll
+++ b/tests/codegen/llvm/basic_while_loop.ll
@@ -14,10 +14,13 @@ entry:
   %1 = bitcast i64* %"$a" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$a", align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   store i64 1, i64* %"$a", align 8
   br label %while_cond
 
-while_cond:                                       ; preds = %while_body, %entry
+while_cond:                                       ; preds = %while_body, %post_hoist
   %2 = load i64, i64* %"$a", align 8
   %3 = icmp sle i64 %2, 150
   %4 = zext i1 %3 to i64

--- a/tests/codegen/llvm/bitshift_left.ll
+++ b/tests/codegen/llvm/bitshift_left.ll
@@ -10,6 +10,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/llvm/bitshift_right.ll
+++ b/tests/codegen/llvm/bitshift_right.ll
@@ -10,6 +10,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/llvm/bitwise_not.ll
+++ b/tests/codegen/llvm/bitwise_not.ll
@@ -10,6 +10,9 @@ define i64 @BEGIN(i8* %0) section "s_BEGIN_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/llvm/builtin_arg.ll
+++ b/tests/codegen/llvm/builtin_arg.ll
@@ -12,6 +12,9 @@ entry:
   %"@y_key" = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 14
   %arg0 = load volatile i64, i64* %2, align 8

--- a/tests/codegen/llvm/builtin_comm.ll
+++ b/tests/codegen/llvm/builtin_comm.ll
@@ -10,6 +10,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
   %comm = alloca [16 x i8], align 1
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast [16 x i8]* %comm to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast [16 x i8]* %comm to i8*

--- a/tests/codegen/llvm/builtin_cpid.ll
+++ b/tests/codegen/llvm/builtin_cpid.ll
@@ -10,6 +10,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@_key", align 8

--- a/tests/codegen/llvm/builtin_cpu.ll
+++ b/tests/codegen/llvm/builtin_cpu.ll
@@ -10,6 +10,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %get_cpu_id = call i64 inttoptr (i64 8 to i64 ()*)()
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)

--- a/tests/codegen/llvm/builtin_ctx.ll
+++ b/tests/codegen/llvm/builtin_ctx.ll
@@ -10,6 +10,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = ptrtoint i8* %0 to i64
   %2 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)

--- a/tests/codegen/llvm/builtin_ctx_field.ll
+++ b/tests/codegen/llvm/builtin_ctx_field.ll
@@ -23,6 +23,9 @@ entry:
   %1 = bitcast i64* %"$x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$x", align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %2 = ptrtoint i8* %0 to i64
   store i64 %2, i64* %"$x", align 8
   %3 = load i64, i64* %"$x", align 8

--- a/tests/codegen/llvm/builtin_curtask.ll
+++ b/tests/codegen/llvm/builtin_curtask.ll
@@ -10,6 +10,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_ptr" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %get_cur_task = call i64 inttoptr (i64 35 to i64 ()*)()
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)

--- a/tests/codegen/llvm/builtin_elapsed.ll
+++ b/tests/codegen/llvm/builtin_elapsed.ll
@@ -12,6 +12,9 @@ entry:
   %"@_key" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %elapsed_key = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %elapsed_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %elapsed_key, align 8
@@ -22,13 +25,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %3 = load i64, i64* %cast, align 8
   store i64 %3, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 

--- a/tests/codegen/llvm/builtin_func.ll
+++ b/tests/codegen/llvm/builtin_func.ll
@@ -10,6 +10,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 16
   %func = load volatile i64, i64* %2, align 8

--- a/tests/codegen/llvm/builtin_func_uprobe.ll
+++ b/tests/codegen/llvm/builtin_func_uprobe.ll
@@ -12,6 +12,9 @@ define i64 @"uprobe:/bin/sh:f"(i8* %0) section "s_uprobe:/bin/sh:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
   %usym = alloca %usym_t, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 16
   %func = load volatile i64, i64* %2, align 8

--- a/tests/codegen/llvm/builtin_func_wild.ll
+++ b/tests/codegen/llvm/builtin_func_wild.ll
@@ -10,6 +10,9 @@ define i64 @"kprobe:do_execve*"(i8* %0) section "s_kprobe:do_execve*_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 16
   %func = load volatile i64, i64* %2, align 8

--- a/tests/codegen/llvm/builtin_kstack.ll
+++ b/tests/codegen/llvm/builtin_kstack.ll
@@ -10,6 +10,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 0)
   %1 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/builtin_nsecs.ll
+++ b/tests/codegen/llvm/builtin_nsecs.ll
@@ -10,6 +10,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %get_ns = call i64 inttoptr (i64 125 to i64 ()*)()
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)

--- a/tests/codegen/llvm/builtin_pid_tid.ll
+++ b/tests/codegen/llvm/builtin_pid_tid.ll
@@ -12,6 +12,9 @@ entry:
   %"@y_key" = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = lshr i64 %get_pid_tgid, 32
   %2 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/builtin_probe.ll
+++ b/tests/codegen/llvm/builtin_probe.ll
@@ -10,6 +10,9 @@ define i64 @"tracepoint:sched:sched_one"(i8* %0) section "s_tracepoint:sched:sch
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/llvm/builtin_probe_wild.ll
+++ b/tests/codegen/llvm/builtin_probe_wild.ll
@@ -10,6 +10,9 @@ define i64 @"tracepoint:sched:sched_one"(i8* %0) section "s_tracepoint:sched:sch
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/llvm/builtin_rand.ll
+++ b/tests/codegen/llvm/builtin_rand.ll
@@ -10,6 +10,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %get_random = call i64 inttoptr (i64 7 to i64 ()*)()
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)

--- a/tests/codegen/llvm/builtin_retval.ll
+++ b/tests/codegen/llvm/builtin_retval.ll
@@ -10,6 +10,9 @@ define i64 @"kretprobe:f"(i8* %0) section "s_kretprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 10
   %retval = load volatile i64, i64* %2, align 8

--- a/tests/codegen/llvm/builtin_sarg.ll
+++ b/tests/codegen/llvm/builtin_sarg.ll
@@ -14,6 +14,9 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %sarg0 = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 19
   %reg_sp = load volatile i64, i64* %2, align 8

--- a/tests/codegen/llvm/builtin_uid_gid.ll
+++ b/tests/codegen/llvm/builtin_uid_gid.ll
@@ -12,6 +12,9 @@ entry:
   %"@y_key" = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %get_uid_gid = call i64 inttoptr (i64 15 to i64 ()*)()
   %1 = and i64 %get_uid_gid, 4294967295
   %2 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/builtin_username.ll
+++ b/tests/codegen/llvm/builtin_username.ll
@@ -12,6 +12,9 @@ entry:
   %"@y_key" = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %get_uid_gid = call i64 inttoptr (i64 15 to i64 ()*)()
   %1 = and i64 %get_uid_gid, 4294967295
   %2 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/builtin_ustack.ll
+++ b/tests/codegen/llvm/builtin_ustack.ll
@@ -10,6 +10,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 256)
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()

--- a/tests/codegen/llvm/call_avg.ll
+++ b/tests/codegen/llvm/call_avg.ll
@@ -14,6 +14,9 @@ entry:
   %"@x_num" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8
@@ -24,13 +27,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %3 = load i64, i64* %cast, align 8
   store i64 %3, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 

--- a/tests/codegen/llvm/call_buf_implicit_size.ll
+++ b/tests/codegen/llvm/call_buf_implicit_size.ll
@@ -16,6 +16,9 @@ entry:
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$foo", align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   store i64 0, i64* %"$foo", align 8
   %2 = bitcast %buffer_16_t* %buffer to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)

--- a/tests/codegen/llvm/call_buf_size_literal.ll
+++ b/tests/codegen/llvm/call_buf_size_literal.ll
@@ -12,6 +12,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
   %buffer = alloca %buffer_1_t, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast %buffer_1_t* %buffer to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = getelementptr %buffer_1_t, %buffer_1_t* %buffer, i32 0, i32 0

--- a/tests/codegen/llvm/call_buf_size_nonliteral.ll
+++ b/tests/codegen/llvm/call_buf_size_nonliteral.ll
@@ -12,6 +12,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
   %buffer = alloca %buffer_64_t, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 13
   %arg1 = load volatile i64, i64* %2, align 8

--- a/tests/codegen/llvm/call_cat.ll
+++ b/tests/codegen/llvm/call_cat.ll
@@ -3,6 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %cat_t = type { i64 }
 
 ; Function Attrs: nounwind
@@ -10,28 +11,57 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
-  %cat_args = alloca %cat_t, align 8
-  %1 = bitcast %cat_t* %cat_args to i8*
+  %helper_error_t = alloca %helper_error_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
+  br label %validate_map_lookup_fmtstr
+
+validate_map_lookup_fmtstr:                       ; preds = %entry
+  %1 = bitcast i32* %lookup_fmtstr_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast %cat_t* %cat_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 8, i1 false)
-  %3 = getelementptr %cat_t, %cat_t* %cat_args, i32 0, i32 0
-  store i64 20000, i64* %3, align 8
+  store i32 0, i32* %lookup_fmtstr_key, align 4
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %cat_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %cat_t* %cat_args, i64 8)
-  %4 = bitcast %cat_t* %cat_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  %lookup_fmtstr_map = call %cat_t* inttoptr (i64 1 to %cat_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %2 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext %cat_t* %lookup_fmtstr_map to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %post_hoist, label %lookup_fmtstr_map_validate_failure
+
+post_hoist:                                       ; preds = %validate_map_lookup_fmtstr
+  %5 = bitcast %cat_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %5, i8 0, i64 8, i1 false)
+  %6 = getelementptr %cat_t, %cat_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 20000, i64* %6, align 8
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output3 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %cat_t*, i64)*)(i8* %0, i64 %pseudo2, i64 4294967295, %cat_t* %lookup_fmtstr_map, i64 8)
+  ret i64 0
+
+lookup_fmtstr_map_validate_failure:               ; preds = %validate_map_lookup_fmtstr
+  %7 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %8 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %8, align 8
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %9, align 8
+  %10 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %10, align 4
+  %11 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %11, align 1
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %12 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/codegen/llvm/call_cgroup.ll
+++ b/tests/codegen/llvm/call_cgroup.ll
@@ -10,16 +10,19 @@ define i64 @"tracepoint:syscalls:sys_enter_openat"(i8* %0) section "s_tracepoint
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %get_cgroup_id = call i64 inttoptr (i64 80 to i64 ()*)()
   %1 = icmp eq i64 %get_cgroup_id, 4294967297
   %2 = zext i1 %1 to i64
   %predcond = icmp eq i64 %2, 0
   br i1 %predcond, label %pred_false, label %pred_true
 
-pred_false:                                       ; preds = %entry
+pred_false:                                       ; preds = %post_hoist
   ret i64 1
 
-pred_true:                                        ; preds = %entry
+pred_true:                                        ; preds = %post_hoist
   %get_cgroup_id1 = call i64 inttoptr (i64 80 to i64 ()*)()
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)

--- a/tests/codegen/llvm/call_clear.ll
+++ b/tests/codegen/llvm/call_clear.ll
@@ -12,6 +12,9 @@ define i64 @BEGIN(i8* %0) section "s_BEGIN_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8
@@ -36,6 +39,9 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"clear_@x" = alloca %clear_t, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast %clear_t* %"clear_@x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = getelementptr %clear_t, %clear_t* %"clear_@x", i64 0, i32 0

--- a/tests/codegen/llvm/call_count.ll
+++ b/tests/codegen/llvm/call_count.ll
@@ -11,6 +11,9 @@ entry:
   %"@x_val" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8
@@ -21,13 +24,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %3 = load i64, i64* %cast, align 8
   store i64 %3, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 

--- a/tests/codegen/llvm/call_delete.ll
+++ b/tests/codegen/llvm/call_delete.ll
@@ -11,6 +11,9 @@ entry:
   %"@x_key1" = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/llvm/call_exit.ll
+++ b/tests/codegen/llvm/call_exit.ll
@@ -11,6 +11,9 @@ entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
   %perfdata = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %perfdata to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 30000, i64* %perfdata, align 8

--- a/tests/codegen/llvm/call_hist.ll
+++ b/tests/codegen/llvm/call_hist.ll
@@ -11,6 +11,9 @@ entry:
   %"@x_val" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = lshr i64 %get_pid_tgid, 32
   %log2 = call i64 @log2(i64 %1)
@@ -24,13 +27,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %4 = load i64, i64* %cast, align 8
   store i64 %4, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 

--- a/tests/codegen/llvm/call_kstack.ll
+++ b/tests/codegen/llvm/call_kstack.ll
@@ -12,6 +12,9 @@ entry:
   %"@y_key" = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
   %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 0)
   %1 = bitcast i64* %"@x_key" to i8*

--- a/tests/codegen/llvm/call_lhist.ll
+++ b/tests/codegen/llvm/call_lhist.ll
@@ -11,6 +11,9 @@ entry:
   %"@x_val" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = lshr i64 %get_pid_tgid, 32
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to i64 ()*)()
@@ -26,13 +29,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %5 = load i64, i64* %cast, align 8
   store i64 %5, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 

--- a/tests/codegen/llvm/call_macaddr.ll
+++ b/tests/codegen/llvm/call_macaddr.ll
@@ -14,6 +14,9 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast [6 x i8]* %macaddr to i8*
   call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 6, i1 false)
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([6 x i8]*, i32, i64)*)([6 x i8]* %macaddr, i32 6, i64 0)
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)

--- a/tests/codegen/llvm/call_max.ll
+++ b/tests/codegen/llvm/call_max.ll
@@ -11,6 +11,9 @@ entry:
   %"@x_val" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8
@@ -21,13 +24,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %3 = load i64, i64* %cast, align 8
   store i64 %3, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 

--- a/tests/codegen/llvm/call_min.ll
+++ b/tests/codegen/llvm/call_min.ll
@@ -11,6 +11,9 @@ entry:
   %"@x_val" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8
@@ -21,13 +24,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %3 = load i64, i64* %cast, align 8
   store i64 %3, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 

--- a/tests/codegen/llvm/call_ntop_char16.ll
+++ b/tests/codegen/llvm/call_ntop_char16.ll
@@ -12,6 +12,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
   %inet = alloca %inet_t, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast %inet_t* %inet to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = getelementptr %inet_t, %inet_t* %inet, i64 0, i32 0

--- a/tests/codegen/llvm/call_ntop_char4.ll
+++ b/tests/codegen/llvm/call_ntop_char4.ll
@@ -12,6 +12,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
   %inet = alloca %inet_t, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast %inet_t* %inet to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = getelementptr %inet_t, %inet_t* %inet, i64 0, i32 0

--- a/tests/codegen/llvm/call_ntop_key.ll
+++ b/tests/codegen/llvm/call_ntop_key.ll
@@ -13,6 +13,9 @@ entry:
   %"@x_val" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %inet = alloca %inet_t, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast %inet_t* %inet to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = getelementptr %inet_t, %inet_t* %inet, i64 0, i32 0
@@ -29,13 +32,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %7 = load i64, i64* %cast, align 8
   store i64 %7, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 

--- a/tests/codegen/llvm/call_override.ll
+++ b/tests/codegen/llvm/call_override.ll
@@ -8,6 +8,9 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 14
   %arg0 = load volatile i64, i64* %2, align 8

--- a/tests/codegen/llvm/call_override_literal.ll
+++ b/tests/codegen/llvm/call_override_literal.ll
@@ -8,6 +8,9 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %override = call i64 inttoptr (i64 58 to i64 (i8*, i64)*)(i8* %0, i64 -1)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_print.ll
+++ b/tests/codegen/llvm/call_print.ll
@@ -12,6 +12,9 @@ define i64 @BEGIN(i8* %0) section "s_BEGIN_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8
@@ -36,6 +39,9 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"print_@x" = alloca %print_t, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast %print_t* %"print_@x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = getelementptr %print_t, %print_t* %"print_@x", i64 0, i32 0

--- a/tests/codegen/llvm/call_print_composit.ll
+++ b/tests/codegen/llvm/call_print_composit.ll
@@ -14,6 +14,9 @@ entry:
   %print_tuple_72_t = alloca %print_tuple_72_t, align 8
   %str = alloca [64 x i8], align 1
   %tuple = alloca %"int64_string[64]__tuple_t", align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast %"int64_string[64]__tuple_t"* %tuple to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast %"int64_string[64]__tuple_t"* %tuple to i8*

--- a/tests/codegen/llvm/call_print_int.ll
+++ b/tests/codegen/llvm/call_print_int.ll
@@ -11,6 +11,9 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %print_integer_8_t = alloca %print_integer_8_t, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = getelementptr %print_integer_8_t, %print_integer_8_t* %print_integer_8_t, i64 0, i32 0

--- a/tests/codegen/llvm/call_printf.ll
+++ b/tests/codegen/llvm/call_printf.ll
@@ -3,6 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %printf_t = type { i64, i64, i64 }
 
 ; Function Attrs: nounwind
@@ -12,55 +13,84 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"struct Foo.l" = alloca i64, align 8
   %"struct Foo.c" = alloca i8, align 1
-  %printf_args = alloca %printf_t, align 8
+  %helper_error_t = alloca %helper_error_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %"$foo" = alloca i64, align 8
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$foo", align 8
-  %2 = bitcast i8* %0 to i64*
-  %3 = getelementptr i64, i64* %2, i64 14
-  %arg0 = load volatile i64, i64* %3, align 8
-  store i64 %arg0, i64* %"$foo", align 8
-  %4 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  %5 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %5, i8 0, i64 24, i1 false)
-  %6 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %6, align 8
-  %7 = load i64, i64* %"$foo", align 8
-  %8 = add i64 %7, 0
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"struct Foo.c")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.c", i32 1, i64 %8)
-  %9 = load i8, i8* %"struct Foo.c", align 1
-  %10 = sext i8 %9 to i64
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct Foo.c")
-  %11 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %10, i64* %11, align 8
-  %12 = load i64, i64* %"$foo", align 8
-  %13 = add i64 %12, 8
-  %14 = bitcast i64* %"struct Foo.l" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
-  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.l", i32 8, i64 %13)
-  %15 = load i64, i64* %"struct Foo.l", align 8
-  %16 = bitcast i64* %"struct Foo.l" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 2
-  store i64 %15, i64* %17, align 8
+  br label %validate_map_lookup_fmtstr
+
+validate_map_lookup_fmtstr:                       ; preds = %entry
+  %2 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i32 0, i32* %lookup_fmtstr_key, align 4
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 24)
-  %18 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %3 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
+  %4 = sext %printf_t* %lookup_fmtstr_map to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %post_hoist, label %lookup_fmtstr_map_validate_failure
+
+post_hoist:                                       ; preds = %validate_map_lookup_fmtstr
+  %6 = bitcast i8* %0 to i64*
+  %7 = getelementptr i64, i64* %6, i64 14
+  %arg0 = load volatile i64, i64* %7, align 8
+  store i64 %arg0, i64* %"$foo", align 8
+  %8 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %8, i8 0, i64 24, i1 false)
+  %9 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, i64* %9, align 8
+  %10 = load i64, i64* %"$foo", align 8
+  %11 = add i64 %10, 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"struct Foo.c")
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.c", i32 1, i64 %11)
+  %12 = load i8, i8* %"struct Foo.c", align 1
+  %13 = sext i8 %12 to i64
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct Foo.c")
+  %14 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 1
+  store i64 %13, i64* %14, align 8
+  %15 = load i64, i64* %"$foo", align 8
+  %16 = add i64 %15, 8
+  %17 = bitcast i64* %"struct Foo.l" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
+  %probe_read_kernel2 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct Foo.l", i32 8, i64 %16)
+  %18 = load i64, i64* %"struct Foo.l", align 8
+  %19 = bitcast i64* %"struct Foo.l" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  %20 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 2
+  store i64 %18, i64* %20, align 8
+  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output4 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo3, i64 4294967295, %printf_t* %lookup_fmtstr_map, i64 24)
+  ret i64 0
+
+lookup_fmtstr_map_validate_failure:               ; preds = %validate_map_lookup_fmtstr
+  %21 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21)
+  %22 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %22, align 8
+  %23 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %23, align 8
+  %24 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %4, i32* %24, align 4
+  %25 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %25, align 1
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %26 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %26)
   ret i64 0
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/codegen/llvm/call_reg.ll
+++ b/tests/codegen/llvm/call_reg.ll
@@ -10,6 +10,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 16
   %reg_ip = load volatile i64, i64* %2, align 8

--- a/tests/codegen/llvm/call_signal.ll
+++ b/tests/codegen/llvm/call_signal.ll
@@ -8,6 +8,9 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 14
   %arg0 = load volatile i64, i64* %2, align 8

--- a/tests/codegen/llvm/call_signal_literal.ll
+++ b/tests/codegen/llvm/call_signal_literal.ll
@@ -8,6 +8,9 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %signal = call i64 inttoptr (i64 109 to i64 (i32)*)(i32 8)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_signal_string_literal.ll
+++ b/tests/codegen/llvm/call_signal_string_literal.ll
@@ -8,6 +8,9 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %signal = call i64 inttoptr (i64 109 to i64 (i32)*)(i32 9)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_sizeof.ll
+++ b/tests/codegen/llvm/call_sizeof.ll
@@ -10,6 +10,9 @@ define i64 @BEGIN(i8* %0) section "s_BEGIN_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/llvm/call_stats.ll
+++ b/tests/codegen/llvm/call_stats.ll
@@ -14,6 +14,9 @@ entry:
   %"@x_num" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8
@@ -24,13 +27,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %3 = load i64, i64* %cast, align 8
   store i64 %3, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 

--- a/tests/codegen/llvm/call_str.ll
+++ b/tests/codegen/llvm/call_str.ll
@@ -11,6 +11,9 @@ entry:
   %"@x_key" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %strlen = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %strlen to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast i64* %strlen to i8*

--- a/tests/codegen/llvm/call_str_2_expr.ll
+++ b/tests/codegen/llvm/call_str_2_expr.ll
@@ -11,6 +11,9 @@ entry:
   %"@x_key" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %strlen = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %strlen to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast i64* %strlen to i8*

--- a/tests/codegen/llvm/call_str_2_lit.ll
+++ b/tests/codegen/llvm/call_str_2_lit.ll
@@ -11,6 +11,9 @@ entry:
   %"@x_key" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
   %strlen = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %strlen to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast i64* %strlen to i8*

--- a/tests/codegen/llvm/call_strftime.ll
+++ b/tests/codegen/llvm/call_strftime.ll
@@ -4,6 +4,7 @@ target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf-pc-linux"
 
 %strftime_t = type <{ i64, i64 }>
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %printf_t = type { i64, [16 x i8] }
 
 ; Function Attrs: nounwind
@@ -12,42 +13,71 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %strftime_args = alloca %strftime_t, align 8
-  %printf_args = alloca %printf_t, align 8
-  %1 = bitcast %printf_t* %printf_args to i8*
+  %helper_error_t = alloca %helper_error_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
+  br label %validate_map_lookup_fmtstr
+
+validate_map_lookup_fmtstr:                       ; preds = %entry
+  %1 = bitcast i32* %lookup_fmtstr_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 24, i1 false)
-  %3 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %3, align 8
-  %4 = bitcast %strftime_t* %strftime_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  %5 = getelementptr %strftime_t, %strftime_t* %strftime_args, i64 0, i32 0
-  store i64 0, i64* %5, align 8
-  %get_ns = call i64 inttoptr (i64 125 to i64 ()*)()
-  %6 = getelementptr %strftime_t, %strftime_t* %strftime_args, i64 0, i32 1
-  store i64 %get_ns, i64* %6, align 8
-  %7 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  %8 = bitcast [16 x i8]* %7 to i8*
-  %9 = bitcast %strftime_t* %strftime_args to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %8, i8* align 1 %9, i64 16, i1 false)
+  store i32 0, i32* %lookup_fmtstr_key, align 4
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 24)
-  %10 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %2 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext %printf_t* %lookup_fmtstr_map to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %post_hoist, label %lookup_fmtstr_map_validate_failure
+
+post_hoist:                                       ; preds = %validate_map_lookup_fmtstr
+  %5 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %5, i8 0, i64 24, i1 false)
+  %6 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, i64* %6, align 8
+  %7 = bitcast %strftime_t* %strftime_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %8 = getelementptr %strftime_t, %strftime_t* %strftime_args, i64 0, i32 0
+  store i64 0, i64* %8, align 8
+  %get_ns = call i64 inttoptr (i64 125 to i64 ()*)()
+  %9 = getelementptr %strftime_t, %strftime_t* %strftime_args, i64 0, i32 1
+  store i64 %get_ns, i64* %9, align 8
+  %10 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 1
+  %11 = bitcast [16 x i8]* %10 to i8*
+  %12 = bitcast %strftime_t* %strftime_args to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %11, i8* align 1 %12, i64 16, i1 false)
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output3 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo2, i64 4294967295, %printf_t* %lookup_fmtstr_map, i64 24)
+  ret i64 0
+
+lookup_fmtstr_map_validate_failure:               ; preds = %validate_map_lookup_fmtstr
+  %13 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %14 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %14, align 8
+  %15 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %15, align 8
+  %16 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %16, align 4
+  %17 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %17, align 1
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %18 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
   ret i64 0
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly %0, i8* noalias nocapture readonly %1, i64 %2, i1 immarg %3) #1
-
-; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/codegen/llvm/call_sum.ll
+++ b/tests/codegen/llvm/call_sum.ll
@@ -11,6 +11,9 @@ entry:
   %"@x_val" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8
@@ -21,13 +24,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %3 = load i64, i64* %cast, align 8
   store i64 %3, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 

--- a/tests/codegen/llvm/call_system.ll
+++ b/tests/codegen/llvm/call_system.ll
@@ -3,6 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %system_t = type { i64, i64 }
 
 ; Function Attrs: nounwind
@@ -10,30 +11,59 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
-  %system_args = alloca %system_t, align 8
-  %1 = bitcast %system_t* %system_args to i8*
+  %helper_error_t = alloca %helper_error_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
+  br label %validate_map_lookup_fmtstr
+
+validate_map_lookup_fmtstr:                       ; preds = %entry
+  %1 = bitcast i32* %lookup_fmtstr_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast %system_t* %system_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 16, i1 false)
-  %3 = getelementptr %system_t, %system_t* %system_args, i32 0, i32 0
-  store i64 10000, i64* %3, align 8
-  %4 = getelementptr %system_t, %system_t* %system_args, i32 0, i32 1
-  store i64 100, i64* %4, align 8
+  store i32 0, i32* %lookup_fmtstr_key, align 4
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %system_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %system_t* %system_args, i64 16)
-  %5 = bitcast %system_t* %system_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %lookup_fmtstr_map = call %system_t* inttoptr (i64 1 to %system_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %2 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext %system_t* %lookup_fmtstr_map to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %post_hoist, label %lookup_fmtstr_map_validate_failure
+
+post_hoist:                                       ; preds = %validate_map_lookup_fmtstr
+  %5 = bitcast %system_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %5, i8 0, i64 16, i1 false)
+  %6 = getelementptr %system_t, %system_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 10000, i64* %6, align 8
+  %7 = getelementptr %system_t, %system_t* %lookup_fmtstr_map, i32 0, i32 1
+  store i64 100, i64* %7, align 8
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output3 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %system_t*, i64)*)(i8* %0, i64 %pseudo2, i64 4294967295, %system_t* %lookup_fmtstr_map, i64 16)
+  ret i64 0
+
+lookup_fmtstr_map_validate_failure:               ; preds = %validate_map_lookup_fmtstr
+  %8 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %9 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %9, align 8
+  %10 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %10, align 8
+  %11 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %11, align 4
+  %12 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %12, align 1
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %13 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/codegen/llvm/call_time.ll
+++ b/tests/codegen/llvm/call_time.ll
@@ -11,6 +11,9 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %time_t = alloca %time_t, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast %time_t* %time_t to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = getelementptr %time_t, %time_t* %time_t, i64 0, i32 0

--- a/tests/codegen/llvm/call_uptr_1.ll
+++ b/tests/codegen/llvm/call_uptr_1.ll
@@ -11,6 +11,9 @@ entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
   %deref = alloca i16, align 2
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 14
   %arg0 = load volatile i64, i64* %2, align 8

--- a/tests/codegen/llvm/call_uptr_2.ll
+++ b/tests/codegen/llvm/call_uptr_2.ll
@@ -11,6 +11,9 @@ entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
   %deref = alloca i32, align 4
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 14
   %arg0 = load volatile i64, i64* %2, align 8

--- a/tests/codegen/llvm/call_ustack.ll
+++ b/tests/codegen/llvm/call_ustack.ll
@@ -12,6 +12,9 @@ entry:
   %"@y_key" = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
   %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 256)
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()

--- a/tests/codegen/llvm/call_usym_key.ll
+++ b/tests/codegen/llvm/call_usym_key.ll
@@ -13,6 +13,9 @@ entry:
   %"@x_val" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %usym = alloca %usym_t, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast %usym_t* %usym to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
@@ -28,13 +31,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %6 = load i64, i64* %cast, align 8
   store i64 %6, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 

--- a/tests/codegen/llvm/call_zero.ll
+++ b/tests/codegen/llvm/call_zero.ll
@@ -12,6 +12,9 @@ define i64 @BEGIN(i8* %0) section "s_BEGIN_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8
@@ -36,6 +39,9 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"zero_@x" = alloca %zero_t, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast %zero_t* %"zero_@x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = getelementptr %zero_t, %zero_t* %"zero_@x", i64 0, i32 0

--- a/tests/codegen/llvm/comparison_extend.ll
+++ b/tests/codegen/llvm/comparison_extend.ll
@@ -10,6 +10,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 14
   %arg0 = load volatile i64, i64* %2, align 8

--- a/tests/codegen/llvm/dereference.ll
+++ b/tests/codegen/llvm/dereference.ll
@@ -11,6 +11,9 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %deref = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %deref to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %deref, i32 8, i64 1234)

--- a/tests/codegen/llvm/empty_function.ll
+++ b/tests/codegen/llvm/empty_function.ll
@@ -8,6 +8,9 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   ret i64 0
 }
 

--- a/tests/codegen/llvm/enum_declaration.ll
+++ b/tests/codegen/llvm/enum_declaration.ll
@@ -12,6 +12,9 @@ entry:
   %"@b_key" = alloca i64, align 8
   %"@a_val" = alloca i64, align 8
   %"@a_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@a_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@a_key", align 8

--- a/tests/codegen/llvm/if_else_printf.ll
+++ b/tests/codegen/llvm/if_else_printf.ll
@@ -3,61 +3,117 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf-pc-linux"
 
-%printf_t.0 = type { i64 }
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %printf_t = type { i64 }
+%printf_t.0 = type { i64 }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
-  %printf_args1 = alloca %printf_t.0, align 8
-  %printf_args = alloca %printf_t, align 8
+  %helper_error_t9 = alloca %helper_error_t, align 8
+  %lookup_fmtstr_key5 = alloca i32, align 4
+  %helper_error_t = alloca %helper_error_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
+  br label %validate_map_lookup_fmtstr
+
+validate_map_lookup_fmtstr:                       ; preds = %entry
+  %1 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i32 0, i32* %lookup_fmtstr_key, align 4
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %2 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext %printf_t* %lookup_fmtstr_map to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %validate_map_lookup_fmtstr4, label %lookup_fmtstr_map_validate_failure
+
+validate_map_lookup_fmtstr4:                      ; preds = %validate_map_lookup_fmtstr
+  %5 = bitcast i32* %lookup_fmtstr_key5 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i32 0, i32* %lookup_fmtstr_key5, align 4
+  %pseudo6 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %lookup_fmtstr_map7 = call %printf_t.0* inttoptr (i64 1 to %printf_t.0* (i64, i32*)*)(i64 %pseudo6, i32* %lookup_fmtstr_key5)
+  %6 = bitcast i32* %lookup_fmtstr_key5 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = sext %printf_t.0* %lookup_fmtstr_map7 to i32
+  %8 = icmp ne i32 %7, 0
+  br i1 %8, label %post_hoist, label %lookup_fmtstr_map_validate_failure8
+
+post_hoist:                                       ; preds = %validate_map_lookup_fmtstr4
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %1 = lshr i64 %get_pid_tgid, 32
-  %2 = icmp ugt i64 %1, 10
-  %3 = zext i1 %2 to i64
-  %true_cond = icmp ne i64 %3, 0
+  %9 = lshr i64 %get_pid_tgid, 32
+  %10 = icmp ugt i64 %9, 10
+  %11 = zext i1 %10 to i64
+  %true_cond = icmp ne i64 %11, 0
   br i1 %true_cond, label %if_body, label %else_body
 
-if_body:                                          ; preds = %entry
-  %4 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  %5 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %5, i8 0, i64 8, i1 false)
-  %6 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %6, align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 8)
-  %7 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+if_body:                                          ; preds = %post_hoist
+  %12 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %12, i8 0, i64 8, i1 false)
+  %13 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, i64* %13, align 8
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output3 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo2, i64 4294967295, %printf_t* %lookup_fmtstr_map, i64 8)
   br label %if_end
 
 if_end:                                           ; preds = %else_body, %if_body
   ret i64 0
 
-else_body:                                        ; preds = %entry
-  %8 = bitcast %printf_t.0* %printf_args1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %9 = bitcast %printf_t.0* %printf_args1 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %9, i8 0, i64 8, i1 false)
-  %10 = getelementptr %printf_t.0, %printf_t.0* %printf_args1, i32 0, i32 0
-  store i64 1, i64* %10, align 8
-  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output3 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.0*, i64)*)(i8* %0, i64 %pseudo2, i64 4294967295, %printf_t.0* %printf_args1, i64 8)
-  %11 = bitcast %printf_t.0* %printf_args1 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+else_body:                                        ; preds = %post_hoist
+  %14 = bitcast %printf_t.0* %lookup_fmtstr_map7 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %14, i8 0, i64 8, i1 false)
+  %15 = getelementptr %printf_t.0, %printf_t.0* %lookup_fmtstr_map7, i32 0, i32 0
+  store i64 1, i64* %15, align 8
+  %pseudo12 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output13 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.0*, i64)*)(i8* %0, i64 %pseudo12, i64 4294967295, %printf_t.0* %lookup_fmtstr_map7, i64 8)
   br label %if_end
+
+lookup_fmtstr_map_validate_failure:               ; preds = %validate_map_lookup_fmtstr
+  %16 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
+  %17 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %17, align 8
+  %18 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %18, align 8
+  %19 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %19, align 4
+  %20 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %20, align 1
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %21 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  ret i64 0
+
+lookup_fmtstr_map_validate_failure8:              ; preds = %validate_map_lookup_fmtstr4
+  %22 = bitcast %helper_error_t* %helper_error_t9 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %22)
+  %23 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t9, i64 0, i32 0
+  store i64 30006, i64* %23, align 8
+  %24 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t9, i64 0, i32 1
+  store i64 1, i64* %24, align 8
+  %25 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t9, i64 0, i32 2
+  store i32 %7, i32* %25, align 4
+  %26 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t9, i64 0, i32 3
+  store i8 1, i8* %26, align 1
+  %pseudo10 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output11 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo10, i64 4294967295, %helper_error_t* %helper_error_t9, i64 21)
+  %27 = bitcast %helper_error_t* %helper_error_t9 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %27)
+  ret i64 0
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/codegen/llvm/if_else_variable.ll
+++ b/tests/codegen/llvm/if_else_variable.ll
@@ -3,6 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %printf_t = type { i64, i64 }
 
 ; Function Attrs: nounwind
@@ -10,51 +11,80 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
-  %printf_args = alloca %printf_t, align 8
+  %helper_error_t = alloca %helper_error_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %"$s" = alloca i64, align 8
   %1 = bitcast i64* %"$s" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$s", align 8
+  br label %validate_map_lookup_fmtstr
+
+validate_map_lookup_fmtstr:                       ; preds = %entry
+  %2 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i32 0, i32* %lookup_fmtstr_key, align 4
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %3 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
+  %4 = sext %printf_t* %lookup_fmtstr_map to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %post_hoist, label %lookup_fmtstr_map_validate_failure
+
+post_hoist:                                       ; preds = %validate_map_lookup_fmtstr
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %2 = lshr i64 %get_pid_tgid, 32
-  %3 = icmp ugt i64 %2, 10000
-  %4 = zext i1 %3 to i64
-  %true_cond = icmp ne i64 %4, 0
+  %6 = lshr i64 %get_pid_tgid, 32
+  %7 = icmp ugt i64 %6, 10000
+  %8 = zext i1 %7 to i64
+  %true_cond = icmp ne i64 %8, 0
   br i1 %true_cond, label %if_body, label %else_body
 
-if_body:                                          ; preds = %entry
+if_body:                                          ; preds = %post_hoist
   store i64 10, i64* %"$s", align 8
   br label %if_end
 
 if_end:                                           ; preds = %else_body, %if_body
-  %5 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 16, i1 false)
-  %7 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %7, align 8
-  %8 = load i64, i64* %"$s", align 8
-  %9 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %8, i64* %9, align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 16)
-  %10 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %9 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %9, i8 0, i64 16, i1 false)
+  %10 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, i64* %10, align 8
+  %11 = load i64, i64* %"$s", align 8
+  %12 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 1
+  store i64 %11, i64* %12, align 8
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output3 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo2, i64 4294967295, %printf_t* %lookup_fmtstr_map, i64 16)
   ret i64 0
 
-else_body:                                        ; preds = %entry
+else_body:                                        ; preds = %post_hoist
   store i64 20, i64* %"$s", align 8
   br label %if_end
+
+lookup_fmtstr_map_validate_failure:               ; preds = %validate_map_lookup_fmtstr
+  %13 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %14 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %14, align 8
+  %15 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %15, align 8
+  %16 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %4, i32* %16, align 4
+  %17 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %17, align 1
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %18 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  ret i64 0
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/codegen/llvm/if_nested_printf.ll
+++ b/tests/codegen/llvm/if_nested_printf.ll
@@ -3,6 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %printf_t = type { i64 }
 
 ; Function Attrs: nounwind
@@ -10,51 +11,80 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
-  %printf_args = alloca %printf_t, align 8
+  %helper_error_t = alloca %helper_error_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
+  br label %validate_map_lookup_fmtstr
+
+validate_map_lookup_fmtstr:                       ; preds = %entry
+  %1 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i32 0, i32* %lookup_fmtstr_key, align 4
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %2 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext %printf_t* %lookup_fmtstr_map to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %post_hoist, label %lookup_fmtstr_map_validate_failure
+
+post_hoist:                                       ; preds = %validate_map_lookup_fmtstr
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %1 = lshr i64 %get_pid_tgid, 32
-  %2 = icmp ugt i64 %1, 10000
-  %3 = zext i1 %2 to i64
-  %true_cond = icmp ne i64 %3, 0
+  %5 = lshr i64 %get_pid_tgid, 32
+  %6 = icmp ugt i64 %5, 10000
+  %7 = zext i1 %6 to i64
+  %true_cond = icmp ne i64 %7, 0
   br i1 %true_cond, label %if_body, label %if_end
 
-if_body:                                          ; preds = %entry
+if_body:                                          ; preds = %post_hoist
   %get_pid_tgid3 = call i64 inttoptr (i64 14 to i64 ()*)()
-  %4 = lshr i64 %get_pid_tgid3, 32
-  %5 = urem i64 %4, 2
-  %6 = icmp eq i64 %5, 0
-  %7 = zext i1 %6 to i64
-  %true_cond4 = icmp ne i64 %7, 0
+  %8 = lshr i64 %get_pid_tgid3, 32
+  %9 = urem i64 %8, 2
+  %10 = icmp eq i64 %9, 0
+  %11 = zext i1 %10 to i64
+  %true_cond4 = icmp ne i64 %11, 0
   br i1 %true_cond4, label %if_body1, label %if_end2
 
-if_end:                                           ; preds = %if_end2, %entry
+if_end:                                           ; preds = %if_end2, %post_hoist
   ret i64 0
 
 if_body1:                                         ; preds = %if_body
-  %8 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %9 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %9, i8 0, i64 8, i1 false)
-  %10 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %10, align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 8)
-  %11 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %12, i8 0, i64 8, i1 false)
+  %13 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, i64* %13, align 8
+  %pseudo6 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output7 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo6, i64 4294967295, %printf_t* %lookup_fmtstr_map, i64 8)
   br label %if_end2
 
 if_end2:                                          ; preds = %if_body1, %if_body
   br label %if_end
+
+lookup_fmtstr_map_validate_failure:               ; preds = %validate_map_lookup_fmtstr
+  %14 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  %15 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %15, align 8
+  %16 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %16, align 8
+  %17 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %17, align 4
+  %18 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %18, align 1
+  %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo5, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %19 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  ret i64 0
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/codegen/llvm/if_printf.ll
+++ b/tests/codegen/llvm/if_printf.ll
@@ -3,6 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %printf_t = type { i64, i64 }
 
 ; Function Attrs: nounwind
@@ -10,43 +11,72 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
-  %printf_args = alloca %printf_t, align 8
+  %helper_error_t = alloca %helper_error_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
+  br label %validate_map_lookup_fmtstr
+
+validate_map_lookup_fmtstr:                       ; preds = %entry
+  %1 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i32 0, i32* %lookup_fmtstr_key, align 4
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %2 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %3 = sext %printf_t* %lookup_fmtstr_map to i32
+  %4 = icmp ne i32 %3, 0
+  br i1 %4, label %post_hoist, label %lookup_fmtstr_map_validate_failure
+
+post_hoist:                                       ; preds = %validate_map_lookup_fmtstr
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %1 = lshr i64 %get_pid_tgid, 32
-  %2 = icmp ugt i64 %1, 10000
-  %3 = zext i1 %2 to i64
-  %true_cond = icmp ne i64 %3, 0
+  %5 = lshr i64 %get_pid_tgid, 32
+  %6 = icmp ugt i64 %5, 10000
+  %7 = zext i1 %6 to i64
+  %true_cond = icmp ne i64 %7, 0
   br i1 %true_cond, label %if_body, label %if_end
 
-if_body:                                          ; preds = %entry
-  %4 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  %5 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %5, i8 0, i64 16, i1 false)
-  %6 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %6, align 8
-  %get_pid_tgid1 = call i64 inttoptr (i64 14 to i64 ()*)()
-  %7 = lshr i64 %get_pid_tgid1, 32
-  %8 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %7, i64* %8, align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 16)
-  %9 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+if_body:                                          ; preds = %post_hoist
+  %8 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %8, i8 0, i64 16, i1 false)
+  %9 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, i64* %9, align 8
+  %get_pid_tgid2 = call i64 inttoptr (i64 14 to i64 ()*)()
+  %10 = lshr i64 %get_pid_tgid2, 32
+  %11 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 1
+  store i64 %10, i64* %11, align 8
+  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output4 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo3, i64 4294967295, %printf_t* %lookup_fmtstr_map, i64 16)
   br label %if_end
 
-if_end:                                           ; preds = %if_body, %entry
+if_end:                                           ; preds = %if_body, %post_hoist
+  ret i64 0
+
+lookup_fmtstr_map_validate_failure:               ; preds = %validate_map_lookup_fmtstr
+  %12 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %13 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %13, align 8
+  %14 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %14, align 8
+  %15 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %3, i32* %15, align 4
+  %16 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %16, align 1
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %17 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
   ret i64 0
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/codegen/llvm/if_variable.ll
+++ b/tests/codegen/llvm/if_variable.ll
@@ -3,6 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %printf_t = type { i64, i64 }
 
 ; Function Attrs: nounwind
@@ -10,47 +11,76 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
-  %printf_args = alloca %printf_t, align 8
+  %helper_error_t = alloca %helper_error_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %"$s" = alloca i64, align 8
   %1 = bitcast i64* %"$s" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$s", align 8
+  br label %validate_map_lookup_fmtstr
+
+validate_map_lookup_fmtstr:                       ; preds = %entry
+  %2 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i32 0, i32* %lookup_fmtstr_key, align 4
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %3 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
+  %4 = sext %printf_t* %lookup_fmtstr_map to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %post_hoist, label %lookup_fmtstr_map_validate_failure
+
+post_hoist:                                       ; preds = %validate_map_lookup_fmtstr
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %2 = lshr i64 %get_pid_tgid, 32
-  %3 = icmp ugt i64 %2, 10000
-  %4 = zext i1 %3 to i64
-  %true_cond = icmp ne i64 %4, 0
+  %6 = lshr i64 %get_pid_tgid, 32
+  %7 = icmp ugt i64 %6, 10000
+  %8 = zext i1 %7 to i64
+  %true_cond = icmp ne i64 %8, 0
   br i1 %true_cond, label %if_body, label %if_end
 
-if_body:                                          ; preds = %entry
+if_body:                                          ; preds = %post_hoist
   store i64 10, i64* %"$s", align 8
   br label %if_end
 
-if_end:                                           ; preds = %if_body, %entry
-  %5 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  %6 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 16, i1 false)
-  %7 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %7, align 8
-  %8 = load i64, i64* %"$s", align 8
-  %9 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %8, i64* %9, align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 16)
-  %10 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+if_end:                                           ; preds = %if_body, %post_hoist
+  %9 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %9, i8 0, i64 16, i1 false)
+  %10 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, i64* %10, align 8
+  %11 = load i64, i64* %"$s", align 8
+  %12 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 1
+  store i64 %11, i64* %12, align 8
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output3 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo2, i64 4294967295, %printf_t* %lookup_fmtstr_map, i64 16)
+  ret i64 0
+
+lookup_fmtstr_map_validate_failure:               ; preds = %validate_map_lookup_fmtstr
+  %13 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %14 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %14, align 8
+  %15 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %15, align 8
+  %16 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %4, i32* %16, align 4
+  %17 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %17, align 1
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %18 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
   ret i64 0
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/codegen/llvm/int_propagation.ll
+++ b/tests/codegen/llvm/int_propagation.ll
@@ -14,6 +14,9 @@ entry:
   %"@x_key1" = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8
@@ -36,13 +39,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %7 = load i64, i64* %cast, align 8
   store i64 %7, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 

--- a/tests/codegen/llvm/intcast_call.ll
+++ b/tests/codegen/llvm/intcast_call.ll
@@ -11,6 +11,9 @@ entry:
   %"@_val" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@_key", align 8
@@ -21,13 +24,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %3 = load i64, i64* %cast, align 8
   store i64 %3, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 

--- a/tests/codegen/llvm/intcast_retval.ll
+++ b/tests/codegen/llvm/intcast_retval.ll
@@ -10,6 +10,9 @@ define i64 @"kretprobe:f"(i8* %0) section "s_kretprobe:f_1" {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 10
   %retval = load volatile i64, i64* %2, align 8

--- a/tests/codegen/llvm/intptrcast_assign_var.ll
+++ b/tests/codegen/llvm/intptrcast_assign_var.ll
@@ -11,6 +11,9 @@ entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
   %deref = alloca i8, align 1
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 4
   %reg_bp = load volatile i64, i64* %2, align 8

--- a/tests/codegen/llvm/intptrcast_call.ll
+++ b/tests/codegen/llvm/intptrcast_call.ll
@@ -12,6 +12,9 @@ entry:
   %"@_val" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@_key", align 8
@@ -22,13 +25,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %3 = load i64, i64* %cast, align 8
   store i64 %3, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 

--- a/tests/codegen/llvm/literal_strncmp.ll
+++ b/tests/codegen/llvm/literal_strncmp.ll
@@ -13,6 +13,9 @@ entry:
   %comm3 = alloca [16 x i8], align 1
   %strcmp.result = alloca i1, align 1
   %comm = alloca [16 x i8], align 1
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast [16 x i8]* %comm to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast [16 x i8]* %comm to i8*
@@ -42,7 +45,7 @@ pred_true:                                        ; preds = %strcmp.false
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-strcmp.false:                                     ; preds = %strcmp.loop1, %strcmp.loop, %entry
+strcmp.false:                                     ; preds = %strcmp.loop1, %strcmp.loop, %post_hoist
   %9 = load i1, i1* %strcmp.result, align 1
   %10 = bitcast i1* %strcmp.result to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
@@ -52,7 +55,7 @@ strcmp.false:                                     ; preds = %strcmp.loop1, %strc
   %predcond = icmp eq i64 %11, 0
   br i1 %predcond, label %pred_false, label %pred_true
 
-strcmp.loop:                                      ; preds = %entry
+strcmp.loop:                                      ; preds = %post_hoist
   %13 = getelementptr [16 x i8], [16 x i8]* %comm, i32 0, i32 1
   %14 = load i8, i8* %13, align 1
   %strcmp.cmp2 = icmp ne i8 %14, 115

--- a/tests/codegen/llvm/logical_and.ll
+++ b/tests/codegen/llvm/logical_and.ll
@@ -11,6 +11,9 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %"&&_result" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"&&_result" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
@@ -20,7 +23,7 @@ entry:
   %lhs_true_cond = icmp ne i64 %4, 0
   br i1 %lhs_true_cond, label %"&&_lhs_true", label %"&&_false"
 
-"&&_lhs_true":                                    ; preds = %entry
+"&&_lhs_true":                                    ; preds = %post_hoist
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to i64 ()*)()
   %5 = lshr i64 %get_pid_tgid1, 32
   %6 = icmp ne i64 %5, 1235
@@ -32,7 +35,7 @@ entry:
   store i64 1, i64* %"&&_result", align 8
   br label %"&&_merge"
 
-"&&_false":                                       ; preds = %"&&_lhs_true", %entry
+"&&_false":                                       ; preds = %"&&_lhs_true", %post_hoist
   store i64 0, i64* %"&&_result", align 8
   br label %"&&_merge"
 

--- a/tests/codegen/llvm/logical_and_or_different_type.ll
+++ b/tests/codegen/llvm/logical_and_or_different_type.ll
@@ -3,6 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %printf_t = type { i64, i64, i64, i64, i64 }
 
 ; Function Attrs: nounwind
@@ -10,160 +11,189 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @BEGIN(i8* %0) section "s_BEGIN_1" {
 entry:
-  %"struct Foo.m16" = alloca i32, align 4
-  %"||_result15" = alloca i64, align 8
-  %"struct Foo.m8" = alloca i32, align 4
+  %"struct Foo.m17" = alloca i32, align 4
+  %"||_result16" = alloca i64, align 8
+  %"struct Foo.m9" = alloca i32, align 4
   %"||_result" = alloca i64, align 8
-  %"struct Foo.m6" = alloca i32, align 4
-  %"&&_result5" = alloca i64, align 8
+  %"struct Foo.m7" = alloca i32, align 4
+  %"&&_result6" = alloca i64, align 8
   %"struct Foo.m" = alloca i32, align 4
   %"&&_result" = alloca i64, align 8
-  %printf_args = alloca %printf_t, align 8
+  %helper_error_t = alloca %helper_error_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %"$foo" = alloca i64, align 8
   %1 = bitcast i64* %"$foo" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$foo", align 8
-  %2 = bitcast i8* %0 to i64*
-  %3 = getelementptr i64, i64* %2, i64 14
-  %arg0 = load volatile i64, i64* %3, align 8
+  br label %validate_map_lookup_fmtstr
+
+validate_map_lookup_fmtstr:                       ; preds = %entry
+  %2 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i32 0, i32* %lookup_fmtstr_key, align 4
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %3 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
+  %4 = sext %printf_t* %lookup_fmtstr_map to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %post_hoist, label %lookup_fmtstr_map_validate_failure
+
+post_hoist:                                       ; preds = %validate_map_lookup_fmtstr
+  %6 = bitcast i8* %0 to i64*
+  %7 = getelementptr i64, i64* %6, i64 14
+  %arg0 = load volatile i64, i64* %7, align 8
   store i64 %arg0, i64* %"$foo", align 8
-  %4 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  %5 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %5, i8 0, i64 40, i1 false)
-  %6 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %6, align 8
-  %7 = bitcast i64* %"&&_result" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %8 = load i64, i64* %"$foo", align 8
-  %9 = add i64 %8, 0
-  %10 = bitcast i32* %"struct Foo.m" to i8*
+  %8 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %8, i8 0, i64 40, i1 false)
+  %9 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, i64* %9, align 8
+  %10 = bitcast i64* %"&&_result" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  %probe_read_user = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.m", i32 4, i64 %9)
-  %11 = load i32, i32* %"struct Foo.m", align 4
-  %12 = sext i32 %11 to i64
+  %11 = load i64, i64* %"$foo", align 8
+  %12 = add i64 %11, 0
   %13 = bitcast i32* %"struct Foo.m" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %lhs_true_cond = icmp ne i64 %12, 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %probe_read_user = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.m", i32 4, i64 %12)
+  %14 = load i32, i32* %"struct Foo.m", align 4
+  %15 = sext i32 %14 to i64
+  %16 = bitcast i32* %"struct Foo.m" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %lhs_true_cond = icmp ne i64 %15, 0
   br i1 %lhs_true_cond, label %"&&_lhs_true", label %"&&_false"
 
-"&&_lhs_true":                                    ; preds = %entry
+lookup_fmtstr_map_validate_failure:               ; preds = %validate_map_lookup_fmtstr
+  %17 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
+  %18 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %18, align 8
+  %19 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %19, align 8
+  %20 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %4, i32* %20, align 4
+  %21 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %21, align 1
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %22 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
+  ret i64 0
+
+"&&_lhs_true":                                    ; preds = %post_hoist
   br i1 false, label %"&&_true", label %"&&_false"
 
 "&&_true":                                        ; preds = %"&&_lhs_true"
   store i64 1, i64* %"&&_result", align 8
   br label %"&&_merge"
 
-"&&_false":                                       ; preds = %"&&_lhs_true", %entry
+"&&_false":                                       ; preds = %"&&_lhs_true", %post_hoist
   store i64 0, i64* %"&&_result", align 8
   br label %"&&_merge"
 
 "&&_merge":                                       ; preds = %"&&_false", %"&&_true"
-  %14 = load i64, i64* %"&&_result", align 8
-  %15 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %14, i64* %15, align 8
-  %16 = bitcast i64* %"&&_result5" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
-  br i1 true, label %"&&_lhs_true1", label %"&&_false3"
-
-"&&_lhs_true1":                                   ; preds = %"&&_merge"
-  %17 = load i64, i64* %"$foo", align 8
-  %18 = add i64 %17, 0
-  %19 = bitcast i32* %"struct Foo.m6" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
-  %probe_read_user7 = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.m6", i32 4, i64 %18)
-  %20 = load i32, i32* %"struct Foo.m6", align 4
-  %21 = sext i32 %20 to i64
-  %22 = bitcast i32* %"struct Foo.m6" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
-  %rhs_true_cond = icmp ne i64 %21, 0
-  br i1 %rhs_true_cond, label %"&&_true2", label %"&&_false3"
-
-"&&_true2":                                       ; preds = %"&&_lhs_true1"
-  store i64 1, i64* %"&&_result5", align 8
-  br label %"&&_merge4"
-
-"&&_false3":                                      ; preds = %"&&_lhs_true1", %"&&_merge"
-  store i64 0, i64* %"&&_result5", align 8
-  br label %"&&_merge4"
-
-"&&_merge4":                                      ; preds = %"&&_false3", %"&&_true2"
-  %23 = load i64, i64* %"&&_result5", align 8
-  %24 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 2
+  %23 = load i64, i64* %"&&_result", align 8
+  %24 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 1
   store i64 %23, i64* %24, align 8
-  %25 = bitcast i64* %"||_result" to i8*
+  %25 = bitcast i64* %"&&_result6" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %25)
+  br i1 true, label %"&&_lhs_true2", label %"&&_false4"
+
+"&&_lhs_true2":                                   ; preds = %"&&_merge"
   %26 = load i64, i64* %"$foo", align 8
   %27 = add i64 %26, 0
-  %28 = bitcast i32* %"struct Foo.m8" to i8*
+  %28 = bitcast i32* %"struct Foo.m7" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %28)
-  %probe_read_user9 = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.m8", i32 4, i64 %27)
-  %29 = load i32, i32* %"struct Foo.m8", align 4
+  %probe_read_user8 = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.m7", i32 4, i64 %27)
+  %29 = load i32, i32* %"struct Foo.m7", align 4
   %30 = sext i32 %29 to i64
-  %31 = bitcast i32* %"struct Foo.m8" to i8*
+  %31 = bitcast i32* %"struct Foo.m7" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %31)
-  %lhs_true_cond10 = icmp ne i64 %30, 0
-  br i1 %lhs_true_cond10, label %"||_true", label %"||_lhs_false"
+  %rhs_true_cond = icmp ne i64 %30, 0
+  br i1 %rhs_true_cond, label %"&&_true3", label %"&&_false4"
 
-"||_lhs_false":                                   ; preds = %"&&_merge4"
+"&&_true3":                                       ; preds = %"&&_lhs_true2"
+  store i64 1, i64* %"&&_result6", align 8
+  br label %"&&_merge5"
+
+"&&_false4":                                      ; preds = %"&&_lhs_true2", %"&&_merge"
+  store i64 0, i64* %"&&_result6", align 8
+  br label %"&&_merge5"
+
+"&&_merge5":                                      ; preds = %"&&_false4", %"&&_true3"
+  %32 = load i64, i64* %"&&_result6", align 8
+  %33 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 2
+  store i64 %32, i64* %33, align 8
+  %34 = bitcast i64* %"||_result" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %34)
+  %35 = load i64, i64* %"$foo", align 8
+  %36 = add i64 %35, 0
+  %37 = bitcast i32* %"struct Foo.m9" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %37)
+  %probe_read_user10 = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.m9", i32 4, i64 %36)
+  %38 = load i32, i32* %"struct Foo.m9", align 4
+  %39 = sext i32 %38 to i64
+  %40 = bitcast i32* %"struct Foo.m9" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %40)
+  %lhs_true_cond11 = icmp ne i64 %39, 0
+  br i1 %lhs_true_cond11, label %"||_true", label %"||_lhs_false"
+
+"||_lhs_false":                                   ; preds = %"&&_merge5"
   br i1 false, label %"||_true", label %"||_false"
 
 "||_false":                                       ; preds = %"||_lhs_false"
   store i64 0, i64* %"||_result", align 8
   br label %"||_merge"
 
-"||_true":                                        ; preds = %"||_lhs_false", %"&&_merge4"
+"||_true":                                        ; preds = %"||_lhs_false", %"&&_merge5"
   store i64 1, i64* %"||_result", align 8
   br label %"||_merge"
 
 "||_merge":                                       ; preds = %"||_true", %"||_false"
-  %32 = load i64, i64* %"||_result", align 8
-  %33 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 3
-  store i64 %32, i64* %33, align 8
-  %34 = bitcast i64* %"||_result15" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %34)
-  br i1 false, label %"||_true13", label %"||_lhs_false11"
-
-"||_lhs_false11":                                 ; preds = %"||_merge"
-  %35 = load i64, i64* %"$foo", align 8
-  %36 = add i64 %35, 0
-  %37 = bitcast i32* %"struct Foo.m16" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %37)
-  %probe_read_user17 = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.m16", i32 4, i64 %36)
-  %38 = load i32, i32* %"struct Foo.m16", align 4
-  %39 = sext i32 %38 to i64
-  %40 = bitcast i32* %"struct Foo.m16" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %40)
-  %rhs_true_cond18 = icmp ne i64 %39, 0
-  br i1 %rhs_true_cond18, label %"||_true13", label %"||_false12"
-
-"||_false12":                                     ; preds = %"||_lhs_false11"
-  store i64 0, i64* %"||_result15", align 8
-  br label %"||_merge14"
-
-"||_true13":                                      ; preds = %"||_lhs_false11", %"||_merge"
-  store i64 1, i64* %"||_result15", align 8
-  br label %"||_merge14"
-
-"||_merge14":                                     ; preds = %"||_true13", %"||_false12"
-  %41 = load i64, i64* %"||_result15", align 8
-  %42 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 4
+  %41 = load i64, i64* %"||_result", align 8
+  %42 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 3
   store i64 %41, i64* %42, align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 40)
-  %43 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %43)
+  %43 = bitcast i64* %"||_result16" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %43)
+  br i1 false, label %"||_true14", label %"||_lhs_false12"
+
+"||_lhs_false12":                                 ; preds = %"||_merge"
+  %44 = load i64, i64* %"$foo", align 8
+  %45 = add i64 %44, 0
+  %46 = bitcast i32* %"struct Foo.m17" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %46)
+  %probe_read_user18 = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.m17", i32 4, i64 %45)
+  %47 = load i32, i32* %"struct Foo.m17", align 4
+  %48 = sext i32 %47 to i64
+  %49 = bitcast i32* %"struct Foo.m17" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %49)
+  %rhs_true_cond19 = icmp ne i64 %48, 0
+  br i1 %rhs_true_cond19, label %"||_true14", label %"||_false13"
+
+"||_false13":                                     ; preds = %"||_lhs_false12"
+  store i64 0, i64* %"||_result16", align 8
+  br label %"||_merge15"
+
+"||_true14":                                      ; preds = %"||_lhs_false12", %"||_merge"
+  store i64 1, i64* %"||_result16", align 8
+  br label %"||_merge15"
+
+"||_merge15":                                     ; preds = %"||_true14", %"||_false13"
+  %50 = load i64, i64* %"||_result16", align 8
+  %51 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 4
+  store i64 %50, i64* %51, align 8
+  %pseudo20 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output21 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo20, i64 4294967295, %printf_t* %lookup_fmtstr_map, i64 40)
   ret i64 0
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/codegen/llvm/logical_not.ll
+++ b/tests/codegen/llvm/logical_not.ll
@@ -12,6 +12,9 @@ entry:
   %"@y_key" = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/llvm/logical_or.ll
+++ b/tests/codegen/llvm/logical_or.ll
@@ -11,6 +11,9 @@ entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %"||_result" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"||_result" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
@@ -20,7 +23,7 @@ entry:
   %lhs_true_cond = icmp ne i64 %4, 0
   br i1 %lhs_true_cond, label %"||_true", label %"||_lhs_false"
 
-"||_lhs_false":                                   ; preds = %entry
+"||_lhs_false":                                   ; preds = %post_hoist
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to i64 ()*)()
   %5 = lshr i64 %get_pid_tgid1, 32
   %6 = icmp eq i64 %5, 1235
@@ -32,7 +35,7 @@ entry:
   store i64 0, i64* %"||_result", align 8
   br label %"||_merge"
 
-"||_true":                                        ; preds = %"||_lhs_false", %entry
+"||_true":                                        ; preds = %"||_lhs_false", %post_hoist
   store i64 1, i64* %"||_result", align 8
   br label %"||_merge"
 

--- a/tests/codegen/llvm/macro_definition.ll
+++ b/tests/codegen/llvm/macro_definition.ll
@@ -10,6 +10,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@_key", align 8

--- a/tests/codegen/llvm/map_assign_array.ll
+++ b/tests/codegen/llvm/map_assign_array.ll
@@ -16,6 +16,9 @@ entry:
   %"@x_key1" = alloca i64, align 8
   %"@x_val" = alloca [4 x i32], align 4
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %2 = bitcast i8* %0 to i64*
   %3 = getelementptr i64, i64* %2, i64 14
   %arg0 = load volatile i64, i64* %3, align 8
@@ -42,12 +45,12 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %11 = bitcast [4 x i32]* %lookup_elem_val to i8*
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %11, i8* align 1 %lookup_elem, i64 16, i1 false)
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   %12 = bitcast [4 x i32]* %lookup_elem_val to i8*
   call void @llvm.memset.p0i8.i64(i8* align 1 %12, i8 0, i64 16, i1 false)
   br label %lookup_merge

--- a/tests/codegen/llvm/map_assign_int.ll
+++ b/tests/codegen/llvm/map_assign_int.ll
@@ -10,6 +10,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/llvm/map_assign_string.ll
+++ b/tests/codegen/llvm/map_assign_string.ll
@@ -10,6 +10,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
   %str = alloca [64 x i8], align 1
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast [64 x i8]* %str to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store [64 x i8] c"blah\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str, align 1

--- a/tests/codegen/llvm/map_increment_decrement.ll
+++ b/tests/codegen/llvm/map_increment_decrement.ll
@@ -22,6 +22,9 @@ entry:
   %"@x_key1" = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8
@@ -44,13 +47,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %7 = load i64, i64* %cast, align 8
   store i64 %7, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 

--- a/tests/codegen/llvm/map_key_array.ll
+++ b/tests/codegen/llvm/map_key_array.ll
@@ -10,6 +10,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca [4 x i32], align 4
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 14
   %arg0 = load volatile i64, i64* %2, align 8

--- a/tests/codegen/llvm/map_key_int.ll
+++ b/tests/codegen/llvm/map_key_int.ll
@@ -10,6 +10,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca [24 x i8], align 1
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast [24 x i8]* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = getelementptr [24 x i8], [24 x i8]* %"@x_key", i64 0, i64 0

--- a/tests/codegen/llvm/map_key_probe.ll
+++ b/tests/codegen/llvm/map_key_probe.ll
@@ -12,6 +12,9 @@ entry:
   %"@x_key1" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8
@@ -22,13 +25,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %3 = load i64, i64* %cast, align 8
   store i64 %3, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
@@ -66,6 +69,9 @@ entry:
   %"@x_key1" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 1, i64* %"@x_key", align 8
@@ -76,13 +82,13 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %cast = bitcast i8* %lookup_elem to i64*
   %3 = load i64, i64* %cast, align 8
   store i64 %3, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   store i64 0, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 

--- a/tests/codegen/llvm/map_key_string.ll
+++ b/tests/codegen/llvm/map_key_string.ll
@@ -12,6 +12,9 @@ entry:
   %str1 = alloca [64 x i8], align 1
   %str = alloca [64 x i8], align 1
   %"@x_key" = alloca [128 x i8], align 1
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast [128 x i8]* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast [64 x i8]* %str to i8*

--- a/tests/codegen/llvm/map_key_struct.ll
+++ b/tests/codegen/llvm/map_key_struct.ll
@@ -10,6 +10,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca [4 x i8], align 1
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 14
   %arg0 = load volatile i64, i64* %2, align 8

--- a/tests/codegen/llvm/multiple_identical_probes.ll
+++ b/tests/codegen/llvm/multiple_identical_probes.ll
@@ -8,11 +8,17 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   ret i64 0
 }
 
 define i64 @"kprobe:f.1"(i8* %0) section "s_kprobe:f_2" {
 entry:
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   ret i64 0
 }
 

--- a/tests/codegen/llvm/nested_array_struct.ll
+++ b/tests/codegen/llvm/nested_array_struct.ll
@@ -14,6 +14,9 @@ entry:
   %"@bar_key1" = alloca i64, align 8
   %"@bar_val" = alloca [2 x [2 x [4 x i8]]], align 1
   %"@bar_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i8* %0 to i64*
   %2 = getelementptr i64, i64* %1, i64 14
   %arg0 = load volatile i64, i64* %2, align 8
@@ -40,12 +43,12 @@ entry:
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
-lookup_success:                                   ; preds = %entry
+lookup_success:                                   ; preds = %post_hoist
   %10 = bitcast [2 x [2 x [4 x i8]]]* %lookup_elem_val to i8*
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %10, i8* align 1 %lookup_elem, i64 16, i1 false)
   br label %lookup_merge
 
-lookup_failure:                                   ; preds = %entry
+lookup_failure:                                   ; preds = %post_hoist
   %11 = bitcast [2 x [2 x [4 x i8]]]* %lookup_elem_val to i8*
   call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 16, i1 false)
   br label %lookup_merge

--- a/tests/codegen/llvm/nested_while_loop.ll
+++ b/tests/codegen/llvm/nested_while_loop.ll
@@ -19,10 +19,13 @@ entry:
   %2 = bitcast i64* %"$i" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 0, i64* %"$i", align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   store i64 1, i64* %"$i", align 8
   br label %while_cond
 
-while_cond:                                       ; preds = %while_end3, %entry
+while_cond:                                       ; preds = %while_end3, %post_hoist
   %3 = load i64, i64* %"$i", align 8
   %4 = icmp sle i64 %3, 100
   %5 = zext i1 %4 to i64

--- a/tests/codegen/llvm/optional_positional_parameter.ll
+++ b/tests/codegen/llvm/optional_positional_parameter.ll
@@ -14,6 +14,9 @@ entry:
   %strlen = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/llvm/pred_binop.ll
+++ b/tests/codegen/llvm/pred_binop.ll
@@ -10,6 +10,9 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  br label %post_hoist
+
+post_hoist:                                       ; preds = %entry
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = lshr i64 %get_pid_tgid, 32
   %2 = icmp eq i64 %1, 1234
@@ -17,10 +20,10 @@ entry:
   %predcond = icmp eq i64 %3, 0
   br i1 %predcond, label %pred_false, label %pred_true
 
-pred_false:                                       ; preds = %entry
+pred_false:                                       ; preds = %post_hoist
   ret i64 0
 
-pred_true:                                        ; preds = %entry
+pred_true:                                        ; preds = %post_hoist
   %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/llvm/ptr_to_ptr.ll
+++ b/tests/codegen/llvm/ptr_to_ptr.ll
@@ -3,6 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%helper_error_t = type <{ i64, i64, i32, i8 }>
 %printf_t = type { i64, i64 }
 
 ; Function Attrs: nounwind
@@ -10,51 +11,80 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
-  %deref1 = alloca i32, align 4
+  %deref2 = alloca i32, align 4
   %deref = alloca i64, align 8
-  %printf_args = alloca %printf_t, align 8
+  %helper_error_t = alloca %helper_error_t, align 8
+  %lookup_fmtstr_key = alloca i32, align 4
   %"$pp" = alloca i64, align 8
   %1 = bitcast i64* %"$pp" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"$pp", align 8
-  store i64 0, i64* %"$pp", align 8
-  %2 = bitcast %printf_t* %printf_args to i8*
+  br label %validate_map_lookup_fmtstr
+
+validate_map_lookup_fmtstr:                       ; preds = %entry
+  %2 = bitcast i32* %lookup_fmtstr_key to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  %3 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %3, i8 0, i64 16, i1 false)
-  %4 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
-  store i64 0, i64* %4, align 8
-  %5 = load i64, i64* %"$pp", align 8
-  %6 = bitcast i64* %deref to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %deref, i32 8, i64 %5)
-  %7 = load i64, i64* %deref, align 8
-  %8 = bitcast i64* %deref to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i32* %deref1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %probe_read_kernel2 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %deref1, i32 4, i64 %7)
-  %10 = load i32, i32* %deref1, align 4
-  %11 = sext i32 %10 to i64
-  %12 = bitcast i32* %deref1 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %11, i64* %13, align 8
+  store i32 0, i32* %lookup_fmtstr_key, align 4
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 16)
-  %14 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %lookup_fmtstr_map = call %printf_t* inttoptr (i64 1 to %printf_t* (i64, i32*)*)(i64 %pseudo, i32* %lookup_fmtstr_key)
+  %3 = bitcast i32* %lookup_fmtstr_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
+  %4 = sext %printf_t* %lookup_fmtstr_map to i32
+  %5 = icmp ne i32 %4, 0
+  br i1 %5, label %post_hoist, label %lookup_fmtstr_map_validate_failure
+
+post_hoist:                                       ; preds = %validate_map_lookup_fmtstr
+  store i64 0, i64* %"$pp", align 8
+  %6 = bitcast %printf_t* %lookup_fmtstr_map to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 16, i1 false)
+  %7 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 0
+  store i64 0, i64* %7, align 8
+  %8 = load i64, i64* %"$pp", align 8
+  %9 = bitcast i64* %deref to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %deref, i32 8, i64 %8)
+  %10 = load i64, i64* %deref, align 8
+  %11 = bitcast i64* %deref to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i32* %deref2 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %probe_read_kernel3 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %deref2, i32 4, i64 %10)
+  %13 = load i32, i32* %deref2, align 4
+  %14 = sext i32 %13 to i64
+  %15 = bitcast i32* %deref2 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %16 = getelementptr %printf_t, %printf_t* %lookup_fmtstr_map, i32 0, i32 1
+  store i64 %14, i64* %16, align 8
+  %pseudo4 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output5 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo4, i64 4294967295, %printf_t* %lookup_fmtstr_map, i64 16)
+  ret i64 0
+
+lookup_fmtstr_map_validate_failure:               ; preds = %validate_map_lookup_fmtstr
+  %17 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
+  %18 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 0
+  store i64 30006, i64* %18, align 8
+  %19 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 1
+  store i64 0, i64* %19, align 8
+  %20 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 2
+  store i32 %4, i32* %20, align 4
+  %21 = getelementptr %helper_error_t, %helper_error_t* %helper_error_t, i64 0, i32 3
+  store i8 1, i8* %21, align 1
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %helper_error_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %helper_error_t* %helper_error_t, i64 21)
+  %22 = bitcast %helper_error_t* %helper_error_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
   ret i64 0
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
-declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
-
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }


### PR DESCRIPTION
Incorporates @mmarchini's RFC https://github.com/iovisor/bpftrace/pull/750.  
Incorporates parts of "big strings" https://github.com/iovisor/bpftrace/pull/1360.

I did **not** implement the `probe_read()` from https://github.com/iovisor/bpftrace/pull/750, because until `str()` too is moved off-stack, we won't be doing any memset/memcpy as large as 1024, and thus won't run into that limitation just yet. at any rate, https://github.com/iovisor/bpftrace/discussions/1800 may give us a way to do a "large memset/memcpy" (i.e. not need to resort to `probe_read()` at all).

My codegen changes are a bit bigger than in https://github.com/iovisor/bpftrace/pull/750, dominated by the handling to "exit if we fail to acquire map".

Both `printf()` and `join()` change in this review; it's possible to spin one of those out into a separate PR, but they'll both rely on this shared core.

One thing I need feedback on in this RFC is whether to simplify the codegen of programs like:

```c
printf();
printf();
```

Or like `tests/codegen/if_else_printf.ll`:

```
if () {
  printf();
} else {
  printf();
}
```

To satisfy the BPF verifier, we check whether we succeeded in acquiring the map. but we end up doing this every time printf() is called, even though it's the same map.

I reckon it'd be good to hoist the map-validation to the start of the program (and do it exactly once), rather than emitting it at the call-site of printf(). should I do this?

### Introduce CreateGetScratchMap helper

This is scratch space for bpftrace (off-stack memory in which we can do work such as prepare perf_event buffers), rather than a map that will be exposed directly to the user.  
`join()` and _format string_ calls (`printf()`, `system()`, `cat()`) now use this.

https://github.com/iovisor/bpftrace/pull/1360 demonstrates that `str()`, `buf()`, map keys and map values can use this in future.  
https://github.com/iovisor/bpftrace/pull/1360 also used it to power map-backed variables (is it still 'scratch' at that point though?). a single per-CPU associative array keyed on variable name could be more appropriate for variable storage.

### Let async_error be fatal

Rather than silently continuing down a no-op branch, we should `exit()` if we fail to acquire a map.

`join()` now _exits_ on failure to acquire map.

### format string off-stack

`printf()` and friends now compose their perf_event buffer off-stack.

### more space on-stack

Originally, `BPFTRACE_STRLEN=240` was the largest shellsnoop that we could fit on-stack.

But now we can go as high as `BPFTRACE_STRLEN=504`:

```bash
sudo BPFTRACE_STRLEN=504 ./src/bpftrace -e 'tracepoint:syscalls:sys_enter_write /pid == 76214/ {
  printf("<%s>\n", str(args->buf, args->count));
}'
```

Originally we were storing both `str()` and `printf()` on-stack.  
Now we're just storing `str()` on-stack.

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
  - No language changes
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
  - Probably worth mentioning the bigger stack, and the "`join()` no longer fails open". Haven't updated yet.
- [x] The new behaviour is covered by tests
  - printf() was already under test, and still works
  - join() was already under test, and still works