### PR TITLE
Type resolution from DWARF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
   - [#2147](https://github.com/iovisor/bpftrace/pull/2147)
 - Improve include paths resolution
   - [#2149](https://github.com/iovisor/bpftrace/pull/2149)
+- Automatic type resolution from DWARF
+  - [#2034](https://github.com/iovisor/bpftrace/pull/2034)
 - Add builtin function: `bswap`
   - [#2166](https://github.com/iovisor/bpftrace/pull/2166)
 

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1193,8 +1193,7 @@ Syntax:
 uprobe: args->NAME
 ```
 
-The arguments can be accessed by dereferencing `args` and accessing the argument's `NAME`. Currently, only
-simple types (integer, char, bool, enum) and pointers to them are supported.
+The arguments can be accessed by dereferencing `args` and accessing the argument's `NAME`.
 
 The list of function's arguments can be retrieved using the verbose list option:
 ```

--- a/src/ast/passes/field_analyser.h
+++ b/src/ast/passes/field_analyser.h
@@ -38,11 +38,13 @@ public:
 private:
   bool resolve_args(Probe &probe);
   bool compare_args(const ProbeArgs &args1, const ProbeArgs &args2);
+  void resolve_fields(SizedType &type);
 
   Node *root_;
   ProbeType probe_type_;
   std::string attach_func_;
   std::string    type_;
+  SizedType sized_type_;
   BPFtrace      &bpftrace_;
   bpf_prog_type  prog_type_;
   bool           has_builtin_args_;
@@ -52,7 +54,7 @@ private:
   std::ostringstream  err_;
 
   ProbeArgs ap_args_;
-  std::map<std::string, std::string> var_types_;
+  std::map<std::string, std::pair<std::string, SizedType>> var_types_;
 };
 
 } // namespace ast

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -2243,7 +2243,8 @@ Dwarf *BPFtrace::get_dwarf(const std::string &filename)
   auto dwarf = dwarves_.find(filename);
   if (dwarf == dwarves_.end())
   {
-    dwarf = dwarves_.emplace(filename, Dwarf::GetFromBinary(filename)).first;
+    dwarf =
+        dwarves_.emplace(filename, Dwarf::GetFromBinary(this, filename)).first;
   }
   return dwarf->second.get();
 }

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -565,7 +565,14 @@ bool ClangParser::visit_children(CXCursor &cursor, BPFtrace &bpftrace)
 
           // Initialize a new record type if needed
           if (!structs.Has(ptypestr))
-            structs.Add(ptypestr, ptypesize);
+            structs.Add(ptypestr, ptypesize, false);
+
+          auto str = structs.Lookup(ptypestr).lock();
+          if (str->allow_override)
+          {
+            str->ClearFields();
+            str->allow_override = false;
+          }
 
           // No need to worry about redefined types b/c we should have already
           // checked clang diagnostics. The diagnostics will tell us if we have

--- a/src/dwarf_parser.h
+++ b/src/dwarf_parser.h
@@ -27,6 +27,9 @@ public:
       const std::string &function) const;
   ProbeArgs resolve_args(const std::string &function);
 
+  SizedType get_stype(const std::string &type_name) const;
+  void resolve_fields(const SizedType &type) const;
+
 private:
   Dwarf(BPFtrace *bpftrace, const std::string &file_path);
 
@@ -36,6 +39,9 @@ private:
   Dwarf_Word get_type_encoding(Dwarf_Die &type_die) const;
   std::optional<Dwarf_Die> find_type(const std::string &name) const;
   static ssize_t get_array_size(Dwarf_Die &subrange_die);
+  static ssize_t get_field_offset(Dwarf_Die &field_die);
+
+  SizedType get_stype(Dwarf_Die &type_die, bool resolve_structs = true) const;
 
   static std::optional<Dwarf_Die> get_child_with_tagname(
       Dwarf_Die *die,
@@ -43,8 +49,6 @@ private:
       const std::string &name);
   static std::vector<Dwarf_Die> get_all_children_with_tag(Dwarf_Die *die,
                                                           int tag);
