### PR TITLE
AOT: Refactor map creation and runtime resource code

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -22,6 +22,7 @@ add_library(libbpftrace
   clang_parser.cpp
   disasm.cpp
   driver.cpp
+  imap.cpp
   lockdown.cpp
   log.cpp
   map.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(libbpftrace
   printf.cpp
   relocator.cpp
   resolve_cgroupid.cpp
+  required_resources.cpp
   struct.cpp
   tracepoint_format_parser.cpp
   types.cpp

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -8,6 +8,7 @@ add_library(ast
   pass_manager.cpp
   portability_analyser.cpp
   printer.cpp
+  resource_analyser.cpp
   semantic_analyser.cpp
   signal.cpp
   visitors.cpp

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <vector>
 
+#include "mapkey.h"
 #include "types.h"
 #include "usdt.h"
 
@@ -182,6 +183,7 @@ public:
   ~Map();
 
   std::string ident;
+  MapKey key_type;
   ExpressionList *vargs = nullptr;
   bool skip_key_validation = false;
 

--- a/src/ast/codegen_llvm.cpp
+++ b/src/ast/codegen_llvm.cpp
@@ -263,12 +263,12 @@ void CodegenLLVM::visit(Builtin &builtin)
   }
   else if (builtin.ident == "probe")
   {
-    auto begin = bpftrace_.probe_ids_.begin();
-    auto end = bpftrace_.probe_ids_.end();
+    auto begin = bpftrace_.resources.probe_ids.begin();
+    auto end = bpftrace_.resources.probe_ids.end();
     auto found = std::find(begin, end, probefull_);
     builtin.probe_id = std::distance(begin, found);
     if (found == end) {
-      bpftrace_.probe_ids_.push_back(probefull_);
+      bpftrace_.resources.probe_ids.push_back(probefull_);
     }
     expr_ = b_.getInt64(builtin.probe_id);
   }
@@ -823,7 +823,7 @@ void CodegenLLVM::visit(Call &call)
       }
 
       // pick to current format string
-      auto ids = bpftrace_.seq_printf_ids_.at(seq_printf_id_);
+      auto ids = bpftrace_.resources.seq_printf_ids.at(seq_printf_id_);
       auto idx = std::get<0>(ids);
       auto size = std::get<1>(ids);
 
@@ -841,7 +841,7 @@ void CodegenLLVM::visit(Call &call)
     {
       createFormatStringCall(call,
                              printf_id_,
-                             bpftrace_.printf_args_,
+                             bpftrace_.resources.printf_args,
                              "printf",
                              AsyncAction::printf);
     }
@@ -850,14 +850,14 @@ void CodegenLLVM::visit(Call &call)
   {
     createFormatStringCall(call,
                            system_id_,
-                           bpftrace_.system_args_,
+                           bpftrace_.resources.system_args,
                            "system",
                            AsyncAction::syscall);
   }
   else if (call.func == "cat")
   {
     createFormatStringCall(
-        call, cat_id_, bpftrace_.cat_args_, "cat", AsyncAction::cat);
+        call, cat_id_, bpftrace_.resources.cat_args, "cat", AsyncAction::cat);
   }
   else if (call.func == "exit")
   {

--- a/src/ast/fake_map.cpp
+++ b/src/ast/fake_map.cpp
@@ -3,45 +3,32 @@
 namespace bpftrace {
 
 FakeMap::FakeMap(const std::string &name,
-                 const SizedType &type __attribute__((unused)),
-                 const MapKey &key __attribute__((unused)),
-                 int min __attribute__((unused)),
-                 int max __attribute__((unused)),
-                 int step __attribute__((unused)),
-                 int max_entries __attribute__((unused)))
+                 const SizedType &type,
+                 const MapKey &key,
+                 int min,
+                 int max,
+                 int step,
+                 int max_entries)
+    : IMap(name, type, key, min, max, step, max_entries)
 {
-  name_ = name;
-  mapfd_ = 0;
 }
 
 FakeMap::FakeMap(const std::string &name,
-                 const SizedType &type __attribute__((unused)),
-                 const MapKey &key __attribute__((unused)),
-                 int max_entries __attribute__((unused)))
+                 enum bpf_map_type type,
+                 int key_size,
+                 int value_size,
+                 int max_entries,
+                 int flags)
+    : IMap(name, type, key_size, value_size, max_entries, flags)
 {
-  name_ = name;
-  mapfd_ = 0;
 }
 
-FakeMap::FakeMap(const std::string &name,
-                 enum bpf_map_type type __attribute__((unused)),
-                 int key_size __attribute__((unused)),
-                 int value_size __attribute__((unused)),
-                 int max_entries __attribute__((unused)),
-                 int flags __attribute__((unused)))
+FakeMap::FakeMap(const SizedType &type) : IMap(type)
 {
-  name_ = name;
-  mapfd_ = 0;
 }
 
-FakeMap::FakeMap(const SizedType &type __attribute__((unused)))
+FakeMap::FakeMap(enum bpf_map_type map_type) : IMap(map_type)
 {
-  mapfd_ = 0;
-}
-
-FakeMap::FakeMap(enum bpf_map_type map_type __attribute__((unused)))
-{
-  mapfd_ = 0;
 }
 
 } // namespace bpftrace

