### PR TITLE
aot: Print out attached_probes message

### DIFF
--- a/src/aot/aot_main.cpp
+++ b/src/aot/aot_main.cpp
@@ -18,6 +18,7 @@ void usage()
   std::cerr << "OPTIONS:" << std::endl;
   std::cerr << "    -f FORMAT      output format ('text', 'json')" << std::endl;
   std::cerr << "    -o file        redirect bpftrace output to file" << std::endl;
+  std::cerr << "    -q,            keep messages quiet" << std::endl;
   std::cerr << "    -v,            verbose messages" << std::endl;
   std::cerr << "    -h, --help     show this help message" << std::endl;
   std::cerr << "    -V, --version  bpftrace version" << std::endl;
@@ -68,7 +69,7 @@ int main(int argc, char* argv[])
   int c;
 
   // TODO: which other options from `bpftrace` should be included?
-  const char* const short_opts = "f:hVo:v";
+  const char* const short_opts = "f:hVo:qv";
   option long_opts[] = {
     option{ "help", no_argument, nullptr, 'h' },
     option{ "version", no_argument, nullptr, 'V' },
@@ -91,6 +92,9 @@ int main(int argc, char* argv[])
       case 'V':
         std::cout << "bpftrace " << BPFTRACE_VERSION << std::endl;
         return 0;
+      case 'q':
+        bt_quiet = true;
+        break;
       case 'v':
         bt_verbose = true;
         break;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -104,6 +104,7 @@ public:
                                      const ast::AttachPoint &ap,
                                      const ast::Probe &probe);
   int num_probes() const;
+  int prerun() const;
   int run(BpfBytecode bytecode);
   std::vector<std::unique_ptr<AttachedProbe>> attach_probe(
       Probe &probe,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -889,27 +889,6 @@ int main(int argc, char* argv[])
   sigaction(SIGINT, &act, NULL);
   sigaction(SIGTERM, &act, NULL);
 
-  uint64_t num_probes = bpftrace.num_probes();
-  if (num_probes == 0)
-  {
-    if (!bt_quiet)
-      std::cout << "No probes to attach" << std::endl;
-    return 1;
-  }
-  else if (num_probes > bpftrace.max_probes_)
-  {
-    LOG(ERROR)
-        << "Can't attach to " << num_probes << " probes because it "
-        << "exceeds the current limit of " << bpftrace.max_probes_
-        << " probes.\n"
-        << "You can increase the limit through the BPFTRACE_MAX_PROBES "
-        << "environment variable, but BE CAREFUL since a high number of probes "
-        << "attached can cause your system to crash.";
-    return 1;
-  }
-  else if (!bt_quiet)
-    bpftrace.out_->attached_probes(num_probes);
-
   err = bpftrace.run(bytecode);
   if (err)
     return err;


### PR DESCRIPTION
Support printing out the # of probes attached as well as the required -q
flag.

Some of the runtime tests rely on this string. And I suppose it's
helpful for end users too so let's just add it.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
