### PR TITLE
embedded: create LLVM container

### DIFF
--- a/.github/workflows/embedded_llvm.yml
+++ b/.github/workflows/embedded_llvm.yml
@@ -1,0 +1,45 @@
+name: Embedded LLVM
+on:
+  push:
+    paths:
+      - docker/Dockerfile.llvm
+      - docker/embedded/*
+  pull_request:
+    paths:
+      - docker/Dockerfile.llvm
+      - docker/embedded/*
+  schedule:
+    - cron: '0 0 1 * *'
+
+jobs:
+  publish_llvm_build:
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        llvm_version: [8]
+        base: [xenial, bionic]
+    steps:
+    - name: Checkout repo
+      uses: actions/checkout@v2
+    - name: Build container
+      run: >
+        docker build
+        -t quay.io/iovisor/bpftrace-llvm:${{ matrix.base }}_${{ matrix.llvm_version }}
+        -t quay.io/iovisor/bpftrace-llvm:${{ matrix.base }}_${{ matrix.llvm_version }}_$(date +%s)
+        -f docker/Dockerfile.llvm
+        --build-arg BASE=${{ matrix.base }}
+        --build-arg LLVM_VERSION=${{ matrix.llvm_version }}
+        .
+    - name: Login quay.io
+      if: >
+        (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) &&
+        github.repository == 'iovisor/bpftrace'
+      env:
+        QUAY_USER: "iovisor+bpftrace_buildbot"
+        QUAY_TOKEN: ${{ secrets.QUAY_TOKEN }}
+      run: 'echo "${QUAY_TOKEN}" | docker login -u="${QUAY_USER}" --password-stdin quay.io'
+    - name: Publish container
+      if: >
+        (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/')) &&
+        github.repository == 'iovisor/bpftrace'
+      run: docker push --all-tags quay.io/iovisor/bpftrace-llvm

--- a/.github/workflows/embedded_llvm.yml
+++ b/.github/workflows/embedded_llvm.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        llvm_version: [8]
+        llvm_version: [8,12]
         base: [xenial, bionic]
     steps:
     - name: Checkout repo

--- a/CMakeLists-LLVM.txt
+++ b/CMakeLists-LLVM.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.16)
+project(bpftrace-llvm-builder)
+
+include(GNUInstallDirs)
+
+set(LLVM_VERSION "8" CACHE STRING "LLVM version to build")
+
+set(STATIC_LINKING ON)
+set(STATIC_LIBC OFF)
+set(EMBED_USE_LLVM ON)
+set(EMBED_BUILD_LLVM ON)
+set(EMBED_LLVM_VERSION ${LLVM_VERSION} CACHE STRING "LLVM version to build")
+
+message(STATUS "Using LLVM: ${EMBED_LLVM_VERSION}")
+
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
+set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/embed)
+include(embed_helpers)
+
+set (CMAKE_CXX_STANDARD 17)
+set (CMAKE_CXX_STANDARD_REQUIRED ON)
+set (CMAKE_CXX_EXTENSIONS OFF)
+
+set(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+set(CMAKE_LINK_SEARCH_START_STATIC TRUE)
+set(CMAKE_LINK_SEARCH_END_STATIC TRUE)
+
+set(FIND_LIBRARY_USE_LIB64_PATHS TRUE)
+
+cmake_policy(SET CMP0075 NEW)
+
+include(embed_llvm)
+include(embed_clang)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,6 +12,7 @@ set(WARNINGS_AS_ERRORS OFF CACHE BOOL "Build with -Werror")
 set(STATIC_LINKING OFF CACHE BOOL "Build bpftrace as a statically linked executable")
 set(STATIC_LIBC OFF CACHE BOOL "Attempt to embed libc, only known to work with musl. Has issues with dlopen.")
 
+set(EMBED_USE_LLVM OFF CACHE BOOL "Use a prebuilt embedded LLVM, speeds up the build process")
 set(EMBED_BUILD_LLVM OFF CACHE BOOL "Build Clang&LLVM static libs as an ExternalProject and link to these instead of system libs.")
 set(EMBED_LLVM_VERSION "8" CACHE STRING "Embedded LLVM/Clang version to build and link against.")
 
@@ -26,7 +27,11 @@ set(FUZZ_TARGET "codegen" CACHE STRING "Fuzzing target")
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
-if(EMBED_BUILD_LLVM OR STATIC_LIBC)
+if(EMBED_BUILD_LLVM)
+  set(EMBED_USE_LLVM ON)
+endif()
+
+if(EMBED_USE_LLVM OR STATIC_LIBC)
   set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake/embed)
   include(embed_helpers)
   if (NOT STATIC_LINKING)

--- a/cmake/embed/embed_clang.cmake
+++ b/cmake/embed/embed_clang.cmake
@@ -13,7 +13,7 @@ endif()
 
 if(${LLVM_VERSION} VERSION_EQUAL "12.0.0")
   set(CLANG_DOWNLOAD_URL "https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/clang-${LLVM_VERSION}.src.tar.xz")
-  set(CLANG_URL_CHECKSUM "SHA256=1267b88d4590d638bab598cc5b54ba0b7520c9aa35d931206941b66f90e7e2f5")
+  set(CLANG_URL_CHECKSUM "SHA256=e26e452e91d4542da3ebbf404f024d3e1cbf103f4cd110c26bf0a19621cca9ed")
 elseif(${LLVM_VERSION} VERSION_EQUAL "8.0.1")
   set(CLANG_DOWNLOAD_URL "https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/cfe-${LLVM_VERSION}.src.tar.xz")
   set(CLANG_URL_CHECKSUM "SHA256=70effd69f7a8ab249f66b0a68aba8b08af52aa2ab710dfb8a0fba102685b1646")

--- a/cmake/embed/embed_llvm.cmake
+++ b/cmake/embed/embed_llvm.cmake
@@ -1,4 +1,4 @@
-if(NOT EMBED_BUILD_LLVM)
+if(NOT EMBED_USE_LLVM)
   return()
 endif()
 include(embed_helpers)
@@ -141,25 +141,27 @@ foreach(llvm_target IN LISTS LLVM_LIBRARY_TARGETS)
   list(APPEND LLVM_TARGET_LIBS "<INSTALL_DIR>/lib/lib${llvm_target}.a")
 endforeach(llvm_target)
 
-ExternalProject_Add(embedded_llvm
-  URL "${LLVM_DOWNLOAD_URL}"
-  URL_HASH "${LLVM_URL_CHECKSUM}"
-  CMAKE_ARGS "${LLVM_CONFIGURE_FLAGS}"
-  BUILD_BYPRODUCTS ${LLVM_TARGET_LIBS}
-  UPDATE_DISCONNECTED 1
-  DOWNLOAD_NO_PROGRESS 1
-)
+if(EMBED_BUILD_LLVM)
+  ExternalProject_Add(embedded_llvm
+    URL "${LLVM_DOWNLOAD_URL}"
+    URL_HASH "${LLVM_URL_CHECKSUM}"
+    CMAKE_ARGS "${LLVM_CONFIGURE_FLAGS}"
+    BUILD_BYPRODUCTS ${LLVM_TARGET_LIBS}
+    UPDATE_DISCONNECTED 1
+    DOWNLOAD_NO_PROGRESS 1
+  )
 
-# Set up build targets and map to embedded paths
-ExternalProject_Get_Property(embedded_llvm INSTALL_DIR)
-set(EMBEDDED_LLVM_INSTALL_DIR ${INSTALL_DIR})
-set(LLVM_EMBEDDED_CMAKE_TARGETS "")
+  # Set up build targets and map to embedded paths
+  ExternalProject_Get_Property(embedded_llvm INSTALL_DIR)
+  set(EMBEDDED_LLVM_INSTALL_DIR ${INSTALL_DIR})
+  set(LLVM_EMBEDDED_CMAKE_TARGETS "")
 
-include_directories(SYSTEM ${EMBEDDED_LLVM_INSTALL_DIR}/include)
+  include_directories(SYSTEM ${EMBEDDED_LLVM_INSTALL_DIR}/include)
 
-foreach(llvm_target IN LISTS LLVM_LIBRARY_TARGETS)
-  list(APPEND LLVM_EMBEDDED_CMAKE_TARGETS ${llvm_target})
-  add_library(${llvm_target} STATIC IMPORTED)
-  set_property(TARGET ${llvm_target} PROPERTY IMPORTED_LOCATION ${EMBEDDED_LLVM_INSTALL_DIR}/lib/lib${llvm_target}.a)
-  add_dependencies(${llvm_target} embedded_llvm)
-endforeach(llvm_target)
+  foreach(llvm_target IN LISTS LLVM_LIBRARY_TARGETS)
+    list(APPEND LLVM_EMBEDDED_CMAKE_TARGETS ${llvm_target})
+    add_library(${llvm_target} STATIC IMPORTED)
+    set_property(TARGET ${llvm_target} PROPERTY IMPORTED_LOCATION ${EMBEDDED_LLVM_INSTALL_DIR}/lib/lib${llvm_target}.a)
+    add_dependencies(${llvm_target} embedded_llvm)
+  endforeach(llvm_target)
+endif(EMBED_BUILD_LLVM)

--- a/docker/Dockerfile.llvm
+++ b/docker/Dockerfile.llvm
@@ -1,0 +1,45 @@
+ARG BASE=bionic
+FROM ubuntu:${BASE}
+
+ARG BASE
+ARG LLVM_VERSION
+
+ENV LLVM_VERSION=${LLVM_VERSION}
+ENV BASE=${BASE}
+
+COPY cmake /build/llvm/cmake
+COPY CMakeLists-LLVM.txt /build/llvm/CMakeLists.txt
+
+RUN if [ "${BASE}" = "xenial" ]; then \
+      apt update \
+      && apt install -y software-properties-common \
+      && add-apt-repository -y ppa:ubuntu-toolchain-r/test \
+      ; fi
+
+RUN apt update \
+  && apt install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    g++-8 \
+    gcc-8 \
+    gcc-8-plugin-dev \
+    make \
+    python \
+    python3 \
+    rsync \
+    tar \
+  && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 60 \
+                         --slave /usr/bin/g++ g++ /usr/bin/g++-8      \
+  && cp /usr/lib/gcc/x86_64-linux-gnu/8/plugin/include/plugin-api.h /usr/local/include
+
+RUN curl -L --output /tmp/cmake.tar.gz \
+  https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-linux-x86_64.tar.gz \
+  && tar -xf /tmp/cmake.tar.gz -C /usr/local/ --strip-components=1
+
+RUN cd /build/llvm \
+  && cmake . -DLLVM_VERSION=${LLVM_VERSION} \
+  && make embedded_llvm -j$(nproc) \
+  && make embedded_clang -j$(nproc) \
+  && rsync -a embedded_clang-prefix/ embedded_llvm-prefix/ \
+    --exclude '/tmp' --exclude '/src' /usr/local \
+  && rm -rf /build/llvm

--- a/docker/Dockerfile.llvm
+++ b/docker/Dockerfile.llvm
@@ -40,6 +40,7 @@ RUN cd /build/llvm \
   && cmake . -DLLVM_VERSION=${LLVM_VERSION} \
   && make embedded_llvm -j$(nproc) \
   && make embedded_clang -j$(nproc) \
-  && rsync -a embedded_clang-prefix/ embedded_llvm-prefix/ \
-    --exclude '/tmp' --exclude '/src' /usr/local \
+  && rm -rf embedded_llvm-prefix/src embedded_clang-prefix/src \
+  && rm -rf embedded_llvm-prefix/tmp embedded_clang-prefix/tmp \
+  && rsync -a embedded_clang-prefix/ embedded_llvm-prefix/ /usr/local \
   && rm -rf /build/llvm

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -40,7 +40,7 @@ if (STATIC_LINKING)
       clangSerialization
       clangToolingCore)
 
-  if(EMBED_BUILD_LLVM)
+  if(EMBED_USE_LLVM)
     list(APPEND clang_libs clangToolingInclusions)
     target_link_libraries(ast ${CLANG_EMBEDDED_CMAKE_TARGETS})
     target_link_libraries(ast ${LLVM_EMBEDDED_CMAKE_TARGETS})


### PR DESCRIPTION
Follow up of #1819 

---

This allows us to split the LLVM build and link (the embedded_x.cmake specify the target so we cant leave it out completely) phase of the LLVM build. By splitting it we can send a container image to quay.io and avoid having to rebuild LLVM every run. We really only have to do it once every release, but this makes sure the process works and includes glibc patches that can be relevant (new base image)

The new cmakelist is there for simplicity. It just builds llvm and doesn't check for bpftrace dependencies

Actually using this CT will be  a follow up, need to get it built first :)