### PR TITLE
Add some assert()s to StdioSilencer

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -117,9 +117,13 @@ void StdioSilencer::silence()
 {
   fflush(ofile);
   int fd = fileno(ofile);
+  assert(fd >= 0);
   old_stdio_ = dup(fd);
+  assert(old_stdio_ >= 0);
   int new_stdio_ = open("/dev/null", O_WRONLY);
-  dup2(new_stdio_, fd);
+  assert(new_stdio_ >= 0);
+  int ret = dup2(new_stdio_, fd);
+  assert(ret >= 0);
   close(new_stdio_);
 }
 
@@ -129,7 +133,9 @@ StdioSilencer::~StdioSilencer()
   {
     fflush(ofile);
     int fd = fileno(ofile);
-    dup2(old_stdio_, fd);
+    assert(fd >= 0);
+    int ret = dup2(old_stdio_, fd);
+    assert(ret >= 0);
     close(old_stdio_);
     old_stdio_ = -1;
   }


### PR DESCRIPTION
Spent most of a day debugging why `--info` output was truncated. Turns
out the root cause was libbpf[0] closing FD 0 which it did not own.
StdioSilencer's saved stderr FD was sometimes 0 and was being closed
behind its back. This mean that once silenced, stderr could not be
unsilenced.

The asserts helped nail down the issue. Since there's buggy libbpf's in
the wild, these asserts might be helpful for other people.

[0]: https://lore.kernel.org/bpf/5969bb991adedb03c6ae93e051fd2a00d293cf25.1627513670.git.dxu@dxuuu.xyz/T/#u

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
