### PR TITLE
Variable strings size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to
   - [#1982](https://github.com/iovisor/bpftrace/pull/1982)
 - Access to uprobe arguments by name
   - [#1994](https://github.com/iovisor/bpftrace/pull/1994)
+- Support variable strings size
+  - [#2044](https://github.com/iovisor/bpftrace/pull/2044)
 
 #### Changed
 - Prevent LLVM from unrolling loops

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1798,7 +1798,8 @@ void CodegenLLVM::visit(AssignMapStatement &assignment)
   auto [key, scoped_key_deleter] = getMapKey(map);
   if (shouldBeOnStackAlready(assignment.expr->type))
   {
-    if (assignment.expr->type.IsStringTy() &&
+    if ((assignment.expr->type.IsStringTy() ||
+         assignment.expr->type.IsTupleTy()) &&
         assignment.expr->type.GetSize() != map.type.GetSize())
     {
       val = b_.CreateAllocaBPF(map.type, map.ident + "_val");

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -99,6 +99,7 @@ private:
 
   SizedType *get_map_type(const Map &map);
   void assign_map_type(const Map &map, const SizedType &type);
+  void update_key_type(const Map &map, const MapKey &new_key);
   bool update_string_size(SizedType &type, const SizedType &new_type);
 
   void builtin_args_tracepoint(AttachPoint *attach_point, Builtin &builtin);

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -102,6 +102,7 @@ private:
   void update_assign_map_type(const Map &map,
                               SizedType &type,
                               const SizedType &new_type);
+  bool update_string_size(SizedType &type, const SizedType &new_type);
 
   void builtin_args_tracepoint(AttachPoint *attach_point, Builtin &builtin);
   ProbeType single_provider_type(void);
@@ -124,7 +125,7 @@ private:
   // SemanticAnalyser.
   int func_arg_idx_ = -1;
 
-  std::map<std::string, SizedType> variable_val_;
+  std::map<Probe *, std::map<std::string, SizedType>> variable_val_;
   std::map<std::string, SizedType> map_val_;
   std::map<std::string, MapKey> map_key_;
   ProbeArgs ap_args_;

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -99,9 +99,6 @@ private:
 
   SizedType *get_map_type(const Map &map);
   void assign_map_type(const Map &map, const SizedType &type);
-  void update_assign_map_type(const Map &map,
-                              SizedType &type,
-                              const SizedType &new_type);
   bool update_string_size(SizedType &type, const SizedType &new_type);
 
   void builtin_args_tracepoint(AttachPoint *attach_point, Builtin &builtin);

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -540,6 +540,29 @@ std::weak_ptr<const Struct> SizedType::GetStruct() const
   return inner_struct_;
 }
 
+// Checks if values of this type can be copied into values of another type
+// Currently checks if strings in the other type (at corresponding places) are
+// larger.
+bool SizedType::FitsInto(const SizedType &t) const
+{
+  if (IsStringTy() && t.IsStringTy())
+    return GetSize() <= t.GetSize();
+
+  if (IsTupleTy() && t.IsTupleTy())
+  {
+    if (GetFieldCount() != t.GetFieldCount())
+      return false;
+
+    for (ssize_t i = 0; i < GetFieldCount(); i++)
+    {
+      if (!GetField(i).type.FitsInto(t.GetField(i).type))
+        return false;
+    }
+    return true;
+  }
+  return IsEqual(t);
+}
+
 } // namespace bpftrace
 
 namespace std {

--- a/src/types.h
+++ b/src/types.h
@@ -195,6 +195,7 @@ public:
   bool operator==(const SizedType &t) const;
   bool operator!=(const SizedType &t) const;
   bool IsSameType(const SizedType &t) const;
+  bool FitsInto(const SizedType &t) const;
 
   bool IsPrintableTy()
   {

--- a/tests/codegen/llvm/call_print_composit.ll
+++ b/tests/codegen/llvm/call_print_composit.ll
@@ -3,49 +3,49 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf-pc-linux"
 
-%print_tuple_72_t = type <{ i64, i64, [72 x i8] }>
-%"int64_string[64]__tuple_t" = type { i64, [64 x i8] }
+%print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
+%"int64_string[4]__tuple_t" = type { i64, [4 x i8] }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
-  %print_tuple_72_t = alloca %print_tuple_72_t, align 8
-  %str = alloca [64 x i8], align 1
-  %tuple = alloca %"int64_string[64]__tuple_t", align 8
-  %1 = bitcast %"int64_string[64]__tuple_t"* %tuple to i8*
+  %print_tuple_16_t = alloca %print_tuple_16_t, align 8
+  %str = alloca [4 x i8], align 1
+  %tuple = alloca %"int64_string[4]__tuple_t", align 8
+  %1 = bitcast %"int64_string[4]__tuple_t"* %tuple to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast %"int64_string[64]__tuple_t"* %tuple to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 72, i1 false)
-  %3 = getelementptr %"int64_string[64]__tuple_t", %"int64_string[64]__tuple_t"* %tuple, i32 0, i32 0
+  %2 = bitcast %"int64_string[4]__tuple_t"* %tuple to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 16, i1 false)
+  %3 = getelementptr %"int64_string[4]__tuple_t", %"int64_string[4]__tuple_t"* %tuple, i32 0, i32 0
   store i64 1, i64* %3, align 8
-  %4 = bitcast [64 x i8]* %str to i8*
+  %4 = bitcast [4 x i8]* %str to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  store [64 x i8] c"abc\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str, align 1
-  %5 = getelementptr %"int64_string[64]__tuple_t", %"int64_string[64]__tuple_t"* %tuple, i32 0, i32 1
-  %6 = bitcast [64 x i8]* %5 to i8*
-  %7 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %6, i8* align 1 %7, i64 64, i1 false)
-  %8 = bitcast [64 x i8]* %str to i8*
+  store [4 x i8] c"abc\00", [4 x i8]* %str, align 1
+  %5 = getelementptr %"int64_string[4]__tuple_t", %"int64_string[4]__tuple_t"* %tuple, i32 0, i32 1
+  %6 = bitcast [4 x i8]* %5 to i8*
+  %7 = bitcast [4 x i8]* %str to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %6, i8* align 1 %7, i64 4, i1 false)
+  %8 = bitcast [4 x i8]* %str to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast %print_tuple_72_t* %print_tuple_72_t to i8*
+  %9 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %10 = getelementptr %print_tuple_72_t, %print_tuple_72_t* %print_tuple_72_t, i64 0, i32 0
+  %10 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 0
   store i64 30007, i64* %10, align 8
-  %11 = getelementptr %print_tuple_72_t, %print_tuple_72_t* %print_tuple_72_t, i64 0, i32 1
+  %11 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i64 0, i32 1
   store i64 0, i64* %11, align 8
-  %12 = getelementptr %print_tuple_72_t, %print_tuple_72_t* %print_tuple_72_t, i32 0, i32 2
-  %13 = bitcast [72 x i8]* %12 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %13, i8 0, i64 72, i1 false)
-  %14 = bitcast [72 x i8]* %12 to i8*
-  %15 = bitcast %"int64_string[64]__tuple_t"* %tuple to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %14, i8* align 1 %15, i64 72, i1 false)
+  %12 = getelementptr %print_tuple_16_t, %print_tuple_16_t* %print_tuple_16_t, i32 0, i32 2
+  %13 = bitcast [16 x i8]* %12 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %13, i8 0, i64 16, i1 false)
+  %14 = bitcast [16 x i8]* %12 to i8*
+  %15 = bitcast %"int64_string[4]__tuple_t"* %tuple to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %14, i8* align 1 %15, i64 16, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %print_tuple_72_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %print_tuple_72_t* %print_tuple_72_t, i64 88)
-  %16 = bitcast %print_tuple_72_t* %print_tuple_72_t to i8*
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %print_tuple_16_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %print_tuple_16_t* %print_tuple_16_t, i64 32)
+  %16 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = bitcast %"int64_string[64]__tuple_t"* %tuple to i8*
+  %17 = bitcast %"int64_string[4]__tuple_t"* %tuple to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
   ret i64 0
 }

