### PR TITLE
tests: Add {{BPFTRACE}} runtime variable

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -60,6 +60,7 @@ before running the test. These exist b/c the values of the variables are general
 not known until test time. The following runtime variables are available for the
 `RUN` directive:
 
+* `{{BPFTRACE}}`: Path to bpftrace executable
 * `{{BEFORE_PID}}`: Process ID of the process in `BEFORE` directive
 
 ### Test programs

--- a/tests/README.md
+++ b/tests/README.md
@@ -53,6 +53,15 @@ separate minimal programs to test tracing functionality, and argument passing
 hasn't been required. If test programs need arguments, a more sophisticated
 approach will be necessary.
 
+## Runtime variables
+
+Runtime variables are placeholders that the runtime test engine will fill out
+before running the test. These exist b/c the values of the variables are generally
+not known until test time. The following runtime variables are available for the
+`RUN` directive:
+
+* `{{BEFORE_PID}}`: Process ID of the process in `BEFORE` directive
+
 ### Test programs
 
 You can add test programs for your runtime tests by placing a `.c` file corresponding to your test program in `tests/testprogs`.

--- a/tests/runtime/addrspace
+++ b/tests/runtime/addrspace
@@ -1,5 +1,5 @@
 NAME openat uptr
-RUN bpftrace -v -e 't:syscalls:sys_enter_openat /comm == "syscall"/ { print(str(uptr(args->filename))) }' -c "./testprogs/syscall openat"
+RUN {{BPFTRACE}} -v -e 't:syscalls:sys_enter_openat /comm == "syscall"/ { print(str(uptr(args->filename))) }' -c "./testprogs/syscall openat"
 EXPECT bpftrace_runtime_test_syscall
 REQUIRES_FEATURE probe_read_kernel
 TIMEOUT 5

--- a/tests/runtime/array
+++ b/tests/runtime/array
@@ -1,137 +1,137 @@
 NAME array element access - assign to map
-RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; @x = $a->x[0]; exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; @x = $a->x[0]; exit(); }'
 EXPECT @x: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array element access - assign to var
-RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a->x[0]; printf("Result: %d\n", $x); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a->x[0]; printf("Result: %d\n", $x); exit(); }'
 EXPECT Result: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array element access - out of bounds
-RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a->x[5]; printf("%d\n", $x); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a->x[5]; printf("%d\n", $x); exit(); }'
 EXPECT the index 5 is out of bounds for array of size 4
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array element access via assignment into var
-RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = ((struct A *) arg0)->x; $x = $a[0]; printf("Result: %d\n", $x); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = ((struct A *) arg0)->x; $x = $a[0]; printf("Result: %d\n", $x); exit(); }'
 EXPECT Result: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array element access via assignment into map
-RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a[0] = ((struct A *) arg0)->x; printf("Result: %d\n", @a[0][0]); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a[0] = ((struct A *) arg0)->x; printf("Result: %d\n", @a[0][0]); exit(); }'
 EXPECT Result: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array element access via assignment into map and var
-RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a[0] = ((struct A *) arg0)->x; $x = @a[0]; printf("Result: %d\n", $x[0]); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a[0] = ((struct A *) arg0)->x; $x = @a[0]; printf("Result: %d\n", $x[0]); exit(); }'
 EXPECT Result: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array assignment into map
-RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a = ((struct A *) arg0)->x; exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a = ((struct A *) arg0)->x; exit(); }'
 EXPECT @a: \[1,2,3,4\]
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as a map key
-RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x[((struct A *) arg0)->x] = 0; exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x[((struct A *) arg0)->x] = 0; exit(); }'
 EXPECT @x\[\[1,2,3,4\]\]: 0
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as a part of map multikey
-RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x[((struct A *) arg0)->x, 42] = 0; exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x[((struct A *) arg0)->x, 42] = 0; exit(); }'
 EXPECT @x\[\[1,2,3,4\], 42\]: 0
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as a map key assigned from another map
-RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a = ((struct A *) arg0)->x; @x[@a] = 0; exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a = ((struct A *) arg0)->x; @x[@a] = 0; exit(); }'
 EXPECT @x\[\[1,2,3,4\]\]: 0
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array in a tuple
-RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x = (1, ((struct A *) arg0)->x); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x = (1, ((struct A *) arg0)->x); exit(); }'
 EXPECT @x: \(1, \[1,2,3,4\]\)
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array element access
-RUN bpftrace -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $x = ((struct B *) arg1)->y[1][0]; printf("Result: %d\n", $x); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $x = ((struct B *) arg1)->y[1][0]; printf("Result: %d\n", $x); exit(); }'
 EXPECT Result: 7
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array element access via assignment into var
-RUN bpftrace -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $b = ((struct B *) arg1)->y; $y = $b[1][0]; printf("Result: %d\n", $y); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $b = ((struct B *) arg1)->y; $y = $b[1][0]; printf("Result: %d\n", $y); exit(); }'
 EXPECT Result: 7
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array element access via assignment into map
-RUN bpftrace -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b[0] = ((struct B *) arg1)->y; printf("Result: %d\n", @b[0][1][0]); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b[0] = ((struct B *) arg1)->y; printf("Result: %d\n", @b[0][1][0]); exit(); }'
 EXPECT Result: 7
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array element access via assignment into map and var
-RUN bpftrace -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b[0] = ((struct B *) arg1)->y; $x = @b[0]; printf("Result: %d\n", $x[1][0]); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b[0] = ((struct B *) arg1)->y; $x = @b[0]; printf("Result: %d\n", $x[1][0]); exit(); }'
 EXPECT Result: 7
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array assignment into map
-RUN bpftrace -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b = ((struct B *) arg1)->y; exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b = ((struct B *) arg1)->y; exit(); }'
 EXPECT @b: \[\[5,6\],\[7,8\]\]
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array as a map key
-RUN bpftrace -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @x[((struct B *) arg1)->y] = 0; exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @x[((struct B *) arg1)->y] = 0; exit(); }'
 EXPECT @x\[\[\[5,6\],\[7,8\]\]]: 0
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array as a map key assigned from another map
-RUN bpftrace -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b = ((struct B *) arg1)->y; @x[@b] = 0; exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b = ((struct B *) arg1)->y; @x[@b] = 0; exit(); }'
 EXPECT @x\[\[\[5,6\],\[7,8\]\]]: 0
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as pointer element access - assign to map
-RUN bpftrace -v -e 'uprobe:./testprogs/array_access:test_array { $a = (int32 *) arg0; @x = $a[0]; exit(); }'
+RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/array_access:test_array { $a = (int32 *) arg0; @x = $a[0]; exit(); }'
 EXPECT @x: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as pointer element access - assign to var
-RUN bpftrace -v -e 'uprobe:./testprogs/array_access:test_array { $a = (int32 *) arg0; $x = $a[0]; printf("Result: %d\n", $x); exit(); }'
+RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/array_access:test_array { $a = (int32 *) arg0; $x = $a[0]; printf("Result: %d\n", $x); exit(); }'
 EXPECT Result: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as pointer access via assignment into var
-RUN bpftrace -v -e 'uprobe:./testprogs/array_access:test_array { $a = (int32 *) arg0; $x = $a[0]; printf("Result: %d\n", $x); exit(); }'
+RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/array_access:test_array { $a = (int32 *) arg0; $x = $a[0]; printf("Result: %d\n", $x); exit(); }'
 EXPECT Result: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as pointer element access via assignment into map
-RUN bpftrace -v -e 'uprobe:./testprogs/array_access:test_array { @a[0] = (int32 *) arg0; printf("Result: %d\n", @a[0][0]); exit(); }'
+RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/array_access:test_array { @a[0] = (int32 *) arg0; printf("Result: %d\n", @a[0][0]); exit(); }'
 EXPECT Result: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as pointer element access via assignment into map and var
-RUN bpftrace -v -e 'uprobe:./testprogs/array_access:test_array { @a[0] = (int32 *) arg0; $x = @a[0]; printf("Result: %d\n", $x[0]); exit(); }'
+RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/array_access:test_array { @a[0] = (int32 *) arg0; $x = @a[0]; printf("Result: %d\n", $x[0]); exit(); }'
 EXPECT Result: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access

--- a/tests/runtime/banned_probes
+++ b/tests/runtime/banned_probes
@@ -1,19 +1,19 @@
 NAME kretprobe:_raw_spin_lock is banned
-RUN bpftrace -v -e 'kretprobe:_raw_spin_lock { exit(); }'
+RUN {{BPFTRACE}} -v -e 'kretprobe:_raw_spin_lock { exit(); }'
 EXPECT error: kretprobe:_raw_spin_lock can't be used as it might lock up your system.
 TIMEOUT 1
 
 NAME kretprobe:queued_spin_lock_slowpath is banned
-RUN bpftrace -v -e 'kretprobe:queued_spin_lock_slowpath { exit(); }'
+RUN {{BPFTRACE}} -v -e 'kretprobe:queued_spin_lock_slowpath { exit(); }'
 EXPECT error: kretprobe:queued_spin_lock_slowpath can't be used as it might lock up your system.
 TIMEOUT 1
 
 NAME kretprobe:_raw_spin_unlock_irqrestore is banned
-RUN bpftrace -v -e 'kretprobe:_raw_spin_unlock_irqrestore { exit(); }'
+RUN {{BPFTRACE}} -v -e 'kretprobe:_raw_spin_unlock_irqrestore { exit(); }'
 EXPECT error: kretprobe:_raw_spin_unlock_irqrestore can't be used as it might lock up your system.
 TIMEOUT 1
 
 NAME kretprobe:_raw_spin_lock_irqsave is banned
-RUN bpftrace -v -e 'kretprobe:_raw_spin_lock_irqsave { exit(); }'
+RUN {{BPFTRACE}} -v -e 'kretprobe:_raw_spin_lock_irqsave { exit(); }'
 EXPECT error: kretprobe:_raw_spin_lock_irqsave can't be used as it might lock up your system.
 TIMEOUT 1

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -1,205 +1,205 @@
 NAME it shows version
-RUN bpftrace --version
+RUN {{BPFTRACE}} --version
 EXPECT bpftrace v
 TIMEOUT 1
 
 NAME it shows usage with help flag
-RUN bpftrace -h
+RUN {{BPFTRACE}} -h
 EXPECT USAGE
 TIMEOUT 1
 
 NAME it shows usage with bad flag
-RUN bpftrace -idonotexist
+RUN {{BPFTRACE}} -idonotexist
 EXPECT USAGE
 TIMEOUT 1
 
 NAME errors on non existent file
-RUN bpftrace non_existent_file.bt
+RUN {{BPFTRACE}} non_existent_file.bt
 EXPECT ERROR: failed to open file 'non_existent_file.bt': No such file or directory
 TIMEOUT 1
 
 NAME piped script
-RUN bpftrace - < runtime/scripts/hello_world.bt
+RUN {{BPFTRACE}} - < runtime/scripts/hello_world.bt
 EXPECT hello world!
 TIMEOUT 1
 
 NAME it lists kprobes
-RUN bpftrace -l | grep kprobes
+RUN {{BPFTRACE}} -l | grep kprobes
 EXPECT kprobe
 TIMEOUT 1
 
 NAME it lists tracepoints
-RUN bpftrace -l | grep tracepoint
+RUN {{BPFTRACE}} -l | grep tracepoint
 EXPECT tracepoint
 TIMEOUT 1
 
 NAME it lists software events
-RUN bpftrace -l | grep software
+RUN {{BPFTRACE}} -l | grep software
 EXPECT software
 TIMEOUT 1
 
 NAME it lists hardware events
-RUN bpftrace -l | grep hardware
+RUN {{BPFTRACE}} -l | grep hardware
 EXPECT hardware
 TIMEOUT 1
 
 NAME it lists kfuncs
-RUN bpftrace -l | grep kfunc
+RUN {{BPFTRACE}} -l | grep kfunc
 EXPECT kfunc
 REQUIRES_FEATURE btf
 TIMEOUT 1
 
 NAME it lists kfunc params
-RUN bpftrace -lv "kfunc:*" | grep kfunc
+RUN {{BPFTRACE}} -lv "kfunc:*" | grep kfunc
 EXPECT \s+[a-zA-Z_\*\s]+
 REQUIRES_FEATURE btf
 TIMEOUT 1
 
 NAME it lists kprobes with regex filter
-RUN bpftrace -l "kprobe:*"
+RUN {{BPFTRACE}} -l "kprobe:*"
 EXPECT kprobe:
 TIMEOUT 1
 
 NAME it lists kretprobes with regex filter
-RUN bpftrace -l "kretprobe:*"
+RUN {{BPFTRACE}} -l "kretprobe:*"
 EXPECT kretprobe:
 TIMEOUT 1
 
 NAME it lists uprobes with regex filter
-RUN bpftrace -l "uprobe:./testprogs/syscall:*"
+RUN {{BPFTRACE}} -l "uprobe:./testprogs/syscall:*"
 EXPECT uprobe:
 TIMEOUT 1
 
 NAME it lists uretprobes with regex filter
-RUN bpftrace -l "uretprobe:./testprogs/syscall:*"
+RUN {{BPFTRACE}} -l "uretprobe:./testprogs/syscall:*"
 EXPECT uretprobe:
 TIMEOUT 1
 
 NAME it lists tracepoints with regex filter
-RUN bpftrace -l "tracepoint:raw_syscalls:*"
+RUN {{BPFTRACE}} -l "tracepoint:raw_syscalls:*"
 EXPECT tracepoint:raw_syscalls:sys_exit
 TIMEOUT 1
 
 NAME it lists software events with regex filter
-RUN bpftrace -l "software:*"
+RUN {{BPFTRACE}} -l "software:*"
 EXPECT software
 TIMEOUT 1
 
 NAME it lists hardware events with regex filter
-RUN bpftrace -l "hardware:*"
+RUN {{BPFTRACE}} -l "hardware:*"
 EXPECT hardware
 TIMEOUT 1
 
 NAME it lists kfuncs events with regex filter
-RUN bpftrace -l "kfunc:*"
+RUN {{BPFTRACE}} -l "kfunc:*"
 EXPECT kfunc
 REQUIRES_FEATURE btf
 TIMEOUT 1
 
 NAME it lists kretfuncs events with regex filter
-RUN bpftrace -l "kretfunc:*"
+RUN {{BPFTRACE}} -l "kretfunc:*"
 EXPECT kretfunc
 REQUIRES_FEATURE btf
 TIMEOUT 1
 
 NAME listing with wildcarded probe type
-RUN bpftrace -l "*ware:*"
+RUN {{BPFTRACE}} -l "*ware:*"
 EXPECT hardware:
 EXPECT software:
 TIMEOUT 1
 
 NAME errors on invalid character in search expression
-RUN bpftrace -l '\n'
+RUN {{BPFTRACE}} -l '\n'
 EXPECT ERROR: invalid character
 TIMEOUT 1
 
 NAME pid fails validation with leading non-number
-RUN bpftrace -p a1111
+RUN {{BPFTRACE}} -p a1111
 EXPECT ERROR: pid 'a1111' is not a valid decimal number
 TIMEOUT 1
 
 NAME pid fails validation with non-number in between
-RUN bpftrace -p 111a1
+RUN {{BPFTRACE}} -p 111a1
 EXPECT ERROR: pid '111a1' is not a valid decimal number
 TIMEOUT 1
 
 NAME pid fails validation with non-numeric argument
-RUN bpftrace -p not_a_pid
+RUN {{BPFTRACE}} -p not_a_pid
 EXPECT ERROR: pid 'not_a_pid' is not a valid decimal number
 TIMEOUT 1
 
 NAME pid outside of valid pid range
-RUN bpftrace -p 5000000
+RUN {{BPFTRACE}} -p 5000000
 EXPECT ERROR: pid '5000000' out of valid pid range \[1,4194304\]
 TIMEOUT 1
 
 NAME libraries under /usr/include are in the search path
-RUN bpftrace -e "$(echo "#include <sys/types.h>"; echo "BEGIN { exit(); }")" 2>&1
+RUN {{BPFTRACE}} -e "$(echo "#include <sys/types.h>"; echo "BEGIN { exit(); }")" 2>&1
 EXPECT ^((?!file not found).)*$
 TIMEOUT 1
 
 NAME non existent library include fails
-RUN bpftrace -e "$(echo "#include <lol/no.h>"; echo "BEGIN { exit(); }")" 2>&1
+RUN {{BPFTRACE}} -e "$(echo "#include <lol/no.h>"; echo "BEGIN { exit(); }")" 2>&1
 EXPECT file not found
 TIMEOUT 1
 
 NAME defines work
-RUN bpftrace -e "$(echo '#define _UNDERSCORE 314'; echo 'BEGIN { printf("%d\\n", _UNDERSCORE); exit(); }')"
+RUN {{BPFTRACE}} -e "$(echo '#define _UNDERSCORE 314'; echo 'BEGIN { printf("%d\\n", _UNDERSCORE); exit(); }')"
 EXPECT 314
 TIMEOUT 1
 
 NAME clear map
-RUN bpftrace -e 'BEGIN { @ = 1; @a[1] = 1; clear(@); clear(@a); printf("ok\n"); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @ = 1; @a[1] = 1; clear(@); clear(@a); printf("ok\n"); exit(); }'
 EXPECT ok
 TIMEOUT 1
 
 NAME clear count-map
-RUN bpftrace -e 'BEGIN { @ = count(); @a[1] = count(); clear(@); clear(@a); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @ = count(); @a[1] = count(); clear(@); clear(@a); exit(); }'
 EXPECT @: 0
 TIMEOUT 1
 
 NAME delete map
-RUN bpftrace -e 'BEGIN { @ = 1; @a[1] = 1; delete(@); delete(@a[1]); printf("ok\n"); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @ = 1; @a[1] = 1; delete(@); delete(@a[1]); printf("ok\n"); exit(); }'
 EXPECT ok
 TIMEOUT 1
 
 NAME delete count-map
-RUN bpftrace -e 'BEGIN { @ = count(); @a[1] = count(); delete(@); delete(@a[1]); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @ = count(); @a[1] = count(); delete(@); delete(@a[1]); exit(); }'
 EXPECT @: 0
 TIMEOUT 1
 
 NAME increment/decrement map
-RUN bpftrace -e 'BEGIN { @x = 10; printf("%d", @x++); printf(" %d", ++@x); printf(" %d", @x--); printf(" %d\n", --@x); delete(@x); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @x = 10; printf("%d", @x++); printf(" %d", ++@x); printf(" %d", @x--); printf(" %d\n", --@x); delete(@x); exit(); }'
 EXPECT 10 12 12 10
 TIMEOUT 1
 
 NAME increment/decrement variable
-RUN bpftrace -e 'BEGIN { $x = 10; printf("%d", $x++); printf(" %d", ++$x); printf(" %d", $x--); printf(" %d\n", --$x); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { $x = 10; printf("%d", $x++); printf(" %d", ++$x); printf(" %d", $x--); printf(" %d\n", --$x); exit(); }'
 EXPECT 10 12 12 10
 TIMEOUT 1
 
 NAME spawn child
-RUN bpftrace -e 'i:ms:500 { printf("%d\n", cpid); }' -c './testprogs/syscall nanosleep 1e9'
+RUN {{BPFTRACE}} -e 'i:ms:500 { printf("%d\n", cpid); }' -c './testprogs/syscall nanosleep 1e9'
 EXPECT [0-9]+
 TIMEOUT 1
 
 NAME info flag
-RUN bpftrace --info
+RUN {{BPFTRACE}} --info
 EXPECT perf_event_array: yes
 TIMEOUT 1
 
 NAME basic while loop
-RUN bpftrace -e 'BEGIN { $a = 0; while ($a <= 100) { @=avg($a++) } exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { $a = 0; while ($a <= 100) { @=avg($a++) } exit(); }'
 EXPECT @: 50
 TIMEOUT 5
 REQUIRES_FEATURE loop
 
 NAME disable warnings
