### PR TITLE
Add serialization capabilities to `RequiredResources`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 ## Unreleased
 
 #### Added
+- Build time dependency on cereal
+  - [#1893](https://github.com/iovisor/bpftrace/pull/1893)
 
 #### Changed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,6 +95,9 @@ include_directories(SYSTEM ${LIBBCC_INCLUDE_DIRS})
 find_package(LibElf REQUIRED)
 include_directories(SYSTEM ${LIBELF_INCLUDE_DIRS})
 
+find_package(LibCereal REQUIRED)
+include_directories(SYSTEM ${CEREAL_INCLUDE_DIRS})
+
 find_package(BISON REQUIRED)
 find_package(FLEX REQUIRED)
 bison_target(bison_parser src/parser.yy ${CMAKE_BINARY_DIR}/parser.tab.cc VERBOSE)

--- a/cmake/FindLibCereal.cmake
+++ b/cmake/FindLibCereal.cmake
@@ -1,0 +1,18 @@
+# - Try to find libcereal
+# Once done this will define
+#
+#  LIBCEREAL_FOUND - system has libcereal
+#  LIBCEREAL_INCLUDE_DIRS - the libcereal include directory
+
+find_path (LIBCEREAL_INCLUDE_DIRS
+  NAMES
+    cereal/cereal.hpp
+  PATHS
+    ENV CPATH)
+
+include (FindPackageHandleStandardArgs)
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibCereal
+  "Please install the libcereal development package"
+  LIBCEREAL_INCLUDE_DIRS)
+
+mark_as_advanced(LIBCEREAL_INCLUDE_DIRS)

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,7 +1,8 @@
 ARG ALPINE_VERSION=3.11
-ARG LLVM_VERSION="9"
-
 FROM alpine:${ALPINE_VERSION}
+
+ARG LLVM_VERSION="9"
+ARG CEREAL_VERSION=1.3.0
 
 RUN apk add --update \
   bash \
@@ -22,6 +23,7 @@ RUN apk add --update \
   llvm${LLVM_VERSION}-dev \
   llvm${LLVM_VERSION}-static \
   python3 \
+  wget \
   zlib-dev \
   zlib-static
 
@@ -30,6 +32,10 @@ WORKDIR /
 RUN mv /usr/lib/libbccbpf.a /usr/lib/libbcc_bpf.a && \
     ln -s $(which python3) /usr/bin/python && \
     ln -s /lib /lib/x86_64-linux-gnu
+
+RUN wget https://github.com/USCiLab/cereal/archive/refs/tags/v${CEREAL_VERSION}.tar.gz && \
+    tar xf v${CEREAL_VERSION}.tar.gz && \
+    cp -r cereal-${CEREAL_VERSION}/include/cereal /usr/include
 
 COPY build.sh /build.sh
 RUN chmod 755 /build.sh

--- a/docker/Dockerfile.bionic
+++ b/docker/Dockerfile.bionic
@@ -29,6 +29,7 @@ RUN apt-get update && apt-get install -y \
       libelf-dev \
       zlib1g-dev \
       libbcc \
+      libcereal-dev \
       clang-${LLVM_VERSION} \
       libclang-${LLVM_VERSION}-dev \
       libclang-common-${LLVM_VERSION}-dev \

--- a/docker/Dockerfile.fedora30
+++ b/docker/Dockerfile.fedora30
@@ -2,6 +2,7 @@ FROM fedora:30
 RUN dnf install -y \
     bison \
     binutils-devel \
+    cereal-devel \
     clang-devel \
     cmake \
     elfutils-libelf-devel \

--- a/docker/Dockerfile.ubuntu-glibc
+++ b/docker/Dockerfile.ubuntu-glibc
@@ -26,6 +26,7 @@ RUN apt-get update \
         zlib1g-dev \
         libiberty-dev \
         libbfd-dev \
+        libcereal-dev \
         libedit-dev \
         systemtap-sdt-dev \
         python3 \

--- a/src/ast/semantic_analyser.cpp
+++ b/src/ast/semantic_analyser.cpp
@@ -1913,7 +1913,7 @@ void SemanticAnalyser::visit(FieldAccess &acc)
     return;
   }
 
