### PR TITLE
parser: move tokens to ast

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -19,13 +19,11 @@ add_library(ast
 target_include_directories(ast PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(ast PUBLIC ${CMAKE_SOURCE_DIR}/src/ast)
 target_include_directories(ast PUBLIC ${CMAKE_BINARY_DIR})
-target_link_libraries(ast arch bpforc)
+target_link_libraries(ast arch bpforc parser)
 
 if (HAVE_BCC_KFUNC)
   target_compile_definitions(ast PRIVATE HAVE_BCC_KFUNC)
 endif(HAVE_BCC_KFUNC)
-
-add_dependencies(ast parser)
 
 if (STATIC_LINKING)
   set(clang_libs

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -1,6 +1,5 @@
 #include "ast.h"
 #include "log.h"
-#include "parser.tab.hh"
 #include "visitors.h"
 #include <iostream>
 
@@ -277,18 +276,17 @@ Variable::Variable(const std::string &ident, location loc)
   is_variable = true;
 }
 
-Binop::Binop(Expression *left, int op, Expression *right, location loc)
+Binop::Binop(Expression *left, Operator op, Expression *right, location loc)
     : Expression(loc), left(left), right(right), op(op)
 {
 }
 
-
-Unop::Unop(int op, Expression *expr, location loc)
+Unop::Unop(Operator op, Expression *expr, location loc)
     : Expression(loc), expr(expr), op(op), is_post_op(false)
 {
 }
 
-Unop::Unop(int op, Expression *expr, bool is_post_op, location loc)
+Unop::Unop(Operator op, Expression *expr, bool is_post_op, location loc)
     : Expression(loc), expr(expr), op(op), is_post_op(is_post_op)
 {
 }
@@ -408,12 +406,14 @@ std::string opstr(Jump &jump)
 {
   switch (jump.ident)
   {
-    case bpftrace::Parser::token::RETURN:
+    case JumpType::RETURN:
       return "return";
-    case bpftrace::Parser::token::BREAK:
+    case JumpType::BREAK:
       return "break";
-    case bpftrace::Parser::token::CONTINUE:
+    case JumpType::CONTINUE:
       return "continue";
+    default:
+      return {};
   }
 
   return {}; // unreached
@@ -422,24 +422,44 @@ std::string opstr(Jump &jump)
 std::string opstr(Binop &binop)
 {
   switch (binop.op) {
-    case bpftrace::Parser::token::EQ:    return "==";
-    case bpftrace::Parser::token::NE:    return "!=";
-    case bpftrace::Parser::token::LE:    return "<=";
-    case bpftrace::Parser::token::GE:    return ">=";
-    case bpftrace::Parser::token::LT:    return "<";
-    case bpftrace::Parser::token::GT:    return ">";
-    case bpftrace::Parser::token::LAND:  return "&&";
-    case bpftrace::Parser::token::LOR:   return "||";
-    case bpftrace::Parser::token::LEFT:  return "<<";
-    case bpftrace::Parser::token::RIGHT: return ">>";
-    case bpftrace::Parser::token::PLUS:  return "+";
-    case bpftrace::Parser::token::MINUS: return "-";
-    case bpftrace::Parser::token::MUL:   return "*";
-    case bpftrace::Parser::token::DIV:   return "/";
-    case bpftrace::Parser::token::MOD:   return "%";
-    case bpftrace::Parser::token::BAND:  return "&";
-    case bpftrace::Parser::token::BOR:   return "|";
-    case bpftrace::Parser::token::BXOR:  return "^";
+    case Operator::EQ:
+      return "==";
+    case Operator::NE:
+      return "!=";
+    case Operator::LE:
+      return "<=";
+    case Operator::GE:
+      return ">=";
+    case Operator::LT:
+      return "<";
+    case Operator::GT:
+      return ">";
+    case Operator::LAND:
+      return "&&";
+    case Operator::LOR:
+      return "||";
+    case Operator::LEFT:
+      return "<<";
+    case Operator::RIGHT:
+      return ">>";
+    case Operator::PLUS:
+      return "+";
+    case Operator::MINUS:
+      return "-";
+    case Operator::MUL:
+      return "*";
+    case Operator::DIV:
+      return "/";
+    case Operator::MOD:
+      return "%";
+    case Operator::BAND:
+      return "&";
+    case Operator::BOR:
+      return "|";
+    case Operator::BXOR:
+      return "^";
+    default:
+      return {};
   }
 
   return {}; // unreached
@@ -448,12 +468,20 @@ std::string opstr(Binop &binop)
 std::string opstr(Unop &unop)
 {
   switch (unop.op) {
-    case bpftrace::Parser::token::LNOT: return "!";
-    case bpftrace::Parser::token::BNOT: return "~";
-    case bpftrace::Parser::token::MINUS: return "-";
-    case bpftrace::Parser::token::MUL: return "dereference";
-    case bpftrace::Parser::token::INCREMENT: return "++";
-    case bpftrace::Parser::token::DECREMENT: return "--";
+    case Operator::LNOT:
+      return "!";
+    case Operator::BNOT:
+      return "~";
+    case Operator::MINUS:
+      return "-";
+    case Operator::MUL:
+      return "dereference";
+    case Operator::INCREMENT:
+      return "++";
+    case Operator::DECREMENT:
+      return "--";
+    default:
+      return {};
   }
 
   return {}; // unreached

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -27,7 +27,44 @@ class VisitorBase;
     return new T(*this);                                                       \
   };
 
-class Node {
+enum class JumpType
+{
+  INVALID = 0,
+  RETURN,
+  CONTINUE,
+  BREAK,
+};
+
+enum class Operator
+{
+  INVALID = 0,
+  ASSIGN,
+  EQ,
+  NE,
+  LE,
+  GE,
+  LEFT,
+  RIGHT,
+  LT,
+  GT,
+  LAND,
+  LOR,
+  PLUS,
+  INCREMENT,
+  DECREMENT,
+  MINUS,
+  MUL,
+  DIV,
+  MOD,
+  BAND,
+  BOR,
+  BXOR,
+  LNOT,
+  BNOT,
+};
+
+class Node
+{
 public:
   Node() = default;
   Node(location loc) : loc(loc){};
@@ -210,13 +247,13 @@ public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(Binop)
 
-  Binop(Expression *left, int op, Expression *right, location loc);
+  Binop(Expression *left, Operator op, Expression *right, location loc);
 
   ~Binop();
 
   Expression *left = nullptr;
   Expression *right = nullptr;
-  int op;
+  Operator op;
 
 private:
   Binop(const Binop &other);
@@ -227,8 +264,8 @@ public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(Unop)
 
-  Unop(int op, Expression *expr, location loc = location());
-  Unop(int op,
+  Unop(Operator op, Expression *expr, location loc = location());
+  Unop(Operator op,
        Expression *expr,
        bool is_post_op = false,
        location loc = location());
@@ -236,7 +273,7 @@ public:
   ~Unop();
 
   Expression *expr = nullptr;
-  int op;
+  Operator op;
   bool is_post_op;
 
 private:
@@ -422,12 +459,12 @@ public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(Jump)
 
-  Jump(int ident, location loc = location()) : Statement(loc), ident(ident)
+  Jump(JumpType ident, location loc = location()) : Statement(loc), ident(ident)
   {
   }
   ~Jump() = default;
 
-  int ident = 0;
+  JumpType ident = JumpType::INVALID;
 
 private:
   Jump(const Jump &other) = default;

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -5,7 +5,6 @@
 #include "ast/bpforc/bpforc.h"
 #include "codegen_helper.h"
 #include "log.h"
-#include "parser.tab.hh"
 #include "signal_bt.h"
 #include "tracepoint_format_parser.h"
 #include "types.h"
@@ -1108,8 +1107,7 @@ void CodegenLLVM::visit(Variable &var)
 
 void CodegenLLVM::binop_string(Binop &binop)
 {
-  if (binop.op != bpftrace::Parser::token::EQ &&
-      binop.op != bpftrace::Parser::token::NE)
+  if (binop.op != Operator::EQ && binop.op != Operator::NE)
   {
     LOG(FATAL) << "missing codegen to string operator \"" << opstr(binop)
                << "\"";
@@ -1118,7 +1116,7 @@ void CodegenLLVM::binop_string(Binop &binop)
   std::string string_literal;
 
   // strcmp returns 0 when strings are equal
-  bool inverse = binop.op == bpftrace::Parser::token::EQ;
+  bool inverse = binop.op == Operator::EQ;
 
   auto left_as = binop.left->type.GetAS();
   auto right_as = binop.right->type.GetAS();
@@ -1162,8 +1160,7 @@ void CodegenLLVM::binop_string(Binop &binop)
 
 void CodegenLLVM::binop_buf(Binop &binop)
 {
-  if (binop.op != bpftrace::Parser::token::EQ &&
-      binop.op != bpftrace::Parser::token::NE)
+  if (binop.op != Operator::EQ && binop.op != Operator::NE)
   {
     LOG(FATAL) << "missing codegen to buffer operator \"" << opstr(binop)
                << "\"";
@@ -1172,7 +1169,7 @@ void CodegenLLVM::binop_buf(Binop &binop)
   std::string string_literal("");
 
   // strcmp returns 0 when strings are equal
-  bool inverse = binop.op == bpftrace::Parser::token::EQ;
+  bool inverse = binop.op == Operator::EQ;
 
   auto scoped_del_right = accept(binop.right);
   Value *right_string = expr_;
@@ -1220,56 +1217,51 @@ void CodegenLLVM::binop_int(Binop &binop)
 
   switch (binop.op)
   {
-    case bpftrace::Parser::token::EQ:
+    case Operator::EQ:
       expr_ = b_.CreateICmpEQ(lhs, rhs);
       break;
-    case bpftrace::Parser::token::NE:
+    case Operator::NE:
       expr_ = b_.CreateICmpNE(lhs, rhs);
       break;
-    case bpftrace::Parser::token::LE:
-    {
+    case Operator::LE: {
       expr_ = do_signed ? b_.CreateICmpSLE(lhs, rhs)
                         : b_.CreateICmpULE(lhs, rhs);
       break;
     }
-    case bpftrace::Parser::token::GE:
-    {
+    case Operator::GE: {
       expr_ = do_signed ? b_.CreateICmpSGE(lhs, rhs)
                         : b_.CreateICmpUGE(lhs, rhs);
       break;
     }
-    case bpftrace::Parser::token::LT:
-    {
+    case Operator::LT: {
       expr_ = do_signed ? b_.CreateICmpSLT(lhs, rhs)
                         : b_.CreateICmpULT(lhs, rhs);
       break;
     }
-    case bpftrace::Parser::token::GT:
-    {
+    case Operator::GT: {
       expr_ = do_signed ? b_.CreateICmpSGT(lhs, rhs)
                         : b_.CreateICmpUGT(lhs, rhs);
       break;
     }
-    case bpftrace::Parser::token::LEFT:
+    case Operator::LEFT:
       expr_ = b_.CreateShl(lhs, rhs);
       break;
-    case bpftrace::Parser::token::RIGHT:
+    case Operator::RIGHT:
       expr_ = b_.CreateLShr(lhs, rhs);
       break;
-    case bpftrace::Parser::token::PLUS:
+    case Operator::PLUS:
       expr_ = b_.CreateAdd(lhs, rhs);
       break;
-    case bpftrace::Parser::token::MINUS:
+    case Operator::MINUS:
       expr_ = b_.CreateSub(lhs, rhs);
       break;
-    case bpftrace::Parser::token::MUL:
+    case Operator::MUL:
       expr_ = b_.CreateMul(lhs, rhs);
       break;
-    case bpftrace::Parser::token::DIV:
+    case Operator::DIV:
       expr_ = b_.CreateUDiv(lhs, rhs);
       break;
-    case bpftrace::Parser::token::MOD:
-    {
+    case Operator::MOD: {
       // Always do an unsigned modulo operation here even if `do_signed`
       // is true. bpf instruction set does not support signed division.
       // We already warn in the semantic analyser that signed modulo can
@@ -1277,18 +1269,17 @@ void CodegenLLVM::binop_int(Binop &binop)
       expr_ = b_.CreateURem(lhs, rhs);
       break;
     }
-    case bpftrace::Parser::token::BAND:
+    case Operator::BAND:
       expr_ = b_.CreateAnd(lhs, rhs);
       break;
-    case bpftrace::Parser::token::BOR:
+    case Operator::BOR:
       expr_ = b_.CreateOr(lhs, rhs);
       break;
-    case bpftrace::Parser::token::BXOR:
+    case Operator::BXOR:
       expr_ = b_.CreateXor(lhs, rhs);
       break;
-    case bpftrace::Parser::token::LAND:
-    case bpftrace::Parser::token::LOR:
-      LOG(FATAL) << "\"" << opstr(binop) << "\" was handled earlier";
+    default:
+      LOG(FATAL) << "BUG: \"" << opstr(binop) << "\" was handled earlier";
   }
   // Using signed extension will result in -1 which will likely confuse users
   expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), false);
@@ -1302,28 +1293,31 @@ void CodegenLLVM::binop_ptr(Binop &binop)
   // Do what C does
   switch (binop.op)
   {
-    case bpftrace::Parser::token::EQ:
-    case bpftrace::Parser::token::NE:
-    case bpftrace::Parser::token::LE:
-    case bpftrace::Parser::token::GE:
-    case bpftrace::Parser::token::LT:
-    case bpftrace::Parser::token::GT:
+    case Operator::EQ:
+    case Operator::NE:
+    case Operator::LE:
+    case Operator::GE:
+    case Operator::LT:
+    case Operator::GT:
       compare = true;
       break;
-    case bpftrace::Parser::token::LEFT:
-    case bpftrace::Parser::token::RIGHT:
-    case bpftrace::Parser::token::MOD:
-    case bpftrace::Parser::token::BAND:
-    case bpftrace::Parser::token::BOR:
-    case bpftrace::Parser::token::BXOR:
-    case bpftrace::Parser::token::MUL:
-    case bpftrace::Parser::token::DIV:
-      assert(false && "BUG: binop_ptr not implemented for type");
+    case Operator::LEFT:
+    case Operator::RIGHT:
+    case Operator::MOD:
+    case Operator::BAND:
+    case Operator::BOR:
+    case Operator::BXOR:
+    case Operator::MUL:
+    case Operator::DIV:
+      LOG(FATAL) << "BUG: binop_ptr: op not implemented for type\""
+                 << opstr(binop) << "\"";
       break;
-    case bpftrace::Parser::token::PLUS:
-    case bpftrace::Parser::token::MINUS:
+    case Operator::PLUS:
+    case Operator::MINUS:
       arith = true;
       break;
+    default:
+      LOG(FATAL) << "BUG: binop_ptr invalid op \"" << opstr(binop) << "\"";
   }
 
   auto scoped_del_left = accept(binop.left);
@@ -1336,28 +1330,30 @@ void CodegenLLVM::binop_ptr(Binop &binop)
   {
     switch (binop.op)
     {
-      case bpftrace::Parser::token::EQ:
+      case Operator::EQ:
         expr_ = b_.CreateICmpEQ(lhs, rhs);
         break;
-      case bpftrace::Parser::token::NE:
+      case Operator::NE:
         expr_ = b_.CreateICmpNE(lhs, rhs);
         break;
-      case bpftrace::Parser::token::LE: {
+      case Operator::LE: {
         expr_ = b_.CreateICmpULE(lhs, rhs);
         break;
       }
-      case bpftrace::Parser::token::GE: {
+      case Operator::GE: {
         expr_ = b_.CreateICmpUGE(lhs, rhs);
         break;
       }
-      case bpftrace::Parser::token::LT: {
+      case Operator::LT: {
         expr_ = b_.CreateICmpULT(lhs, rhs);
         break;
       }
-      case bpftrace::Parser::token::GT: {
+      case Operator::GT: {
         expr_ = b_.CreateICmpUGT(lhs, rhs);
         break;
       }
+      default:
+        LOG(FATAL) << "BUG: invalid op \"" << opstr(binop) << "\"";
     }
   }
   else if (arith)
@@ -1369,7 +1365,7 @@ void CodegenLLVM::binop_ptr(Binop &binop)
     Value *other_expr = leftptr ? rhs : lhs;
     auto elem_size = b_.getInt64(ptr.GetPointeeTy()->GetSize());
     expr_ = b_.CreateMul(elem_size, other_expr);
-    if (binop.op == bpftrace::Parser::token::PLUS)
+    if (binop.op == Operator::PLUS)
       expr_ = b_.CreateAdd(ptr_expr, expr_);
     else
       expr_ = b_.CreateSub(ptr_expr, expr_);
@@ -1379,12 +1375,12 @@ void CodegenLLVM::binop_ptr(Binop &binop)
 void CodegenLLVM::visit(Binop &binop)
 {
   // Handle && and || separately so short circuiting works
-  if (binop.op == bpftrace::Parser::token::LAND)
+  if (binop.op == Operator::LAND)
   {
     expr_ = createLogicalAnd(binop);
     return;
   }
-  else if (binop.op == bpftrace::Parser::token::LOR)
+  else if (binop.op == Operator::LOR)
   {
     expr_ = createLogicalOr(binop);
     return;
@@ -1413,8 +1409,7 @@ static bool unop_skip_accept(Unop &unop)
 {
   if (unop.expr->type.IsIntTy())
   {
-    if (unop.op == bpftrace::Parser::token::INCREMENT ||
-        unop.op == bpftrace::Parser::token::DECREMENT)
+    if (unop.op == Operator::INCREMENT || unop.op == Operator::DECREMENT)
       return unop.expr->is_map || unop.expr->is_variable;
   }
 
@@ -1426,7 +1421,7 @@ void CodegenLLVM::unop_int(Unop &unop)
   SizedType &type = unop.expr->type;
   switch (unop.op)
   {
-    case bpftrace::Parser::token::LNOT: {
+    case Operator::LNOT: {
       auto ty = expr_->getType();
       Value *zero_value = Constant::getNullValue(ty);
       expr_ = b_.CreateICmpEQ(expr_, zero_value);
@@ -1436,18 +1431,18 @@ void CodegenLLVM::unop_int(Unop &unop)
       expr_ = b_.CreateIntCast(expr_, ty, false);
       break;
     }
-    case bpftrace::Parser::token::BNOT:
+    case Operator::BNOT:
       expr_ = b_.CreateNot(expr_);
       break;
-    case bpftrace::Parser::token::MINUS:
+    case Operator::MINUS:
       expr_ = b_.CreateNeg(expr_);
       break;
-    case bpftrace::Parser::token::INCREMENT:
-    case bpftrace::Parser::token::DECREMENT: {
+    case Operator::INCREMENT:
+    case Operator::DECREMENT: {
       createIncDec(unop);
       break;
     }
-    case bpftrace::Parser::token::MUL: {
+    case Operator::MUL: {
       // When dereferencing a 32-bit integer, only read in 32-bits, etc.
       int size = type.GetSize();
       auto as = type.GetAS();
@@ -1460,6 +1455,8 @@ void CodegenLLVM::unop_int(Unop &unop)
       b_.CreateLifetimeEnd(dst);
       break;
     }
+    default:
+      LOG(FATAL) << "BUG: unop_int: invalid op \"" << opstr(unop) << "\"";
   }
 }
 
@@ -1468,7 +1465,7 @@ void CodegenLLVM::unop_ptr(Unop &unop)
   SizedType &type = unop.expr->type;
   switch (unop.op)
   {
-    case bpftrace::Parser::token::MUL: {
+    case Operator::MUL: {
       if (unop.type.IsIntegerTy() || unop.type.IsPtrTy())
       {
         auto *et = type.GetPointeeTy();
@@ -1483,8 +1480,8 @@ void CodegenLLVM::unop_ptr(Unop &unop)
       }
       break;
     }
-    case bpftrace::Parser::token::INCREMENT:
-    case bpftrace::Parser::token::DECREMENT: {
+    case Operator::INCREMENT:
+    case Operator::DECREMENT: {
       createIncDec(unop);
       break;
     }
@@ -2018,16 +2015,18 @@ void CodegenLLVM::visit(Jump &jump)
 {
   switch (jump.ident)
   {
-    case bpftrace::Parser::token::RETURN:
+    case JumpType::RETURN:
       // return can be used outside of loops
       createRet();
       break;
-    case bpftrace::Parser::token::BREAK:
+    case JumpType::BREAK:
       b_.CreateBr(std::get<1>(loops_.back()));
       break;
-    case bpftrace::Parser::token::CONTINUE:
+    case JumpType::CONTINUE:
       b_.CreateBr(std::get<0>(loops_.back()));
       break;
+    default:
+      LOG(FATAL) << "BUG: jump: invalid op \"" << opstr(jump) << "\"";
   }
 
   // LLVM doesn't like having instructions after an unconditional branch (segv)
@@ -3205,7 +3204,7 @@ void CodegenLLVM::probereadDatastructElem(Value *src_data,
 
 void CodegenLLVM::createIncDec(Unop &unop)
 {
-  bool is_increment = unop.op == bpftrace::Parser::token::INCREMENT;
+  bool is_increment = unop.op == Operator::INCREMENT;
   SizedType &type = unop.expr->type;
   uint64_t step = type.IsPtrTy() ? type.GetPointeeTy()->GetSize() : 1;
 

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -3,6 +3,7 @@
 #include "ast/attachpoint_parser.h"
 #include "driver.h"
 #include "log.h"
+#include "parser.tab.hh"
 
 extern void *yy_scan_string(const char *yy_str, yyscan_t yyscanner);
 extern int yylex_init(yyscan_t *scanner);

--- a/src/driver.h
+++ b/src/driver.h
@@ -5,11 +5,8 @@
 
 #include "ast/ast.h"
 #include "bpftrace.h"
-#include "parser.tab.hh"
 
 typedef void* yyscan_t;
-#define YY_DECL bpftrace::Parser::symbol_type yylex(bpftrace::Driver &driver, yyscan_t yyscanner)
-YY_DECL;
 
 namespace bpftrace {
 

--- a/src/lexer.h
+++ b/src/lexer.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "driver.h"
+#include "parser.tab.hh"
+
+#define YY_DECL                                                                \
+  bpftrace::Parser::symbol_type yylex(bpftrace::Driver &driver,                \
+                                      yyscan_t yyscanner)
+YY_DECL;

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -9,6 +9,7 @@
 #include "utils.h"
 #include "parser.tab.hh"
 #include "ast/int_parser.h"
+#include "lexer.h"
 
 bpftrace::location loc;
 static std::string struct_type;


### PR DESCRIPTION
As the parser generates the tokens used in the AST everything depends on
the parser. Any small change in the parser will regenerate the parser
headers and in turn for the ast the recompile which in turn causes all
of bpftrace to recompile. This makes the dev cycle for parser changes
long and painful.

There are work arounds, `make parser` followed by manually linking works
but it would be nice if it just works out of the box.

This is a bit of an overhaul but it reverses the relationship between
the parser and ast. Parser changes now only force the relinking of the
binary but ast changes force the recreation of the parser as the parser
uses Tokens from the ast.

The downside is that we now have to keep both lists in sync, but adding
new symbols to the parser is unlikely and updating is easy so it
shouldn't be an issue.
