### PR TITLE
Improve non-existing kprobe error message

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2418,8 +2418,8 @@ void SemanticAnalyser::visit(AttachPoint &ap)
       {
         LOG(WARNING, ap.loc, out_)
             << ap.func
-            << " is not traceable (probably it is inlined or marked as "
-               "\"notrace\"), attaching to it will likely fail";
+            << " is not traceable (either non-existing, inlined, or marked as "
+               "\"notrace\"); attaching to it will likely fail";
       }
     }
   }


### PR DESCRIPTION
The old message seemed to imply it's an existing but untraceable
function. I think in reality, it's more likely the user typos and the
funciton simply does not exist.

Update the message to reflect the most likely case.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