-  std::map<std::string, const Struct *> structs;
+  std::map<std::string, std::weak_ptr<const Struct>> structs;
 
   if (type.is_tparg)
   {
@@ -1944,7 +1944,7 @@ void SemanticAnalyser::visit(FieldAccess &acc)
 
   for (auto it : structs) {
     std::string cast_type = it.first;
-    const Struct *record = it.second;
+    const auto record = it.second.lock();
     if (!record->HasField(acc.field))
     {
       LOG(ERROR, acc.loc, err_)

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -569,7 +569,7 @@ bool ClangParser::visit_children(CXCursor &cursor, BPFtrace &bpftrace)
           // No need to worry about redefined types b/c we should have already
           // checked clang diagnostics. The diagnostics will tell us if we have
           // duplicated types.
-          structs.Lookup(ptypestr)->AddField(
+          structs.Lookup(ptypestr).lock()->AddField(
               ident, sized_type, offset, is_bitfield, bitfield, is_data_loc);
         }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -632,6 +632,13 @@ int main(int argc, char* argv[])
   if (!parse_env(bpftrace))
     return 1;
 
+  // Difficult to serialize flex generated types
+  if (helper_check_level && build_mode == BuildMode::AHEAD_OF_TIME)
+  {
+    LOG(ERROR) << "Cannot use -k[k] with --aot";
+    return 1;
+  }
+
   bpftrace.usdt_file_activation_ = usdt_file_activation;
   bpftrace.safe_mode_ = safe_mode;
   bpftrace.helper_check_level_ = helper_check_level;

--- a/src/mapkey.h
+++ b/src/mapkey.h
@@ -3,6 +3,8 @@
 #include <string>
 #include <vector>
 
+#include <cereal/access.hpp>
+
 #include "types.h"
 
 namespace bpftrace {
@@ -28,6 +30,13 @@ private:
   static std::string argument_value(BPFtrace &bpftrace,
                                     const SizedType &arg,
                                     const void *data);
+
+  friend class cereal::access;
+  template <typename Archive>
+  void serialize(Archive &archive)
+  {
+    archive(args_);
+  }
 };
 
 } // namespace bpftrace

--- a/src/required_resources.cpp
+++ b/src/required_resources.cpp
@@ -1,5 +1,13 @@
 #include "required_resources.h"
 
+#include <cereal/archives/binary.hpp>
+#include <cereal/types/map.hpp>
+#include <cereal/types/memory.hpp>
+#include <cereal/types/string.hpp>
+#include <cereal/types/tuple.hpp>
+#include <cereal/types/unordered_set.hpp>
+#include <cereal/types/vector.hpp>
+
 #include "bpftrace.h"
 #include "fake_map.h"
 #include "log.h"
@@ -130,6 +138,18 @@ int RequiredResources::create_maps_impl(BPFtrace &bpftrace, bool fake)
   }
 
   return failed_maps;
+}
+
+void RequiredResources::save_state(std::ostream &out) const
+{
+  cereal::BinaryOutputArchive archive(out);
+  archive(*this);
+}
+
+void RequiredResources::load_state(std::istream &in)
+{
+  cereal::BinaryInputArchive archive(in);
+  archive(*this);
 }
 
 } // namespace bpftrace

--- a/src/struct.cpp
+++ b/src/struct.cpp
@@ -121,16 +121,17 @@ void StructManager::Add(const std::string &name, size_t size)
   struct_map_[name] = std::make_unique<Struct>(size);
 }
 
-Struct *StructManager::Lookup(const std::string &name) const
+std::weak_ptr<Struct> StructManager::Lookup(const std::string &name) const
 {
   auto s = struct_map_.find(name);
-  return s != struct_map_.end() ? s->second.get() : nullptr;
+  return s != struct_map_.end() ? s->second : std::weak_ptr<Struct>();
 }
 
-Struct *StructManager::LookupOrAdd(const std::string &name, size_t size)
+std::weak_ptr<Struct> StructManager::LookupOrAdd(const std::string &name,
+                                                 size_t size)
 {
   auto s = struct_map_.insert({ name, std::make_unique<Struct>(size) });
-  return s.first->second.get();
+  return s.first->second;
 }
 
 bool StructManager::Has(const std::string &name) const
@@ -138,10 +139,10 @@ bool StructManager::Has(const std::string &name) const
   return struct_map_.find(name) != struct_map_.end();
 }
 
-Struct *StructManager::AddTuple(std::vector<SizedType> fields)
+std::weak_ptr<Struct> StructManager::AddTuple(std::vector<SizedType> fields)
 {
   auto t = tuples_.insert(Struct::CreateTuple(std::move(fields)));
-  return t.first->get();
+  return *t.first;
 }
 
 size_t StructManager::GetTuplesCnt() const

