### PR TITLE
build: Improve error message on wrong LLVM version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,8 +164,12 @@ else()
     find_package(LLVM REQUIRED)
   endif()
 
-  if((${LLVM_VERSION_MAJOR} VERSION_LESS 6) OR (${LLVM_VERSION_MAJOR} VERSION_GREATER 12))
-    message(SEND_ERROR "Unsupported LLVM version found: ${LLVM_INCLUDE_DIRS}")
+  set(MIN_LLVM_MAJOR 6)
+  set(MAX_LLVM_MAJOR 12)
+
+  if((${LLVM_VERSION_MAJOR} VERSION_LESS ${MIN_LLVM_MAJOR}) OR (${LLVM_VERSION_MAJOR} VERSION_GREATER ${MAX_LLVM_MAJOR}))
+    message(SEND_ERROR "Unsupported LLVM version found via ${LLVM_INCLUDE_DIRS}: ${LLVM_VERSION_MAJOR}")
+    message(SEND_ERROR "Only versions between ${MIN_LLVM_MAJOR} and ${MAX_LLVM_MAJOR} are supported")
     message(SEND_ERROR "Specify an LLVM major version using LLVM_REQUESTED_VERSION=<major version>")
   endif()
 


### PR DESCRIPTION
Instead of just printing $LLVM_INCLUDE_DIRS, additionally print the
version we found and the allowed versions.

Sample output:

```
CMake Error at CMakeLists.txt:171 (message):
  Unsupported LLVM version found via /usr/include: 13


CMake Error at CMakeLists.txt:172 (message):
  Only versions between 6 and 12 are supported


CMake Error at CMakeLists.txt:173 (message):
  Specify an LLVM major version using LLVM_REQUESTED_VERSION=<major version>

```