### PR TITLE
tracepoint: Do not expose common fields in tracepoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to
 #### Added
 
 #### Changed
+- Disallow accessing common tracepoint fields
+  - [#1810](https://github.com/iovisor/bpftrace/pull/1810)
 
 #### Deprecated
 

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -112,7 +112,7 @@ void setup_mock_bpftrace(MockBPFtrace &bpftrace)
     .fields = { { "saddr_v6",
                   Field{
                       .type = CreateArray(16, CreateUInt(8)),
-                      .offset = 0,
+                      .offset = 8,
                       .is_bitfield = false,
                       .bitfield = {},
                   } } },
@@ -121,7 +121,14 @@ void setup_mock_bpftrace(MockBPFtrace &bpftrace)
   auto ptr_type = CreatePointer(CreateInt8());
   bpftrace.structs_["struct _tracepoint_file_filename"] = Struct{
     .size = 8,
-    .fields = { { "filename",
+    .fields = { { "common_field",
+                  Field{
+                      .type = CreateUInt64(),
+                      .offset = 0,
+                      .is_bitfield = false,
+                      .bitfield = {},
+                  } },
+                { "filename",
                   Field{
                       .type = ptr_type,
                       .offset = 8,

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2200,6 +2200,12 @@ TEST(semantic_analyser, int_ident)
   test("BEGIN { print(int32) }", 1);
 }
 
+TEST(semantic_analyser, tracepoint_common_field)
+{
+  test("tracepoint:file:filename { args->filename }", 0);
+  test("tracepoint:file:filename { args->common_field }", 1);
+}
+
 #ifdef HAVE_LIBBPF_BTF_DUMP
 
 #include "btf_common.h"


### PR DESCRIPTION
The kernel (bpf) uses the first 8 bytes to store `struct pt_regs`. Any
access to the first 8 bytes of ctx are rejected by the verifier.

Previous behavior:
```
$ sudo bpftrace -e 't:kmem:mm_page_alloc { args->common_preempt_count }' -v
INFO: node count: 7
Attaching 1 probe...

Error log:
0: (71) r1 = *(u8 *)(r1 +3)
invalid bpf_context access off=3 size=1
processed 1 insns (limit 1000000) max_states_per_insn 0 total_states ...

ERROR: Error loading program: tracepoint:kmem:mm_page_alloc
```

New behavior:
```
$ sudo bpftrace -e 't:kmem:mm_page_alloc { args->common_preempt_count }'
stdin:1:24-50: ERROR: BPF does not support accessing common tracepoint fields
t:kmem:mm_page_alloc { args->common_preempt_count }
                       ~~~~~~~~~~~~~~~~~~~~~~~~~~
```

Note that `-lv` (verbose listing) already does the right thing and skip
the common fields.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
