### PR TITLE
Fix memleaks in work with struct types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
 #### Removed
 
 #### Fixed
+- Fix memory leaks in struct types
+  - [#1885](https://github.com/iovisor/bpftrace/pull/1885)
 
 #### Tools
 

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1932,8 +1932,8 @@ void SemanticAnalyser::visit(FieldAccess &acc)
       for (auto &match : matches) {
         std::string tracepoint_struct = TracepointFormatParser::get_struct_name(
             match);
-        structs[tracepoint_struct] =
-            bpftrace_.structs.Lookup(tracepoint_struct).get();
+        structs[tracepoint_struct] = bpftrace_.structs.Lookup(
+            tracepoint_struct);
       }
     }
   }
@@ -2074,7 +2074,7 @@ void SemanticAnalyser::visit(Tuple &tuple)
     elements.emplace_back(elem->type);
   }
 
-  tuple.type = CreateTuple(elements);
+  tuple.type = CreateTuple(bpftrace_.structs.AddTuple(elements));
 }
 
 void SemanticAnalyser::visit(ExprStatement &expr)

--- a/src/struct.cpp
+++ b/src/struct.cpp
@@ -118,25 +118,30 @@ void StructManager::Add(const std::string &name, size_t size)
   if (struct_map_.find(name) != struct_map_.end())
     throw std::runtime_error("Type redefinition: type with name \'" + name +
                              "\' already exists");
-  struct_map_[name] = std::make_shared<Struct>(size);
+  struct_map_[name] = std::make_unique<Struct>(size);
 }
 
-std::shared_ptr<Struct> StructManager::Lookup(const std::string &name) const
+Struct *StructManager::Lookup(const std::string &name) const
 {
   auto s = struct_map_.find(name);
-  return s != struct_map_.end() ? s->second : nullptr;
+  return s != struct_map_.end() ? s->second.get() : nullptr;
 }
 
-std::shared_ptr<Struct> StructManager::LookupOrAdd(const std::string &name,
-                                                   size_t size)
+Struct *StructManager::LookupOrAdd(const std::string &name, size_t size)
 {
-  auto s = struct_map_.insert({ name, std::make_shared<Struct>(size) });
-  return s.first->second;
+  auto s = struct_map_.insert({ name, std::make_unique<Struct>(size) });
+  return s.first->second.get();
 }
 
 bool StructManager::Has(const std::string &name) const
 {
   return struct_map_.find(name) != struct_map_.end();
+}
+
+Struct *StructManager::AddTuple(std::vector<SizedType> fields)
+{
+  tuples_.push_back(Struct::CreateTuple(fields));
+  return tuples_.back().get();
 }
 
 } // namespace bpftrace

--- a/src/struct.cpp
+++ b/src/struct.cpp
@@ -140,8 +140,13 @@ bool StructManager::Has(const std::string &name) const
 
 Struct *StructManager::AddTuple(std::vector<SizedType> fields)
 {
-  tuples_.push_back(Struct::CreateTuple(fields));
-  return tuples_.back().get();
+  auto t = tuples_.insert(Struct::CreateTuple(std::move(fields)));
+  return t.first->get();
+}
+
+size_t StructManager::GetTuplesCnt() const
+{
+  return tuples_.size();
 }
 
 } // namespace bpftrace

--- a/src/struct.h
+++ b/src/struct.h
@@ -92,6 +92,25 @@ struct hash<bpftrace::Struct>
     return hash;
   }
 };