-
-  SizedType get_stype(Dwarf_Die &type_die) const;
 
   Dwfl *dwfl = nullptr;
   Dwfl_Callbacks callbacks;
@@ -87,6 +91,16 @@ public:
   ProbeArgs resolve_args(const std::string &function __attribute__((unused)))
   {
     return {};
+  }
+
+  SizedType get_stype(const std::string &type_name
+                      __attribute__((unused))) const
+  {
+    return CreateNone();
+  }
+
+  void resolve_fields(const SizedType &type __attribute__((unused))) const
+  {
   }
 };
 

--- a/src/dwarf_parser.h
+++ b/src/dwarf_parser.h
@@ -35,6 +35,7 @@ private:
   std::string get_type_name(Dwarf_Die &type_die) const;
   Dwarf_Word get_type_encoding(Dwarf_Die &type_die) const;
   std::optional<Dwarf_Die> find_type(const std::string &name) const;
+  static ssize_t get_array_size(Dwarf_Die &subrange_die);
 
   static std::optional<Dwarf_Die> get_child_with_tagname(
       Dwarf_Die *die,

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -411,7 +411,7 @@ FuncParamLists ProbeMatcher::get_uprobe_params(
   {
     std::string fun = match;
     std::string path = erase_prefix(fun);
-    auto dwarf = Dwarf::GetFromBinary(path);
+    auto dwarf = Dwarf::GetFromBinary(nullptr, path);
     if (dwarf)
       params.emplace(match, dwarf->get_function_params(fun));
     else

--- a/src/struct.cpp
+++ b/src/struct.cpp
@@ -113,12 +113,24 @@ void Struct::AddField(const std::string &field_name,
                                .is_data_loc = is_data_loc });
 }
 
-void StructManager::Add(const std::string &name, size_t size)
+bool Struct::HasFields() const
+{
+  return !fields.empty();
+}
+
+void Struct::ClearFields()
+{
+  fields.clear();
+}
+
+void StructManager::Add(const std::string &name,
+                        size_t size,
+                        bool allow_override)
 {
   if (struct_map_.find(name) != struct_map_.end())
     throw std::runtime_error("Type redefinition: type with name \'" + name +
                              "\' already exists");
-  struct_map_[name] = std::make_unique<Struct>(size);
+  struct_map_[name] = std::make_unique<Struct>(size, allow_override);
 }
 
 std::weak_ptr<Struct> StructManager::Lookup(const std::string &name) const
@@ -128,9 +140,11 @@ std::weak_ptr<Struct> StructManager::Lookup(const std::string &name) const
 }
 
 std::weak_ptr<Struct> StructManager::LookupOrAdd(const std::string &name,
-                                                 size_t size)
+                                                 size_t size,
+                                                 bool allow_override)
 {
-  auto s = struct_map_.insert({ name, std::make_unique<Struct>(size) });
+  auto s = struct_map_.insert(
+      { name, std::make_unique<Struct>(size, allow_override) });
   return s.first->second;
 }
 

--- a/src/struct.h
+++ b/src/struct.h
@@ -73,8 +73,11 @@ struct Struct
   bool padded = false;
   Fields fields;
 
+  bool allow_override = true;
+
   Struct() = default;
-  explicit Struct(int size) : size(size)
+  explicit Struct(int size, bool allow_override = true)
+      : size(size), allow_override(allow_override)
   {
   }
 
@@ -86,6 +89,8 @@ struct Struct
                 bool is_bitfield,
                 const Bitfield &bitfield,
                 bool is_data_loc);
+  bool HasFields() const;
+  void ClearFields();
 
   static std::unique_ptr<Struct> CreateTuple(std::vector<SizedType> fields);
   void Dump(std::ostream &os);
