### PR TITLE
Fix parsing of traceable functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to
   - [#1812](https://github.com/iovisor/bpftrace/pull/1812)
 - Make kaddr() report failure for unknown kernel symbols
   - [#1836](https://github.com/iovisor/bpftrace/pull/1836)
+- Fix false non-traceable function warnings
+  - [#1866](https://github.com/iovisor/bpftrace/pull/1866)
 
 #### Tools
 

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -73,10 +73,9 @@ std::set<std::string> ProbeMatcher::get_matches_in_stream(
   std::set<std::string> matches;
   while (std::getline(symbol_stream, line, delim))
   {
-    if (ignore_trailing_module && !line.empty() && line[line.size() - 1] == ']')
+    if (ignore_trailing_module && symbol_has_module(line))
     {
-      if (size_t idx = line.rfind(" ["); idx != std::string::npos)
-        line = line.substr(0, idx);
+      line = strip_symbol_module(line);
     }
 
     if (!wildcard_match(line, tokens, start_wildcard, end_wildcard))

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -783,7 +783,12 @@ std::unordered_set<std::string> get_traceable_funcs()
   std::unordered_set<std::string> result;
   std::string line;
   while (std::getline(available_funs, line))
-    result.insert(line);
+  {
+    if (symbol_has_module(line))
+      result.insert(strip_symbol_module(line));
+    else
+      result.insert(line);
+  }
   return result;
 #endif
 }
@@ -977,6 +982,17 @@ uint64_t max_value(const std::vector<uint8_t> &value, int nvalues)
       max = val;
   }
   return max;
+}
+
+bool symbol_has_module(const std::string &symbol)
+{
+  return !symbol.empty() && symbol[symbol.size() - 1] == ']';
+}
+
+std::string strip_symbol_module(const std::string &symbol)
+{
+  size_t idx = symbol.rfind(" [");
+  return idx != std::string::npos ? symbol.substr(0, idx) : symbol;
 }
 
 } // namespace bpftrace

--- a/src/utils.h
+++ b/src/utils.h
@@ -162,6 +162,8 @@ bool symbol_has_cpp_mangled_signature(const std::string &sym_name);
 pid_t parse_pid(const std::string &str);
 std::string hex_format_buffer(const char *buf, size_t size);
 std::optional<std::string> abs_path(const std::string &rel_path);
+bool symbol_has_module(const std::string &symbol);
+std::string strip_symbol_module(const std::string &symbol);
 
 // Generate object file section name for a given probe
 inline std::string get_section_name_for_probe(


### PR DESCRIPTION
The function for reading `available_filter_functions` reads entire lines which may contain a module and in such case, the function name is not collected properly. This change strips the module part (the same way as it is done for wildcard matching).

Fixes #1864.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