--- a/src/ast/fake_map.h
+++ b/src/ast/fake_map.h
@@ -10,7 +10,8 @@ public:
   FakeMap(const std::string &name,
           const SizedType &type,
           const MapKey &key,
-          int max_entries = 0);
+          int max_entries)
+      : FakeMap(name, type, key, 0, 0, 0, max_entries){};
   FakeMap(const SizedType &type);
   FakeMap(enum bpf_map_type map_type);
   FakeMap(const std::string &name,

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1153,7 +1153,8 @@ void IRBuilderBPF::CreateHelperError(Value *ctx,
     return;
 
   int error_id = helper_error_id_++;
-  bpftrace_.helper_error_info_[error_id] = { .func_id = func_id, .loc = loc };
+  bpftrace_.resources.helper_error_info[error_id] = { .func_id = func_id,
+                                                      .loc = loc };
 
   auto elements = AsyncEvent::HelperError().asLLVMType(*this);
   StructType *helper_error_struct = GetStructType("helper_error_t",

--- a/src/ast/pass_manager.h
+++ b/src/ast/pass_manager.h
@@ -59,14 +59,6 @@ struct PassContext
 public:
   PassContext(BPFtrace &b) : b(b){};
   BPFtrace &b;
-
-private:
-  // As semantic pass and map creation are separate passes we need this
-  SemanticAnalyser *semant;
-
-  // Only ones allowed to access semant
-  friend Pass CreateSemanticPass();
-  friend Pass CreateMapCreatePass();
 };
 
 using PassFPtr = std::function<PassResult(Node &, PassContext &)>;

--- a/src/ast/resource_analyser.cpp
+++ b/src/ast/resource_analyser.cpp
@@ -1,0 +1,32 @@
+#include "resource_analyser.h"
+
+#include "bpftrace.h"
+
+namespace bpftrace {
+namespace ast {
+
+ResourceAnalyser::ResourceAnalyser(Node *root) : root_(root)
+{
+}
+
+RequiredResources ResourceAnalyser::analyse()
+{
+  Visit(*root_);
+  return resources_;
+}
+
+Pass CreateResourcePass()
+{
+  auto fn = [](Node &n, PassContext &ctx) {
+    ResourceAnalyser analyser{ &n };
+    auto resources = analyser.analyse();
+    ctx.b.resources = resources;
+
+    return PassResult::Success();
+  };
+
+  return Pass("ResourceAnalyser", fn);
+}
+
+} // namespace ast
+} // namespace bpftrace

--- a/src/ast/resource_analyser.cpp
+++ b/src/ast/resource_analyser.cpp
@@ -1,18 +1,174 @@
 #include "resource_analyser.h"
 
 #include "bpftrace.h"
+#include "struct.h"
 
 namespace bpftrace {
 namespace ast {
 
-ResourceAnalyser::ResourceAnalyser(Node *root) : root_(root)
+namespace {
+
+// This helper differs from SemanticAnalyser::single_provider_type() in that
+// for situations where a single probetype is required we assume the AST is
+// well formed.
+ProbeType single_provider_type_postsema(Probe *probe)
+{
+  for (auto &attach_point : *probe->attach_points)
+    return probetype(attach_point->provider);
+
+  return ProbeType::invalid;
+}
+
+std::string get_literal_string(Expression &expr)
+{
+  String &str = static_cast<String &>(expr);
+  return str.str;
+}
+
+} // namespace
+
+ResourceAnalyser::ResourceAnalyser(Node *root) : root_(root), probe_(nullptr)
 {
 }
 
 RequiredResources ResourceAnalyser::analyse()
 {
   Visit(*root_);
+  prepare_seq_printf_ids();
+
   return resources_;
+}
+
+void ResourceAnalyser::visit(Probe &probe)
+{
+  probe_ = &probe;
+  Visitor::visit(probe);
+}
+
+void ResourceAnalyser::visit(Builtin &builtin)
+{
+  if (builtin.ident == "elapsed")
+  {
+    resources_.needs_elapsed_map = true;
+  }
+  else if (builtin.ident == "kstack" || builtin.ident == "ustack")
+  {
+    resources_.stackid_maps.insert(StackType{});
+  }
+}
+
+void ResourceAnalyser::visit(Call &call)
+{
+  Visitor::visit(call);
+
+  if (call.func == "printf" || call.func == "system" || call.func == "cat")
+  {
+    std::string fmt = get_literal_string(*call.vargs->at(0));
+    std::vector<Field> args;
+    for (auto it = call.vargs->begin() + 1; it != call.vargs->end(); it++)
+    {
+      // Promote to 64-bit if it's not an aggregate type
+      SizedType ty = (*it)->type; // copy
+      if (!ty.IsAggregate() && !ty.IsTimestampTy())
+        ty.SetSize(8);
+
+      args.push_back(Field{
+          .name = "",
+          .type = ty,
+          .offset = 0,
+          .is_bitfield = false,
+          .bitfield =
+              Bitfield{
+                  .read_bytes = 0,
+                  .access_rshift = 0,
+                  .mask = 0,
+              },
+      });
+    }
+
+    if (call.func == "printf")
+    {
+      if (single_provider_type_postsema(probe_) == ProbeType::iter)
+      {
+        resources_.seq_printf_args.emplace_back(fmt, args);
+        resources_.needs_data_map = true;
+      }
+      else
+      {
+        resources_.printf_args.emplace_back(fmt, args);
+      }
+    }
+    else if (call.func == "system")
+    {
+      resources_.system_args.emplace_back(fmt, args);
+    }
+    else
+    {
+      resources_.cat_args.emplace_back(fmt, args);
+    }
+  }
+  else if (call.func == "join")
+  {
+    resources_.join_args.push_back(get_literal_string(*call.vargs->at(1)));
+    resources_.needs_join_map = true;
+  }
+  else if (call.func == "lhist")
+  {
+    Expression &min_arg = *call.vargs->at(1);
+    Expression &max_arg = *call.vargs->at(2);
+    Expression &step_arg = *call.vargs->at(3);
+    Integer &min = static_cast<Integer &>(min_arg);
+    Integer &max = static_cast<Integer &>(max_arg);
+    Integer &step = static_cast<Integer &>(step_arg);
+
+    resources_.lhist_args[call.map->ident] = LinearHistogramArgs{
+      .min = min.n,
+      .max = max.n,
+      .step = step.n,
+    };
+  }
+  else if (call.func == "time")
+  {
+    if (call.vargs && call.vargs->size() > 0)
+      resources_.time_args.push_back(get_literal_string(*call.vargs->at(0)));
+    else
+      resources_.time_args.push_back("%H:%M:%S\n");
+  }
+  else if (call.func == "strftime")
+  {
+    resources_.strftime_args.push_back(get_literal_string(*call.vargs->at(0)));
+  }
+  else if (call.func == "print")
+  {
+    auto &arg = *call.vargs->at(0);
+    if (!arg.is_map)
+      resources_.non_map_print_args.push_back(arg.type);
+  }
+  else if (call.func == "kstack" || call.func == "ustack")
+  {
+    resources_.stackid_maps.insert(call.type.stack_type);
+  }
+}
+
+void ResourceAnalyser::visit(Map &map)
+{
+  Visitor::visit(map);
+
+  resources_.map_vals[map.ident] = map.type;
+  resources_.map_keys[map.ident] = map.key_type;
+}
+
+void ResourceAnalyser::prepare_seq_printf_ids()
+{
+  int idx = 0;
+
+  for (auto &arg : resources_.seq_printf_args)
+  {
+    assert(resources_.needs_data_map);
+    auto len = std::get<0>(arg).size();
+    resources_.seq_printf_ids.push_back({ idx, len + 1 });
+    idx += len + 1;
+  }
 }
 
 Pass CreateResourcePass()

--- a/src/ast/resource_analyser.cpp
+++ b/src/ast/resource_analyser.cpp
@@ -109,7 +109,9 @@ void ResourceAnalyser::visit(Call &call)
   }
   else if (call.func == "join")
   {
-    resources_.join_args.push_back(get_literal_string(*call.vargs->at(1)));
+    auto delim = call.vargs->size() > 1 ? get_literal_string(*call.vargs->at(1))
+                                        : " ";
+    resources_.join_args.push_back(delim);
     resources_.needs_join_map = true;
   }
   else if (call.func == "lhist")
@@ -177,6 +179,11 @@ Pass CreateResourcePass()
     ResourceAnalyser analyser{ &n };
     auto resources = analyser.analyse();
     ctx.b.resources = resources;
+
+    // Create fake maps so that codegen has access to map IDs
+    //
+    // At runtime we will replace the fake maps with real maps
+    ctx.b.resources.create_maps(ctx.b, true);
 
     return PassResult::Success();
   };

--- a/src/ast/resource_analyser.h
+++ b/src/ast/resource_analyser.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include <iostream>
+#include <sstream>
+
+#include "pass_manager.h"
+#include "required_resources.h"
+#include "visitors.h"
+
+namespace bpftrace {
+namespace ast {
+
+// Resource analysis pass on AST
+//
+// This pass collects information on what runtime resources a script needs.
+// For example, how many maps to create, what sizes the keys and values are,
+// all the async printf argument types, etc.
+class ResourceAnalyser : public Visitor
+{
+public:
+  ResourceAnalyser(Node *root);
+
+  // Note we don't return errors here b/c we assume we are run after
+  // semantic analysis and AST is well formed.
+  RequiredResources analyse();
+
+private:
+  RequiredResources resources_;
+  Node *root_;
+};
+
+Pass CreateResourcePass();
+
+} // namespace ast
+} // namespace bpftrace

--- a/src/ast/resource_analyser.h
+++ b/src/ast/resource_analyser.h
@@ -15,6 +15,10 @@ namespace ast {
 // This pass collects information on what runtime resources a script needs.
 // For example, how many maps to create, what sizes the keys and values are,
 // all the async printf argument types, etc.
+//
+// TODO(danobi): Note that while complete resource collection in this pass is
+// the goal, there are still places where the goal is not yet realized. For
+// example the helper error metadata is still being collected during codegen.
 class ResourceAnalyser : public Visitor
 {
 public:
@@ -25,8 +29,20 @@ public:
   RequiredResources analyse();
 
 private:
+  void visit(Probe &probe) override;
+  void visit(Builtin &map) override;
+  void visit(Call &call) override;
+  void visit(Map &map) override;
+
+  // All the seq_printf format strings are stored head to tail in a data
+  // map. This method loads `RequiredResources::seq_printf_ids` with the
+  // starting indicies and lengths of each format string in the data map.
+  void prepare_seq_printf_ids();
+
   RequiredResources resources_;
   Node *root_;
+  // Current probe we're analysing
+  Probe *probe_;
 };
 
 Pass CreateResourcePass();

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1414,6 +1414,12 @@ void SemanticAnalyser::visit(Map &map)
     }
     map.type = CreateNone();
   }
+
+  // MapKey default initializes to no args so we don't need to do anything
+  // if we don't find a key here
+  auto map_key_search_val = map_key_.find(map.ident);
+  if (map_key_search_val != map_key_.end())
+    map.key_type = map_key_search_val->second;
 }
 
 void SemanticAnalyser::visit(Variable &var)

