### PR TITLE
tools: Make tools rely on BTF instead of header files.

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -3522,7 +3522,8 @@ Histograms can also be printed on-demand, using the `print()` function. Eg:
 # BTF Support
 
 If kernel has BTF, kernel types are automatically available and there is no need to include additional headers
-to use them.
+to use them. To allow users to detect this situation in scripts, the preprocessor macro `BPFTRACE_HAVE_BTF` 
+is defined if BTF is detected. See tools/ for examples of its usage.
 
 Requirements for using BTF:
 

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -748,6 +748,9 @@ bool ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<s
     // Since we're omitting <linux/types.h> there's no reason to
     // add the wokarounds for it
     args.push_back("-D__CLANG_WORKAROUNDS_H");
+    // Let script know we have BTF -- this is useful for prewritten tools to
+    // conditionally include headers if BTF isn't available.
+    args.push_back("-DBPFTRACE_HAVE_BTF");
 
     if (handler.parse_file("definitions.h", input, args, input_files, false) &&
         handler.has_redefinition_error())
@@ -778,6 +781,7 @@ bool ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<s
   {
     // There is a conflict (redefinition) between user-supplied types and types
     // taken from BTF. We cannot use BTF in such a case.
+    args.pop_back();
     args.pop_back();
     args.pop_back();
     input_files.back() = get_empty_btf_generated_header();

--- a/tools/biosnoop.bt
+++ b/tools/biosnoop.bt
@@ -1,5 +1,4 @@
 #!/usr/bin/env bpftrace
-#include <linux/blkdev.h>
 /*
  * biosnoop.bt   Block I/O tracing tool, showing per I/O latency.
  *               For Linux, uses bpftrace, eBPF.
@@ -10,6 +9,10 @@
  *
  * 15-Nov-2017	Brendan Gregg	Created this.
  */
+
+#ifndef BPFTRACE_HAVE_BTF
+#include <linux/blkdev.h>
+#endif
 
 BEGIN
 {

--- a/tools/dcsnoop.bt
+++ b/tools/dcsnoop.bt
@@ -15,6 +15,7 @@
  * 08-Sep-2018	Brendan Gregg	Created this.
  */
 
+#ifndef BPFTRACE_HAVE_BTF
 #include <linux/fs.h>
 #include <linux/sched.h>
 
@@ -24,6 +25,7 @@ struct nameidata {
         struct qstr     last;
         // [...]
 };
+#endif
 
 BEGIN
 {

--- a/tools/mdflush.bt
+++ b/tools/mdflush.bt
@@ -13,8 +13,10 @@
  * 08-Sep-2018	Brendan Gregg	Created this.
  */
 
+#ifndef BPFTRACE_HAVE_BTF
 #include <linux/genhd.h>
 #include <linux/bio.h>
+#endif
 
 BEGIN
 {

--- a/tools/naptime.bt
+++ b/tools/naptime.bt
@@ -13,8 +13,10 @@
  * 16-Feb-2019  Brendan Gregg   Created this.
  */
 
+#ifndef BPFTRACE_HAVE_BTF
 #include <linux/time.h>
 #include <linux/sched.h>
+#endif
 
 BEGIN
 {

--- a/tools/oomkill.bt
+++ b/tools/oomkill.bt
@@ -20,7 +20,9 @@
  * 07-Sep-2018	Brendan Gregg	Created this.
  */
 
+#ifndef BPFTRACE_HAVE_BTF
 #include <linux/oom.h>
+#endif
 
 BEGIN
 {

--- a/tools/runqlen.bt
+++ b/tools/runqlen.bt
@@ -11,17 +11,19 @@
  * 07-Oct-2018	Brendan Gregg	Created this.
  */
 
+#ifndef BPFTRACE_HAVE_BTF
 #include <linux/sched.h>
 
 // Until BTF is available, we'll need to declare some of this struct manually,
 // since it isn't available to be #included. This will need maintenance to match
 // your kernel version. It is from kernel/sched/sched.h:
-struct cfs_rq_partial {
+struct cfs_rq {
 	struct load_weight load;
 	unsigned long runnable_weight;
 	unsigned int nr_running;
 	unsigned int h_nr_running;
 };
+#endif
 
 BEGIN
 {
@@ -31,7 +33,7 @@ BEGIN
 profile:hz:99
 {
 	$task = (struct task_struct *)curtask;
-	$my_q = (struct cfs_rq_partial *)$task->se.cfs_rq;
+	$my_q = (struct cfs_rq *)$task->se.cfs_rq;
 	$len = $my_q->nr_running;
 	$len = $len > 0 ? $len - 1 : 0;	// subtract currently running task
 	@runqlen = lhist($len, 0, 100, 1);

--- a/tools/tcpaccept.bt
+++ b/tools/tcpaccept.bt
@@ -16,8 +16,12 @@
  * 23-Nov-2018	Dale Hamel	created this.
  */
 
+#ifndef BPFTRACE_HAVE_BTF
 #include <linux/socket.h>
 #include <net/sock.h>
+#else
+#include <sys/socket.h>
+#endif
 
 BEGIN
 {

--- a/tools/tcpconnect.bt
+++ b/tools/tcpconnect.bt
@@ -19,8 +19,12 @@
  * 23-Nov-2018	Dale Hamel	created this.
  */
 
+#ifndef BPFTRACE_HAVE_BTF
 #include <linux/socket.h>
 #include <net/sock.h>
+#else
+#include <sys/socket.h>
+#endif
 
 BEGIN
 {

--- a/tools/tcpdrop.bt
+++ b/tools/tcpdrop.bt
@@ -17,8 +17,12 @@
  * 23-Nov-2018	Dale Hamel	created this.
  */
 
+#ifndef BPFTRACE_HAVE_BTF
 #include <linux/socket.h>
 #include <net/sock.h>
+#else
+#include <sys/socket.h>
+#endif
 
 BEGIN
 {

--- a/tools/tcplife.bt
+++ b/tools/tcplife.bt
@@ -13,10 +13,14 @@
  * 17-Apr-2019  Brendan Gregg   Created this.
  */
 
+#ifndef BPFTRACE_HAVE_BTF
 #include <net/tcp_states.h>
 #include <net/sock.h>
 #include <linux/socket.h>
 #include <linux/tcp.h>
+#else
+#include <sys/socket.h>
+#endif
 
 BEGIN
 {

--- a/tools/tcpretrans.bt
+++ b/tools/tcpretrans.bt
@@ -17,8 +17,12 @@
  * 23-Nov-2018  Dale Hamel      created this.
  */
 
+#ifndef BPFTRACE_HAVE_BTF
 #include <linux/socket.h>
 #include <net/sock.h>
+#else
+#include <sys/socket.h>
+#endif
 
 BEGIN
 {

--- a/tools/tcpsynbl.bt
+++ b/tools/tcpsynbl.bt
@@ -13,7 +13,9 @@
  * 19-Apr-2019  Brendan Gregg   Created this.
  */
 
+#ifndef BPFTRACE_HAVE_BTF
 #include <net/sock.h>
+#endif
 
 BEGIN
 {


### PR DESCRIPTION
Many distribution already ship BTF and this is more robust that
parsing header files.

Fixes #1820
