### PR TITLE
Allow resizing empty string assigned to a map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to
 #### Changed
 - Prevent LLVM from unrolling loops
   - [#1967](https://github.com/iovisor/bpftrace/pull/1967)
+- Allow resizing empty string assigned to a map
+  - [#2036](https://github.com/iovisor/bpftrace/pull/2036)
 
 #### Deprecated
 

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -99,9 +99,10 @@ private:
 
   SizedType *get_map_type(const Map &map);
   void assign_map_type(const Map &map, const SizedType &type);
-  void update_assign_map_type(const Map &map,
+  bool update_assign_map_type(const Map &map,
                               SizedType &type,
                               const SizedType &new_type);
+  bool update_expr_assigned_to_map(const SizedType &map_type, Expression *expr);
 
   void builtin_args_tracepoint(AttachPoint *attach_point, Builtin &builtin);
   ProbeType single_provider_type(void);

--- a/src/types.h
+++ b/src/types.h
@@ -112,6 +112,8 @@ public:
 
 private:
   size_t size_ = -1; // in bytes
+  size_t real_size_ = -1; // used for string literals to store the actual size
+                          // of the literal
   bool is_signed_ = false;
   std::shared_ptr<SizedType> element_type_; // for "container" and pointer
                                             // (like) types
@@ -218,6 +220,16 @@ public:
              size == 64);
       size_bits_ = size * 8;
     }
+  }
+
+  size_t GetRealSize() const
+  {
+    return real_size_;
+  }
+
+  void SetRealSize(size_t size)
+  {
+    real_size_ = size;
   }
 
   size_t GetIntBitWidth() const

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -55,3 +55,15 @@ NAME tracepoint arg casts in predicates
 RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_enter_wait4 /args->ru/ { @ru[tid] = args->ru; } tracepoint:syscalls:sys_exit_wait4 /@ru[tid]/ { @++; exit(); }' -c ./testprogs/wait4_ru
 EXPECT @: 1
 TIMEOUT 5
+
+NAME map resize empty string
+RUN {{BPFTRACE}} -e 'BEGIN { @ = ""; } k:vfs_read { @ = comm; exit(); }'
+EXPECT @: .*
+TIMEOUT 5
+AFTER ./testprogs/syscall read
+
+NAME map resize empty string in tuple
+RUN {{BPFTRACE}} -e 'BEGIN { @ = ("", 0); } k:vfs_read { @ = (comm, 1); exit(); }'
+EXPECT @: \(.*, 1\)
+TIMEOUT 5
+AFTER ./testprogs/syscall read

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -245,6 +245,14 @@ TEST(semantic_analyser, consistent_map_keys)
   test("kprobe:f { @x[1,\"a\",kstack] = 0; @x[\"b\", 2, kstack]; }", 10);
 }
 
+TEST(semantic_analyser, map_empty_string_resize)
+{
+  // "" should be resized from string[64] to string[16] (type of comm)
+  // both if used directly or inside a tuple
+  test("kprobe:f { @x = \"\"; } kprobe:g { @x = comm; }", 0);
+  test("kprobe:f { @x = (\"\", 0); } kprobe:g { @x = (comm, 1); }", 0);
+}
+
 TEST(semantic_analyser, if_statements)
 {
   test("kprobe:f { if(1) { 123 } }", 0);


### PR DESCRIPTION
Type of an empty string literal is by default `string[64]`, however this may cause problems when assigning it to a map that contains string of a different size.

For example:
```
# bpftrace -e 'BEGIN { @ = "" } k:vfs_read { @ = comm }'
```

Here, `comm` is `string[16]` which causes bpftrace to fail (see #2025 for a real case).

This PR attempts to resolve the above problem by resizing the empty string to the actual size stored inside the map (since empty string fits any string size), including the case when the string is inside a tuple.

The problem is that the implementation is rather complex (introducing a new `SizedType` field, semantic analysis changing an expression type from `visit` of another expression, ...) considering the fact that it only solves an edge case. If we don't want to introduce this amount of complexity, an alternative would be to just emit a correct error in semantic analyser (since the above example now fails during runtime).

Fixes #2025.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