--- a/src/ast/semantic_analyser.h
+++ b/src/ast/semantic_analyser.h
@@ -70,7 +70,6 @@ public:
   void visit(AttachPoint &ap) override;
   void visit(Probe &probe) override;
   void visit(Program &program) override;
-  int create_maps(bool debug);
 
   int analyse();
 
@@ -105,8 +104,6 @@ private:
 
   void builtin_args_tracepoint(AttachPoint *attach_point, Builtin &builtin);
   ProbeType single_provider_type(void);
-  template <typename T>
-  int create_maps_impl(void);
   AddrSpace find_addrspace(ProbeType pt);
 
   void binop_int(Binop &op);
@@ -128,14 +125,9 @@ private:
   std::map<std::string, SizedType> variable_val_;
   std::map<std::string, SizedType> map_val_;
   std::map<std::string, MapKey> map_key_;
-  std::map<std::string, ExpressionList> map_args_;
   std::map<std::string, SizedType> ap_args_;
-  std::unordered_set<StackType> needs_stackid_maps_;
 
   uint32_t loop_depth_ = 0;
-  bool needs_join_map_ = false;
-  bool needs_elapsed_map_ = false;
-  bool needs_data_map_ = false;
   bool has_begin_probe_ = false;
   bool has_end_probe_ = false;
   bool has_child_ = false;