--- a/tests/codegen/llvm/map_assign_string.ll
+++ b/tests/codegen/llvm/map_assign_string.ll
@@ -9,18 +9,18 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
-  %str = alloca [64 x i8], align 1
-  %1 = bitcast [64 x i8]* %str to i8*
+  %str = alloca [5 x i8], align 1
+  %1 = bitcast [5 x i8]* %str to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store [64 x i8] c"blah\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str, align 1
+  store [5 x i8] c"blah\00", [5 x i8]* %str, align 1
   %2 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* %"@x_key", [64 x i8]* %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [5 x i8]*, i64)*)(i64 %pseudo, i64* %"@x_key", [5 x i8]* %str, i64 0)
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [64 x i8]* %str to i8*
+  %4 = bitcast [5 x i8]* %str to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   ret i64 0
 }

--- a/tests/codegen/llvm/map_key_string.ll
+++ b/tests/codegen/llvm/map_key_string.ll
@@ -9,35 +9,35 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
-  %str1 = alloca [64 x i8], align 1
-  %str = alloca [64 x i8], align 1
-  %"@x_key" = alloca [128 x i8], align 1
-  %1 = bitcast [128 x i8]* %"@x_key" to i8*
+  %str1 = alloca [2 x i8], align 1
+  %str = alloca [2 x i8], align 1
+  %"@x_key" = alloca [4 x i8], align 1
+  %1 = bitcast [4 x i8]* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast [64 x i8]* %str to i8*
+  %2 = bitcast [2 x i8]* %str to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store [64 x i8] c"a\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str, align 1
-  %3 = getelementptr [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 0
-  %4 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %3, i8* align 1 %4, i64 64, i1 false)
-  %5 = bitcast [64 x i8]* %str to i8*
+  store [2 x i8] c"a\00", [2 x i8]* %str, align 1
+  %3 = getelementptr [4 x i8], [4 x i8]* %"@x_key", i64 0, i64 0
+  %4 = bitcast [2 x i8]* %str to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %3, i8* align 1 %4, i64 2, i1 false)
+  %5 = bitcast [2 x i8]* %str to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast [64 x i8]* %str1 to i8*
+  %6 = bitcast [2 x i8]* %str1 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  store [64 x i8] c"b\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str1, align 1
-  %7 = getelementptr [128 x i8], [128 x i8]* %"@x_key", i64 0, i64 64
-  %8 = bitcast [64 x i8]* %str1 to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %7, i8* align 1 %8, i64 64, i1 false)
-  %9 = bitcast [64 x i8]* %str1 to i8*
+  store [2 x i8] c"b\00", [2 x i8]* %str1, align 1
+  %7 = getelementptr [4 x i8], [4 x i8]* %"@x_key", i64 0, i64 2
+  %8 = bitcast [2 x i8]* %str1 to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %7, i8* align 1 %8, i64 2, i1 false)
+  %9 = bitcast [2 x i8]* %str1 to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   %10 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 44, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [128 x i8]*, i64*, i64)*)(i64 %pseudo, [128 x i8]* %"@x_key", i64* %"@x_val", i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [4 x i8]*, i64*, i64)*)(i64 %pseudo, [4 x i8]* %"@x_key", i64* %"@x_val", i64 0)
   %11 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast [128 x i8]* %"@x_key" to i8*
