### PR TITLE
Fix memory leak in AttachedProbe

### DIFF
--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -73,9 +73,7 @@ private:
   std::vector<int> perf_event_fds_;
   int progfd_ = -1;
   uint64_t offset_ = 0;
-#ifdef HAVE_BCC_KFUNC
   int tracing_fd_ = -1;
-#endif
   std::function<void()> usdt_destructor_;
 };
 


### PR DESCRIPTION
Not entirely sure why but for some reason the destructor deallocates
less bytes than it should:

```
==14571==ERROR: AddressSanitizer: new-delete-type-mismatch on 0x60b000003740 in thread T0:
  object passed to delete has wrong type:
  size of the allocated type:   112 bytes;
  size of the deallocated type: 104 bytes.

    #0 0x7f192d4879c8 in operator delete(void*, unsigned long) (/usr/lib/x86_64-linux-gnu/libasan.so.4+0xe19c8)
    #1 0x5569f26b5c4c in std::default_delete<bpftrace::AttachedProbe>::operator()(bpftrace::AttachedProbe*) const /usr/include/c++/7/bits/unique_ptr.h:78
    #2 0x5569f26b1364 in std::unique_ptr<bpftrace::AttachedProbe, std::default_delete<bpftrace::AttachedProbe> >::~unique_ptr() (/home/vagrant/build/src/bpftrace+0xdd364)
    #3 0x5569f26acc41 in void std::_Destroy<std::unique_ptr<bpftrace::AttachedProbe, std::default_delete<bpftrace::AttachedProbe> > >(std::unique_ptr<bpftrace::AttachedProbe, std::default_delete<bpftrace::AttachedProbe> >*) (/home/vagrant/build/src/bpftrace+0xd8c41)
```

Removing the ifdef fixes is. Having the extra field won't hurt.

Fixes #1853