+
+template <>
+struct hash<unique_ptr<bpftrace::Struct>>
+{
+  size_t operator()(const std::unique_ptr<bpftrace::Struct> &s_ptr) const
+  {
+    return std::hash<bpftrace::Struct>()(*s_ptr);
+  }
+};
+
+template <>
+struct equal_to<unique_ptr<bpftrace::Struct>>
+{
+  bool operator()(const std::unique_ptr<bpftrace::Struct> &lhs,
+                  const std::unique_ptr<bpftrace::Struct> &rhs) const
+  {
+    return *lhs == *rhs;
+  }
+};
 } // namespace std
 
 namespace bpftrace {
@@ -99,15 +118,19 @@ namespace bpftrace {
 class StructManager
 {
 public:
+  // struct map manipulation
   void Add(const std::string &name, size_t size);
-  Struct *AddTuple(std::vector<SizedType> fields);
   Struct *Lookup(const std::string &name) const;
   Struct *LookupOrAdd(const std::string &name, size_t size);
   bool Has(const std::string &name) const;
 
+  // tuples set manipulation
+  Struct *AddTuple(std::vector<SizedType> fields);
+  size_t GetTuplesCnt() const;
+
 private:
   std::map<std::string, std::unique_ptr<Struct>> struct_map_;
-  std::vector<std::unique_ptr<Struct>> tuples_;
+  std::unordered_set<std::unique_ptr<Struct>> tuples_;
 };
 
 } // namespace bpftrace

--- a/src/struct.h
+++ b/src/struct.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "types.h"
+#include "utils.h"
 #include <map>
 
 namespace bpftrace {
@@ -76,6 +77,24 @@ struct Struct
 };
 
 std::ostream &operator<<(std::ostream &os, const Fields &t);
+
+} // namespace bpftrace
+
+namespace std {
+template <>
+struct hash<bpftrace::Struct>
+{
+  size_t operator()(const bpftrace::Struct &s) const
+  {
+    size_t hash = std::hash<int>()(s.size);
+    for (auto &field : s.fields)
+      bpftrace::hash_combine(hash, field.type);
+    return hash;
+  }
+};
+} // namespace std
+
+namespace bpftrace {
 
 class StructManager
 {

--- a/src/struct.h
+++ b/src/struct.h
@@ -68,12 +68,14 @@ class StructManager
 {
 public:
   void Add(const std::string &name, size_t size);
-  std::shared_ptr<Struct> Lookup(const std::string &name) const;
-  std::shared_ptr<Struct> LookupOrAdd(const std::string &name, size_t size);
+  Struct *AddTuple(std::vector<SizedType> fields);
+  Struct *Lookup(const std::string &name) const;
+  Struct *LookupOrAdd(const std::string &name, size_t size);
   bool Has(const std::string &name) const;
 
 private:
-  std::map<std::string, std::shared_ptr<Struct>> struct_map_;
+  std::map<std::string, std::unique_ptr<Struct>> struct_map_;
+  std::vector<std::unique_ptr<Struct>> tuples_;
 };
 
 } // namespace bpftrace

--- a/src/struct.h
+++ b/src/struct.h
@@ -34,6 +34,13 @@ struct Field
   // The last 2 bytes is the offset from the start of the tracepoint struct
   // where the data begins.
   bool is_data_loc = false;
+
+  bool operator==(const Field &rhs) const
+  {
+    return name == rhs.name && type == rhs.type && offset == rhs.offset &&
+           is_bitfield == rhs.is_bitfield && bitfield == rhs.bitfield &&
+           is_data_loc == rhs.is_data_loc;
+  }
 };
 
 using Fields = std::vector<Field>;
@@ -60,6 +67,12 @@ struct Struct
 
   static std::unique_ptr<Struct> CreateTuple(std::vector<SizedType> fields);
   void Dump(std::ostream &os);
+
+  bool operator==(const Struct &rhs) const
+  {
+    return size == rhs.size && align == rhs.align && padded == rhs.padded &&
+           fields == rhs.fields;
+  }
 };
 
 std::ostream &operator<<(std::ostream &os, const Fields &t);

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -356,7 +356,7 @@ SizedType CreatePointer(const SizedType &pointee_type, AddrSpace as)
   return ty;
 }
 
-SizedType CreateRecord(const std::string &name, std::shared_ptr<Struct> record)
+SizedType CreateRecord(const std::string &name, Struct *record)
 {
   auto ty = SizedType(Type::record, record ? record->size : 0);
   ty.name_ = name;
@@ -448,11 +448,10 @@ SizedType CreateTimestamp()
   return SizedType(Type::timestamp, 16);
 }
 
-SizedType CreateTuple(const std::vector<SizedType> &fields)
+SizedType CreateTuple(Struct *tuple)
 {
-  auto s = SizedType(Type::tuple, 0);
-  s.inner_struct_ = Struct::CreateTuple(fields);
-  s.size_ = s.inner_struct_->size;
+  auto s = SizedType(Type::tuple, tuple->size);
+  s.inner_struct_ = tuple;
   return s;
 }
 
@@ -531,7 +530,7 @@ const Field &SizedType::GetField(const std::string &name) const
 const Struct *SizedType::GetStruct() const
 {
   assert(IsRecordTy());
-  return inner_struct_.get();
+  return inner_struct_;
 }
 
 } // namespace bpftrace

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -541,3 +541,60 @@ const Struct *SizedType::GetStruct() const
 }
 
 } // namespace bpftrace
