### PR TITLE
Add cgroup_path built-in function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to
 ## Unreleased
 
 #### Added
+- Add builtin function: `cgroup_path`
+  - [#2055](https://github.com/iovisor/bpftrace/pull/2055)
+
 #### Changed
 #### Deprecated
 #### Removed

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -96,6 +96,7 @@ discussion to other files in /docs, the /tools/\*\_examples.txt files, or blog p
     - [26. `uptr()`: Annotate userspace pointer](#26-uptr-annotate-userspace-pointer)
     - [27. `kptr()`: Annotate kernelspace pointer](#27-kptr-annotate-kernelspace-pointer)
     - [28. `macaddr()`: Convert MAC address data to text](#28-macaddr-convert-mac-address-data-to-text)
+    - [29. `cgroup_path()`: Convert cgroup id to cgroup path](#29-cgroup_path-convert-cgroup-id-to-cgroup-path)
 - [Map Functions](#map-functions)
     - [1. Builtins](#1-builtins-2)
     - [2. `count()`: Count](#2-count-count)
@@ -3090,6 +3091,25 @@ Example:
 # bpftrace -e 'kprobe:arp_create { printf("SRC %s, DST %s\n", macaddr(sarg0), macaddr(sarg1)); }'
 SRC 18:C0:4D:08:2E:BB, DST 74:83:C2:7F:8C:FF
 ^C
+```
+
+## 29. `cgroup_path`: Convert cgroup id to cgroup path
+
+Syntax: `cgroup_path(int cgroupid, string filter)`
+
+Converts the given cgroup id into the corresponding cgroup path for each cgroup hierarchy the id
+appears in. Because the conversion is done in user space, the resulting object can only be used for
+printing.
+
+Optionally a string literal may be passed as the second argument to filter cgroup hierarchies to look
+in (interpreted as a wildcard expression).
+
+Example:
+
+```
+# bpftrace -e 'BEGIN { print(cgroup_path(5386)); }'
+Attaching 1 probe...
+unified:/user.slice/user-1000.slice/session-3.scope
 ```
 
 # Map Functions

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1287,6 +1287,34 @@ t:syscalls:sys_enter_execve {
 55f683ee2000-55f683ee3000 rw-p 00000000 00:00 0
 ----
 
+=== cgroup_path
+
+.variants
+* `cgroup_path cgroup_path(int cgroupid, string filter)`
+
+Convert cgroup id to cgroup path.
+This is done asynchronously in userspace when the cgroup_path value is printed,
+therefore it can resolve to a different value if the cgroup id gets reassigned.
+This also means that the returned value can only be used for printing.
+
+A string literal may be passed as an optional second argument to filter cgroup
+hierarchies in which the cgroup id is looked up by a wildcard expression (cgroup2
+is always represented by "unified", regardless of where it is mounted).
+
+The currently mounted hierarchy at /sys/fs/cgroup is used to do the lookup. If
+the cgroup with the given id isn't present here (e.g. when running in a Docker
+container), the cgroup path won't be found (unlike when looking up the cgroup
+path of a process via /proc/.../cgroup).
+
+----
+BEGIN {
+  $cgroup_path = cgroup_path(3436);
+  print($cgroup_path);
+  print($cgroup_path); /* This may print a different path */
+  printf("%s %s", $cgroup_path, $cgroup_path); /* This may print two different paths */
+}
+----
+
 === cgroupid
 
 .variants

--- a/src/ast/async_event_types.cpp
+++ b/src/ast/async_event_types.cpp
@@ -86,5 +86,13 @@ std::vector<llvm::Type*> WatchpointUnwatch::asLLVMType(ast::IRBuilderBPF& b)
   };
 }
 
+std::vector<llvm::Type*> CgroupPath::asLLVMType(ast::IRBuilderBPF& b)
+{
+  return {
+    b.getInt64Ty(), // cgroup path (pseudo-event) id
+    b.getInt64Ty(), // cgroup id
+  };
+}
+
 } // namespace AsyncEvent
 } // namespace bpftrace

--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -109,5 +109,13 @@ struct WatchpointUnwatch
   std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b);
 } __attribute__((packed));
 
+struct CgroupPath
+{
+  uint64_t cgroup_path_id;
+  uint64_t cgroup_id;
+
+  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b);
+} __attribute__((packed));
+
 } // namespace AsyncEvent
 } // namespace bpftrace

--- a/src/ast/codegen_helper.h
+++ b/src/ast/codegen_helper.h
@@ -7,7 +7,7 @@ namespace ast {
 
 inline bool needMemcpy(const SizedType &stype)
 {
-  return stype.IsAggregate() || stype.IsTimestampTy();
+  return stype.IsAggregate() || stype.IsTimestampTy() || stype.IsCgroupPathTy();
 }
 
 inline bool shouldBeOnStackAlready(const SizedType &type)

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -221,6 +221,7 @@ private:
   int system_id_ = 0;
   int non_map_print_id_ = 0;
   uint64_t watchpoint_id_ = 0;
+  int cgroup_path_id_ = 0;
 
   Function *linear_func_ = nullptr;
   Function *log2_func_ = nullptr;

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -152,6 +152,14 @@ void ResourceAnalyser::visit(Call &call)
   {
     resources_.stackid_maps.insert(call.type.stack_type);
   }
+  else if (call.func == "cgroup_path")
+  {
+    if (call.vargs->size() > 1)
+      resources_.cgroup_path_args.push_back(
+          get_literal_string(*call.vargs->at(1)));
+    else
+      resources_.cgroup_path_args.push_back("*");
+  }
 }
 
 void ResourceAnalyser::visit(Map &map)

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1021,6 +1021,15 @@ void SemanticAnalyser::visit(Call &call)
       }
     }
   }
+  else if (call.func == "cgroup_path")
+  {
+    call.type = CreateCgroupPath();
+    if (check_varargs(call, 1, 2))
+    {
+      check_arg(call, Type::integer, 0, false);
+      call.vargs->size() > 1 && check_arg(call, Type::string, 1, false);
+    }
+  }
   else if (call.func == "clear") {
     check_assignment(call, false, false, false);
     if (check_nargs(call, 1)) {

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -126,6 +126,8 @@ public:
                             struct symbol *sym,
                             const std::string &path) const;
   std::string resolve_mac_address(const uint8_t *mac_addr) const;
+  std::string resolve_cgroup_path(uint64_t cgroup_path_id,
+                                  uint64_t cgroup_id) const;
   virtual std::string extract_func_symbols_from_path(const std::string &path) const;
   std::string resolve_probe(uint64_t probe_id) const;
   uint64_t resolve_cgroupid(const std::string &path) const;

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -38,7 +38,7 @@ vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#\*])+
 builtin  arg[0-9]|args|cgroup|comm|cpid|cpu|ctx|curtask|elapsed|func|gid|nsecs|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
-call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|reg|signal|sizeof|stats|str|strftime|strncmp|sum|system|time|uaddr|uptr|usym|zero|path|unwatch
+call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|sizeof|stats|str|strftime|strncmp|sum|system|time|uaddr|uptr|usym|zero|path|unwatch
 
 /* Don't add to this! Use builtin OR call not both */
 call_and_builtin kstack|ustack

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -275,6 +275,11 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
             ->nsecs_since_boot);
   else if (type.IsMacAddressTy())
     return bpftrace.resolve_mac_address(value.data());
+  else if (type.IsCgroupPathTy())
+    return bpftrace.resolve_cgroup_path(
+        reinterpret_cast<AsyncEvent::CgroupPath *>(value.data())
+            ->cgroup_path_id,
+        reinterpret_cast<AsyncEvent::CgroupPath *>(value.data())->cgroup_id);
   else
     return std::to_string(read_data<int64_t>(value.data()) / div);
 }

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -38,7 +38,7 @@ std::string verify_format_string(const std::string &fmt, std::vector<Field> args
         arg_type == Type::probe || arg_type == Type::username ||
         arg_type == Type::kstack || arg_type == Type::ustack ||
         arg_type == Type::inet || arg_type == Type::timestamp ||
-        arg_type == Type::mac_address)
+        arg_type == Type::mac_address || arg_type == Type::cgroup_path)
       arg_type = Type::string; // Symbols should be printed as strings
     if (arg_type == Type::pointer)
       arg_type = Type::integer; // Casts (pointers) can be printed as integers

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -35,25 +35,6 @@ static int add_symbol(const char* symname,
 #endif
 
 /*
- * Splits input string by '*' delimiter and return the individual parts.
- * Sets start_wildcard and end_wildcard if input starts or ends with '*'.
- */
-std::vector<std::string> get_tokens(const std::string& input,
-                                    bool& start_wildcard,
-                                    bool& end_wildcard)
-{
-  if (input.empty())
-    return {};
-
-  start_wildcard = input[0] == '*';
-  end_wildcard = input[input.length() - 1] == '*';
-
-  std::vector<std::string> tokens = split_string(input, '*');
-  tokens.erase(std::remove(tokens.begin(), tokens.end(), ""), tokens.end());
-  return tokens;
-}
-
-/*
  * Finds all matches of search_input in the provided input stream.
  *
  * If `ignore_trailing_module` is true, will ignore trailing kernel module.
@@ -67,7 +48,7 @@ std::set<std::string> ProbeMatcher::get_matches_in_stream(
     const char delim)
 {
   bool start_wildcard, end_wildcard;
-  auto tokens = get_tokens(search_input, start_wildcard, end_wildcard);
+  auto tokens = get_wildcard_tokens(search_input, start_wildcard, end_wildcard);
 
   std::string line;
   std::set<std::string> matches;

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -80,6 +80,7 @@ public:
   std::vector<std::string> join_args;
   std::vector<std::string> time_args;
   std::vector<std::string> strftime_args;
+  std::vector<std::string> cgroup_path_args;
   std::vector<std::tuple<std::string, std::vector<Field>>> cat_args;
   std::vector<SizedType> non_map_print_args;
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -121,7 +121,7 @@ bool SizedType::IsByteArray() const
 {
   return type == Type::string || type == Type::usym || type == Type::inet ||
          type == Type::buffer || type == Type::timestamp ||
-         type == Type::mac_address;
+         type == Type::mac_address || type == Type::cgroup_path;
 }
 
 bool SizedType::IsAggregate() const
@@ -183,6 +183,7 @@ std::string typestr(Type t)
     case Type::tuple:    return "tuple";    break;
     case Type::timestamp:return "timestamp";break;
     case Type::mac_address: return "mac_address"; break;
+    case Type::cgroup_path: return "cgroup_path"; break;
       // clang-format on
   }
 
@@ -469,6 +470,11 @@ SizedType CreateMacAddress()
   return st;
 }
 
+SizedType CreateCgroupPath()
+{
+  return SizedType(Type::cgroup_path, 16);
+}
+
 bool SizedType::IsSigned(void) const
 {
   return is_signed_;
@@ -615,6 +621,7 @@ size_t hash<bpftrace::SizedType>::operator()(
     case bpftrace::Type::buffer:
     case bpftrace::Type::timestamp:
     case bpftrace::Type::mac_address:
+    case bpftrace::Type::cgroup_path:
       break;
   }
 

--- a/src/types.h
+++ b/src/types.h
@@ -47,7 +47,8 @@ enum class Type
   buffer,
   tuple,
   timestamp,
-  mac_address
+  mac_address,
+  cgroup_path
   // clang-format on
 };
 
@@ -363,6 +364,10 @@ public:
   {
     return type == Type::mac_address;
   };
+  bool IsCgroupPathTy(void) const
+  {
+    return type == Type::cgroup_path;
+  };
 
   friend std::ostream &operator<<(std::ostream &, const SizedType &);
   friend std::ostream &operator<<(std::ostream &, Type);
@@ -421,6 +426,7 @@ SizedType CreateKSym();
 SizedType CreateBuffer(size_t size);
 SizedType CreateTimestamp();
 SizedType CreateMacAddress();
+SizedType CreateCgroupPath();
 
 std::ostream &operator<<(std::ostream &os, const SizedType &type);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -149,6 +149,9 @@ bool wildcard_match(const std::string &str,
                     std::vector<std::string> &tokens,
                     bool start_wildcard,
                     bool end_wildcard);
+std::vector<std::string> get_wildcard_tokens(const std::string &input,
+                                             bool &start_wildcard,
+                                             bool &end_wildcard);
 std::vector<int> get_online_cpus();
 std::vector<int> get_possible_cpus();
 bool is_dir(const std::string &path);
@@ -158,6 +161,12 @@ std::tuple<std::string, std::string> get_kernel_dirs(
 std::vector<std::string> get_kernel_cflags(const char *uname_machine,
                                            const std::string &ksrc,
                                            const std::string &kobj);
+std::string get_cgroup_path_in_hierarchy(uint64_t cgroupid,
+                                         std::string base_path);
+std::vector<std::pair<std::string, std::string>> get_cgroup_hierarchy_roots();
+std::vector<std::pair<std::string, std::string>> get_cgroup_paths(
+    uint64_t cgroupid,
+    std::string filter);
 std::unordered_set<std::string> get_traceable_funcs();
 const std::string &is_deprecated(const std::string &str);
 bool is_unsafe_func(const std::string &func_name);

--- a/tests/codegen/call_cgroup_path.cpp
+++ b/tests/codegen/call_cgroup_path.cpp
@@ -1,0 +1,14 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, call_cgroup_path)
+{
+  test("kprobe:f { print(cgroup_path(cgroup)); }", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/call_cgroup_path.ll
+++ b/tests/codegen/llvm/call_cgroup_path.ll
@@ -1,0 +1,51 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%print_cgroup_path_16_t = type <{ i64, i64, [16 x i8] }>
+%cgroup_path_t = type <{ i64, i64 }>
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
+entry:
+  %print_cgroup_path_16_t = alloca %print_cgroup_path_16_t, align 8
+  %cgroup_path_args = alloca %cgroup_path_t, align 8
+  %1 = bitcast %cgroup_path_t* %cgroup_path_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  %2 = getelementptr %cgroup_path_t, %cgroup_path_t* %cgroup_path_args, i64 0, i32 0
+  store i64 0, i64* %2, align 8
+  %get_cgroup_id = call i64 inttoptr (i64 80 to i64 ()*)()
+  %3 = getelementptr %cgroup_path_t, %cgroup_path_t* %cgroup_path_args, i64 0, i32 1
+  store i64 %get_cgroup_id, i64* %3, align 8
+  %4 = bitcast %print_cgroup_path_16_t* %print_cgroup_path_16_t to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  %5 = getelementptr %print_cgroup_path_16_t, %print_cgroup_path_16_t* %print_cgroup_path_16_t, i64 0, i32 0
+  store i64 30007, i64* %5, align 8
+  %6 = getelementptr %print_cgroup_path_16_t, %print_cgroup_path_16_t* %print_cgroup_path_16_t, i64 0, i32 1
+  store i64 0, i64* %6, align 8
+  %7 = getelementptr %print_cgroup_path_16_t, %print_cgroup_path_16_t* %print_cgroup_path_16_t, i32 0, i32 2
+  %8 = bitcast [16 x i8]* %7 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %8, i8 0, i64 16, i1 false)
+  %probe_read = call i64 inttoptr (i64 4 to i64 ([16 x i8]*, i32, %cgroup_path_t*)*)([16 x i8]* %7, i32 16, %cgroup_path_t* %cgroup_path_args)
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %print_cgroup_path_16_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %print_cgroup_path_16_t* %print_cgroup_path_16_t, i64 32)
+  %9 = bitcast %print_cgroup_path_16_t* %print_cgroup_path_16_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -337,3 +337,17 @@ PROG iter:task_file { printf("OK"); }
 EXPECT OK
 REQUIRES_FEATURE iter:task_file
 TIMEOUT 5
+
+NAME cgroup_path
+PROG BEGIN { print(cgroup_path(cgroup & ((1 << 32) - 1))); exit(); }
+EXPECT ([a-z]*:\/.*;)*[a-z]*:\/.*
+REQUIRES grep -q '^cgroup2' /proc/mounts
+TIMEOUT 5
+MIN_KERNEL 4.18
+
+NAME cgroup_path printf
+PROG BEGIN { printf("path: %s", cgroup_path(cgroup & ((1 << 32) - 1))); exit(); }
+EXPECT path: ([a-z]*:\/.*;)*[a-z]*:\/.*
+REQUIRES grep -q '^cgroup2' /proc/mounts
+TIMEOUT 5
+MIN_KERNEL 4.18

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -868,6 +868,21 @@ TEST(semantic_analyser, call_macaddr)
   test("kprobe:f { macaddr(\"hello\"); }", 1);
 }
 
+TEST(semantic_analyser, call_cgroup_path)
+{
+  test("kprobe:f { cgroup_path(1) }", 0);
+  test("kprobe:f { cgroup_path(1, \"hello\") }", 0);
+
+  test("kprobe:f { cgroup_path(1, 2) }", 10);
+  test("kprobe:f { cgroup_path(\"1\") }", 10);
+
+  test("kprobe:f { printf(\"%s\", cgroup_path(1)) }", 0);
+  test("kprobe:f { printf(\"%s %s\", cgroup_path(1), cgroup_path(2)) }", 0);
+  test("kprobe:f { $var = cgroup_path(0); printf(\"%s %s\", $var, $var) }", 0);
+
+  test("kprobe:f { printf(\"%d\", cgroup_path(1)) }", 10);
+}
+
 TEST(semantic_analyser, map_reassignment)
 {
   test("kprobe:f { @x = 1; @x = 2; }", 0);


### PR DESCRIPTION
The function takes a cgroup id and sends it to userspace via a perf
event, where it gets converted to a cgroup path.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

By combining the generic print mechanism with finding the cgroup path in userspace this provides an easy workaround to #1500, avoiding the possibility of an in-kernel deadlock. A limitation is that due to the conversion occuring in userspace, the cgroup path string cannot be manipulated.

I'm also not sure if `print_cgroup_path` is the best name for the function, maybe it would be better to name it `cgrouppath` to be consistent with other such printing functions like `join` that don't include "print" in their name.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