-RUN bpftrace --no-warnings -e 'BEGIN { @x = stats(10); print(@x, 2); clear(@x); exit();}' 2>&1| grep -c -E "WARNING|invalid option"
+RUN {{BPFTRACE}} --no-warnings -e 'BEGIN { @x = stats(10); print(@x, 2); clear(@x); exit();}' 2>&1| grep -c -E "WARNING|invalid option"
 EXPECT ^0$
 TIMEOUT 1
 
 NAME kaddr fails
-RUN bpftrace -e 'BEGIN { print(kaddr("asdfzzzzzzz")) }'
+RUN {{BPFTRACE}} -e 'BEGIN { print(kaddr("asdfzzzzzzz")) }'
 EXPECT Failed to resolve kernel symbol
 TIMEOUT 1

--- a/tests/runtime/btf
+++ b/tests/runtime/btf
@@ -1,35 +1,35 @@
 NAME user_supplied_c_def_using_btf
-RUN bpftrace -v -e 'struct foo { struct task_struct t; } BEGIN { exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct foo { struct task_struct t; } BEGIN { exit(); }'
 EXPECT Attaching 1 probe...
 TIMEOUT 5
 REQUIRES_FEATURE btf
 
 NAME tracepoint_pointer_type_resolution
-RUN bpftrace -v -e 'tracepoint:syscalls:sys_enter_nanosleep { args->rqtp->tv_sec; exit(); }'
+RUN {{BPFTRACE}} -v -e 'tracepoint:syscalls:sys_enter_nanosleep { args->rqtp->tv_sec; exit(); }'
 EXPECT Attaching 1 probe...
 TIMEOUT 5
 REQUIRES_FEATURE btf
 
 NAME tracepoint_nested_pointer_type_resolution
-RUN bpftrace -e 'tracepoint:napi:napi_poll { args->napi->dev->name; exit(); }'
+RUN {{BPFTRACE}} -e 'tracepoint:napi:napi_poll { args->napi->dev->name; exit(); }'
 EXPECT Attaching 1 probe...
 TIMEOUT 5
 REQUIRES_FEATURE btf
 
 NAME enum_value_reference
-RUN bpftrace -v -e 'BEGIN { printf("%d\n", sizeof(BTF_VAR_STATIC)); exit(); }'
+RUN {{BPFTRACE}} -v -e 'BEGIN { printf("%d\n", sizeof(BTF_VAR_STATIC)); exit(); }'
 EXPECT ^8$
 TIMEOUT 5
 REQUIRES_FEATURE btf
 
 NAME redefine_btf_type
-RUN bpftrace -v -e 'struct task_struct { int x; } BEGIN { printf("%d\n", curtask->x); }'
+RUN {{BPFTRACE}} -v -e 'struct task_struct { int x; } BEGIN { printf("%d\n", curtask->x); }'
 EXPECT -?[0-9][0-9]*
 TIMEOUT 5
 REQUIRES_FEATURE btf
 
 NAME redefine_btf_type_missing_def
-RUN bpftrace -v -e 'struct task_struct { struct thread_info x; } BEGIN { printf("%d\n", curtask->x.status); }'
+RUN {{BPFTRACE}} -v -e 'struct task_struct { struct thread_info x; } BEGIN { printf("%d\n", curtask->x.status); }'
 EXPECT error:.*'struct thread_info'
 TIMEOUT 5
 REQUIRES_FEATURE btf

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -1,200 +1,200 @@
 NAME pid
-RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT SUCCESS pid [0-9][0-9]*
 TIMEOUT 5
 
 NAME tid
-RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", tid); exit(); }'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", tid); exit(); }'
 EXPECT SUCCESS tid [0-9][0-9]*
 TIMEOUT 5
 
 NAME uid
-RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", uid); exit(); }'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", uid); exit(); }'
 EXPECT SUCCESS uid [0-9][0-9]*
 TIMEOUT 5
 
 NAME gid
-RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", gid); exit(); }'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", gid); exit(); }'
 EXPECT SUCCESS gid [0-9][0-9]*
 TIMEOUT 5
 
 NAME nsecs
-RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", nsecs); exit(); }'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", nsecs); exit(); }'
 EXPECT SUCCESS nsecs -?[0-9][0-9]*
 TIMEOUT 5
 
 NAME elapsed
-RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", elapsed); exit(); }'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", elapsed); exit(); }'
 EXPECT SUCCESS elapsed -?[0-9][0-9]*
 TIMEOUT 5
 
 NAME cpu
-RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", cpu); exit(); }'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", cpu); exit(); }'
 EXPECT SUCCESS cpu -?[0-9][0-9]*
 TIMEOUT 5
 
 NAME comm
-RUN bpftrace -v -e 'k:vfs_read { printf("SUCCESS '$test' %s\n", comm); exit(); }'
+RUN {{BPFTRACE}} -v -e 'k:vfs_read { printf("SUCCESS '$test' %s\n", comm); exit(); }'
 EXPECT SUCCESS comm .*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME stack
-RUN bpftrace -v -e 'k:vfs_read{ printf("SUCCESS '$test' %s\n", stack); exit(); }'
+RUN {{BPFTRACE}} -v -e 'k:vfs_read{ printf("SUCCESS '$test' %s\n", stack); exit(); }'
 EXPECT SUCCESS stack
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kstack
-RUN bpftrace -v -e 'k:vfs_read{ printf("SUCCESS '$test' %s\n", kstack); exit(); }'
+RUN {{BPFTRACE}} -v -e 'k:vfs_read{ printf("SUCCESS '$test' %s\n", kstack); exit(); }'
 EXPECT SUCCESS kstack
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME ustack
-RUN bpftrace -v -e 'k:vfs_read { printf("SUCCESS '$test' %s\n", ustack); exit(); }'
+RUN {{BPFTRACE}} -v -e 'k:vfs_read { printf("SUCCESS '$test' %s\n", ustack); exit(); }'
 EXPECT SUCCESS ustack
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME arg
-RUN bpftrace -v -e 'k:vfs_read { printf("SUCCESS '$test' %d\n", arg0); exit(); }'
+RUN {{BPFTRACE}} -v -e 'k:vfs_read { printf("SUCCESS '$test' %d\n", arg0); exit(); }'
 EXPECT SUCCESS arg -?[0-9][0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME sarg
-RUN bpftrace -v -e 'uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS '$test' %d %d\n", sarg0, sarg1); exit(); }'
+RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS '$test' %d %d\n", sarg0, sarg1); exit(); }'
 EXPECT SUCCESS sarg 32 64
 ARCH x86_64
 TIMEOUT 5
 AFTER ./testprogs/stack_args
 
 NAME sarg
-RUN bpftrace -v -e 'uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS '$test' %d %d\n", sarg0, sarg1); exit(); }'
+RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS '$test' %d %d\n", sarg0, sarg1); exit(); }'
 EXPECT SUCCESS sarg 128 256
 ARCH aarch64|ppc64|ppc64le
 TIMEOUT 5
 AFTER ./testprogs/stack_args
 
 NAME sarg
-RUN bpftrace -v -e 'uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS '$test' %d %d\n", sarg0, sarg1); exit(); }'
+RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS '$test' %d %d\n", sarg0, sarg1); exit(); }'
 EXPECT SUCCESS sarg 16 32
 ARCH s390x
 TIMEOUT 5
 AFTER ./testprogs/stack_args
 
 NAME retval
-RUN bpftrace -v -e 'kretprobe:vfs_read { printf("SUCCESS '$test' %d\n", retval); exit(); }'
+RUN {{BPFTRACE}} -v -e 'kretprobe:vfs_read { printf("SUCCESS '$test' %d\n", retval); exit(); }'
 EXPECT SUCCESS retval .*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME func
-RUN bpftrace -v -e 'k:vfs_read { printf("SUCCESS '$test' %s\n", func); exit(); }'
+RUN {{BPFTRACE}} -v -e 'k:vfs_read { printf("SUCCESS '$test' %s\n", func); exit(); }'
 EXPECT SUCCESS func .*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME func_uprobe
-RUN bpftrace -v -e 'uprobe:./testprogs/uprobe_negative_retval:function1 { printf("SUCCESS %s\n", func); exit(); }'
+RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/uprobe_negative_retval:function1 { printf("SUCCESS %s\n", func); exit(); }'
 EXPECT SUCCESS .*
 AFTER ./testprogs/uprobe_negative_retval
 TIMEOUT 5
 
 NAME username
-RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %s\n", username); exit(); }'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("SUCCESS '$test' %s\n", username); exit(); }'
 EXPECT SUCCESS username .*
 TIMEOUT 5
 
 NAME probe
-RUN bpftrace -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n", probe); exit(); }'
+RUN {{BPFTRACE}} -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n", probe); exit(); }'
 EXPECT SUCCESS probe kprobe:do_nanosleep
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME begin probe
-RUN bpftrace -e 'BEGIN { printf("%s", probe);exit(); } END{printf("-%s\n", probe); }'
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%s", probe);exit(); } END{printf("-%s\n", probe); }'
 EXPECT ^BEGIN-END$
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME curtask
-RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", curtask); exit(); }'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", curtask); exit(); }'
 EXPECT SUCCESS curtask -?[0-9][0-9]*
 TIMEOUT 5
 
 NAME curtask_field
-RUN bpftrace -v -e 'struct task_struct {int x;} i:ms:1 { printf("SUCCESS '$test' %d\n", curtask->x); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct task_struct {int x;} i:ms:1 { printf("SUCCESS '$test' %d\n", curtask->x); exit(); }'
 EXPECT SUCCESS curtask_field -?[0-9][0-9]*
 TIMEOUT 5
 
 NAME rand
-RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", rand); exit(); }'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", rand); exit(); }'
 EXPECT SUCCESS rand -?[0-9][0-9]*
 TIMEOUT 5
 
 NAME cgroup
-RUN bpftrace -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", cgroup); exit(); }'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", cgroup); exit(); }'
 EXPECT SUCCESS cgroup -?[0-9][0-9]*
 TIMEOUT 5
 MIN_KERNEL 4.18
 
 NAME ctx
-RUN bpftrace -v -e 'struct x {unsigned long x}; i:ms:1 { printf("SUCCESS '$test' %d\n", ((struct x*)ctx)->x); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct x {unsigned long x}; i:ms:1 { printf("SUCCESS '$test' %d\n", ((struct x*)ctx)->x); exit(); }'
 EXPECT SUCCESS ctx -?[0-9][0-9]*
 TIMEOUT 5
 
 NAME cat
-RUN bpftrace -e 'i:ms:1 { cat("/proc/loadavg"); exit(); }'
+RUN {{BPFTRACE}} -e 'i:ms:1 { cat("/proc/loadavg"); exit(); }'
 EXPECT ^([0-9]+\.[0-9]+ ?)+.*$
 TIMEOUT 5
 
 NAME cat limited output
 ENV BPFTRACE_CAT_BYTES_MAX=1
-RUN bpftrace -e 'i:ms:1 { cat("/proc/loadavg"); exit(); }'
+RUN {{BPFTRACE}} -e 'i:ms:1 { cat("/proc/loadavg"); exit(); }'
 EXPECT ^[0-9]$
 TIMEOUT 5
 
 NAME cat format str
-RUN bpftrace -e 'i:ms:1 { $s = "loadavg"; cat("/proc/%s", $s); exit(); }'
+RUN {{BPFTRACE}} -e 'i:ms:1 { $s = "loadavg"; cat("/proc/%s", $s); exit(); }'
 EXPECT ^([0-9]+\.[0-9]+ ?)+.*$
 TIMEOUT 5
 
 NAME log size too small
 ENV BPFTRACE_LOG_SIZE=1
-RUN bpftrace -ve 'BEGIN { if (str($1) == str($2)) { printf("%s\n", str($1)); exit() } }' "hello" "hello"
+RUN {{BPFTRACE}} -ve 'BEGIN { if (str($1) == str($2)) { printf("%s\n", str($1)); exit() } }' "hello" "hello"
 EXPECT Error loading program: BEGIN
 TIMEOUT 5
 
 NAME increase log size
-RUN bpftrace -ve 'BEGIN { if (str($1) == str($2)) { printf("%s\n", str($1)); exit() } }' "hello" "hello"
+RUN {{BPFTRACE}} -ve 'BEGIN { if (str($1) == str($2)) { printf("%s\n", str($1)); exit() } }' "hello" "hello"
 EXPECT ^Attaching 1 probe
 TIMEOUT 5
 
 NAME cat "no such file"
-RUN bpftrace -e 'i:ms:1 { cat("/does/not/exist/file"); exit(); }'
+RUN {{BPFTRACE}} -e 'i:ms:1 { cat("/does/not/exist/file"); exit(); }'
 EXPECT ^ERROR: failed to open file '/does/not/exist/file': No such file or directory$
 TIMEOUT 5
 
 NAME sizeof
-RUN bpftrace -e 'struct Foo { int x; char c; } BEGIN { $x = 1; printf("%d %d %d %d %d\n", sizeof(struct Foo), sizeof((*(struct Foo*)0).x), sizeof((*(struct Foo*)0).c), sizeof(1 == 1), sizeof($x)); exit(); }'
+RUN {{BPFTRACE}} -e 'struct Foo { int x; char c; } BEGIN { $x = 1; printf("%d %d %d %d %d\n", sizeof(struct Foo), sizeof((*(struct Foo*)0).x), sizeof((*(struct Foo*)0).c), sizeof(1 == 1), sizeof($x)); exit(); }'
 EXPECT ^8 4 1 8 8$
 TIMEOUT 5
 
 NAME sizeof_ints
-RUN bpftrace -e 'BEGIN { printf("%d %d %d %d %d %d\n", sizeof(uint8), sizeof(int8), sizeof(uint16), sizeof(int16), sizeof(uint32), sizeof(int32)); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%d %d %d %d %d %d\n", sizeof(uint8), sizeof(int8), sizeof(uint16), sizeof(int16), sizeof(uint32), sizeof(int32)); exit(); }'
 EXPECT ^1 1 2 2 4 4$
 TIMEOUT 5
 
 # printf only takes 7 args
 NAME sizeof_ints_pt2
-RUN bpftrace -e 'BEGIN { printf("%d %d\n", sizeof(uint64), sizeof(int64)); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%d %d\n", sizeof(uint64), sizeof(int64)); exit(); }'
 EXPECT ^8 8$
 TIMEOUT 5
 
 NAME sizeof_btf
-RUN bpftrace -e 'BEGIN { printf("size=%d\n", sizeof(struct task_struct)); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { printf("size=%d\n", sizeof(struct task_struct)); exit(); }'
 EXPECT ^size=
 TIMEOUT 5
 REQUIRES_FEATURE btf

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -1,262 +1,262 @@
 NAME printf
-RUN bpftrace -v -e 'i:ms:1 { printf("hi!\n"); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("hi!\n"); exit();}'
 EXPECT hi!
 TIMEOUT 5
 
 NAME printf_long_fmt
-RUN bpftrace -v -e 'i:ms:1 { printf("hi abcdefghijklmnopqrstuvwxyzzyxwvutsrqponmlkjihgfedcbaabcdefghijklmnopqrstuvwxyz!\n"); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("hi abcdefghijklmnopqrstuvwxyzzyxwvutsrqponmlkjihgfedcbaabcdefghijklmnopqrstuvwxyz!\n"); exit();}'
 EXPECT ^hi abcdefghijklmnopqrstuvwxyzzyxwvutsrqponmlkjihgfedcbaabcdefghijklmnopqrstuvwxyz!
 TIMEOUT 5
 
 NAME printf_argument
-RUN bpftrace -v -e 'i:ms:1 { printf("value: %dms100\n", 100); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("value: %dms100\n", 100); exit();}'
 EXPECT value: 100ms100
 TIMEOUT 5
 
 NAME printf_llu
-RUN bpftrace -e 'BEGIN { @start = nsecs; } i:s:1 { printf("Elapsed time: %llus\n", (nsecs - @start)/1000000000); clear(@start); exit();}'
+RUN {{BPFTRACE}} -e 'BEGIN { @start = nsecs; } i:s:1 { printf("Elapsed time: %llus\n", (nsecs - @start)/1000000000); clear(@start); exit();}'
 EXPECT Elapsed time: 1s
 TIMEOUT 5
 
 NAME printf_argument_alignment
-RUN bpftrace -v -e 'struct Foo { int a; char b[10]; } uprobe:testprogs/uprobe_test:function2 { $foo = (struct Foo *)arg0; $foo2 = (struct Foo *)arg1; printf("%d %s %d %s\n", $foo->a, $foo->b, $foo2->a, $foo2->b) }' -c ./testprogs/uprobe_test
+RUN {{BPFTRACE}} -v -e 'struct Foo { int a; char b[10]; } uprobe:testprogs/uprobe_test:function2 { $foo = (struct Foo *)arg0; $foo2 = (struct Foo *)arg1; printf("%d %s %d %s\n", $foo->a, $foo->b, $foo2->a, $foo2->b) }' -c ./testprogs/uprobe_test
 EXPECT 123 hello 456 world
 TIMEOUT 5
 
 NAME printf_more_arguments
-RUN bpftrace -v -e 'BEGIN { printf("%dst: %sa; %dnd: %sb;; %drd: %sc;;; %dth: %sd;;;;\\n", 1, "a", 2, "ab", 3, "abc", 4, "abcd"); exit(); }'
+RUN {{BPFTRACE}} -v -e 'BEGIN { printf("%dst: %sa; %dnd: %sb;; %drd: %sc;;; %dth: %sd;;;;\\n", 1, "a", 2, "ab", 3, "abc", 4, "abcd"); exit(); }'
 EXPECT 1st: aa; 2nd: abb;; 3rd: abcc;;; 4th: abcdd;;;;
 TIMEOUT 5
 
 NAME time
-RUN bpftrace -v -e 'i:ms:1 { time("%H:%M:%S\n"); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 { time("%H:%M:%S\n"); exit();}'
 EXPECT [0-9]*:[0-9]*:[0-9]*
 TIMEOUT 5
 
 NAME time_short
-RUN bpftrace -v -e 'i:ms:1 { time("%H-%M:%S\n"); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 { time("%H-%M:%S\n"); exit();}'
 EXPECT [0-9]*-[0-9]*
 TIMEOUT 5
 
 NAME join
-RUN bpftrace --unsafe -v -e 'i:ms:1 { system("echo 'A'"); } kprobe:sys_execve { join(arg1); exit();}'
+RUN {{BPFTRACE}} --unsafe -v -e 'i:ms:1 { system("echo 'A'"); } kprobe:sys_execve { join(arg1); exit();}'
 EXPECT A
 TIMEOUT 5
 
 NAME join_delim
-RUN bpftrace --unsafe -v -e 'i:ms:1 { system("echo 'A'"); } kprobe:sys_execve { join(arg1, ","); exit();}'
+RUN {{BPFTRACE}} --unsafe -v -e 'i:ms:1 { system("echo 'A'"); } kprobe:sys_execve { join(arg1, ","); exit();}'
 EXPECT A
 TIMEOUT 5
 
 NAME str
