### PR TITLE
parser: rewrite to remove most conflicts

### DIFF
--- a/src/parser.yy
+++ b/src/parser.yy
@@ -114,28 +114,28 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %token <long> INT "integer"
 %token <std::string> STACK_MODE "stack_mode"
 
-%type <std::string> c_definitions
-%type <ast::ProbeList *> probes
-%type <ast::Probe *> probe
-%type <ast::Predicate *> pred
-%type <ast::Ternary *> ternary
-%type <ast::StatementList *> block stmts block_or_if
-%type <ast::Statement *> if_stmt block_stmt stmt semicolon_ended_stmt compound_assignment jump_stmt loop_stmt tuple_assignment
-%type <ast::Expression *> expr
-%type <ast::Call *> call
-%type <ast::Map *> map
-%type <ast::Variable *> var
-%type <ast::ExpressionList *> vargs
-%type <ast::AttachPointList *> attach_points
-%type <ast::AttachPoint *> attach_point
-%type <std::string> attach_point_def
-%type <ast::PositionalParameter *> param
-%type <std::string> ident
-%type <ast::Expression *> map_or_var
-%type <ast::Expression *> pre_post_op
-%type <ast::Integer *> int
 
-%right ASSIGN
+%type <int> unary_op compound_op
+%type <std::string> attach_point_def c_definitions ident
+
+%type <ast::AttachPoint *> attach_point
+%type <ast::AttachPointList *> attach_points
+%type <ast::Call *> call
+%type <ast::Expression *> and_expr arith_expr primary_expr cast_expr conditional_expr equality_expr expr logical_and_expr
+%type <ast::Expression *> logical_or_expr map_or_var or_expr postfix_expr relational_expr shift_expr tuple_access_expr unary_expr xor_expr
+%type <ast::ExpressionList *> vargs
+%type <ast::Integer *> int
+%type <ast::Map *> map
+%type <ast::PositionalParameter *> param
+%type <ast::Predicate *> pred
+%type <ast::Probe *> probe
+%type <ast::ProbeList *> probes
+%type <ast::Statement *> assign_stmt block_stmt expr_stmt if_stmt jump_stmt loop_stmt
+%type <ast::StatementList *> block block_or_if stmt_list
+%type <ast::Variable *> var
+
+%left COMMA
+%right ASSIGN LEFTASSIGN RIGHTASSIGN PLUSASSIGN MINUSASSIGN MULASSIGN DIVASSIGN MODASSIGN BANDASSIGN BORASSIGN BXORASSIGN
 %left QUES COLON
 %left LOR
 %left LAND
@@ -147,264 +147,375 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %left LEFT RIGHT
 %left PLUS MINUS
 %left MUL DIV MOD
-%right LNOT BNOT DEREF CAST
-%left DOT PTR
+%right LNOT BNOT
+%left LPAREN RPAREN LBRACKET RBRACKET DOT PTR
 
 %start program
 
 %%
 
