### PR TITLE
remove unused cmake flag from Dockerfile.llvm

### DIFF
--- a/docker/Dockerfile.llvm
+++ b/docker/Dockerfile.llvm
@@ -39,7 +39,7 @@ RUN curl -L --output /tmp/cmake.tar.gz \
   && tar -xf /tmp/cmake.tar.gz -C /usr/local/ --strip-components=1
 
 RUN cd /build/llvm \
-  && cmake . -DLLVM_VERSION=${LLVM_VERSION} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} -DENABLE_MAN=0 \
+  && cmake . -DLLVM_VERSION=${LLVM_VERSION} -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
   && make embedded_llvm -j$(nproc) \
   && make embedded_clang -j$(nproc) \
   && rm -rf embedded_llvm-prefix/src embedded_clang-prefix/src \


### PR DESCRIPTION
LLVM has its own stripped CMakeList.txt

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
