### PR TITLE
tests: Use less hacky mechanism to synchronize AFTER directive

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -402,7 +402,6 @@ The verifier log:
 processed 26 insns (limit 131072), stack depth 40
 
 Attaching tracepoint:syscalls:sys_enter_nanosleep
-Running...
 iscsid is sleeping.
 iscsid is sleeping.
 [...]

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1190,8 +1190,9 @@ int BPFtrace::run(BpfBytecode bytecode)
     }
   }
 
-  if (bt_verbose)
-    std::cerr << "Running..." << std::endl;
+  // Used by runtime test framework to know when to run AFTER directive
+  if (std::getenv("__BPFTRACE_NOTIFY_PROBES_ATTACHED"))
+    std::cerr << "__BPFTRACE_NOTIFY_PROBES_ATTACHED" << std::endl;
 
   if (has_iter_)
   {

--- a/tests/runtime/addrspace
+++ b/tests/runtime/addrspace
@@ -1,5 +1,5 @@
 NAME openat uptr
-RUN {{BPFTRACE}} -v -e 't:syscalls:sys_enter_openat /comm == "syscall"/ { print(str(uptr(args->filename))) }' -c "./testprogs/syscall openat"
+RUN {{BPFTRACE}} -e 't:syscalls:sys_enter_openat /comm == "syscall"/ { print(str(uptr(args->filename))) }' -c "./testprogs/syscall openat"
 EXPECT bpftrace_runtime_test_syscall
 REQUIRES_FEATURE probe_read_kernel
 TIMEOUT 5

--- a/tests/runtime/array
+++ b/tests/runtime/array
@@ -1,137 +1,137 @@
 NAME array element access - assign to map
-RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; @x = $a->x[0]; exit(); }'
+RUN {{BPFTRACE}} -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; @x = $a->x[0]; exit(); }'
 EXPECT @x: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array element access - assign to var
-RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a->x[0]; printf("Result: %d\n", $x); exit(); }'
+RUN {{BPFTRACE}} -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a->x[0]; printf("Result: %d\n", $x); exit(); }'
 EXPECT Result: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array element access - out of bounds
-RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a->x[5]; printf("%d\n", $x); exit(); }'
+RUN {{BPFTRACE}} -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a->x[5]; printf("%d\n", $x); exit(); }'
 EXPECT the index 5 is out of bounds for array of size 4
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array element access via assignment into var
-RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = ((struct A *) arg0)->x; $x = $a[0]; printf("Result: %d\n", $x); exit(); }'
+RUN {{BPFTRACE}} -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = ((struct A *) arg0)->x; $x = $a[0]; printf("Result: %d\n", $x); exit(); }'
 EXPECT Result: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array element access via assignment into map
-RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a[0] = ((struct A *) arg0)->x; printf("Result: %d\n", @a[0][0]); exit(); }'
+RUN {{BPFTRACE}} -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a[0] = ((struct A *) arg0)->x; printf("Result: %d\n", @a[0][0]); exit(); }'
 EXPECT Result: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array element access via assignment into map and var
-RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a[0] = ((struct A *) arg0)->x; $x = @a[0]; printf("Result: %d\n", $x[0]); exit(); }'
+RUN {{BPFTRACE}} -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a[0] = ((struct A *) arg0)->x; $x = @a[0]; printf("Result: %d\n", $x[0]); exit(); }'
 EXPECT Result: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array assignment into map
-RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a = ((struct A *) arg0)->x; exit(); }'
+RUN {{BPFTRACE}} -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a = ((struct A *) arg0)->x; exit(); }'
 EXPECT @a: \[1,2,3,4\]
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as a map key
-RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x[((struct A *) arg0)->x] = 0; exit(); }'
+RUN {{BPFTRACE}} -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x[((struct A *) arg0)->x] = 0; exit(); }'
 EXPECT @x\[\[1,2,3,4\]\]: 0
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as a part of map multikey
-RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x[((struct A *) arg0)->x, 42] = 0; exit(); }'
+RUN {{BPFTRACE}} -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x[((struct A *) arg0)->x, 42] = 0; exit(); }'
 EXPECT @x\[\[1,2,3,4\], 42\]: 0
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as a map key assigned from another map
-RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a = ((struct A *) arg0)->x; @x[@a] = 0; exit(); }'
+RUN {{BPFTRACE}} -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @a = ((struct A *) arg0)->x; @x[@a] = 0; exit(); }'
 EXPECT @x\[\[1,2,3,4\]\]: 0
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array in a tuple
-RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x = (1, ((struct A *) arg0)->x); exit(); }'
+RUN {{BPFTRACE}} -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { @x = (1, ((struct A *) arg0)->x); exit(); }'
 EXPECT @x: \(1, \[1,2,3,4\]\)
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array element access
-RUN {{BPFTRACE}} -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $x = ((struct B *) arg1)->y[1][0]; printf("Result: %d\n", $x); exit(); }'
+RUN {{BPFTRACE}} -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $x = ((struct B *) arg1)->y[1][0]; printf("Result: %d\n", $x); exit(); }'
 EXPECT Result: 7
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array element access via assignment into var
-RUN {{BPFTRACE}} -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $b = ((struct B *) arg1)->y; $y = $b[1][0]; printf("Result: %d\n", $y); exit(); }'
+RUN {{BPFTRACE}} -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $b = ((struct B *) arg1)->y; $y = $b[1][0]; printf("Result: %d\n", $y); exit(); }'
 EXPECT Result: 7
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array element access via assignment into map
-RUN {{BPFTRACE}} -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b[0] = ((struct B *) arg1)->y; printf("Result: %d\n", @b[0][1][0]); exit(); }'
+RUN {{BPFTRACE}} -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b[0] = ((struct B *) arg1)->y; printf("Result: %d\n", @b[0][1][0]); exit(); }'
 EXPECT Result: 7
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array element access via assignment into map and var
-RUN {{BPFTRACE}} -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b[0] = ((struct B *) arg1)->y; $x = @b[0]; printf("Result: %d\n", $x[1][0]); exit(); }'
+RUN {{BPFTRACE}} -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b[0] = ((struct B *) arg1)->y; $x = @b[0]; printf("Result: %d\n", $x[1][0]); exit(); }'
 EXPECT Result: 7
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array assignment into map
-RUN {{BPFTRACE}} -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b = ((struct B *) arg1)->y; exit(); }'
+RUN {{BPFTRACE}} -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b = ((struct B *) arg1)->y; exit(); }'
 EXPECT @b: \[\[5,6\],\[7,8\]\]
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array as a map key
-RUN {{BPFTRACE}} -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @x[((struct B *) arg1)->y] = 0; exit(); }'
+RUN {{BPFTRACE}} -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @x[((struct B *) arg1)->y] = 0; exit(); }'
 EXPECT @x\[\[\[5,6\],\[7,8\]\]]: 0
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME multi-dimensional array as a map key assigned from another map
-RUN {{BPFTRACE}} -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b = ((struct B *) arg1)->y; @x[@b] = 0; exit(); }'
+RUN {{BPFTRACE}} -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { @b = ((struct B *) arg1)->y; @x[@b] = 0; exit(); }'
 EXPECT @x\[\[\[5,6\],\[7,8\]\]]: 0
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as pointer element access - assign to map
-RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/array_access:test_array { $a = (int32 *) arg0; @x = $a[0]; exit(); }'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/array_access:test_array { $a = (int32 *) arg0; @x = $a[0]; exit(); }'
 EXPECT @x: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as pointer element access - assign to var
-RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/array_access:test_array { $a = (int32 *) arg0; $x = $a[0]; printf("Result: %d\n", $x); exit(); }'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/array_access:test_array { $a = (int32 *) arg0; $x = $a[0]; printf("Result: %d\n", $x); exit(); }'
 EXPECT Result: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as pointer access via assignment into var
-RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/array_access:test_array { $a = (int32 *) arg0; $x = $a[0]; printf("Result: %d\n", $x); exit(); }'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/array_access:test_array { $a = (int32 *) arg0; $x = $a[0]; printf("Result: %d\n", $x); exit(); }'
 EXPECT Result: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as pointer element access via assignment into map
-RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/array_access:test_array { @a[0] = (int32 *) arg0; printf("Result: %d\n", @a[0][0]); exit(); }'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/array_access:test_array { @a[0] = (int32 *) arg0; printf("Result: %d\n", @a[0][0]); exit(); }'
 EXPECT Result: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array as pointer element access via assignment into map and var
-RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/array_access:test_array { @a[0] = (int32 *) arg0; $x = @a[0]; printf("Result: %d\n", $x[0]); exit(); }'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/array_access:test_array { @a[0] = (int32 *) arg0; $x = @a[0]; printf("Result: %d\n", $x[0]); exit(); }'
 EXPECT Result: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access

--- a/tests/runtime/banned_probes
+++ b/tests/runtime/banned_probes
@@ -1,19 +1,19 @@
 NAME kretprobe:_raw_spin_lock is banned
-RUN {{BPFTRACE}} -v -e 'kretprobe:_raw_spin_lock { exit(); }'
+RUN {{BPFTRACE}} -e 'kretprobe:_raw_spin_lock { exit(); }'
 EXPECT error: kretprobe:_raw_spin_lock can't be used as it might lock up your system.
 TIMEOUT 1
 
 NAME kretprobe:queued_spin_lock_slowpath is banned
-RUN {{BPFTRACE}} -v -e 'kretprobe:queued_spin_lock_slowpath { exit(); }'
+RUN {{BPFTRACE}} -e 'kretprobe:queued_spin_lock_slowpath { exit(); }'
 EXPECT error: kretprobe:queued_spin_lock_slowpath can't be used as it might lock up your system.
 TIMEOUT 1
 
 NAME kretprobe:_raw_spin_unlock_irqrestore is banned
-RUN {{BPFTRACE}} -v -e 'kretprobe:_raw_spin_unlock_irqrestore { exit(); }'
+RUN {{BPFTRACE}} -e 'kretprobe:_raw_spin_unlock_irqrestore { exit(); }'
 EXPECT error: kretprobe:_raw_spin_unlock_irqrestore can't be used as it might lock up your system.
 TIMEOUT 1
 
 NAME kretprobe:_raw_spin_lock_irqsave is banned
-RUN {{BPFTRACE}} -v -e 'kretprobe:_raw_spin_lock_irqsave { exit(); }'
+RUN {{BPFTRACE}} -e 'kretprobe:_raw_spin_lock_irqsave { exit(); }'
 EXPECT error: kretprobe:_raw_spin_lock_irqsave can't be used as it might lock up your system.
 TIMEOUT 1

--- a/tests/runtime/btf
+++ b/tests/runtime/btf
@@ -1,11 +1,11 @@
 NAME user_supplied_c_def_using_btf
-RUN {{BPFTRACE}} -v -e 'struct foo { struct task_struct t; } BEGIN { exit(); }'
+RUN {{BPFTRACE}} -e 'struct foo { struct task_struct t; } BEGIN { exit(); }'
 EXPECT Attaching 1 probe...
 TIMEOUT 5
 REQUIRES_FEATURE btf
 
 NAME tracepoint_pointer_type_resolution
-RUN {{BPFTRACE}} -v -e 'tracepoint:syscalls:sys_enter_nanosleep { args->rqtp->tv_sec; exit(); }'
+RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_enter_nanosleep { args->rqtp->tv_sec; exit(); }'
 EXPECT Attaching 1 probe...
 TIMEOUT 5
 REQUIRES_FEATURE btf
@@ -17,19 +17,19 @@ TIMEOUT 5
 REQUIRES_FEATURE btf
 
 NAME enum_value_reference