-program : c_definitions probes { driver.root_ = new ast::Program($1, $2); }
+program:
+                c_definitions probes { driver.root_ = new ast::Program($1, $2); }
+                ;
+
+c_definitions:
+                CPREPROC c_definitions    { $$ = $1 + "\n" + $2; }
+        |       STRUCT_DEFN c_definitions { $$ = $1 + ";\n" + $2; }
+        |       ENUM c_definitions        { $$ = $1 + ";\n" + $2; }
+        |       %empty                    { $$ = std::string(); }
+                ;
+
+probes:
+                probes probe { $$ = $1; $1->push_back($2); }
+        |       probe        { $$ = new ast::ProbeList; $$->push_back($1); }
+                ;
+
+probe:
+                attach_points pred block
+                {
+                  if (!driver.listing_)
+                    $$ = new ast::Probe($1, $2, $3);
+                  else
+                  {
+                    error(@$, "unexpected listing query format");
+                    YYERROR;
+                  }
+                }
+        |       attach_points END
+                {
+                  if (driver.listing_)
+                    $$ = new ast::Probe($1, nullptr, nullptr);
+                  else
+                  {
+                    error(@$, "unexpected end of file, expected {");
+                    YYERROR;
+                  }
+                }
+                ;
+
+attach_points:
+                attach_points "," attach_point { $$ = $1; $1->push_back($3); }
+        |       attach_point                   { $$ = new ast::AttachPointList; $$->push_back($1); }
+                ;
+
+attach_point:
+                attach_point_def                { $$ = new ast::AttachPoint($1, @$); }
+                ;
+
+attach_point_def:
+                attach_point_def ident    { $$ = $1 + $2; }
+                // Since we're double quoting the STRING for the benefit of the
+                // AttachPointParser, we have to make sure we re-escape any double
+                // quotes.
+        |       attach_point_def STRING   { $$ = $1 + "\"" + std::regex_replace($2, std::regex("\""), "\\\"") + "\""; }
+        |       attach_point_def PATH     { $$ = $1 + $2; }
+        |       attach_point_def INT      { $$ = $1 + std::to_string($2); }
+        |       attach_point_def COLON    { $$ = $1 + ":"; }
+        |       attach_point_def DOT      { $$ = $1 + "."; }
+        |       attach_point_def PLUS     { $$ = $1 + "+"; }
+        |       attach_point_def MUL      { $$ = $1 + "*"; }
+        |       attach_point_def LBRACKET { $$ = $1 + "["; }
+        |       attach_point_def RBRACKET { $$ = $1 + "]"; }
+        |       attach_point_def param
+                {
+                  if ($2->ptype != PositionalParameterType::positional)
+                  {
+                    error(@$, "Not a positional parameter");
+                    YYERROR;
+                  }
+                  // "Un-parse" the positional parameter back into text so
+                  // we can give it to the AttachPointParser. This is kind of
+                  // a hack but there doesn't look to be any other way.
+                  $$ = $1 + "$" + std::to_string($2->n);
+                  delete $2;
+                }
+        |       %empty                    { $$ = ""; }
+                ;
+
+pred:
+                DIV expr ENDPRED { $$ = new ast::Predicate($2, @$); }
+        |        %empty           { $$ = nullptr; }
+                ;
+
+
+param:
+                PARAM {
+                        try {
+                          long n = std::stol($1.substr(1, $1.size()-1));
+                          if (n == 0) throw std::exception();
+                          $$ = new ast::PositionalParameter(PositionalParameterType::positional, n, @$);
+                        } catch (std::exception const& e) {
+                          error(@1, "param " + $1 + " is out of integer range [1, " +
+                                std::to_string(std::numeric_limits<long>::max()) + "]");
+                          YYERROR;
+                        }
+                      }
+        |       PARAMCOUNT { $$ = new ast::PositionalParameter(PositionalParameterType::count, 0, @$); }
+                ;
+
+block:
+                "{" stmt_list "}"     { $$ = $2; }
+                ;
+
+stmt_list:
+/*
+ * expressions must be followed by a semicolon _unless_ its the last one
+ */
+                expr_stmt ";" stmt_list { $$ = $3; $3->insert($3->begin(), $1); }
+        |       expr_stmt               { $$ = new ast::StatementList; $$->push_back($1); }
+/*
+ * blocks can't be followed by semicolon
+ */
+        |       block_stmt stmt_list    { $$ = $2; $2->insert($2->begin(), $1); }
+        |       %empty                  { $$ = new ast::StatementList; }
+                ;
+
+block_stmt:
+                loop_stmt    { $$ = $1; }
+        |       if_stmt      { $$ = $1; }
+                ;
+
+expr_stmt:
+                expr               { $$ = new ast::ExprStatement($1, @1); }
+        |       jump_stmt          { $$ = $1; }
+/*
+ * quirk. Assignment is not an expression but the AssignMapStatement makes it difficult
+ * this avoids a r/r conflict
+ */
+        |       assign_stmt        { $$ = $1; }
+                ;
+
+jump_stmt:
+                BREAK    { $$ = new ast::Jump(token::BREAK, @$); }
+        |       CONTINUE { $$ = new ast::Jump(token::CONTINUE, @$); }
+        |       RETURN   { $$ = new ast::Jump(token::RETURN, @$); }
+                ;
+
+loop_stmt:
+                UNROLL "(" int ")" block             { $$ = new ast::Unroll($3, $5, @1 + @4); }
+        |       UNROLL "(" param ")" block           { $$ = new ast::Unroll($3, $5, @1 + @4); }
+        |       WHILE  "(" expr ")" block            { $$ = new ast::While($3, $5, @1); }
+                ;
+
+if_stmt:
+                IF "(" expr ")" block                  { $$ = new ast::If($3, $5); }
+        |       IF "(" expr ")" block ELSE block_or_if { $$ = new ast::If($3, $5, $7); }
+                ;
+
+block_or_if:
+                block        { $$ = $1; }
+        |       if_stmt      { $$ = new ast::StatementList; $$->emplace_back($1); }
+                ;
+
+assign_stmt:
+                tuple_access_expr ASSIGN expr
+                {
+                  error(@1 + @3, "Tuples are immutable once created. Consider creating a new tuple and assigning it instead.");
+                  YYERROR;
+                }
+        |       map ASSIGN expr      { $$ = new ast::AssignMapStatement($1, $3, false, @2); }
+        |       var ASSIGN expr      { $$ = new ast::AssignVarStatement($1, $3, false, @2); }
+        |       map compound_op unary_expr
+                {
+                  auto b = new ast::Binop($1, $2, $3, @2);
+                  $$ = new ast::AssignMapStatement($1, b, true, @$);
+                }
+        |       var compound_op unary_expr
+                {
+                  auto b = new ast::Binop($1, $2, $3, @2);
+                  $$ = new ast::AssignVarStatement($1, b, true, @$);
+                }
         ;
 
