### PR TITLE
Add invalid_watchpoint_modes function in mips

### DIFF
--- a/src/arch/mips64.cpp
+++ b/src/arch/mips64.cpp
@@ -161,5 +161,11 @@ std::string name()
   return std::string("mips64");
 }
 
+std::vector<std::string> invalid_watchpoint_modes()
+{
+  throw std::runtime_error(
+      "Watchpoints are not supported on this architecture");
+}
+
 } // namespace arch
 } // namespace bpftrace


### PR DESCRIPTION
Currently bpftrace has compilation problems on mips :

/usr/bin/ld: ast/libast.a(semantic_analyser.cpp.o): in function `bpftrace::ast::SemanticAnalyser::visit(bpftrace::ast::AttachPoint&)':
semantic_analyser.cpp:(.text+0xc230): undefined reference to `bpftrace::arch::invalid_watchpoint_modes[abi:cxx11]()'
/usr/bin/ld: semantic_analyser.cpp:(.text+0xc2b8): undefined reference to `bpftrace::arch::invalid_watchpoint_modes[abi:cxx11]()'
/usr/bin/ld: semantic_analyser.cpp:(.text+0xc2c0): undefined reference to `bpftrace::arch::invalid_watchpoint_modes[abi:cxx11]()'
collect2: error: ld returned 1 exit status
make[2]: *** [src/CMakeFiles/bpftrace.dir/build.make:94：src/bpftrace] error 1
make[1]: *** [CMakeFiles/Makefile2:1262：src/CMakeFiles/bpftrace.dir/all] error 2

So add invalid_watchpoint_modes function,  and breakpoint seems not to be supported in mips kernel
##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
