### PR TITLE
codegen: Fix crash when attaching to invalid attachpoint

### DIFF
--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -108,12 +108,18 @@ private:
     std::function<void()> deleter_;
   };
 
+  // Generate a probe for `current_attach_point_`
+  //
+  // If `dummy` is passed, then code is generated but immediately thrown away.
+  // This is used to progress state (eg. asyncids) in this class instance for
+  // invalid probes that still need to be visited.
   void generateProbe(Probe &probe,
                      const std::string &full_func_id,
                      const std::string &section_name,
                      FunctionType *func_type,
                      bool expansion,
-                     std::optional<int> usdt_location_index = std::nullopt);
+                     std::optional<int> usdt_location_index = std::nullopt,
+                     bool dummy = false);
 
   [[nodiscard]] ScopedExprDeleter accept(Node *node);
   [[nodiscard]] std::tuple<Value *, ScopedExprDeleter> getMapKey(Map &map);

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -38,3 +38,9 @@ NAME single_arg_wildcard_listing_tracepoint
 RUN {{BPFTRACE}} -l "*sched_switch*"
 EXPECT tracepoint:sched:sched_switch
 TIMEOUT 1
+
+# https://github.com/iovisor/bpftrace/issues/1952
+NAME async_id_invalid_probe_expansion
+RUN {{BPFTRACE}} -e 'kprobe:zzzzz { probe; printf("asdf\n") } BEGIN { printf("_%s_\n", "success"); exit() }'
+EXPECT _success_
+TIMEOUT 1


### PR DESCRIPTION
This commit fixes a crash when attaching to a `need_expansion` probe
with an invalid attachpoint that uses an asyncid helper.

The root cause was that codegen increments the asyncids when visiting
helpers like `printf` and friends. However, if the attachpoint is
invalid (ie. `ProbeMatcher` does not find any attachpoints), then the
visiting is liable to be skipped. Thus, the asyncids are out of sync.
This can result in crashes inside LLVM b/c the types are all messed up.

See attached issue for more info.

This closes #1952 .

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