-RUN {{BPFTRACE}} -v -e 'BEGIN { printf("%d\n", sizeof(BTF_VAR_STATIC)); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%d\n", sizeof(BTF_VAR_STATIC)); exit(); }'
 EXPECT ^8$
 TIMEOUT 5
 REQUIRES_FEATURE btf
 
 NAME redefine_btf_type
-RUN {{BPFTRACE}} -v -e 'struct task_struct { int x; } BEGIN { printf("%d\n", curtask->x); }'
+RUN {{BPFTRACE}} -e 'struct task_struct { int x; } BEGIN { printf("%d\n", curtask->x); }'
 EXPECT -?[0-9][0-9]*
 TIMEOUT 5
 REQUIRES_FEATURE btf
 
 NAME redefine_btf_type_missing_def
-RUN {{BPFTRACE}} -v -e 'struct task_struct { struct thread_info x; } BEGIN { printf("%d\n", curtask->x.status); }'
+RUN {{BPFTRACE}} -e 'struct task_struct { struct thread_info x; } BEGIN { printf("%d\n", curtask->x.status); }'
 EXPECT error:.*'struct thread_info'
 TIMEOUT 5
 REQUIRES_FEATURE btf

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -1,114 +1,114 @@
 NAME pid
-RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN {{BPFTRACE}} -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT SUCCESS pid [0-9][0-9]*
 TIMEOUT 5
 
 NAME tid
-RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", tid); exit(); }'
+RUN {{BPFTRACE}} -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", tid); exit(); }'
 EXPECT SUCCESS tid [0-9][0-9]*
 TIMEOUT 5
 
 NAME uid
-RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", uid); exit(); }'
+RUN {{BPFTRACE}} -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", uid); exit(); }'
 EXPECT SUCCESS uid [0-9][0-9]*
 TIMEOUT 5
 
 NAME gid
-RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", gid); exit(); }'
+RUN {{BPFTRACE}} -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", gid); exit(); }'
 EXPECT SUCCESS gid [0-9][0-9]*
 TIMEOUT 5
 
 NAME nsecs
-RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", nsecs); exit(); }'
+RUN {{BPFTRACE}} -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", nsecs); exit(); }'
 EXPECT SUCCESS nsecs -?[0-9][0-9]*
 TIMEOUT 5
 
 NAME elapsed
-RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", elapsed); exit(); }'
+RUN {{BPFTRACE}} -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", elapsed); exit(); }'
 EXPECT SUCCESS elapsed -?[0-9][0-9]*
 TIMEOUT 5
 
 NAME cpu
-RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", cpu); exit(); }'
+RUN {{BPFTRACE}} -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", cpu); exit(); }'
 EXPECT SUCCESS cpu -?[0-9][0-9]*
 TIMEOUT 5
 
 NAME comm
-RUN {{BPFTRACE}} -v -e 'k:vfs_read { printf("SUCCESS '$test' %s\n", comm); exit(); }'
+RUN {{BPFTRACE}} -e 'k:vfs_read { printf("SUCCESS '$test' %s\n", comm); exit(); }'
 EXPECT SUCCESS comm .*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME stack
-RUN {{BPFTRACE}} -v -e 'k:vfs_read{ printf("SUCCESS '$test' %s\n", stack); exit(); }'
+RUN {{BPFTRACE}} -e 'k:vfs_read{ printf("SUCCESS '$test' %s\n", stack); exit(); }'
 EXPECT SUCCESS stack
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kstack
-RUN {{BPFTRACE}} -v -e 'k:vfs_read{ printf("SUCCESS '$test' %s\n", kstack); exit(); }'
+RUN {{BPFTRACE}} -e 'k:vfs_read{ printf("SUCCESS '$test' %s\n", kstack); exit(); }'
 EXPECT SUCCESS kstack
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME ustack
-RUN {{BPFTRACE}} -v -e 'k:vfs_read { printf("SUCCESS '$test' %s\n", ustack); exit(); }'
+RUN {{BPFTRACE}} -e 'k:vfs_read { printf("SUCCESS '$test' %s\n", ustack); exit(); }'
 EXPECT SUCCESS ustack
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME arg
-RUN {{BPFTRACE}} -v -e 'k:vfs_read { printf("SUCCESS '$test' %d\n", arg0); exit(); }'
+RUN {{BPFTRACE}} -e 'k:vfs_read { printf("SUCCESS '$test' %d\n", arg0); exit(); }'
 EXPECT SUCCESS arg -?[0-9][0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME sarg
-RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS '$test' %d %d\n", sarg0, sarg1); exit(); }'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS '$test' %d %d\n", sarg0, sarg1); exit(); }'
 EXPECT SUCCESS sarg 32 64
 ARCH x86_64
 TIMEOUT 5
 AFTER ./testprogs/stack_args
 
 NAME sarg
-RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS '$test' %d %d\n", sarg0, sarg1); exit(); }'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS '$test' %d %d\n", sarg0, sarg1); exit(); }'
 EXPECT SUCCESS sarg 128 256
 ARCH aarch64|ppc64|ppc64le
 TIMEOUT 5
 AFTER ./testprogs/stack_args
 
 NAME sarg
-RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS '$test' %d %d\n", sarg0, sarg1); exit(); }'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS '$test' %d %d\n", sarg0, sarg1); exit(); }'
 EXPECT SUCCESS sarg 16 32
 ARCH s390x
 TIMEOUT 5
 AFTER ./testprogs/stack_args
 
 NAME retval
-RUN {{BPFTRACE}} -v -e 'kretprobe:vfs_read { printf("SUCCESS '$test' %d\n", retval); exit(); }'
+RUN {{BPFTRACE}} -e 'kretprobe:vfs_read { printf("SUCCESS '$test' %d\n", retval); exit(); }'
 EXPECT SUCCESS retval .*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME func
-RUN {{BPFTRACE}} -v -e 'k:vfs_read { printf("SUCCESS '$test' %s\n", func); exit(); }'
+RUN {{BPFTRACE}} -e 'k:vfs_read { printf("SUCCESS '$test' %s\n", func); exit(); }'
 EXPECT SUCCESS func .*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME func_uprobe
-RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/uprobe_negative_retval:function1 { printf("SUCCESS %s\n", func); exit(); }'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/uprobe_negative_retval:function1 { printf("SUCCESS %s\n", func); exit(); }'
 EXPECT SUCCESS .*
 AFTER ./testprogs/uprobe_negative_retval
 TIMEOUT 5
 
 NAME username
-RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("SUCCESS '$test' %s\n", username); exit(); }'
+RUN {{BPFTRACE}} -e 'i:ms:1 { printf("SUCCESS '$test' %s\n", username); exit(); }'
 EXPECT SUCCESS username .*
 TIMEOUT 5
 
 NAME probe
-RUN {{BPFTRACE}} -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n", probe); exit(); }'
+RUN {{BPFTRACE}} -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n", probe); exit(); }'
 EXPECT SUCCESS probe kprobe:do_nanosleep
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep 1e8
@@ -120,28 +120,28 @@ TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME curtask
-RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", curtask); exit(); }'
+RUN {{BPFTRACE}} -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", curtask); exit(); }'
 EXPECT SUCCESS curtask -?[0-9][0-9]*
 TIMEOUT 5
 
 NAME curtask_field
-RUN {{BPFTRACE}} -v -e 'struct task_struct {int x;} i:ms:1 { printf("SUCCESS '$test' %d\n", curtask->x); exit(); }'
+RUN {{BPFTRACE}} -e 'struct task_struct {int x;} i:ms:1 { printf("SUCCESS '$test' %d\n", curtask->x); exit(); }'
 EXPECT SUCCESS curtask_field -?[0-9][0-9]*
 TIMEOUT 5
 
 NAME rand
-RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", rand); exit(); }'
+RUN {{BPFTRACE}} -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", rand); exit(); }'
 EXPECT SUCCESS rand -?[0-9][0-9]*
 TIMEOUT 5
 
 NAME cgroup
-RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", cgroup); exit(); }'
+RUN {{BPFTRACE}} -e 'i:ms:1 { printf("SUCCESS '$test' %d\n", cgroup); exit(); }'
 EXPECT SUCCESS cgroup -?[0-9][0-9]*
 TIMEOUT 5
 MIN_KERNEL 4.18
 
 NAME ctx
-RUN {{BPFTRACE}} -v -e 'struct x {unsigned long x}; i:ms:1 { printf("SUCCESS '$test' %d\n", ((struct x*)ctx)->x); exit(); }'
+RUN {{BPFTRACE}} -e 'struct x {unsigned long x}; i:ms:1 { printf("SUCCESS '$test' %d\n", ((struct x*)ctx)->x); exit(); }'
 EXPECT SUCCESS ctx -?[0-9][0-9]*
 TIMEOUT 5
 

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -275,13 +275,13 @@ EXPECT 123
 TIMEOUT 1
 
 NAME print_avg_map_args
-RUN {{BPFTRACE}} -e 'BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 2, 10); print("END"); clear(@); exit(); }'
-EXPECT Attaching 1 probe\.\.\.\n@\[c\]: 3\n@\[d\]: 4\n\nEND
+RUN {{BPFTRACE}} -e 'BEGIN { print("BEGIN"); @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 2, 10); print("END"); clear(@); exit(); }'
+EXPECT BEGIN\n@\[c\]: 3\n@\[d\]: 4\n\nEND
 TIMEOUT 1
 
 NAME print_avg_map_with_large_top
-RUN {{BPFTRACE}} -e 'BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 10, 10); print("END"); clear(@); exit(); }'
-EXPECT Attaching 1 probe\.\.\.\n@\[a\]: 1\n@\[b\]: 2\n@\[c\]: 3\n@\[d\]: 4\n\nEND
+RUN {{BPFTRACE}} -e 'BEGIN { print("BEGIN"); @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 10, 10); print("END"); clear(@); exit(); }'
+EXPECT BEGIN\n@\[a\]: 1\n@\[b\]: 2\n@\[c\]: 3\n@\[d\]: 4\n\nEND
 TIMEOUT 1
 
 NAME print_hist_with_top_arg

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -1,15 +1,15 @@
 NAME printf
-RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("hi!\n"); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 { printf("hi!\n"); exit();}'
 EXPECT hi!
 TIMEOUT 5
 
 NAME printf_long_fmt
-RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("hi abcdefghijklmnopqrstuvwxyzzyxwvutsrqponmlkjihgfedcbaabcdefghijklmnopqrstuvwxyz!\n"); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 { printf("hi abcdefghijklmnopqrstuvwxyzzyxwvutsrqponmlkjihgfedcbaabcdefghijklmnopqrstuvwxyz!\n"); exit();}'
 EXPECT ^hi abcdefghijklmnopqrstuvwxyzzyxwvutsrqponmlkjihgfedcbaabcdefghijklmnopqrstuvwxyz!
 TIMEOUT 5
 
 NAME printf_argument
-RUN {{BPFTRACE}} -v -e 'i:ms:1 { printf("value: %dms100\n", 100); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 { printf("value: %dms100\n", 100); exit();}'
 EXPECT value: 100ms100
 TIMEOUT 5
 
@@ -19,190 +19,190 @@ EXPECT Elapsed time: 1s
 TIMEOUT 5
 
 NAME printf_argument_alignment
-RUN {{BPFTRACE}} -v -e 'struct Foo { int a; char b[10]; } uprobe:testprogs/uprobe_test:function2 { $foo = (struct Foo *)arg0; $foo2 = (struct Foo *)arg1; printf("%d %s %d %s\n", $foo->a, $foo->b, $foo2->a, $foo2->b) }' -c ./testprogs/uprobe_test
+RUN {{BPFTRACE}} -e 'struct Foo { int a; char b[10]; } uprobe:testprogs/uprobe_test:function2 { $foo = (struct Foo *)arg0; $foo2 = (struct Foo *)arg1; printf("%d %s %d %s\n", $foo->a, $foo->b, $foo2->a, $foo2->b) }' -c ./testprogs/uprobe_test
 EXPECT 123 hello 456 world
 TIMEOUT 5
 
 NAME printf_more_arguments
