### PR TITLE
aot: completely remove dependency on LLVM

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -121,7 +121,7 @@ if(STATIC_LINKING)
 endif(STATIC_LINKING)
 
 
-target_link_libraries(libbpftrace parser resources runtime aot ast arch)
+target_link_libraries(libbpftrace parser resources runtime aot ast arch cxxdemangler_llvm)
 
 if (LIBBPF_BTF_DUMP_FOUND)
   target_include_directories(runtime PUBLIC ${LIBBPF_INCLUDE_DIRS})
@@ -210,3 +210,4 @@ unset(BPFTRACE)
 add_subdirectory(aot)
 add_subdirectory(arch)
 add_subdirectory(ast)
+add_subdirectory(cxxdemangler)

--- a/src/aot/CMakeLists.txt
+++ b/src/aot/CMakeLists.txt
@@ -9,12 +9,8 @@ if(NOT LIBBCC_BPF_CONTAINS_RUNTIME)
   return()
 endif()
 
-# TODO(dxu): remove LLVM requirement
-# Currently the only LLVM API the runtime uses is llvm::itaniumDemangle()
-find_package(LLVM REQUIRED CONFIG)
-
 add_executable(bpftrace-aotrt aot_main.cpp)
-target_link_libraries(bpftrace-aotrt aot runtime arch ast_defs LLVMDemangle LLVMSupport)
+target_link_libraries(bpftrace-aotrt aot runtime arch ast_defs cxxdemangler_stdlib)
 install(TARGETS bpftrace-aotrt DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 # Linking

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(ast_defs ast.cpp)
 
 add_library(ast
+  async_event_types.cpp
   attachpoint_parser.cpp
   int_parser.cpp
   irbuilderbpf.cpp

--- a/src/ast/async_event_types.cpp
+++ b/src/ast/async_event_types.cpp
@@ -1,0 +1,90 @@
+#include "async_event_types.h"
+
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Type.h>
+
+#include "irbuilderbpf.h"
+
+namespace bpftrace {
+namespace AsyncEvent {
+
+std::vector<llvm::Type*> Print::asLLVMType(ast::IRBuilderBPF& b)
+{
+  return {
+    b.getInt64Ty(), // asyncid
+    b.getInt32Ty(), // map id
+    b.getInt32Ty(), // top
+    b.getInt32Ty(), // div
+  };
+}
+
+std::vector<llvm::Type*> PrintNonMap::asLLVMType(ast::IRBuilderBPF& b,
+                                                 size_t size)
+{
+  return {
+    b.getInt64Ty(),                            // asyncid
+    b.getInt64Ty(),                            // print id
+    llvm::ArrayType::get(b.getInt8Ty(), size), // content
+  };
+}
+
+std::vector<llvm::Type*> MapEvent::asLLVMType(ast::IRBuilderBPF& b)
+{
+  return {
+    b.getInt64Ty(), // asyncid
+    b.getInt32Ty(), // map id
+  };
+}
+
+std::vector<llvm::Type*> Time::asLLVMType(ast::IRBuilderBPF& b)
+{
+  return {
+    b.getInt64Ty(), // asyncid
+    b.getInt32Ty(), // time id
+  };
+}
+
+std::vector<llvm::Type*> Strftime::asLLVMType(ast::IRBuilderBPF& b)
+{
+  return {
+    b.getInt64Ty(), // strftime id
+    b.getInt64Ty(), // strftime arg, time elapsed since boot
+  };
+}
+
+std::vector<llvm::Type*> Buf::asLLVMType(ast::IRBuilderBPF& b, size_t length)
+{
+  return {
+    b.getInt8Ty(),                               // buffer length
+    llvm::ArrayType::get(b.getInt8Ty(), length), // buffer content
+  };
+}
+
+std::vector<llvm::Type*> HelperError::asLLVMType(ast::IRBuilderBPF& b)
+{
+  return {
+    b.getInt64Ty(), // asyncid
+    b.getInt64Ty(), // error_id
+    b.getInt32Ty(), // return value
+  };
+}
+
+std::vector<llvm::Type*> Watchpoint::asLLVMType(ast::IRBuilderBPF& b)
+{
+  return {
+    b.getInt64Ty(), // asyncid
+    b.getInt64Ty(), // watchpoint_idx
+    b.getInt64Ty(), // addr
+  };
+}
+
+std::vector<llvm::Type*> WatchpointUnwatch::asLLVMType(ast::IRBuilderBPF& b)
+{
+  return {
+    b.getInt64Ty(), // asyncid
+    b.getInt64Ty(), // addr
+  };
+}
+
+} // namespace AsyncEvent
+} // namespace bpftrace

--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -1,14 +1,28 @@
 #pragma once
 
-#include "irbuilderbpf.h"
+#include <cstddef>
 #include <cstdint>
-#include <llvm/IR/IRBuilder.h>
-#include <llvm/IR/Type.h>
+#include <vector>
+
+// Forward declare some LLVM types here. We do not #include any LLVM
+// headers b/c that will pull in LLVM's ABI checking machinery. We want
+// this header to be independent of LLVM during link time so that AOT
+// does not need to link against LLVM.
+namespace llvm {
+class Type;
+} // namespace llvm
+namespace bpftrace {
+namespace ast {
+class IRBuilderBPF;
+} // namespace ast
+} // namespace bpftrace
 
 /*
-  The main goal here is to keep the struct definitions close to each other,
-  making it easier to spot type mismatches.
-*/
+ * The main goal here is to keep the struct definitions close to each other,
+ * making it easier to spot type mismatches.
+ *
+ * If you update a type, remember to update the .cpp too!
+ */
 
 namespace bpftrace {
 namespace AsyncEvent {
@@ -20,15 +34,7 @@ struct Print
   uint32_t top;
   uint32_t div;
 
-  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b)
-  {
-    return {
-      b.getInt64Ty(), // asyncid
-      b.getInt32Ty(), // map id
-      b.getInt32Ty(), // top
-      b.getInt32Ty(), // div
-    };
-  }
+  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b);
 } __attribute__((packed));
 
 struct PrintNonMap
@@ -38,14 +44,7 @@ struct PrintNonMap
   // See below why we don't use a flexible length array
   uint8_t content[0];
 
-  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b, size_t size)
-  {
-    return {
-      b.getInt64Ty(),                            // asyncid
-      b.getInt64Ty(),                            // print id
-      llvm::ArrayType::get(b.getInt8Ty(), size), // content
-    };
-  }
+  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b, size_t size);
 } __attribute__((packed));
 
 struct MapEvent