-RUN bpftrace -v -e 't:syscalls:sys_enter_execve { printf("P: %s\n", str(args->filename)); exit();}'
+RUN {{BPFTRACE}} -v -e 't:syscalls:sys_enter_execve { printf("P: %s\n", str(args->filename)); exit();}'
 AFTER ./testprogs/syscall execve /bin/ls
 EXPECT P: /*.
 TIMEOUT 5
 
 NAME buf
-RUN bpftrace -v -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s->a, 4), buf($s->b, 4), buf($s->c), buf($s->d), buf($s->e), buf($s->f)); exit(); }' -c ./testprogs/complex_struct
+RUN {{BPFTRACE}} -v -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s->a, 4), buf($s->b, 4), buf($s->c), buf($s->d), buf($s->e), buf($s->f)); exit(); }' -c ./testprogs/complex_struct
 EXPECT P: \\x09\\x08\\x07\\x06-\\x05\\x04\\x03\\x02-\\x01\\x02\\x03\\x04-\\x05\\x00\\x00\\x00\\x06\\x00\\x00\\x00\\x07\\x00\\x00\\x00\\x08\\x00\\x00\\x00-\\x09\\x00\\x0a\\x00\\x0b\\x00\\x0c\\x00-\\x0d\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0e\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0f\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x10\\x00\\x00\\x00\\x00\\x00\\x00\\x00
 TIMEOUT 5
 ARCH x86_64|ppc64le|aarch64
 
 NAME buf
-RUN bpftrace -v -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s->a, 4), buf($s->b, 4), buf($s->c), buf($s->d), buf($s->e), buf($s->f)); exit(); }' -c ./testprogs/complex_struct
+RUN {{BPFTRACE}} -v -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s->a, 4), buf($s->b, 4), buf($s->c), buf($s->d), buf($s->e), buf($s->f)); exit(); }' -c ./testprogs/complex_struct
 EXPECT P: \\x09\\x08\\x07\\x06-\\x05\\x04\\x03\\x02-\\x01\\x02\\x03\\x04-\\x00\\x00\\x00\\x05\\x00\\x00\\x00\\x06\\x00\\x00\\x00\\x07\\x00\\x00\\x00\\x08-\\x00\\x09\\x00\\x0a\\x00\\x0b\\x00\\x0c-\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0d\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0e\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0f\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x10
 TIMEOUT 5
 ARCH s390x|ppc64
 
 NAME buf_map_key
-RUN bpftrace -v -e 'i:ms:100 { @[buf("ok_key", 6)] = 1; exit(); }'
+RUN {{BPFTRACE}} -v -e 'i:ms:100 { @[buf("ok_key", 6)] = 1; exit(); }'
 EXPECT @\[ok_key\]: 1
 TIMEOUT 5
 
 NAME buf_map_value
-RUN bpftrace -v -e 'i:ms:100 { @ = buf("ok_value", 8); exit(); }'
+RUN {{BPFTRACE}} -v -e 'i:ms:100 { @ = buf("ok_value", 8); exit(); }'
 EXPECT @: ok_value
 TIMEOUT 5
 
 NAME ksym
-RUN bpftrace -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("ip"))); exit();}'
+RUN {{BPFTRACE}} -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("ip"))); exit();}'
 EXPECT do_nanosleep
 TIMEOUT 5
 ARCH x86_64
 AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME ksym
-RUN bpftrace -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("pswaddr"))); exit();}'
+RUN {{BPFTRACE}} -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("pswaddr"))); exit();}'
 EXPECT do_nanosleep
 TIMEOUT 5
 ARCH s390x
 AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME ksym
-RUN bpftrace -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("pc"))); exit();}'
+RUN {{BPFTRACE}} -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("pc"))); exit();}'
 EXPECT do_nanosleep
 TIMEOUT 5
 ARCH aarch64
 AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME ksym
-RUN bpftrace -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("nip"))); exit();}'
+RUN {{BPFTRACE}} -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("nip"))); exit();}'
 EXPECT do_nanosleep
 TIMEOUT 5
 ARCH ppc64|ppc64le
 AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME system
-RUN bpftrace --unsafe -v -e 'i:ms:100 { system("echo 'ok_system'"); exit();}'
+RUN {{BPFTRACE}} --unsafe -v -e 'i:ms:100 { system("echo 'ok_system'"); exit();}'
 EXPECT ok_system
 TIMEOUT 5
 
 NAME system_more_args
-RUN bpftrace --unsafe -v -e 'i:ms:100 { system("echo %d %d %d %d %d %d %d", 1, 2, 3, 4, 5, 6, 7); exit();}'
+RUN {{BPFTRACE}} --unsafe -v -e 'i:ms:100 { system("echo %d %d %d %d %d %d %d", 1, 2, 3, 4, 5, 6, 7); exit();}'
 EXPECT 1 2 3 4 5 6 7
 TIMEOUT 5
 
 NAME count
-RUN bpftrace -v -e 'i:ms:100 { @ = count(); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:100 { @ = count(); exit();}'
 EXPECT @:\s[0-9]+
 TIMEOUT 5
 
 NAME sum
-RUN bpftrace -v -e 'kprobe:vfs_read { @bytes[comm] = sum(arg2); exit();}'
+RUN {{BPFTRACE}} -v -e 'kprobe:vfs_read { @bytes[comm] = sum(arg2); exit();}'
 EXPECT @.*\[.*\]\:\s[0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME avg
-RUN bpftrace -v -e 'kprobe:vfs_read { @bytes[comm] = avg(arg2); exit();}'
+RUN {{BPFTRACE}} -v -e 'kprobe:vfs_read { @bytes[comm] = avg(arg2); exit();}'
 EXPECT @.*\[.*\]\:\s[0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME min
-RUN bpftrace -v -e 'kprobe:vfs_read { @bytes[comm] = min(arg2); exit();}'
+RUN {{BPFTRACE}} -v -e 'kprobe:vfs_read { @bytes[comm] = min(arg2); exit();}'
 EXPECT @.*\[.*\]\:\s[0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME max
-RUN bpftrace -v -e 'kprobe:vfs_read { @bytes[comm] = max(arg2); exit();}'
+RUN {{BPFTRACE}} -v -e 'kprobe:vfs_read { @bytes[comm] = max(arg2); exit();}'
 EXPECT @.*\[.*\]\:\s[0-9]*
 AFTER ./testprogs/syscall read
 TIMEOUT 5
 
 NAME stats
-RUN bpftrace -v -e 'kprobe:vfs_read { @bytes[comm] = stats(arg2); exit();}'
+RUN {{BPFTRACE}} -v -e 'kprobe:vfs_read { @bytes[comm] = stats(arg2); exit();}'
 EXPECT @.*\[.*\]\:\scount\s[0-9]*\,\saverage\s[0-9]*\,\stotal\s[0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME hist
-RUN bpftrace -v -e 'kretprobe:vfs_read { @bytes = hist(retval); exit();}'
+RUN {{BPFTRACE}} -v -e 'kretprobe:vfs_read { @bytes = hist(retval); exit();}'
 EXPECT @bytes: *\n[\[(].*
 AFTER ./testprogs/syscall read
 TIMEOUT 5
 
 NAME lhist
-RUN bpftrace -v -e 'kretprobe:vfs_read { @bytes = lhist(retval, 0, 10000, 1000); exit()}'
+RUN {{BPFTRACE}} -v -e 'kretprobe:vfs_read { @bytes = lhist(retval, 0, 10000, 1000); exit()}'
 EXPECT @bytes: *\n[\[(].*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kstack
-RUN bpftrace -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n%s\n", kstack(), kstack(1)); exit(); }'
+RUN {{BPFTRACE}} -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n%s\n", kstack(), kstack(1)); exit(); }'
 EXPECT SUCCESS kstack
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME kstack perf mode
-RUN bpftrace -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n", kstack(perf, 1)); exit(); }'
+RUN {{BPFTRACE}} -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n", kstack(perf, 1)); exit(); }'
 EXPECT SUCCESS kstack
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8
 
 
 NAME ustack
-RUN bpftrace -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n%s\n", ustack(), ustack(1)); exit(); }'
+RUN {{BPFTRACE}} -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n%s\n", ustack(), ustack(1)); exit(); }'
 EXPECT SUCCESS ustack
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME cat
-RUN bpftrace -v -e 'i:ms:1 { cat("/proc/uptime"); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 { cat("/proc/uptime"); exit();}'
 EXPECT [0-9]*.[0-9]* [0-9]*.[0-9]*
 TIMEOUT 5
 
 NAME cat_more_args
-RUN bpftrace -v -e 'i:ms:1 { cat("/%s%s%s%s/%s%s%s", "p", "r", "o", "c", "u", "p", "time"); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 { cat("/%s%s%s%s/%s%s%s", "p", "r", "o", "c", "u", "p", "time"); exit();}'
 EXPECT [0-9]*.[0-9]* [0-9]*.[0-9]*
 TIMEOUT 5
 
 NAME uaddr
-RUN bpftrace -v -e 'uprobe:testprogs/uprobe_test:function1 { printf("0x%lx -- 0x%lx\n", *uaddr("GLOBAL_A"), *uaddr("GLOBAL_C")); exit(); }' -c ./testprogs/uprobe_test
+RUN {{BPFTRACE}} -v -e 'uprobe:testprogs/uprobe_test:function1 { printf("0x%lx -- 0x%lx\n", *uaddr("GLOBAL_A"), *uaddr("GLOBAL_C")); exit(); }' -c ./testprogs/uprobe_test
 EXPECT 0x55555555 -- 0x33333333
 TIMEOUT 5
 
 NAME ntop static ip
-RUN bpftrace -v -e 'i:ms:100 { printf("IP: %s, %s, %s, %s\n", ntop(1), ntop(0x0100007f), ntop(0xffff0000), ntop(0x0000ffff)); exit() }'
+RUN {{BPFTRACE}} -v -e 'i:ms:100 { printf("IP: %s, %s, %s, %s\n", ntop(1), ntop(0x0100007f), ntop(0xffff0000), ntop(0x0000ffff)); exit() }'
 EXPECT IP: 1.0.0.0, 127.0.0.1, 0.0.255.255, 255.255.0.0
 ARCH x86_64|aarch64|ppc64le
 TIMEOUT 5
 
 NAME ntop static ip
-RUN bpftrace -v -e 'i:ms:100 { printf("IP: %s, %s, %s, %s\n", ntop(0x01000000), ntop(0x7f000001), ntop(0x0000ffff), ntop(0xffff0000)); exit() }'
+RUN {{BPFTRACE}} -v -e 'i:ms:100 { printf("IP: %s, %s, %s, %s\n", ntop(0x01000000), ntop(0x7f000001), ntop(0x0000ffff), ntop(0xffff0000)); exit() }'
 EXPECT IP: 1.0.0.0, 127.0.0.1, 0.0.255.255, 255.255.0.0
 ARCH s390x|ppc64
 TIMEOUT 5
 
 NAME usym
-RUN bpftrace -e 'i:ms:100 { @=usym(1); @a=@; exit(); }'
+RUN {{BPFTRACE}} -e 'i:ms:100 { @=usym(1); @a=@; exit(); }'
 EXPECT ^@a: 0x1$
 TIMEOUT 5
 
 NAME print_non_map
-RUN bpftrace -e 'BEGIN { $x = 5; print($x); exit() }'
+RUN {{BPFTRACE}} -e 'BEGIN { $x = 5; print($x); exit() }'
 EXPECT 5
 TIMEOUT 1
 
 NAME print_non_map_builtin
-RUN bpftrace -e 'BEGIN { print(comm); exit() }'
+RUN {{BPFTRACE}} -e 'BEGIN { print(comm); exit() }'
 EXPECT bpftrace
 TIMEOUT 1
 
 NAME print_non_map_tuple
-RUN bpftrace -e 'BEGIN { $t = (1, 2, "string"); print($t); exit() }'
+RUN {{BPFTRACE}} -e 'BEGIN { $t = (1, 2, "string"); print($t); exit() }'
 EXPECT (1, 2, string)
 TIMEOUT 1
 
 NAME print_non_map_array
-RUN bpftrace -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = ((struct A *) arg0)->x; print($a); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = ((struct A *) arg0)->x; print($a); exit(); }'
 EXPECT \[1,2,3,4\]
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME print_non_map_multi_dimensional_array
-RUN bpftrace -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $b = ((struct B *) arg1)->y; print($b); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $b = ((struct B *) arg1)->y; print($b); exit(); }'
 EXPECT \[\[5,6\],\[7,8\]\]
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME print_non_map_struct
-RUN bpftrace -v -e 'struct Foo { int m; int n; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); print($f); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct Foo { int m; int n; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); print($f); exit(); }'
 EXPECT { .m = 2, .n = 3 }
 TIMEOUT 5
 AFTER ./testprogs/simple_struct
 
 NAME strftime
-RUN bpftrace -v -e 'BEGIN { $ts = strftime("%m/%d/%y", nsecs); printf("%s\n", $ts); exit(); } '
+RUN {{BPFTRACE}} -v -e 'BEGIN { $ts = strftime("%m/%d/%y", nsecs); printf("%s\n", $ts); exit(); } '
 EXPECT [0-9]{2}\/[0-9]{2}\/[0-9]{2}
 TIMEOUT 5
 
 NAME strftime_as_map_key
-RUN bpftrace -v -e 'BEGIN { @[strftime("%m/%d/%y", nsecs)] = 1; exit();}'
+RUN {{BPFTRACE}} -v -e 'BEGIN { @[strftime("%m/%d/%y", nsecs)] = 1; exit();}'
 EXPECT \[[0-9]{2}\/[0-9]{2}\/[0-9]{2}\]: 1
 TIMEOUT 5
 
 NAME strftime_as_map_value
-RUN bpftrace -v -e 'BEGIN { @[nsecs] = strftime("%m/%d/%y", nsecs); exit();}'
+RUN {{BPFTRACE}} -v -e 'BEGIN { @[nsecs] = strftime("%m/%d/%y", nsecs); exit();}'
 EXPECT @\[[0-9]*\]: [0-9]{2}\/[0-9]{2}\/[0-9]{2}
 TIMEOUT 5
 
@@ -264,66 +264,66 @@ TIMEOUT 5
 #
 # Note we add a `1` before the timestamp b/c leading zeros (eg `0123`) is invalid integer in python.
 NAME strftime_microsecond_extension
-RUN bpftrace -e 'BEGIN { printf("%s - %s\n", strftime("1%f", 1000123000), strftime("1%f", 0)); exit(); }' | tail -n +2 | xargs -I{} python -c "print({})"
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%s - %s\n", strftime("1%f", 1000123000), strftime("1%f", 0)); exit(); }' | tail -n +2 | xargs -I{} python -c "print({})"
 EXPECT 123
 TIMEOUT 1
 
 # Similar to above test but test that rolling over past 1s works as expected
 NAME strftime_microsecond_extension_rollover
-RUN bpftrace -e 'BEGIN { printf("%s - %s\n", strftime("1%f", 1000000123000), strftime("1%f", 0)); exit(); }' | tail -n +2 | xargs -I{} python -c "print({})"
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%s - %s\n", strftime("1%f", 1000000123000), strftime("1%f", 0)); exit(); }' | tail -n +2 | xargs -I{} python -c "print({})"
 EXPECT 123
 TIMEOUT 1
 
 NAME print_avg_map_args
-RUN bpftrace -e 'BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 2, 10); print("END"); clear(@); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 2, 10); print("END"); clear(@); exit(); }'
 EXPECT Attaching 1 probe\.\.\.\n@\[c\]: 3\n@\[d\]: 4\n\nEND
 TIMEOUT 1
 
 NAME print_avg_map_with_large_top
-RUN bpftrace -e 'BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 10, 10); print("END"); clear(@); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 10, 10); print("END"); clear(@); exit(); }'
 EXPECT Attaching 1 probe\.\.\.\n@\[a\]: 1\n@\[b\]: 2\n@\[c\]: 3\n@\[d\]: 4\n\nEND
 TIMEOUT 1
 
 NAME print_hist_with_top_arg
-RUN bpftrace -e 'BEGIN { print("BEGIN"); @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 2); print("END"); clear(@); exit(); } '
+RUN {{BPFTRACE}} -e 'BEGIN { print("BEGIN"); @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 2); print("END"); clear(@); exit(); } '
 EXPECT BEGIN\n@\[2\]:(.*\n)+@\[3\]:(.*\n)+END
 TIMEOUT 1
 
 NAME print_hist_with_large_top_arg
-RUN bpftrace -e 'BEGIN { print("BEGIN"); @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 10); print("END"); clear(@); exit(); } '
+RUN {{BPFTRACE}} -e 'BEGIN { print("BEGIN"); @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 10); print("END"); clear(@); exit(); } '
 EXPECT BEGIN\n@\[1\]:(.*\n)+@\[2\]:(.*\n)+@\[3\]:(.*\n)+END
 TIMEOUT 1
 
 NAME path
-RUN bpftrace -ve 'kfunc:filp_close { $f = path(args->filp->f_path); if (!strncmp($f, "/tmp/bpftrace_runtime_test_syscall_gen_read_temp", 49)) { printf("OK\n"); exit(); } }'
+RUN {{BPFTRACE}} -ve 'kfunc:filp_close { $f = path(args->filp->f_path); if (!strncmp($f, "/tmp/bpftrace_runtime_test_syscall_gen_read_temp", 49)) { printf("OK\n"); exit(); } }'
 EXPECT OK
 REQUIRES_FEATURE dpath
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME macaddr
-RUN bpftrace -e 'struct MyStruct { const char* ignore; char mac[6]; }; u:./testprogs/complex_struct:func { $s = ((struct MyStruct *)arg0); printf("P: %s\n", macaddr($s->mac)); exit(); }' -c ./testprogs/complex_struct
+RUN {{BPFTRACE}} -e 'struct MyStruct { const char* ignore; char mac[6]; }; u:./testprogs/complex_struct:func { $s = ((struct MyStruct *)arg0); printf("P: %s\n", macaddr($s->mac)); exit(); }' -c ./testprogs/complex_struct
 EXPECT P: 05:04:03:02:01:02
 TIMEOUT 5
 
 NAME macaddr as map key
-RUN bpftrace -e 'struct MyStruct { const char* ignore; char mac[6]; }; u:./testprogs/complex_struct:func { $s = ((struct MyStruct *)arg0); @[macaddr($s->mac)] = 1; exit(); }' -c ./testprogs/complex_struct
+RUN {{BPFTRACE}} -e 'struct MyStruct { const char* ignore; char mac[6]; }; u:./testprogs/complex_struct:func { $s = ((struct MyStruct *)arg0); @[macaddr($s->mac)] = 1; exit(); }' -c ./testprogs/complex_struct
 EXPECT @\[05:04:03:02:01:02\]: 1
 TIMEOUT 5
 
 NAME macaddr as map value
-RUN bpftrace -e 'struct MyStruct { const char* ignore; char mac[6]; }; u:./testprogs/complex_struct:func { $s = ((struct MyStruct *)arg0); @[1] = macaddr($s->mac); exit(); }' -c ./testprogs/complex_struct
+RUN {{BPFTRACE}} -e 'struct MyStruct { const char* ignore; char mac[6]; }; u:./testprogs/complex_struct:func { $s = ((struct MyStruct *)arg0); @[1] = macaddr($s->mac); exit(); }' -c ./testprogs/complex_struct
 EXPECT \[1\]: 05:04:03:02:01:02
 TIMEOUT 5
 
 NAME iter:task
-RUN bpftrace -ve 'iter:task { printf("OK"); }'
+RUN {{BPFTRACE}} -ve 'iter:task { printf("OK"); }'
 EXPECT OK
 REQUIRES_FEATURE iter:task
 TIMEOUT 5
 
 NAME iter:task_file
-RUN bpftrace -ve 'iter:task_file { printf("OK"); }'
+RUN {{BPFTRACE}} -ve 'iter:task_file { printf("OK"); }'
 EXPECT OK
 REQUIRES_FEATURE iter:task_file
 TIMEOUT 5

--- a/tests/runtime/complex_types
+++ b/tests/runtime/complex_types
@@ -1,14 +1,14 @@
 NAME struct-array
-RUN bpftrace runtime/scripts/struct_array.bt -c ./testprogs/struct_array
+RUN {{BPFTRACE}} runtime/scripts/struct_array.bt -c ./testprogs/struct_array
 EXPECT 100 102 104 106 108 -- 1 3 5 7 9 -- 100 98 96 94 92
 TIMEOUT 5
 
 NAME struct-array with variables
-RUN bpftrace runtime/scripts/struct_array_vars.bt -c ./testprogs/struct_array
+RUN {{BPFTRACE}} runtime/scripts/struct_array_vars.bt -c ./testprogs/struct_array
 EXPECT 100 102 104 106 108 -- 1 3 5 7 9 -- 100 98 96 94 92 -- 42
 TIMEOUT 5
 
 NAME pointer_to_pointer
-RUN bpftrace -e 'struct Foo { int a; char b[10]; } uprobe:./testprogs/ptr_to_ptr:function { $pp = (struct Foo **)arg0; printf("%d\n", (*$pp)->a); }' -c ./testprogs/ptr_to_ptr
+RUN {{BPFTRACE}} -e 'struct Foo { int a; char b[10]; } uprobe:./testprogs/ptr_to_ptr:function { $pp = (struct Foo **)arg0; printf("%d\n", (*$pp)->a); }' -c ./testprogs/ptr_to_ptr
 EXPECT 123
 TIMEOUT 5

--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -14,7 +14,24 @@ class UnknownFieldError(Exception):
     pass
 
 
-TestStruct = namedtuple('TestStruct', 'name run expect timeout before after suite kernel requirement env arch, feature_requirement neg_feature_requirement')
+TestStruct = namedtuple(
+    'TestStruct',
+    [
+        'name',
+        'run',
+        'expect',
+        'timeout',
+        'before',
+        'after',
+        'suite',
+        'kernel',
+        'requirement',
+        'env',
+        'arch',
+        'feature_requirement',
+        'neg_feature_requirement',
+    ],
+)
 
 
 class TestParser(object):

--- a/tests/runtime/engine/utils.py
+++ b/tests/runtime/engine/utils.py
@@ -75,7 +75,8 @@ class Utils(object):
 
     @staticmethod
     def prepare_bpf_call(test):
-        return BPF_PATH + test.run
+        bpftrace_path = "{}/bpftrace".format(BPF_PATH)
+        return re.sub("{{BPFTRACE}}", bpftrace_path, test.run)
 
     @staticmethod
     def __handler(signum, frame):

--- a/tests/runtime/file-output
+++ b/tests/runtime/file-output
@@ -1,19 +1,19 @@
 NAME printf to file
-RUN bpftrace -v -e 'i:ms:10 { printf("%s %d\n", "SUCCESS", 1); exit() }' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
+RUN {{BPFTRACE}} -v -e 'i:ms:10 { printf("%s %d\n", "SUCCESS", 1); exit() }' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
 EXPECT ^SUCCESS 1$
 TIMEOUT 5
 
 NAME cat to file
-RUN bpftrace -v -e 'i:ms:10 { cat("/proc/loadavg"); exit(); }' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
+RUN {{BPFTRACE}} -v -e 'i:ms:10 { cat("/proc/loadavg"); exit(); }' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
 EXPECT ^([0-9]+\.[0-9]+ )+.*$
 TIMEOUT 5
 
 NAME print map to file
-RUN bpftrace -v -e 'i:ms:10 { @=lhist(50, 0, 100, 10); exit();}' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
+RUN {{BPFTRACE}} -v -e 'i:ms:10 { @=lhist(50, 0, 100, 10); exit();}' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
 EXPECT ^\[50, 60\).*\@+\|$
 TIMEOUT 5
 
 NAME system stdout to file
-RUN bpftrace -v --unsafe -e 'i:ms:10 { system("cat /proc/loadavg"); exit(); }' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
+RUN {{BPFTRACE}} -v --unsafe -e 'i:ms:10 { system("cat /proc/loadavg"); exit(); }' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
 EXPECT ^([0-9]+\.[0-9]+ )+.*$
 TIMEOUT 5

--- a/tests/runtime/intcast
+++ b/tests/runtime/intcast
@@ -1,16 +1,16 @@
 NAME Casting retval should work
-RUN bpftrace -v -e 'ur:./testprogs/uprobe_negative_retval:main   /(int32)retval < 0/ { @[(int32)retval]=count(); exit();}'
+RUN {{BPFTRACE}} -v -e 'ur:./testprogs/uprobe_negative_retval:main   /(int32)retval < 0/ { @[(int32)retval]=count(); exit();}'
 AFTER ./testprogs/uprobe_negative_retval
 EXPECT ^@\[-100\]: 1$
 TIMEOUT 5
 
 NAME Sum casted retval
-RUN bpftrace -v -e 'ur:./testprogs/uprobe_negative_retval:function1 { @=stats((int32)retval); exit();} ur:./testprogs/uprobe_negative_retval:main { exit() }'
+RUN {{BPFTRACE}} -v -e 'ur:./testprogs/uprobe_negative_retval:function1 { @=stats((int32)retval); exit();} ur:./testprogs/uprobe_negative_retval:main { exit() }'
 AFTER ./testprogs/uprobe_negative_retval
 EXPECT ^@: count 221, average -10, total -2210$
 TIMEOUT 5
 
 NAME Casting ints
-RUN bpftrace -v -e 'BEGIN{printf("Values: %d %d\n", (uint8) -10, (uint16) 131087); exit(); }'
+RUN {{BPFTRACE}} -v -e 'BEGIN{printf("Values: %d %d\n", (uint8) -10, (uint16) 131087); exit(); }'
 EXPECT Values: 246 15$
 TIMEOUT 5

--- a/tests/runtime/intptrcast
+++ b/tests/runtime/intptrcast
@@ -1,68 +1,68 @@
 NAME Sum casted value
-RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("sp")+8)); exit();}'
+RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("sp")+8)); exit();}'
 EXPECT ^@: 3258
 TIMEOUT 5
 ARCH x86_64
 AFTER ./testprogs/intptrcast
 
 NAME Sum casted value
-RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("sp")+0)); exit();}'
+RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("sp")+0)); exit();}'
 EXPECT ^@: 3258
 TIMEOUT 5
 ARCH aarch64
 AFTER ./testprogs/intptrcast
 
 NAME Sum casted value
-RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r1")+96)); exit();}'
+RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r1")+96)); exit();}'
 EXPECT ^@: 3258
 TIMEOUT 5
 ARCH ppc64le
 AFTER ./testprogs/intptrcast
 
 NAME Sum casted value
-RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r1")+112)); exit();}'
+RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r1")+112)); exit();}'
 EXPECT ^@: 3258
 TIMEOUT 5
 ARCH ppc64
 AFTER ./testprogs/intptrcast
 
 NAME Sum casted value
-RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r15")+160)); exit();}'
+RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r15")+160)); exit();}'
 EXPECT ^@: 4660
 TIMEOUT 5
 ARCH s390x
 AFTER ./testprogs/intptrcast
 
 NAME Casting ints
-RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("sp")+8); printf("%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("sp")+8); printf("%d\n", $a); exit();}'
 EXPECT 3258
 TIMEOUT 5
 ARCH x86_64
 AFTER ./testprogs/intptrcast
 
 NAME Casting ints
-RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("sp")+0); printf("%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("sp")+0); printf("%d\n", $a); exit();}'
 EXPECT 3258
 TIMEOUT 5
 ARCH aarch64
 AFTER ./testprogs/intptrcast
 
 NAME Casting ints
-RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("r1")+96); printf("%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("r1")+96); printf("%d\n", $a); exit();}'
 EXPECT 3258
 TIMEOUT 5
 ARCH ppc64le
 AFTER ./testprogs/intptrcast
 
 NAME Casting ints
-RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("r1")+112); printf("%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("r1")+112); printf("%d\n", $a); exit();}'
 EXPECT 3258
 TIMEOUT 5
 ARCH ppc64
 AFTER ./testprogs/intptrcast
 
 NAME Casting ints
-RUN bpftrace -v -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("r15")+160); printf("%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("r15")+160); printf("%d\n", $a); exit();}'
 EXPECT 4660
 TIMEOUT 5
 ARCH s390x

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -1,149 +1,149 @@
 NAME invalid_format
-RUN bpftrace -q -f jsonx -e 'BEGIN { @scalar = 5; exit(); }'
+RUN {{BPFTRACE}} -q -f jsonx -e 'BEGIN { @scalar = 5; exit(); }'
 EXPECT ^ERROR: Invalid output format "jsonx"$
 TIMEOUT 5
 
 NAME scalar
-RUN bpftrace -q -f json -e 'BEGIN { @scalar = 5; exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin) == json.load(open("runtime/outputs/scalar.json")))'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @scalar = 5; exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin) == json.load(open("runtime/outputs/scalar.json")))'
 EXPECT ^True$
 TIMEOUT 5
 
 NAME scalar_str
-RUN bpftrace -q -f json -e 'BEGIN { @scalar_str = "a b \n d e"; exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin) == json.load(open("runtime/outputs/scalar_str.json")))'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @scalar_str = "a b \n d e"; exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin) == json.load(open("runtime/outputs/scalar_str.json")))'
 EXPECT ^True$
 TIMEOUT 5
 
 NAME complex
-RUN bpftrace -q -f json -e 'BEGIN { @complex[comm,2] = 5; exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin) == json.load(open("runtime/outputs/complex.json")))'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @complex[comm,2] = 5; exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin) == json.load(open("runtime/outputs/complex.json")))'
 EXPECT ^True$
 TIMEOUT 5
 
 NAME map
-RUN bpftrace -q -f json -e 'BEGIN { @map["key1"] = 2; @map["key2"] = 3; exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin) == json.load(open("runtime/outputs/map.json")))'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @map["key1"] = 2; @map["key2"] = 3; exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin) == json.load(open("runtime/outputs/map.json")))'
 EXPECT ^True$
 TIMEOUT 5
 
 NAME histogram
-RUN bpftrace -q -f json -e 'BEGIN { @hist = hist(2); @hist = hist(1025); exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin) == json.load(open("runtime/outputs/hist.json")))'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @hist = hist(2); @hist = hist(1025); exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin) == json.load(open("runtime/outputs/hist.json")))'
 EXPECT ^True$
 TIMEOUT 5
 
 NAME multiple histograms
-RUN bpftrace -q -f json -e 'BEGIN { @["bpftrace"] = hist(2); @["curl"] = hist(-1); @["curl"] = hist(0); @["curl"] = hist(511); @["curl"] = hist(1024); @["curl"] = hist(1025); exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin) == json.load(open("runtime/outputs/hist_multiple.json")))'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @["bpftrace"] = hist(2); @["curl"] = hist(-1); @["curl"] = hist(0); @["curl"] = hist(511); @["curl"] = hist(1024); @["curl"] = hist(1025); exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin) == json.load(open("runtime/outputs/hist_multiple.json")))'
 EXPECT ^True$
 TIMEOUT 5
 
 NAME linear histogram
-RUN bpftrace -q -f json -e 'BEGIN { @h = lhist(2, 0, 100, 10); @h = lhist(50, 0, 100, 10); @h = lhist(1000, 0, 100, 10); exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin) == json.load(open("runtime/outputs/lhist.json")))'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @h = lhist(2, 0, 100, 10); @h = lhist(50, 0, 100, 10); @h = lhist(1000, 0, 100, 10); exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin) == json.load(open("runtime/outputs/lhist.json")))'
 EXPECT ^True$
 TIMEOUT 5
 
 NAME multiple linear histograms
-RUN bpftrace -q -f json -e 'BEGIN { @stats["bpftrace"] = lhist(2, 0, 100, 10); @stats["curl"] = lhist(50, 0, 100, 10); @stats["bpftrace"] = lhist(1000, 0, 100, 10); exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin) == json.load(open("runtime/outputs/lhist_multiple.json")))'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @stats["bpftrace"] = lhist(2, 0, 100, 10); @stats["curl"] = lhist(50, 0, 100, 10); @stats["bpftrace"] = lhist(1000, 0, 100, 10); exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin) == json.load(open("runtime/outputs/lhist_multiple.json")))'
 EXPECT ^True$
 TIMEOUT 5
 
 NAME stats
-RUN bpftrace -q -f json -e 'BEGIN { @stats = stats(2); @stats = stats(10); exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin) == json.load(open("runtime/outputs/stats.json")))'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @stats = stats(2); @stats = stats(10); exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin) == json.load(open("runtime/outputs/stats.json")))'
 EXPECT ^True$
 TIMEOUT 5
 
 NAME multiple stats
-RUN bpftrace -q -f json -e 'BEGIN { @stats["curl"] = stats(2); @stats["zsh"] = stats(10); exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin) == json.load(open("runtime/outputs/stats_multiple.json")))'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @stats["curl"] = stats(2); @stats["zsh"] = stats(10); exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin) == json.load(open("runtime/outputs/stats_multiple.json")))'
 EXPECT ^True$
 TIMEOUT 5
 
 NAME printf
-RUN bpftrace -q -f json -v -e 'BEGIN { printf("test %d", 5); exit(); }'
+RUN {{BPFTRACE}} -q -f json -v -e 'BEGIN { printf("test %d", 5); exit(); }'
 EXPECT ^{"type": "printf", "data": "test 5"}$
 TIMEOUT 5
 
 NAME printf_escaping
-RUN bpftrace -q -f json -v -e 'BEGIN { printf("test \r \n \t \\ \" bar"); exit(); }'
+RUN {{BPFTRACE}} -q -f json -v -e 'BEGIN { printf("test \r \n \t \\ \" bar"); exit(); }'
 EXPECT ^{"type": "printf", "data": "test \\r \\n \\t \\\\ \\\" bar"}$
 TIMEOUT 5
 
 NAME time
-RUN bpftrace -q -f json -v -e 'BEGIN { time(); exit(); }'
+RUN {{BPFTRACE}} -q -f json -v -e 'BEGIN { time(); exit(); }'
 EXPECT ^{"type": "time", "data": "[0-9]*:[0-9]*:[0-9]*\\n"}$
 TIMEOUT 5
 
 NAME syscall
-RUN bpftrace --unsafe -v -f json -e 'BEGIN { system("echo a b c"); exit(); }'
+RUN {{BPFTRACE}} --unsafe -v -f json -e 'BEGIN { system("echo a b c"); exit(); }'
 EXPECT ^{"type": "syscall", "data": "a b c\\n"}$
 TIMEOUT 5
 
 NAME join_delim
-RUN bpftrace --unsafe -f json -e 'tracepoint:syscalls:sys_enter_execve { join(args->argv, ","); }' -c "./testprogs/syscall execve /bin/echo 'A'"
+RUN {{BPFTRACE}} --unsafe -f json -e 'tracepoint:syscalls:sys_enter_execve { join(args->argv, ","); }' -c "./testprogs/syscall execve /bin/echo 'A'"
 EXPECT ^{"type": "join", "data": "/bin/echo,'A'"}
 TIMEOUT 5
 
 NAME cat
-RUN bpftrace -v -f json -e 'BEGIN { cat("/proc/uptime"); exit(); }'
+RUN {{BPFTRACE}} -v -f json -e 'BEGIN { cat("/proc/uptime"); exit(); }'
 EXPECT ^{"type": "cat", "data": "[0-9]*.[0-9]* [0-9]*.[0-9]*\\n"}$
 TIMEOUT 5
 
 # Careful with '[' and ']', they are read by the test engine as a regex
 # character class, so make sure to escape them.
 NAME tuple
-RUN bpftrace -q -f json -e 'BEGIN { @ = (1, 2, "string", (4, 5)); exit(); }'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @ = (1, 2, "string", (4, 5)); exit(); }'
 EXPECT ^{"type": "map", "data": {"@": \[1,2,"string",\[4,5\]\]}}$
 TIMEOUT 5
 
 NAME tuple_with_struct
-RUN bpftrace -v -f json -e 'struct Foo { int m; int n; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); @ = (0, $f); exit(); }'
+RUN {{BPFTRACE}} -v -f json -e 'struct Foo { int m; int n; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); @ = (0, $f); exit(); }'
 EXPECT ^{"type": "map", "data": {"@": \[0,{ "m": 2, "n": 3 }\]}}$
 TIMEOUT 5
 AFTER ./testprogs/simple_struct
 
 NAME tuple_with_escaped_string
-RUN bpftrace -q -f json -e 'BEGIN { @ = (1, 2, "string with \"quotes\""); exit(); }'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @ = (1, 2, "string with \"quotes\""); exit(); }'
 EXPECT ^{"type": "map", "data": {"@": \[1,2,"string with \\"quotes\\""\]}}$
 TIMEOUT 5
 
 NAME print_non_map
-RUN bpftrace -q -f json -e 'BEGIN { $x = 5; print($x); exit() }'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { $x = 5; print($x); exit() }'
 EXPECT ^{"type": "value", "data": 5}$
 TIMEOUT 1
 
 NAME print_non_map_builtin
-RUN bpftrace -q -f json -e 'BEGIN { print(comm); exit() }'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { print(comm); exit() }'
 EXPECT ^{"type": "value", "data": "bpftrace"}$
 TIMEOUT 1
 
 NAME print_non_map_tuple
-RUN bpftrace -q -f json -e 'BEGIN { $t = (1, 2, "string"); print($t); exit() }'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { $t = (1, 2, "string"); print($t); exit() }'
 EXPECT ^{"type": "value", "data": \[1,2,"string"\]}$
 TIMEOUT 1
 
 NAME print_non_map_struct
-RUN bpftrace -v -f json -e 'struct Foo { int m; int n; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); print($f); exit(); }'
+RUN {{BPFTRACE}} -v -f json -e 'struct Foo { int m; int n; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); print($f); exit(); }'
 EXPECT ^{"type": "value", "data": { "m": 2, "n": 3 }}$
 TIMEOUT 5
 AFTER ./testprogs/simple_struct
 
 NAME print_non_map_nested_struct
-RUN bpftrace -v -f json -e 'struct Foo { struct { int m[1] } y; struct { int n; } a; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); print($f); exit(); }'
+RUN {{BPFTRACE}} -v -f json -e 'struct Foo { struct { int m[1] } y; struct { int n; } a; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); print($f); exit(); }'
 EXPECT ^{"type": "value", "data": { "y": { "m": \[2\] }, "a": { "n": 3 } }}$
 TIMEOUT 5
 AFTER ./testprogs/simple_struct
 
 NAME print_avg_map_args
-RUN bpftrace -q -f json -e 'BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 2, 10); clear(@); exit(); }'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 2, 10); clear(@); exit(); }'
 EXPECT {"type": "stats", "data": {"@": { *"c": 3, *"d": 4}}}
 TIMEOUT 1
 
 NAME print_avg_map_with_large_top
-RUN bpftrace -q -f json -e 'BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 10, 10); clear(@); exit(); }'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 10, 10); clear(@); exit(); }'
 EXPECT {"type": "stats", "data": {"@": { *"a": 1, *"b": 2, *"c": 3, *"d": 4}}}
 TIMEOUT 1
 
 NAME print_hist_with_top_arg
-RUN bpftrace -q -f json -e 'BEGIN { @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 2); clear(@); exit(); }'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 2); clear(@); exit(); }'
 EXPECT {"type": "hist", "data": {"@": {"2": \[{"min": 16, "max": 31, "count": 1}\], "3": \[{"min": 16, "max": 31, "count": 1}\]}}}
 TIMEOUT 1
 
 NAME print_hist_with_large_top_arg
-RUN bpftrace -q -f json -e 'BEGIN { @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 10); clear(@); exit(); }'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 10); clear(@); exit(); }'
 EXPECT {"type": "hist", "data": {"@": {"1": \[{"min": 8, "max": 15, "count": 1}\], "2": \[{"min": 16, "max": 31, "count": 1}\], "3": \[{"min": 16, "max": 31, "count": 1}\]}}}
 TIMEOUT 1

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -1,222 +1,222 @@
 NAME if_gt
-RUN bpftrace -v -e 'i:ms:1 {$a = 10; if ($a > 2) { $a = 20 } printf("a=%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = 10; if ($a > 2) { $a = 20 } printf("a=%d\n", $a); exit();}'
 EXPECT a=20
 TIMEOUT 5
 
 NAME if_lt
-RUN bpftrace -v -e 'i:ms:1 {$a = 10; if ($a < 2) { $a = 20 } printf("a=%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = 10; if ($a < 2) { $a = 20 } printf("a=%d\n", $a); exit();}'
 EXPECT a=10
 TIMEOUT 5
 
 NAME ifelse_go_else
-RUN bpftrace -v -e 'i:ms:1 {$a = ""; if (10 < 2) { $a = "hi" } else {$a = "hello"} printf("a=%s\n", $a); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = ""; if (10 < 2) { $a = "hi" } else {$a = "hello"} printf("a=%s\n", $a); exit();}'
 EXPECT a=hello
 TIMEOUT 5
 
 NAME ifelse_go_if
-RUN bpftrace -v -e 'i:ms:1 {$a = ""; if (10 > 2) { $a = "hi" } else {$a = "hello"} printf("a=%s\n", $a); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = ""; if (10 > 2) { $a = "hi" } else {$a = "hello"} printf("a=%s\n", $a); exit();}'
 EXPECT a=hi
 TIMEOUT 5
 
 NAME ifelseif_go_elseif
-RUN bpftrace -v -e 'i:ms:1 {$a = ""; if (1 > 2) { $a = "hi" } else if (2 < 3) { $a = "hello" } printf("a=%s\n", $a); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = ""; if (1 > 2) { $a = "hi" } else if (2 < 3) { $a = "hello" } printf("a=%s\n", $a); exit();}'
 EXPECT a=hello
 TIMEOUT 5
 
 NAME ifelseifelse_go_else
-RUN bpftrace -v -e 'i:ms:1 {$a = ""; if (1 > 2) { $a = "hi" } else if (5 < 3) { $a = "hello" } else { $a = "asdf" } printf("a=%s\n", $a); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = ""; if (1 > 2) { $a = "hi" } else if (5 < 3) { $a = "hello" } else { $a = "asdf" } printf("a=%s\n", $a); exit();}'
 EXPECT a=asdf
 TIMEOUT 5
 
 NAME if_cast
-RUN bpftrace -v -e 'i:ms:1 { if ((int32)pid) {} printf("done\n"); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 { if ((int32)pid) {} printf("done\n"); exit();}'
 EXPECT done
 TIMEOUT 5
 
 NAME ternary
-RUN bpftrace -v -e 'i:ms:1 { $a = 1 ? "yes" : "no"; printf("%s\n", $a); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 { $a = 1 ? "yes" : "no"; printf("%s\n", $a); exit();}'
 EXPECT yes
 TIMEOUT 5
 
 NAME ternary_lnot
-RUN bpftrace -v -e 'i:ms:1 { $a = !nsecs ? 0 : 1; printf("%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 { $a = !nsecs ? 0 : 1; printf("%d\n", $a); exit();}'
 EXPECT 0
 TIMEOUT 5
 
 NAME ternary_int8
-RUN bpftrace -v -e 'i:ms:1 { $a = 1 ? (int8)1 : 0; printf("%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 { $a = 1 ? (int8)1 : 0; printf("%d\n", $a); exit();}'
 EXPECT 1
 TIMEOUT 5
 
 NAME ternary_none_type
-RUN bpftrace -v -e 'i:ms:1 { nsecs ? printf("yes\n") : printf("no") ; exit(); }'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 { nsecs ? printf("yes\n") : printf("no") ; exit(); }'
 EXPECT  yes
 TIMEOUT 5
 
 NAME unroll
-RUN bpftrace -v -e 'i:ms:1 {$a = 1; unroll (10) { $a = $a + 1; } printf("a=%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = 1; unroll (10) { $a = $a + 1; } printf("a=%d\n", $a); exit();}'
 EXPECT a=11
 TIMEOUT 5
 
 NAME unroll_max_value
-RUN bpftrace -v -e 'i:ms:1 {$a = 1; unroll (101) { $a = $a + 2; } printf("a=%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = 1; unroll (101) { $a = $a + 2; } printf("a=%d\n", $a); exit();}'
 EXPECT unroll maximum value is 100
 TIMEOUT 5
 
 NAME unroll_min_value
-RUN bpftrace -v -e 'i:ms:1 {$a = 1; unroll (0) { $a = $a + 2; } printf("a=%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = 1; unroll (0) { $a = $a + 2; } printf("a=%d\n", $a); exit();}'
 EXPECT unroll minimum value is 1
 TIMEOUT 5
 
 NAME unroll_param
-RUN bpftrace -v -e 'i:ms:1 {$a = 1; unroll ($1) { $a = $a + 1; } printf("a=%d\n", $a); exit();}' 10
+RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = 1; unroll ($1) { $a = $a + 1; } printf("a=%d\n", $a); exit();}' 10
 EXPECT a=11
 TIMEOUT 5
 
 NAME if_compare_and_print_string
-RUN bpftrace -v -e 'BEGIN { if (comm == "bpftrace") { printf("comm: %s\n", comm);} exit();}'
+RUN {{BPFTRACE}} -v -e 'BEGIN { if (comm == "bpftrace") { printf("comm: %s\n", comm);} exit();}'
 EXPECT comm: bpftrace
 TIMEOUT 5
 
 NAME struct positional string compare - equal returns true
-RUN bpftrace -v -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} exit();}' "hello" "hello"
+RUN {{BPFTRACE}} -v -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} exit();}' "hello" "hello"
 EXPECT I got hello
 TIMEOUT 5
 
 NAME struct positional string compare - equal returns false
-RUN bpftrace -v -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hi" "hello"
+RUN {{BPFTRACE}} -v -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hi" "hello"
 EXPECT not equal
 TIMEOUT 5
 
 NAME struct positional string compare - not equal
-RUN bpftrace -v -e 'BEGIN { if (str($1) != str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hello" "hello"
+RUN {{BPFTRACE}} -v -e 'BEGIN { if (str($1) != str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hello" "hello"
 EXPECT not equal
 TIMEOUT 5
 
 NAME positional attachpoint
-RUN bpftrace -e 'i:ms:$1 { printf("hello world\n"); exit(); }' 1
+RUN {{BPFTRACE}} -e 'i:ms:$1 { printf("hello world\n"); exit(); }' 1
 EXPECT hello world
 TIMEOUT 1
 
 NAME positional attachpoint probe
-RUN bpftrace -e 'BEG$1 { printf("hello world\n"); exit(); }' IN
+RUN {{BPFTRACE}} -e 'BEG$1 { printf("hello world\n"); exit(); }' IN
 EXPECT hello world
 TIMEOUT 1
 
 NAME string compare map lookup
-RUN bpftrace -v -e 't:syscalls:sys_enter_openat /comm == "syscall"/ { @[comm] = 1; }' -c "./testprogs/syscall openat"
+RUN {{BPFTRACE}} -v -e 't:syscalls:sys_enter_openat /comm == "syscall"/ { @[comm] = 1; }' -c "./testprogs/syscall openat"
 EXPECT @\[syscall\]: 1
 TIMEOUT 5
 
 NAME struct partial string compare - pass
-RUN bpftrace -v -e 'BEGIN { if (strncmp(str($1), str($2), 4) == 0) { printf("I got %s\n", str($1));} exit();}' "hhvm" "hhvm-proc"
+RUN {{BPFTRACE}} -v -e 'BEGIN { if (strncmp(str($1), str($2), 4) == 0) { printf("I got %s\n", str($1));} exit();}' "hhvm" "hhvm-proc"
 EXPECT I got hhvm
 TIMEOUT 5
 
 NAME struct partial string compare - pass reverse
-RUN bpftrace -v -e 'BEGIN { if (strncmp(str($1), str($2), 4) == 0) { printf("I got %s\n", str($1));} exit();}' "hhvm-proc" "hhvm"
+RUN {{BPFTRACE}} -v -e 'BEGIN { if (strncmp(str($1), str($2), 4) == 0) { printf("I got %s\n", str($1));} exit();}' "hhvm-proc" "hhvm"
 EXPECT I got hhvm-proc
 TIMEOUT 5
 
 NAME strncmp function argument
-RUN bpftrace -v -e 'struct F {char s[8];} u:./testprogs/string_args:print { @=strncmp(((struct F*)arg0)->s, "hello", 5); }' -c ./testprogs/string_args
+RUN {{BPFTRACE}} -v -e 'struct F {char s[8];} u:./testprogs/string_args:print { @=strncmp(((struct F*)arg0)->s, "hello", 5); }' -c ./testprogs/string_args
 EXPECT @: 0
 TIMEOUT 5
 
 NAME short non null-terminated string print
-RUN bpftrace -v -e 'struct F {char s[5];} u:./testprogs/string_args:print { $a = ((struct F*)arg0)->s; printf("%s %s\n", $a, $a); }' -c ./testprogs/string_args
+RUN {{BPFTRACE}} -v -e 'struct F {char s[5];} u:./testprogs/string_args:print { $a = ((struct F*)arg0)->s; printf("%s %s\n", $a, $a); }' -c ./testprogs/string_args
 EXPECT hello hello
 TIMEOUT 5
 
 NAME optional_positional_int
-RUN bpftrace -e 'BEGIN { printf("-%d-\n", $1); exit() }'
+RUN {{BPFTRACE}} -e 'BEGIN { printf("-%d-\n", $1); exit() }'
 EXPECT -0-
 TIMEOUT 1
 
 NAME optional_positional_str
-RUN bpftrace -e 'BEGIN { printf("-%s-\n", str($1)); exit() }'
+RUN {{BPFTRACE}} -e 'BEGIN { printf("-%s-\n", str($1)); exit() }'
 EXPECT --
 TIMEOUT 1
 
 NAME positional number as string
-RUN bpftrace -e 'BEGIN { printf("-%s-\n", str($1)); exit() }' 1
+RUN {{BPFTRACE}} -e 'BEGIN { printf("-%s-\n", str($1)); exit() }' 1
 EXPECT -1-
 TIMEOUT 1
 
 NAME positional as string literal
-RUN bpftrace -e 'BEGIN { @ = kaddr(str($1)); exit() }' vfs_read
+RUN {{BPFTRACE}} -e 'BEGIN { @ = kaddr(str($1)); exit() }' vfs_read
 EXPECT Attaching 1 probe...
 TIMEOUT 5
 
 NAME positional arg count
-RUN bpftrace -v -e 'BEGIN { printf("got %d args: %s %d\n", $#, str($1), $2); exit();}' "one" 2
+RUN {{BPFTRACE}} -v -e 'BEGIN { printf("got %d args: %s %d\n", $#, str($1), $2); exit();}' "one" 2
 EXPECT got 2 args: one 2
 TIMEOUT 5
 
 NAME positional multiple bases
-RUN bpftrace -e 'BEGIN { printf("got: %d %d 0x%x\n", $1, $2, $3); exit() }' 123 0775 0x123
+RUN {{BPFTRACE}} -e 'BEGIN { printf("got: %d %d 0x%x\n", $1, $2, $3); exit() }' 123 0775 0x123
 EXPECT got: 123 509 0x123
 TIMEOUT 5
 
 NAME positional pointer arithmetics
-RUN bpftrace -e 'BEGIN { printf("%s", str($1 + 1)); exit(); }' hello
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%s", str($1 + 1)); exit(); }' hello
 EXPECT ello
 TIMEOUT 1
 
 NAME lhist can be cleared
-RUN bpftrace -e 'BEGIN{ @[1] = lhist(3,0,10,1); clear(@); exit() }'
+RUN {{BPFTRACE}} -e 'BEGIN{ @[1] = lhist(3,0,10,1); clear(@); exit() }'
 EXPECT .*
 TIMEOUT 1
 
 NAME hist can be cleared
-RUN bpftrace -e 'BEGIN{ @[1] = hist(1); clear(@); exit() }'
+RUN {{BPFTRACE}} -e 'BEGIN{ @[1] = hist(1); clear(@); exit() }'
 EXPECT .*
 TIMEOUT 1
 
 NAME stats can be cleared
-RUN bpftrace -e 'BEGIN{ @[1] = stats(1); clear(@); exit() }'
+RUN {{BPFTRACE}} -e 'BEGIN{ @[1] = stats(1); clear(@); exit() }'
 EXPECT .*
 TIMEOUT 1
 
 NAME avg can be cleared
-RUN bpftrace -e 'BEGIN{ @[1] = avg(1); clear(@); exit() }'
+RUN {{BPFTRACE}} -e 'BEGIN{ @[1] = avg(1); clear(@); exit() }'
 EXPECT .*
 TIMEOUT 1
 
 NAME sigint under heavy load
-RUN bpftrace --unsafe -v -e 'tracepoint:sched:sched_switch { system("echo foo"); } END { printf("end"); }'
+RUN {{BPFTRACE}} --unsafe -v -e 'tracepoint:sched:sched_switch { system("echo foo"); } END { printf("end"); }'
 EXPECT end
 TIMEOUT 5
 AFTER  ./testprogs/syscall nanosleep 2e9; pkill -SIGINT bpftrace
 
 NAME bitfield access
-RUN bpftrace -v -e 'struct Foo { unsigned int a:4, b:8, c:3, d:1, e:16; } uprobe:./testprogs/bitfield_test:func{ $foo = (struct Foo *)arg0; printf("%d %d %d %d %d\n", $foo->a, $foo->b, $foo->c, $foo->d, $foo->e); exit()}'
+RUN {{BPFTRACE}} -v -e 'struct Foo { unsigned int a:4, b:8, c:3, d:1, e:16; } uprobe:./testprogs/bitfield_test:func{ $foo = (struct Foo *)arg0; printf("%d %d %d %d %d\n", $foo->a, $foo->b, $foo->c, $foo->d, $foo->e); exit()}'
 EXPECT 1 2 5 0 65535
 TIMEOUT 5
 AFTER ./testprogs/bitfield_test
 
 NAME bitfield_access_2
-RUN bpftrace -v -e 'struct Bar { short a:4, b:8, c:3, d:1; int e:9, f:15, g:1, h:2, i:5 } uprobe:./testprogs/bitfield_test:func2 { $bar = (struct Bar *)arg0; printf("%d %d %d %d %d", $bar->a, $bar->b, $bar->c, $bar->d, $bar->e); printf(" %d %d %d %d", $bar->f, $bar->g, $bar->h, $bar->i); exit()}'
+RUN {{BPFTRACE}} -v -e 'struct Bar { short a:4, b:8, c:3, d:1; int e:9, f:15, g:1, h:2, i:5 } uprobe:./testprogs/bitfield_test:func2 { $bar = (struct Bar *)arg0; printf("%d %d %d %d %d", $bar->a, $bar->b, $bar->c, $bar->d, $bar->e); printf(" %d %d %d %d", $bar->f, $bar->g, $bar->h, $bar->i); exit()}'
 EXPECT 1 217 5 1 500 31117 1 2 27
 TIMEOUT 5
 AFTER ./testprogs/bitfield_test
 
 NAME exit exits immediately
-RUN bpftrace -e 'i:ms:100 { @++; exit(); @++ }'
+RUN {{BPFTRACE}} -e 'i:ms:100 { @++; exit(); @++ }'
 EXPECT @: 1
 TIMEOUT 1
 
 NAME map_assign_map_ptr
-RUN bpftrace -e 'i:ms:100 { @ = curtask; @a = @; printf("%d\n", @a); exit(); }'
+RUN {{BPFTRACE}} -e 'i:ms:100 { @ = curtask; @a = @; printf("%d\n", @a); exit(); }'
 EXPECT -?[0-9]+
 TIMEOUT 1
 
 NAME runtime_error_check_delete
-RUN bpftrace -k -e 'i:ms:100 { @[1] = 1; delete(@[2]); exit(); }'
+RUN {{BPFTRACE}} -k -e 'i:ms:100 { @[1] = 1; delete(@[2]); exit(); }'
 EXPECT WARNING: Failed to map_delete_elem: No such file or directory \(-2\)
 TIMEOUT 1
 
 NAME runtime_error_check_lookup
-RUN bpftrace -kk -e 'i:ms:100 { @[1] = 1; printf("%d\n", @[2]); exit(); }'
+RUN {{BPFTRACE}} -kk -e 'i:ms:100 { @[1] = 1; printf("%d\n", @[2]); exit(); }'
 EXPECT WARNING: Failed to map_lookup_elem: 0
 TIMEOUT 1

--- a/tests/runtime/pointers
+++ b/tests/runtime/pointers
@@ -1,94 +1,94 @@
 NAME u8 pointer increment
-RUN bpftrace -e 'BEGIN { @=(int8*) 32; @+=1; exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @=(int8*) 32; @+=1; exit(); }'
 EXPECT ^@: 33
 TIMEOUT 5
 
 NAME u16 pointer increment
-RUN bpftrace -e 'BEGIN { @=(int16*) 32; @+=1; exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @=(int16*) 32; @+=1; exit(); }'
 EXPECT ^@: 34
 TIMEOUT 5
 
 NAME u32 pointer increment
-RUN bpftrace -e 'BEGIN { @=(int32*) 32; @+=1; exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @=(int32*) 32; @+=1; exit(); }'
 EXPECT ^@: 36
 TIMEOUT 5
 
 NAME u64 pointer increment
-RUN bpftrace -e 'BEGIN { @=(int64*) 32; @+=1; exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @=(int64*) 32; @+=1; exit(); }'
 EXPECT ^@: 40
 TIMEOUT 5
 
 NAME u8 pointer unop post increment
-RUN bpftrace -e 'BEGIN { @=(int8*) 32; @++; exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @=(int8*) 32; @++; exit(); }'
 EXPECT ^@: 33
 TIMEOUT 5
 
 NAME u16 pointer unop post increment
-RUN bpftrace -e 'BEGIN { @=(int16*) 32; @++; exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @=(int16*) 32; @++; exit(); }'
 EXPECT ^@: 34
 TIMEOUT 5
 
 NAME u32 pointer unop post increment
-RUN bpftrace -e 'BEGIN { @=(int32*) 32; @++; exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @=(int32*) 32; @++; exit(); }'
 EXPECT ^@: 36
 TIMEOUT 5
 
 NAME u64 pointer unop post increment
-RUN bpftrace -e 'BEGIN { @=(int64*) 32; @++; exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @=(int64*) 32; @++; exit(); }'
 EXPECT ^@: 40
 TIMEOUT 5
 
 NAME u8 pointer unop pre increment
-RUN bpftrace -e 'BEGIN { @=(int8*) 32; @++; exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @=(int8*) 32; @++; exit(); }'
 EXPECT ^@: 33
 TIMEOUT 5
 
 NAME u16 pointer unop pre increment
-RUN bpftrace -e 'BEGIN { @=(int16*) 32; @++; exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @=(int16*) 32; @++; exit(); }'
 EXPECT ^@: 34
 TIMEOUT 5
 
 NAME u32 pointer unop pre increment
-RUN bpftrace -e 'BEGIN { @=(int32*) 32; @++; exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @=(int32*) 32; @++; exit(); }'
 EXPECT ^@: 36
 TIMEOUT 5
 
 NAME u64 pointer unop pre increment
-RUN bpftrace -e 'BEGIN { @=(int64*) 32; @++; exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @=(int64*) 32; @++; exit(); }'
 EXPECT ^@: 40
 TIMEOUT 5
 
 NAME Pointer decrement 1
-RUN bpftrace -e 'BEGIN { @=(int32*) 32; @-=1; exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @=(int32*) 32; @-=1; exit(); }'
 EXPECT ^@: 28
 TIMEOUT 5
 
 NAME Pointer decrement
-RUN bpftrace -e 'BEGIN { @=(int32*) 32; @--; exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @=(int32*) 32; @--; exit(); }'
 EXPECT ^@: 28
 TIMEOUT 5
 
 NAME Pointer increment 6
-RUN bpftrace -e 'BEGIN { @=(int32*) 32; @+=6; exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @=(int32*) 32; @+=6; exit(); }'
 EXPECT ^@: 56
 TIMEOUT 5
 
 NAME Pointer decrement 6
-RUN bpftrace -e 'BEGIN { @=(int32*) 32; @-=6; exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @=(int32*) 32; @-=6; exit(); }'
 EXPECT ^@: 8
 TIMEOUT 5
 
 NAME Struct pointer math
-RUN bpftrace -e 'struct A {int32_t a; int32_t b; char c[28] }; BEGIN { $a=(struct A*) 1024; printf("%lu - 5 x %lu = %lu\n", $a, sizeof(struct A), $a-5); exit(); }'
+RUN {{BPFTRACE}} -e 'struct A {int32_t a; int32_t b; char c[28] }; BEGIN { $a=(struct A*) 1024; printf("%lu - 5 x %lu = %lu\n", $a, sizeof(struct A), $a-5); exit(); }'
 EXPECT 1024 - 5 x 36 = 844
 TIMEOUT 5
 
 NAME Pointer decrement with map
-RUN bpftrace -e 'BEGIN { @dec = 4; @=(int32*) 32; @-=@dec; exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @dec = 4; @=(int32*) 32; @-=@dec; exit(); }'
 EXPECT ^@: 16
 TIMEOUT 5
 
 NAME Pointer walk through struct
-RUN bpftrace runtime/scripts/struct_walk.bt -c ./testprogs/struct_walk
+RUN {{BPFTRACE}} runtime/scripts/struct_walk.bt -c ./testprogs/struct_walk
 EXPECT ^a: 45 b: 1000
 TIMEOUT 5

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -1,28 +1,28 @@
 NAME kprobe
-RUN bpftrace -v -e 'kprobe:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN {{BPFTRACE}} -v -e 'kprobe:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT SUCCESS kprobe [0-9][0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kprobe_short_name
-RUN bpftrace -v -e 'k:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN {{BPFTRACE}} -v -e 'k:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT SUCCESS kprobe_short_name [0-9][0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kprobe_target
-RUN bpftrace -v -e 'kprobe:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN {{BPFTRACE}} -v -e 'kprobe:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT kprobe probe type requires 1 argument
 TIMEOUT 5
 
 NAME kprobe_order
-RUN bpftrace -v runtime/scripts/kprobe_order.bt
+RUN {{BPFTRACE}} -v runtime/scripts/kprobe_order.bt
 EXPECT first second
 TIMEOUT 5
 AFTER /bin/bash -c "./testprogs/syscall nanosleep 1000"; /bin/bash -c "./testprogs/syscall nanosleep 1000"
 
 NAME kprobe_offset
-RUN bpftrace -v -e 'kprobe:vfs_read+0 { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN {{BPFTRACE}} -v -e 'kprobe:vfs_read+0 { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT SUCCESS kprobe_offset [0-9][0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
@@ -31,149 +31,149 @@ AFTER ./testprogs/syscall read
 # yet. Reason is b/c bpftrace will look for a vmlinux based on the running kernel's
 # version.
 NAME kprobe_offset_fail_size
-RUN bpftrace -v -e 'kprobe:vfs_read+1000000 { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN {{BPFTRACE}} -v -e 'kprobe:vfs_read+1000000 { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT Offset outside the function bounds \('vfs_read' size is*
 TIMEOUT 5
 
 NAME kretprobe
-RUN bpftrace -v -e 'kretprobe:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN {{BPFTRACE}} -v -e 'kretprobe:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT SUCCESS kretprobe [0-9][0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kretprobe_short_name
-RUN bpftrace -v -e 'kr:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN {{BPFTRACE}} -v -e 'kr:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT SUCCESS kretprobe_short_name [0-9][0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kretprobe_target
-RUN bpftrace -v -e 'kretprobe:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN {{BPFTRACE}} -v -e 'kretprobe:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT kretprobe probe type requires 1 argument
 TIMEOUT 5
 
 NAME kretprobe_order
-RUN bpftrace -v runtime/scripts/kretprobe_order.bt
+RUN {{BPFTRACE}} -v runtime/scripts/kretprobe_order.bt
 EXPECT first second
 TIMEOUT 5
 AFTER /bin/bash -c "./testprogs/syscall nanosleep 1000"; /bin/bash -c "./testprogs/syscall nanosleep 1000"
 
 NAME uprobe
-RUN bpftrace -v -e 'uprobe:/bin/bash:echo_builtin { printf("arg0: %d\n", arg0); exit();}'
+RUN {{BPFTRACE}} -v -e 'uprobe:/bin/bash:echo_builtin { printf("arg0: %d\n", arg0); exit();}'
 EXPECT arg0: [0-9]*
 TIMEOUT 5
 AFTER /bin/bash -c "echo lala"
 
 NAME uprobe_offset
-RUN bpftrace -v -e 'uprobe:/bin/bash:echo_builtin+0 { printf("arg0: %d\n", arg0); exit();}'
+RUN {{BPFTRACE}} -v -e 'uprobe:/bin/bash:echo_builtin+0 { printf("arg0: %d\n", arg0); exit();}'
 EXPECT arg0: [0-9]*
 TIMEOUT 5
 AFTER /bin/bash -c "echo lala"
 
 NAME uprobe_offset
-RUN bpftrace -v -e 'uprobe:/bin/bash:"echo_builtin"+0 { printf("arg0: %d\n", arg0); exit();}'
+RUN {{BPFTRACE}} -v -e 'uprobe:/bin/bash:"echo_builtin"+0 { printf("arg0: %d\n", arg0); exit();}'
 EXPECT arg0: [0-9]*
 TIMEOUT 5
 AFTER /bin/bash -c "echo lala"
 
 NAME uprobe_offset_fail_size
-RUN bpftrace -e 'uprobe:/bin/bash:echo_builtin+1000000 { printf("arg0: %d\n", arg0); exit();}'
+RUN {{BPFTRACE}} -e 'uprobe:/bin/bash:echo_builtin+1000000 { printf("arg0: %d\n", arg0); exit();}'
 EXPECT Offset outside the function bounds \('echo_builtin' size is*
 TIMEOUT 5
 
 NAME uprobe_address_fail_resolve
-RUN bpftrace -e 'uprobe:/bin/bash:10 { printf("arg0: %d\n", arg0); exit();}'
+RUN {{BPFTRACE}} -e 'uprobe:/bin/bash:10 { printf("arg0: %d\n", arg0); exit();}'
 EXPECT Could not resolve address: /bin/bash:0xa
 TIMEOUT 5
 
 NAME uprobe_order
-RUN bpftrace -v runtime/scripts/uprobe_order.bt
+RUN {{BPFTRACE}} -v runtime/scripts/uprobe_order.bt
 EXPECT first second
 TIMEOUT 5
 AFTER /bin/bash -c "echo lala"; /bin/bash -c "echo lala"
 
 NAME uretprobe
-RUN bpftrace -v -e 'uretprobe:/bin/bash:echo_builtin { printf("readline: %d\n", retval); exit();}'
+RUN {{BPFTRACE}} -v -e 'uretprobe:/bin/bash:echo_builtin { printf("readline: %d\n", retval); exit();}'
 EXPECT readline: [0-9]*
 TIMEOUT 5
 AFTER /bin/bash -c "echo lala"
 
 NAME uretprobe_order
-RUN bpftrace -v runtime/scripts/uretprobe_order.bt
+RUN {{BPFTRACE}} -v runtime/scripts/uretprobe_order.bt
 EXPECT first second
 TIMEOUT 5
 AFTER /bin/bash -c "echo lala"; /bin/bash -c "echo lala"
 
 NAME tracepoint
-RUN bpftrace -v -e 'tracepoint:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", gid); exit(); }'
+RUN {{BPFTRACE}} -v -e 'tracepoint:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", gid); exit(); }'
 EXPECT SUCCESS tracepoint [0-9][0-9]*
 AFTER ./testprogs/syscall nanosleep 1e8
 TIMEOUT 5
 
 NAME tracepoint_short_name
-RUN bpftrace -v -e 't:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", gid); exit(); }'
+RUN {{BPFTRACE}} -v -e 't:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", gid); exit(); }'
 EXPECT SUCCESS tracepoint_short_name [0-9][0-9]*
 AFTER ./testprogs/syscall nanosleep 1e8
 TIMEOUT 5
 
 NAME tracepoint_order
-RUN bpftrace -v runtime/scripts/tracepoint_order.bt
+RUN {{BPFTRACE}} -v runtime/scripts/tracepoint_order.bt
 EXPECT first second
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep 1e8; ./testprogs/syscall nanosleep 1e8
 
 NAME tracepoint_expansion
-RUN bpftrace -v -e 'tracepoint:syscalls:sys_*_nanosleep { printf("hit "); }' -c "./testprogs/syscall nanosleep 1e8"
+RUN {{BPFTRACE}} -v -e 'tracepoint:syscalls:sys_*_nanosleep { printf("hit "); }' -c "./testprogs/syscall nanosleep 1e8"
 EXPECT hit hit
 TIMEOUT 5
 
 # Test that we get at least two characters out
 NAME tracepoint_data_loc
-RUN bpftrace -v -e 'tracepoint:irq:irq_handler_entry { print(str(args->name)); exit(); }'
+RUN {{BPFTRACE}} -v -e 'tracepoint:irq:irq_handler_entry { print(str(args->name)); exit(); }'
 EXPECT ..+
 TIMEOUT 5
 
 NAME profile
-RUN bpftrace -v -e 'profile:hz:599 { @[tid] = count(); exit();}'
+RUN {{BPFTRACE}} -v -e 'profile:hz:599 { @[tid] = count(); exit();}'
 EXPECT \@\[[0-9]*\]\:\s[0-9]
 TIMEOUT 5
 
 NAME profile_short_name
-RUN bpftrace -v -e 'p:hz:599 { @[tid] = count(); exit();}'
+RUN {{BPFTRACE}} -v -e 'p:hz:599 { @[tid] = count(); exit();}'
 EXPECT \@\[[0-9]*\]\:\s[0-9]
 TIMEOUT 5
 
 NAME interval
-RUN bpftrace -v -e 't:raw_syscalls:sys_enter { @syscalls = count(); } interval:ms:1{ print(@syscalls); clear(@syscalls); exit();}'
+RUN {{BPFTRACE}} -v -e 't:raw_syscalls:sys_enter { @syscalls = count(); } interval:ms:1{ print(@syscalls); clear(@syscalls); exit();}'
 EXPECT @syscalls\:\s[0-9]*
 TIMEOUT 5
 
 NAME interval_short_name
-RUN bpftrace -v -e 't:raw_syscalls:sys_enter { @syscalls = count(); } i:ms:1{ print(@syscalls); clear(@syscalls); exit();}'
+RUN {{BPFTRACE}} -v -e 't:raw_syscalls:sys_enter { @syscalls = count(); } i:ms:1{ print(@syscalls); clear(@syscalls); exit();}'
 EXPECT @syscalls\:\s[0-9]*
 TIMEOUT 5
 
 NAME software
-RUN bpftrace -v -e 'software:faults:1 { @[comm] = count(); exit();}'
+RUN {{BPFTRACE}} -v -e 'software:faults:1 { @[comm] = count(); exit();}'
 EXPECT @\[.*\]\:\s[0-9]*
 TIMEOUT 5
 
 NAME software_order
-RUN bpftrace -v runtime/scripts/software_order.bt
+RUN {{BPFTRACE}} -v runtime/scripts/software_order.bt
 EXPECT first second
 TIMEOUT 5
 
 NAME hardware
 REQUIRES ls /sys/devices/cpu/events/cache-misses
-RUN bpftrace -v -e 'hardware:cache-misses:10 { @[pid] = count(); exit(); }'
+RUN {{BPFTRACE}} -v -e 'hardware:cache-misses:10 { @[pid] = count(); exit(); }'
 EXPECT @\[.*\]\:\s[0-9]*
 TIMEOUT 5
 NAME BEGIN
-RUN bpftrace -v -e 'BEGIN { printf("Hello\n"); exit();}'
+RUN {{BPFTRACE}} -v -e 'BEGIN { printf("Hello\n"); exit();}'
 EXPECT Hello
 TIMEOUT 2
 
 NAME END_processing_after_exit
-RUN bpftrace -v -e "interval:s:1 { exit(); } END { printf("end"); }"
+RUN {{BPFTRACE}} -v -e "interval:s:1 { exit(); } END { printf("end"); }"
 EXPECT end
 TIMEOUT 2

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -1,11 +1,11 @@
 # https://github.com/iovisor/bpftrace/pull/566#issuecomment-487295113
 NAME codegen_struct_save_nested
-RUN bpftrace -e 'struct Foo { int m; struct { int x; int y; } bar; int n; } BEGIN { @foo = (struct Foo)0; @bar = @foo.bar; @x = @foo.bar.x; printf("done\n"); exit(); }'
+RUN {{BPFTRACE}} -e 'struct Foo { int m; struct { int x; int y; } bar; int n; } BEGIN { @foo = (struct Foo)0; @bar = @foo.bar; @x = @foo.bar.x; printf("done\n"); exit(); }'
 EXPECT done
 TIMEOUT 1
 
 NAME logical_and_or_different_sizes
-RUN bpftrace -v -e 'struct Foo { int m; } uprobe:./testprogs/simple_struct:func { $foo = (struct Foo*)arg0; printf("%d %d %d %d %d\n", $foo->m, $foo->m && 0, 1 && $foo->m, $foo->m || 0, 0 || $foo->m); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct Foo { int m; } uprobe:./testprogs/simple_struct:func { $foo = (struct Foo*)arg0; printf("%d %d %d %d %d\n", $foo->m, $foo->m && 0, 1 && $foo->m, $foo->m || 0, 0 || $foo->m); exit(); }'
 AFTER ./testprogs/simple_struct
 EXPECT 2 0 1 1 1
 TIMEOUT 5
@@ -13,34 +13,34 @@ TIMEOUT 5
 # https://github.com/iovisor/bpftrace/issues/759
 # Update test once https://github.com/iovisor/bpftrace/pull/781 lands
 # NAME ntop_map_printf
-# RUN bpftrace -v -e 'union ip { char v4[4]; char v6[16]; } uprobe:./testprogs/ntop:test_ntop { @a = ntop(2, ((union ip*)arg0)->v4); printf("v4: %s; ", @a); @b = ntop(10, ((union ip*)arg1)->v6); exit() } END { printf("v6: %s", @b); clear(@a); clear(@b) }'
+# RUN {{BPFTRACE}} -v -e 'union ip { char v4[4]; char v6[16]; } uprobe:./testprogs/ntop:test_ntop { @a = ntop(2, ((union ip*)arg0)->v4); printf("v4: %s; ", @a); @b = ntop(10, ((union ip*)arg1)->v6); exit() } END { printf("v6: %s", @b); clear(@a); clear(@b) }'
 # AFTER ./testprogs/ntop
 # EXPECT v4: 127.0.0.1; v6: ffee:ffee:ddcc:ddcc:bbaa:bbaa:c0a8:1
 # TIMEOUT 1
 
 NAME modulo_operator
-RUN bpftrace -v -e 'BEGIN { @x = 4; printf("%d\n", @x % 2) }'
+RUN {{BPFTRACE}} -v -e 'BEGIN { @x = 4; printf("%d\n", @x % 2) }'
 EXPECT 0
 TIMEOUT 5
 
 NAME ntop_tracepoint_args
-RUN bpftrace -v -e 'tracepoint:tcp:tcp_destroy_sock { printf("%s\n", ntop(args->daddr)); exit(); }'
+RUN {{BPFTRACE}} -v -e 'tracepoint:tcp:tcp_destroy_sock { printf("%s\n", ntop(args->daddr)); exit(); }'
 EXPECT [0-9]+.[0-9]+.[0-9]+.[0-9]+
 AFTER curl -s www.google.com > /dev/null
 TIMEOUT 5
 
 NAME c_array_indexing
-RUN bpftrace -v -e 'struct Foo { int a; uint8_t b[10]; } uprobe:testprogs/uprobe_test:function2 { $foo = (struct Foo *)arg0; printf("%c %c %c %c %c\n", $foo->b[0], $foo->b[1], $foo->b[2], $foo->b[3], $foo->b[4]) }' -c ./testprogs/uprobe_test
+RUN {{BPFTRACE}} -v -e 'struct Foo { int a; uint8_t b[10]; } uprobe:testprogs/uprobe_test:function2 { $foo = (struct Foo *)arg0; printf("%c %c %c %c %c\n", $foo->b[0], $foo->b[1], $foo->b[2], $foo->b[3], $foo->b[4]) }' -c ./testprogs/uprobe_test
 EXPECT h e l l o
 TIMEOUT 5
 
 # https://github.com/iovisor/bpftrace/issues/1773
 NAME single_arg_wildcard_listing
-RUN bpftrace -l "*do_nanosleep*"
+RUN {{BPFTRACE}} -l "*do_nanosleep*"
 EXPECT kprobe:do_nanosleep
 TIMEOUT 1
 
 NAME single_arg_wildcard_listing_tracepoint
-RUN bpftrace -l "*sched_switch*"
+RUN {{BPFTRACE}} -l "*sched_switch*"
 EXPECT tracepoint:sched:sched_switch
 TIMEOUT 1

--- a/tests/runtime/sigint
+++ b/tests/runtime/sigint
@@ -1,9 +1,9 @@
 NAME strace no quit
-RUN bpftrace -v -e 'i:s:1 { printf("%s %d\n", "SUCCESS", 1); exit() }' & (./testprogs/syscall nanosleep 5e8 && strace -p $! -o /dev/null)
+RUN {{BPFTRACE}} -v -e 'i:s:1 { printf("%s %d\n", "SUCCESS", 1); exit() }' & (./testprogs/syscall nanosleep 5e8 && strace -p $! -o /dev/null)
 EXPECT SUCCESS 1
 TIMEOUT 3
 
 NAME sigint quit
-RUN bpftrace -v -e 'END { printf("%s %d", "SUCCESS", 1) }' & (./testprogs/syscall nanosleep 1e9 && /usr/bin/env kill -s SIGINT $!)
+RUN {{BPFTRACE}} -v -e 'END { printf("%s %d", "SUCCESS", 1) }' & (./testprogs/syscall nanosleep 1e9 && /usr/bin/env kill -s SIGINT $!)
 EXPECT ^SUCCESS 1$
 TIMEOUT 2

--- a/tests/runtime/signed_ints
+++ b/tests/runtime/signed_ints
@@ -1,34 +1,34 @@
 NAME stats with negative values
-RUN bpftrace -e 'BEGIN { @=stats(-10); @=stats(-5); @=stats(5); exit() }'
+RUN {{BPFTRACE}} -e 'BEGIN { @=stats(-10); @=stats(-5); @=stats(5); exit() }'
 EXPECT ^@:\scount\s3,\saverage\s-3+,\stotal\s-10$
 TIMEOUT 5
 
 NAME avg with negative values
-RUN bpftrace -e 'BEGIN { @=avg(-30); @=avg(-10); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @=avg(-30); @=avg(-10); exit(); }'
 EXPECT ^@:\s-20$
 TIMEOUT 5
 
 NAME negative map value
-RUN bpftrace -e 'BEGIN { @ = -11; exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @ = -11; exit(); }'
 EXPECT @: -11$
 TIMEOUT 1
 
 NAME sum negative maps
-RUN bpftrace -e 'BEGIN { @ = -11; @+=@; exit() }'
+RUN {{BPFTRACE}} -e 'BEGIN { @ = -11; @+=@; exit() }'
 EXPECT @: -22$
 TIMEOUT 1
 
 NAME Comparison should print as 0 or 1
-RUN bpftrace -e 'struct x { uint64_t x; }; BEGIN { $a = (*(struct x*)0).x; printf("%d %d\n", $a > -1, $a < 1); exit(); }'
+RUN {{BPFTRACE}} -e 'struct x { uint64_t x; }; BEGIN { $a = (*(struct x*)0).x; printf("%d %d\n", $a > -1, $a < 1); exit(); }'
 EXPECT ^0 1$
 TIMEOUT 1
 
 NAME sum with negative value
-RUN bpftrace -e 'BEGIN { @=sum(10); @=sum(-20); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @=sum(10); @=sum(-20); exit(); }'
 EXPECT ^@: -10$
 TIMEOUT 1
 
 NAME mixed values
-RUN bpftrace -e 'BEGIN { printf("%d %d %d %d\n", (int8) -10, -5555, (int16)-123, 100); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%d %d %d %d\n", (int8) -10, -5555, (int16)-123, 100); exit(); }'
 EXPECT ^-10 -5555 -123 100$
 TIMEOUT 5

--- a/tests/runtime/struct
+++ b/tests/runtime/struct
@@ -1,47 +1,47 @@
 NAME struct assignment into variable
-RUN bpftrace -v -e 'struct Foo { int m; } u:./testprogs/simple_struct:func { $s = *((struct Foo *)arg0); printf("Result: %d\n", $s.m); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct Foo { int m; } u:./testprogs/simple_struct:func { $s = *((struct Foo *)arg0); printf("Result: %d\n", $s.m); exit(); }'
 EXPECT Result: 2
 TIMEOUT 4
 AFTER ./testprogs/simple_struct
 
 NAME struct assignment into map
-RUN bpftrace -v -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @s = *((struct Foo *)arg0); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @s = *((struct Foo *)arg0); exit(); }'
 EXPECT @s: { .m = 2, .n = 3 }
 TIMEOUT 4
 AFTER ./testprogs/simple_struct
 
 NAME struct field order
-RUN bpftrace -v -e 'struct Foo { int n; int m; } u:./testprogs/simple_struct:func { @s = *((struct Foo *)arg0); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct Foo { int n; int m; } u:./testprogs/simple_struct:func { @s = *((struct Foo *)arg0); exit(); }'
 EXPECT @s: { .n = 2, .m = 3 }
 TIMEOUT 4
 AFTER ./testprogs/simple_struct
 
 NAME nested struct assignment into map
-RUN bpftrace -v -e 'struct Foo { struct { int m[1] } y; struct { int n } a; } u:./testprogs/simple_struct:func { @s = *((struct Foo *)arg0); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct Foo { struct { int m[1] } y; struct { int n } a; } u:./testprogs/simple_struct:func { @s = *((struct Foo *)arg0); exit(); }'
 EXPECT @s: { .y = { .m = \[2\] }, .a = { .n = 3 } }
 TIMEOUT 4
 AFTER ./testprogs/simple_struct
 
 NAME struct as a map key
-RUN bpftrace -v -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @s[*((struct Foo *)arg0)] = 0; exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @s[*((struct Foo *)arg0)] = 0; exit(); }'
 EXPECT @s\[{.m=2,.n=3}\]: 0
 TIMEOUT 4
 AFTER ./testprogs/simple_struct
 
 NAME struct as a part of multikey
-RUN bpftrace -v -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @s[*((struct Foo *)arg0), 42] = 0; exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @s[*((struct Foo *)arg0), 42] = 0; exit(); }'
 EXPECT @s\[{.m=2,.n=3}, 42\]: 0
 TIMEOUT 4
 AFTER ./testprogs/simple_struct
 
 NAME struct as a map key assigned from another map
-RUN bpftrace -v -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @x = *((struct Foo *)arg0); @s[@x] = 0; exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @x = *((struct Foo *)arg0); @s[@x] = 0; exit(); }'
 EXPECT @s\[{.m=2,.n=3}\]: 0
 TIMEOUT 4
 AFTER ./testprogs/simple_struct
 
 NAME struct in a tuple
-RUN bpftrace -v -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @s = (1, *((struct Foo *)arg0)); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @s = (1, *((struct Foo *)arg0)); exit(); }'
 EXPECT @s: \(1, { .m = 2, .n = 3 }\)
 TIMEOUT 4
 AFTER ./testprogs/simple_struct

--- a/tests/runtime/tuples
+++ b/tests/runtime/tuples
@@ -1,90 +1,90 @@
 NAME basic tuple
-RUN bpftrace -e 'BEGIN { $v = 99; $t = (0, 1, "str", (5, 6), $v); printf("%d %d %s %d %d %d\n", $t.0, $t.1, $t.2, $t.3.0, $t.3.1, $t.4); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { $v = 99; $t = (0, 1, "str", (5, 6), $v); printf("%d %d %s %d %d %d\n", $t.0, $t.1, $t.2, $t.3.0, $t.3.1, $t.4); exit(); }'
 EXPECT 0 1 str 5 6 99
 TIMEOUT 5
 
 NAME basic tuple map
-RUN bpftrace -e 'BEGIN { $v = 99; @t = (0, 1, "str"); printf("%d %d %s\n", @t.0, @t.1, @t.2); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { $v = 99; @t = (0, 1, "str"); printf("%d %d %s\n", @t.0, @t.1, @t.2); exit(); }'
 EXPECT 0 1 str
 TIMEOUT 5
 
 NAME mixed int tuple map
-RUN bpftrace -e 'BEGIN { @ = ( (int32) -100, (int8) 10, 50 ); exit();}'
+RUN {{BPFTRACE}} -e 'BEGIN { @ = ( (int32) -100, (int8) 10, 50 ); exit();}'
 EXPECT @: \(-100, 10, 50\)
 TIMEOUT 5
 
 NAME mixed int tuple map 2
-RUN bpftrace -e 'BEGIN { @ = ( -100, (int8) 10, (int32) 50 ); exit();}'
+RUN {{BPFTRACE}} -e 'BEGIN { @ = ( -100, (int8) 10, (int32) 50 ); exit();}'
 EXPECT @: \(-100, 10, 50\)
 TIMEOUT 5
 
 NAME mixed int tuple map 3
-RUN bpftrace -e 'BEGIN { @ = ( -100, (int8) 10, (int32) 50, 100 ); exit();}'
+RUN {{BPFTRACE}} -e 'BEGIN { @ = ( -100, (int8) 10, (int32) 50, 100 ); exit();}'
 EXPECT @: \(-100, 10, 50, 100\)
 TIMEOUT 5
 
 NAME complex tuple 1
-RUN bpftrace -e 'BEGIN { print(((int8)-100, (int8) 100, "abcdef", 3, (int32) 1, (int64)-10, (int8)10, (int16)-555)); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { print(((int8)-100, (int8) 100, "abcdef", 3, (int32) 1, (int64)-10, (int8)10, (int16)-555)); exit(); }'
 EXPECT \(-100, 100, abcdef, 3, 1, -10, 10, -555\)
 TIMEOUT 5
 
 NAME tuple struct sizing 1
-RUN bpftrace -e 'BEGIN { $t = ((int8) 1, (int64) 1, (int8) 1, (int64) 1); print(sizeof($t)); exit() }'
+RUN {{BPFTRACE}} -e 'BEGIN { $t = ((int8) 1, (int64) 1, (int8) 1, (int64) 1); print(sizeof($t)); exit() }'
 EXPECT 32
 TIMEOUT 5
 
 NAME tuple struct sizing 2
-RUN bpftrace -e 'BEGIN { $t = ((int8) 1, (int16) 1, (int32) 1); print(sizeof($t)); exit() }'
+RUN {{BPFTRACE}} -e 'BEGIN { $t = ((int8) 1, (int16) 1, (int32) 1); print(sizeof($t)); exit() }'
 EXPECT 8
 TIMEOUT 5
 
 NAME tuple struct sizing 3
-RUN bpftrace -e 'BEGIN { $t = ((int32) 1, (int16) 1, (int8) 1); print(sizeof($t)); exit() }'
+RUN {{BPFTRACE}} -e 'BEGIN { $t = ((int32) 1, (int16) 1, (int8) 1); print(sizeof($t)); exit() }'
 EXPECT 8
 TIMEOUT 5
 
 NAME complex tuple 4
-RUN bpftrace -e 'BEGIN { $a = ((int8)-100, (int8) 100, "abcdef", 3, (int32) 1, (int64)-10, (int8)10, (int16)-555, "abc"); print(sizeof($a)); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { $a = ((int8)-100, (int8) 100, "abcdef", 3, (int32) 1, (int64)-10, (int8)10, (int16)-555, "abc"); print(sizeof($a)); exit(); }'
 EXPECT 168
 TIMEOUT 5
 
 NAME struct in tuple
-RUN bpftrace -v -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @t = (1, *((struct Foo *)arg0)); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @t = (1, *((struct Foo *)arg0)); exit(); }'
 EXPECT @t: \(1, \{ .m = 2, .n = 3 \}\)
 TIMEOUT 5
 AFTER ./testprogs/simple_struct
 
 NAME struct in tuple sizing
-RUN bpftrace -v -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { $t = ((int32)1, *((struct Foo *)arg0)); print(sizeof($t)); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { $t = ((int32)1, *((struct Foo *)arg0)); print(sizeof($t)); exit(); }'
 EXPECT 12
 TIMEOUT 5
 AFTER ./testprogs/simple_struct
 
 NAME array in tuple
-RUN bpftrace -v -e 'struct A { int x[4]; } u:./testprogs/array_access:test_struct { @t = (1, ((struct A *)arg0)->x); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } u:./testprogs/array_access:test_struct { @t = (1, ((struct A *)arg0)->x); exit(); }'
 EXPECT @t: \(1, \[1,2,3,4\]\)
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array in tuple sizing
-RUN bpftrace -v -e 'struct A { int x[4]; } u:./testprogs/array_access:test_struct { $t = ((int32)1, ((struct A *)arg0)->x); print(sizeof($t)); exit(); }'
+RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } u:./testprogs/array_access:test_struct { $t = ((int32)1, ((struct A *)arg0)->x); print(sizeof($t)); exit(); }'
 EXPECT 20
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME nested tuple
-RUN bpftrace -e 'BEGIN{ @ = ((int8)1, ((int8)-20, (int8)30)); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN{ @ = ((int8)1, ((int8)-20, (int8)30)); exit(); }'
 EXPECT @: \(1, \(-20, 30\)\)
 TIMEOUT 5
 
 # Careful with '(' and ')', they are read by the test engine as a regex group,
 # so make sure to escape them.
 NAME tuple print
-RUN bpftrace -e 'BEGIN { @ = (1, 2, "string", (4, 5)); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @ = (1, 2, "string", (4, 5)); exit(); }'
 EXPECT ^@: \(1, 2, string, \(4, 5\)\)$
 TIMEOUT 5
 
 NAME tuple strftime type is packed
-RUN bpftrace -e 'BEGIN { @ = (nsecs, strftime("%M:%S", nsecs)); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { @ = (nsecs, strftime("%M:%S", nsecs)); exit(); }'
 EXPECT ^@: \(\d+, \d+:\d+\)$
 TIMEOUT 5

--- a/tests/runtime/uprobe
+++ b/tests/runtime/uprobe
@@ -1,63 +1,63 @@
 NAME "uprobes - list probes by file"
-RUN bpftrace -l 'uprobe:./testprogs/uprobe_test:*'
+RUN {{BPFTRACE}} -l 'uprobe:./testprogs/uprobe_test:*'
 EXPECT uprobe:./testprogs/uprobe_test:function1
 TIMEOUT 5
 
 NAME "uprobes - list probes by file with wildcarded filter"
-RUN bpftrace -l 'uprobe:./testprogs/uprobe_test:func*'
+RUN {{BPFTRACE}} -l 'uprobe:./testprogs/uprobe_test:func*'
 EXPECT uprobe:./testprogs/uprobe_test:function1
 TIMEOUT 5
 
 NAME "uprobes - list probes with wildcarded file matching multiple files"
-RUN bpftrace -l 'uprobe:./testprogs/uprobe*:*'
+RUN {{BPFTRACE}} -l 'uprobe:./testprogs/uprobe*:*'
 EXPECT uprobe:./testprogs/uprobe_test:function1
 TIMEOUT 5
 
 NAME "uprobes - list probes by file with wildcarded file and filter"
-RUN bpftrace -l 'uprobe:./testprogs/uprobe_test*:func*'
+RUN {{BPFTRACE}} -l 'uprobe:./testprogs/uprobe_test*:func*'
 EXPECT uprobe:./testprogs/uprobe_test:function1
 TIMEOUT 5
 
 NAME "uprobes - list probes by file with specific filter"
-RUN bpftrace -l 'uprobe:./testprogs/uprobe_test:function1'
+RUN {{BPFTRACE}} -l 'uprobe:./testprogs/uprobe_test:function1'
 EXPECT uprobe:./testprogs/uprobe_test:function1
 TIMEOUT 5
 
 NAME "uprobes - list probes by file with wildcarded probe type"
-RUN bpftrace -l '*:./testprogs/uprobe_test:*' | grep -e '^uprobe:'
+RUN {{BPFTRACE}} -l '*:./testprogs/uprobe_test:*' | grep -e '^uprobe:'
 EXPECT uprobe:./testprogs/uprobe_test:function1
 TIMEOUT 5
 
 NAME "uprobes - list probes by pid"
-RUN bpftrace -l -p {{BEFORE_PID}} | grep -e '^uprobe'
+RUN {{BPFTRACE}} -l -p {{BEFORE_PID}} | grep -e '^uprobe'
 EXPECT uprobe:.*/testprogs/uprobe_test:function1
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME "uprobes - list probes by pid; uprobes only"
-RUN bpftrace -l 'uprobe:*' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -l 'uprobe:*' -p {{BEFORE_PID}}
 EXPECT uprobe:.*/testprogs/uprobe_test:function1
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME "uprobes - list probes by pid in separate mount namespace"
-RUN bpftrace -l -p {{BEFORE_PID}} | grep -e '^uprobe'
+RUN {{BPFTRACE}} -l -p {{BEFORE_PID}} | grep -e '^uprobe'
 EXPECT uprobe:.*/bpftrace-unshare-mountns-test/uprobe_test:function1
 TIMEOUT 5
 BEFORE ./testprogs/mountns_wrapper uprobe_test
 
 NAME "uprobes - attach to probe for executable in separate mount namespace"
