### PR TITLE
git: ignore ignored/ dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ tests/**/*.bc
 [._]s[a-rt-v][a-z]
 [._]ss[a-gi-z]
 [._]sw[a-p]
+
+ignored/


### PR DESCRIPTION
As the project root dir sync in vagrant it's the easiest place to share
test scripts for testing inside a VM with. This helps to avoid
accidentally committing those

