### PR TITLE
Improve work with struct (record) types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
   - [#1778](https://github.com/iovisor/bpftrace/pull/1778)
 - Return 1 from tracepoint probes
   - [#1857](https://github.com/iovisor/bpftrace/pull/1857)
+- Preserve original order of struct types
+  - [#1850](https://github.com/iovisor/bpftrace/pull/1850)
 
 #### Deprecated
 

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -1566,10 +1566,9 @@ void CodegenLLVM::visit(FieldAccess &acc)
   }
 
   std::string cast_type = is_tparg ? tracepoint_struct_ : type.GetName();
-  Struct &cstruct = bpftrace_.structs_[cast_type];
 
   // This overwrites the stored type!
-  type = CreateRecord(cstruct.size, cast_type);
+  type = CreateRecord(cast_type, bpftrace_.structs.Lookup(cast_type));
   if (is_ctx)
     type.MarkCtxAccess();
   type.is_tparg = is_tparg;
@@ -1579,7 +1578,7 @@ void CodegenLLVM::visit(FieldAccess &acc)
   // struct MyStruct { const int* a; };  $s = (struct MyStruct *)arg0;  $s->a
   type.SetAS(addrspace);
 
-  auto &field = cstruct.fields[acc.field];
+  auto &field = type.GetField(acc.field);
 
   if (onStack(type))
   {
@@ -3014,8 +3013,8 @@ CodegenLLVM::ScopedExprDeleter CodegenLLVM::accept(Node *node)
 //   scoped_del scope deleter for the data structure
 void CodegenLLVM::readDatastructElemFromStack(Value *src_data,
                                               Value *index,
-                                              SizedType &data_type,
-                                              SizedType &elem_type,
+                                              const SizedType &data_type,
+                                              const SizedType &elem_type,
                                               ScopedExprDeleter &scoped_del)
 {
   // src_data should contain a pointer to the data structure, but it may be
@@ -3058,8 +3057,8 @@ void CodegenLLVM::readDatastructElemFromStack(Value *src_data,
 //   temp_name  name of a temporary variable, if the function creates any
 void CodegenLLVM::probereadDatastructElem(Value *src_data,
                                           Value *offset,
-                                          SizedType &data_type,
-                                          SizedType &elem_type,
+                                          const SizedType &data_type,
+                                          const SizedType &elem_type,
                                           ScopedExprDeleter &scoped_del,
                                           location loc,
                                           const std::string &temp_name)

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -151,13 +151,13 @@ private:
 
   void readDatastructElemFromStack(Value *src_data,
                                    Value *index,
-                                   SizedType &data_type,
-                                   SizedType &elem_type,
+                                   const SizedType &data_type,
+                                   const SizedType &elem_type,
                                    ScopedExprDeleter &scoped_del);
   void probereadDatastructElem(Value *src_data,
                                Value *offset,
-                               SizedType &data_type,
-                               SizedType &elem_type,
+                               const SizedType &data_type,
+                               const SizedType &elem_type,
                                ScopedExprDeleter &scoped_del,
                                location loc,
                                const std::string &temp_name);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -149,7 +149,7 @@ public:
 
   MapManager maps;
   std::unique_ptr<BpfOrc> bpforc_;
-  std::map<std::string, Struct> structs_;
+  StructManager structs;
   std::map<std::string, std::string> macros_;
   std::map<std::string, uint64_t> enums_;
   std::vector<std::tuple<std::string, std::vector<Field>>> printf_args_;

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -393,7 +393,11 @@ SizedType BTF::get_stype(__u32 id)
     const char *cast = btf_str(btf, t->name_off);
     assert(cast);
     std::string comp = btf_is_struct(t) ? "struct" : "union";
-    stype = CreateRecord(t->size, comp + " " + cast);
+    std::string name = comp + " " + cast;
+    // We're usually resolving types before running ClangParser, so the struct
+    // definitions are not yet pulled into the struct map. We initialize them
+    // now and fill them later.
+    stype = CreateRecord(name, bpftrace_->structs.LookupOrAdd(name, t->size));
   }
   else if (btf_is_ptr(t))
   {

--- a/src/btf.h
+++ b/src/btf.h
@@ -26,7 +26,7 @@ class BTF
 
 public:
   BTF();
-  BTF(const BPFtrace* bpftrace) : BTF()
+  BTF(BPFtrace* bpftrace) : BTF()
   {
     bpftrace_ = bpftrace;
   };
@@ -52,7 +52,7 @@ private:
 
   struct btf* btf;
   enum state state = NODATA;
-  const BPFtrace* bpftrace_ = nullptr;
+  BPFtrace* bpftrace_ = nullptr;
 };
 
 inline bool BTF::has_data(void) const

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -131,7 +131,7 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
     case Type::record:
     {
       std::vector<std::string> elems;
-      for (auto &field : arg.GetStructFields())
+      for (auto &field : arg.GetFields())
       {
         elems.push_back("." + field.name + "=" +
                         argument_value(bpftrace,

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -131,7 +131,7 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
     case Type::record:
     {
       std::vector<std::string> elems;
-      for (auto &field : bpftrace.structs_[arg.GetName()].fields)
+      for (auto &field : arg.GetStructFields())
       {
         elems.push_back(
             "." + field.first + "=" +

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -133,11 +133,10 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
       std::vector<std::string> elems;
       for (auto &field : arg.GetStructFields())
       {
-        elems.push_back(
-            "." + field.first + "=" +
-            argument_value(bpftrace,
-                           field.second.type,
-                           (const uint8_t *)data + field.second.offset));
+        elems.push_back("." + field.name + "=" +
+                        argument_value(bpftrace,
+                                       field.type,
+                                       (const uint8_t *)data + field.offset));
       }
       return "{" + str_join(elems, ",") + "}";
     }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -196,7 +196,7 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
   else if (type.IsRecordTy())
   {
     std::vector<std::string> elems;
-    for (auto &field : type.GetStructFields())
+    for (auto &field : type.GetFields())
     {
       std::vector<uint8_t> elem_data(value.begin() + field.offset,
                                      value.begin() + field.offset +

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -195,9 +195,8 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
   }
   else if (type.IsRecordTy())
   {
-    auto &struct_type = bpftrace.structs_[type.GetName()];
     std::vector<std::string> elems;
-    for (auto &field : struct_type.fields)
+    for (auto &field : type.GetStructFields())
     {
       std::vector<uint8_t> elem_data(value.begin() + field.second.offset,
                                      value.begin() + field.second.offset +

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -198,13 +198,12 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
     std::vector<std::string> elems;
     for (auto &field : type.GetStructFields())
     {
-      std::vector<uint8_t> elem_data(value.begin() + field.second.offset,
-                                     value.begin() + field.second.offset +
-                                         field.second.type.GetSize());
+      std::vector<uint8_t> elem_data(value.begin() + field.offset,
+                                     value.begin() + field.offset +
+                                         field.type.GetSize());
       elems.push_back(field_to_str(
-          field.first,
-          value_to_str(
-              bpftrace, field.second.type, elem_data, is_per_cpu, div)));
+          field.name,
+          value_to_str(bpftrace, field.type, elem_data, is_per_cpu, div)));
     }
     return struct_to_str(elems);
   }

--- a/src/struct.cpp
+++ b/src/struct.cpp
@@ -76,4 +76,54 @@ void Tuple::Dump(std::ostream &os)
   os << "} sizeof: [" << size << "]" << std::endl;
 }
 
+bool Struct::HasField(const std::string &name) const
+{
+  return fields.find(name) != fields.end();
+}
+
+const Field &Struct::GetField(const std::string &name) const
+{
+  return fields.at(name);
+}
+
+void Struct::AddField(const std::string &field_name,
+                      const SizedType &type,
+                      ssize_t offset,
+                      bool is_bitfield,
+                      const Bitfield &bitfield,
+                      bool is_data_loc)
+{
+  fields[field_name] = Field{ .type = type,
+                              .offset = offset,
+                              .is_bitfield = is_bitfield,
+                              .bitfield = bitfield,
+                              .is_data_loc = is_data_loc };
+}
+
+void StructManager::Add(const std::string &name, size_t size)
+{
+  if (struct_map_.find(name) != struct_map_.end())
+    throw std::runtime_error("Type redefinition: type with name \'" + name +
+                             "\' already exists");
+  struct_map_[name] = std::make_shared<Struct>(size);
+}
+
+std::shared_ptr<Struct> StructManager::Lookup(const std::string &name) const
+{
+  auto s = struct_map_.find(name);
+  return s != struct_map_.end() ? s->second : nullptr;
+}
+
+std::shared_ptr<Struct> StructManager::LookupOrAdd(const std::string &name,
+                                                   size_t size)
+{
+  auto s = struct_map_.insert({ name, std::make_shared<Struct>(size) });
+  return s.first->second;
+}
+
+bool StructManager::Has(const std::string &name) const
+{
+  return struct_map_.find(name) != struct_map_.end();
+}
+
 } // namespace bpftrace

--- a/src/struct.cpp
+++ b/src/struct.cpp
@@ -32,6 +32,7 @@ std::unique_ptr<Tuple> Tuple::Create(std::vector<SizedType> fields)
     offset += padding;
 
     tuple->fields.push_back(Field{
+        .name = "",
         .type = field,
         .offset = offset,
         .is_bitfield = false,
@@ -78,12 +79,22 @@ void Tuple::Dump(std::ostream &os)
 
 bool Struct::HasField(const std::string &name) const
 {
-  return fields.find(name) != fields.end();
+  for (auto &field : fields)
+  {
+    if (field.name == name)
+      return true;
+  }
+  return false;
 }
 
 const Field &Struct::GetField(const std::string &name) const
 {
-  return fields.at(name);
+  for (auto &field : fields)
+  {
+    if (field.name == name)
+      return field;
+  }
+  throw std::runtime_error("struct has no field named " + name);
 }
 
 void Struct::AddField(const std::string &field_name,
@@ -93,11 +104,13 @@ void Struct::AddField(const std::string &field_name,
                       const Bitfield &bitfield,
                       bool is_data_loc)
 {
-  fields[field_name] = Field{ .type = type,
-                              .offset = offset,
-                              .is_bitfield = is_bitfield,
-                              .bitfield = bitfield,
-                              .is_data_loc = is_data_loc };
+  if (!HasField(field_name))
+    fields.emplace_back(Field{ .name = field_name,
+                               .type = type,
+                               .offset = offset,
+                               .is_bitfield = is_bitfield,
+                               .bitfield = bitfield,
+                               .is_data_loc = is_data_loc });
 }
 
 void StructManager::Add(const std::string &name, size_t size)

--- a/src/struct.cpp
+++ b/src/struct.cpp
@@ -13,10 +13,10 @@ bool Bitfield::operator!=(const Bitfield &other) const {
   return !(*this == other);
 }
 
-std::unique_ptr<Tuple> Tuple::Create(std::vector<SizedType> fields)
+std::unique_ptr<Struct> Struct::CreateTuple(std::vector<SizedType> fields)
 {
   // See llvm::StructLayout::StructLayout source
-  std::unique_ptr<Tuple> tuple(new Tuple);
+  std::unique_ptr<Struct> tuple(new Struct(0));
   ssize_t offset = 0;
   ssize_t struct_align = 1;
 
@@ -50,9 +50,9 @@ std::unique_ptr<Tuple> Tuple::Create(std::vector<SizedType> fields)
   return tuple;
 }
 
-void Tuple::Dump(std::ostream &os)
+void Struct::Dump(std::ostream &os)
 {
-  os << "tuple {" << std::endl;
+  os << " {" << std::endl;
 
   auto pad = [](int size) -> std::string {
     return "__pad[" + std::to_string(size) + "]";

--- a/src/struct.h
+++ b/src/struct.h
@@ -42,6 +42,19 @@ struct Struct
 {
   int size; // in bytes
   FieldsMap fields;
+
+  explicit Struct(int size) : size(size)
+  {
+  }
+
+  bool HasField(const std::string &name) const;
+  const Field &GetField(const std::string &name) const;
+  void AddField(const std::string &field_name,
+                const SizedType &type,
+                ssize_t offset,
+                bool is_bitfield,
+                const Bitfield &bitfield,
+                bool is_data_loc);
 };
 
 struct Tuple
@@ -56,4 +69,17 @@ struct Tuple
 };
 
 std::ostream &operator<<(std::ostream &os, const TupleFields &t);
+
+class StructManager
+{
+public:
+  void Add(const std::string &name, size_t size);
+  std::shared_ptr<Struct> Lookup(const std::string &name) const;
+  std::shared_ptr<Struct> LookupOrAdd(const std::string &name, size_t size);
+  bool Has(const std::string &name) const;
+
+private:
+  std::map<std::string, std::shared_ptr<Struct>> struct_map_;
+};
+
 } // namespace bpftrace

--- a/src/struct.h
+++ b/src/struct.h
@@ -20,6 +20,7 @@ struct Bitfield
 
 struct Field
 {
+  std::string name;
   SizedType type;
   ssize_t offset;
 
@@ -35,13 +36,12 @@ struct Field
   bool is_data_loc = false;
 };
 
-using FieldsMap = std::map<std::string, Field>;
-using TupleFields = std::vector<Field>;
+using Fields = std::vector<Field>;
 
 struct Struct
 {
   int size; // in bytes
-  FieldsMap fields;
+  Fields fields;
 
   explicit Struct(int size) : size(size)
   {
@@ -62,13 +62,13 @@ struct Tuple
   size_t size; // in bytes
   int align;   // in bytes
   bool padded = false;
-  TupleFields fields;
+  Fields fields;
 
   static std::unique_ptr<Tuple> Create(std::vector<SizedType> fields);
   void Dump(std::ostream &os);
 };
 
-std::ostream &operator<<(std::ostream &os, const TupleFields &t);
+std::ostream &operator<<(std::ostream &os, const Fields &t);
 
 class StructManager
 {

--- a/src/struct.h
+++ b/src/struct.h
@@ -41,6 +41,8 @@ using Fields = std::vector<Field>;
 struct Struct
 {
   int size; // in bytes
+  int align = 1; // in bytes, used for tuples only
+  bool padded = false;
   Fields fields;
 
   explicit Struct(int size) : size(size)
@@ -55,16 +57,8 @@ struct Struct
                 bool is_bitfield,
                 const Bitfield &bitfield,
                 bool is_data_loc);
-};
 
-struct Tuple
-{
-  size_t size; // in bytes
-  int align;   // in bytes
-  bool padded = false;
-  Fields fields;
-
-  static std::unique_ptr<Tuple> Create(std::vector<SizedType> fields);
+  static std::unique_ptr<Struct> CreateTuple(std::vector<SizedType> fields);
   void Dump(std::ostream &os);
 };
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -2,6 +2,7 @@
 #include <cassert>
 #include <iostream>
 
+#include "bpftrace.h"
 #include "log.h"
 #include "struct.h"
 #include "types.h"
@@ -355,10 +356,11 @@ SizedType CreatePointer(const SizedType &pointee_type, AddrSpace as)
   return ty;
 }
 
-SizedType CreateRecord(size_t size, const std::string &name)
+SizedType CreateRecord(const std::string &name, std::shared_ptr<Struct> record)
 {
-  auto ty = SizedType(Type::record, size);
+  auto ty = SizedType(Type::record, record ? record->size : 0);
   ty.name_ = name;
+  ty.record = record;
   return ty;
 }
 
@@ -508,6 +510,18 @@ ssize_t SizedType::GetAlignment() const
     return 4;
   else
     return 8;
+}
+
+const std::map<std::string, Field> &SizedType::GetStructFields() const
+{
+  assert(IsRecordTy() && record);
+  return record->fields;
+}
+
+const Field &SizedType::GetField(const std::string &name) const
+{
+  assert(IsRecordTy());
+  return record->fields[name];
 }
 
 } // namespace bpftrace

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -360,7 +360,7 @@ SizedType CreateRecord(const std::string &name, std::shared_ptr<Struct> record)
 {
   auto ty = SizedType(Type::record, record ? record->size : 0);
   ty.name_ = name;
-  ty.record = record;
+  ty.inner_struct_ = record;
   return ty;
 }
 
@@ -451,8 +451,8 @@ SizedType CreateTimestamp()
 SizedType CreateTuple(const std::vector<SizedType> &fields)
 {
   auto s = SizedType(Type::tuple, 0);
-  s.tuple_fields = Tuple::Create(fields);
-  s.size_ = s.tuple_fields->size;
+  s.inner_struct_ = Struct::CreateTuple(fields);
+  s.size_ = s.inner_struct_->size;
   return s;
 }
 
@@ -470,28 +470,32 @@ bool SizedType::IsSigned(void) const
 
 std::vector<Field> &SizedType::GetFields() const
 {
-  assert(IsTupleTy());
-  return tuple_fields->fields;
+  assert(IsTupleTy() || IsRecordTy());
+  return inner_struct_->fields;
 }
 
 Field &SizedType::GetField(ssize_t n) const
 {
-  assert(IsTupleTy());
+  assert(IsTupleTy() || IsRecordTy());
   if (n >= GetFieldCount())
     throw std::runtime_error("Getfield(): out of bound");
-  return tuple_fields->fields[n];
+  return inner_struct_->fields[n];
 }
 
 ssize_t SizedType::GetFieldCount() const
 {
-  assert(IsTupleTy());
-  return tuple_fields->fields.size();
+  assert(IsTupleTy() || IsRecordTy());
+  return inner_struct_->fields.size();
 }
 
 void SizedType::DumpStructure(std::ostream &os)
 {
   assert(IsTupleTy());
-  return tuple_fields->Dump(os);
+  if (IsTupleTy())
+    os << "tuple";
+  else
+    os << "struct";
+  return inner_struct_->Dump(os);
 }
 
 ssize_t SizedType::GetAlignment() const
@@ -499,8 +503,8 @@ ssize_t SizedType::GetAlignment() const
   if (IsStringTy())
     return 1;
 
-  if (IsTupleTy())
-    return tuple_fields->align;
+  if (IsTupleTy() || IsRecordTy())
+    return inner_struct_->align;
 
   if (GetSize() <= 2)
     return GetSize();
@@ -512,22 +516,22 @@ ssize_t SizedType::GetAlignment() const
     return 8;
 }
 
-const std::vector<Field> &SizedType::GetStructFields() const
+bool SizedType::HasField(const std::string &name) const
 {
-  assert(IsRecordTy() && record);
-  return record->fields;
+  assert(IsRecordTy());
+  return inner_struct_->HasField(name);
 }
 
 const Field &SizedType::GetField(const std::string &name) const
 {
   assert(IsRecordTy());
-  return record->GetField(name);
+  return inner_struct_->GetField(name);
 }
 
 const Struct *SizedType::GetStruct() const
 {
   assert(IsRecordTy());
-  return record.get();
+  return inner_struct_.get();
 }
 
 } // namespace bpftrace

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -512,7 +512,7 @@ ssize_t SizedType::GetAlignment() const
     return 8;
 }
 
-const std::map<std::string, Field> &SizedType::GetStructFields() const
+const std::vector<Field> &SizedType::GetStructFields() const
 {
   assert(IsRecordTy() && record);
   return record->fields;
@@ -521,7 +521,13 @@ const std::map<std::string, Field> &SizedType::GetStructFields() const
 const Field &SizedType::GetField(const std::string &name) const
 {
   assert(IsRecordTy());
-  return record->fields[name];
+  return record->GetField(name);
+}
+
+const Struct *SizedType::GetStruct() const
+{
+  assert(IsRecordTy());
+  return record.get();
 }
 
 } // namespace bpftrace

--- a/src/types.h
+++ b/src/types.h
@@ -77,7 +77,6 @@ struct StackType
 
 class BPFtrace;
 struct Struct;
-struct Tuple;
 struct Field;
 
 class SizedType
@@ -112,22 +111,17 @@ private:
   AddrSpace as_ = AddrSpace::none;
   ssize_t size_bits_ = -1; // size in bits for integer types
 
-  std::shared_ptr<Tuple> tuple_fields; // tuple fields
-  std::shared_ptr<Struct> record;      // struct type
+  std::shared_ptr<Struct> inner_struct_; // inner struct for records and tuples
 
 public:
   /**
-     Tuple accessors
+     Tuple/struct accessors
   */
   std::vector<Field> &GetFields() const;
+  bool HasField(const std::string &name) const;
+  const Field &GetField(const std::string &name) const;
   Field &GetField(ssize_t n) const;
   ssize_t GetFieldCount() const;
-
-  /**
-     Struct field accessors
-   */
-  const std::vector<Field> &GetStructFields() const;
-  const Field &GetField(const std::string &name) const;
   const Struct *GetStruct() const;
 
   /**

--- a/src/types.h
+++ b/src/types.h
@@ -126,8 +126,9 @@ public:
   /**
      Struct field accessors
    */
-  const std::map<std::string, Field> &GetStructFields() const;
+  const std::vector<Field> &GetStructFields() const;
   const Field &GetField(const std::string &name) const;
+  const Struct *GetStruct() const;
 
   /**
      Required alignment for this type

--- a/src/types.h
+++ b/src/types.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cassert>
+#include <map>
 #include <memory>
 #include <ostream>
 #include <sstream>
@@ -74,6 +75,8 @@ struct StackType
   }
 };
 
+class BPFtrace;
+struct Struct;
 struct Tuple;
 struct Field;
 
@@ -110,6 +113,7 @@ private:
   ssize_t size_bits_ = -1; // size in bits for integer types
 
   std::shared_ptr<Tuple> tuple_fields; // tuple fields
+  std::shared_ptr<Struct> record;      // struct type
 
 public:
   /**
@@ -118,6 +122,12 @@ public:
   std::vector<Field> &GetFields() const;
   Field &GetField(ssize_t n) const;
   ssize_t GetFieldCount() const;
+
+  /**
+     Struct field accessors
+   */
+  const std::map<std::string, Field> &GetStructFields() const;
+  const Field &GetField(const std::string &name) const;
 
   /**
      Required alignment for this type
@@ -334,7 +344,8 @@ public:
                                const SizedType &element_type);
 
   friend SizedType CreatePointer(const SizedType &pointee_type, AddrSpace as);
-  friend SizedType CreateRecord(size_t size, const std::string &name);
+  friend SizedType CreateRecord(const std::string &name,
+                                std::shared_ptr<Struct> record);
   friend SizedType CreateInteger(size_t bits, bool is_signed);
   friend SizedType CreateTuple(const std::vector<SizedType> &fields);
 };
@@ -358,11 +369,8 @@ SizedType CreateString(size_t size);
 SizedType CreateArray(size_t num_elements, const SizedType &element_type);
 SizedType CreatePointer(const SizedType &pointee_type,
                         AddrSpace as = AddrSpace::none);
-/**
-   size in bytes
- */
-SizedType CreateRecord(size_t size, const std::string &name);
 
+SizedType CreateRecord(const std::string &name, std::shared_ptr<Struct> record);
 SizedType CreateTuple(const std::vector<SizedType> &fields);
 
 SizedType CreateStackMode();

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -75,67 +75,39 @@ void setup_mock_probe_matcher(MockProbeMatcher &matcher)
 void setup_mock_bpftrace(MockBPFtrace &bpftrace)
 {
   // Fill in some default tracepoint struct definitions
-  bpftrace.structs_["struct _tracepoint_sched_sched_one"] = Struct{
-    .size = 8,
-    .fields = { { "common_field",
-                  Field{
-                      .type = CreateUInt64(),
-                      .offset = 8,
-                      .is_bitfield = false,
-                      .bitfield = {},
-                  } } },
-  };
-  bpftrace.structs_["struct _tracepoint_sched_sched_two"] = Struct{
-    .size = 8,
-    .fields = { { "common_field",
-                  Field{
-                      .type = CreateUInt64(),
-                      .offset = 16, // different offset than
-                                    // sched_one.common_field
-                      .is_bitfield = false,
-                      .bitfield = {},
-                  } } },
-  };
-  bpftrace.structs_["struct _tracepoint_sched_extra_sched_extra"] = Struct{
-    .size = 8,
-    .fields = { { "common_field",
-                  Field{
-                      .type = CreateUInt64(),
-                      .offset = 24, // different offset than
-                                    // sched_(one|two).common_field
-                      .is_bitfield = false,
-                      .bitfield = {},
-                  } } },
-  };
-  bpftrace.structs_["struct _tracepoint_tcp_some_tcp_tp"] = Struct{
-    .size = 16,
-    .fields = { { "saddr_v6",
-                  Field{
-                      .type = CreateArray(16, CreateUInt(8)),
-                      .offset = 8,
-                      .is_bitfield = false,
-                      .bitfield = {},
-                  } } },
-  };
+  bpftrace.structs.Add("struct _tracepoint_sched_sched_one", 8);
+  bpftrace.structs.Lookup("struct _tracepoint_sched_sched_one")
+      ->AddField("common_field", CreateUInt64(), 8, false, {}, false);
+
+  bpftrace.structs.Add("struct _tracepoint_sched_sched_two", 8);
+  bpftrace.structs.Lookup("struct _tracepoint_sched_sched_two")
+      ->AddField("common_field",
+                 CreateUInt64(),
+                 16, // different offset than
+                     // sched_one.common_field
+                 false,
+                 {},
+                 false);
+  bpftrace.structs.Add("struct _tracepoint_sched_extra_sched_extra", 8);
+  bpftrace.structs.Lookup("struct _tracepoint_sched_extra_sched_extra")
+      ->AddField("common_field",
+                 CreateUInt64(),
+                 24, // different offset than
+                     // sched_(one|two).common_field
+                 false,
+                 {},
+                 false);
+  bpftrace.structs.Add("struct _tracepoint_tcp_some_tcp_tp", 16);
+  bpftrace.structs.Lookup("struct _tracepoint_tcp_some_tcp_tp")
+      ->AddField(
+          "saddr_v6", CreateArray(16, CreateUInt(8)), 8, false, {}, false);
 
   auto ptr_type = CreatePointer(CreateInt8());
-  bpftrace.structs_["struct _tracepoint_file_filename"] = Struct{
-    .size = 8,
-    .fields = { { "common_field",
-                  Field{
-                      .type = CreateUInt64(),
-                      .offset = 0,
-                      .is_bitfield = false,
-                      .bitfield = {},
-                  } },
-                { "filename",
-                  Field{
-                      .type = ptr_type,
-                      .offset = 8,
-                      .is_bitfield = false,
-                      .bitfield = {},
-                  } } },
-  };
+  bpftrace.structs.Add("struct _tracepoint_file_filename", 8);
+  bpftrace.structs.Lookup("struct _tracepoint_file_filename")
+      ->AddField("common_field", CreateUInt64(), 0, false, {}, false);
+  bpftrace.structs.Lookup("struct _tracepoint_file_filename")
+      ->AddField("filename", ptr_type, 8, false, {}, false);
 }
 
 std::unique_ptr<MockBPFtrace> get_mock_bpftrace()

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -124,7 +124,7 @@ AFTER ./testprogs/simple_struct
 
 NAME print_non_map_nested_struct
 RUN bpftrace -v -f json -e 'struct Foo { struct { int m[1] } y; struct { int n; } a; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); print($f); exit(); }'
-EXPECT ^{"type": "value", "data": { "a": { "n": 3 }, "y": { "m": \[2\] } }}$
+EXPECT ^{"type": "value", "data": { "y": { "m": \[2\] }, "a": { "n": 3 } }}$
 TIMEOUT 5
 AFTER ./testprogs/simple_struct
 

--- a/tests/runtime/struct
+++ b/tests/runtime/struct
@@ -10,9 +10,15 @@ EXPECT @s: { .m = 2, .n = 3 }
 TIMEOUT 4
 AFTER ./testprogs/simple_struct
 
+NAME struct field order
+RUN bpftrace -v -e 'struct Foo { int n; int m; } u:./testprogs/simple_struct:func { @s = *((struct Foo *)arg0); exit(); }'
+EXPECT @s: { .n = 2, .m = 3 }
+TIMEOUT 4
+AFTER ./testprogs/simple_struct
+
 NAME nested struct assignment into map
 RUN bpftrace -v -e 'struct Foo { struct { int m[1] } y; struct { int n } a; } u:./testprogs/simple_struct:func { @s = *((struct Foo *)arg0); exit(); }'
-EXPECT @s: { .a = { .n = 3 }, .y = { .m = \[2\] } }
+EXPECT @s: { .y = { .m = \[2\] }, .a = { .n = 3 } }
 TIMEOUT 4
 AFTER ./testprogs/simple_struct
 


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

This PR attempts to improve (mainly internal) work with record types in several ways:
- Adds reference to the struct layout (the `Struct` type) into `SizedType`. This allows to access the record's fields directly from the expression type, without the need to fall back to `bpftrace.structs_`. In fact, the work with `bpftrace.structs_` is now completely hidden from the users of `SizedType`.
- Preserves the original order of struct fields. Since we now allow to print structs, changing the field order could confuse the user.
- Unifies the internal structure of records and tuples (classes `Struct` and `Tuple` are merged). The only difference is that tuple fields have empty names.

This should resolve #1396.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