+  %12 = bitcast [4 x i8]* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }

--- a/tests/codegen/llvm/string_propagation.ll
+++ b/tests/codegen/llvm/string_propagation.ll
@@ -9,40 +9,40 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@y_key" = alloca i64, align 8
-  %lookup_elem_val = alloca [64 x i8], align 1
+  %lookup_elem_val = alloca [5 x i8], align 1
   %"@x_key1" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %str = alloca [64 x i8], align 1
-  %1 = bitcast [64 x i8]* %str to i8*
+  %str = alloca [5 x i8], align 1
+  %1 = bitcast [5 x i8]* %str to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store [64 x i8] c"asdf\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str, align 1
+  store [5 x i8] c"asdf\00", [5 x i8]* %str, align 1
   %2 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo, i64* %"@x_key", [64 x i8]* %str, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [5 x i8]*, i64)*)(i64 %pseudo, i64* %"@x_key", [5 x i8]* %str, i64 0)
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast [64 x i8]* %str to i8*
+  %4 = bitcast [5 x i8]* %str to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
   %5 = bitcast i64* %"@x_key1" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
   store i64 0, i64* %"@x_key1", align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo2, i64* %"@x_key1")
-  %6 = bitcast [64 x i8]* %lookup_elem_val to i8*
+  %6 = bitcast [5 x i8]* %lookup_elem_val to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %7 = bitcast [64 x i8]* %lookup_elem_val to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %7, i8* align 1 %lookup_elem, i64 64, i1 false)
+  %7 = bitcast [5 x i8]* %lookup_elem_val to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %7, i8* align 1 %lookup_elem, i64 5, i1 false)
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  %8 = bitcast [64 x i8]* %lookup_elem_val to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %8, i8 0, i64 64, i1 false)
+  %8 = bitcast [5 x i8]* %lookup_elem_val to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %8, i8 0, i64 5, i1 false)
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
@@ -52,10 +52,10 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 0, i64* %"@y_key", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [64 x i8]*, i64)*)(i64 %pseudo3, i64* %"@y_key", [64 x i8]* %lookup_elem_val, i64 0)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, [5 x i8]*, i64)*)(i64 %pseudo3, i64* %"@y_key", [5 x i8]* %lookup_elem_val, i64 0)
   %11 = bitcast i64* %"@y_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast [64 x i8]* %lookup_elem_val to i8*
