### PR TITLE
Fix unroll() with async calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to
   - [#1974](https://github.com/iovisor/bpftrace/pull/1974)
 - Fix strncmp() to check for NUL terminator
   - [#1974](https://github.com/iovisor/bpftrace/pull/1974)
+- Fix unroll() with async calls
+  - [#1972](https://github.com/iovisor/bpftrace/pull/1972)
 
 #### Tools
 

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2251,27 +2251,7 @@ void CodegenLLVM::visit(Probe &probe)
      * We begin by saving state that gets changed by the codegen pass, so we
      * can restore it for the next pass (printf_id_, time_id_).
      */
-    int starting_printf_id = printf_id_;
-    int starting_cat_id = cat_id_;
-    int starting_system_id = system_id_;
-    int starting_time_id = time_id_;
-    int starting_strftime_id = strftime_id_;
-    int starting_join_id = join_id_;
-    int starting_helper_error_id = b_.helper_error_id_;
-    int starting_non_map_print_id = non_map_print_id_;
-    int starting_seq_printf_id = seq_printf_id_;
-
-    auto reset_ids = [&]() {
-      printf_id_ = starting_printf_id;
-      cat_id_ = starting_cat_id;
-      system_id_ = starting_system_id;
-      time_id_ = starting_time_id;
-      strftime_id_ = starting_strftime_id;
-      join_id_ = starting_join_id;
-      b_.helper_error_id_ = starting_helper_error_id;
-      non_map_print_id_ = starting_non_map_print_id;
-      seq_printf_id_ = starting_seq_printf_id;
-    };
+    auto reset_ids = create_reset_ids();
 
     for (auto attach_point : *probe.attach_points) {
       current_attach_point_ = attach_point;
@@ -3286,6 +3266,30 @@ void CodegenLLVM::createIncDec(Unop &unop)
   {
     LOG(FATAL) << "invalid expression passed to " << opstr(unop);
   }
+}
+
+std::function<void()> CodegenLLVM::create_reset_ids()
+{
+  return [this,
+          starting_printf_id = this->printf_id_,
+          starting_cat_id = this->cat_id_,
+          starting_system_id = this->system_id_,
+          starting_time_id = this->time_id_,
+          starting_strftime_id = this->strftime_id_,
+          starting_join_id = this->join_id_,
+          starting_helper_error_id = this->b_.helper_error_id_,
+          starting_non_map_print_id = this->non_map_print_id_,
+          starting_seq_printf_id = this->seq_printf_id_] {
+    this->printf_id_ = starting_printf_id;
+    this->cat_id_ = starting_cat_id;
+    this->system_id_ = starting_system_id;
+    this->time_id_ = starting_time_id;
+    this->strftime_id_ = starting_strftime_id;
+    this->join_id_ = starting_join_id;
+    this->b_.helper_error_id_ = starting_helper_error_id;
+    this->non_map_print_id_ = starting_non_map_print_id;
+    this->seq_printf_id_ = starting_seq_printf_id;
+  };
 }
 
 } // namespace ast

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2006,10 +2006,16 @@ void CodegenLLVM::visit(If &if_block)
 void CodegenLLVM::visit(Unroll &unroll)
 {
   for (int i=0; i < unroll.var; i++) {
+    // Make sure to save/restore async ID state b/c we could be processing
+    // the same async calls multiple times.
+    auto reset_ids = create_reset_ids();
+
     for (Statement *stmt : *unroll.stmts)
     {
       auto scoped_del = accept(stmt);
     }
+
+    reset_ids();
   }
 }
 

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <iostream>
 #include <optional>
 #include <ostream>
@@ -176,6 +177,12 @@ private:
                                const std::string &temp_name);
 
   void createIncDec(Unop &unop);
+
+  // Return a lambda that has captured-by-value CodegenLLVM's async id state
+  // (ie `printf_id_`, `seq_printf_id_`, etc.).  Running the returned lambda
+  // will restore `CodegenLLVM`s async id state back to when this function was
+  // first called.
+  std::function<void()> create_reset_ids();
 
   Node *root_ = nullptr;
 

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1895,8 +1895,7 @@ void SemanticAnalyser::visit(Unroll &unroll)
     LOG(ERROR, unroll.loc, err_) << "unroll minimum value is 1";
   }
 
