### PR TITLE
Expand int syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to
   - [#1893](https://github.com/iovisor/bpftrace/pull/1893)
 - Support microsecond timestamps in stftime()
   - [#1922](https://github.com/iovisor/bpftrace/pull/1922)
+- Add `_` as integer literal digit separator
+  - [#1900](https://github.com/iovisor/bpftrace/pull/1900)
 
 #### Changed
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -27,17 +27,18 @@ discussion to other files in /docs, the /tools/\*\_examples.txt files, or blog p
     - [1. `{...}`: Action Blocks](#1--action-blocks)
     - [2. `/.../`: Filtering](#2--filtering)
     - [3. `//`, `/*`: Comments](#3---comments)
-    - [4. `->`: C Struct Navigation](#4---c-struct-navigation)
-    - [5. `struct`: Struct Declaration](#5-struct-struct-declaration)
-    - [6. `? :`: ternary operators](#6---ternary-operators)
-    - [7. `if () {...} else {...}`: if-else statements](#7-if---else--if-else-statements)
-    - [8. `unroll () {...}`: unroll](#8-unroll---unroll)
-    - [9. `++ and --`: increment operators](#9--and----increment-operators)
-    - [10. `[]`: Array access](#10--array-access)
-    - [11. Integer casts](#11-integer-casts)
-    - [12. Looping constructs](#12-looping-constructs)
-    - [13. `return`: Terminate Early](#13-return-terminate-early)
-    - [14. `( , )`: Tuples](#14----tuples)
+    - [4. Literals](#4-literals)
+    - [5. `->`: C Struct Navigation](#5---c-struct-navigation)
+    - [6. `struct`: Struct Declaration](#6-struct-struct-declaration)
+    - [7. `? :`: ternary operators](#7---ternary-operators)
+    - [8. `if () {...} else {...}`: if-else statements](#8-if---else--if-else-statements)
+    - [9. `unroll () {...}`: unroll](#9-unroll---unroll)
+    - [10. `++ and --`: increment operators](#10--and----increment-operators)
+    - [11. `[]`: Array access](#11--array-access)
+    - [12. Integer casts](#12-integer-casts)
+    - [13. Looping constructs](#13-looping-constructs)
+    - [14. `return`: Terminate Early](#14-return-terminate-early)
+    - [15. `( , )`: Tuples](#15----tuples)
 - [Probes](#probes)
     - [1. `kprobe`/`kretprobe`: Dynamic Tracing, Kernel-Level](#1-kprobekretprobe-dynamic-tracing-kernel-level)
     - [2. `kprobe`/`kretprobe`: Dynamic Tracing, Kernel-Level Arguments](#2-kprobekretprobe-dynamic-tracing-kernel-level-arguments)
@@ -607,7 +608,26 @@ Syntax
 
 These can be used in bpftrace scripts to document your code.
 
-## 4. `->`: C Struct Navigation
+## 4. Literals
+
+ Integer, char and string literals are supported.
+ Integer literals are a sequence of digits with an optional underscore (`_`) as
+ field separator.
+ Scientific notation is also supported but only for integer values as BPF
+ doesn't support floating point.
+
+ ```
+ # bpftrace -e 'BEGIN { printf("%lu %lu %lu", 1000000, 1e6, 1_000_000)}'
+Attaching 1 probe...
+1000000 1000000 1000000
+ ```
+
+ Char literals are enclosed in single quotes, e.g. `'a'` and `'@'`.
+
+ String literals are enclosed in double quotes, e.g. `"a string"`.
+
+
+## 5. `->`: C Struct Navigation
 
 tracepoint example:
 
@@ -647,7 +667,7 @@ open path: retrans_time_ms
 This uses dynamic tracing of the `vfs_open()` kernel function, via the short script path.bt. Some kernel
 headers needed to be included to understand the `path` and `dentry` structs.
 
-## 5. `struct`: Struct Declaration
+## 6. `struct`: Struct Declaration
 
 Example:
 
@@ -664,7 +684,7 @@ You can define your own structs when needed. In some cases, kernel structs are n
 headers package, and are declared manually in bpftrace tools (or partial structs are: enough to reach the
 member to dereference).
 
-## 6. `? :`: ternary operators
+## 7. `? :`: ternary operators
 
 Examples:
 
@@ -683,7 +703,7 @@ Attaching 1 probe...
 Odd
 ```
 
-## 7. `if () {...} else {...}`: if-else statements
+## 8. `if () {...} else {...}`: if-else statements
 
 Example:
 
@@ -697,7 +717,7 @@ Attaching 1 probe...
 @reads: 80
 ```
 
-## 8. `unroll () {...}`: Unroll
+## 9. `unroll () {...}`: Unroll
 
 Example:
 
@@ -713,7 +733,7 @@ i: 5
 
 ```
 
-## 9. `++` and `--`: Increment operators
+## 10. `++` and `--`: Increment operators
 
 `++` and `--` can be used to conveniently increment or decrement counters in maps or variables.
 
@@ -750,7 +770,7 @@ Attaching 1 probe...
 @[kprobe:vfs_read]: 13369
 ```
 
-## 10. `[]`: Array Access
+## 11. `[]`: Array Access
 
 You may access one-dimensional constant arrays with the array access operator `[]`.
 
@@ -764,7 +784,7 @@ Attaching 1 probe...
 @x: 1
 ```
 
-## 11. Integer casts
+## 12. Integer casts
 
 Integers are internally represented as 64 bit signed. If you need another
 representation, you may cast to the following built in types:
@@ -789,7 +809,7 @@ Attaching 1 probe...
 ^C
 ```
 
-## 12. Looping Constructs
+## 13. Looping Constructs
 
 **Experimental**
 
@@ -803,12 +823,12 @@ bpftrace supports C style while loops:
 
 Loops can be short circuited by using the `continue` and `break` keywords.
 
-## 13. `return`: Terminate Early
+## 14. `return`: Terminate Early
 
 The `return` keyword is used to exit the current probe. This differs from
 `exit()` in that it doesn't exit bpftrace.
 
-## 14. `( , )`: Tuples
+## 15. `( , )`: Tuples
 
 N-tuples are supported, where N is any integer greater than 1.
 

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(ast
   codegen_llvm.cpp
   fake_map.cpp
   field_analyser.cpp
+  int_parser.cpp
   irbuilderbpf.cpp
   pass_manager.cpp
   portability_analyser.cpp

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -501,7 +501,7 @@ public:
   std::string func;
   std::string pin;
   usdt_probe_entry usdt; // resolved USDT entry, used to support arguments with wildcard matches
-  int freq = 0;
+  int64_t freq = 0;
   uint64_t len = 0;   // for watchpoint probes, the width of watched addr
   std::string mode;   // for watchpoint probes, the watch mode
   bool async = false; // for watchpoint probes, if it's an async watchpoint

--- a/src/ast/attachpoint_parser.h
+++ b/src/ast/attachpoint_parser.h
@@ -59,6 +59,7 @@ private:
   State iter_parser();
 
   std::optional<uint64_t> stoull(const std::string &str);
+  std::optional<int64_t> stoll(const std::string &str);
 
   Program *root_{ nullptr }; // Non-owning pointer
   BPFtrace &bpftrace_;

--- a/src/ast/int_parser.cpp
+++ b/src/ast/int_parser.cpp
@@ -1,0 +1,142 @@
+#include <algorithm>
+#include <exception>
+#include <sstream>
+#include <stdexcept>
+#include <type_traits>
+#include <variant>
+
+#include "int_parser.h"
+
+namespace {
+
+template <typename T>
+T _parse_int(const std::string &num, size_t *idx, int base)
+{
+  static_assert(not std::is_same_v<T, T>,
+                "BUG: _parse_int not implemented for type");
+}
+
+template <>
+int64_t _parse_int(const std::string &num, size_t *idx, int base)
+{
+  return std::stoll(num, idx, base);
+}
+
+template <>
+uint64_t _parse_int(const std::string &num, size_t *idx, int base)
+{
+  return std::stoull(num, idx, base);
+}
+
+template <typename T>
+std::variant<T, std::string> _parse_int(const std::string &num, int base)
+{
+  try
+  {
+    std::size_t idx;
+    T ret = _parse_int<T>(num, &idx, base);
+
+    if (idx != num.size())
+      return "Found trailing non-numeric characters";
+
+    return ret;
+  }
+  catch (const std::exception &ex)
+  {
+    return ex.what();
+  }
+}
+
+// integer variant of   10^exp
+uint64_t _ten_pow(uint64_t exp)
+{
+  static const uint64_t v[] = { 1, 10, 100, 1000, 10000, 100000, 1000000 };
+  if (exp > 6)
+    return v[6] * _ten_pow(exp - 6);
+  return v[exp];
+}
+
+// integer variant of scientific notation parsing
+template <typename T>
+std::variant<T, std::string> _parse_exp(const std::string &coeff,
+                                        const std::string &exp)
+{
+  std::stringstream errmsg;
+  auto maybe_coeff = _parse_int<T>(coeff, 10);
+  if (auto err = std::get_if<std::string>(&maybe_coeff))
+  {
+    errmsg << "Coefficient part of scientific literal is not a valid number: "
+           << coeff << ": " << err;
+    return errmsg.str();
+  }
+
+  auto maybe_exp = _parse_int<T>(exp, 10);
+  if (auto err = std::get_if<std::string>(&maybe_exp))
+  {
+    errmsg << "Exponent part of scientific literal is not a valid number: "
+           << exp << ": " << err;
+    return errmsg.str();
+  }
+
+  auto c = std::get<T>(maybe_coeff);
+  auto e = std::get<T>(maybe_exp);
+
+  if (c > 9)
+  {
+    errmsg << "Coefficient part of scientific literal must be in range (0,9), "
+              "got: "
+           << coeff;
+    return errmsg.str();
+  }
+
+  if (e > 16)
+  {
+    errmsg << "Exponent will overflow integer range: " << exp;
+    return errmsg.str();
+  }
+
+  return c * (T)_ten_pow(e);
+}
+
+} // namespace
+
+namespace bpftrace {
+namespace ast {
+namespace int_parser {
+
+template <typename T>
+T to_int(const std::string &num, int base)
+{
+  std::string n(num);
+  n.erase(std::remove(n.begin(), n.end(), '_'), n.end());
+
+  std::variant<T, std::string> res;
+
+  auto pos = n.find_first_of("eE");
+  if (pos != std::string::npos)
+  {
+    res = _parse_exp<T>(n.substr(0, pos), n.substr(pos + 1, std::string::npos));
+  }
+  else
+  {
+    res = _parse_int<T>(n, base);
+  }
+
+  if (auto err = std::get_if<std::string>(&res))
+    throw std::invalid_argument(*err);
+  return std::get<T>(res);
+}
+
+int64_t to_int(const std::string &num, int base)
+{
+  return to_int<int64_t>(num, base);
+}
+
+uint64_t to_uint(const std::string &num, int base)
+{
+  return to_int<uint64_t>(num, base);
+}
+
+} // namespace int_parser
+} // namespace ast
+} // namespace bpftrace

--- a/src/ast/int_parser.h
+++ b/src/ast/int_parser.h
@@ -1,0 +1,23 @@
+#include <string>
+
+namespace bpftrace {
+namespace ast {
+namespace int_parser {
+
+/*
+  String -> int conversion specific to bpftrace
+
+  - error when trailing characters are found
+  - supports scientific notation, e.g. 1e6
+    - error when out of int range (1e20)
+    - error when base > 9 (12e3)
+  - support underscore as separator, e.g. 1_234_000
+
+  All errors are raised as std::invalid_argument exception
+ */
+int64_t to_int(const std::string &num, int base);
+uint64_t to_uint(const std::string &num, int base);
+
+} // namespace int_parser
+} // namespace ast
+} // namespace bpftrace

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -19,13 +19,15 @@ static std::string buffer;
 using namespace bpftrace;
 %}
 
+/* Number with underscores in it, e.g. 1_000_000 */
+int      [0-9]([0-9_]*[0-9])?
+hex      0[xX][0-9a-fA-F]+
+/* scientific notation, e.g. 2e4 or 1e6 */
+exponent {int}[eE]{int}
+
 ident    [_a-zA-Z][_a-zA-Z0-9]*
 map      @{ident}|@
 var      ${ident}
-int      [0-9]+|0[xX][0-9a-fA-F]+
-exponent [0-9]+e[0-9]+
-hex      (x|X)[0-9a-fA-F]{1,2}
-oct      [0-7]{1,3}
 hspace   [ \t]
 vspace   [\n\r]
 space    {hspace}|{vspace}
@@ -35,6 +37,11 @@ call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|
 
 /* Don't add to this! Use builtin OR call not both */
 call_and_builtin kstack|ustack
+
+/* escape sequences in strings */
+hex_esc  (x|X)[0-9a-fA-F]{1,2}
+oct_esc  [0-7]{1,3}
+
 %x STR
 %x STRUCT
 %x ENUM
@@ -60,13 +67,14 @@ bpftrace|perf           { return Parser::make_STACK_MODE(yytext, loc); }
 {builtin}               { return Parser::make_BUILTIN(yytext, loc); }
 {call}                  { return Parser::make_CALL(yytext, loc); }
 {call_and_builtin}      { return Parser::make_CALL_BUILTIN(yytext, loc); }
-{int}                   { return Parser::make_INT(strtoul(yytext, NULL, 0), loc); }
-{exponent}              {
-                          uint64_t num;
-                          try {
-                            num = parse_exponent(yytext);
-                            return Parser::make_INT(num, loc);
-                          } catch (std::exception const &e) {
+{int}|{hex}|{exponent}  {
+                          try
+                          {
+                            auto res = ast::int_parser::to_uint(yytext, 0);
+                            return Parser::make_INT(res, loc);
+                          }
+                          catch (const std::exception &e)
+                          {
                             driver.error(loc, e.what());
                           }
                         }
@@ -140,14 +148,14 @@ bpftrace|perf           { return Parser::make_STACK_MODE(yytext, loc); }
   \\r                   buffer += '\r';
   \\\"                  buffer += '\"';
   \\\\                  buffer += '\\';
-  \\{oct}               {
+  \\{oct_esc}           {
                             long value = strtol(yytext+1, NULL, 8);
                             if (value > UCHAR_MAX)
                               driver.error(loc, std::string("octal escape sequence out of range '") +
                                                 yytext + "'");
                             buffer += value;
                         }
-  \\{hex}               buffer += strtol(yytext+2, NULL, 16);
+  \\{hex_esc}           buffer += strtol(yytext+2, NULL, 16);
   \n                    driver.error(loc, "unterminated string"); yy_pop_state(yyscanner); loc.lines(1); loc.step();
   <<EOF>>               driver.error(loc, "unterminated string"); yy_pop_state(yyscanner);
   \\.                   { driver.error(loc, std::string("invalid escape character '") +

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -7,6 +7,7 @@
 #include "driver.h"
 #include "utils.h"
 #include "parser.tab.hh"
+#include "ast/int_parser.h"
 
 bpftrace::location loc;
 static std::string struct_type;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -793,22 +793,6 @@ std::unordered_set<std::string> get_traceable_funcs()
 #endif
 }
 
-uint64_t parse_exponent(const char *str)
-{
-  char *e_offset;
-  auto base = strtoll(str, &e_offset, 10);
-
-  if (*e_offset != 'e')
-    return base;
-
-  auto exp = strtoll(e_offset + 1, nullptr, 10);
-  auto num = base * std::pow(10, exp);
-  uint64_t max = std::numeric_limits<uint64_t>::max();
-  if (num > (double)max)
-    throw std::runtime_error(std::string(str) + " is too big for uint64_t");
-  return num;
-}
-
 /**
  * Search for LINUX_VERSION_CODE in the vDSO, returning 0 if it can't be found.
  */

--- a/src/utils.h
+++ b/src/utils.h
@@ -223,7 +223,6 @@ T read_data(const void *src)
   return v;
 }
 
-uint64_t parse_exponent(const char *str);
 uint32_t kernel_version(int attempt);
 
 template <typename T>

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1094,6 +1094,16 @@ TEST(Parser, interval_probe)
       " interval:s:1\n"
       "  int: 1\n");
 
+  test("interval:s:1e3 { 1 }",
+       "Program\n"
+       " interval:s:1000\n"
+       "  int: 1\n");
+
+  test("interval:s:1_0_0_0 { 1 }",
+       "Program\n"
+       " interval:s:1000\n"
+       "  int: 1\n");
+
   test_parse_failure("interval:s:1b { 1 }");
 }
 
@@ -1104,6 +1114,16 @@ TEST(Parser, software_probe)
       " software:faults:1000\n"
       "  int: 1\n");
 
+  test("software:faults:1e3 { 1 }",
+       "Program\n"
+       " software:faults:1000\n"
+       "  int: 1\n");
+
+  test("software:faults:1_000 { 1 }",
+       "Program\n"
+       " software:faults:1000\n"
+       "  int: 1\n");
+
   test_parse_failure("software:faults:1b { 1 }");
 }
 
@@ -1113,6 +1133,16 @@ TEST(Parser, hardware_probe)
       "Program\n"
       " hardware:cache-references:1000000\n"
       "  int: 1\n");
+
+  test("hardware:cache-references:1e6 { 1 }",
+       "Program\n"
+       " hardware:cache-references:1000000\n"
+       "  int: 1\n");
+
+  test("hardware:cache-references:1_000_000 { 1 }",
+       "Program\n"
+       " hardware:cache-references:1000000\n"
+       "  int: 1\n");
 
   test_parse_failure("hardware:cache-references:1b { 1 }");
 }
@@ -1689,15 +1719,28 @@ TEST(Parser, empty_arguments)
   test_parse_failure(":w:0x10000000:8:rw { 1 }");
 }
 
-TEST(Parser, scientific_notation)
+TEST(Parser, int_notation)
 {
   test("k:f { print(1e6); }",
        "Program\n kprobe:f\n  call: print\n   int: 1000000\n");
   test("k:f { print(5e9); }",
        "Program\n kprobe:f\n  call: print\n   int: 5000000000\n");
+  test("k:f { print(1e1_0); }",
+       "Program\n kprobe:f\n  call: print\n   int: 10000000000\n");
+  test("k:f { print(1_000_000_000_0); }",
+       "Program\n kprobe:f\n  call: print\n   int: 10000000000\n");
+  test("k:f { print(1_0_0_0_00_0_000_0); }",
+       "Program\n kprobe:f\n  call: print\n   int: 10000000000\n");
+  test("k:f { print(123_456_789_0); }",
+       "Program\n kprobe:f\n  call: print\n   int: 1234567890\n");
 
   test_parse_failure("k:f { print(5e-9); }");
-  test_parse_failure("k:f { print(1e100); }");
+  test_parse_failure("k:f { print(1e17); }");
+  test_parse_failure("k:f { print(12e4); }");
+  test_parse_failure("k:f { print(1_1e100); }");
+  test_parse_failure("k:f { print(1e1_1_); }");
+  test_parse_failure("k:f { print(1_1_e100); }");
+  test_parse_failure("k:f { print(1_1_); }");
 }
 
 TEST(Parser, while_loop)

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -129,19 +129,6 @@ TEST(utils, resolve_binary_path)
   exec_system(("rm -rf " + path).c_str());
 }
 
-TEST(utils, parse_exponent)
-{
-  EXPECT_EQ(parse_exponent((const char*)"1e0"), 1e0);
-  EXPECT_EQ(parse_exponent((const char*)"1e1"), 1e1);
-  EXPECT_EQ(parse_exponent((const char*)"1e9"), 1e9);
-  EXPECT_EQ(parse_exponent((const char*)"2e1"), 2e1);
-  EXPECT_EQ(parse_exponent((const char*)"2e9"), 2e9);
-  EXPECT_EQ(parse_exponent((const char*)"2e9"), 2e9);
-  EXPECT_EQ(parse_exponent((const char*)"010e010"), 1e11);
-
-  EXPECT_EQ(parse_exponent((const char*)"2a9"), 2ULL);
-}
-
 TEST(utils, abs_path)
 {
   std::string path = "/tmp/bpftrace-test-utils-XXXXXX";


### PR DESCRIPTION
This will allow us use underscores as int digit separator to improve readability, e.g. 1_000_000 and unifies the int parsing logic allowing us to use the same syntax in attach points. E.g. hardware:cache-misses:1e6 or 1_000 are now valid instead.

The exponent parsing thing feels a bit clunky, c++ supports it out of the box but for doubles only, might be easier to just use that instead. But its hidden behind a simple interface so we can always change it if needed.

Fixes #1897 
Fixes #1898
