### PR TITLE
Support microsecond timestamps in strftime()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to
 #### Added
 - Build time dependency on cereal
   - [#1893](https://github.com/iovisor/bpftrace/pull/1893)
+- Support microsecond timestamps in stftime()
+  - [#1922](https://github.com/iovisor/bpftrace/pull/1922)
 
 #### Changed
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -2939,6 +2939,12 @@ Use format specifier "%s" when printing the return value. Note that `strftime`
 does not actually return a string in bpf (kernel), the formatting happens in
 userspace.
 
+bpftrace also supports the following format string extensions:
+
+Specifier | Description
+---- | -----------
+`%f` | Microsecond as a decimal number, zero-padded on the left
+
 Examples:
 
 ```
@@ -2949,6 +2955,11 @@ Attaching 1 probe...
 13:11:24
 13:11:25
 13:11:26
+^C
+
+# bpftrace -e 'i:s:1 { printf("%s\n", strftime("%H:%M:%S:%f", nsecs)); }'
+Attaching 1 probe...
+15:22:24:104033
 ^C
 ```
 

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -260,6 +260,18 @@ RUN bpftrace -v -e 'BEGIN { @[nsecs] = strftime("%m/%d/%y", nsecs); exit();}'
 EXPECT @\[[0-9]*\]: [0-9]{2}\/[0-9]{2}\/[0-9]{2}
 TIMEOUT 5
 
+# Output two microsecond timestamps, 123000 nsecs apart. Use python to evaluate and verify there's a 123us delta
+NAME strftime_microsecond_extension
+RUN bpftrace -e 'BEGIN { printf("%s - %s\n", strftime("%f", 1000123000), strftime("%f", 0)); exit(); }' | tail -n +2 | xargs -I{} python -c "print({})"
+EXPECT 123
+TIMEOUT 1
+
+# Similar to above test but test that rolling over past 1s works as expected
+NAME strftime_microsecond_extension_rollover
+RUN bpftrace -e 'BEGIN { printf("%s - %s\n", strftime("%f", 1000000123000), strftime("%f", 0)); exit(); }' | tail -n +2 | xargs -I{} python -c "print({})"
+EXPECT 123
+TIMEOUT 1
+
 NAME print_avg_map_args
 RUN bpftrace -e 'BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 2, 10); print("END"); clear(@); exit(); }'
 EXPECT Attaching 1 probe\.\.\.\n@\[c\]: 3\n@\[d\]: 4\n\nEND


### PR DESCRIPTION
This commit adds `%f` specifier for microsecond timestamp. This is
similar to python's `%f` extension:
https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes .

This closes #1921.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [x] Language changes are updated in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
