### PR TITLE
Disable llvm 8 build

### DIFF
--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -32,31 +32,6 @@ jobs:
           DISTRO: ubuntu-glibc
           CMAKE_EXTRA_FLAGS: "-DCMAKE_CXX_FLAGS='-include /usr/local/include/bcc/compat/linux/bpf.h -D__LINUX_BPF_H__'"
           VENDOR_GTEST: ON
-        - TYPE: Release
-          NAME: vanilla_llvm+clang+glibc2.27
-          LLVM_VERSION: 8
-          STATIC_LINKING: ON
-          STATIC_LIBC: OFF
-          EMBED_BUILD_LLVM: OFF
-          EMBED_USE_LLVM: ON
-          RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size
-          BASE: bionic
-          DISTRO: ubuntu-glibc
-          VENDOR_GTEST: ON
-        - TYPE: Release
-          NAME: vanilla_llvm+clang+glibc2.23
-          LLVM_VERSION: 8
-          STATIC_LINKING: ON
-          STATIC_LIBC: OFF
-          EMBED_BUILD_LLVM: OFF
-          EMBED_USE_LLVM: ON
-          RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size,other.string compare map lookup
-          BASE: xenial
-          DISTRO: ubuntu-glibc
-          CMAKE_EXTRA_FLAGS: "-DCMAKE_CXX_FLAGS='-include /usr/local/include/bcc/compat/linux/bpf.h -D__LINUX_BPF_H__'"
-          VENDOR_GTEST: ON
         - TYPE: Debug
           NAME: alpine
           LLVM_VERSION: 9

--- a/.github/workflows/embedded_llvm.yml
+++ b/.github/workflows/embedded_llvm.yml
@@ -3,11 +3,13 @@ on:
   push:
     paths:
       - docker/Dockerfile.llvm
-      - docker/embedded/*
+      - cmake/embedded/*
+      - .github/workflows/embedded_llvm.yml
   pull_request:
     paths:
       - docker/Dockerfile.llvm
-      - docker/embedded/*
+      - cmake/embedded/*
+      - .github/workflows/embedded_llvm.yml
   schedule:
     - cron: '0 0 1 * *'
 
@@ -16,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        llvm_version: [8,12]
+        llvm_version: [12]
         base: [xenial, bionic]
     steps:
     - name: Checkout repo


### PR DESCRIPTION
LLVM8 image build fails, we don't really need it anyway so lets just get rid of it. 