-  for (int i = 0; i < unroll.var; i++)
-    accept_statements(unroll.stmts);
+  accept_statements(unroll.stmts);
 }
 
 void SemanticAnalyser::visit(Jump &jump)

--- a/tests/codegen/llvm/unroll_async_id.ll
+++ b/tests/codegen/llvm/unroll_async_id.ll
@@ -1,0 +1,100 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%printf_t.3 = type { i64 }
+%printf_t.2 = type { i64 }
+%printf_t.1 = type { i64 }
+%printf_t.0 = type { i64 }
+%printf_t = type { i64 }
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @BEGIN(i8* %0) section "s_BEGIN_1" {
+entry:
+  %printf_args11 = alloca %printf_t.3, align 8
+  %printf_args8 = alloca %printf_t.2, align 8
+  %printf_args5 = alloca %printf_t.1, align 8
+  %printf_args2 = alloca %printf_t.0, align 8
+  %printf_args = alloca %printf_t, align 8
+  %"@i_val" = alloca i64, align 8
+  %"@i_key" = alloca i64, align 8
+  %1 = bitcast i64* %"@i_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 0, i64* %"@i_key", align 8
+  %2 = bitcast i64* %"@i_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@i_val", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@i_key", i64* %"@i_val", i64 0)
+  %3 = bitcast i64* %"@i_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
+  %4 = bitcast i64* %"@i_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  %5 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %6, i8 0, i64 8, i1 false)
+  %7 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
+  store i64 0, i64* %7, align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %printf_t* %printf_args, i64 8)
+  %8 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast %printf_t.0* %printf_args2 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %10 = bitcast %printf_t.0* %printf_args2 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %10, i8 0, i64 8, i1 false)
+  %11 = getelementptr %printf_t.0, %printf_t.0* %printf_args2, i32 0, i32 0
+  store i64 0, i64* %11, align 8
+  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output4 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.0*, i64)*)(i8* %0, i64 %pseudo3, i64 4294967295, %printf_t.0* %printf_args2, i64 8)
+  %12 = bitcast %printf_t.0* %printf_args2 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast %printf_t.1* %printf_args5 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %14 = bitcast %printf_t.1* %printf_args5 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %14, i8 0, i64 8, i1 false)
+  %15 = getelementptr %printf_t.1, %printf_t.1* %printf_args5, i32 0, i32 0
+  store i64 0, i64* %15, align 8
+  %pseudo6 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output7 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.1*, i64)*)(i8* %0, i64 %pseudo6, i64 4294967295, %printf_t.1* %printf_args5, i64 8)
+  %16 = bitcast %printf_t.1* %printf_args5 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = bitcast %printf_t.2* %printf_args8 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
+  %18 = bitcast %printf_t.2* %printf_args8 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %18, i8 0, i64 8, i1 false)
+  %19 = getelementptr %printf_t.2, %printf_t.2* %printf_args8, i32 0, i32 0
+  store i64 0, i64* %19, align 8
+  %pseudo9 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output10 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.2*, i64)*)(i8* %0, i64 %pseudo9, i64 4294967295, %printf_t.2* %printf_args8, i64 8)
+  %20 = bitcast %printf_t.2* %printf_args8 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
+  %21 = bitcast %printf_t.3* %printf_args11 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21)
+  %22 = bitcast %printf_t.3* %printf_args11 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %22, i8 0, i64 8, i1 false)
+  %23 = getelementptr %printf_t.3, %printf_t.3* %printf_args11, i32 0, i32 0
+  store i64 0, i64* %23, align 8
+  %pseudo12 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output13 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.3*, i64)*)(i8* %0, i64 %pseudo12, i64 4294967295, %printf_t.3* %printf_args11, i64 8)
+  %24 = bitcast %printf_t.3* %printf_args11 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }

--- a/tests/codegen/unroll_async_id.cpp
+++ b/tests/codegen/unroll_async_id.cpp
@@ -1,0 +1,14 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, unroll_async_id)
+{
+  test(R"(BEGIN { @i = 0; unroll(5) { printf("hi") } })", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace


### PR DESCRIPTION
For example, something like this was broken since commit c66e7ad5719:
```
BEGIN {
  unroll(3) {
    printf("hi\n");
  }
}
```

This issue was discovered when trying out https://github.com/shivashin/bpftrace-2048

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
