### PR TITLE
Fix ClangParser memory leak

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to
   - [#1836](https://github.com/iovisor/bpftrace/pull/1836)
 - Fix false non-traceable function warnings
   - [#1866](https://github.com/iovisor/bpftrace/pull/1866)
+- Fix memory leak in clang parser
+  - [#1878](https://github.com/iovisor/bpftrace/pull/1878)
 
 #### Tools
 

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -367,6 +367,9 @@ CXErrorCode ClangParser::ClangParserHandler::parse_translation_unit(
     unsigned num_unsaved_files,
     unsigned options)
 {
+  // Clean up previous translation unit to prevent resource leak
+  clang_disposeTranslationUnit(translation_unit);
+
   return clang_parseTranslationUnit2(
       index,
       source_filename,

--- a/src/clang_parser.h
+++ b/src/clang_parser.h
@@ -101,7 +101,7 @@ private:
 
   private:
     CXIndex index;
-    CXTranslationUnit translation_unit;
+    CXTranslationUnit translation_unit = nullptr;
     std::vector<std::string> error_msgs;
   };
 };

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,6 +59,11 @@ endif()
 
 target_compile_definitions(bpftrace_test PRIVATE ${BPFTRACE_FLAGS})
 
+if(BUILD_ASAN)
+  target_compile_options(bpftrace_test PUBLIC "-fsanitize=address")
+  target_link_options(bpftrace_test PUBLIC "-fsanitize=address")
+endif()
+
 if(STATIC_LINKING)
   if(EMBED_USE_LLVM)
     target_link_options(bpftrace_test BEFORE PRIVATE "-static-libgcc" "-static-libstdc++")


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

This fix takes max RSS usage for `bpftrace_test` down from ~3G -> ~750M.

This closes #1852.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