+  %12 = bitcast [5 x i8]* %lookup_elem_val to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }

--- a/tests/codegen/llvm/ternary_str.ll
+++ b/tests/codegen/llvm/ternary_str.ll
@@ -9,8 +9,8 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
-  %str1 = alloca [64 x i8], align 1
-  %str = alloca [64 x i8], align 1
+  %str1 = alloca [3 x i8], align 1
+  %str = alloca [3 x i8], align 1
   %buf = alloca [64 x i8], align 1
   %result = alloca [64 x i8], align 1
   %1 = bitcast [64 x i8]* %result to i8*
@@ -25,27 +25,27 @@ entry:
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
-  %6 = bitcast [64 x i8]* %str to i8*
+  %6 = bitcast [3 x i8]* %str to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  store [64 x i8] c"lo\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str, align 1
+  store [3 x i8] c"lo\00", [3 x i8]* %str, align 1
   %7 = bitcast [64 x i8]* %buf to i8*
-  %8 = bitcast [64 x i8]* %str to i8*
+  %8 = bitcast [3 x i8]* %str to i8*
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %7, i8* align 1 %8, i64 64, i1 false)
   br label %done
 
 right:                                            ; preds = %entry
-  %9 = bitcast [64 x i8]* %str1 to i8*
+  %9 = bitcast [3 x i8]* %str1 to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store [64 x i8] c"hi\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str1, align 1
+  store [3 x i8] c"hi\00", [3 x i8]* %str1, align 1
   %10 = bitcast [64 x i8]* %buf to i8*
-  %11 = bitcast [64 x i8]* %str1 to i8*
+  %11 = bitcast [3 x i8]* %str1 to i8*
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %10, i8* align 1 %11, i64 64, i1 false)
   br label %done
 
 done:                                             ; preds = %right, %left