+
+namespace std {
+size_t hash<bpftrace::SizedType>::operator()(
+    const bpftrace::SizedType &type) const
+{
+  auto hash = std::hash<unsigned>()(static_cast<unsigned>(type.type));
+  bpftrace::hash_combine(hash, type.GetSize());
+
+  switch (type.type)
+  {
+    case bpftrace::Type::integer:
+      bpftrace::hash_combine(hash, type.IsSigned());
+      break;
+    case bpftrace::Type::pointer:
+      bpftrace::hash_combine(hash, *type.GetPointeeTy());
+      break;
+    case bpftrace::Type::record:
+      bpftrace::hash_combine(hash, type.GetName());
+      break;
+    case bpftrace::Type::kstack:
+    case bpftrace::Type::ustack:
+      bpftrace::hash_combine(hash, type.stack_type);
+      break;
+    case bpftrace::Type::array:
+      bpftrace::hash_combine(hash, *type.GetElementTy());
+      bpftrace::hash_combine(hash, type.GetNumElements());
+      break;
+    case bpftrace::Type::tuple:
+      bpftrace::hash_combine(hash, *type.GetStruct());
+      break;
+    // No default case (explicitly skip all remaining types instead) to get
+    // a compiler warning when we add a new type
+    case bpftrace::Type::none:
+    case bpftrace::Type::hist:
+    case bpftrace::Type::lhist:
+    case bpftrace::Type::count:
+    case bpftrace::Type::sum:
+    case bpftrace::Type::min:
+    case bpftrace::Type::max:
+    case bpftrace::Type::avg:
+    case bpftrace::Type::stats:
+    case bpftrace::Type::string:
+    case bpftrace::Type::ksym:
+    case bpftrace::Type::usym:
+    case bpftrace::Type::probe:
+    case bpftrace::Type::username:
+    case bpftrace::Type::inet:
+    case bpftrace::Type::stack_mode:
+    case bpftrace::Type::buffer:
+    case bpftrace::Type::timestamp:
+    case bpftrace::Type::mac_address:
+      break;
+  }
+
+  return hash;
+}
+} // namespace std

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -96,6 +96,13 @@ bool SizedType::IsEqual(const SizedType &t) const
   if (IsPtrTy())
     return *t.GetPointeeTy() == *GetPointeeTy();
 
+  if (IsArrayTy())
+    return t.GetNumElements() == GetNumElements() &&
+           *t.GetElementTy() == *GetElementTy();
+
+  if (IsTupleTy())
+    return *t.GetStruct() == *GetStruct();
+
   return type == t.type && GetSize() == t.GetSize() &&
          is_signed_ == t.is_signed_;
 }
@@ -529,7 +536,7 @@ const Field &SizedType::GetField(const std::string &name) const
 
 const Struct *SizedType::GetStruct() const
 {
-  assert(IsRecordTy());
+  assert(IsRecordTy() || IsTupleTy());
   return inner_struct_;
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -501,6 +501,8 @@ enum class PositionalParameterType
 
 } // namespace bpftrace
 
+// SizedType hash function
+// Allows to use SizedType in unordered_set/map.
 namespace std {
 template <>
 struct hash<bpftrace::StackType>
@@ -517,6 +519,12 @@ struct hash<bpftrace::StackType>
 
     return {}; // unreached
   }
+};
+
+template <>
+struct hash<bpftrace::SizedType>
+{
+  size_t operator()(const bpftrace::SizedType &type) const;
 };
 
 } // namespace std

--- a/src/types.h
+++ b/src/types.h
@@ -111,7 +111,8 @@ private:
   AddrSpace as_ = AddrSpace::none;
   ssize_t size_bits_ = -1; // size in bits for integer types
 