@@ -148,9 +153,11 @@ class StructManager
 {
 public:
   // struct map manipulation
-  void Add(const std::string &name, size_t size);
+  void Add(const std::string &name, size_t size, bool allow_override = true);
   std::weak_ptr<Struct> Lookup(const std::string &name) const;
-  std::weak_ptr<Struct> LookupOrAdd(const std::string &name, size_t size);
+  std::weak_ptr<Struct> LookupOrAdd(const std::string &name,
+                                    size_t size,
+                                    bool allow_override = true);
   bool Has(const std::string &name) const;
 
   // tuples set manipulation

--- a/tests/runtime/dwarf
+++ b/tests/runtime/dwarf
@@ -10,7 +10,7 @@ EXPECT int\* n
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 
-NAME list uprobe args - pointer type
+NAME list uprobe args - struct pointer type
 RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test:function2'
 EXPECT struct Foo\* foo1
 REQUIRES_FEATURE dwarf
@@ -26,6 +26,41 @@ BEFORE ./testprogs/uprobe_test
 NAME uprobe arg by name - pointer
 PROG uprobe:./testprogs/uprobe_test:function1 { printf("n = %d\n", *(args->n)); exit(); }
 EXPECT n = 13
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+
+NAME uprobe arg by name - struct
+PROG uprobe:./testprogs/uprobe_test:function2 { printf("foo1->a = %d\n", args->foo1->a); exit(); }
+EXPECT foo1->a = 123
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+
+NAME struct field string
+PROG uprobe:./testprogs/uprobe_test:function2 { printf("foo1->b = %s\n", args->foo1->b); exit(); }
+EXPECT foo1->b = hello
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+
+NAME struct field array
+PROG uprobe:./testprogs/uprobe_test:function2 { print(args->foo1->c); exit(); }
+EXPECT \[1,2,3\]
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+
+NAME cast to struct
+PROG uprobe:./testprogs/uprobe_test:function2 { printf("foo1->a = %d\n", ((struct Foo *)arg0)->a); exit(); }
+EXPECT foo1->a = 123
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+
+NAME struct override
+PROG struct Foo { int b; } uprobe:./testprogs/uprobe_test:function2 { printf("foo1->b = %d\n", ((struct Foo *)arg0)->b); exit(); }
+EXPECT foo1->b = 123
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test

--- a/tests/testprogs/uprobe_test.c
+++ b/tests/testprogs/uprobe_test.c
@@ -9,6 +9,7 @@ struct Foo
 {
   int a;
   char b[10];
+  int c[3];
 };
 
 int function1(int *n, char c __attribute__((unused)))
@@ -29,8 +30,8 @@ int main(int argc __attribute__((unused)), char **argv __attribute__((unused)))
   char c = 'x';
   function1(&n, c);
 
-  struct Foo foo1 = { .a = 123, .b = "hello" };
-  struct Foo foo2 = { .a = 456, .b = "world" };
+  struct Foo foo1 = { .a = 123, .b = "hello", .c = { 1, 2, 3 } };
+  struct Foo foo2 = { .a = 456, .b = "world", .c = { 4, 5, 6 } };
   function2(&foo1, &foo2);
 
   return 0;


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

When tracing userspace programs, this extension automatically resolves types from DWARF (if it is available). This has mostly 2 advantages:
- bpftrace program doesn't need to define the types (or include the headers) used in the traced binary
- uprobe arguments of struct type can be accessed by name

Version 2:
Parsing of structure types from DWARF is done in `FieldAnalyser`, which directly fills structs in `StructManager`. `ClangParser` may override these types if user defined some custom types or included some headers.

Version 1 (abandoned):
Since we're relying on Clang parser to do the actual type resolution, we need to dump types from DWARF into compilable C format. Even though there probably exist libraries that can do this (e.g. libdwarves), I decided to implement this by hand, to have more control over the supported types and to avoid yet another dependency.
We now have two sources of type information - BTF and DWARF. To avoid potential collisions, for now we use DWARF for userspace tracing and BTF for kernel tracing.

I also believe that this resolves #1742.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
