### PR TITLE
tracepoint: Return 1 from tracepoint probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
   - [#1810](https://github.com/iovisor/bpftrace/pull/1810)
 - Improve JSON printing (nested structs)
   - [#1778](https://github.com/iovisor/bpftrace/pull/1778)
+- Return 1 from tracepoint probes
+  - [#1857](https://github.com/iovisor/bpftrace/pull/1857)
 
 #### Deprecated
 

--- a/src/ast/codegen_llvm.h
+++ b/src/ast/codegen_llvm.h
@@ -129,6 +129,11 @@ private:
                      StackType stack_type,
                      const location &loc);
 
+  // Create return instruction
+  //
+  // If null, return value will depend on current attach point
+  void createRet(Value *value = nullptr);
+
   // Every time we see a watchpoint that specifies a function + arg pair, we
   // generate a special "setup" probe that:
   //

--- a/tests/codegen/llvm/args_multiple_tracepoints.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints.ll
@@ -49,7 +49,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   %13 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  ret i64 0
+  ret i64 1
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
@@ -101,7 +101,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   %13 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  ret i64 0
+  ret i64 1
 }
 
 attributes #0 = { nounwind }

--- a/tests/codegen/llvm/args_multiple_tracepoints_category_wild.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints_category_wild.ll
@@ -49,7 +49,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   %13 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  ret i64 0
+  ret i64 1
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
@@ -101,7 +101,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   %13 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  ret i64 0
+  ret i64 1
 }
 
 define i64 @"tracepoint:sched_extra:sched_extra"(i8* %0) section "s_tracepoint:sched_extra:sched_extra_3" {
@@ -147,7 +147,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   %13 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  ret i64 0
+  ret i64 1
 }
 
 attributes #0 = { nounwind }

--- a/tests/codegen/llvm/args_multiple_tracepoints_wild.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints_wild.ll
@@ -49,7 +49,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   %13 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  ret i64 0
+  ret i64 1
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
@@ -101,7 +101,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   %13 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  ret i64 0
+  ret i64 1
 }
 
 attributes #0 = { nounwind }

--- a/tests/codegen/llvm/builtin_probe.ll
+++ b/tests/codegen/llvm/builtin_probe.ll
@@ -22,7 +22,7 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
   %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
-  ret i64 0
+  ret i64 1
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/builtin_probe_wild.ll
+++ b/tests/codegen/llvm/builtin_probe_wild.ll
@@ -22,7 +22,7 @@ entry:
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
   %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
-  ret i64 0
+  ret i64 1
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/call_cgroup.ll
+++ b/tests/codegen/llvm/call_cgroup.ll
@@ -17,7 +17,7 @@ entry:
   br i1 %predcond, label %pred_false, label %pred_true
 
 pred_false:                                       ; preds = %entry
-  ret i64 0
+  ret i64 1
 
 pred_true:                                        ; preds = %entry
   %get_cgroup_id1 = call i64 inttoptr (i64 80 to i64 ()*)()
@@ -33,7 +33,7 @@ pred_true:                                        ; preds = %entry
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
   %6 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  ret i64 0
+  ret i64 1
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/map_key_probe.ll
+++ b/tests/codegen/llvm/map_key_probe.ll
@@ -51,7 +51,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   %11 = bitcast i64* %"@x_key1" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  ret i64 0
+  ret i64 1
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
@@ -105,7 +105,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   %11 = bitcast i64* %"@x_key1" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  ret i64 0
+  ret i64 1
 }
 
 attributes #0 = { nounwind }

--- a/tests/codegen/llvm/strncmp.ll
+++ b/tests/codegen/llvm/strncmp.ll
@@ -54,7 +54,7 @@ entry:
   br i1 %strcmp.cmp, label %strcmp.false, label %strcmp.loop_null_cmp
 
 pred_false:                                       ; preds = %strcmp.false
-  ret i64 0
+  ret i64 1
 
 pred_true:                                        ; preds = %strcmp.false
   %19 = bitcast i64* %"@_key" to i8*
@@ -69,7 +69,7 @@ pred_true:                                        ; preds = %strcmp.false
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
   %22 = bitcast i64* %"@_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
-  ret i64 0
+  ret i64 1
 
 strcmp.false:                                     ; preds = %strcmp.done, %strcmp.loop86, %strcmp.loop80, %strcmp.loop74, %strcmp.loop68, %strcmp.loop62, %strcmp.loop56, %strcmp.loop50, %strcmp.loop44, %strcmp.loop38, %strcmp.loop32, %strcmp.loop26, %strcmp.loop20, %strcmp.loop14, %strcmp.loop8, %strcmp.loop2, %strcmp.loop, %entry
   %23 = load i1, i1* %strcmp.result, align 1


### PR DESCRIPTION
Returning 0 from a tracepoint prog causes the perf subsystem to ignore
the tracepoint event. We should return 1 to be a better citizen.

And yes, everyone in the kernel thinks it's weird too. But it's too late
to change.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