-c_definitions : CPREPROC c_definitions    { $$ = $1 + "\n" + $2; }
-              | STRUCT_DEFN c_definitions { $$ = $1 + ";\n" + $2; }
-              | ENUM c_definitions        { $$ = $1 + ";\n" + $2; }
-              |                           { $$ = std::string(); }
-              ;
+primary_expr:
+                IDENT              { $$ = new ast::Identifier($1, @$); }
+        |       int                { $$ = $1; }
+        |       STRING             { $$ = new ast::String($1, @$); }
+        |       STACK_MODE         { $$ = new ast::StackMode($1, @$); }
+        |       BUILTIN            { $$ = new ast::Builtin($1, @$); }
+        |       CALL_BUILTIN       { $$ = new ast::Builtin($1, @$); }
+        |       LPAREN expr RPAREN { $$ = $2; }
+        |       param              { $$ = $1; }
+        |       map_or_var         { $$ = $1; }
+        |       "("expr "," vargs ")"
+                {
+                  auto args = new ast::ExpressionList;
+                  args->emplace_back($2);
+                  args->insert(args->end(), $4->begin(), $4->end());
+                  $$ = new ast::Tuple(args, @$);
+                }
+                ;
 
-probes : probes probe { $$ = $1; $1->push_back($2); }
-       | probe        { $$ = new ast::ProbeList; $$->push_back($1); }
-       ;
+postfix_expr:
+                primary_expr                { $$ = $1; }
+/* pointer  */
+        |       postfix_expr DOT ident    { $$ = new ast::FieldAccess($1, $3, @2); }
+        |       postfix_expr PTR ident    { $$ = new ast::FieldAccess(new ast::Unop(token::MUL, $1, @2), $3, @$); }
+/* tuple  */
+        |       tuple_access_expr         { $$ = $1; }
+/* array  */
+        |       postfix_expr "[" expr "]" { $$ = new ast::ArrayAccess($1, $3, @2 + @4); }
+        |       call                      { $$ = $1; }
+        |       map_or_var INCREMENT      { $$ = new ast::Unop(token::INCREMENT, $1, true, @2); }
+        |       map_or_var DECREMENT      { $$ = new ast::Unop(token::DECREMENT, $1, true, @2); }
+/* errors */
+        |       INCREMENT ident           { error(@1, "The ++ operator must be applied to a map or variable"); YYERROR; }
+        |       DECREMENT ident           { error(@1, "The -- operator must be applied to a map or variable"); YYERROR; }
+                ;
 
-probe : attach_points pred block { if (!driver.listing_)
-                                     $$ = new ast::Probe($1, $2, $3);
-                                   else
-                                   {
-                                     error(@$, "unexpected listing query format");
-                                     YYERROR;
-                                   }
-                                 }
-      | attach_points END { if (driver.listing_)
-                              $$ = new ast::Probe($1, nullptr, nullptr);
-                            else
-                            {
-                              error(@$, "unexpected end of file, expected {");
-                              YYERROR;
-                            }
-                          }
-      ;
+/* Tuple factored out so we can use it in the tuple field assignment error */
+tuple_access_expr:
+                postfix_expr DOT INT      { $$ = new ast::FieldAccess($1, $3, @3); }
+                ;
 
-attach_points : attach_points "," attach_point { $$ = $1; $1->push_back($3); }
-              | attach_point                   { $$ = new ast::AttachPointList; $$->push_back($1); }
-              ;
 