@@ -53,13 +52,7 @@ struct MapEvent
   uint64_t action_id;
   uint32_t mapid;
 
-  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b)
-  {
-    return {
-      b.getInt64Ty(), // asyncid
-      b.getInt32Ty(), // map id
-    };
-  }
+  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b);
 } __attribute__((packed));
 
 struct Time
@@ -67,13 +60,7 @@ struct Time
   uint64_t action_id;
   uint32_t time_id;
 
-  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b)
-  {
-    return {
-      b.getInt64Ty(), // asyncid
-      b.getInt32Ty(), // time id
-    };
-  }
+  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b);
 } __attribute__((packed));
 
 struct Strftime
@@ -81,13 +68,7 @@ struct Strftime
   uint64_t strftime_id;
   uint64_t nsecs_since_boot;
 
-  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b)
-  {
-    return {
-      b.getInt64Ty(), // strftime id
-      b.getInt64Ty(), // strftime arg, time elapsed since boot
-    };
-  }
+  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b);
 } __attribute__((packed));
 
 struct Buf
@@ -99,13 +80,7 @@ struct Buf
   // the issue doesn't exist in GCC 7.5.x.
   char content[0];
 
-  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b, size_t length)
-  {
-    return {
-      b.getInt8Ty(),                               // buffer length
-      llvm::ArrayType::get(b.getInt8Ty(), length), // buffer content
-    };
-  }
+  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b, size_t length);
 } __attribute__((packed));
 
 struct HelperError
