### PR TITLE
tests: Fix warning spew in codegen tests

### DIFF
--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -138,7 +138,7 @@ public:
   bool is_aslr_enabled(int pid);
   std::string get_string_literal(const ast::Expression *expr) const;
   std::optional<std::string> get_watchpoint_binary_path() const;
-  bool is_traceable_func(const std::string &func_name) const;
+  virtual bool is_traceable_func(const std::string &func_name) const;
 
   std::vector<std::unique_ptr<AttachedProbe>> attached_probes_;
   std::vector<Probe> watchpoint_probes_;

--- a/tests/codegen/call_kstack.cpp
+++ b/tests/codegen/call_kstack.cpp
@@ -19,64 +19,64 @@ TEST(codegen, call_kstack)
 
 TEST(codegen, call_kstack_mapids)
 {
-  BPFtrace bpftrace;
-  Driver driver(bpftrace);
+  auto bpftrace = get_mock_bpftrace();
+  Driver driver(*bpftrace);
 
   ASSERT_EQ(driver.parse_str(
                 "kprobe:f { @x = kstack(5); @y = kstack(6); @z = kstack(6) }"),
             0);
 
   ClangParser clang;
-  clang.parse(driver.root_, bpftrace);
+  clang.parse(driver.root_, *bpftrace);
 
   // Override to mockbpffeature.
-  bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace);
+  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+  ast::SemanticAnalyser semantics(driver.root_, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 
-  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  ast::CodegenLLVM codegen(driver.root_, *bpftrace);
   codegen.compile();
 
-  ASSERT_EQ(std::distance(bpftrace.maps.begin(), bpftrace.maps.end()), 6);
-  ASSERT_EQ(bpftrace.maps.CountStackTypes(), 2U);
+  ASSERT_EQ(std::distance(bpftrace->maps.begin(), bpftrace->maps.end()), 6);
+  ASSERT_EQ(bpftrace->maps.CountStackTypes(), 2U);
 
   StackType stack_type;
   stack_type.limit = 5;
-  ASSERT_TRUE(bpftrace.maps.Has(stack_type));
+  ASSERT_TRUE(bpftrace->maps.Has(stack_type));
   stack_type.limit = 6;
-  ASSERT_TRUE(bpftrace.maps.Has(stack_type));
+  ASSERT_TRUE(bpftrace->maps.Has(stack_type));
 }
 
 TEST(codegen, call_kstack_modes_mapids)
 {
-  BPFtrace bpftrace;
-  Driver driver(bpftrace);
+  auto bpftrace = get_mock_bpftrace();
+  Driver driver(*bpftrace);
 
   ASSERT_EQ(driver.parse_str("kprobe:f { @x = kstack(perf); @y = "
                              "kstack(bpftrace); @z = kstack() }"),
             0);
 
   ClangParser clang;
-  clang.parse(driver.root_, bpftrace);
+  clang.parse(driver.root_, *bpftrace);
 
   // Override to mockbpffeature.
-  bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace);
+  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+  ast::SemanticAnalyser semantics(driver.root_, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 
-  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  ast::CodegenLLVM codegen(driver.root_, *bpftrace);
   codegen.compile();
 
-  ASSERT_EQ(std::distance(bpftrace.maps.begin(), bpftrace.maps.end()), 6);
-  ASSERT_EQ(bpftrace.maps.CountStackTypes(), 2U);
+  ASSERT_EQ(std::distance(bpftrace->maps.begin(), bpftrace->maps.end()), 6);
+  ASSERT_EQ(bpftrace->maps.CountStackTypes(), 2U);
 
   StackType stack_type;
   stack_type.mode = StackMode::perf;
-  ASSERT_TRUE(bpftrace.maps.Has(stack_type));
+  ASSERT_TRUE(bpftrace->maps.Has(stack_type));
   stack_type.mode = StackMode::bpftrace;
-  ASSERT_TRUE(bpftrace.maps.Has(stack_type));
+  ASSERT_TRUE(bpftrace->maps.Has(stack_type));
 }
 
 } // namespace codegen