-attach_point : attach_point_def                { $$ = new ast::AttachPoint($1, @$); }
-             ;
 
-attach_point_def : attach_point_def ident    { $$ = $1 + $2; }
-                 // Since we're double quoting the STRING for the benefit of the
-                 // AttachPointParser, we have to make sure we re-escape any double
-                 // quotes.
-                 | attach_point_def STRING   { $$ = $1 + "\"" + std::regex_replace($2, std::regex("\""), "\\\"") + "\""; }
-                 | attach_point_def PATH     { $$ = $1 + $2; }
-                 | attach_point_def INT      { $$ = $1 + std::to_string($2); }
-                 | attach_point_def COLON    { $$ = $1 + ":"; }
-                 | attach_point_def DOT      { $$ = $1 + "."; }
-                 | attach_point_def PLUS     { $$ = $1 + "+"; }
-                 | attach_point_def MUL      { $$ = $1 + "*"; }
-                 | attach_point_def LBRACKET { $$ = $1 + "["; }
-                 | attach_point_def RBRACKET { $$ = $1 + "]"; }
-                 | attach_point_def param    {
-                                               if ($2->ptype != PositionalParameterType::positional)
-                                               {
-                                                  error(@$, "Not a positional parameter");
-                                                  YYERROR;
-                                               }
+unary_expr:
+                unary_op cast_expr   { $$ = new ast::Unop($1, $2, @1); }
+        |       postfix_expr         { $$ = $1; }
+        |       INCREMENT map_or_var { $$ = new ast::Unop(token::INCREMENT, $2, @1); }
+        |       DECREMENT map_or_var { $$ = new ast::Unop(token::DECREMENT, $2, @1); }
+/* errors */
+        |       ident DECREMENT      { error(@1, "The -- operator must be applied to a map or variable"); YYERROR; }
+        |       ident INCREMENT      { error(@1, "The ++ operator must be applied to a map or variable"); YYERROR; }
+                ;
 
-                                               // "Un-parse" the positional parameter back into text so
-                                               // we can give it to the AttachPointParser. This is kind of
-                                               // a hack but there doesn't look to be any other way.
-                                               $$ = $1 + "$" + std::to_string($2->n);
-                                               delete $2;
-                                             }
-                 |                           { $$ = ""; }
-                 ;
+unary_op:
+                MUL    { $$ = token::MUL; }
+        |       BNOT   { $$ = token::BNOT; }
+        |       LNOT   { $$ = token::LNOT; }
+        |       MINUS  { $$ = token::MINUS; }
+                ;
 
-pred : DIV expr ENDPRED { $$ = new ast::Predicate($2, @$); }
-     |                  { $$ = nullptr; }
-     ;
+expr:
+                conditional_expr    { $$ = $1; }
+                ;
 
-ternary : expr QUES expr COLON expr { $$ = new ast::Ternary($1, $3, $5, @$); }
-        ;
+conditional_expr:
+                logical_or_expr                                  { $$ = $1; }
+        |       logical_or_expr QUES expr COLON conditional_expr { $$ = new ast::Ternary($1, $3, $5, @$); }
+                ;
 
-param : PARAM      {
-                     try {
-                       long n = std::stol($1.substr(1, $1.size()-1));
-                       if (n == 0) throw std::exception();
-                       $$ = new ast::PositionalParameter(PositionalParameterType::positional, n, @$);
-                     } catch (std::exception const& e) {
-                       error(@1, "param " + $1 + " is out of integer range [1, " +
-                             std::to_string(std::numeric_limits<long>::max()) + "]");
-                       YYERROR;
-                     }
-                   }
-      | PARAMCOUNT { $$ = new ast::PositionalParameter(PositionalParameterType::count, 0, @$); }
-      ;
 
-block : "{" stmts "}"     { $$ = $2; }
-      ;
+logical_or_expr:
+                logical_and_expr                     { $$ = $1; }
+        |       logical_or_expr LOR logical_and_expr { $$ = new ast::Binop($1, token::LOR, $3, @2); }
+                ;
 
-semicolon_ended_stmt: stmt ";"  { $$ = $1; }
-                    ;
+logical_and_expr:
+                or_expr                       { $$ = $1; }
+        |       logical_and_expr LAND or_expr { $$ = new ast::Binop($1, token::LAND, $3, @2); }
+                ;
 
