### PR TITLE
Improve docs for the buf builtin function

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -2161,7 +2161,6 @@ Tracing block I/O sizes > 0 bytes
 - `time(char *fmt)` - Print formatted time
 - `join(char *arr[] [, char *delim])` - Print the array
 - `str(char *s [, int length])` - Returns the string pointed to by s
-- `buf(void *d [, int length])` - Returns a hex-formatted string of the data pointed to by d
 - `ksym(void *p)` - Resolve kernel address
 - `usym(void *p)` - Resolve user space address
 - `kaddr(char *name)` - Resolve kernel symbol name
@@ -2177,7 +2176,7 @@ Tracing block I/O sizes > 0 bytes
 - `signal(char[] signal | u32 signal)` - Send a signal to the current task
 - `strncmp(char *s1, char *s2, int length)` - Compare first n characters of two strings
 - `override(u64 rc)` - Override return value
-- `buf(void *d [, length])` - Hex-format a buffer
+- `buf(void *d [, int length])` - Returns a hex-formatted string of the data pointed to by d
 - `sizeof(...)` - Return size of a type or expression
 - `print(...)` - Print a non-map value with default formatting
 - `strftime(char *format, int nsecs)` - Return a formatted timestamp
@@ -2876,6 +2875,9 @@ Returns a hex-formatted string of the data pointed to by `d` that is safe to pri
 length of the buffer cannot always be inferred, the `length` parameter may be provided to
 limit the number of bytes that are read. By default, the maximum number of bytes is 64, but this can
 be tuned using the [`BPFTRACE_STRLEN`](#91-bpftrace_strlen) environment variable.
+
+Bytes with values >=32 and <=126 are printed using their ASCII character, other
+bytes are printed in hex form (e.g. `\x00`).
 
 For example, we can take the `buff` parameter (`void *`) of `sys_enter_sendto`, read the
 number of bytes specified by `len` (`size_t`), and format the bytes in hexadecimal so that

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1249,6 +1249,8 @@ For arrays the `length` is optional, it is automatically inferred from the signa
 
 The `buf_t` object returned by `buf` can safely be printed as a hex encoded string with the `%r` format specifier.
 
+Bytes with values >=32 and \<=126 are printed using their ASCII character, other bytes are printed in hex form (e.g. `\x00`).
+
 ----
 i:s:1 {
   printf("%r\n", buf(kaddr("avenrun"), 8));


### PR DESCRIPTION
`buf` prints ASCII character for bytes >=32 and <=126, otherwise it prints hex representation. 

This may be confusing for users (see #2009) so it should be at least documented.

But the question here is: is this a desired behaviour? Shouldn't we allow to print *all bytes* in the hex form? 
Perhaps we could allow both behaviours by adding one more `printf` specifier.

@fbs, @danobi what do you think?

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
