### PR TITLE
embedded: do a MinSizeRel llvm build

### DIFF
--- a/.github/workflows/embedded_llvm.yml
+++ b/.github/workflows/embedded_llvm.yml
@@ -28,6 +28,7 @@ jobs:
         -t quay.io/iovisor/bpftrace-llvm:${{ matrix.base }}_${{ matrix.llvm_version }}_$(date +%s)
         -f docker/Dockerfile.llvm
         --build-arg BASE=${{ matrix.base }}
+        --build-arg BULD_TYPE="Release"
         --build-arg LLVM_VERSION=${{ matrix.llvm_version }}
         .
     - name: Login quay.io

--- a/docker/Dockerfile.llvm
+++ b/docker/Dockerfile.llvm
@@ -3,9 +3,11 @@ FROM ubuntu:${BASE}
 
 ARG BASE
 ARG LLVM_VERSION
+ARG BUILD_TYPE="Release"
 
 ENV LLVM_VERSION=${LLVM_VERSION}
 ENV BASE=${BASE}
+ENV BUILD_TYPE=${BUILD_TYPE}
 
 COPY cmake /build/llvm/cmake
 COPY CMakeLists-LLVM.txt /build/llvm/CMakeLists.txt
@@ -37,7 +39,7 @@ RUN curl -L --output /tmp/cmake.tar.gz \
   && tar -xf /tmp/cmake.tar.gz -C /usr/local/ --strip-components=1
 
 RUN cd /build/llvm \
-  && cmake . -DLLVM_VERSION=${LLVM_VERSION} \
+  && cmake . -DLLVM_VERSION=${LLVM_VERSION} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
   && make embedded_llvm -j$(nproc) \
   && make embedded_clang -j$(nproc) \
   && rm -rf embedded_llvm-prefix/src embedded_clang-prefix/src \


### PR DESCRIPTION
We're currently doing a Debug build (cmake default) which gets mapped to
a `RelWithDebInfo` build in cmake/embed/embed_llvm.cmake. But for our
release we want the smallest build possible.