-stmts : semicolon_ended_stmt stmts { $$ = $2; $2->insert($2->begin(), $1); }
-      | block_stmt stmts           { $$ = $2; $2->insert($2->begin(), $1); }
-      | stmt                       { $$ = new ast::StatementList; $$->push_back($1); }
-      |                            { $$ = new ast::StatementList; }
-      ;
+or_expr:
+                xor_expr             { $$ = $1; }
+        |       or_expr BOR xor_expr { $$ = new ast::Binop($1, token::BOR, $3, @2); }
+                ;
 
-block_stmt : if_stmt                  { $$ = $1; }
-           | jump_stmt                { $$ = $1; }
-           | loop_stmt                { $$ = $1; }
-           ;
+xor_expr:
+                and_expr               { $$ = $1; }
+        |       xor_expr BXOR and_expr { $$ = new ast::Binop($1, token::BXOR, $3, @2); }
+                ;
 
-jump_stmt  : BREAK    { $$ = new ast::Jump(token::BREAK, @$); }
-           | CONTINUE { $$ = new ast::Jump(token::CONTINUE, @$); }
-           | RETURN   { $$ = new ast::Jump(token::RETURN, @$); }
-           ;
 
-loop_stmt  : UNROLL "(" int ")" block             { $$ = new ast::Unroll($3, $5, @1 + @4); }
-           | UNROLL "(" param ")" block           { $$ = new ast::Unroll($3, $5, @1 + @4); }
-           | WHILE  "(" expr ")" block            { $$ = new ast::While($3, $5, @1); }
-           ;
+and_expr:
+                equality_expr               { $$ = $1; }
+        |       and_expr BAND equality_expr { $$ = new ast::Binop($1, token::BAND, $3, @2); }
+                ;
 
-if_stmt : IF "(" expr ")" block                  { $$ = new ast::If($3, $5); }
-        | IF "(" expr ")" block ELSE block_or_if { $$ = new ast::If($3, $5, $7); }
-        ;
+equality_expr:
+                relational_expr                  { $$ = $1; }
+        |       equality_expr EQ relational_expr { $$ = new ast::Binop($1, token::EQ, $3, @2); }
+        |       equality_expr NE relational_expr { $$ = new ast::Binop($1, token::NE, $3, @2); }
+                ;
 
-block_or_if : block        { $$ = $1; }
-            | if_stmt      { $$ = new ast::StatementList; $$->emplace_back($1); }
-            ;
+relational_expr:
+                shift_expr                    { $$ = $1; }
+        |       relational_expr LE shift_expr { $$ = new ast::Binop($1, token::LE, $3, @2); }
+        |       relational_expr GE shift_expr { $$ = new ast::Binop($1, token::GE, $3, @2); }
+        |       relational_expr LT shift_expr { $$ = new ast::Binop($1, token::LT, $3, @2); }
+        |       relational_expr GT shift_expr { $$ = new ast::Binop($1, token::GT, $3, @2); }
+                ;
 
-stmt : expr                { $$ = new ast::ExprStatement($1, @1); }
-     | compound_assignment { $$ = $1; }
-     | jump_stmt           { $$ = $1; }
-     | map "=" expr        { $$ = new ast::AssignMapStatement($1, $3, false, @2); }
-     | var "=" expr        { $$ = new ast::AssignVarStatement($1, $3, false, @2); }
-     | tuple_assignment
-     ;
+shift_expr:
+                arith_expr                  { $$ = $1; }
+        |       shift_expr LEFT arith_expr  { $$ = new ast::Binop($1, token::LEFT, $3, @2); }
+        |       shift_expr RIGHT arith_expr { $$ = new ast::Binop($1, token::RIGHT, $3, @2); }
+                ;
 
