### PR TITLE
codegen: Fix interaction with verifier when accessing ctx field twice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,8 @@ and this project adheres to
   - [#1972](https://github.com/iovisor/bpftrace/pull/1972)
 - Fix string comparison codegen
   - [#1979](https://github.com/iovisor/bpftrace/pull/1979)
+- Fix verifier error when accessing same tracepoint field twice
+  - [#2008](https://github.com/iovisor/bpftrace/pull/2008)
 
 #### Tools
 

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -3111,21 +3111,8 @@ void CodegenLLVM::probereadDatastructElem(Value *src_data,
   {
     // Read data onto stack
     AllocaInst *dst = b_.CreateAllocaBPF(elem_type, temp_name);
-    if (data_type.IsCtxAccess())
-    {
-      // Map functions only accept a pointer to a element in the stack
-      // Copy data to avoid the above issue
-      b_.CREATE_MEMCPY_VOLATILE(dst,
-                                b_.CreateIntToPtr(src,
-                                                  dst_type->getPointerTo()),
-                                elem_type.GetSize(),
-                                1);
-    }
-    else
-    {
-      b_.CreateProbeRead(
-          ctx_, dst, elem_type.GetSize(), src, data_type.GetAS(), loc);
-    }
+    b_.CreateProbeRead(
+        ctx_, dst, elem_type.GetSize(), src, data_type.GetAS(), loc);
     expr_ = dst;
     expr_deleter_ = [this, dst]() { b_.CreateLifetimeEnd(dst); };
   }

--- a/tests/codegen/llvm/builtin_ctx_field.ll
+++ b/tests/codegen/llvm/builtin_ctx_field.ll
@@ -103,19 +103,16 @@ entry:
   %43 = add i64 %42, 32
   %44 = bitcast [4 x i8]* %"struct x.e" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %44)
-  %45 = inttoptr i64 %43 to [4 x i8]*
-  %46 = bitcast [4 x i8]* %"struct x.e" to i8*
-  %47 = bitcast [4 x i8]* %45 to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %46, i8* align 1 %47, i64 4, i1 true)
-  %48 = bitcast i64* %"@e_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %48)
+  %probe_read_kernel7 = call i64 inttoptr (i64 113 to i64 ([4 x i8]*, i32, i64)*)([4 x i8]* %"struct x.e", i32 4, i64 %43)
+  %45 = bitcast i64* %"@e_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %45)
   store i64 0, i64* %"@e_key", align 8
-  %pseudo7 = call i64 @llvm.bpf.pseudo(i64 1, i64 4)
-  %update_elem8 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [4 x i8]*, i64)*)(i64 %pseudo7, i64* %"@e_key", [4 x i8]* %"struct x.e", i64 0)
-  %49 = bitcast i64* %"@e_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %49)
-  %50 = bitcast [4 x i8]* %"struct x.e" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %50)
+  %pseudo8 = call i64 @llvm.bpf.pseudo(i64 1, i64 4)
+  %update_elem9 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [4 x i8]*, i64)*)(i64 %pseudo8, i64* %"@e_key", [4 x i8]* %"struct x.e", i64 0)
+  %46 = bitcast i64* %"@e_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %46)
+  %47 = bitcast [4 x i8]* %"struct x.e" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %47)
   ret i64 0
 }
 
@@ -124,9 +121,6 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
-
-; Function Attrs: argmemonly nofree nosync nounwind willreturn
-declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly %0, i8* noalias nocapture readonly %1, i64 %2, i1 immarg %3) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -69,3 +69,10 @@ NAME strncmp with prefix
 RUN {{BPFTRACE}} -e 'BEGIN { if (strncmp("hello", "hell") == 0) { printf("equal"); } else { printf("not equal"); } exit(); }'
 EXPECT not equal
 TIMEOUT 3
+
+# The issue this test catches is the verifier doesn't allow multiple ALU ops on ctx pointer.
+# ctx+const is ok, but ctx+const+const is not ok.
+NAME access ctx struct field twice
+RUN {{BPFTRACE}} -e 'tracepoint:sched:sched_wakeup { if (args->comm == "asdf") { print(args->comm) } exit(); }'
+EXPECT Attaching 1 probe
+TIMEOUT 1


### PR DESCRIPTION
The verifier doesn't like it if we modify the ctx pointer twice before
dereferencing it. In other words, ctx+8 is OK, but ctx+4+4 is NOT.
The reasoning in kernel land is due to interactions w/ socket buffer
(skb) access rewrites. Without this limitation, the kernel may let the
prog write past the end of the skb.

We trip over this issue when accessing the same tracepoint field twice.
LLVM decides to save ctx+8 in a temporary register and reuse the value
when indexing into the struct in the unrolled memcpy loop.

Fix this issue by using bpf_probe_read_*() so that we only modify the
ctx pointer once.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