--- a/src/struct.h
+++ b/src/struct.h
@@ -1,8 +1,10 @@
 #pragma once
 
+#include <map>
+#include <memory>
+
 #include "types.h"
 #include "utils.h"
-#include <map>
 
 namespace bpftrace {
 
@@ -94,19 +96,19 @@ struct hash<bpftrace::Struct>
 };
 
 template <>
-struct hash<unique_ptr<bpftrace::Struct>>
+struct hash<shared_ptr<bpftrace::Struct>>
 {
-  size_t operator()(const std::unique_ptr<bpftrace::Struct> &s_ptr) const
+  size_t operator()(const std::shared_ptr<bpftrace::Struct> &s_ptr) const
   {
     return std::hash<bpftrace::Struct>()(*s_ptr);
   }
 };
 
 template <>
-struct equal_to<unique_ptr<bpftrace::Struct>>
+struct equal_to<shared_ptr<bpftrace::Struct>>
 {
-  bool operator()(const std::unique_ptr<bpftrace::Struct> &lhs,
-                  const std::unique_ptr<bpftrace::Struct> &rhs) const
+  bool operator()(const std::shared_ptr<bpftrace::Struct> &lhs,
+                  const std::shared_ptr<bpftrace::Struct> &rhs) const
   {
     return *lhs == *rhs;
   }
@@ -120,17 +122,17 @@ class StructManager
 public:
   // struct map manipulation
   void Add(const std::string &name, size_t size);
-  Struct *Lookup(const std::string &name) const;
-  Struct *LookupOrAdd(const std::string &name, size_t size);
+  std::weak_ptr<Struct> Lookup(const std::string &name) const;
+  std::weak_ptr<Struct> LookupOrAdd(const std::string &name, size_t size);
   bool Has(const std::string &name) const;
 
   // tuples set manipulation
-  Struct *AddTuple(std::vector<SizedType> fields);
+  std::weak_ptr<Struct> AddTuple(std::vector<SizedType> fields);
   size_t GetTuplesCnt() const;
 
 private:
-  std::map<std::string, std::unique_ptr<Struct>> struct_map_;
-  std::unordered_set<std::unique_ptr<Struct>> tuples_;
+  std::map<std::string, std::shared_ptr<Struct>> struct_map_;
+  std::unordered_set<std::shared_ptr<Struct>> tuples_;
 };
 
 } // namespace bpftrace

--- a/src/types.h
+++ b/src/types.h
@@ -111,8 +111,9 @@ private:
   AddrSpace as_ = AddrSpace::none;
   ssize_t size_bits_ = -1; // size in bits for integer types
 
