### PR TITLE
Stop warnings about variables only used in assert statements

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -122,7 +122,7 @@ void StdioSilencer::silence()
   assert(old_stdio_ >= 0);
   int new_stdio_ = open("/dev/null", O_WRONLY);
   assert(new_stdio_ >= 0);
-  int ret = dup2(new_stdio_, fd);
+  [[maybe_unused]] int ret = dup2(new_stdio_, fd);
   assert(ret >= 0);
   close(new_stdio_);
 }
@@ -134,7 +134,7 @@ StdioSilencer::~StdioSilencer()
     fflush(ofile);
     int fd = fileno(ofile);
     assert(fd >= 0);
-    int ret = dup2(old_stdio_, fd);
+    [[maybe_unused]] int ret = dup2(old_stdio_, fd);
     assert(ret >= 0);
     close(old_stdio_);
     old_stdio_ = -1;


### PR DESCRIPTION
Release builds were emitting warnings about unused variables when a
variable was only used in an assert statement. For example:

```cpp
int res = // ...
assert(res >= 0);
```

C++17 has a nice [[maybe_unused]] attribute which we can use here to
silence the warning.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
