### PR TITLE
Warn if attaching a kprobe to a non-traceable function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 ## Unreleased
 
 #### Added
+- Warn if attaching a kprobe to a non-traceable function
+  - [#1835](https://github.com/iovisor/bpftrace/pull/1835)
 
 #### Changed
 - Disallow accessing common tracepoint fields

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -2329,6 +2329,17 @@ void SemanticAnalyser::visit(AttachPoint &ap)
       LOG(ERROR, ap.loc, err_) << "kprobes should not have a target";
     if (ap.func == "")
       LOG(ERROR, ap.loc, err_) << "kprobes should be attached to a function";
+    if (is_final_pass())
+    {
+      // Warn if user tries to attach to a non-traceable function
+      if (!has_wildcard(ap.func) && !bpftrace_.is_traceable_func(ap.func))
+      {
+        LOG(WARNING, ap.loc, out_)
+            << ap.func
+            << " is not traceable (probably it is inlined or marked as "
+               "\"notrace\"), attaching to it will likely fail";
+      }
+    }
   }
   else if (ap.provider == "uprobe" || ap.provider == "uretprobe") {
     if (ap.target == "")

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -2142,4 +2142,14 @@ std::string BPFtrace::get_string_literal(const ast::Expression *expr) const
   return "";
 }
 
+bool BPFtrace::is_traceable_func(const std::string &func_name) const
+{
+#ifdef FUZZ
+  (void)func_name;
+  return true;
+#else
+  return traceable_funcs_.find(func_name) != traceable_funcs_.end();
+#endif
+}
+
 } // namespace bpftrace

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -93,9 +93,11 @@ class BPFtrace
 {
 public:
   BPFtrace(std::unique_ptr<Output> o = std::make_unique<TextOutput>(std::cout))
-      : out_(std::move(o)),
+      : traceable_funcs_(get_traceable_funcs()),
+        out_(std::move(o)),
         feature_(std::make_unique<BPFfeature>()),
         probe_matcher_(std::make_unique<ProbeMatcher>(this)),
+        btf_(this),
         ncpus_(get_possible_cpus().size())
   {
   }
@@ -136,6 +138,7 @@ public:
   bool is_aslr_enabled(int pid);
   std::string get_string_literal(const ast::Expression *expr) const;
   std::optional<std::string> get_watchpoint_binary_path() const;
+  bool is_traceable_func(const std::string &func_name) const;
 
   std::vector<std::unique_ptr<AttachedProbe>> attached_probes_;
   std::vector<Probe> watchpoint_probes_;
@@ -158,6 +161,7 @@ public:
   std::vector<std::tuple<std::string, std::vector<Field>>> cat_args_;
   std::vector<SizedType> non_map_print_args_;
   std::unordered_map<int64_t, struct HelperErrorInfo> helper_error_info_;
+  std::unordered_set<std::string> traceable_funcs_;
 
   std::vector<std::string> probe_ids_;
   unsigned int join_argnum_ = 16;

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -24,6 +24,8 @@
 #pragma GCC diagnostic pop
 #include <bpf/libbpf.h>
 
+#include "bpftrace.h"
+
 namespace bpftrace {
 
 static unsigned char *get_data(const char *file, ssize_t *sizep)
@@ -158,11 +160,6 @@ BTF::BTF(void) : btf(nullptr), state(NODATA)
   if (btf)
   {
     libbpf_set_print(libbpf_print);
-#ifdef FUZZ
-    traceable_funcs_ = {};
-#else
-    traceable_funcs_ = get_traceable_funcs();
-#endif
     state = OK;
   }
   else if (bt_debug != DebugLevel::kNone)
@@ -435,9 +432,9 @@ int BTF::resolve_args(const std::string &func,
       throw std::runtime_error("not a function");
     }
 
-    if (!is_traceable_func(name))
+    if (bpftrace_ && !bpftrace_->is_traceable_func(name))
     {
-      if (traceable_funcs_.empty())
+      if (bpftrace_->traceable_funcs_.empty())
         throw std::runtime_error("could not read traceable functions from " +
                                  kprobe_path + " (is debugfs mounted?)");
       else
@@ -523,7 +520,7 @@ std::unique_ptr<std::istream> BTF::get_all_funcs() const
       break;
     }
 
-    if (!is_traceable_func(func_name))
+    if (bpftrace_ && !bpftrace_->is_traceable_func(func_name))
       continue;
 
     if (btf_vlen(t) > arch::max_arg() + 1)
@@ -709,16 +706,6 @@ std::set<std::string> BTF::get_all_structs() const
   }
 
   return struct_set;
-}
-
-bool BTF::is_traceable_func(const std::string &func_name) const
-{
-#ifdef FUZZ
-  (void)func_name;
-  return true;
-#else
-  return traceable_funcs_.find(func_name) != traceable_funcs_.end();
-#endif
 }
 
 } // namespace bpftrace

--- a/src/btf.h
+++ b/src/btf.h
@@ -14,6 +14,8 @@ struct btf_type;
 
 namespace bpftrace {
 
+class BPFtrace;
+
 class BTF
 {
   enum state
@@ -24,6 +26,10 @@ class BTF
 
 public:
   BTF();
+  BTF(const BPFtrace* bpftrace) : BTF()
+  {
+    bpftrace_ = bpftrace;
+  };
   ~BTF();
 
   bool has_data(void) const;
@@ -43,11 +49,10 @@ public:
 private:
   SizedType get_stype(__u32 id);
   const struct btf_type* btf_type_skip_modifiers(const struct btf_type* t);
-  bool is_traceable_func(const std::string& func_name) const;
 
   struct btf* btf;
   enum state state = NODATA;
-  std::unordered_set<std::string> traceable_funcs_;
+  const BPFtrace* bpftrace_ = nullptr;
 };
 
 inline bool BTF::has_data(void) const

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -759,6 +759,9 @@ std::string hex_format_buffer(const char *buf, size_t size)
 
 std::unordered_set<std::string> get_traceable_funcs()
 {
+#ifdef FUZZ
+  return {};
+#else
   // Try to get the list of functions from BPFTRACE_AVAILABLE_FUNCTIONS_TEST env
   const char *path = std::getenv("BPFTRACE_AVAILABLE_FUNCTIONS_TEST");
 
@@ -782,6 +785,7 @@ std::unordered_set<std::string> get_traceable_funcs()
   while (std::getline(available_funs, line))
     result.insert(line);
   return result;
+#endif
 }
 
 uint64_t parse_exponent(const char *str)


### PR DESCRIPTION
Currently, when trying to attach a kprobe a non-traceable function, `bpf_attach_kprobe` will fail and we're relying on libbpf to print an error message. This error messgage may be confusing (see example in #1818) though, so it's better if we print our own warning to the user.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
