### PR TITLE
llvm: remove useless generator

### DIFF
--- a/src/bpforcv2.cpp
+++ b/src/bpforcv2.cpp
@@ -14,9 +14,6 @@ BpfOrc::BpfOrc(TargetMachine *TM, DataLayout DL)
       CTX(std::make_unique<LLVMContext>()),
       MainJD(cantFail(ES.createJITDylib("<main>")))
 {
-  MainJD.addGenerator(
-      cantFail(DynamicLibrarySearchGenerator::GetForCurrentProcess(
-          DL.getGlobalPrefix())));
 }
 
 LLVMContext &BpfOrc::getContext()


### PR DESCRIPTION
> When JITDylibs are searched during lookup, if no existing definition
> of a symbol is found, then any generators that have been added are run
> (in the order that they were added) to potentially generate a
> definition.

> Creates a DynamicLibrarySearchGenerator that searches for symbols in the current process.

We don't have to search the current process for symbols as we're not
really JITing, we're just using the wrong api to extract bpf code

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