-  std::shared_ptr<Struct> inner_struct_; // inner struct for records and tuples
+  Struct *inner_struct_; // inner struct for records and tuples
+                         // the actual Struct object is owned by StructManager
 
 public:
   /**
@@ -339,10 +340,9 @@ public:
                                const SizedType &element_type);
 
   friend SizedType CreatePointer(const SizedType &pointee_type, AddrSpace as);
-  friend SizedType CreateRecord(const std::string &name,
-                                std::shared_ptr<Struct> record);
+  friend SizedType CreateRecord(const std::string &name, Struct *record);
   friend SizedType CreateInteger(size_t bits, bool is_signed);
-  friend SizedType CreateTuple(const std::vector<SizedType> &fields);
+  friend SizedType CreateTuple(Struct *tuple);
 };
 // Type helpers
 
@@ -365,8 +365,8 @@ SizedType CreateArray(size_t num_elements, const SizedType &element_type);
 SizedType CreatePointer(const SizedType &pointee_type,
                         AddrSpace as = AddrSpace::none);
 
-SizedType CreateRecord(const std::string &name, std::shared_ptr<Struct> record);
-SizedType CreateTuple(const std::vector<SizedType> &fields);
+SizedType CreateRecord(const std::string &name, Struct *record);
+SizedType CreateTuple(Struct *tuple);
 
 SizedType CreateStackMode();
 SizedType CreateStack(bool kernel, StackType st = StackType());

--- a/src/utils.h
+++ b/src/utils.h
@@ -239,4 +239,13 @@ T reduce_value(const std::vector<uint8_t> &value, int nvalues)
 int64_t min_value(const std::vector<uint8_t> &value, int nvalues);
 uint64_t max_value(const std::vector<uint8_t> &value, int nvalues);
 
+// Combination of 2 hashes
+// The algorithm is taken from boost::hash_combine
+template <class T>
+inline void hash_combine(std::size_t &seed, const T &value)
+{
+  std::hash<T> hasher;
+  seed ^= hasher(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
+}
+
 } // namespace bpftrace

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2116,7 +2116,8 @@ TEST(semantic_analyser, tuple_assign_var)
 {
   BPFtrace bpftrace;
   Driver driver(bpftrace);
-  SizedType ty = CreateTuple({ CreateInt64(), CreateString(64) });
+  SizedType ty = CreateTuple(
+      bpftrace.structs.AddTuple({ CreateInt64(), CreateString(64) }));
   test(driver, R"_(BEGIN { $t = (1, "str"); $t = (4, "other"); })_", 0);
 
   auto &stmts = driver.root_->probes->at(0)->stmts;
@@ -2142,14 +2143,14 @@ TEST(semantic_analyser, tuple_assign_map)
 
   // $t = (1, 3, 3, 7);
   auto assignment = static_cast<ast::AssignMapStatement *>(stmts->at(0));
-  ty = CreateTuple(
-      { CreateInt64(), CreateUInt64(), CreateUInt64(), CreateUInt64() });
+  ty = CreateTuple(bpftrace.structs.AddTuple(
+      { CreateInt64(), CreateUInt64(), CreateUInt64(), CreateUInt64() }));
   EXPECT_EQ(ty, assignment->map->type);
 
   // $t = (0, 0, 0, 0);
   assignment = static_cast<ast::AssignMapStatement *>(stmts->at(1));
-  ty = CreateTuple(
-      { CreateInt64(), CreateInt64(), CreateInt64(), CreateInt64() });
+  ty = CreateTuple(bpftrace.structs.AddTuple(
+      { CreateInt64(), CreateInt64(), CreateInt64(), CreateInt64() }));
   EXPECT_EQ(ty, assignment->map->type);
 }
 
@@ -2158,8 +2159,10 @@ TEST(semantic_analyser, tuple_nested)
 {
   BPFtrace bpftrace;
   Driver driver(bpftrace);
-  SizedType ty_inner = CreateTuple({ CreateInt64(), CreateInt64() });
-  SizedType ty = CreateTuple({ CreateInt64(), ty_inner });
+  SizedType ty_inner = CreateTuple(
+      bpftrace.structs.AddTuple({ CreateInt64(), CreateInt64() }));
+  SizedType ty = CreateTuple(
+      bpftrace.structs.AddTuple({ CreateInt64(), ty_inner }));
   test(driver, R"_(BEGIN { $t = (1,(1,2)); })_", 0);
 
   auto &stmts = driver.root_->probes->at(0)->stmts;

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2189,6 +2189,14 @@ TEST(semantic_analyser, tuple_nested)
   EXPECT_EQ(ty, assignment->var->type);
 }
 
+TEST(semantic_analyser, tuple_types_unique)
+{
+  auto bpftrace = get_mock_bpftrace();
+  test(*bpftrace, R"_(BEGIN { $t = (1, "str"); $t = (4, "other"); })_", 0);
+
+  EXPECT_EQ(bpftrace->structs.GetTuplesCnt(), 1);
+}
+
 TEST(semantic_analyser, multi_pass_type_inference_zero_size_int)
 {
   auto bpftrace = get_mock_bpftrace();


### PR DESCRIPTION
Using `std::shared_ptr` to store the inner struct in `SizedType` causes memleaks when working with recursive types (due to cycles in shared pointers). This PR replaces the `std::shared_ptr` by a raw pointer.

Fixes #1879.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
