### PR TITLE
tests: Make probe.tracepoint_data_loc less flaky

### DIFF
--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -129,7 +129,7 @@ TIMEOUT 5
 
 # Test that we get at least two characters out
 NAME tracepoint_data_loc
-RUN bpftrace -v -e 'tracepoint:irq:irq_handler_entry { print(str(args->name)) }'
+RUN bpftrace -v -e 'tracepoint:irq:irq_handler_entry { print(str(args->name)); exit(); }'
 EXPECT ..+
 TIMEOUT 5
 


### PR DESCRIPTION
I was seeing some flakiness on my dev machine for this test (test would
hang). I'm guessing it's b/c the perf buffer was so overloaded with
events it took a while to drain.

Should be good enough to exit after one sample. Would be weird for an
irq handler to have a single character name.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
