### PR TITLE
tests: Fix broken strftime test

### DIFF
--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -261,14 +261,16 @@ EXPECT @\[[0-9]*\]: [0-9]{2}\/[0-9]{2}\/[0-9]{2}
 TIMEOUT 5
 
 # Output two microsecond timestamps, 123000 nsecs apart. Use python to evaluate and verify there's a 123us delta
+#
+# Note we add a `1` before the timestamp b/c leading zeros (eg `0123`) is invalid integer in python.
 NAME strftime_microsecond_extension
-RUN bpftrace -e 'BEGIN { printf("%s - %s\n", strftime("%f", 1000123000), strftime("%f", 0)); exit(); }' | tail -n +2 | xargs -I{} python -c "print({})"
+RUN bpftrace -e 'BEGIN { printf("%s - %s\n", strftime("1%f", 1000123000), strftime("1%f", 0)); exit(); }' | tail -n +2 | xargs -I{} python -c "print({})"
 EXPECT 123
 TIMEOUT 1
 
 # Similar to above test but test that rolling over past 1s works as expected
 NAME strftime_microsecond_extension_rollover
-RUN bpftrace -e 'BEGIN { printf("%s - %s\n", strftime("%f", 1000000123000), strftime("%f", 0)); exit(); }' | tail -n +2 | xargs -I{} python -c "print({})"
+RUN bpftrace -e 'BEGIN { printf("%s - %s\n", strftime("1%f", 1000000123000), strftime("1%f", 0)); exit(); }' | tail -n +2 | xargs -I{} python -c "print({})"
 EXPECT 123
 TIMEOUT 1
 


### PR DESCRIPTION
A leading 0 in an integer is invalid python syntax.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