-RUN bpftrace -e 'uprobe:/tmp/bpftrace-unshare-mountns-test/uprobe_test:function1 { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -e 'uprobe:/tmp/bpftrace-unshare-mountns-test/uprobe_test:function1 { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT Attaching 1 probe...
 TIMEOUT 5
 BEFORE ./testprogs/mountns_wrapper uprobe_test
 
 NAME "uprobes - list probes in non-executable library"
-RUN bpftrace -l 'uprobe:./testlibs/libsimple.so:fun'
+RUN {{BPFTRACE}} -l 'uprobe:./testlibs/libsimple.so:fun'
 EXPECT uprobe:./testlibs/libsimple.so:fun
 TIMEOUT 5
 
 NAME "uprobes - probe function in non-executable library"
-RUN bpftrace -e 'uprobe:./testlibs/libsimple.so:fun {}'
+RUN {{BPFTRACE}} -e 'uprobe:./testlibs/libsimple.so:fun {}'
 EXPECT Attaching 1 probe...
 TIMEOUT 5

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -1,102 +1,102 @@
 NAME "usdt probes - list probes by file"
-RUN bpftrace -l 'usdt:./testprogs/usdt_test:*'
+RUN {{BPFTRACE}} -l 'usdt:./testprogs/usdt_test:*'
 EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe
 TIMEOUT 5
 REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt - list probes by file with wildcarded probe type"
-RUN bpftrace -l '*:./testprogs/usdt_test:*' | grep -e '^usdt:'
+RUN {{BPFTRACE}} -l '*:./testprogs/usdt_test:*' | grep -e '^usdt:'
 EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe
 TIMEOUT 5
 
 NAME "usdt probes - list probes by pid"
-RUN bpftrace -l -p {{BEFORE_PID}} | grep -e '^usdt:'
+RUN {{BPFTRACE}} -l -p {{BEFORE_PID}} | grep -e '^usdt:'
 EXPECT usdt:.*/testprogs/usdt_test:tracetest:testprobe
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - list probes by pid; usdt only"
-RUN bpftrace -l 'usdt:*' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -l 'usdt:*' -p {{BEFORE_PID}}
 EXPECT usdt_test:tracetest:testprobe
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - lists linked library probes by pid"
-RUN bpftrace -l 'usdt:*' -p $(pidof usdt_lib)
+RUN {{BPFTRACE}} -l 'usdt:*' -p $(pidof usdt_lib)
 EXPECT libusdt_tp.so:tracetestlib:lib_probe_1
 TIMEOUT 5
 BEFORE ./testprogs/usdt_lib
 REQUIRES ./testprogs/usdt_lib should_not_skip
 
 NAME "usdt probes - filter probes by file on provider"
-RUN bpftrace -l 'usdt:./testprogs/usdt_test:tracetest2:*'
+RUN {{BPFTRACE}} -l 'usdt:./testprogs/usdt_test:tracetest2:*'
 EXPECT usdt:./testprogs/usdt_test:tracetest2:testprobe2
 TIMEOUT 5
 REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - filter probes by pid on provider"
-RUN bpftrace -l 'usdt:*:tracetest2:*' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -l 'usdt:*:tracetest2:*' -p {{BEFORE_PID}}
 EXPECT usdt_test:tracetest2:testprobe2
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - filter probes by wildcard file and wildcard probe name"
-RUN bpftrace -l 'usdt:./testprogs/usdt_test*:tracetest:test*'
+RUN {{BPFTRACE}} -l 'usdt:./testprogs/usdt_test*:tracetest:test*'
 EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe2
 TIMEOUT 5
 REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - filter probes by file and wildcard probe name"
-RUN bpftrace -l 'usdt:./testprogs/usdt_test:tracetest:test*'
+RUN {{BPFTRACE}} -l 'usdt:./testprogs/usdt_test:tracetest:test*'
 EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe2
 TIMEOUT 5
 REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - filter probes by pid and wildcard probe name"
-RUN bpftrace -l 'usdt:*:tracetest:test*' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -l 'usdt:*:tracetest:test*' -p {{BEFORE_PID}}
 EXPECT usdt_test:tracetest:testprobe2
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - attach to fully specified probe by file"
-RUN bpftrace -e 'usdt:./testprogs/usdt_test:tracetest:testprobe { printf("here\n" ); exit(); }'
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:tracetest:testprobe { printf("here\n" ); exit(); }'
 EXPECT here
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 TIMEOUT 5
 
 NAME "usdt probes - attach to fully specified probe of child"
-RUN bpftrace -e 'usdt:./testprogs/usdt_test:tracetest:testprobe { printf("here\n" ); exit(); }' -c ./testprogs/usdt_test
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:tracetest:testprobe { printf("here\n" ); exit(); }' -c ./testprogs/usdt_test
 EXPECT here
 TIMEOUT 5
 
 NAME "usdt probes - attach to fully specified probe by pid"
-RUN bpftrace -e 'usdt::tracetest:testprobe { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -e 'usdt::tracetest:testprobe { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT here
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 TIMEOUT 5
 
 NAME "usdt probes - attach to fully specified library probe by pid"
-RUN bpftrace -e 'usdt:./testlibs/libusdt_tp.so:tracetestlib:lib_probe_1 { printf("here\n" ); exit(); }' -p $(pidof usdt_lib)
+RUN {{BPFTRACE}} -e 'usdt:./testlibs/libusdt_tp.so:tracetestlib:lib_probe_1 { printf("here\n" ); exit(); }' -p $(pidof usdt_lib)
 BEFORE ./testprogs/usdt_lib
 EXPECT here
 TIMEOUT 5
 REQUIRES ./testprogs/usdt_lib should_not_skip
 
 NAME "usdt probes - all probes by wildcard and file"
-RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("here\n" ); exit(); }'
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:* { printf("here\n" ); exit(); }'
 EXPECT Attaching 3 probes...
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - all probes by wildcard and file with child"
-RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("here\n" ); exit(); }' -c ./testprogs/usdt_test
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:* { printf("here\n" ); exit(); }' -c ./testprogs/usdt_test
 EXPECT Attaching 3 probes...
 TIMEOUT 5
 