-  %12 = bitcast [64 x i8]* %str1 to i8*
+  %12 = bitcast [3 x i8]* %str1 to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast [64 x i8]* %str to i8*
+  %13 = bitcast [3 x i8]* %str to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   %14 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)

--- a/tests/codegen/llvm/tuple.ll
+++ b/tests/codegen/llvm/tuple.ll
@@ -3,7 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf-pc-linux"
 
-%"int64_int64_string[64]__tuple_t" = type { i64, i64, [64 x i8] }
+%"int64_int64_string[4]__tuple_t" = type { i64, i64, [4 x i8] }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -11,33 +11,33 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@t_key" = alloca i64, align 8
-  %str = alloca [64 x i8], align 1
-  %tuple = alloca %"int64_int64_string[64]__tuple_t", align 8
-  %1 = bitcast %"int64_int64_string[64]__tuple_t"* %tuple to i8*
+  %str = alloca [4 x i8], align 1
+  %tuple = alloca %"int64_int64_string[4]__tuple_t", align 8
+  %1 = bitcast %"int64_int64_string[4]__tuple_t"* %tuple to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  %2 = bitcast %"int64_int64_string[64]__tuple_t"* %tuple to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 80, i1 false)
-  %3 = getelementptr %"int64_int64_string[64]__tuple_t", %"int64_int64_string[64]__tuple_t"* %tuple, i32 0, i32 0
+  %2 = bitcast %"int64_int64_string[4]__tuple_t"* %tuple to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 24, i1 false)
+  %3 = getelementptr %"int64_int64_string[4]__tuple_t", %"int64_int64_string[4]__tuple_t"* %tuple, i32 0, i32 0
   store i64 1, i64* %3, align 8
-  %4 = getelementptr %"int64_int64_string[64]__tuple_t", %"int64_int64_string[64]__tuple_t"* %tuple, i32 0, i32 1
+  %4 = getelementptr %"int64_int64_string[4]__tuple_t", %"int64_int64_string[4]__tuple_t"* %tuple, i32 0, i32 1
   store i64 2, i64* %4, align 8
-  %5 = bitcast [64 x i8]* %str to i8*
+  %5 = bitcast [4 x i8]* %str to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
-  store [64 x i8] c"str\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00\00", [64 x i8]* %str, align 1
-  %6 = getelementptr %"int64_int64_string[64]__tuple_t", %"int64_int64_string[64]__tuple_t"* %tuple, i32 0, i32 2
-  %7 = bitcast [64 x i8]* %6 to i8*
-  %8 = bitcast [64 x i8]* %str to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %7, i8* align 1 %8, i64 64, i1 false)
-  %9 = bitcast [64 x i8]* %str to i8*
+  store [4 x i8] c"str\00", [4 x i8]* %str, align 1
+  %6 = getelementptr %"int64_int64_string[4]__tuple_t", %"int64_int64_string[4]__tuple_t"* %tuple, i32 0, i32 2
+  %7 = bitcast [4 x i8]* %6 to i8*
+  %8 = bitcast [4 x i8]* %str to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %7, i8* align 1 %8, i64 4, i1 false)
+  %9 = bitcast [4 x i8]* %str to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   %10 = bitcast i64* %"@t_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 0, i64* %"@t_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %"int64_int64_string[64]__tuple_t"*, i64)*)(i64 %pseudo, i64* %"@t_key", %"int64_int64_string[64]__tuple_t"* %tuple, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %"int64_int64_string[4]__tuple_t"*, i64)*)(i64 %pseudo, i64* %"@t_key", %"int64_int64_string[4]__tuple_t"* %tuple, i64 0)
   %11 = bitcast i64* %"@t_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast %"int64_int64_string[64]__tuple_t"* %tuple to i8*
+  %12 = bitcast %"int64_int64_string[4]__tuple_t"* %tuple to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 }