@@ -114,14 +89,7 @@ struct HelperError
   uint64_t error_id;
   int32_t return_value;
 
-  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b)
-  {
-    return {
-      b.getInt64Ty(), // asyncid
-      b.getInt64Ty(), // error_id
-      b.getInt32Ty(), // return value
-    };
-  }
+  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b);
 } __attribute__((packed));
 
 struct Watchpoint
@@ -130,14 +98,7 @@ struct Watchpoint
   uint64_t watchpoint_idx;
   uint64_t addr;
 
-  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b)
-  {
-    return {
-      b.getInt64Ty(), // asyncid
-      b.getInt64Ty(), // watchpoint_idx
-      b.getInt64Ty(), // addr
-    };
-  }
+  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b);
 } __attribute__((packed));
 
 struct WatchpointUnwatch
@@ -145,13 +106,7 @@ struct WatchpointUnwatch
   uint64_t action_id;
   uint64_t addr;
 
-  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b)
-  {
-    return {
-      b.getInt64Ty(), // asyncid
-      b.getInt64Ty(), // addr
-    };
-  }
+  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b);
 } __attribute__((packed));
 
 } // namespace AsyncEvent

--- a/src/cxxdemangler/CMakeLists.txt
+++ b/src/cxxdemangler/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_library(cxxdemangler_stdlib cxxdemangler_stdlib.cpp)
+add_library(cxxdemangler_llvm cxxdemangler_llvm.cpp)

--- a/src/cxxdemangler/cxxdemangler.h
+++ b/src/cxxdemangler/cxxdemangler.h
@@ -1,0 +1,10 @@
+#pragma once
+
+namespace bpftrace {
+
+// Demangle a mangled C++ symbol name
+//
+// Note: callee `free()`ed
+char* cxxdemangle(const char* mangled);
+
+} // namespace bpftrace

--- a/src/cxxdemangler/cxxdemangler_llvm.cpp
+++ b/src/cxxdemangler/cxxdemangler_llvm.cpp
@@ -1,0 +1,12 @@
+#include "cxxdemangler.h"
+
+#include <llvm/Demangle/Demangle.h>
+
+namespace bpftrace {
+
+char* cxxdemangle(const char* mangled)
+{
+  return llvm::itaniumDemangle(mangled, nullptr, nullptr, nullptr);
+}
+
+} // namespace bpftrace

--- a/src/cxxdemangler/cxxdemangler_stdlib.cpp
+++ b/src/cxxdemangler/cxxdemangler_stdlib.cpp
@@ -1,0 +1,12 @@
+#include "cxxdemangler.h"
+
+#include <cxxabi.h>
+
+namespace bpftrace {
+
+char* cxxdemangle(const char* mangled)
+{
+  return abi::__cxa_demangle(mangled, nullptr, nullptr, nullptr);
+}
+
+} // namespace bpftrace

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -7,14 +7,13 @@
 #include <vector>
 
 #include "bpftrace.h"
+#include "cxxdemangler/cxxdemangler.h"
 #include "dwarf_parser.h"
 #include "log.h"
 #include "probe_matcher.h"
 #include "utils.h"
 
 #include <bcc/bcc_syms.h>
-
-#include <llvm/Demangle/Demangle.h>
 
 #ifdef HAVE_BCC_ELF_FOREACH_SYM
 #include <bcc/bcc_elf.h>
@@ -87,8 +86,7 @@ std::set<std::string> ProbeMatcher::get_matches_in_stream(
                         : "";
       if (symbol_has_cpp_mangled_signature(fun_line))
       {
-        char* demangled_name = llvm::itaniumDemangle(
-            fun_line.c_str(), nullptr, nullptr, nullptr);
+        char* demangled_name = cxxdemangle(fun_line.c_str());
         if (demangled_name)
         {
           if (!wildcard_match(prefix + demangled_name, tokens, true, true))


### PR DESCRIPTION
After this PR, the AOT runtime is completely free of LLVM at the binary
artifact level.

See individual commits for more details.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