@@ -109,7 +109,7 @@ TIMEOUT 5
 #  - Fix https://github.com/iovisor/bpftrace/issues/565#issuecomment-496731112
 #    and https://github.com/iovisor/bpftrace/issues/688
 NAME "usdt probes - all probes by wildcard and pid"
-RUN bpftrace -e 'usdt:* { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -e 'usdt:* { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT Attaching 3 probes...
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
@@ -117,36 +117,36 @@ REQUIRES bash -c "exit 1"
 # REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - attach to probe by wildcard and file"
-RUN bpftrace -e 'usdt:./testprogs/usdt_test::*probe2 { printf("here\n" ); exit(); }'
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test::*probe2 { printf("here\n" ); exit(); }'
 EXPECT Attaching 2 probes...
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - attach to probe by wildcard and file with child"
-RUN bpftrace -e 'usdt:./testprogs/usdt_test::*probe2 { printf("here\n" ); exit(); }' -c ./testprogs/usdt_test
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test::*probe2 { printf("here\n" ); exit(); }' -c ./testprogs/usdt_test
 EXPECT Attaching 2 probes...
 TIMEOUT 5
 
 NAME "usdt probes - attach to probes by wildcard file"
-RUN bpftrace -e 'usdt:./testprogs/usdt_test*::* { printf("here\n" ); exit(); }'
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test*::* { printf("here\n" ); exit(); }'
 EXPECT Attaching 3 probes...
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 TIMEOUT 5
 
 NAME "usdt probes - attach to probes by wildcard file with child"
-RUN bpftrace -e 'usdt:./testprogs/usdt_test*::* { printf("here\n" ); exit(); }' -c ./testprogs/usdt_test
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test*::* { printf("here\n" ); exit(); }' -c ./testprogs/usdt_test
 EXPECT Attaching 3 probes...
 TIMEOUT 5
 
 NAME "usdt probes - attach to probe on multiple files by wildcard"
-RUN bpftrace -e 'usdt:./testprogs/usdt*::* { printf("here\n" ); exit(); }'
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt*::* { printf("here\n" ); exit(); }'
 EXPECT Attaching 41 probes...
 TIMEOUT 5
 
 NAME "usdt probes - attach to probe on multiple providers by wildcard and pid"
-RUN bpftrace -e 'usdt:::*probe2 { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -e 'usdt:::*probe2 { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT Attaching 2 probes...
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
@@ -157,7 +157,7 @@ REQUIRES ./testprogs/usdt_test should_not_skip
 # we should:
 #  - Skip if bcc doesn't support multiple probes with the same name
 NAME "usdt probes - attach to probe with args by file"
-RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("%s\n", str(arg1) ); exit(); }'
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:* { printf("%s\n", str(arg1) ); exit(); }'
 EXPECT Hello world
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
@@ -169,7 +169,7 @@ REQUIRES bash -c "exit 1"
 # we should:
 #  - Skip if bcc doesn't support multiple probes with the same name
 NAME "usdt probes - attach to probe with args by pid"
-RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("%s\n", str(arg1) ); exit(); }' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:* { printf("%s\n", str(arg1) ); exit(); }' -p {{BEFORE_PID}}
 EXPECT Hello world
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
@@ -177,40 +177,40 @@ REQUIRES bash -c "exit 1"
 # REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - attach to probe with probe builtin and args by file"
-RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }'
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }'
 EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - attach to probe with probe builtin and args by file with child"
-RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }' -c ./testprogs/usdt_test
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }' -c ./testprogs/usdt_test
 EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe
 TIMEOUT 5
 
 NAME "usdt probes - attach to probe with probe builtin and args by pid"
-RUN bpftrace -e 'usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }' -p {{BEFORE_PID}}
 EXPECT usdt_test:tracetest:testprobe
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 
 NAME "usdt probes - attach to probe with semaphore"
-RUN bpftrace -e 'usdt::tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -e 'usdt::tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }' -p {{BEFORE_PID}}
 EXPECT tracetest_testprobe_semaphore: [1-9]
 TIMEOUT 5
 BEFORE ./testprogs/usdt_semaphore_test
 REQUIRES ./testprogs/usdt_semaphore_test should_not_skip
 
 NAME "usdt probes - file based semaphore activation"
-RUN bpftrace -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }' --usdt-file-activation
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }' --usdt-file-activation
 EXPECT tracetest_testprobe_semaphore: [1-9]
 TIMEOUT 5
 BEFORE ./testprogs/usdt_semaphore_test
 REQUIRES ./testprogs/usdt_semaphore_test should_not_skip
 
 NAME "usdt probes - file based semaphore activation no process"
