### PR TITLE
tools: add new tool dropwatch.bt

### DIFF
--- a/tools/hwdrop.bt
+++ b/tools/hwdrop.bt
@@ -1,0 +1,52 @@
+#!/usr/bin/bpftrace
+/*
+ * hwdrop.bt	Trace kernel packets hardware drops.
+ *		For Linux, uses bpftrace and eBPF.
+ *
+ * USAGE: hwdrop.bt
+ *
+ * This provides kernel packets hardware drops with interface and trap info.
+ *
+ * Copyright (c) 2021 Hangbin Liu.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ */
+
+#include <linux/devlink.h>
+#include <net/devlink.h>
+
+// from net/core/devlink.c
+struct devlink_trap_item {
+        struct devlink_trap *trap;
+        // [...]
+};
+
+BEGIN
+{
+	printf("Tracing kernel hardware packets drops. Hit Ctrl-C to end.\n");
+}
+
+kprobe:devlink_trap_report
+{
+	$devlink = (struct devlink *)arg0;
+	$skb = (struct sk_buff*)arg1;
+	$trap_item = (struct devlink_trap_item *)arg2;
+	$devlink_port = (struct devlink_port *)arg4;
+
+	/* The same with dropwatch, we only ignore CONTROL type, see
+	 * include/uapi/linux/devlink.h: enum devlink_trap_type
+	*/
+	if ($trap_item->trap->type == DEVLINK_TRAP_TYPE_CONTROL) {
+		return;
+	}
+
+	if ($devlink_port->type == DEVLINK_PORT_TYPE_ETH) {
+		$dev = (struct net_device *)$devlink_port->type_dev;
+		printf("drop at %s, input port name %s, ifindex %d, dev driver %s, protocol 0x%02x, skb len %u\n",
+		       str($trap_item->trap->name), $dev->name, $dev->ifindex,
+		       str($devlink->dev->driver->name), $skb->protocol, $skb->len);
+	} else {
+		printf("drop at %s, dev driver %s, protocol 0x%02x, skb len %u\n",
+		       str($trap_item->trap->name), str($devlink->dev->driver->name),
+		       $skb->protocol, $skb->len);
+	}
+}

--- a/tools/hwdrop_example.bt
+++ b/tools/hwdrop_example.bt
@@ -1,0 +1,22 @@
+Demonstrations of hwdrop, the Linux bpftrace/eBPF version.
+
+hwdrop prints packet interface and trap info that were dropped by the
+kernel hardware.
+
+# ./hwdrop.bt
+Attaching 2 probes...
+Tracing kernel hardware packets drops. Hit Ctrl-C to end.
+drop at fid_miss, dev driver netdevsim, protocol 0x08, skb len 142
+drop at ttl_value_is_too_small, dev driver netdevsim, protocol 0x08, skb len 142
+drop at fid_miss, dev driver netdevsim, protocol 0x08, skb len 142
+drop at blackhole_route, dev driver netdevsim, protocol 0x08, skb len 142
+drop at ttl_value_is_too_small, dev driver netdevsim, protocol 0x08, skb len 142
+[...]
+
+The example shows devlink tap info when there are kernel hardware drops.
+
+This tool is useful to diagnose where packets are getting dropped in hardware.
+
+USAGE:
+
+# ./hwdrop.bt

--- a/tools/swdrop.bt
+++ b/tools/swdrop.bt
@@ -1,0 +1,38 @@
+#!/usr/bin/env bpftrace
+/*
+ * swdrop.bt	Trace kernel packets software drops.
+ *		For Linux, uses bpftrace and eBPF.
+ *
+ * USAGE: swdrop.bt
+ *
+ * This provides kernel packets software drops by tracking kernel function
+ * kfree_skb(). It will printing drop stacks every 1 second.
+ *
+ * Copyright (c) 2021 Hangbin Liu.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ */
+
+#include <linux/devlink.h>
+#include <net/devlink.h>
+
+BEGIN
+{
+	printf("Tracing kernel software packets drops. Hit Ctrl-C to end.\n");
+}
+
+tracepoint:skb:kfree_skb
+{
+	@[kstack] = count();
+}
+
+interval:s:1
+{
+        time();
+        print(@);
+        clear(@);
+}
+
+END
+{
+        clear(@);
+}

--- a/tools/swdrop_example.bt
+++ b/tools/swdrop_example.bt
@@ -1,0 +1,44 @@
+Demonstrations of swdrop, the Linux bpftrace/eBPF version.
+
+swdrop prints details of packets that were dropped by the kernel from
+software stack.
+
+# ./swdrop.bt
+Attaching 4 probes...
+Tracing kernel software packets drops. Hit Ctrl-C to end.
+08:40:25
+@[
+    kfree_skb+1
+    ip_rcv_core.isra.23+487
+    ip_list_rcv+202
+    __netif_receive_skb_list_core+667
+    netif_receive_skb_list_internal+451
+    gro_normal_list.part.155+25
+    napi_complete_done+103
+    virtqueue_napi_complete+42
+    virtnet_poll+790
+    __napi_poll+43
+    net_rx_action+566
+    __softirqentry_text_start+201
+    irq_exit_rcu+212
+    common_interrupt+127
+    asm_common_interrupt+30
+    default_idle+19
+    default_idle_call+50
+    do_idle+514
+    cpu_startup_entry+25
+    start_secondary+283
+    secondary_startup_64_no_verify+194
+]: 3
+
+[...]
+
+The example shows kernel packet drops via kfree_skb.
+
+Although there may have some false positives as some driver may free the
+skb wrongly with kfree_skb() instead of consume_skb(), which is a bug.
+It's still the most useful way to find where packets are getting dropped.
+
+USAGE:
+
+# ./swdrop.bt


### PR DESCRIPTION
This is a bpftrace version of dropwatch. It's used to show where are
packets are dropped. Both software and hardware stack are supported.

Signed-off-by: Hangbin Liu <liuhangbin@gmail.com>