--- a/tests/codegen/call_ustack.cpp
+++ b/tests/codegen/call_ustack.cpp
@@ -19,64 +19,64 @@ TEST(codegen, call_ustack)
 
 TEST(codegen, call_ustack_mapids)
 {
-  BPFtrace bpftrace;
-  Driver driver(bpftrace);
+  auto bpftrace = get_mock_bpftrace();
+  Driver driver(*bpftrace);
 
   ASSERT_EQ(driver.parse_str(
                 "kprobe:f { @x = ustack(5); @y = ustack(6); @z = ustack(6) }"),
             0);
 
   ClangParser clang;
-  clang.parse(driver.root_, bpftrace);
+  clang.parse(driver.root_, *bpftrace);
 
   // Override to mockbpffeature.
-  bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace);
+  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+  ast::SemanticAnalyser semantics(driver.root_, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 
-  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  ast::CodegenLLVM codegen(driver.root_, *bpftrace);
   codegen.compile();
 
-  ASSERT_EQ(std::distance(bpftrace.maps.begin(), bpftrace.maps.end()), 6);
-  ASSERT_EQ(bpftrace.maps.CountStackTypes(), 2U);
+  ASSERT_EQ(std::distance(bpftrace->maps.begin(), bpftrace->maps.end()), 6);
+  ASSERT_EQ(bpftrace->maps.CountStackTypes(), 2U);
 
   StackType stack_type;
   stack_type.limit = 5;
-  ASSERT_TRUE(bpftrace.maps.Has(stack_type));
+  ASSERT_TRUE(bpftrace->maps.Has(stack_type));
   stack_type.limit = 6;
-  ASSERT_TRUE(bpftrace.maps.Has(stack_type));
+  ASSERT_TRUE(bpftrace->maps.Has(stack_type));
 }
 
 TEST(codegen, call_ustack_modes_mapids)
 {
-  BPFtrace bpftrace;
-  Driver driver(bpftrace);
+  auto bpftrace = get_mock_bpftrace();
+  Driver driver(*bpftrace);
 
   ASSERT_EQ(driver.parse_str("kprobe:f { @x = ustack(perf); @y = "
                              "ustack(bpftrace); @z = ustack() }"),
             0);
 
   ClangParser clang;
-  clang.parse(driver.root_, bpftrace);
+  clang.parse(driver.root_, *bpftrace);
 
   // Override to mockbpffeature.
-  bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace);
+  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+  ast::SemanticAnalyser semantics(driver.root_, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
   ASSERT_EQ(semantics.create_maps(true), 0);
 
-  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  ast::CodegenLLVM codegen(driver.root_, *bpftrace);
   codegen.compile();
 
-  ASSERT_EQ(std::distance(bpftrace.maps.begin(), bpftrace.maps.end()), 6);
-  ASSERT_EQ(bpftrace.maps.CountStackTypes(), 2U);
+  ASSERT_EQ(std::distance(bpftrace->maps.begin(), bpftrace->maps.end()), 6);
+  ASSERT_EQ(bpftrace->maps.CountStackTypes(), 2U);
 
   StackType stack_type;
   stack_type.mode = StackMode::perf;
-  ASSERT_TRUE(bpftrace.maps.Has(stack_type));
+  ASSERT_TRUE(bpftrace->maps.Has(stack_type));
   stack_type.mode = StackMode::bpftrace;
-  ASSERT_TRUE(bpftrace.maps.Has(stack_type));
+  ASSERT_TRUE(bpftrace->maps.Has(stack_type));
 }
 
 } // namespace codegen

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -81,9 +81,9 @@ static void test(const std::string &input,
                  const std::string &name,
                  bool safe_mode = true)
 {
-  BPFtrace bpftrace;
-  bpftrace.safe_mode_ = safe_mode;
-  test(bpftrace, input, name);
+  auto bpftrace = get_mock_bpftrace();
+  bpftrace->safe_mode_ = safe_mode;
+  test(*bpftrace, input, name);
 }
 
 } // namespace codegen

