### PR TITLE
Disable build tests when install bpftrace.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -249,7 +249,7 @@ sudo apt-get install -y bison cmake flex g++ git libelf-dev zlib1g-dev libfl-dev
 sudo apt-get install -y llvm-7-dev llvm-7-runtime libclang-7-dev clang-7
 git clone https://github.com/iovisor/bpftrace
 mkdir bpftrace/build; cd bpftrace/build;
-cmake -DCMAKE_BUILD_TYPE=Release ..
+cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF ..
 make -j8
 sudo make install
 ```
@@ -266,7 +266,7 @@ You'll want the newest kernel possible (see kernel requirements), eg, by using F
 sudo dnf install -y bison flex cmake make git gcc-c++ elfutils-libelf-devel zlib-devel llvm-devel clang-devel bcc-devel systemtap-sdt-devel binutils-devel
 git clone https://github.com/iovisor/bpftrace
 cd bpftrace
-mkdir build; cd build; cmake -DCMAKE_BUILD_TYPE=Release ..
+mkdir build; cd build; cmake -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF ..
 make -j8
 sudo make install
 ```


### PR DESCRIPTION
Disable build tests when install bpftrace to address this error
```
CMake Error at
/usr/share/cmake-3.16/Modules/FindPackageHandleStandardArgs.cmake:146
(message):
  Please install the bcc library package, which is required.  Depending
on
  your distro, it may be called bpfcclib or bcclib (Ubuntu), bcc-devel
  (Fedora), or something else.  If unavailable, install bcc from source
  (github.com/iovisor/bcc).  (missing: LIBBCC_LIBRARIES
LIBBCC_INCLUDE_DIRS)
Call Stack (most recent call first):
  /usr/share/cmake-3.16/Modules/FindPackageHandleStandardArgs.cmake:393
(_FPHSA_FAILURE_MESSAGE)
  cmake/FindLibBcc.cmake:72 (FIND_PACKAGE_HANDLE_STANDARD_ARGS)
  CMakeLists.txt:86 (find_package)
```

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