-compound_assignment : map LEFTASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::LEFT,  $3, @2), true, @$); }
-                    | var LEFTASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::LEFT,  $3, @2), true, @$); }
-                    | map RIGHTASSIGN expr { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::RIGHT, $3, @2), true, @$); }
-                    | var RIGHTASSIGN expr { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::RIGHT, $3, @2), true, @$); }
-                    | map PLUSASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::PLUS,  $3, @2), true, @$); }
-                    | var PLUSASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::PLUS,  $3, @2), true, @$); }
-                    | map MINUSASSIGN expr { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MINUS, $3, @2), true, @$); }
-                    | var MINUSASSIGN expr { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MINUS, $3, @2), true, @$); }
-                    | map MULASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MUL,   $3, @2), true, @$); }
-                    | var MULASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MUL,   $3, @2), true, @$); }
-                    | map DIVASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::DIV,   $3, @2), true, @$); }
-                    | var DIVASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::DIV,   $3, @2), true, @$); }
-                    | map MODASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::MOD,   $3, @2), true, @$); }
-                    | var MODASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::MOD,   $3, @2), true, @$); }
-                    | map BANDASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BAND,  $3, @2), true, @$); }
-                    | var BANDASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BAND,  $3, @2), true, @$); }
-                    | map BORASSIGN expr   { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BOR,   $3, @2), true, @$); }
-                    | var BORASSIGN expr   { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BOR,   $3, @2), true, @$); }
-                    | map BXORASSIGN expr  { $$ = new ast::AssignMapStatement($1, new ast::Binop($1, token::BXOR,  $3, @2), true, @$); }
-                    | var BXORASSIGN expr  { $$ = new ast::AssignVarStatement($1, new ast::Binop($1, token::BXOR,  $3, @2), true, @$); }
-                    ;
+arith_expr:
+                cast_expr                  { $$ = $1; }
+        |       arith_expr PLUS cast_expr  { $$ = new ast::Binop($1, token::PLUS, $3, @2); }
+        |       arith_expr MINUS cast_expr { $$ = new ast::Binop($1, token::MINUS, $3, @2); }
+        |       arith_expr MUL cast_expr   { $$ = new ast::Binop($1, token::MUL, $3, @2); }
+        |       arith_expr DIV cast_expr   { $$ = new ast::Binop($1, token::DIV, $3, @2); }
+        |       arith_expr MOD cast_expr   { $$ = new ast::Binop($1, token::MOD, $3, @2); }
+                ;
 
-tuple_assignment : expr DOT INT "=" expr { error(@1 + @5, "Tuples are immutable once created. Consider creating a new tuple and assigning it instead."); YYERROR; }
+cast_expr:
+                unary_expr                            { $$ = $1; }
+        |       LPAREN IDENT RPAREN cast_expr         { $$ = new ast::Cast($2, false, false, $4, @1 + @3); }
+        |       LPAREN IDENT MUL RPAREN cast_expr     { $$ = new ast::Cast($2, true, false, $5, @1 + @3); }
+        |       LPAREN IDENT MUL MUL RPAREN cast_expr { $$ = new ast::Cast($2, true, true, $6, @1 + @3); }
+                ;
 
-int : MINUS INT    { $$ = new ast::Integer((long)(~(unsigned long)($2) + 1), @$); }
-    | INT          { $$ = new ast::Integer($1, @$); }
-    ;
+int:
+                MINUS INT    { $$ = new ast::Integer((long)(~(unsigned long)($2) + 1), @$); }
+        |       INT          { $$ = new ast::Integer($1, @$); }
+                ;
 
