### PR TITLE
tests: Remove ntop regression test

### DIFF
--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -23,12 +23,6 @@ RUN {{BPFTRACE}} -e 'BEGIN { @x = 4; printf("%d\n", @x % 2); exit() }'
 EXPECT 0
 TIMEOUT 5
 
-NAME ntop_tracepoint_args
-RUN {{BPFTRACE}} -e 'tracepoint:tcp:tcp_destroy_sock { printf("%s\n", ntop(args->daddr)); exit(); }'
-EXPECT [0-9]+.[0-9]+.[0-9]+.[0-9]+
-AFTER curl -s www.google.com > /dev/null
-TIMEOUT 5
-
 NAME c_array_indexing
 RUN {{BPFTRACE}} -e 'struct Foo { int a; uint8_t b[10]; } uprobe:testprogs/uprobe_test:function2 { $foo = (struct Foo *)arg0; printf("%c %c %c %c %c\n", $foo->b[0], $foo->b[1], $foo->b[2], $foo->b[3], $foo->b[4]) }' -c ./testprogs/uprobe_test
 EXPECT h e l l o


### PR DESCRIPTION
Been very flakely in CI recently. Type::ctx has also been removed a
while ago so what the test was originally testing for is probably not
going to happen again.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
