### PR TITLE
Fix misaligned stack access for map keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to
   - [#2008](https://github.com/iovisor/bpftrace/pull/2008)
 - Fix reading too many bits for <64 bit kfunc args
   - [#2014](https://github.com/iovisor/bpftrace/pull/2014)
+- Fix misaligned stack access for map keys
+  - [#2012](https://github.com/iovisor/bpftrace/pull/2012)
 
 #### Tools
 

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1218,5 +1218,16 @@ void IRBuilderBPF::CreateSeqPrintf(Value *ctx,
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_seq_printf, loc);
 }
 
+StoreInst *IRBuilderBPF::createAlignedStore(Value *val,
+                                            Value *ptr,
+                                            unsigned int align)
+{
+#if LLVM_VERSION_MAJOR < 10
+  return CreateAlignedStore(val, ptr, align);
+#else
+  return CreateAlignedStore(val, ptr, MaybeAlign(align));
+#endif
+}
+
 } // namespace ast
 } // namespace bpftrace

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -144,6 +144,8 @@ public:
                        AllocaInst *data,
                        Value *data_len,
                        const location &loc);
+
+  StoreInst *createAlignedStore(Value *val, Value *ptr, unsigned align);
   // moves the insertion point to the start of the function you're inside,
   // invokes functor, then moves the insertion point back to its original
   // position. this enables you to emit instructions at the start of your

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -124,6 +124,9 @@ private:
 
   [[nodiscard]] ScopedExprDeleter accept(Node *node);
   [[nodiscard]] std::tuple<Value *, ScopedExprDeleter> getMapKey(Map &map);
+  AllocaInst *getMultiMapKey(Map &map,
+                             const std::vector<Value *> &extra_keys,
+                             size_t extra_keys_size);
 
   void compareStructure(SizedType &our_type, llvm::Type *llvm_type);
 

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -71,6 +71,16 @@ RUN {{BPFTRACE}} -e 'i:ms:100 { @[buf("ok_key", 6)] = 1; exit(); }'
 EXPECT @\[ok_key\]: 1
 TIMEOUT 5
 
+NAME buf_map_multikey
+RUN {{BPFTRACE}} -e 'BEGIN { @[buf("ok_key", 8), 1] = hist(1); exit(); }'
+EXPECT @\[ok_key\\x00\\x00\, 1]
+TIMEOUT 5
+
+NAME buf_hist_map_key
+RUN {{BPFTRACE}} -e 'BEGIN { @[buf("ok_key", 8)] = hist(1); exit(); }'
+EXPECT @\[ok_key\\x00\\x00\]
+TIMEOUT 5
+
 NAME buf_map_value
 RUN {{BPFTRACE}} -e 'i:ms:100 { @ = buf("ok_value", 8); exit(); }'
 EXPECT @: ok_value


### PR DESCRIPTION
Using multi-value keys with one component not aligned to 8 bytes (e.g. by using `buf`) may cause misaligned stack access errors. This is because scalar components of keys (e.g. those of `int` type) are stored onto stack with 8-byte alignment.

The simplest fix is to change the alignment to 1. Hopefully, this shouldn't cause any trouble since we read the keys byte-by-byte anyways.

Fixes #2006.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