@@ -143,6 +135,5 @@ private:
 };
 
 Pass CreateSemanticPass();
-Pass CreateMapCreatePass();
 } // namespace ast
 } // namespace bpftrace

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1284,8 +1284,7 @@ int BPFtrace::print_maps()
 {
   for (auto &mapmap : maps)
   {
-    // Only print out named maps
-    if (mapmap->name_.empty())
+    if (!mapmap->is_printable())
       continue;
 
     int err = print_map(*mapmap.get(), 0, 0);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -21,6 +21,7 @@
 #include "printf.h"
 #include "probe_matcher.h"
 #include "procmon.h"
+#include "required_resources.h"
 #include "struct.h"
 #include "types.h"
 #include "utils.h"
@@ -147,6 +148,7 @@ public:
   // Global variable checking if an exit signal was received
   static volatile sig_atomic_t exitsig_recv;
 
+  RequiredResources resources;
   MapManager maps;
   std::unique_ptr<BpfOrc> bpforc_;
   StructManager structs;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -148,18 +148,8 @@ public:
   StructManager structs;
   std::map<std::string, std::string> macros_;
   std::map<std::string, uint64_t> enums_;
-  std::vector<std::tuple<std::string, std::vector<Field>>> printf_args_;
-  std::vector<std::tuple<std::string, std::vector<Field>>> system_args_;
-  std::vector<std::tuple<std::string, std::vector<Field>>> seq_printf_args_;
-  std::vector<std::string> join_args_;
-  std::vector<std::string> time_args_;
-  std::vector<std::string> strftime_args_;
-  std::vector<std::tuple<std::string, std::vector<Field>>> cat_args_;
-  std::vector<SizedType> non_map_print_args_;
-  std::unordered_map<int64_t, struct HelperErrorInfo> helper_error_info_;
   std::unordered_set<std::string> traceable_funcs_;
 
-  std::vector<std::string> probe_ids_;
   unsigned int join_argnum_ = 16;
   unsigned int join_argsize_ = 1024;
   std::unique_ptr<Output> out_;
@@ -200,8 +190,6 @@ public:
   }
   int ncpus_;
   int online_cpus_;
-
-  std::vector<std::tuple<int, int>> seq_printf_ids_;
 
   std::vector<Probe> probes_;
   std::vector<Probe> special_probes_;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -84,12 +84,6 @@ private:
   std::string msg_;
 };
 
