### PR TITLE
tests: Actually test data_loc output

### DIFF
--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -127,10 +127,9 @@ RUN bpftrace -v -e 'tracepoint:syscalls:sys_*_nanosleep { printf("hit "); }' -c 
 EXPECT hit hit
 TIMEOUT 5
 
-# Test that we get at least two characters out
 NAME tracepoint_data_loc
-RUN bpftrace -v -e 'tracepoint:irq:irq_handler_entry { print(str(args->name)); exit(); }'
-EXPECT ..+
+RUN bpftrace -v -e 'tracepoint:irq:irq_handler_entry { printf("irq: %s\n", str(args->name)); exit(); }'
+EXPECT irq: .+
 TIMEOUT 5
 
 NAME profile


### PR DESCRIPTION
I realized that the previous test would match against "Attaching 1
probe..." output. Which makes the test meaningless. This makes the test
actually test output.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