-expr : int                                      { $$ = $1; }
-     | STRING                                   { $$ = new ast::String($1, @$); }
-     | BUILTIN                                  { $$ = new ast::Builtin($1, @$); }
-     | CALL_BUILTIN                             { $$ = new ast::Builtin($1, @$); }
-     | IDENT                                    { $$ = new ast::Identifier($1, @$); }
-     | STACK_MODE                               { $$ = new ast::StackMode($1, @$); }
-     | ternary                                  { $$ = $1; }
-     | param                                    { $$ = $1; }
-     | map_or_var                               { $$ = $1; }
-     | call                                     { $$ = $1; }
-     | "(" expr ")"                             { $$ = $2; }
-     | expr EQ expr                             { $$ = new ast::Binop($1, token::EQ, $3, @2); }
-     | expr NE expr                             { $$ = new ast::Binop($1, token::NE, $3, @2); }
-     | expr LE expr                             { $$ = new ast::Binop($1, token::LE, $3, @2); }
-     | expr GE expr                             { $$ = new ast::Binop($1, token::GE, $3, @2); }
-     | expr LT expr                             { $$ = new ast::Binop($1, token::LT, $3, @2); }
-     | expr GT expr                             { $$ = new ast::Binop($1, token::GT, $3, @2); }
-     | expr LAND expr                           { $$ = new ast::Binop($1, token::LAND,  $3, @2); }
-     | expr LOR expr                            { $$ = new ast::Binop($1, token::LOR,   $3, @2); }
-     | expr LEFT expr                           { $$ = new ast::Binop($1, token::LEFT,  $3, @2); }
-     | expr RIGHT expr                          { $$ = new ast::Binop($1, token::RIGHT, $3, @2); }
-     | expr PLUS expr                           { $$ = new ast::Binop($1, token::PLUS,  $3, @2); }
-     | expr MINUS expr                          { $$ = new ast::Binop($1, token::MINUS, $3, @2); }
-     | expr MUL expr                            { $$ = new ast::Binop($1, token::MUL,   $3, @2); }
-     | expr DIV expr                            { $$ = new ast::Binop($1, token::DIV,   $3, @2); }
-     | expr MOD expr                            { $$ = new ast::Binop($1, token::MOD,   $3, @2); }
-     | expr BAND expr                           { $$ = new ast::Binop($1, token::BAND,  $3, @2); }
-     | expr BOR expr                            { $$ = new ast::Binop($1, token::BOR,   $3, @2); }
-     | expr BXOR expr                           { $$ = new ast::Binop($1, token::BXOR,  $3, @2); }
-     | LNOT expr                                { $$ = new ast::Unop(token::LNOT, $2, @1); }
-     | BNOT expr                                { $$ = new ast::Unop(token::BNOT, $2, @1); }
-     | MINUS expr                               { $$ = new ast::Unop(token::MINUS, $2, @1); }
-     | MUL  expr %prec DEREF                    { $$ = new ast::Unop(token::MUL,  $2, @1); }
-     | expr DOT ident                           { $$ = new ast::FieldAccess($1, $3, @2); }
-     | expr DOT INT                             { $$ = new ast::FieldAccess($1, $3, @3); }
-     | expr PTR ident                           { $$ = new ast::FieldAccess(new ast::Unop(token::MUL, $1, @2), $3, @$); }
-     | expr "[" expr "]"                        { $$ = new ast::ArrayAccess($1, $3, @2 + @4); }
-     | "(" IDENT ")" expr %prec CAST            { $$ = new ast::Cast($2, false, false, $4, @1 + @3); }
-     | "(" IDENT MUL ")" expr %prec CAST        { $$ = new ast::Cast($2, true, false, $5, @1 + @4); }
-     | "(" IDENT MUL MUL ")" expr %prec CAST    { $$ = new ast::Cast($2, true, true, $6, @1 + @5); }
-     | "(" expr "," vargs ")"                   {
-                                                  auto args = new ast::ExpressionList;
-                                                  args->emplace_back($2);
-                                                  args->insert(args->end(), $4->begin(), $4->end());
-                                                  $$ = new ast::Tuple(args, @$);
-                                                }
-     | pre_post_op                              { $$ = $1; }
-     ;
+ident:
+                IDENT         { $$ = $1; }
+        |       BUILTIN       { $$ = $1; }
+        |       CALL          { $$ = $1; }
+        |       CALL_BUILTIN  { $$ = $1; }
+        |       STACK_MODE    { $$ = $1; }
+                ;
 
-pre_post_op : map_or_var INCREMENT   { $$ = new ast::Unop(token::INCREMENT, $1, true, @2); }
-            | map_or_var DECREMENT   { $$ = new ast::Unop(token::DECREMENT, $1, true, @2); }
-            | INCREMENT map_or_var   { $$ = new ast::Unop(token::INCREMENT, $2, @1); }
-            | DECREMENT map_or_var   { $$ = new ast::Unop(token::DECREMENT, $2, @1); }
-            | ident INCREMENT      { error(@1, "The ++ operator must be applied to a map or variable"); YYERROR; }
-            | INCREMENT ident      { error(@1, "The ++ operator must be applied to a map or variable"); YYERROR; }
-            | ident DECREMENT      { error(@1, "The -- operator must be applied to a map or variable"); YYERROR; }
-            | DECREMENT ident      { error(@1, "The -- operator must be applied to a map or variable"); YYERROR; }
-            ;
+call:
+                CALL "(" ")"                 { $$ = new ast::Call($1, @$); }
+        |       CALL "(" vargs ")"           { $$ = new ast::Call($1, $3, @$); }
+        |       CALL_BUILTIN  "(" ")"        { $$ = new ast::Call($1, @$); }
+        |       CALL_BUILTIN "(" vargs ")"   { $$ = new ast::Call($1, $3, @$); }
+        |       IDENT "(" ")"                { error(@1, "Unknown function: " + $1); YYERROR;  }
+        |       IDENT "(" vargs ")"          { error(@1, "Unknown function: " + $1); YYERROR;  }
+        |       BUILTIN "(" ")"              { error(@1, "Unknown function: " + $1); YYERROR;  }
+        |       BUILTIN "(" vargs ")"        { error(@1, "Unknown function: " + $1); YYERROR;  }
+        |       STACK_MODE "(" ")"           { error(@1, "Unknown function: " + $1); YYERROR;  }
+        |       STACK_MODE "(" vargs ")"     { error(@1, "Unknown function: " + $1); YYERROR;  }
+                ;
 