-struct HelperErrorInfo
-{
-  int func_id;
-  location loc;
-};
-
 class BPFtrace
 {
 public:

--- a/src/imap.cpp
+++ b/src/imap.cpp
@@ -1,0 +1,56 @@
+#include "imap.h"
+
+#include <linux/version.h>
+
+namespace bpftrace {
+
+IMap::IMap(const std::string &name,
+           const SizedType &type,
+           const MapKey &key,
+           int min,
+           int max,
+           int step,
+           int max_entries __attribute__((unused)))
+    : name_(name), type_(type), key_(key), lqmin(min), lqmax(max), lqstep(step)
+{
+  if (type.IsCountTy() && !key.args_.size())
+  {
+    map_type_ = BPF_MAP_TYPE_PERCPU_ARRAY;
+  }
+  else if ((type.IsHistTy() || type.IsLhistTy() || type.IsCountTy() ||
+            type.IsSumTy() || type.IsMinTy() || type.IsMaxTy() ||
+            type.IsAvgTy() || type.IsStatsTy()) &&
+           (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)))
+  {
+    map_type_ = BPF_MAP_TYPE_PERCPU_HASH;
+  }
+  else
+  {
+    map_type_ = BPF_MAP_TYPE_HASH;
+  }
+}
+
+IMap::IMap(const std::string &name,
+           enum bpf_map_type type,
+           int key_size __attribute__((unused)),
+           int value_size __attribute__((unused)),
+           int max_entries __attribute__((unused)),
+           int flags __attribute__((unused)))
+    : name_(name), map_type_(type)
+{
+}
+
+IMap::IMap(const SizedType &type)
+    : type_(type), map_type_(BPF_MAP_TYPE_STACK_TRACE)
+{
+  // This constructor should only be called with stack types
+  assert(type.IsStack());
+}
+
+IMap::IMap(enum bpf_map_type map_type) : map_type_(map_type)
+{
+  // This constructor should only be called for perf events
+  assert(map_type == BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+}
+
+} // namespace bpftrace

--- a/src/imap.h
+++ b/src/imap.h
@@ -12,16 +12,44 @@ namespace bpftrace {
 class IMap
 {
 public:
-  virtual ~IMap() { }
-  IMap() { }
+  IMap(const std::string &name,
+       const SizedType &type,
+       const MapKey &key,
+       int max_entries)
+      : IMap(name, type, key, 0, 0, 0, max_entries){};
+  IMap(const std::string &name,
+       const SizedType &type,
+       const MapKey &key,
+       int min,
+       int max,
+       int step,
+       int max_entries);
+  IMap(const std::string &name,
+       enum bpf_map_type type,
+       int key_size,
+       int value_size,
+       int max_entries,
+       int flags);
+  IMap(const SizedType &type);
+  IMap(enum bpf_map_type map_type);
+  virtual ~IMap() = default;
   IMap(const IMap &) = delete;
   IMap &operator=(const IMap &) = delete;
 
-  int mapfd_;
+  // unique id of this map. Used by runtime to reference this map
+  uint32_t id = static_cast<uint32_t>(-1);
+
+  int mapfd_ = -1;
   std::string name_;
   SizedType type_;
   MapKey key_;
-  enum bpf_map_type map_type_;
+  enum bpf_map_type map_type_ = BPF_MAP_TYPE_UNSPEC;
+
+  // used by lhist(). TODO: move to separate Map object.
+  int lqmin = 0;
+  int lqmax = 0;
+  int lqstep = 0;
+
   bool is_per_cpu_type()
   {
     return map_type_ == BPF_MAP_TYPE_PERCPU_HASH ||
@@ -32,14 +60,6 @@ public:
     return map_type_ != BPF_MAP_TYPE_ARRAY &&
            map_type_ != BPF_MAP_TYPE_PERCPU_ARRAY;
   }
-
-  // unique id of this map. Used by (bpf) runtime to reference
-  // this map
-  uint32_t id;
-  // used by lhist(). TODO: move to separate Map object.
-  int lqmin;
-  int lqmax;
-  int lqstep;
 };
 
 } // namespace bpftrace

--- a/src/imap.h
+++ b/src/imap.h
@@ -44,6 +44,7 @@ public:
   SizedType type_;
   MapKey key_;
   enum bpf_map_type map_type_ = BPF_MAP_TYPE_UNSPEC;
+  bool printable_ = true;
 
   // used by lhist(). TODO: move to separate Map object.
   int lqmin = 0;
@@ -59,6 +60,10 @@ public:
   {
     return map_type_ != BPF_MAP_TYPE_ARRAY &&
            map_type_ != BPF_MAP_TYPE_PERCPU_ARRAY;
+  }
+  bool is_printable() const
+  {
+    return printable_;
   }
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -412,7 +412,6 @@ ast::PassManager CreateDynamicPM()
   pm.AddPass(ast::CreateSemanticPass());
   pm.AddPass(ast::CreateCounterPass());
   pm.AddPass(ast::CreateResourcePass());
-  pm.AddPass(ast::CreateMapCreatePass());
 
   return pm;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -16,6 +16,7 @@
 #include "ast/node_counter.h"
 #include "ast/pass_manager.h"
 #include "ast/portability_analyser.h"
+#include "ast/resource_analyser.h"
 #include "ast/semantic_analyser.h"
 #include "bpffeature.h"
 #include "bpforc.h"
@@ -410,6 +411,7 @@ ast::PassManager CreateDynamicPM()
   ast::PassManager pm;
   pm.AddPass(ast::CreateSemanticPass());
   pm.AddPass(ast::CreateCounterPass());
+  pm.AddPass(ast::CreateResourcePass());
   pm.AddPass(ast::CreateMapCreatePass());
 
   return pm;
@@ -420,6 +422,7 @@ ast::PassManager CreateAotPM(std::string __attribute__((unused)))
   ast::PassManager pm;
   pm.AddPass(ast::CreateSemanticPass());
   pm.AddPass(ast::CreatePortabilityPass());
+  pm.AddPass(ast::CreateResourcePass());
 
   return pm;
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -195,6 +195,7 @@ void MapManager::Set(MapManager::Type t, std::unique_ptr<IMap> map)
 {
   auto id = maps_by_id_.size();
   map->id = id;
+  map->printable_ = false;
   maps_by_type_[t] = map.get();
   maps_by_id_.emplace_back(std::move(map));
 }
@@ -219,6 +220,7 @@ void MapManager::Set(StackType t, std::unique_ptr<IMap> map)
 {
   auto id = maps_by_id_.size();
   map->id = id;
+  map->printable_ = false;
   stackid_maps_[t] = map.get();
   maps_by_id_.emplace_back(std::move(map));
 }

--- a/src/map.h
+++ b/src/map.h
@@ -28,12 +28,5 @@ public:
   Map(const SizedType &type);
   Map(enum bpf_map_type map_type);
   virtual ~Map() override;
-
-  int create_map(enum bpf_map_type map_type,
-                 const std::string &name,
-                 int key_size,
-                 int value_size,
-                 int max_entries,
-                 int flags);
 };
 } // namespace bpftrace

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -101,7 +101,7 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
     case Type::username:
       return bpftrace.resolve_uid(read_data<uint64_t>(data));
     case Type::probe:
