### PR TITLE
fix typos

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -7,7 +7,7 @@ We use clang-format with our custom config for formatting code. This was
 was already written. Instead of formatting the whole code base at once and
 breaking `git blame` we're taking an incremental approach, each new/modified bit
 of code needs to be formatted.
-The CI checks this too, if the changes don't adhere to our style the job will fali.
+The CI checks this too, if the changes don't adhere to our style the job will fail.
 
 ### Using clang-format
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -407,7 +407,7 @@ iscsid is sleeping.
 [...]
 ```
 
-This includes `The verifier log:` and then the log message from the in-kernel vertifier.
+This includes `The verifier log:` and then the log message from the in-kernel verifier.
 
 ## 7. Preprocessor Options
 
@@ -717,7 +717,7 @@ i: 5
 
 `++` and `--` can be used to conveniently increment or decrement counters in maps or variables.
 
-Note that maps will be implictly declared and initialized to 0 if not already
+Note that maps will be implicitly declared and initialized to 0 if not already
 declared or defined. Scratch variables must be initialized before using these
 operators.
 


### PR DESCRIPTION
I came across a typo in the reference guide, and decided to fix any others that I found. in the docs directory. 

Thanks for making and maintaining bpftrace and friends!