-ident : IDENT         { $$ = $1; }
-      | BUILTIN       { $$ = $1; }
-      | CALL          { $$ = $1; }
-      | CALL_BUILTIN  { $$ = $1; }
-      | STACK_MODE    { $$ = $1; }
-      ;
+map:
+                MAP               { $$ = new ast::Map($1, @$); }
+        |       MAP "[" vargs "]" { $$ = new ast::Map($1, $3, @$); }
+                ;
 
-call : CALL "(" ")"                 { $$ = new ast::Call($1, @$); }
-     | CALL "(" vargs ")"           { $$ = new ast::Call($1, $3, @$); }
-     | CALL_BUILTIN  "(" ")"        { $$ = new ast::Call($1, @$); }
-     | CALL_BUILTIN "(" vargs ")"   { $$ = new ast::Call($1, $3, @$); }
-     | IDENT "(" ")"                { error(@1, "Unknown function: " + $1); YYERROR;  }
-     | IDENT "(" vargs ")"          { error(@1, "Unknown function: " + $1); YYERROR;  }
-     | BUILTIN "(" ")"              { error(@1, "Unknown function: " + $1); YYERROR;  }
-     | BUILTIN "(" vargs ")"        { error(@1, "Unknown function: " + $1); YYERROR;  }
-     | STACK_MODE "(" ")"           { error(@1, "Unknown function: " + $1); YYERROR;  }
-     | STACK_MODE "(" vargs ")"     { error(@1, "Unknown function: " + $1); YYERROR;  }
-     ;
+var:
+                VAR { $$ = new ast::Variable($1, @$); }
+                ;
 
-map : MAP               { $$ = new ast::Map($1, @$); }
-    | MAP "[" vargs "]" { $$ = new ast::Map($1, $3, @$); }
-    ;
+map_or_var:
+                var { $$ = $1; }
+        |       map { $$ = $1; }
+                ;
 
-var : VAR { $$ = new ast::Variable($1, @$); }
-    ;
+vargs:
+                vargs "," expr { $$ = $1; $1->push_back($3); }
+        |       expr           { $$ = new ast::ExpressionList; $$->push_back($1); }
+                ;
 
-map_or_var : var { $$ = $1; }
-           | map { $$ = $1; }
-           ;
-
-vargs : vargs "," expr { $$ = $1; $1->push_back($3); }
-      | expr           { $$ = new ast::ExpressionList; $$->push_back($1); }
-      ;
+compound_op:
+                LEFTASSIGN   { $$ = token::LEFT; }
+        |       BANDASSIGN   { $$ = token::BAND; }
+        |       BORASSIGN    { $$ = token::BOR; }
+        |       BXORASSIGN   { $$ = token::BXOR; }
+        |       DIVASSIGN    { $$ = token::DIV; }
+        |       MINUSASSIGN  { $$ = token::MINUS; }
+        |       MODASSIGN    { $$ = token::MOD; }
+        |       MULASSIGN    { $$ = token::MUL; }
+        |       PLUSASSIGN   { $$ = token::PLUS; }
+        |       RIGHTASSIGN  { $$ = token::RIGHT; }
+                ;
 
 %%
 


### PR DESCRIPTION
R/R conflicts should be avoided in LALR parsers (like ours) but we had
31 of them.

This completely restructures the parser to follow a more common
approach [1][2] which removes most of the ambiguities and *should* make
the parser easier to extend and understand.

The attach point part still has a r/r conflict which will be for a
follow up.

This still has a few s/r conflicts but those aren't as big of an issue

```
 warning: 4 shift/reduce conflicts [-Wconflicts-sr]
 warning: 1 reduce/reduce conflict [-Wconflicts-rr]

State 10 conflicts: 1 reduce/reduce
State 41 conflicts: 1 shift/reduce
State 51 conflicts: 1 shift/reduce
State 81 conflicts: 2 shift/reduce
```

[1]: http://www.quut.com/c/ANSI-C-grammar-y-2011.html#inclusive_or_expression
[2]: https://github.com/dtrace4linux/linux/blob/master/libdtrace/dt_grammar.y


