### PR TITLE
Forbid casting of struct types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
   - [#1857](https://github.com/iovisor/bpftrace/pull/1857)
 - Preserve original order of struct types
   - [#1850](https://github.com/iovisor/bpftrace/pull/1850)
+- Forbid casting from/to struct types
+  - [#1873](https://github.com/iovisor/bpftrace/pull/1873)
 
 #### Deprecated
 

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -2007,6 +2007,12 @@ void SemanticAnalyser::visit(Cast &cast)
 {
   cast.expr->accept(*this);
 
+  if (cast.expr->type.IsRecordTy())
+  {
+    LOG(ERROR, cast.loc, err_)
+        << "Cannot cast from struct type \"" << cast.expr->type << "\"";
+  }
+
   bool is_ctx = cast.expr->type.IsCtxAccess();
   auto &intcasts = getIntcasts();
   auto k_v = intcasts.find(cast.cast_type);
@@ -2066,12 +2072,8 @@ void SemanticAnalyser::visit(Cast &cast)
   }
   else
   {
-    auto &etype = cast.expr->type;
-    if (etype.IsIntegerTy() || etype.IsPtrTy())
-    {
-      LOG(ERROR, cast.loc, err_) << "Cannot convert " << etype << " to struct";
-    }
-    cast.type = struct_type;
+    LOG(ERROR, cast.loc, err_)
+        << "Cannot cast to struct type \"" << cast.cast_type << "\"";
   }
   if (is_ctx)
     cast.type.MarkCtxAccess();


### PR DESCRIPTION
C does not allow casting struct types by value, so we should do the same in BPFtrace.

Resolves #1869.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
