### PR TITLE
codegen: Disable LLVM loop unrolling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to
   - [#1881](https://github.com/iovisor/bpftrace/pull/1881)
 
 #### Changed
+- Prevent LLVM from unrolling loops
+  - [#1967](https://github.com/iovisor/bpftrace/pull/1967)
 
 #### Deprecated
 

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -122,6 +122,7 @@ private:
 
   Function *createLog2Function();
   Function *createLinearFunction();
+  MDNode *createLoopMetadata();
 
   void binop_string(Binop &binop);
   void binop_buf(Binop &binop);
@@ -205,6 +206,7 @@ private:
 
   Function *linear_func_ = nullptr;
   Function *log2_func_ = nullptr;
+  MDNode *loop_metadata_ = nullptr;
 
   size_t getStructSize(StructType *s)
   {

--- a/tests/codegen/llvm/basic_while_loop.ll
+++ b/tests/codegen/llvm/basic_while_loop.ll
@@ -22,7 +22,7 @@ while_cond:                                       ; preds = %while_body, %entry
   %3 = icmp sle i64 %2, 150
   %4 = zext i1 %3 to i64
   %true_cond = icmp ne i64 %4, 0
-  br i1 %true_cond, label %while_body, label %while_end
+  br i1 %true_cond, label %while_body, label %while_end, !llvm.loop !0
 
 while_body:                                       ; preds = %while_cond
   %5 = load i64, i64* %"$a", align 8
@@ -54,3 +54,6 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+
+!0 = distinct !{!0, !1}
+!1 = !{!"llvm.loop.unroll.disable"}

--- a/tests/codegen/llvm/nested_while_loop.ll
+++ b/tests/codegen/llvm/nested_while_loop.ll
@@ -27,7 +27,7 @@ while_cond:                                       ; preds = %while_end3, %entry
   %4 = icmp sle i64 %3, 100
   %5 = zext i1 %4 to i64
   %true_cond = icmp ne i64 %5, 0
-  br i1 %true_cond, label %while_body, label %while_end
+  br i1 %true_cond, label %while_body, label %while_end, !llvm.loop !0
 
 while_body:                                       ; preds = %while_cond
   store i64 0, i64* %"$j", align 8
@@ -44,7 +44,7 @@ while_cond1:                                      ; preds = %lookup_merge, %whil
   %9 = icmp sle i64 %8, 100
   %10 = zext i1 %9 to i64
   %true_cond4 = icmp ne i64 %10, 0
-  br i1 %true_cond4, label %while_body2, label %while_end3
+  br i1 %true_cond4, label %while_body2, label %while_end3, !llvm.loop !0
 
 while_body2:                                      ; preds = %while_cond1
   %11 = bitcast i64* %"@_key" to i8*
@@ -98,3 +98,6 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+
+!0 = distinct !{!0, !1}
+!1 = !{!"llvm.loop.unroll.disable"}

--- a/tests/codegen/llvm/while_loop_no_unroll.ll
+++ b/tests/codegen/llvm/while_loop_no_unroll.ll
@@ -1,0 +1,59 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @"interval:s:1"(i8* %0) section "s_interval:s:1_1" {
+entry:
+  %"@_val" = alloca i64, align 8
+  %"@_key" = alloca i64, align 8
+  %"$a" = alloca i64, align 8
+  %1 = bitcast i64* %"$a" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 0, i64* %"$a", align 8
+  store i64 0, i64* %"$a", align 8
+  br label %while_cond
+
+while_cond:                                       ; preds = %while_body, %entry
+  %2 = load i64, i64* %"$a", align 8
+  %3 = icmp sle i64 %2, 10
+  %4 = zext i1 %3 to i64
+  %true_cond = icmp ne i64 %4, 0
+  br i1 %true_cond, label %while_body, label %while_end, !llvm.loop !0
+
+while_body:                                       ; preds = %while_cond
+  %5 = load i64, i64* %"$a", align 8
+  %6 = add i64 %5, 1
+  store i64 %6, i64* %"$a", align 8
+  %7 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i64 0, i64* %"@_key", align 8
+  %8 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 %5, i64* %"@_val", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
+  %9 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  br label %while_cond
+
+while_end:                                        ; preds = %while_cond
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+
+!0 = distinct !{!0, !1}
+!1 = !{!"llvm.loop.unroll.disable"}

--- a/tests/codegen/while_loop_no_unroll.cpp
+++ b/tests/codegen/while_loop_no_unroll.cpp
@@ -1,0 +1,17 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+// Trip counts under 10 are usually unrolled automatically.
+//
+// This tests that the loop isn't unrolled.
+TEST(codegen, while_loop_no_unroll)
+{
+  test("i:s:1 { $a = 0; while ($a <= 10) { @=$a++; }}", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace


### PR DESCRIPTION
B/c of verifier instruction limits, it's better to handle loop unrolling
from bpftrace and not leave it up to LLVM.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