-RUN bpftrace -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { exit(); }' --usdt-file-activation
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { exit(); }' --usdt-file-activation
 EXPECT Failed to find processes running
 TIMEOUT 5
 REQUIRES ./testprogs/usdt_semaphore_test should_not_skip
@@ -219,7 +219,7 @@ REQUIRES_FEATURE !uprobe_refcount
 # We should be able to attach a probe even without any running processes
 # if the kernel handles the semaphore
 NAME "usdt probes - file based semaphore activation no process, kernel usdt semaphore"
-RUN bpftrace -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { exit(); }' --usdt-file-activation
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { exit(); }' --usdt-file-activation
 EXPECT Attaching 1 probe
 TIMEOUT 5
 REQUIRES ./testprogs/usdt_semaphore_test should_not_skip
@@ -228,7 +228,7 @@ REQUIRES_FEATURE uprobe_refcount
 # We should be able to activate a semaphore without specifying a PID or
 # --usdt-file-activation if the kernel handles the semaphore
 NAME "usdt probes - file based semaphore activation"
-RUN bpftrace -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }'
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }'
 EXPECT tracetest_testprobe_semaphore: [1-9]
 TIMEOUT 5
 BEFORE ./testprogs/usdt_semaphore_test
@@ -236,14 +236,14 @@ REQUIRES ./testprogs/usdt_semaphore_test should_not_skip
 REQUIRES_FEATURE uprobe_refcount
 
 NAME "usdt probes - file based semaphore activation multi process"