--- a/tests/codegen/dereference.cpp
+++ b/tests/codegen/dereference.cpp
@@ -6,7 +6,7 @@ namespace codegen {
 
 TEST(codegen, dereference)
 {
-  test("kprobe:f { @x = *1234 }",
+  test("kprobe:f { @x = *kptr(1234) }",
 
        NAME);
 }

--- a/tests/codegen/llvm/dereference.ll
+++ b/tests/codegen/llvm/dereference.ll
@@ -13,7 +13,7 @@ entry:
   %deref = alloca i64, align 8
   %1 = bitcast i64* %deref to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* %deref, i32 8, i64 1234)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %deref, i32 8, i64 1234)
   %2 = load i64, i64* %deref, align 8
   %3 = bitcast i64* %deref to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)

--- a/tests/codegen/llvm/ptr_to_ptr.ll
+++ b/tests/codegen/llvm/ptr_to_ptr.ll
@@ -27,13 +27,13 @@ entry:
   %5 = load i64, i64* %"$pp", align 8
   %6 = bitcast i64* %deref to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %probe_read = call i64 inttoptr (i64 4 to i64 (i64*, i32, i64)*)(i64* %deref, i32 8, i64 %5)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %deref, i32 8, i64 %5)
   %7 = load i64, i64* %deref, align 8
   %8 = bitcast i64* %deref to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
   %9 = bitcast i32* %deref1 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %probe_read2 = call i64 inttoptr (i64 4 to i64 (i32*, i32, i64)*)(i32* %deref1, i32 4, i64 %7)
+  %probe_read_kernel2 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %deref1, i32 4, i64 %7)
   %10 = load i32, i32* %deref1, align 4
   %11 = sext i32 %10 to i64
   %12 = bitcast i32* %deref1 to i8*

--- a/tests/codegen/ptr_to_ptr.cpp
+++ b/tests/codegen/ptr_to_ptr.cpp
@@ -6,9 +6,10 @@ namespace codegen {
 
 TEST(codegen, ptr_to_ptr)
 {
-  test(R"PROG(kprobe:f { $pp = (int32 **)0; printf("%d\n", **$pp); })PROG",
+  test(
+      R"PROG(kprobe:f { $pp = (int32 **)0; printf("%d\n", **kptr($pp)); })PROG",
 
-       NAME);
+      NAME);
 }
 
 } // namespace codegen

--- a/tests/codegen/runtime_error_check.cpp
+++ b/tests/codegen/runtime_error_check.cpp
@@ -6,16 +6,16 @@ namespace codegen {
 
 TEST(codegen, runtime_error_check)
 {
-  BPFtrace bpftrace;
-  bpftrace.helper_check_level_ = 1;
-  test(bpftrace, "kprobe:f { @++; }", NAME);
+  auto bpftrace = get_mock_bpftrace();
+  bpftrace->helper_check_level_ = 1;
+  test(*bpftrace, "kprobe:f { @++; }", NAME);
 }
 
 TEST(codegen, runtime_error_check_lookup)
 {
-  BPFtrace bpftrace;
-  bpftrace.helper_check_level_ = 2;
-  test(bpftrace, "kprobe:f { @++; }", NAME);
+  auto bpftrace = get_mock_bpftrace();
+  bpftrace->helper_check_level_ = 2;
+  test(*bpftrace, "kprobe:f { @++; }", NAME);
 }
 
 } // namespace codegen

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -67,6 +67,12 @@ public:
     return 0;
   }
 
+  bool is_traceable_func(
+      const std::string &__attribute__((unused))) const override
+  {
+    return true;
+  }
+
   void set_mock_probe_matcher(std::unique_ptr<MockProbeMatcher> probe_matcher)
   {
     probe_matcher_ = std::move(probe_matcher);


### PR DESCRIPTION
See individual commits for details.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
