### PR TITLE
Fix hex literal parsing

### DIFF
--- a/src/ast/int_parser.cpp
+++ b/src/ast/int_parser.cpp
@@ -74,18 +74,18 @@ std::variant<T, std::string> _parse_exp(const std::string &coeff,
 {
   std::stringstream errmsg;
   auto maybe_coeff = _parse_int<T>(coeff, 10);
-  if (auto err = std::get_if<std::string>(&maybe_coeff))
+  if (std::string *err = std::get_if<std::string>(&maybe_coeff))
   {
     errmsg << "Coefficient part of scientific literal is not a valid number: "
-           << coeff << ": " << err;
+           << coeff << ": " << *err;
     return errmsg.str();
   }
 
   auto maybe_exp = _parse_int<T>(exp, 10);
-  if (auto err = std::get_if<std::string>(&maybe_exp))
+  if (std::string *err = std::get_if<std::string>(&maybe_exp))
   {
     errmsg << "Exponent part of scientific literal is not a valid number: "
-           << exp << ": " << err;
+           << exp << ": " << *err;
     return errmsg.str();
   }
 
@@ -133,7 +133,7 @@ T to_int(const std::string &num, int base)
     res = _parse_int<T>(n, base);
   }
 
-  if (auto err = std::get_if<std::string>(&res))
+  if (std::string *err = std::get_if<std::string>(&res))
     throw std::invalid_argument(*err);
   return std::get<T>(res);
 }

--- a/src/ast/int_parser.cpp
+++ b/src/ast/int_parser.cpp
@@ -123,14 +123,23 @@ T to_int(const std::string &num, int base)
 
   std::variant<T, std::string> res;
 
-  auto pos = n.find_first_of("eE");
-  if (pos != std::string::npos)
+  // If hex
+  if ((n.rfind("0x", 0) == 0) || (n.rfind("0X", 0) == 0))
   {
-    res = _parse_exp<T>(n.substr(0, pos), n.substr(pos + 1, std::string::npos));
+    res = _parse_int<T>(n, base);
   }
   else
   {
-    res = _parse_int<T>(n, base);
+    auto pos = n.find_first_of("eE");
+    if (pos != std::string::npos)
+    {
+      res = _parse_exp<T>(n.substr(0, pos),
+                          n.substr(pos + 1, std::string::npos));
+    }
+    else
+    {
+      res = _parse_int<T>(n, base);
+    }
   }
 
   if (std::string *err = std::get_if<std::string>(&res))

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1733,6 +1733,16 @@ TEST(Parser, int_notation)
        "Program\n kprobe:f\n  call: print\n   int: 10000000000\n");
   test("k:f { print(123_456_789_0); }",
        "Program\n kprobe:f\n  call: print\n   int: 1234567890\n");
+  test("k:f { print(0xe5); }",
+       "Program\n kprobe:f\n  call: print\n   int: 229\n");
+  test("k:f { print(0x5e5); }",
+       "Program\n kprobe:f\n  call: print\n   int: 1509\n");
+  test("k:f { print(0xeeee); }",
+       "Program\n kprobe:f\n  call: print\n   int: 61166\n");
+  test("k:f { print(0777); }",
+       "Program\n kprobe:f\n  call: print\n   int: 511\n");
+  test("k:f { print(0123); }",
+       "Program\n kprobe:f\n  call: print\n   int: 83\n");
 
   test("k:f { print(1_000u); }",
        "Program\n kprobe:f\n  call: print\n   int: 1000\n");


### PR DESCRIPTION
Reported on irc:

```
aarents | Hi bpftrace,
aarents | I'm wondering if it is the expected behavior:
aarents | ./bpftrace -e 'BEGIN { $x = 0xe ; exit()}'
aarents | stdin:1:14-17: ERROR: Coefficient part of scientific literal is not a valid number: 0x: 0x7ffd13407fc0
aarents | BEGIN { $x = 0xe ; exit()}
aarents |              ~~~
aarents | It gets scientic coeff instead of getting the hex value ?
```

Now:

```
./src/bpftrace -qe 'BEGIN { $x = 0xe ; print($x); exit()}'
14
```