-RUN bpftrace -v runtime/scripts/usdt_file_activation_multiprocess.bt --usdt-file-activation
+RUN {{BPFTRACE}} -v runtime/scripts/usdt_file_activation_multiprocess.bt --usdt-file-activation
 EXPECT found 2 processes
 TIMEOUT 5
 BEFORE ./testprogs/usdt_semaphore_test & ./testprogs/usdt_semaphore_test
 REQUIRES ./testprogs/usdt_semaphore_test should_not_skip
 
 NAME "usdt probes - list probes by pid in separate mountns"
-RUN bpftrace -l 'usdt:*' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -l 'usdt:*' -p {{BEFORE_PID}}
 EXPECT usdt:.*/tmp/bpftrace-unshare-mountns-test/usdt_test:tracetest:testprobe
 TIMEOUT 5
 BEFORE ./testprogs/mountns_wrapper usdt_test
@@ -252,27 +252,27 @@ BEFORE ./testprogs/mountns_wrapper usdt_test
 # This test relies on the latest version of bcc (expected to be released as 0.13.0)
 # Once we build against this version with USDT fixes, we should re-enable this test.
 NAME "usdt probes - attach to fully specified probe by pid in separate mountns"
-RUN bpftrace -e 'usdt:/tmp/bpftrace-unshare-mountns-test/usdt_test:tracetest:testprobe { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -e 'usdt:/tmp/bpftrace-unshare-mountns-test/usdt_test:tracetest:testprobe { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT here
 TIMEOUT 5
 BEFORE ./testprogs/mountns_wrapper usdt_test
 REQUIRES bash -c "exit 1"
 
 NAME "usdt quoted probe name"
-RUN bpftrace -e 'usdt:./testprogs/usdt_quoted_probe:test:"\"probe1\"" { printf("%d\n", arg0); exit(); }' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_quoted_probe:test:"\"probe1\"" { printf("%d\n", arg0); exit(); }' -p {{BEFORE_PID}}
 EXPECT 1
 TIMEOUT 5
 BEFORE ./testprogs/usdt_quoted_probe
 REQUIRES ./testprogs/usdt_quoted_probe should_not_skip
 
 NAME "usdt sized arguments"
-RUN bpftrace -e 'usdt:./testprogs/usdt_sized_args:test:probe2 { printf("%ld\n", arg0); exit(); }' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_sized_args:test:probe2 { printf("%ld\n", arg0); exit(); }' -p {{BEFORE_PID}}
 EXPECT ^1$
 TIMEOUT 5
 BEFORE ./testprogs/usdt_sized_args
 
 NAME "usdt constant arguments"
-RUN bpftrace -e 'usdt:./testprogs/usdt_args:usdt_args:const_* { printf("%lld ", arg0); }' -c ./testprogs/usdt_args
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_args:usdt_args:const_* { printf("%lld ", arg0); }' -c ./testprogs/usdt_args
 EXPECT 4092785136 -202182160 61936 -3600 240 -16
 #EXPECT -579005069656919568 -579005069656919568 4092785136 -202182160 61936 -3600 240 -16
 # Bug in bcc, constants are stored in a 32-bit int, so 64-bit values are truncated
@@ -280,19 +280,19 @@ TIMEOUT 5
 REQUIRES ./testprogs/usdt_args should_not_skip
 
 NAME "usdt reg arguments"
-RUN bpftrace -e 'usdt:./testprogs/usdt_args:usdt_args:reg_* { printf("%lld ", arg0); }' -c ./testprogs/usdt_args
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_args:usdt_args:reg_* { printf("%lld ", arg0); }' -c ./testprogs/usdt_args
 EXPECT -579005069656919568 -579005069656919568 4092785136 -202182160 61936 -3600 240 -16
 TIMEOUT 5
 REQUIRES ./testprogs/usdt_args should_not_skip
 
 NAME "usdt addr arguments"
-RUN bpftrace -e 'usdt:./testprogs/usdt_args:usdt_args:addr_* { printf("%lld ", arg0); }' -c ./testprogs/usdt_args
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_args:usdt_args:addr_* { printf("%lld ", arg0); }' -c ./testprogs/usdt_args
 EXPECT -579005069656919568 -579005069656919568 4092785136 -202182160 61936 -3600 240 -16
 TIMEOUT 5
 REQUIRES ./testprogs/usdt_args should_not_skip
 
 NAME "usdt addr+index arguments"
-RUN bpftrace -e 'usdt:./testprogs/usdt_args:usdt_args:index_* { printf("%lld ", arg0); }' -c ./testprogs/usdt_args
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_args:usdt_args:index_* { printf("%lld ", arg0); }' -c ./testprogs/usdt_args
 EXPECT -579005069656919568 -579005069656919568 4092785136 -202182160 61936 -3600 240 -16
 TIMEOUT 5
 REQUIRES ./testprogs/usdt_args should_not_skip
@@ -300,13 +300,13 @@ REQUIRES ./testprogs/usdt_args should_not_skip
 # USDT probes can be inlined which creates duplicate identical probes. We must
 # attach to all of them
 NAME "usdt duplicated markers"
-RUN bpftrace -e 'usdt:./testprogs/usdt_inlined:tracetest:testprobe { printf("%d\n", arg1); @a += 1; if (@a >= 2) {exit();} }' -c ./testprogs/usdt_inlined
+RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_inlined:tracetest:testprobe { printf("%d\n", arg1); @a += 1; if (@a >= 2) {exit();} }' -c ./testprogs/usdt_inlined
 EXPECT Attaching 2 probes.*\s999\s*100
 TIMEOUT 1
 REQUIRES ./testprogs/usdt_inlined should_not_skip
 
 NAME "usdt probes in multiple modules"
-RUN bpftrace runtime/scripts/usdt_multi_modules.bt -c ./testprogs/usdt_test
+RUN {{BPFTRACE}} runtime/scripts/usdt_multi_modules.bt -c ./testprogs/usdt_test
 EXPECT Attaching 2 probes
 TIMEOUT 1
 REQUIRES ./testprogs/usdt_test should_not_skip

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -1,57 +1,57 @@
 NAME global_int
-RUN bpftrace -v -e 'i:ms:1 {@a = 10; printf("%d\n", @a); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 {@a = 10; printf("%d\n", @a); exit();}'
 EXPECT \@a: 10
 TIMEOUT 5
 
 NAME global_string
-RUN bpftrace -v -e 'i:ms:1 {@a = "hi"; printf("%s\n", @a); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 {@a = "hi"; printf("%s\n", @a); exit();}'
 EXPECT @a: hi
 TIMEOUT 5
 
 NAME global_buf
-RUN bpftrace -v -e 'i:ms:1 {@a = buf("hi", 2); printf("%r\n", @a); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 {@a = buf("hi", 2); printf("%r\n", @a); exit();}'
 EXPECT @a: hi
 TIMEOUT 5
 
 NAME local_int
-RUN bpftrace -v -e 'i:ms:1  {$a = 10; printf("a=%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1  {$a = 10; printf("a=%d\n", $a); exit();}'
 EXPECT a=10
 TIMEOUT 5
 
 NAME local_string
-RUN bpftrace -v -e 'i:ms:1  {$a = "hi"; printf("a=%s\n", $a); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1  {$a = "hi"; printf("a=%s\n", $a); exit();}'
 EXPECT a=hi
 TIMEOUT 5
 
 NAME local_buf
-RUN bpftrace -v -e 'i:ms:1 {$a = buf("hi", 2); printf("a=%r\n", $a); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = buf("hi", 2); printf("a=%r\n", $a); exit();}'
 EXPECT a=hi
 TIMEOUT 5
 
 NAME buf_equality
-RUN bpftrace -v -e 'i:ms:1 {$a = buf("hi", 2); $b = buf("bye", 3); printf("equal=%d, unequal=%d\n", $a == $a, $a != $b); exit();}'
+RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = buf("hi", 2); $b = buf("bye", 3); printf("equal=%d, unequal=%d\n", $a == $a, $a != $b); exit();}'
 EXPECT equal=1, unequal=1
 TIMEOUT 5
 
 NAME global_associative_arrays
-RUN bpftrace -v -e 'k:vfs_read { @start[tid] = nsecs; } kretprobe:vfs_read /@start[tid] != 0/ { printf("slept for %d ms\n", (nsecs - @start[tid]) / 1000000); delete(@start[tid]); exit();}'
+RUN {{BPFTRACE}} -v -e 'k:vfs_read { @start[tid] = nsecs; } kretprobe:vfs_read /@start[tid] != 0/ { printf("slept for %d ms\n", (nsecs - @start[tid]) / 1000000); delete(@start[tid]); exit();}'
 EXPECT slept for [0-9]+ ms
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME scratch
-RUN bpftrace -v -e 'k:vfs_read { @start[tid] = nsecs; } kretprobe:vfs_read /@start[tid] != 0/ { $delta = nsecs - @start[tid]; printf("slept for %d ms\n", $delta / 1000000); delete(@start[tid]); exit(); }'
+RUN {{BPFTRACE}} -v -e 'k:vfs_read { @start[tid] = nsecs; } kretprobe:vfs_read /@start[tid] != 0/ { $delta = nsecs - @start[tid]; printf("slept for %d ms\n", $delta / 1000000); delete(@start[tid]); exit(); }'
 EXPECT slept for [0-9]* ms
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME 32-bit tracepoint arg
-RUN bpftrace -v -e 'tracepoint:random:urandom_read { $i = args->got_bits; printf("bits: %d\n", $i); if ($i == 24) { exit() } }'
+RUN {{BPFTRACE}} -v -e 'tracepoint:random:urandom_read { $i = args->got_bits; printf("bits: %d\n", $i); if ($i == 24) { exit() } }'
 EXPECT bits: 24
 TIMEOUT 5
 AFTER dd if=/dev/urandom bs=3 count=1
 
 NAME tracepoint arg casts in predicates
-RUN bpftrace -v -e 'tracepoint:syscalls:sys_enter_wait4 /args->ru/ { @ru[tid] = args->ru; } tracepoint:syscalls:sys_exit_wait4 /@ru[tid]/ { @++; exit(); }' -c ./testprogs/wait4_ru
+RUN {{BPFTRACE}} -v -e 'tracepoint:syscalls:sys_enter_wait4 /args->ru/ { @ru[tid] = args->ru; } tracepoint:syscalls:sys_exit_wait4 /@ru[tid]/ { @++; exit(); }' -c ./testprogs/wait4_ru
 EXPECT @: 1
 TIMEOUT 5

--- a/tests/runtime/watchpoint
+++ b/tests/runtime/watchpoint
@@ -1,32 +1,32 @@
 NAME watchpoint - absolute address
-RUN bpftrace -v -e 'watchpoint::0x10000000:8:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint
+RUN {{BPFTRACE}} -v -e 'watchpoint::0x10000000:8:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint
 EXPECT hit!
 ARCH aarch64|ppc64|ppc64le|x86_64
 TIMEOUT 5
 
 NAME kwatchpoint - knl absolute address
-RUN bpftrace -v -e "watchpoint:0x$(awk '$3 == "jiffies" {print $1}' /proc/kallsyms):4:w { printf(\"hit\n\"); exit(); }"
+RUN {{BPFTRACE}} -v -e "watchpoint:0x$(awk '$3 == "jiffies" {print $1}' /proc/kallsyms):4:w { printf(\"hit\n\"); exit(); }"
 EXPECT hit
 ARCH aarch64|ppc64|ppc64le|x86_64
 TIMEOUT 5
 REQUIRES awk '$3 == "jiffies" {got=1} END {exit !got}' /proc/kallsyms
 
 NAME function_arg_addr
-RUN bpftrace -v -e 'watchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint_func
+RUN {{BPFTRACE}} -v -e 'watchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint_func
 EXPECT hit!
 ARCH aarch64|x86_64
 TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME async_function_arg_addr
-RUN bpftrace -v -e 'asyncwatchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint_func
+RUN {{BPFTRACE}} -v -e 'asyncwatchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint_func
 EXPECT hit!
 ARCH aarch64|x86_64
 TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME function_arg_addr_process_flag
-RUN bpftrace -v -e 'watchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }' -p $(pidof watchpoint_func)
+RUN {{BPFTRACE}} -v -e 'watchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }' -p $(pidof watchpoint_func)
 BEFORE ./testprogs/watchpoint_func
 EXPECT hit!
 ARCH aarch64|x86_64
@@ -34,35 +34,35 @@ TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME many_function_probes
-RUN bpftrace -e 'watchpoint:increment+arg0:4:w { printf("hit!\n") }' -c ./testprogs/watchpoint_func_many_probes
+RUN {{BPFTRACE}} -e 'watchpoint:increment+arg0:4:w { printf("hit!\n") }' -c ./testprogs/watchpoint_func_many_probes
 EXPECT You are out of watchpoint registers
 ARCH aarch64|x86_64
 TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME unwatch
-RUN bpftrace runtime/scripts/watchpoint_unwatch.bt -c ./testprogs/watchpoint_unwatch
+RUN {{BPFTRACE}} runtime/scripts/watchpoint_unwatch.bt -c ./testprogs/watchpoint_unwatch
 EXPECT count=1
 ARCH aarch64|x86_64
 TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME function_multiattach
-RUN bpftrace -v runtime/scripts/watchpoint_multiattach.bt -c ./testprogs/watchpoint_func_wildcard
+RUN {{BPFTRACE}} -v runtime/scripts/watchpoint_multiattach.bt -c ./testprogs/watchpoint_func_wildcard
 EXPECT count=3
 ARCH aarch64|x86_64
 TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME wildcarded_function
-RUN bpftrace -v -e 'watchpoint:increment_*+arg0:4:w { printf("hit!\n") }' -c ./testprogs/watchpoint_func_wildcard
+RUN {{BPFTRACE}} -v -e 'watchpoint:increment_*+arg0:4:w { printf("hit!\n") }' -c ./testprogs/watchpoint_func_wildcard
 EXPECT You are out of watchpoint registers
 ARCH aarch64|x86_64
 TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME unique_probe_bodies
-RUN bpftrace -v -e 'watchpoint:increment_*+arg0:4:w { printf("%s!\n", probe) }' -c ./testprogs/watchpoint_func_wildcard
+RUN {{BPFTRACE}} -v -e 'watchpoint:increment_*+arg0:4:w { printf("%s!\n", probe) }' -c ./testprogs/watchpoint_func_wildcard
 EXPECT .*increment_0:4:w!
 ARCH aarch64|x86_64
 TIMEOUT 5


### PR DESCRIPTION
Previously we were just tacking the build path directory to the front of
the `RUN` directive string. This worked fine unless you needed to call
bpftrace twice. It was also kind of confusing for newcomers to the test
framework.

This PR adds `{{BPFTRACE}}` runtime var so that it's more obvious
what the test framework is doing. See individual commits for more details.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
