### PR TITLE
Memory leak tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,20 @@ jobs:
           BASE: bionic
           VENDOR_GTEST: ON
           BUILD_LIBBPF: ON
+        - NAME: Memleak test (LLVM 11 Debug)
+          TYPE: Debug
+          LLVM_VERSION: 11
+          BASE: bionic
+          RUN_MEMLEAK_TEST: 1
+          RUN_TESTS: 0
+          VENDOR_GTEST: ON
+        - NAME: Memleak test (LLVM 11 Release)
+          TYPE: Release
+          LLVM_VERSION: 11
+          BASE: bionic
+          RUN_MEMLEAK_TEST: 1
+          RUN_TESTS: 0
+          VENDOR_GTEST: ON
     steps:
     - uses: actions/checkout@v2
     - name: Get date
@@ -177,7 +191,9 @@ jobs:
         -v /sys/kernel/debug:/sys/kernel/debug:rw
         -v /lib/modules:/lib/modules:ro
         -v /usr/src:/usr/src:ro
+        -e RUN_TESTS=${RUN_TESTS}
         -e RUN_ALL_TESTS=${RUN_ALL_TESTS}
+        -e RUN_MEMLEAK_TEST="${RUN_MEMLEAK_TEST}"
         -e CMAKE_EXTRA_FLAGS="${CMAKE_EXTRA_FLAGS}"
         -e RUNTIME_TEST_DISABLE="${RUNTIME_TEST_DISABLE}"
         -e VENDOR_GTEST="${VENDOR_GTEST}"

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -11,6 +11,7 @@ EMBED_BUILD_LLVM=${EMBED_BUILD_LLVM:-OFF}
 ALLOW_UNSAFE_PROBE=${ALLOW_UNSAFE_PROBE:-OFF}
 DEPS_ONLY=${DEPS_ONLY:-OFF}
 RUN_TESTS=${RUN_TESTS:-1}
+RUN_MEMLEAK_TEST=${RUN_MEMLEAK_TEST:-0}
 VENDOR_GTEST=${VENDOR_GTEST:-OFF}
 CI_TIMEOUT=${CI_TIMEOUT:-0}
 BUILD_LIBBPF=${BUILD_LIBBPF:-OFF}
@@ -39,6 +40,7 @@ cmake -DCMAKE_BUILD_TYPE="$2" \
       -DEMBED_LLVM_VERSION=$LLVM_VERSION \
       -DALLOW_UNSAFE_PROBE:BOOL=$ALLOW_UNSAFE_PROBE \
       -DVENDOR_GTEST=$VENDOR_GTEST \
+      -DBUILD_ASAN:BOOL=$RUN_MEMLEAK_TEST \
       -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
       "${CMAKE_EXTRA_FLAGS}" \
       ../
@@ -55,4 +57,10 @@ if [ $RUN_TESTS = 1 ]; then
   else
     ./tests/bpftrace_test $TEST_ARGS;
   fi
+fi
+
+# Memleak tests require bpftrace built with -fsanitize=address so it cannot be
+# usually run with unit/runtime tests (RUN_TESTS should be set to 0). 
+if [ $RUN_MEMLEAK_TEST = 1 ]; then
+  ./tests/memleak-tests.sh
 fi

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -8,7 +8,9 @@ if(BUILD_FUZZ)
   set(BPFTRACE bpftrace_fuzz)
 else()
   set(MAIN_SRC main.cpp)
-  set(BPFTRACE bpftrace)
+  if (NOT DEFINED BPFTRACE)
+    set(BPFTRACE bpftrace)
+  endif ()
 endif()
 
 add_library(libbpftrace

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -188,6 +188,11 @@ configure_file(tools-parsing-test.sh tools-parsing-test.sh COPYONLY)
 add_custom_target(tools-parsing-test COMMAND ./tools-parsing-test.sh)
 add_test(NAME tools-parsing-test COMMAND ./tools-parsing-test.sh)
 
+if (BUILD_ASAN)
+  configure_file(memleak-tests.sh memleak-tests.sh COPYONLY)
+  add_custom_target(memleak-test COMMAND ./memleak-tests.sh)
+endif()
+
 if(ENABLE_TEST_VALIDATE_CODEGEN)
   if(${LLVM_VERSION_MAJOR} VERSION_EQUAL 12)
     message(STATUS "Adding codegen-validator test")

--- a/tests/memleak-tests.sh
+++ b/tests/memleak-tests.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+
+if [[ $EUID -ne 0 ]]; then
+    >&2 echo "Must be run as root"
+    exit 1
+fi
+
+set -e;
+
+pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1
+
+BPFTRACE_ASAN=${BPFTRACE_ASAN:-../src/bpftrace}
+
+if ! nm $BPFTRACE_ASAN | grep -q __asan; then
+    >&2 echo "WARNING: bpftrace seems to be compiled without -fsanitize=address,"
+    >&2 echo "results may be incorrect (make sure to use -DBUILD_ASAN=On with CMake)"
+fi
+
+if tty -s; then
+    RED=`tput setaf 1`
+    GREEN=`tput setaf 2`
+    NC=`tput sgr 0`
+else
+    RED=
+    GREEN=
+    NC=
+fi
+
+# Add new testcases here
+tests=(
+    '"BEGIN { exit(); }"'
+    $'"#include <linux/skbuff.h>\n BEGIN { \$x = ((struct sk_buff *)curtask)->data_len; exit(); }"'
+    )
+
+echo "${GREEN}[==========]${NC} Running ${#tests[@]} tests"
+
+result=0
+for tst in "${tests[@]}"; do
+    echo "${GREEN}[ RUN      ]${NC} bpftrace -e $tst"
+
+    export ASAN_OPTIONS="alloc_dealloc_mismatch=0"
+    if eval $BPFTRACE_ASAN -e "$tst" > /dev/null 2>&1 ; then
+        echo "${GREEN}[       OK ]"
+    else
+        echo "${RED}[  MEMLEAK ]"
+        result=1
+    fi
+done
+
+echo "${GREEN}[==========]"
+
+if [ $result -eq 0 ]; then
+    echo "${GREEN}[  PASSED  ]${NC} All tests were succesful"
+else
+    echo "${RED}[  FAILED  ]${NC} Memory leaks detected"
+fi
+
+exit $result
+


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

This PR introduces a simple test suite for memory leaks. It is implemented as a bash script (`tests/memleak-tests.sh`) which expects bpftrace built with address sanitizer (`-fsanitize=address`) and simply checks if the given test cases fail.

Currently, the test cases are included in (and should be added directly to) the script.

The tests are added to the CI with some configurations being skipped:
- LLVM 12, as it seems to contain a memory leak
- embedded Alpine, as it doesn't seem to be able to build with ASAN

Since we need to rebuild bpftrace with ASAN, the CI is prolonged.

Suggestions for further improvements/changes are welcome :-)

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