--- a/tests/runtime/tuples
+++ b/tests/runtime/tuples
@@ -45,7 +45,7 @@ TIMEOUT 5
 
 NAME complex tuple 4
 PROG BEGIN { $a = ((int8)-100, (int8) 100, "abcdef", 3, (int32) 1, (int64)-10, (int8)10, (int16)-555, "abc"); print(sizeof($a)); exit(); }
-EXPECT 168
+EXPECT 48
 TIMEOUT 5
 
 NAME struct in tuple

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -55,3 +55,8 @@ NAME tracepoint arg casts in predicates
 RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_enter_wait4 /args->ru/ { @ru[tid] = args->ru; } tracepoint:syscalls:sys_exit_wait4 /@ru[tid]/ { @++; exit(); }' -c ./testprogs/wait4_ru
 EXPECT @: 1
 TIMEOUT 5
+
+NAME variable string type resize
+PROG BEGIN { $x = "hello"; $x = "hi"; printf("%s\n", $x); exit(); }
+EXPECT hi
+TIMEOUT 2

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -75,3 +75,8 @@ NAME map multi-key string type resize
 PROG BEGIN { @["hello", 0] = 0; } i:ms:1 { @["hi", 1] = 1; exit(); }
 EXPECT @\[hi, 1\]: 1
 TIMEOUT 2
+
+NAME tuple string resize
+PROG BEGIN { @ = ("hello", 0); } i:ms:1 { @ = ("hi", 1); exit(); }
+EXPECT @: \(hi, 1\)
+TIMEOUT 2

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -65,3 +65,13 @@ NAME map string type resize
 PROG BEGIN { @ = "hello"; } i:ms:1 { @ = "hi"; exit(); }
 EXPECT @: hi
 TIMEOUT 2
+
+NAME map key string type resize
+PROG BEGIN { @["hello"] = 0; } i:ms:1 { @["hi"] = 1; exit(); }
+EXPECT @\[hi\]: 1
+TIMEOUT 2
+
+NAME map multi-key string type resize
+PROG BEGIN { @["hello", 0] = 0; } i:ms:1 { @["hi", 1] = 1; exit(); }
+EXPECT @\[hi, 1\]: 1
+TIMEOUT 2

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -60,3 +60,8 @@ NAME variable string type resize
 PROG BEGIN { $x = "hello"; $x = "hi"; printf("%s\n", $x); exit(); }
 EXPECT hi
 TIMEOUT 2
+
+NAME map string type resize
+PROG BEGIN { @ = "hello"; } i:ms:1 { @ = "hi"; exit(); }
+EXPECT @: hi
+TIMEOUT 2

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2409,6 +2409,12 @@ TEST(semantic_analyser, string_size)
   auto var_assign = dynamic_cast<ast::AssignVarStatement *>(stmt);
   ASSERT_TRUE(var_assign->var->type.IsStringTy());
   ASSERT_EQ(var_assign->var->type.GetSize(), 6);
+
+  test(bpftrace, true, driver, R"_(k:f1 {@ = "hi";} k:f2 {@ = "hello";})_", 0);
+  stmt = driver.root->probes->at(0)->stmts->at(0);
+  auto map_assign = dynamic_cast<ast::AssignMapStatement *>(stmt);
+  ASSERT_TRUE(map_assign->map->type.IsStringTy());
+  ASSERT_EQ(map_assign->map->type.GetSize(), 6);
 }
 
 #ifdef HAVE_LIBBPF_BTF_DUMP


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

Instead of using 64 bytes for all strings, use the actual size for string literals. The size includes the terminating null character.  When multiple different strings are assigned to a variable/map/map key, its size is determined by the largest assigned string. Strings with length unknown at compile time remain 64 bytes long.

This saves some space on the stack as string literals are usually short and also fixes issues coming from different string sizes, such as #2025.

Fixes #2025, also replaces and closes #2036.

Note: to simplify reviewing, I split implementation for variables, maps, and tuples into separate commits. However, tests do not pass after each commit (since the string literal size is changed in the first commit) so I can squash them together after the reviews, if you prefer.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
