### PR TITLE
codegen: kfunc: Read correct sized argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to
   - [#1979](https://github.com/iovisor/bpftrace/pull/1979)
 - Fix verifier error when accessing same tracepoint field twice
   - [#2008](https://github.com/iovisor/bpftrace/pull/2008)
+- Fix reading too many bits for <64 bit kfunc args
+  - [#2014](https://github.com/iovisor/bpftrace/pull/2014)
 
 #### Tools
 

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1054,8 +1054,9 @@ Value *IRBuilderBPF::CreatKFuncArg(Value *ctx,
                                    SizedType &type,
                                    std::string &name)
 {
+  assert(type.IsIntTy() || type.IsPtrTy());
   ctx = CreatePointerCast(ctx, getInt64Ty()->getPointerTo());
-  Value *expr = CreateLoad(getInt64Ty(),
+  Value *expr = CreateLoad(GetType(type),
                            CreateGEP(ctx, getInt64(type.kfarg_idx)),
                            name);
 


### PR DESCRIPTION
Before, we were always reading 64 bits for the arg. The arg does not
_have_ to be 64 bits wide, it can also be 32 bits wide for example. If
it's 32 bits, the upper 32 bits are junk, so reading it is not ok.

Fix by reading the correct size integer.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