-      return bpftrace.probe_ids_[read_data<uint64_t>(data)];
+      return bpftrace.resources.probe_ids[read_data<uint64_t>(data)];
     case Type::string:
     {
       auto p = static_cast<const char *>(data);

--- a/src/mapmanager.h
+++ b/src/mapmanager.h
@@ -16,11 +16,11 @@ class MapManager
 {
 public:
   MapManager() = default;
+  MapManager &operator=(MapManager &&) = default;
 
   MapManager(const MapManager &) = delete;
   MapManager &operator=(const MapManager &) = delete;
   MapManager(MapManager &&) = delete;
-  MapManager &operator=(MapManager &&) = delete;
 
   /**
      Store and lookup named maps

--- a/src/mapmanager.h
+++ b/src/mapmanager.h
@@ -3,6 +3,7 @@
 #include "imap.h"
 #include <map>
 #include <memory>
+#include <optional>
 #include <unordered_map>
 
 namespace bpftrace {

--- a/src/required_resources.cpp
+++ b/src/required_resources.cpp
@@ -1,0 +1,1 @@
+#include "required_resources.h"

--- a/src/required_resources.cpp
+++ b/src/required_resources.cpp
@@ -18,7 +18,9 @@ template <typename T>
 int RequiredResources::create_maps_impl(BPFtrace &bpftrace, bool fake)
 {
   uint32_t failed_maps = 0;
-  auto is_invalid_map = [](int a) -> uint8_t { return a < 0 ? 1 : 0; };
+  auto is_invalid_map = [=](int a) -> uint8_t {
+    return (!fake && a < 0) ? 1 : 0;
+  };
   for (auto &map_val : map_vals)
   {
     std::string map_name = map_val.first;

--- a/src/required_resources.cpp
+++ b/src/required_resources.cpp
@@ -1,1 +1,133 @@
 #include "required_resources.h"
+
+#include "bpftrace.h"
+#include "fake_map.h"
+#include "log.h"
+
+namespace bpftrace {
+
+int RequiredResources::create_maps(BPFtrace &bpftrace, bool fake)
+{
+  if (fake)
+    return create_maps_impl<bpftrace::FakeMap>(bpftrace, fake);
+  else
+    return create_maps_impl<bpftrace::Map>(bpftrace, fake);
+}
+
+template <typename T>
+int RequiredResources::create_maps_impl(BPFtrace &bpftrace, bool fake)
+{
+  uint32_t failed_maps = 0;
+  auto is_invalid_map = [](int a) -> uint8_t { return a < 0 ? 1 : 0; };
+  for (auto &map_val : map_vals)
+  {
+    std::string map_name = map_val.first;
+    SizedType type = map_val.second;
+
+    auto search_args = map_keys.find(map_name);
+    if (search_args == map_keys.end())
+      LOG(FATAL) << "map key \"" << map_name << "\" not found";
+
+    auto &key = search_args->second;
+
+    if (type.IsLhistTy())
+    {
+      auto args = lhist_args.find(map_name);
+      if (args == lhist_args.end())
+        LOG(FATAL) << "map arg \"" << map_name << "\" not found";
+
+      auto min = args->second.min;
+      auto max = args->second.max;
+      auto step = args->second.step;
+      auto map = std::make_unique<T>(
+          map_name, type, key, min, max, step, bpftrace.mapmax_);
+      failed_maps += is_invalid_map(map->mapfd_);
+      bpftrace.maps.Add(std::move(map));
+    }
+    else
+    {
+      auto map = std::make_unique<T>(map_name, type, key, bpftrace.mapmax_);
+      failed_maps += is_invalid_map(map->mapfd_);
+      bpftrace.maps.Add(std::move(map));
+    }
+  }
+
+  for (StackType stack_type : stackid_maps)
+  {
+    // The stack type doesn't matter here, so we use kstack to force SizedType
+    // to set stack_size.
+    auto map = std::make_unique<T>(CreateStack(true, stack_type));
+    failed_maps += is_invalid_map(map->mapfd_);
+    bpftrace.maps.Set(stack_type, std::move(map));
+  }
+
+  if (needs_join_map)
+  {
+    // join uses map storage as we'd like to process data larger than can fit on
+    // the BPF stack.
+    int value_size = 8 + 8 + bpftrace.join_argnum_ * bpftrace.join_argsize_;
+    auto map = std::make_unique<T>(
+        "join", BPF_MAP_TYPE_PERCPU_ARRAY, 4, value_size, 1, 0);
+    failed_maps += is_invalid_map(map->mapfd_);
+    bpftrace.maps.Set(MapManager::Type::Join, std::move(map));
+  }
+  if (needs_elapsed_map)
+  {
+    std::string map_ident = "elapsed";
+    SizedType type = CreateUInt64();
+    MapKey key;
+    auto map = std::make_unique<T>(map_ident, type, key, 1);
+    failed_maps += is_invalid_map(map->mapfd_);
+    bpftrace.maps.Set(MapManager::Type::Elapsed, std::move(map));
+  }
+  if (needs_data_map)
+  {
+    // get size of all the format strings
+    size_t size = 0;
+    for (auto it : seq_printf_args)
+      size += std::get<0>(it).size() + 1;
+
+    // compute buffer size to hold all the formats and create map with that
+    int ptr_size = sizeof(unsigned long);
+    size = (size / ptr_size + 1) * ptr_size;
+    auto map = std::make_unique<T>("data", BPF_MAP_TYPE_ARRAY, 4, size, 1, 0);
+
+    // copy all the format strings to buffer, head to tail
+    uint32_t idx = 0;
+    std::vector<uint8_t> formats(size, 0);
+    for (auto &arg : seq_printf_args)
+    {
+      auto str = std::get<0>(arg).c_str();
+      auto len = std::get<0>(arg).size();
+      memcpy(&formats.data()[idx], str, len);
+      idx += len + 1;
+    }
+
+    // store the data in map
+    uint64_t id = 0;
+    int ret = bpf_update_elem(map->mapfd_, &id, formats.data(), 0);
+
+    if (is_invalid_map(map->mapfd_) || (!fake && ret == -1))
+      failed_maps += 1;
+
+    bpftrace.maps.Set(MapManager::Type::SeqPrintfData, std::move(map));
+  }
+  {
+    auto map = std::make_unique<T>(BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+    failed_maps += is_invalid_map(map->mapfd_);
+    bpftrace.maps.Set(MapManager::Type::PerfEvent, std::move(map));
+  }
+
+  if (failed_maps > 0)
+  {
+    std::cerr << "Creation of the required BPF maps has failed." << std::endl;
+    std::cerr << "Make sure you have all the required permissions and are not";
+    std::cerr << " confined (e.g. like" << std::endl;
+    std::cerr << "snapcraft does). `dmesg` will likely have useful output for";
+    std::cerr << " further troubleshooting" << std::endl;
+  }
+
+  return failed_maps;
+}
+
+} // namespace bpftrace

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <tuple>
 #include <unordered_set>
@@ -37,6 +38,16 @@ struct LinearHistogramArgs
 class RequiredResources
 {
 public:
+  // Create maps in `maps` based on stored metadata
+  //
+  // If `fake` is set, then `FakeMap`s will be created. This is useful for:
+  // * allocating map IDs for codegen, because there's no need to prematurely
+  //   create resources that may not get used (debug mode, AOT codepath, etc.)
+  // * unit tests, as unit tests should not make system state changes
+  //
+  // Returns 0 on success, number of maps that failed to be created otherwise
+  int create_maps(BPFtrace &bpftrace, bool fake);
+
   // Async argument metadata
   std::vector<std::tuple<std::string, std::vector<Field>>> system_args;
   std::vector<std::tuple<std::string, std::vector<Field>>> seq_printf_args;
@@ -65,6 +76,10 @@ public:
   bool needs_join_map = false;
   bool needs_elapsed_map = false;
   bool needs_data_map = false;
+
+private:
+  template <typename T>
+  int create_maps_impl(BPFtrace &bpftrace, bool fake);
 };
 
 } // namespace bpftrace

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -1,8 +1,32 @@
 #pragma once
 
+#include <string>
+#include <tuple>
+#include <unordered_set>
+#include <vector>
+
+#include "location.hh"
+#include "mapkey.h"
+#include "mapmanager.h"
+#include "struct.h"
+#include "types.h"
+
 namespace bpftrace {
 
 class BPFtrace;
+
+struct HelperErrorInfo
+{
+  int func_id = -1;
+  location loc;
+};
+
+struct LinearHistogramArgs
+{
+  long min = -1;
+  long max = -1;
+  long step = -1;
+};
 
 // This class contains script-specific metadata that bpftrace's runtime needs.
 //
@@ -12,6 +36,35 @@ class BPFtrace;
 // script on another host.
 class RequiredResources
 {
+public:
+  // Async argument metadata
+  std::vector<std::tuple<std::string, std::vector<Field>>> system_args;
+  std::vector<std::tuple<std::string, std::vector<Field>>> seq_printf_args;
+  std::vector<std::tuple<int, int>> seq_printf_ids;
+  std::vector<std::string> join_args;
+  std::vector<std::string> time_args;
+  std::vector<std::string> strftime_args;
+  std::vector<std::tuple<std::string, std::vector<Field>>> cat_args;
+  std::vector<SizedType> non_map_print_args;
+
+  // Async argument metadata that codegen creates. Ideally ResourceAnalyser
+  // pass should be collecting this, but it's complex to move the logic.
+  //
+  // Don't add more async arguments here!.
+  std::unordered_map<int64_t, struct HelperErrorInfo> helper_error_info;
+  // `printf_args` is created here but the field offsets are fixed up
+  // by codegen -- only codegen knows data layout to compute offsets
+  std::vector<std::tuple<std::string, std::vector<Field>>> printf_args;
+  std::vector<std::string> probe_ids;
+
+  // Map metadata
+  std::map<std::string, SizedType> map_vals;
+  std::map<std::string, LinearHistogramArgs> lhist_args;
+  std::map<std::string, MapKey> map_keys;
+  std::unordered_set<StackType> stackid_maps;
+  bool needs_join_map = false;
+  bool needs_elapsed_map = false;
+  bool needs_data_map = false;
 };
 
 } // namespace bpftrace

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -1,0 +1,17 @@
+#pragma once
+
+namespace bpftrace {
+
+class BPFtrace;
+
+// This class contains script-specific metadata that bpftrace's runtime needs.
+//
+// This class is intended to completely encapsulate all of a script's runtime
+// needs such as maps, async printf argument metadata, etc. An instance of this
+// class plus the actual bpf bytecode should be all that's necessary to run a
+// script on another host.
+class RequiredResources
+{
+};
+
+} // namespace bpftrace

--- a/tests/codegen/call_kstack.cpp
+++ b/tests/codegen/call_kstack.cpp
@@ -33,7 +33,11 @@ TEST(codegen, call_kstack_mapids)
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   ast::SemanticAnalyser semantics(driver.root_, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
-  ASSERT_EQ(semantics.create_maps(true), 0);
+
+  ast::ResourceAnalyser resource_analyser(driver.root_);
+  auto resources = resource_analyser.analyse();
+  ASSERT_EQ(resources.create_maps(*bpftrace, true), 0);
+  bpftrace->resources = resources;
 
   ast::CodegenLLVM codegen(driver.root_, *bpftrace);
   codegen.compile();
@@ -64,7 +68,11 @@ TEST(codegen, call_kstack_modes_mapids)
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   ast::SemanticAnalyser semantics(driver.root_, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
-  ASSERT_EQ(semantics.create_maps(true), 0);
+
+  ast::ResourceAnalyser resource_analyser(driver.root_);
+  auto resources = resource_analyser.analyse();
+  ASSERT_EQ(resources.create_maps(*bpftrace, true), 0);
+  bpftrace->resources = resources;
 
   ast::CodegenLLVM codegen(driver.root_, *bpftrace);
   codegen.compile();

--- a/tests/codegen/call_ustack.cpp
+++ b/tests/codegen/call_ustack.cpp
@@ -33,7 +33,11 @@ TEST(codegen, call_ustack_mapids)
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   ast::SemanticAnalyser semantics(driver.root_, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
-  ASSERT_EQ(semantics.create_maps(true), 0);
+
+  ast::ResourceAnalyser resource_analyser(driver.root_);
+  auto resources = resource_analyser.analyse();
+  ASSERT_EQ(resources.create_maps(*bpftrace, true), 0);
+  bpftrace->resources = resources;
 
   ast::CodegenLLVM codegen(driver.root_, *bpftrace);
   codegen.compile();
@@ -64,7 +68,11 @@ TEST(codegen, call_ustack_modes_mapids)
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   ast::SemanticAnalyser semantics(driver.root_, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
-  ASSERT_EQ(semantics.create_maps(true), 0);
+
+  ast::ResourceAnalyser resource_analyser(driver.root_);
+  auto resources = resource_analyser.analyse();
+  ASSERT_EQ(resources.create_maps(*bpftrace, true), 0);
+  bpftrace->resources = resources;
 
   ast::CodegenLLVM codegen(driver.root_, *bpftrace);
   codegen.compile();

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -6,6 +6,7 @@
 #include "gtest/gtest.h"
 
 #include "../mocks.h"
+#include "ast/resource_analyser.h"
 #include "ast/semantic_analyser.h"
 #include "bpffeature.h"
 #include "bpforc.h"
@@ -51,7 +52,11 @@ static void test(BPFtrace &bpftrace,
   bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
   ast::SemanticAnalyser semantics(driver.root_, bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
-  ASSERT_EQ(semantics.create_maps(true), 0);
+
+  ast::ResourceAnalyser resource_analyser(driver.root_);
+  auto resources = resource_analyser.analyse();
+  ASSERT_EQ(resources.create_maps(bpftrace, true), 0);
+  bpftrace.resources = resources;
 
   std::stringstream out;
   ast::CodegenLLVM codegen(driver.root_, bpftrace);

--- a/tests/codegen/regression.cpp
+++ b/tests/codegen/regression.cpp
@@ -1,6 +1,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+#include "ast/resource_analyser.h"
 #include "ast/semantic_analyser.h"
 #include "bpforc.h"
 #include "bpftrace.h"
@@ -25,7 +26,12 @@ TEST(codegen, regression_957)
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   ast::SemanticAnalyser semantics(driver.root_, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
-  ASSERT_EQ(semantics.create_maps(true), 0);
+
+  ast::ResourceAnalyser resource_analyser(driver.root_);
+  auto resources = resource_analyser.analyse();
+  ASSERT_EQ(resources.create_maps(*bpftrace, true), 0);
+  bpftrace->resources = resources;
+
   ast::CodegenLLVM codegen(driver.root_, *bpftrace);
   codegen.compile();
 }

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -1,4 +1,5 @@
 #include "ast/field_analyser.h"
+#include "ast/resource_analyser.h"
 #include "ast/semantic_analyser.h"
 #include "bpforc.h"
 #include "bpftrace.h"
@@ -35,7 +36,11 @@ void gen_bytecode(const std::string &input, std::stringstream &out)
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
   ast::SemanticAnalyser semantics(driver.root_, *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
-  ASSERT_EQ(semantics.create_maps(true), 0);
+
+  ast::ResourceAnalyser resource_analyser(driver.root_);
+  auto resources = resource_analyser.analyse();
+  ASSERT_EQ(resources.create_maps(*bpftrace, true), 0);
+  bpftrace->resources = resources;
 
   ast::CodegenLLVM codegen(driver.root_, *bpftrace);
   codegen.generate_ir();

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -612,7 +612,7 @@ TEST(semantic_analyser, call_str_state_leak_regression_test)
 TEST(semantic_analyser, call_buf)
 {
   test("kprobe:f { buf(arg0, 1); }", 0);
-  test("kprobe:f { buf(arg0, -1); }", 10);
+  test("kprobe:f { buf(arg0, -1); }", 1);
   test("kprobe:f { @x = buf(arg0, 1); }", 0);
   test("kprobe:f { $x = buf(arg0, 1); }", 0);
   test("kprobe:f { buf(); }", 1);


### PR DESCRIPTION
This PR refactors map creation and runtime resource collection. This
is mostly a non-functional change with a few bug fixes. I think it's also
a fairly nice cleanup for the code base as well.

In broad strokes, this PR:
* Makes the type information stored in AST nodes more complete
* Splits out map metadata collection and map creation code from
  `SemanticAnalyser` and moves it into `ResourceAnalyser` pass
* Splits out async argument collection from `SemanticAnalyser` and
  moves it to `ResourceAnalyser`
* Encapsulates all runtime metadata in `RequiredResources`

This is generally good (in my opinion) because `SemanticAnalyser`
and `BPFtrace` were a bit bloated with responsibilities. By splitting
responsibility out, we can better encapsulate and contain complexity.

This PR is a major building block for AOT b/c we'll later add
serialization/deserialization capabilities to `RuntimeResources`. The
goal is to make a bpftrace script fully portable by transporting around
BPF bytecode and `RuntimeResources`.

I've included more details in each individual commit.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
