### PR TITLE
mocks: Mock out ktime_get_boot_ns feature check

### DIFF
--- a/tests/codegen/llvm/builtin_elapsed.ll
+++ b/tests/codegen/llvm/builtin_elapsed.ll
@@ -36,7 +36,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   %4 = load i64, i64* %lookup_elem_val, align 8
   %5 = bitcast i64* %lookup_elem_val to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %get_ns = call i64 inttoptr (i64 5 to i64 ()*)()
+  %get_ns = call i64 inttoptr (i64 125 to i64 ()*)()
   %6 = sub i64 %get_ns, %4
   %7 = bitcast i64* %elapsed_key to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)

--- a/tests/codegen/llvm/builtin_nsecs.ll
+++ b/tests/codegen/llvm/builtin_nsecs.ll
@@ -10,7 +10,7 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_ns = call i64 inttoptr (i64 5 to i64 ()*)()
+  %get_ns = call i64 inttoptr (i64 125 to i64 ()*)()
   %1 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8

--- a/tests/codegen/llvm/call_strftime.ll
+++ b/tests/codegen/llvm/call_strftime.ll
@@ -23,7 +23,7 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   %5 = getelementptr %strftime_t, %strftime_t* %strftime_args, i64 0, i32 0
   store i64 0, i64* %5, align 8
-  %get_ns = call i64 inttoptr (i64 5 to i64 ()*)()
+  %get_ns = call i64 inttoptr (i64 125 to i64 ()*)()
   %6 = getelementptr %strftime_t, %strftime_t* %strftime_args, i64 0, i32 1
   store i64 %get_ns, i64* %6, align 8
   %7 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -100,6 +100,7 @@ public:
     has_probe_read_kernel_ = std::make_optional<bool>(has_features);
     has_features_ = has_features;
     has_d_path_ = std::make_optional<bool>(has_features);
+    has_ktime_get_boot_ns_ = std::make_optional<bool>(has_features);
   };
   bool has_features_;
 };


### PR DESCRIPTION
CI kernel has the feature now. Best mock it out so codegen tests
aren't kernel dependent.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
