### PR TITLE
Update Fedora build instruction

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -296,7 +296,8 @@ sudo dnf install -y bison \
   libbpf-devel \
   gtest-devel \
   gmock-devel \
-  cereal-devel
+  cereal-devel \
+  asciidoctor
 git clone https://github.com/iovisor/bpftrace
 cd bpftrace
 mkdir build; cd build; cmake -DCMAKE_BUILD_TYPE=Release ..


### PR DESCRIPTION
`asciidoctor` is needed for build, but its installation is missing from Fedora build instruction.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
