### PR TITLE
Switch build.sh to use bionic and llvm 12 as base

### DIFF
--- a/build-docker-image.sh
+++ b/build-docker-image.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -eu
 pushd docker
-docker build --network host -t bpftrace-builder-alpine -f Dockerfile.alpine .
+docker build --network host -t bpftrace-builder-${BASE} --build-arg LLVM_VERSION=${LLVM_VERSION} -f Dockerfile.${BASE} .
 popd

--- a/build-release.sh
+++ b/build-release.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
-set -e
-docker run --network host --rm -it -u $(id -u):$(id -g) -v $(pwd):$(pwd) -e STATIC_LINKING=ON -e STATIC_LIBC=ON -e ALLOW_UNSAFE_PROBE=OFF -e RUN_TESTS=0 bpftrace-builder-alpine "$(pwd)/build-release" Release "$@"
+set -eu
+docker run --network host --rm -it -u $(id -u):$(id -g) -v $(pwd):$(pwd) -e STATIC_LINKING=OFF -e STATIC_LIBC=OFF -e ALLOW_UNSAFE_PROBE=OFF -e VENDOR_GTEST=ON -e RUN_TESTS=${RUN_TESTS} bpftrace-builder-${BASE} "$(pwd)/build-release-${BASE}" Release "$@"

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
 set -e
+export BASE=bionic
+export LLVM_VERSION=12
+export RUN_TESTS=1
 ./build-docker-image.sh
 ./build-release.sh "$@"


### PR DESCRIPTION
Switch build.sh to use bionic and llvm 12 as base, also disable static linking, set vendor_gtest, enable run_test

1. alpine build is not working currently, due to various issues like missing sys/sdt.h , missing libdwdl.h etc.
2. currently main CI all uses bionic as base, so switch default to that make more sense.
3. after the patch ./build.sh success

- [X] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [X] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [X] The new behaviour is covered by tests
