### PR TITLE
compare_tool_elf.sh: Tell objdump to display source inlined with disassembly

### DIFF
--- a/scripts/compare_tool_elf.sh
+++ b/scripts/compare_tool_elf.sh
@@ -53,7 +53,7 @@ for script in ${TOOLDIR}/*.bt; do
     if [[ $(hash "a_${s}") != $(hash "b_${s}")  ]]; then
         echo "###############################"
         echo "Change detected for script: ${s}"
-        diff -u <($OBJDUMP "a_${s}") <($OBJDUMP "b_${s}")
+        diff -u <($OBJDUMP -S "a_${s}") <($OBJDUMP -S "b_${s}")
     fi
 done
 


### PR DESCRIPTION
Tell objdump to display source inlined with disassembly, by passing [`-S` (`-source`) option](https://www.mankier.com/1/llvm-objdump-11).  
_Option was gleaned from https://github.com/iovisor/bpftrace/pull/1429#issuecomment-660643692_.

Without this change, objdump would output the help text (i.e. because no options were supplied):

```
OVERVIEW: llvm object file dumper

USAGE: llvm-objdump-7 [options] <input object files>

OPTIONS:
  -aarch64-neon-syntax                              - Choose style of NEON code to emit from AArch64 backend:
    =generic                                        -   Emit generic NEON assembly
    =apple                                          -   Emit Apple-style NEON assembly
  -all-headers                                      - Display all available header information
```

And thus the diff would come out empty (see https://github.com/iovisor/bpftrace/pull/1792#issuecomment-830691618):

```
Checking tcpaccept
Checking tcpconnect
###############################
Change detected for script: tcpconnect
Checking tcpdrop
###############################
Change detected for script: tcpdrop
```

Whereas now it shows a bytecode difference:

```diff
Checking tcpaccept
Checking tcpconnect
###############################
Change detected for script: tcpconnect
--- /dev/fd/63	2021-05-01 22:14:00.168518607 +0100
+++ /dev/fd/62	2021-05-01 22:14:00.168518607 +0100
@@ -1,5 +1,5 @@
 
-a_tcpconnect:	file format ELF64-BPF
+b_tcpconnect:	file format ELF64-BPF
```

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
  - No language changes
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
  - No user-visible / non-trivial changes
- [x] The new behaviour is covered by tests
  - Manually tested by running `compare_tool_elf.sh`