-  Struct *inner_struct_; // inner struct for records and tuples
-                         // the actual Struct object is owned by StructManager
+  std::weak_ptr<Struct> inner_struct_; // inner struct for records and tuples
+                                       // the actual Struct object is owned by
+                                       // StructManager
 
 public:
   /**
@@ -123,7 +124,7 @@ public:
   const Field &GetField(const std::string &name) const;
   Field &GetField(ssize_t n) const;
   ssize_t GetFieldCount() const;
-  const Struct *GetStruct() const;
+  std::weak_ptr<const Struct> GetStruct() const;
 
   /**
      Required alignment for this type
@@ -340,9 +341,10 @@ public:
                                const SizedType &element_type);
 
   friend SizedType CreatePointer(const SizedType &pointee_type, AddrSpace as);
-  friend SizedType CreateRecord(const std::string &name, Struct *record);
+  friend SizedType CreateRecord(const std::string &name,
+                                std::weak_ptr<Struct> record);
   friend SizedType CreateInteger(size_t bits, bool is_signed);
-  friend SizedType CreateTuple(Struct *tuple);
+  friend SizedType CreateTuple(std::weak_ptr<Struct> tuple);
 };
 // Type helpers
 
@@ -365,8 +367,8 @@ SizedType CreateArray(size_t num_elements, const SizedType &element_type);
 SizedType CreatePointer(const SizedType &pointee_type,
                         AddrSpace as = AddrSpace::none);
 
-SizedType CreateRecord(const std::string &name, Struct *record);
-SizedType CreateTuple(Struct *tuple);
+SizedType CreateRecord(const std::string &name, std::weak_ptr<Struct> record);
+SizedType CreateTuple(std::weak_ptr<Struct> tuple);
 
 SizedType CreateStackMode();
 SizedType CreateStack(bool kernel, StackType st = StackType());

--- a/src/types.h
+++ b/src/types.h
@@ -10,6 +10,8 @@
 #include <unistd.h>
 #include <vector>
 
+#include <cereal/access.hpp>
+
 namespace bpftrace {
 
 const int MAX_STACK_SIZE = 1024;
@@ -73,6 +75,14 @@ struct StackType
   bool operator ==(const StackType &obj) const {
     return limit == obj.limit && mode == obj.mode;
   }
+
+private:
+  friend class cereal::access;
+  template <typename Archive>
+  void serialize(Archive &archive)
+  {
+    archive(limit, mode);
+  }
 };
 
 class BPFtrace;
@@ -114,6 +124,27 @@ private:
   std::weak_ptr<Struct> inner_struct_; // inner struct for records and tuples
                                        // the actual Struct object is owned by
                                        // StructManager
+
+  friend class cereal::access;
+  template <typename Archive>
+  void serialize(Archive &archive)
+  {
+    archive(type,
+            stack_type,
+            is_internal,
+            is_tparg,
+            is_kfarg,
+            kfarg_idx,
+            size_,
+            is_signed_,
+            element_type_,
+            num_elements_,
+            name_,
+            ctx_,
+            as_,
+            size_bits_,
+            inner_struct_);
+  }
 
 public:
   /**

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,7 @@ add_executable(bpftrace_test
   portability_analyser.cpp
   procmon.cpp
   probe.cpp
+  required_resources.cpp
   semantic_analyser.cpp
   tracepoint_format_parser.cpp
   utils.cpp

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -30,7 +30,7 @@ TEST(clang_parser, integers)
   parse("struct Foo { int x; int y, z; }", bpftrace);
 
   ASSERT_TRUE(bpftrace.structs.Has("struct Foo"));
-  auto foo = bpftrace.structs.Lookup("struct Foo");
+  auto foo = bpftrace.structs.Lookup("struct Foo").lock();
 
   EXPECT_EQ(foo->size, 12);
   ASSERT_EQ(foo->fields.size(), 3U);
@@ -57,7 +57,7 @@ TEST(clang_parser, c_union)
   parse("union Foo { char c; short s; int i; long l; }", bpftrace);
 
   ASSERT_TRUE(bpftrace.structs.Has("union Foo"));
-  auto foo = bpftrace.structs.Lookup("union Foo");
+  auto foo = bpftrace.structs.Lookup("union Foo").lock();
 
   EXPECT_EQ(foo->size, 8);
   ASSERT_EQ(foo->fields.size(), 4U);
@@ -89,7 +89,7 @@ TEST(clang_parser, c_enum)
   parse("enum E {NONE}; struct Foo { enum E e; }", bpftrace);
 
   ASSERT_TRUE(bpftrace.structs.Has("struct Foo"));
-  auto foo = bpftrace.structs.Lookup("struct Foo");
+  auto foo = bpftrace.structs.Lookup("struct Foo").lock();
 
   EXPECT_EQ(foo->size, 4);
   ASSERT_EQ(foo->fields.size(), 1U);
@@ -106,7 +106,7 @@ TEST(clang_parser, integer_ptr)
   parse("struct Foo { int *x; }", bpftrace);
 
   ASSERT_TRUE(bpftrace.structs.Has("struct Foo"));
-  auto foo = bpftrace.structs.Lookup("struct Foo");
+  auto foo = bpftrace.structs.Lookup("struct Foo").lock();
 
   EXPECT_EQ(foo->size, 8);
   ASSERT_EQ(foo->fields.size(), 1U);
@@ -124,7 +124,7 @@ TEST(clang_parser, string_ptr)
   parse("struct Foo { char *str; }", bpftrace);
 
   ASSERT_TRUE(bpftrace.structs.Has("struct Foo"));
-  auto foo = bpftrace.structs.Lookup("struct Foo");
+  auto foo = bpftrace.structs.Lookup("struct Foo").lock();
 
   EXPECT_EQ(foo->size, 8);
   ASSERT_EQ(foo->fields.size(), 1U);
@@ -143,7 +143,7 @@ TEST(clang_parser, string_array)
   parse("struct Foo { char str[32]; }", bpftrace);
 
   ASSERT_TRUE(bpftrace.structs.Has("struct Foo"));
-  auto foo = bpftrace.structs.Lookup("struct Foo");
+  auto foo = bpftrace.structs.Lookup("struct Foo").lock();
 
   EXPECT_EQ(foo->size, 32);
   ASSERT_EQ(foo->fields.size(), 1U);
@@ -161,7 +161,7 @@ TEST(clang_parser, nested_struct_named)
 
   ASSERT_TRUE(bpftrace.structs.Has("struct Foo"));
   ASSERT_TRUE(bpftrace.structs.Has("struct Bar"));
-  auto foo = bpftrace.structs.Lookup("struct Foo");
+  auto foo = bpftrace.structs.Lookup("struct Foo").lock();
 
   EXPECT_EQ(foo->size, 4);
   ASSERT_EQ(foo->fields.size(), 1U);
@@ -181,7 +181,7 @@ TEST(clang_parser, nested_struct_ptr_named)
 
   ASSERT_TRUE(bpftrace.structs.Has("struct Foo"));
   ASSERT_TRUE(bpftrace.structs.Has("struct Bar"));
-  auto foo = bpftrace.structs.Lookup("struct Foo");
+  auto foo = bpftrace.structs.Lookup("struct Foo").lock();
 
   EXPECT_EQ(foo->size, 8);
   ASSERT_EQ(foo->fields.size(), 1U);
@@ -208,9 +208,9 @@ TEST(clang_parser, nested_struct_no_type)
   ASSERT_TRUE(bpftrace.structs.Has("struct Foo"));
   ASSERT_TRUE(bpftrace.structs.Has(bar_name));
   ASSERT_TRUE(bpftrace.structs.Has(baz_name));
-  auto foo = bpftrace.structs.Lookup("struct Foo");
-  auto bar = bpftrace.structs.Lookup(bar_name);
-  auto baz = bpftrace.structs.Lookup(baz_name);
+  auto foo = bpftrace.structs.Lookup("struct Foo").lock();
+  auto bar = bpftrace.structs.Lookup(bar_name).lock();
+  auto baz = bpftrace.structs.Lookup(baz_name).lock();
 
   EXPECT_EQ(foo->size, 8);
   ASSERT_EQ(foo->fields.size(), 2U);
@@ -259,8 +259,8 @@ TEST(clang_parser, nested_struct_unnamed_fields)
 
   ASSERT_TRUE(bpftrace.structs.Has("struct Foo"));
   ASSERT_TRUE(bpftrace.structs.Has("struct Bar"));
-  auto foo = bpftrace.structs.Lookup("struct Foo");
-  auto bar = bpftrace.structs.Lookup("struct Bar");
+  auto foo = bpftrace.structs.Lookup("struct Foo").lock();
+  auto bar = bpftrace.structs.Lookup("struct Bar").lock();
 
   EXPECT_EQ(foo->size, 12);
   ASSERT_EQ(foo->fields.size(), 3U);
@@ -303,7 +303,7 @@ TEST(clang_parser, nested_struct_anon_union_struct)
         bpftrace);
 
   ASSERT_TRUE(bpftrace.structs.Has("struct Foo"));
-  auto foo = bpftrace.structs.Lookup("struct Foo");
+  auto foo = bpftrace.structs.Lookup("struct Foo").lock();
 
   EXPECT_EQ(foo->size, 16);
   ASSERT_EQ(foo->fields.size(), 5U);
@@ -340,7 +340,7 @@ TEST(clang_parser, bitfields)
   parse("struct Foo { int a:8, b:8, c:16; }", bpftrace);
 
   ASSERT_TRUE(bpftrace.structs.Has("struct Foo"));
-  auto foo = bpftrace.structs.Lookup("struct Foo");
+  auto foo = bpftrace.structs.Lookup("struct Foo").lock();
 
   EXPECT_EQ(foo->size, 4);
   ASSERT_EQ(foo->fields.size(), 3U);
@@ -379,7 +379,7 @@ TEST(clang_parser, bitfields_uneven_fields)
   parse("struct Foo { int a:1, b:1, c:3, d:20, e:7; }", bpftrace);
 
   ASSERT_TRUE(bpftrace.structs.Has("struct Foo"));
-  auto foo = bpftrace.structs.Lookup("struct Foo");
+  auto foo = bpftrace.structs.Lookup("struct Foo").lock();
 
   EXPECT_EQ(foo->size, 4);
   ASSERT_EQ(foo->fields.size(), 5U);
@@ -436,7 +436,7 @@ TEST(clang_parser, bitfields_with_padding)
   parse("struct Foo { int pad; int a:28, b:4; long int end;}", bpftrace);
 
   ASSERT_TRUE(bpftrace.structs.Has("struct Foo"));
-  auto foo = bpftrace.structs.Lookup("struct Foo");
+  auto foo = bpftrace.structs.Lookup("struct Foo").lock();
 
   EXPECT_EQ(foo->size, 16);
   ASSERT_EQ(foo->fields.size(), 4U);
@@ -469,7 +469,7 @@ TEST(clang_parser, builtin_headers)
   parse("#include <stddef.h>\nstruct Foo { size_t x, y, z; }", bpftrace);
 
   ASSERT_TRUE(bpftrace.structs.Has("struct Foo"));
-  auto foo = bpftrace.structs.Lookup("struct Foo");
+  auto foo = bpftrace.structs.Lookup("struct Foo").lock();
 
   EXPECT_EQ(foo->size, 24);
   ASSERT_EQ(foo->fields.size(), 3U);
@@ -533,10 +533,10 @@ TEST_F(clang_parser_btf, btf)
   ASSERT_TRUE(bpftrace.structs.Has("struct Foo2"));
   ASSERT_TRUE(bpftrace.structs.Has("struct Foo3"));
   ASSERT_TRUE(bpftrace.structs.Has("struct task_struct"));
-  auto foo1 = bpftrace.structs.Lookup("struct Foo1");
-  auto foo2 = bpftrace.structs.Lookup("struct Foo2");
-  auto foo3 = bpftrace.structs.Lookup("struct Foo3");
-  auto task_struct = bpftrace.structs.Lookup("struct task_struct");
+  auto foo1 = bpftrace.structs.Lookup("struct Foo1").lock();
+  auto foo2 = bpftrace.structs.Lookup("struct Foo2").lock();
+  auto foo3 = bpftrace.structs.Lookup("struct Foo3").lock();
+  auto task_struct = bpftrace.structs.Lookup("struct task_struct").lock();
 
   EXPECT_EQ(foo1->size, 16);
   ASSERT_EQ(foo1->fields.size(), 3U);
@@ -645,7 +645,7 @@ TEST(clang_parser, btf_unresolved_typedef)
   parse("struct Foo { size_t x; };", bpftrace);
 
   ASSERT_TRUE(bpftrace.structs.Has("struct Foo"));
-  auto foo = bpftrace.structs.Lookup("struct Foo");
+  auto foo = bpftrace.structs.Lookup("struct Foo").lock();
 
   EXPECT_EQ(foo->size, 8);
   ASSERT_EQ(foo->fields.size(), 1U);
@@ -666,7 +666,7 @@ TEST_F(clang_parser_btf, btf_type_override)
         "kprobe:sys_read { @x = ((struct Foo1 *)curtask); }");
 
   ASSERT_TRUE(bpftrace.structs.Has("struct Foo1"));
-  auto foo1 = bpftrace.structs.Lookup("struct Foo1");
+  auto foo1 = bpftrace.structs.Lookup("struct Foo1").lock();
   ASSERT_EQ(foo1->fields.size(), 1U);
   ASSERT_TRUE(foo1->HasField("a"));
 
@@ -698,8 +698,8 @@ TEST(clang_parser, struct_typedef)
 
   ASSERT_TRUE(bpftrace.structs.Has("struct max_align_t"));
   ASSERT_TRUE(bpftrace.structs.Has("max_align_t"));
-  auto max_align_struct = bpftrace.structs.Lookup("struct max_align_t");
-  auto max_align_typedef = bpftrace.structs.Lookup("max_align_t");
+  auto max_align_struct = bpftrace.structs.Lookup("struct max_align_t").lock();
+  auto max_align_typedef = bpftrace.structs.Lookup("max_align_t").lock();
 
   // Non-typedef'd struct
   EXPECT_EQ(max_align_struct->size, 4);
@@ -740,7 +740,7 @@ TEST(clang_parser, struct_qualifiers)
         bpftrace);
 
   ASSERT_TRUE(bpftrace.structs.Has("struct b"));
-  auto SB = bpftrace.structs.Lookup("struct b");
+  auto SB = bpftrace.structs.Lookup("struct b").lock();
   EXPECT_EQ(SB->size, 16);
   EXPECT_EQ(SB->fields.size(), 2U);
 
@@ -774,7 +774,8 @@ struct _tracepoint_irq_irq_handler_entry
 
   ASSERT_TRUE(bpftrace.structs.Has("struct _tracepoint_irq_irq_handler_entry"));
 
-  auto s = bpftrace.structs.Lookup("struct _tracepoint_irq_irq_handler_entry");
+  auto s = bpftrace.structs.Lookup("struct _tracepoint_irq_irq_handler_entry")
+               .lock();
   EXPECT_EQ(s->size, 16);
   EXPECT_EQ(s->fields.size(), 3U);
 

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -77,10 +77,12 @@ void setup_mock_bpftrace(MockBPFtrace &bpftrace)
   // Fill in some default tracepoint struct definitions
   bpftrace.structs.Add("struct _tracepoint_sched_sched_one", 8);
   bpftrace.structs.Lookup("struct _tracepoint_sched_sched_one")
+      .lock()
       ->AddField("common_field", CreateUInt64(), 8, false, {}, false);
 
   bpftrace.structs.Add("struct _tracepoint_sched_sched_two", 8);
   bpftrace.structs.Lookup("struct _tracepoint_sched_sched_two")
+      .lock()
       ->AddField("common_field",
                  CreateUInt64(),
                  16, // different offset than
@@ -90,6 +92,7 @@ void setup_mock_bpftrace(MockBPFtrace &bpftrace)
                  false);
   bpftrace.structs.Add("struct _tracepoint_sched_extra_sched_extra", 8);
   bpftrace.structs.Lookup("struct _tracepoint_sched_extra_sched_extra")
+      .lock()
       ->AddField("common_field",
                  CreateUInt64(),
                  24, // different offset than
@@ -99,14 +102,17 @@ void setup_mock_bpftrace(MockBPFtrace &bpftrace)
                  false);
   bpftrace.structs.Add("struct _tracepoint_tcp_some_tcp_tp", 16);
   bpftrace.structs.Lookup("struct _tracepoint_tcp_some_tcp_tp")
+      .lock()
       ->AddField(
           "saddr_v6", CreateArray(16, CreateUInt(8)), 8, false, {}, false);
 
   auto ptr_type = CreatePointer(CreateInt8());
   bpftrace.structs.Add("struct _tracepoint_file_filename", 8);
   bpftrace.structs.Lookup("struct _tracepoint_file_filename")
+      .lock()
       ->AddField("common_field", CreateUInt64(), 0, false, {}, false);
   bpftrace.structs.Lookup("struct _tracepoint_file_filename")
+      .lock()
       ->AddField("filename", ptr_type, 8, false, {}, false);
 }
 

--- a/tests/required_resources.cpp
+++ b/tests/required_resources.cpp
@@ -1,0 +1,186 @@
+#include "required_resources.h"
+
+#include <iostream>
+#include <sstream>
+
+#include <gtest/gtest.h>
+
+#include "struct.h"
+#include "types.h"
+
+namespace bpftrace {
+namespace test {
+
+// ========================================================================
+// It's a bit overkill to completely test every field in `RequiredResources`
+// so for these tests we opt to get coverage on every type we serialize.
+// ========================================================================
+
+TEST(required_resources, round_trip_simple)
+{
+  std::ostringstream serialized(std::ios::binary);
+  {
+    RequiredResources r;
+    r.probe_ids.emplace_back("itsastring");
+    r.save_state(serialized);
+  }
+
+  std::istringstream input(serialized.str());
+  {
+    RequiredResources r;
+    r.load_state(input);
+    ASSERT_EQ(r.probe_ids.size(), 1);
+    EXPECT_EQ(r.probe_ids[0], "itsastring");
+  }
+}
+
+TEST(required_resources, round_trip_field_sized_type)
+{
+  std::ostringstream serialized(std::ios::binary);
+  {
+    RequiredResources r;
+    r.system_args.emplace_back("field0",
+                               std::vector{ Field{
+                                   .name = "myfield",
+                                   .type = CreateInt32(),
+                                   .offset = 123,
+                                   .is_bitfield = false,
+                                   .bitfield =
+                                       Bitfield{
+                                           .read_bytes = 1,
+                                           .access_rshift = 2,
+                                           .mask = 0xFF,
+                                       },
+                               } });
+    r.save_state(serialized);
+  }
+
+  std::istringstream input(serialized.str());
+  {
+    RequiredResources r;
+    r.load_state(input);
+
+    ASSERT_EQ(r.system_args.size(), 1);
+    EXPECT_EQ(std::get<0>(r.system_args[0]), "field0");
+
+    auto &fields = std::get<1>(r.system_args[0]);
+    ASSERT_EQ(fields.size(), 1);
+    auto &field = fields[0];
+    EXPECT_EQ(field.name, "myfield");
+    EXPECT_TRUE(field.type.IsIntTy());
+    EXPECT_EQ(field.type.GetSize(), 4);
+    EXPECT_EQ(field.offset, 123);
+    EXPECT_EQ(field.is_bitfield, false);
+    EXPECT_EQ(field.bitfield.read_bytes, 1);
+    EXPECT_EQ(field.bitfield.access_rshift, 2);
+    EXPECT_EQ(field.bitfield.mask, 0xFF);
+  }
+}
+
+TEST(required_resources, round_trip_map_sized_type)
+{
+  std::ostringstream serialized(std::ios::binary);
+  {
+    RequiredResources r;
+    r.map_vals.insert({ "mymap", CreateInet(3) });
+    r.save_state(serialized);
+  }
+
+  std::istringstream input(serialized.str());
+  {
+    RequiredResources r;
+    r.load_state(input);
+
+    ASSERT_EQ(r.map_vals.count("mymap"), 1);
+    auto &type = r.map_vals["mymap"];
+    EXPECT_TRUE(type.IsInetTy());
+    EXPECT_EQ(type.GetSize(), 3);
+  }
+}
+
+TEST(required_resources, round_trip_map_lhist_args)
+{
+  std::ostringstream serialized(std::ios::binary);
+  {
+    RequiredResources r;
+    r.lhist_args.insert({ "mymap",
+                          LinearHistogramArgs{
+                              .min = 99,
+                              .max = 123,
+                              .step = 33,
+                          } });
+    r.save_state(serialized);
+  }
+
+  std::istringstream input(serialized.str());
+  {
+    RequiredResources r;
+    r.load_state(input);
+
+    ASSERT_EQ(r.lhist_args.count("mymap"), 1);
+    auto &args = r.lhist_args["mymap"];
+    EXPECT_EQ(args.min, 99);
+    EXPECT_EQ(args.max, 123);
+    EXPECT_EQ(args.step, 33);
+  }
+}
+
+TEST(required_resources, round_trip_set_stack_type)
+{
+  std::ostringstream serialized(std::ios::binary);
+  {
+    RequiredResources r;
+    r.stackid_maps.insert(StackType{
+        .limit = 33,
+        .mode = StackMode::perf,
+    });
+    r.save_state(serialized);
+  }
+
+  std::istringstream input(serialized.str());
+  {
+    RequiredResources r;
+    r.load_state(input);
+
+    ASSERT_EQ(r.stackid_maps.size(), 1);
+    for (const auto &st : r.stackid_maps)
+    {
+      EXPECT_EQ(st.limit, 33);
+      EXPECT_EQ(st.mode, StackMode::perf);
+    }
+  }
+}
+
+TEST(required_resources, round_trip_multiple_members)
+{
+  std::ostringstream serialized(std::ios::binary);
+  {
+    RequiredResources r;
+    r.join_args.emplace_back("joinarg0");
+    r.stackid_maps.insert(StackType{
+        .limit = 33,
+        .mode = StackMode::perf,
+    });
+    r.needs_elapsed_map = true;
+    r.save_state(serialized);
+  }
+
+  std::istringstream input(serialized.str());
+  {
+    RequiredResources r;
+    r.load_state(input);
+
+    ASSERT_EQ(r.join_args.size(), 1);
+    EXPECT_EQ(r.join_args[0], "joinarg0");
+    ASSERT_EQ(r.stackid_maps.size(), 1);
+    for (const auto &st : r.stackid_maps)
+    {
+      EXPECT_EQ(st.limit, 33);
+      EXPECT_EQ(st.mode, StackMode::perf);
+    }
+    EXPECT_TRUE(r.needs_elapsed_map);
+  }
+}
+
+} // namespace test
+} // namespace bpftrace


### PR DESCRIPTION
This PR enables `RequiredResources` to be serialized to disk and
then later deserialized back into memory.

Maintaining serialization/deserialization is a tad invasive and it will
require constant vigilance when new fields are added. Fortunately,
it's not too many types and other types of changes (renames, type
changes) should be caught by the compiler. Hopefully it's not too
much of a bother.

Note that this change also adds a new required dependency:
libcereal. Most distros have it packaged: https://pkgs.org/search/?q=cereal .

cereal was chosen over libnop b/c cereal seems more widely
used and popular and is also packaged in more distros.

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