-RUN {{BPFTRACE}} -v -e 'BEGIN { printf("%dst: %sa; %dnd: %sb;; %drd: %sc;;; %dth: %sd;;;;\\n", 1, "a", 2, "ab", 3, "abc", 4, "abcd"); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%dst: %sa; %dnd: %sb;; %drd: %sc;;; %dth: %sd;;;;\\n", 1, "a", 2, "ab", 3, "abc", 4, "abcd"); exit(); }'
 EXPECT 1st: aa; 2nd: abb;; 3rd: abcc;;; 4th: abcdd;;;;
 TIMEOUT 5
 
 NAME time
-RUN {{BPFTRACE}} -v -e 'i:ms:1 { time("%H:%M:%S\n"); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 { time("%H:%M:%S\n"); exit();}'
 EXPECT [0-9]*:[0-9]*:[0-9]*
 TIMEOUT 5
 
 NAME time_short
-RUN {{BPFTRACE}} -v -e 'i:ms:1 { time("%H-%M:%S\n"); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 { time("%H-%M:%S\n"); exit();}'
 EXPECT [0-9]*-[0-9]*
 TIMEOUT 5
 
 NAME join
-RUN {{BPFTRACE}} --unsafe -v -e 'i:ms:1 { system("echo 'A'"); } kprobe:sys_execve { join(arg1); exit();}'
+RUN {{BPFTRACE}} --unsafe -e 'i:ms:1 { system("echo 'A'"); } kprobe:sys_execve { join(arg1); exit();}'
 EXPECT A
 TIMEOUT 5
 
 NAME join_delim
-RUN {{BPFTRACE}} --unsafe -v -e 'i:ms:1 { system("echo 'A'"); } kprobe:sys_execve { join(arg1, ","); exit();}'
+RUN {{BPFTRACE}} --unsafe -e 'i:ms:1 { system("echo 'A'"); } kprobe:sys_execve { join(arg1, ","); exit();}'
 EXPECT A
 TIMEOUT 5
 
 NAME str
