### PR TITLE
Support positional parameters as integer literals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to
   - [#1881](https://github.com/iovisor/bpftrace/pull/1881)
 - Automatic resolution of library paths for uprobes
   - [#1971](https://github.com/iovisor/bpftrace/pull/1971)
+- Support positional parameters as integer literals
+  - [#1982](https://github.com/iovisor/bpftrace/pull/1982)
 
 #### Changed
 - Prevent LLVM from unrolling loops

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -552,7 +552,7 @@ void CodegenLLVM::visit(Call &call)
           cmp, proposed_length, max_length, "length.select");
 
       if (arg.is_literal)
-        fixed_buffer_length = static_cast<Integer &>(arg).n;
+        fixed_buffer_length = *bpftrace_.get_int_literal(&arg);
     }
     else
     {
@@ -985,7 +985,7 @@ void CodegenLLVM::visit(Call &call)
     expr_ = b_.getInt64(call.vargs->at(0)->type.GetSize());
   }
   else if (call.func == "strncmp") {
-    uint64_t size = static_cast<Integer *>(call.vargs->at(2))->n;
+    uint64_t size = (uint64_t)*bpftrace_.get_int_literal(call.vargs->at(2));
     const auto& left_arg = call.vargs->at(0);
     const auto& right_arg = call.vargs->at(1);
     auto left_as = left_arg->type.GetAS();

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -2196,6 +2196,36 @@ std::string BPFtrace::get_string_literal(const ast::Expression *expr) const
   return "";
 }
 
+std::optional<long> BPFtrace::get_int_literal(const ast::Expression *expr) const
+{
+  if (expr->is_literal)
+  {
+    if (auto *integer = dynamic_cast<const ast::Integer *>(expr))
+      return integer->n;
+    else if (auto *pos_param = dynamic_cast<const ast::PositionalParameter *>(
+                 expr))
+    {
+      if (pos_param->ptype == PositionalParameterType::positional)
+      {
+        auto param_str = get_param(pos_param->n, false);
+        if (is_numeric(param_str))
+          return std::stol(param_str);
+        else
+        {
+          LOG(ERROR, pos_param->loc)
+              << "$" << pos_param->n << " used numerically but given \""
+              << param_str << "\"";
+          return std::nullopt;
+        }
+      }
+      else
+        return (long)num_params();
+    }
+  }
+
+  return std::nullopt;
+}
+
 bool BPFtrace::is_traceable_func(const std::string &func_name) const
 {
 #ifdef FUZZ

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -134,6 +134,7 @@ public:
   void request_finalize();
   bool is_aslr_enabled(int pid);
   std::string get_string_literal(const ast::Expression *expr) const;
+  std::optional<long> get_int_literal(const ast::Expression *expr) const;
   std::optional<std::string> get_watchpoint_binary_path() const;
   virtual bool is_traceable_func(const std::string &func_name) const;
 

--- a/tests/runtime/array
+++ b/tests/runtime/array
@@ -135,3 +135,9 @@ RUN {{BPFTRACE}} -e 'uprobe:./testprogs/array_access:test_array { @a[0] = (int32
 EXPECT Result: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
+
+NAME array element access via positional index
+RUN {{BPFTRACE}} -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a->x[$1]; printf("Result: %d\n", $x); exit(); }' 0
+EXPECT Result: 1
+TIMEOUT 5
+AFTER ./testprogs/array_access

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -163,6 +163,34 @@ RUN {{BPFTRACE}} -e 'BEGIN { printf("%s", str($1 + 1)); exit(); }' hello
 EXPECT ello
 TIMEOUT 1
 
+NAME positional strncmp
+RUN {{BPFTRACE}} -e 'BEGIN { if (strncmp("hello", "hell", $1) == 0) { printf("ok\n"); } exit(); }' 3
+EXPECT ok
+TIMEOUT 1
+
+NAME positional lhist
+RUN {{BPFTRACE}} -e 'kretprobe:vfs_read { @bytes = lhist(retval, $1, $2, $3); exit()}' 0 10000 1000
+EXPECT @bytes: *\n[\[(].*
+TIMEOUT 5
+AFTER ./testprogs/syscall read
+
+NAME positional buf
+RUN {{BPFTRACE}} -e 'BEGIN { @ = buf("hello", $1); exit(); }' 5
+EXPECT @: hello
+TIMEOUT 1
+
+NAME positional kstack
+RUN {{BPFTRACE}} -e 'k:do_nanosleep { printf("SUCCESS %s\n%s\n", kstack(), kstack($1)); exit(); }' 1
+EXPECT SUCCESS
+TIMEOUT 5
+AFTER ./testprogs/syscall nanosleep  1e8
+
+NAME positional ustack
+RUN {{BPFTRACE}} -e 'k:do_nanosleep { printf("SUCCESS %s\n%s\n", ustack(), ustack($1)); exit(); }' 1
+EXPECT SUCCESS
+TIMEOUT 5
+AFTER ./testprogs/syscall nanosleep  1e8
+
 NAME lhist can be cleared
 RUN {{BPFTRACE}} -e 'BEGIN{ @[1] = lhist(3,0,10,1); clear(@); exit() }'
 EXPECT .*


### PR DESCRIPTION
In all places where an integer literal is expected, we now also accept an integer positional parameter.
These are namely:
- builtin function calls (`lhist`, `buf`, `signal`, `strncmp`)
- array indices.

Fixes #1980.

Note: the only function that is not supported is `str`, since the solution conflicts with the way `str` currently handles positional parameters.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