-RUN {{BPFTRACE}} -v -e 't:syscalls:sys_enter_execve { printf("P: %s\n", str(args->filename)); exit();}'
+RUN {{BPFTRACE}} -e 't:syscalls:sys_enter_execve { printf("P: %s\n", str(args->filename)); exit();}'
 AFTER ./testprogs/syscall execve /bin/ls
 EXPECT P: /*.
 TIMEOUT 5
 
 NAME buf
-RUN {{BPFTRACE}} -v -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s->a, 4), buf($s->b, 4), buf($s->c), buf($s->d), buf($s->e), buf($s->f)); exit(); }' -c ./testprogs/complex_struct
+RUN {{BPFTRACE}} -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s->a, 4), buf($s->b, 4), buf($s->c), buf($s->d), buf($s->e), buf($s->f)); exit(); }' -c ./testprogs/complex_struct
 EXPECT P: \\x09\\x08\\x07\\x06-\\x05\\x04\\x03\\x02-\\x01\\x02\\x03\\x04-\\x05\\x00\\x00\\x00\\x06\\x00\\x00\\x00\\x07\\x00\\x00\\x00\\x08\\x00\\x00\\x00-\\x09\\x00\\x0a\\x00\\x0b\\x00\\x0c\\x00-\\x0d\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0e\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0f\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x10\\x00\\x00\\x00\\x00\\x00\\x00\\x00
 TIMEOUT 5
 ARCH x86_64|ppc64le|aarch64
 
 NAME buf
-RUN {{BPFTRACE}} -v -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s->a, 4), buf($s->b, 4), buf($s->c), buf($s->d), buf($s->e), buf($s->f)); exit(); }' -c ./testprogs/complex_struct
+RUN {{BPFTRACE}} -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s->a, 4), buf($s->b, 4), buf($s->c), buf($s->d), buf($s->e), buf($s->f)); exit(); }' -c ./testprogs/complex_struct
 EXPECT P: \\x09\\x08\\x07\\x06-\\x05\\x04\\x03\\x02-\\x01\\x02\\x03\\x04-\\x00\\x00\\x00\\x05\\x00\\x00\\x00\\x06\\x00\\x00\\x00\\x07\\x00\\x00\\x00\\x08-\\x00\\x09\\x00\\x0a\\x00\\x0b\\x00\\x0c-\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0d\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0e\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0f\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x10
 TIMEOUT 5
 ARCH s390x|ppc64
 
 NAME buf_map_key
-RUN {{BPFTRACE}} -v -e 'i:ms:100 { @[buf("ok_key", 6)] = 1; exit(); }'
+RUN {{BPFTRACE}} -e 'i:ms:100 { @[buf("ok_key", 6)] = 1; exit(); }'
 EXPECT @\[ok_key\]: 1
 TIMEOUT 5
 
 NAME buf_map_value
-RUN {{BPFTRACE}} -v -e 'i:ms:100 { @ = buf("ok_value", 8); exit(); }'
+RUN {{BPFTRACE}} -e 'i:ms:100 { @ = buf("ok_value", 8); exit(); }'
 EXPECT @: ok_value
 TIMEOUT 5
 
 NAME ksym
-RUN {{BPFTRACE}} -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("ip"))); exit();}'
+RUN {{BPFTRACE}} -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("ip"))); exit();}'
 EXPECT do_nanosleep
 TIMEOUT 5
 ARCH x86_64
 AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME ksym
-RUN {{BPFTRACE}} -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("pswaddr"))); exit();}'
+RUN {{BPFTRACE}} -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("pswaddr"))); exit();}'
 EXPECT do_nanosleep
 TIMEOUT 5
 ARCH s390x
 AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME ksym
-RUN {{BPFTRACE}} -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("pc"))); exit();}'
+RUN {{BPFTRACE}} -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("pc"))); exit();}'
 EXPECT do_nanosleep
 TIMEOUT 5
 ARCH aarch64
 AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME ksym
-RUN {{BPFTRACE}} -v -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("nip"))); exit();}'
+RUN {{BPFTRACE}} -e 'kprobe:do_nanosleep { printf("%s\n", ksym(reg("nip"))); exit();}'
 EXPECT do_nanosleep
 TIMEOUT 5
 ARCH ppc64|ppc64le
 AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME system
-RUN {{BPFTRACE}} --unsafe -v -e 'i:ms:100 { system("echo 'ok_system'"); exit();}'
+RUN {{BPFTRACE}} --unsafe -e 'i:ms:100 { system("echo 'ok_system'"); exit();}'
 EXPECT ok_system
 TIMEOUT 5
 
 NAME system_more_args
-RUN {{BPFTRACE}} --unsafe -v -e 'i:ms:100 { system("echo %d %d %d %d %d %d %d", 1, 2, 3, 4, 5, 6, 7); exit();}'
+RUN {{BPFTRACE}} --unsafe -e 'i:ms:100 { system("echo %d %d %d %d %d %d %d", 1, 2, 3, 4, 5, 6, 7); exit();}'
 EXPECT 1 2 3 4 5 6 7
 TIMEOUT 5
 
 NAME count
-RUN {{BPFTRACE}} -v -e 'i:ms:100 { @ = count(); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:100 { @ = count(); exit();}'
 EXPECT @:\s[0-9]+
 TIMEOUT 5
 
 NAME sum
-RUN {{BPFTRACE}} -v -e 'kprobe:vfs_read { @bytes[comm] = sum(arg2); exit();}'
+RUN {{BPFTRACE}} -e 'kprobe:vfs_read { @bytes[comm] = sum(arg2); exit();}'
 EXPECT @.*\[.*\]\:\s[0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME avg
-RUN {{BPFTRACE}} -v -e 'kprobe:vfs_read { @bytes[comm] = avg(arg2); exit();}'
+RUN {{BPFTRACE}} -e 'kprobe:vfs_read { @bytes[comm] = avg(arg2); exit();}'
 EXPECT @.*\[.*\]\:\s[0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME min
-RUN {{BPFTRACE}} -v -e 'kprobe:vfs_read { @bytes[comm] = min(arg2); exit();}'
+RUN {{BPFTRACE}} -e 'kprobe:vfs_read { @bytes[comm] = min(arg2); exit();}'
 EXPECT @.*\[.*\]\:\s[0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME max
-RUN {{BPFTRACE}} -v -e 'kprobe:vfs_read { @bytes[comm] = max(arg2); exit();}'
+RUN {{BPFTRACE}} -e 'kprobe:vfs_read { @bytes[comm] = max(arg2); exit();}'
 EXPECT @.*\[.*\]\:\s[0-9]*
 AFTER ./testprogs/syscall read
 TIMEOUT 5
 
 NAME stats
-RUN {{BPFTRACE}} -v -e 'kprobe:vfs_read { @bytes[comm] = stats(arg2); exit();}'
+RUN {{BPFTRACE}} -e 'kprobe:vfs_read { @bytes[comm] = stats(arg2); exit();}'
 EXPECT @.*\[.*\]\:\scount\s[0-9]*\,\saverage\s[0-9]*\,\stotal\s[0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME hist
-RUN {{BPFTRACE}} -v -e 'kretprobe:vfs_read { @bytes = hist(retval); exit();}'
+RUN {{BPFTRACE}} -e 'kretprobe:vfs_read { @bytes = hist(retval); exit();}'
 EXPECT @bytes: *\n[\[(].*
 AFTER ./testprogs/syscall read
 TIMEOUT 5
 
 NAME lhist
-RUN {{BPFTRACE}} -v -e 'kretprobe:vfs_read { @bytes = lhist(retval, 0, 10000, 1000); exit()}'
+RUN {{BPFTRACE}} -e 'kretprobe:vfs_read { @bytes = lhist(retval, 0, 10000, 1000); exit()}'
 EXPECT @bytes: *\n[\[(].*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kstack
-RUN {{BPFTRACE}} -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n%s\n", kstack(), kstack(1)); exit(); }'
+RUN {{BPFTRACE}} -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n%s\n", kstack(), kstack(1)); exit(); }'
 EXPECT SUCCESS kstack
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME kstack perf mode
-RUN {{BPFTRACE}} -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n", kstack(perf, 1)); exit(); }'
+RUN {{BPFTRACE}} -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n", kstack(perf, 1)); exit(); }'
 EXPECT SUCCESS kstack
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8
 
 
 NAME ustack
-RUN {{BPFTRACE}} -v -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n%s\n", ustack(), ustack(1)); exit(); }'
+RUN {{BPFTRACE}} -e 'k:do_nanosleep { printf("SUCCESS '$test' %s\n%s\n", ustack(), ustack(1)); exit(); }'
 EXPECT SUCCESS ustack
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME cat
-RUN {{BPFTRACE}} -v -e 'i:ms:1 { cat("/proc/uptime"); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 { cat("/proc/uptime"); exit();}'
 EXPECT [0-9]*.[0-9]* [0-9]*.[0-9]*
 TIMEOUT 5
 
 NAME cat_more_args
-RUN {{BPFTRACE}} -v -e 'i:ms:1 { cat("/%s%s%s%s/%s%s%s", "p", "r", "o", "c", "u", "p", "time"); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 { cat("/%s%s%s%s/%s%s%s", "p", "r", "o", "c", "u", "p", "time"); exit();}'
 EXPECT [0-9]*.[0-9]* [0-9]*.[0-9]*
 TIMEOUT 5
 
 NAME uaddr
-RUN {{BPFTRACE}} -v -e 'uprobe:testprogs/uprobe_test:function1 { printf("0x%lx -- 0x%lx\n", *uaddr("GLOBAL_A"), *uaddr("GLOBAL_C")); exit(); }' -c ./testprogs/uprobe_test
+RUN {{BPFTRACE}} -e 'uprobe:testprogs/uprobe_test:function1 { printf("0x%lx -- 0x%lx\n", *uaddr("GLOBAL_A"), *uaddr("GLOBAL_C")); exit(); }' -c ./testprogs/uprobe_test
 EXPECT 0x55555555 -- 0x33333333
 TIMEOUT 5
 
 NAME ntop static ip
-RUN {{BPFTRACE}} -v -e 'i:ms:100 { printf("IP: %s, %s, %s, %s\n", ntop(1), ntop(0x0100007f), ntop(0xffff0000), ntop(0x0000ffff)); exit() }'
+RUN {{BPFTRACE}} -e 'i:ms:100 { printf("IP: %s, %s, %s, %s\n", ntop(1), ntop(0x0100007f), ntop(0xffff0000), ntop(0x0000ffff)); exit() }'
 EXPECT IP: 1.0.0.0, 127.0.0.1, 0.0.255.255, 255.255.0.0
 ARCH x86_64|aarch64|ppc64le
 TIMEOUT 5
 
 NAME ntop static ip
-RUN {{BPFTRACE}} -v -e 'i:ms:100 { printf("IP: %s, %s, %s, %s\n", ntop(0x01000000), ntop(0x7f000001), ntop(0x0000ffff), ntop(0xffff0000)); exit() }'
+RUN {{BPFTRACE}} -e 'i:ms:100 { printf("IP: %s, %s, %s, %s\n", ntop(0x01000000), ntop(0x7f000001), ntop(0x0000ffff), ntop(0xffff0000)); exit() }'
 EXPECT IP: 1.0.0.0, 127.0.0.1, 0.0.255.255, 255.255.0.0
 ARCH s390x|ppc64
 TIMEOUT 5
@@ -228,35 +228,35 @@ EXPECT (1, 2, string)
 TIMEOUT 1
 
 NAME print_non_map_array
-RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = ((struct A *) arg0)->x; print($a); exit(); }'
+RUN {{BPFTRACE}} -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = ((struct A *) arg0)->x; print($a); exit(); }'
 EXPECT \[1,2,3,4\]
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME print_non_map_multi_dimensional_array
-RUN {{BPFTRACE}} -v -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $b = ((struct B *) arg1)->y; print($b); exit(); }'
+RUN {{BPFTRACE}} -e 'struct B { int y[2][2]; } uprobe:./testprogs/array_access:test_struct { $b = ((struct B *) arg1)->y; print($b); exit(); }'
 EXPECT \[\[5,6\],\[7,8\]\]
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME print_non_map_struct
-RUN {{BPFTRACE}} -v -e 'struct Foo { int m; int n; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); print($f); exit(); }'
+RUN {{BPFTRACE}} -e 'struct Foo { int m; int n; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); print($f); exit(); }'
 EXPECT { .m = 2, .n = 3 }
 TIMEOUT 5
 AFTER ./testprogs/simple_struct
 
 NAME strftime
-RUN {{BPFTRACE}} -v -e 'BEGIN { $ts = strftime("%m/%d/%y", nsecs); printf("%s\n", $ts); exit(); } '
+RUN {{BPFTRACE}} -e 'BEGIN { $ts = strftime("%m/%d/%y", nsecs); printf("%s\n", $ts); exit(); } '
 EXPECT [0-9]{2}\/[0-9]{2}\/[0-9]{2}
 TIMEOUT 5
 
 NAME strftime_as_map_key
-RUN {{BPFTRACE}} -v -e 'BEGIN { @[strftime("%m/%d/%y", nsecs)] = 1; exit();}'
+RUN {{BPFTRACE}} -e 'BEGIN { @[strftime("%m/%d/%y", nsecs)] = 1; exit();}'
 EXPECT \[[0-9]{2}\/[0-9]{2}\/[0-9]{2}\]: 1
 TIMEOUT 5
 
 NAME strftime_as_map_value
-RUN {{BPFTRACE}} -v -e 'BEGIN { @[nsecs] = strftime("%m/%d/%y", nsecs); exit();}'
+RUN {{BPFTRACE}} -e 'BEGIN { @[nsecs] = strftime("%m/%d/%y", nsecs); exit();}'
 EXPECT @\[[0-9]*\]: [0-9]{2}\/[0-9]{2}\/[0-9]{2}
 TIMEOUT 5
 

--- a/tests/runtime/engine/utils.py
+++ b/tests/runtime/engine/utils.py
@@ -175,7 +175,10 @@ class Utils(object):
             if test.before:
                 childpid = subprocess.Popen(["pidof", "-s", child_name], stdout=subprocess.PIPE, universal_newlines=True).communicate()[0].strip()
                 bpf_call = re.sub("{{BEFORE_PID}}", str(childpid), bpf_call)
-            env = {'test': test.name}
+            env = {
+                'test': test.name,
+                '__BPFTRACE_NOTIFY_PROBES_ATTACHED': '1',
+            }
             env.update(test.env)
             p = subprocess.Popen(
                 bpf_call,
@@ -195,7 +198,7 @@ class Utils(object):
             while p.poll() is None:
                 nextline = p.stdout.readline()
                 output += nextline
-                if nextline == "Running...\n":
+                if nextline == "__BPFTRACE_NOTIFY_PROBES_ATTACHED\n":
                     signal.alarm(test.timeout or DEFAULT_TIMEOUT)
                     if not after and test.after:
                         after = subprocess.Popen(test.after, shell=True, preexec_fn=os.setsid)

--- a/tests/runtime/file-output
+++ b/tests/runtime/file-output
@@ -1,19 +1,19 @@
 NAME printf to file
-RUN {{BPFTRACE}} -v -e 'i:ms:10 { printf("%s %d\n", "SUCCESS", 1); exit() }' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
+RUN {{BPFTRACE}} -e 'i:ms:10 { printf("%s %d\n", "SUCCESS", 1); exit() }' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
 EXPECT ^SUCCESS 1$
 TIMEOUT 5
 
 NAME cat to file
-RUN {{BPFTRACE}} -v -e 'i:ms:10 { cat("/proc/loadavg"); exit(); }' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
+RUN {{BPFTRACE}} -e 'i:ms:10 { cat("/proc/loadavg"); exit(); }' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
 EXPECT ^([0-9]+\.[0-9]+ )+.*$
 TIMEOUT 5
 
 NAME print map to file
-RUN {{BPFTRACE}} -v -e 'i:ms:10 { @=lhist(50, 0, 100, 10); exit();}' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
+RUN {{BPFTRACE}} -e 'i:ms:10 { @=lhist(50, 0, 100, 10); exit();}' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
 EXPECT ^\[50, 60\).*\@+\|$
 TIMEOUT 5
 
 NAME system stdout to file
-RUN {{BPFTRACE}} -v --unsafe -e 'i:ms:10 { system("cat /proc/loadavg"); exit(); }' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
+RUN {{BPFTRACE}} --unsafe -e 'i:ms:10 { system("cat /proc/loadavg"); exit(); }' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
 EXPECT ^([0-9]+\.[0-9]+ )+.*$
 TIMEOUT 5

--- a/tests/runtime/intcast
+++ b/tests/runtime/intcast
@@ -1,16 +1,16 @@
 NAME Casting retval should work
-RUN {{BPFTRACE}} -v -e 'ur:./testprogs/uprobe_negative_retval:main   /(int32)retval < 0/ { @[(int32)retval]=count(); exit();}'
+RUN {{BPFTRACE}} -e 'ur:./testprogs/uprobe_negative_retval:main   /(int32)retval < 0/ { @[(int32)retval]=count(); exit();}'
 AFTER ./testprogs/uprobe_negative_retval
 EXPECT ^@\[-100\]: 1$
 TIMEOUT 5
 
 NAME Sum casted retval
-RUN {{BPFTRACE}} -v -e 'ur:./testprogs/uprobe_negative_retval:function1 { @=stats((int32)retval); exit();} ur:./testprogs/uprobe_negative_retval:main { exit() }'
+RUN {{BPFTRACE}} -e 'ur:./testprogs/uprobe_negative_retval:function1 { @=stats((int32)retval); exit();} ur:./testprogs/uprobe_negative_retval:main { exit() }'
 AFTER ./testprogs/uprobe_negative_retval
 EXPECT ^@: count 221, average -10, total -2210$
 TIMEOUT 5
 
 NAME Casting ints
-RUN {{BPFTRACE}} -v -e 'BEGIN{printf("Values: %d %d\n", (uint8) -10, (uint16) 131087); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN{printf("Values: %d %d\n", (uint8) -10, (uint16) 131087); exit(); }'
 EXPECT Values: 246 15$
 TIMEOUT 5

--- a/tests/runtime/intptrcast
+++ b/tests/runtime/intptrcast
@@ -1,68 +1,68 @@
 NAME Sum casted value
-RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("sp")+8)); exit();}'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("sp")+8)); exit();}'
 EXPECT ^@: 3258
 TIMEOUT 5
 ARCH x86_64
 AFTER ./testprogs/intptrcast
 
 NAME Sum casted value
-RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("sp")+0)); exit();}'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("sp")+0)); exit();}'
 EXPECT ^@: 3258
 TIMEOUT 5
 ARCH aarch64
 AFTER ./testprogs/intptrcast
 
 NAME Sum casted value
-RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r1")+96)); exit();}'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r1")+96)); exit();}'
 EXPECT ^@: 3258
 TIMEOUT 5
 ARCH ppc64le
 AFTER ./testprogs/intptrcast
 
 NAME Sum casted value
-RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r1")+112)); exit();}'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r1")+112)); exit();}'
 EXPECT ^@: 3258
 TIMEOUT 5
 ARCH ppc64
 AFTER ./testprogs/intptrcast
 
 NAME Sum casted value
-RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r15")+160)); exit();}'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r15")+160)); exit();}'
 EXPECT ^@: 4660
 TIMEOUT 5
 ARCH s390x
 AFTER ./testprogs/intptrcast
 
 NAME Casting ints
-RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("sp")+8); printf("%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("sp")+8); printf("%d\n", $a); exit();}'
 EXPECT 3258
 TIMEOUT 5
 ARCH x86_64
 AFTER ./testprogs/intptrcast
 
 NAME Casting ints
-RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("sp")+0); printf("%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("sp")+0); printf("%d\n", $a); exit();}'
 EXPECT 3258
 TIMEOUT 5
 ARCH aarch64
 AFTER ./testprogs/intptrcast
 
 NAME Casting ints
-RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("r1")+96); printf("%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("r1")+96); printf("%d\n", $a); exit();}'
 EXPECT 3258
 TIMEOUT 5
 ARCH ppc64le
 AFTER ./testprogs/intptrcast
 
 NAME Casting ints
-RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("r1")+112); printf("%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("r1")+112); printf("%d\n", $a); exit();}'
 EXPECT 3258
 TIMEOUT 5
 ARCH ppc64
 AFTER ./testprogs/intptrcast
 
 NAME Casting ints
-RUN {{BPFTRACE}} -v -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("r15")+160); printf("%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -e 'uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("r15")+160); printf("%d\n", $a); exit();}'
 EXPECT 4660
 TIMEOUT 5
 ARCH s390x

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -54,22 +54,22 @@ EXPECT ^True$
 TIMEOUT 5
 
 NAME printf
-RUN {{BPFTRACE}} -q -f json -v -e 'BEGIN { printf("test %d", 5); exit(); }'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { printf("test %d", 5); exit(); }'
 EXPECT ^{"type": "printf", "data": "test 5"}$
 TIMEOUT 5
 
 NAME printf_escaping
-RUN {{BPFTRACE}} -q -f json -v -e 'BEGIN { printf("test \r \n \t \\ \" bar"); exit(); }'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { printf("test \r \n \t \\ \" bar"); exit(); }'
 EXPECT ^{"type": "printf", "data": "test \\r \\n \\t \\\\ \\\" bar"}$
 TIMEOUT 5
 
 NAME time
-RUN {{BPFTRACE}} -q -f json -v -e 'BEGIN { time(); exit(); }'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { time(); exit(); }'
 EXPECT ^{"type": "time", "data": "[0-9]*:[0-9]*:[0-9]*\\n"}$
 TIMEOUT 5
 
 NAME syscall
-RUN {{BPFTRACE}} --unsafe -v -f json -e 'BEGIN { system("echo a b c"); exit(); }'
+RUN {{BPFTRACE}} --unsafe -f json -e 'BEGIN { system("echo a b c"); exit(); }'
 EXPECT ^{"type": "syscall", "data": "a b c\\n"}$
 TIMEOUT 5
 
@@ -79,7 +79,7 @@ EXPECT ^{"type": "join", "data": "/bin/echo,'A'"}
 TIMEOUT 5
 
 NAME cat
-RUN {{BPFTRACE}} -v -f json -e 'BEGIN { cat("/proc/uptime"); exit(); }'
+RUN {{BPFTRACE}} -f json -e 'BEGIN { cat("/proc/uptime"); exit(); }'
 EXPECT ^{"type": "cat", "data": "[0-9]*.[0-9]* [0-9]*.[0-9]*\\n"}$
 TIMEOUT 5
 
@@ -91,7 +91,7 @@ EXPECT ^{"type": "map", "data": {"@": \[1,2,"string",\[4,5\]\]}}$
 TIMEOUT 5
 
 NAME tuple_with_struct
-RUN {{BPFTRACE}} -v -f json -e 'struct Foo { int m; int n; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); @ = (0, $f); exit(); }'
+RUN {{BPFTRACE}} -f json -e 'struct Foo { int m; int n; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); @ = (0, $f); exit(); }'
 EXPECT ^{"type": "map", "data": {"@": \[0,{ "m": 2, "n": 3 }\]}}$
 TIMEOUT 5
 AFTER ./testprogs/simple_struct
@@ -117,13 +117,13 @@ EXPECT ^{"type": "value", "data": \[1,2,"string"\]}$
 TIMEOUT 1
 
 NAME print_non_map_struct
-RUN {{BPFTRACE}} -v -f json -e 'struct Foo { int m; int n; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); print($f); exit(); }'
+RUN {{BPFTRACE}} -f json -e 'struct Foo { int m; int n; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); print($f); exit(); }'
 EXPECT ^{"type": "value", "data": { "m": 2, "n": 3 }}$
 TIMEOUT 5
 AFTER ./testprogs/simple_struct
 
 NAME print_non_map_nested_struct
-RUN {{BPFTRACE}} -v -f json -e 'struct Foo { struct { int m[1] } y; struct { int n; } a; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); print($f); exit(); }'
+RUN {{BPFTRACE}} -f json -e 'struct Foo { struct { int m[1] } y; struct { int n; } a; } uprobe:./testprogs/simple_struct:func { $f = *((struct Foo *) arg0); print($f); exit(); }'
 EXPECT ^{"type": "value", "data": { "y": { "m": \[2\] }, "a": { "n": 3 } }}$
 TIMEOUT 5
 AFTER ./testprogs/simple_struct

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -1,40 +1,40 @@
 NAME if_gt
-RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = 10; if ($a > 2) { $a = 20 } printf("a=%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 {$a = 10; if ($a > 2) { $a = 20 } printf("a=%d\n", $a); exit();}'
 EXPECT a=20
 TIMEOUT 5
 
 NAME if_lt
-RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = 10; if ($a < 2) { $a = 20 } printf("a=%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 {$a = 10; if ($a < 2) { $a = 20 } printf("a=%d\n", $a); exit();}'
 EXPECT a=10
 TIMEOUT 5
 
 NAME ifelse_go_else
-RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = ""; if (10 < 2) { $a = "hi" } else {$a = "hello"} printf("a=%s\n", $a); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 {$a = ""; if (10 < 2) { $a = "hi" } else {$a = "hello"} printf("a=%s\n", $a); exit();}'
 EXPECT a=hello
 TIMEOUT 5
 
 NAME ifelse_go_if
-RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = ""; if (10 > 2) { $a = "hi" } else {$a = "hello"} printf("a=%s\n", $a); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 {$a = ""; if (10 > 2) { $a = "hi" } else {$a = "hello"} printf("a=%s\n", $a); exit();}'
 EXPECT a=hi
 TIMEOUT 5
 
 NAME ifelseif_go_elseif
-RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = ""; if (1 > 2) { $a = "hi" } else if (2 < 3) { $a = "hello" } printf("a=%s\n", $a); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 {$a = ""; if (1 > 2) { $a = "hi" } else if (2 < 3) { $a = "hello" } printf("a=%s\n", $a); exit();}'
 EXPECT a=hello
 TIMEOUT 5
 
 NAME ifelseifelse_go_else
-RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = ""; if (1 > 2) { $a = "hi" } else if (5 < 3) { $a = "hello" } else { $a = "asdf" } printf("a=%s\n", $a); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 {$a = ""; if (1 > 2) { $a = "hi" } else if (5 < 3) { $a = "hello" } else { $a = "asdf" } printf("a=%s\n", $a); exit();}'
 EXPECT a=asdf
 TIMEOUT 5
 
 NAME if_cast
-RUN {{BPFTRACE}} -v -e 'i:ms:1 { if ((int32)pid) {} printf("done\n"); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 { if ((int32)pid) {} printf("done\n"); exit();}'
 EXPECT done
 TIMEOUT 5
 
 NAME ternary
-RUN {{BPFTRACE}} -v -e 'i:ms:1 { $a = 1 ? "yes" : "no"; printf("%s\n", $a); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 { $a = 1 ? "yes" : "no"; printf("%s\n", $a); exit();}'
 EXPECT yes
 TIMEOUT 5
 
@@ -44,52 +44,52 @@ EXPECT 1
 TIMEOUT 5
 
 NAME ternary_int8
-RUN {{BPFTRACE}} -v -e 'i:ms:1 { $a = 1 ? (int8)1 : 0; printf("%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 { $a = 1 ? (int8)1 : 0; printf("%d\n", $a); exit();}'
 EXPECT 1
 TIMEOUT 5
 
 NAME ternary_none_type
-RUN {{BPFTRACE}} -v -e 'i:ms:1 { nsecs ? printf("yes\n") : printf("no") ; exit(); }'
+RUN {{BPFTRACE}} -e 'i:ms:1 { nsecs ? printf("yes\n") : printf("no") ; exit(); }'
 EXPECT  yes
 TIMEOUT 5
 
 NAME unroll
-RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = 1; unroll (10) { $a = $a + 1; } printf("a=%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 {$a = 1; unroll (10) { $a = $a + 1; } printf("a=%d\n", $a); exit();}'
 EXPECT a=11
 TIMEOUT 5
 
 NAME unroll_max_value
-RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = 1; unroll (101) { $a = $a + 2; } printf("a=%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 {$a = 1; unroll (101) { $a = $a + 2; } printf("a=%d\n", $a); exit();}'
 EXPECT unroll maximum value is 100
 TIMEOUT 5
 
 NAME unroll_min_value
-RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = 1; unroll (0) { $a = $a + 2; } printf("a=%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 {$a = 1; unroll (0) { $a = $a + 2; } printf("a=%d\n", $a); exit();}'
 EXPECT unroll minimum value is 1
 TIMEOUT 5
 
 NAME unroll_param
-RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = 1; unroll ($1) { $a = $a + 1; } printf("a=%d\n", $a); exit();}' 10
+RUN {{BPFTRACE}} -e 'i:ms:1 {$a = 1; unroll ($1) { $a = $a + 1; } printf("a=%d\n", $a); exit();}' 10
 EXPECT a=11
 TIMEOUT 5
 
 NAME if_compare_and_print_string
-RUN {{BPFTRACE}} -v -e 'BEGIN { if (comm == "bpftrace") { printf("comm: %s\n", comm);} exit();}'
+RUN {{BPFTRACE}} -e 'BEGIN { if (comm == "bpftrace") { printf("comm: %s\n", comm);} exit();}'
 EXPECT comm: bpftrace
 TIMEOUT 5
 
 NAME struct positional string compare - equal returns true
-RUN {{BPFTRACE}} -v -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} exit();}' "hello" "hello"
+RUN {{BPFTRACE}} -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} exit();}' "hello" "hello"
 EXPECT I got hello
 TIMEOUT 5
 
 NAME struct positional string compare - equal returns false
-RUN {{BPFTRACE}} -v -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hi" "hello"
+RUN {{BPFTRACE}} -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hi" "hello"
 EXPECT not equal
 TIMEOUT 5
 
 NAME struct positional string compare - not equal
-RUN {{BPFTRACE}} -v -e 'BEGIN { if (str($1) != str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hello" "hello"
+RUN {{BPFTRACE}} -e 'BEGIN { if (str($1) != str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hello" "hello"
 EXPECT not equal
 TIMEOUT 5
 
@@ -104,27 +104,27 @@ EXPECT hello world
 TIMEOUT 1
 
 NAME string compare map lookup
-RUN {{BPFTRACE}} -v -e 't:syscalls:sys_enter_openat /comm == "syscall"/ { @[comm] = 1; }' -c "./testprogs/syscall openat"
+RUN {{BPFTRACE}} -e 't:syscalls:sys_enter_openat /comm == "syscall"/ { @[comm] = 1; }' -c "./testprogs/syscall openat"
 EXPECT @\[syscall\]: 1
 TIMEOUT 5
 
 NAME struct partial string compare - pass
-RUN {{BPFTRACE}} -v -e 'BEGIN { if (strncmp(str($1), str($2), 4) == 0) { printf("I got %s\n", str($1));} exit();}' "hhvm" "hhvm-proc"
+RUN {{BPFTRACE}} -e 'BEGIN { if (strncmp(str($1), str($2), 4) == 0) { printf("I got %s\n", str($1));} exit();}' "hhvm" "hhvm-proc"
 EXPECT I got hhvm
 TIMEOUT 5
 
 NAME struct partial string compare - pass reverse
-RUN {{BPFTRACE}} -v -e 'BEGIN { if (strncmp(str($1), str($2), 4) == 0) { printf("I got %s\n", str($1));} exit();}' "hhvm-proc" "hhvm"
+RUN {{BPFTRACE}} -e 'BEGIN { if (strncmp(str($1), str($2), 4) == 0) { printf("I got %s\n", str($1));} exit();}' "hhvm-proc" "hhvm"
 EXPECT I got hhvm-proc
 TIMEOUT 5
 
 NAME strncmp function argument
-RUN {{BPFTRACE}} -v -e 'struct F {char s[8];} u:./testprogs/string_args:print { @=strncmp(((struct F*)arg0)->s, "hello", 5); }' -c ./testprogs/string_args
+RUN {{BPFTRACE}} -e 'struct F {char s[8];} u:./testprogs/string_args:print { @=strncmp(((struct F*)arg0)->s, "hello", 5); }' -c ./testprogs/string_args
 EXPECT @: 0
 TIMEOUT 5
 
 NAME short non null-terminated string print
-RUN {{BPFTRACE}} -v -e 'struct F {char s[5];} u:./testprogs/string_args:print { $a = ((struct F*)arg0)->s; printf("%s %s\n", $a, $a); }' -c ./testprogs/string_args
+RUN {{BPFTRACE}} -e 'struct F {char s[5];} u:./testprogs/string_args:print { $a = ((struct F*)arg0)->s; printf("%s %s\n", $a, $a); }' -c ./testprogs/string_args
 EXPECT hello hello
 TIMEOUT 5
 
@@ -149,7 +149,7 @@ EXPECT Attaching 1 probe...
 TIMEOUT 5
 
 NAME positional arg count
-RUN {{BPFTRACE}} -v -e 'BEGIN { printf("got %d args: %s %d\n", $#, str($1), $2); exit();}' "one" 2
+RUN {{BPFTRACE}} -e 'BEGIN { printf("got %d args: %s %d\n", $#, str($1), $2); exit();}' "one" 2
 EXPECT got 2 args: one 2
 TIMEOUT 5
 
@@ -184,19 +184,19 @@ EXPECT .*
 TIMEOUT 1
 
 NAME sigint under heavy load
-RUN {{BPFTRACE}} --unsafe -v -e 'tracepoint:sched:sched_switch { system("echo foo"); } END { printf("end"); }'
+RUN {{BPFTRACE}} --unsafe -e 'tracepoint:sched:sched_switch { system("echo foo"); } END { printf("end"); }'
 EXPECT end
 TIMEOUT 5
 AFTER  ./testprogs/syscall nanosleep 2e9; pkill -SIGINT bpftrace
 
 NAME bitfield access
-RUN {{BPFTRACE}} -v -e 'struct Foo { unsigned int a:4, b:8, c:3, d:1, e:16; } uprobe:./testprogs/bitfield_test:func{ $foo = (struct Foo *)arg0; printf("%d %d %d %d %d\n", $foo->a, $foo->b, $foo->c, $foo->d, $foo->e); exit()}'
+RUN {{BPFTRACE}} -e 'struct Foo { unsigned int a:4, b:8, c:3, d:1, e:16; } uprobe:./testprogs/bitfield_test:func{ $foo = (struct Foo *)arg0; printf("%d %d %d %d %d\n", $foo->a, $foo->b, $foo->c, $foo->d, $foo->e); exit()}'
 EXPECT 1 2 5 0 65535
 TIMEOUT 5
 AFTER ./testprogs/bitfield_test
 
 NAME bitfield_access_2
-RUN {{BPFTRACE}} -v -e 'struct Bar { short a:4, b:8, c:3, d:1; int e:9, f:15, g:1, h:2, i:5 } uprobe:./testprogs/bitfield_test:func2 { $bar = (struct Bar *)arg0; printf("%d %d %d %d %d", $bar->a, $bar->b, $bar->c, $bar->d, $bar->e); printf(" %d %d %d %d", $bar->f, $bar->g, $bar->h, $bar->i); exit()}'
+RUN {{BPFTRACE}} -e 'struct Bar { short a:4, b:8, c:3, d:1; int e:9, f:15, g:1, h:2, i:5 } uprobe:./testprogs/bitfield_test:func2 { $bar = (struct Bar *)arg0; printf("%d %d %d %d %d", $bar->a, $bar->b, $bar->c, $bar->d, $bar->e); printf(" %d %d %d %d", $bar->f, $bar->g, $bar->h, $bar->i); exit()}'
 EXPECT 1 217 5 1 500 31117 1 2 27
 TIMEOUT 5
 AFTER ./testprogs/bitfield_test

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -39,8 +39,8 @@ EXPECT yes
 TIMEOUT 5
 
 NAME ternary_lnot
-RUN {{BPFTRACE}} -v -e 'i:ms:1 { $a = !nsecs ? 0 : 1; printf("%d\n", $a); exit();}'
-EXPECT 0
+RUN {{BPFTRACE}} -e 'i:ms:1 { $a = !nsecs ? 0 : 1; printf("%d\n", $a); exit() }'
+EXPECT 1
 TIMEOUT 5
 
 NAME ternary_int8

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -1,28 +1,28 @@
 NAME kprobe
-RUN {{BPFTRACE}} -v -e 'kprobe:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN {{BPFTRACE}} -e 'kprobe:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT SUCCESS kprobe [0-9][0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kprobe_short_name
-RUN {{BPFTRACE}} -v -e 'k:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN {{BPFTRACE}} -e 'k:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT SUCCESS kprobe_short_name [0-9][0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kprobe_target
-RUN {{BPFTRACE}} -v -e 'kprobe:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN {{BPFTRACE}} -e 'kprobe:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT kprobe probe type requires 1 argument
 TIMEOUT 5
 
 NAME kprobe_order
-RUN {{BPFTRACE}} -v runtime/scripts/kprobe_order.bt
+RUN {{BPFTRACE}} runtime/scripts/kprobe_order.bt
 EXPECT first second
 TIMEOUT 5
 AFTER /bin/bash -c "./testprogs/syscall nanosleep 1000"; /bin/bash -c "./testprogs/syscall nanosleep 1000"
 
 NAME kprobe_offset
-RUN {{BPFTRACE}} -v -e 'kprobe:vfs_read+0 { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN {{BPFTRACE}} -e 'kprobe:vfs_read+0 { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT SUCCESS kprobe_offset [0-9][0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
@@ -31,47 +31,47 @@ AFTER ./testprogs/syscall read
 # yet. Reason is b/c bpftrace will look for a vmlinux based on the running kernel's
 # version.
 NAME kprobe_offset_fail_size
-RUN {{BPFTRACE}} -v -e 'kprobe:vfs_read+1000000 { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN {{BPFTRACE}} -e 'kprobe:vfs_read+1000000 { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT Offset outside the function bounds \('vfs_read' size is*
 TIMEOUT 5
 
 NAME kretprobe
-RUN {{BPFTRACE}} -v -e 'kretprobe:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN {{BPFTRACE}} -e 'kretprobe:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT SUCCESS kretprobe [0-9][0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kretprobe_short_name
-RUN {{BPFTRACE}} -v -e 'kr:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN {{BPFTRACE}} -e 'kr:vfs_read { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT SUCCESS kretprobe_short_name [0-9][0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kretprobe_target
-RUN {{BPFTRACE}} -v -e 'kretprobe:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", pid); exit(); }'
+RUN {{BPFTRACE}} -e 'kretprobe:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", pid); exit(); }'
 EXPECT kretprobe probe type requires 1 argument
 TIMEOUT 5
 
 NAME kretprobe_order
-RUN {{BPFTRACE}} -v runtime/scripts/kretprobe_order.bt
+RUN {{BPFTRACE}} runtime/scripts/kretprobe_order.bt
 EXPECT first second
 TIMEOUT 5
 AFTER /bin/bash -c "./testprogs/syscall nanosleep 1000"; /bin/bash -c "./testprogs/syscall nanosleep 1000"
 
 NAME uprobe
-RUN {{BPFTRACE}} -v -e 'uprobe:/bin/bash:echo_builtin { printf("arg0: %d\n", arg0); exit();}'
+RUN {{BPFTRACE}} -e 'uprobe:/bin/bash:echo_builtin { printf("arg0: %d\n", arg0); exit();}'
 EXPECT arg0: [0-9]*
 TIMEOUT 5
 AFTER /bin/bash -c "echo lala"
 
 NAME uprobe_offset
-RUN {{BPFTRACE}} -v -e 'uprobe:/bin/bash:echo_builtin+0 { printf("arg0: %d\n", arg0); exit();}'
+RUN {{BPFTRACE}} -e 'uprobe:/bin/bash:echo_builtin+0 { printf("arg0: %d\n", arg0); exit();}'
 EXPECT arg0: [0-9]*
 TIMEOUT 5
 AFTER /bin/bash -c "echo lala"
 
 NAME uprobe_offset
-RUN {{BPFTRACE}} -v -e 'uprobe:/bin/bash:"echo_builtin"+0 { printf("arg0: %d\n", arg0); exit();}'
+RUN {{BPFTRACE}} -e 'uprobe:/bin/bash:"echo_builtin"+0 { printf("arg0: %d\n", arg0); exit();}'
 EXPECT arg0: [0-9]*
 TIMEOUT 5
 AFTER /bin/bash -c "echo lala"
@@ -87,93 +87,93 @@ EXPECT Could not resolve address: /bin/bash:0xa
 TIMEOUT 5
 
 NAME uprobe_order
-RUN {{BPFTRACE}} -v runtime/scripts/uprobe_order.bt
+RUN {{BPFTRACE}} runtime/scripts/uprobe_order.bt
 EXPECT first second
 TIMEOUT 5
 AFTER /bin/bash -c "echo lala"; /bin/bash -c "echo lala"
 
 NAME uretprobe
-RUN {{BPFTRACE}} -v -e 'uretprobe:/bin/bash:echo_builtin { printf("readline: %d\n", retval); exit();}'
+RUN {{BPFTRACE}} -e 'uretprobe:/bin/bash:echo_builtin { printf("readline: %d\n", retval); exit();}'
 EXPECT readline: [0-9]*
 TIMEOUT 5
 AFTER /bin/bash -c "echo lala"
 
 NAME uretprobe_order
-RUN {{BPFTRACE}} -v runtime/scripts/uretprobe_order.bt
+RUN {{BPFTRACE}} runtime/scripts/uretprobe_order.bt
 EXPECT first second
 TIMEOUT 5
 AFTER /bin/bash -c "echo lala"; /bin/bash -c "echo lala"
 
 NAME tracepoint
-RUN {{BPFTRACE}} -v -e 'tracepoint:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", gid); exit(); }'
+RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", gid); exit(); }'
 EXPECT SUCCESS tracepoint [0-9][0-9]*
 AFTER ./testprogs/syscall nanosleep 1e8
 TIMEOUT 5
 
 NAME tracepoint_short_name
-RUN {{BPFTRACE}} -v -e 't:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", gid); exit(); }'
+RUN {{BPFTRACE}} -e 't:syscalls:sys_exit_nanosleep { printf("SUCCESS '$test' %d\n", gid); exit(); }'
 EXPECT SUCCESS tracepoint_short_name [0-9][0-9]*
 AFTER ./testprogs/syscall nanosleep 1e8
 TIMEOUT 5
 
 NAME tracepoint_order
-RUN {{BPFTRACE}} -v runtime/scripts/tracepoint_order.bt
+RUN {{BPFTRACE}} runtime/scripts/tracepoint_order.bt
 EXPECT first second
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep 1e8; ./testprogs/syscall nanosleep 1e8
 
 NAME tracepoint_expansion
-RUN {{BPFTRACE}} -v -e 'tracepoint:syscalls:sys_*_nanosleep { printf("hit "); }' -c "./testprogs/syscall nanosleep 1e8"
+RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_*_nanosleep { printf("hit "); }' -c "./testprogs/syscall nanosleep 1e8"
 EXPECT hit hit
 TIMEOUT 5
 
 # Test that we get at least two characters out
 NAME tracepoint_data_loc
-RUN {{BPFTRACE}} -v -e 'tracepoint:irq:irq_handler_entry { print(str(args->name)); exit(); }'
+RUN {{BPFTRACE}} -e 'tracepoint:irq:irq_handler_entry { print(str(args->name)); exit(); }'
 EXPECT ..+
 TIMEOUT 5
 
 NAME profile
-RUN {{BPFTRACE}} -v -e 'profile:hz:599 { @[tid] = count(); exit();}'
+RUN {{BPFTRACE}} -e 'profile:hz:599 { @[tid] = count(); exit();}'
 EXPECT \@\[[0-9]*\]\:\s[0-9]
 TIMEOUT 5
 
 NAME profile_short_name
-RUN {{BPFTRACE}} -v -e 'p:hz:599 { @[tid] = count(); exit();}'
+RUN {{BPFTRACE}} -e 'p:hz:599 { @[tid] = count(); exit();}'
 EXPECT \@\[[0-9]*\]\:\s[0-9]
 TIMEOUT 5
 
 NAME interval
-RUN {{BPFTRACE}} -v -e 't:raw_syscalls:sys_enter { @syscalls = count(); } interval:ms:1{ print(@syscalls); clear(@syscalls); exit();}'
+RUN {{BPFTRACE}} -e 't:raw_syscalls:sys_enter { @syscalls = count(); } interval:ms:1{ print(@syscalls); clear(@syscalls); exit();}'
 EXPECT @syscalls\:\s[0-9]*
 TIMEOUT 5
 
 NAME interval_short_name
-RUN {{BPFTRACE}} -v -e 't:raw_syscalls:sys_enter { @syscalls = count(); } i:ms:1{ print(@syscalls); clear(@syscalls); exit();}'
+RUN {{BPFTRACE}} -e 't:raw_syscalls:sys_enter { @syscalls = count(); } i:ms:1{ print(@syscalls); clear(@syscalls); exit();}'
 EXPECT @syscalls\:\s[0-9]*
 TIMEOUT 5
 
 NAME software
-RUN {{BPFTRACE}} -v -e 'software:faults:1 { @[comm] = count(); exit();}'
+RUN {{BPFTRACE}} -e 'software:faults:1 { @[comm] = count(); exit();}'
 EXPECT @\[.*\]\:\s[0-9]*
 TIMEOUT 5
 
 NAME software_order
-RUN {{BPFTRACE}} -v runtime/scripts/software_order.bt
+RUN {{BPFTRACE}} runtime/scripts/software_order.bt
 EXPECT first second
 TIMEOUT 5
 
 NAME hardware
 REQUIRES ls /sys/devices/cpu/events/cache-misses
-RUN {{BPFTRACE}} -v -e 'hardware:cache-misses:10 { @[pid] = count(); exit(); }'
+RUN {{BPFTRACE}} -e 'hardware:cache-misses:10 { @[pid] = count(); exit(); }'
 EXPECT @\[.*\]\:\s[0-9]*
 TIMEOUT 5
 NAME BEGIN
-RUN {{BPFTRACE}} -v -e 'BEGIN { printf("Hello\n"); exit();}'
+RUN {{BPFTRACE}} -e 'BEGIN { printf("Hello\n"); exit();}'
 EXPECT Hello
 TIMEOUT 2
 
 NAME END_processing_after_exit
-RUN {{BPFTRACE}} -v -e "interval:s:1 { exit(); } END { printf("end"); }"
+RUN {{BPFTRACE}} -e "interval:s:1 { exit(); } END { printf("end"); }"
 EXPECT end
 TIMEOUT 2

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -5,7 +5,7 @@ EXPECT done
 TIMEOUT 1
 
 NAME logical_and_or_different_sizes
-RUN {{BPFTRACE}} -v -e 'struct Foo { int m; } uprobe:./testprogs/simple_struct:func { $foo = (struct Foo*)arg0; printf("%d %d %d %d %d\n", $foo->m, $foo->m && 0, 1 && $foo->m, $foo->m || 0, 0 || $foo->m); exit(); }'
+RUN {{BPFTRACE}} -e 'struct Foo { int m; } uprobe:./testprogs/simple_struct:func { $foo = (struct Foo*)arg0; printf("%d %d %d %d %d\n", $foo->m, $foo->m && 0, 1 && $foo->m, $foo->m || 0, 0 || $foo->m); exit(); }'
 AFTER ./testprogs/simple_struct
 EXPECT 2 0 1 1 1
 TIMEOUT 5
@@ -13,7 +13,7 @@ TIMEOUT 5
 # https://github.com/iovisor/bpftrace/issues/759
 # Update test once https://github.com/iovisor/bpftrace/pull/781 lands
 # NAME ntop_map_printf
-# RUN {{BPFTRACE}} -v -e 'union ip { char v4[4]; char v6[16]; } uprobe:./testprogs/ntop:test_ntop { @a = ntop(2, ((union ip*)arg0)->v4); printf("v4: %s; ", @a); @b = ntop(10, ((union ip*)arg1)->v6); exit() } END { printf("v6: %s", @b); clear(@a); clear(@b) }'
+# RUN {{BPFTRACE}} -e 'union ip { char v4[4]; char v6[16]; } uprobe:./testprogs/ntop:test_ntop { @a = ntop(2, ((union ip*)arg0)->v4); printf("v4: %s; ", @a); @b = ntop(10, ((union ip*)arg1)->v6); exit() } END { printf("v6: %s", @b); clear(@a); clear(@b) }'
 # AFTER ./testprogs/ntop
 # EXPECT v4: 127.0.0.1; v6: ffee:ffee:ddcc:ddcc:bbaa:bbaa:c0a8:1
 # TIMEOUT 1
@@ -24,13 +24,13 @@ EXPECT 0
 TIMEOUT 5
 
 NAME ntop_tracepoint_args
-RUN {{BPFTRACE}} -v -e 'tracepoint:tcp:tcp_destroy_sock { printf("%s\n", ntop(args->daddr)); exit(); }'
+RUN {{BPFTRACE}} -e 'tracepoint:tcp:tcp_destroy_sock { printf("%s\n", ntop(args->daddr)); exit(); }'
 EXPECT [0-9]+.[0-9]+.[0-9]+.[0-9]+
 AFTER curl -s www.google.com > /dev/null
 TIMEOUT 5
 
 NAME c_array_indexing
-RUN {{BPFTRACE}} -v -e 'struct Foo { int a; uint8_t b[10]; } uprobe:testprogs/uprobe_test:function2 { $foo = (struct Foo *)arg0; printf("%c %c %c %c %c\n", $foo->b[0], $foo->b[1], $foo->b[2], $foo->b[3], $foo->b[4]) }' -c ./testprogs/uprobe_test
+RUN {{BPFTRACE}} -e 'struct Foo { int a; uint8_t b[10]; } uprobe:testprogs/uprobe_test:function2 { $foo = (struct Foo *)arg0; printf("%c %c %c %c %c\n", $foo->b[0], $foo->b[1], $foo->b[2], $foo->b[3], $foo->b[4]) }' -c ./testprogs/uprobe_test
 EXPECT h e l l o
 TIMEOUT 5
 

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -19,7 +19,7 @@ TIMEOUT 5
 # TIMEOUT 1
 
 NAME modulo_operator
-RUN {{BPFTRACE}} -v -e 'BEGIN { @x = 4; printf("%d\n", @x % 2) }'
+RUN {{BPFTRACE}} -e 'BEGIN { @x = 4; printf("%d\n", @x % 2); exit() }'
 EXPECT 0
 TIMEOUT 5
 

--- a/tests/runtime/sigint
+++ b/tests/runtime/sigint
@@ -1,9 +1,9 @@
 NAME strace no quit
-RUN {{BPFTRACE}} -v -e 'i:s:1 { printf("%s %d\n", "SUCCESS", 1); exit() }' & (./testprogs/syscall nanosleep 5e8 && strace -p $! -o /dev/null)
+RUN {{BPFTRACE}} -e 'i:s:1 { printf("%s %d\n", "SUCCESS", 1); exit() }' & (./testprogs/syscall nanosleep 5e8 && strace -p $! -o /dev/null)
 EXPECT SUCCESS 1
 TIMEOUT 3
 
 NAME sigint quit
-RUN {{BPFTRACE}} -v -e 'END { printf("%s %d", "SUCCESS", 1) }' & (./testprogs/syscall nanosleep 1e9 && /usr/bin/env kill -s SIGINT $!)
+RUN {{BPFTRACE}} -e 'END { printf("%s %d", "SUCCESS", 1) }' & (./testprogs/syscall nanosleep 1e9 && /usr/bin/env kill -s SIGINT $!)
 EXPECT ^SUCCESS 1$
 TIMEOUT 2

--- a/tests/runtime/struct
+++ b/tests/runtime/struct
@@ -1,47 +1,47 @@
 NAME struct assignment into variable
-RUN {{BPFTRACE}} -v -e 'struct Foo { int m; } u:./testprogs/simple_struct:func { $s = *((struct Foo *)arg0); printf("Result: %d\n", $s.m); exit(); }'
+RUN {{BPFTRACE}} -e 'struct Foo { int m; } u:./testprogs/simple_struct:func { $s = *((struct Foo *)arg0); printf("Result: %d\n", $s.m); exit(); }'
 EXPECT Result: 2
 TIMEOUT 4
 AFTER ./testprogs/simple_struct
 
 NAME struct assignment into map
-RUN {{BPFTRACE}} -v -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @s = *((struct Foo *)arg0); exit(); }'
+RUN {{BPFTRACE}} -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @s = *((struct Foo *)arg0); exit(); }'
 EXPECT @s: { .m = 2, .n = 3 }
 TIMEOUT 4
 AFTER ./testprogs/simple_struct
 
 NAME struct field order
-RUN {{BPFTRACE}} -v -e 'struct Foo { int n; int m; } u:./testprogs/simple_struct:func { @s = *((struct Foo *)arg0); exit(); }'
+RUN {{BPFTRACE}} -e 'struct Foo { int n; int m; } u:./testprogs/simple_struct:func { @s = *((struct Foo *)arg0); exit(); }'
 EXPECT @s: { .n = 2, .m = 3 }
 TIMEOUT 4
 AFTER ./testprogs/simple_struct
 
 NAME nested struct assignment into map
-RUN {{BPFTRACE}} -v -e 'struct Foo { struct { int m[1] } y; struct { int n } a; } u:./testprogs/simple_struct:func { @s = *((struct Foo *)arg0); exit(); }'
+RUN {{BPFTRACE}} -e 'struct Foo { struct { int m[1] } y; struct { int n } a; } u:./testprogs/simple_struct:func { @s = *((struct Foo *)arg0); exit(); }'
 EXPECT @s: { .y = { .m = \[2\] }, .a = { .n = 3 } }
 TIMEOUT 4
 AFTER ./testprogs/simple_struct
 
 NAME struct as a map key
-RUN {{BPFTRACE}} -v -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @s[*((struct Foo *)arg0)] = 0; exit(); }'
+RUN {{BPFTRACE}} -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @s[*((struct Foo *)arg0)] = 0; exit(); }'
 EXPECT @s\[{.m=2,.n=3}\]: 0
 TIMEOUT 4
 AFTER ./testprogs/simple_struct
 
 NAME struct as a part of multikey
-RUN {{BPFTRACE}} -v -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @s[*((struct Foo *)arg0), 42] = 0; exit(); }'
+RUN {{BPFTRACE}} -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @s[*((struct Foo *)arg0), 42] = 0; exit(); }'
 EXPECT @s\[{.m=2,.n=3}, 42\]: 0
 TIMEOUT 4
 AFTER ./testprogs/simple_struct
 
 NAME struct as a map key assigned from another map
-RUN {{BPFTRACE}} -v -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @x = *((struct Foo *)arg0); @s[@x] = 0; exit(); }'
+RUN {{BPFTRACE}} -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @x = *((struct Foo *)arg0); @s[@x] = 0; exit(); }'
 EXPECT @s\[{.m=2,.n=3}\]: 0
 TIMEOUT 4
 AFTER ./testprogs/simple_struct
 
 NAME struct in a tuple
-RUN {{BPFTRACE}} -v -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @s = (1, *((struct Foo *)arg0)); exit(); }'
+RUN {{BPFTRACE}} -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @s = (1, *((struct Foo *)arg0)); exit(); }'
 EXPECT @s: \(1, { .m = 2, .n = 3 }\)
 TIMEOUT 4
 AFTER ./testprogs/simple_struct

--- a/tests/runtime/tuples
+++ b/tests/runtime/tuples
@@ -49,25 +49,25 @@ EXPECT 168
 TIMEOUT 5
 
 NAME struct in tuple
-RUN {{BPFTRACE}} -v -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @t = (1, *((struct Foo *)arg0)); exit(); }'
+RUN {{BPFTRACE}} -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @t = (1, *((struct Foo *)arg0)); exit(); }'
 EXPECT @t: \(1, \{ .m = 2, .n = 3 \}\)
 TIMEOUT 5
 AFTER ./testprogs/simple_struct
 
 NAME struct in tuple sizing
-RUN {{BPFTRACE}} -v -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { $t = ((int32)1, *((struct Foo *)arg0)); print(sizeof($t)); exit(); }'
+RUN {{BPFTRACE}} -e 'struct Foo { int m; int n; } u:./testprogs/simple_struct:func { $t = ((int32)1, *((struct Foo *)arg0)); print(sizeof($t)); exit(); }'
 EXPECT 12
 TIMEOUT 5
 AFTER ./testprogs/simple_struct
 
 NAME array in tuple
-RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } u:./testprogs/array_access:test_struct { @t = (1, ((struct A *)arg0)->x); exit(); }'
+RUN {{BPFTRACE}} -e 'struct A { int x[4]; } u:./testprogs/array_access:test_struct { @t = (1, ((struct A *)arg0)->x); exit(); }'
 EXPECT @t: \(1, \[1,2,3,4\]\)
 TIMEOUT 5
 AFTER ./testprogs/array_access
 
 NAME array in tuple sizing
-RUN {{BPFTRACE}} -v -e 'struct A { int x[4]; } u:./testprogs/array_access:test_struct { $t = ((int32)1, ((struct A *)arg0)->x); print(sizeof($t)); exit(); }'
+RUN {{BPFTRACE}} -e 'struct A { int x[4]; } u:./testprogs/array_access:test_struct { $t = ((int32)1, ((struct A *)arg0)->x); print(sizeof($t)); exit(); }'
 EXPECT 20
 TIMEOUT 5
 AFTER ./testprogs/array_access

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -236,7 +236,7 @@ REQUIRES ./testprogs/usdt_semaphore_test should_not_skip
 REQUIRES_FEATURE uprobe_refcount
 
 NAME "usdt probes - file based semaphore activation multi process"
-RUN {{BPFTRACE}} -v runtime/scripts/usdt_file_activation_multiprocess.bt --usdt-file-activation
+RUN {{BPFTRACE}} runtime/scripts/usdt_file_activation_multiprocess.bt --usdt-file-activation
 EXPECT found 2 processes
 TIMEOUT 5
 BEFORE ./testprogs/usdt_semaphore_test & ./testprogs/usdt_semaphore_test

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -301,7 +301,7 @@ REQUIRES ./testprogs/usdt_args should_not_skip
 # attach to all of them
 NAME "usdt duplicated markers"
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_inlined:tracetest:testprobe { printf("%d\n", arg1); @a += 1; if (@a >= 2) {exit();} }' -c ./testprogs/usdt_inlined
-EXPECT Attaching 2 probes.*\s999\s*100
+EXPECT Attaching 2 probes.*\n.*\s999\s*100
 TIMEOUT 1
 REQUIRES ./testprogs/usdt_inlined should_not_skip
 

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -1,57 +1,57 @@
 NAME global_int
-RUN {{BPFTRACE}} -v -e 'i:ms:1 {@a = 10; printf("%d\n", @a); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 {@a = 10; printf("%d\n", @a); exit();}'
 EXPECT \@a: 10
 TIMEOUT 5
 
 NAME global_string
-RUN {{BPFTRACE}} -v -e 'i:ms:1 {@a = "hi"; printf("%s\n", @a); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 {@a = "hi"; printf("%s\n", @a); exit();}'
 EXPECT @a: hi
 TIMEOUT 5
 
 NAME global_buf
-RUN {{BPFTRACE}} -v -e 'i:ms:1 {@a = buf("hi", 2); printf("%r\n", @a); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 {@a = buf("hi", 2); printf("%r\n", @a); exit();}'
 EXPECT @a: hi
 TIMEOUT 5
 
 NAME local_int
-RUN {{BPFTRACE}} -v -e 'i:ms:1  {$a = 10; printf("a=%d\n", $a); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1  {$a = 10; printf("a=%d\n", $a); exit();}'
 EXPECT a=10
 TIMEOUT 5
 
 NAME local_string
-RUN {{BPFTRACE}} -v -e 'i:ms:1  {$a = "hi"; printf("a=%s\n", $a); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1  {$a = "hi"; printf("a=%s\n", $a); exit();}'
 EXPECT a=hi
 TIMEOUT 5
 
 NAME local_buf
-RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = buf("hi", 2); printf("a=%r\n", $a); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 {$a = buf("hi", 2); printf("a=%r\n", $a); exit();}'
 EXPECT a=hi
 TIMEOUT 5
 
 NAME buf_equality
-RUN {{BPFTRACE}} -v -e 'i:ms:1 {$a = buf("hi", 2); $b = buf("bye", 3); printf("equal=%d, unequal=%d\n", $a == $a, $a != $b); exit();}'
+RUN {{BPFTRACE}} -e 'i:ms:1 {$a = buf("hi", 2); $b = buf("bye", 3); printf("equal=%d, unequal=%d\n", $a == $a, $a != $b); exit();}'
 EXPECT equal=1, unequal=1
 TIMEOUT 5
 
 NAME global_associative_arrays
-RUN {{BPFTRACE}} -v -e 'k:vfs_read { @start[tid] = nsecs; } kretprobe:vfs_read /@start[tid] != 0/ { printf("slept for %d ms\n", (nsecs - @start[tid]) / 1000000); delete(@start[tid]); exit();}'
+RUN {{BPFTRACE}} -e 'k:vfs_read { @start[tid] = nsecs; } kretprobe:vfs_read /@start[tid] != 0/ { printf("slept for %d ms\n", (nsecs - @start[tid]) / 1000000); delete(@start[tid]); exit();}'
 EXPECT slept for [0-9]+ ms
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME scratch
-RUN {{BPFTRACE}} -v -e 'k:vfs_read { @start[tid] = nsecs; } kretprobe:vfs_read /@start[tid] != 0/ { $delta = nsecs - @start[tid]; printf("slept for %d ms\n", $delta / 1000000); delete(@start[tid]); exit(); }'
+RUN {{BPFTRACE}} -e 'k:vfs_read { @start[tid] = nsecs; } kretprobe:vfs_read /@start[tid] != 0/ { $delta = nsecs - @start[tid]; printf("slept for %d ms\n", $delta / 1000000); delete(@start[tid]); exit(); }'
 EXPECT slept for [0-9]* ms
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME 32-bit tracepoint arg
-RUN {{BPFTRACE}} -v -e 'tracepoint:random:urandom_read { $i = args->got_bits; printf("bits: %d\n", $i); if ($i == 24) { exit() } }'
+RUN {{BPFTRACE}} -e 'tracepoint:random:urandom_read { $i = args->got_bits; printf("bits: %d\n", $i); if ($i == 24) { exit() } }'
 EXPECT bits: 24
 TIMEOUT 5
 AFTER dd if=/dev/urandom bs=3 count=1
 
 NAME tracepoint arg casts in predicates
-RUN {{BPFTRACE}} -v -e 'tracepoint:syscalls:sys_enter_wait4 /args->ru/ { @ru[tid] = args->ru; } tracepoint:syscalls:sys_exit_wait4 /@ru[tid]/ { @++; exit(); }' -c ./testprogs/wait4_ru
+RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_enter_wait4 /args->ru/ { @ru[tid] = args->ru; } tracepoint:syscalls:sys_exit_wait4 /@ru[tid]/ { @++; exit(); }' -c ./testprogs/wait4_ru
 EXPECT @: 1
 TIMEOUT 5

--- a/tests/runtime/watchpoint
+++ b/tests/runtime/watchpoint
@@ -1,32 +1,32 @@
 NAME watchpoint - absolute address
-RUN {{BPFTRACE}} -v -e 'watchpoint::0x10000000:8:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint
+RUN {{BPFTRACE}} -e 'watchpoint::0x10000000:8:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint
 EXPECT hit!
 ARCH aarch64|ppc64|ppc64le|x86_64
 TIMEOUT 5
 
 NAME kwatchpoint - knl absolute address
-RUN {{BPFTRACE}} -v -e "watchpoint:0x$(awk '$3 == "jiffies" {print $1}' /proc/kallsyms):4:w { printf(\"hit\n\"); exit(); }"
+RUN {{BPFTRACE}} -e "watchpoint:0x$(awk '$3 == "jiffies" {print $1}' /proc/kallsyms):4:w { printf(\"hit\n\"); exit(); }"
 EXPECT hit
 ARCH aarch64|ppc64|ppc64le|x86_64
 TIMEOUT 5
 REQUIRES awk '$3 == "jiffies" {got=1} END {exit !got}' /proc/kallsyms
 
 NAME function_arg_addr
-RUN {{BPFTRACE}} -v -e 'watchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint_func
+RUN {{BPFTRACE}} -e 'watchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint_func
 EXPECT hit!
 ARCH aarch64|x86_64
 TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME async_function_arg_addr
-RUN {{BPFTRACE}} -v -e 'asyncwatchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint_func
+RUN {{BPFTRACE}} -e 'asyncwatchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint_func
 EXPECT hit!
 ARCH aarch64|x86_64
 TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME function_arg_addr_process_flag
-RUN {{BPFTRACE}} -v -e 'watchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }' -p $(pidof watchpoint_func)
+RUN {{BPFTRACE}} -e 'watchpoint:increment+arg1:4:w { printf("hit!\n"); exit() }' -p $(pidof watchpoint_func)
 BEFORE ./testprogs/watchpoint_func
 EXPECT hit!
 ARCH aarch64|x86_64
@@ -48,21 +48,21 @@ TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME function_multiattach
-RUN {{BPFTRACE}} -v runtime/scripts/watchpoint_multiattach.bt -c ./testprogs/watchpoint_func_wildcard
+RUN {{BPFTRACE}} runtime/scripts/watchpoint_multiattach.bt -c ./testprogs/watchpoint_func_wildcard
 EXPECT count=3
 ARCH aarch64|x86_64
 TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME wildcarded_function
-RUN {{BPFTRACE}} -v -e 'watchpoint:increment_*+arg0:4:w { printf("hit!\n") }' -c ./testprogs/watchpoint_func_wildcard
+RUN {{BPFTRACE}} -e 'watchpoint:increment_*+arg0:4:w { printf("hit!\n") }' -c ./testprogs/watchpoint_func_wildcard
 EXPECT You are out of watchpoint registers
 ARCH aarch64|x86_64
 TIMEOUT 5
 REQUIRES_FEATURE signal
 
 NAME unique_probe_bodies
-RUN {{BPFTRACE}} -v -e 'watchpoint:increment_*+arg0:4:w { printf("%s!\n", probe) }' -c ./testprogs/watchpoint_func_wildcard
+RUN {{BPFTRACE}} -e 'watchpoint:increment_*+arg0:4:w { printf("%s!\n", probe) }' -c ./testprogs/watchpoint_func_wildcard
 EXPECT .*increment_0:4:w!
 ARCH aarch64|x86_64
 TIMEOUT 5


### PR DESCRIPTION
Before, the AFTER directive implicitly required `-v` to be passed to
bpftrace executable. This is hacky bc it's not obvious `-v` was used as
a synchronization mechanism. It also put unnecessary burden on the test
writer to know about `-v` being required.

Commit 2 fixes some bugs the `-v` synchronization covered up. Commit 3
removes `-v` from all the runtime tests.
##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
