### PR TITLE
Headers organization in AST

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -1,7 +1,9 @@
-#include "ast.h"
-#include "log.h"
-#include "visitors.h"
+#include "ast/ast.h"
+
 #include <iostream>
+
+#include "ast/visitors.h"
+#include "log.h"
 
 namespace bpftrace {
 namespace ast {

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1,14 +1,14 @@
 #pragma once
 
-#include "location.hh"
-#include "utils.h"
 #include <map>
 #include <string>
 #include <vector>
 
+#include "location.hh"
 #include "mapkey.h"
 #include "types.h"
 #include "usdt.h"
+#include "utils.h"
 
 namespace bpftrace {
 namespace ast {

--- a/src/ast/async_event_types.cpp
+++ b/src/ast/async_event_types.cpp
@@ -1,9 +1,9 @@
-#include "async_event_types.h"
+#include "ast/async_event_types.h"
 
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Type.h>
 
-#include "irbuilderbpf.h"
+#include "ast/irbuilderbpf.h"
 
 namespace bpftrace {
 namespace AsyncEvent {

--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -1,4 +1,4 @@
-#include "attachpoint_parser.h"
+#include "ast/attachpoint_parser.h"
 
 #include <algorithm>
 #include <exception>
@@ -7,13 +7,13 @@
 #include <unordered_map>
 #include <vector>
 
-#include "int_parser.h"
-#include "log.h"
-#include "types.h"
-
 #ifdef HAVE_BCC_WHICH_SO
 #include <bcc/bcc_proc.h>
 #endif
+
+#include "ast/int_parser.h"
+#include "log.h"
+#include "types.h"
 
 namespace bpftrace {
 namespace ast {

--- a/src/ast/attachpoint_parser.h
+++ b/src/ast/attachpoint_parser.h
@@ -4,7 +4,7 @@
 #include <sstream>
 #include <vector>
 
-#include "ast.h"
+#include "ast/ast.h"
 #include "bpftrace.h"
 
 namespace bpftrace {

--- a/src/ast/codegen_helper.h
+++ b/src/ast/codegen_helper.h
@@ -1,4 +1,5 @@
 #pragma once
+
 #include "bpftrace.h"
 
 namespace bpftrace {

--- a/src/ast/int_parser.cpp
+++ b/src/ast/int_parser.cpp
@@ -1,3 +1,5 @@
+#include "ast/int_parser.h"
+
 #include <algorithm>
 #include <exception>
 #include <regex>
@@ -5,8 +7,6 @@
 #include <stdexcept>
 #include <type_traits>
 #include <variant>
-
-#include "int_parser.h"
 
 namespace {
 

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1,16 +1,17 @@
+#include "ast/irbuilderbpf.h"
+
 #include <iostream>
 #include <sstream>
 
-#include "arch/arch.h"
-#include "ast/async_event_types.h"
-#include "bpftrace.h"
-#include "codegen_helper.h"
-#include "irbuilderbpf.h"
-#include "log.h"
-#include "utils.h"
-
 #include <llvm/IR/DataLayout.h>
 #include <llvm/IR/Module.h>
+
+#include "arch/arch.h"
+#include "ast/async_event_types.h"
+#include "ast/codegen_helper.h"
+#include "bpftrace.h"
+#include "log.h"
+#include "utils.h"
 
 namespace libbpf {
 #undef __BPF_FUNC_MAPPER

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -1,12 +1,13 @@
 #pragma once
 
-#include "ast.h"
-#include "bpftrace.h"
-#include "types.h"
 #include <bcc/bcc_usdt.h>
 
 #include <llvm/Config/llvm-config.h>
 #include <llvm/IR/IRBuilder.h>
+
+#include "ast/ast.h"
+#include "bpftrace.h"
+#include "types.h"
 
 #if LLVM_VERSION_MAJOR >= 5 && LLVM_VERSION_MAJOR < 7
 #define CREATE_MEMCPY(dst, src, size, algn)                                    \

--- a/src/ast/pass_manager.cpp
+++ b/src/ast/pass_manager.cpp
@@ -1,8 +1,9 @@
-#include <ostream>
-#include <pass_manager.h>
+#include "ast/pass_manager.h"
 
+#include <ostream>
+
+#include "ast/passes/printer.h"
 #include "bpftrace.h"
-#include "passes/printer.h"
 
 namespace bpftrace {
 namespace ast {

--- a/src/ast/passes/callback_visitor.h
+++ b/src/ast/passes/callback_visitor.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "visitors.h"
 #include <functional>
+
+#include "ast/visitors.h"
 
 namespace bpftrace {
 namespace ast {

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1,14 +1,5 @@
 #include "codegen_llvm.h"
-#include "arch/arch.h"
-#include "ast.h"
-#include "ast/async_event_types.h"
-#include "ast/bpforc/bpforc.h"
-#include "codegen_helper.h"
-#include "log.h"
-#include "signal_bt.h"
-#include "tracepoint_format_parser.h"
-#include "types.h"
-#include "usdt.h"
+
 #include <algorithm>
 #include <arpa/inet.h>
 #include <cerrno>
@@ -23,6 +14,17 @@
 #include <llvm/IR/Metadata.h>
 #include <llvm/Transforms/IPO.h>
 #include <llvm/Transforms/IPO/PassManagerBuilder.h>
+
+#include "arch/arch.h"
+#include "ast.h"
+#include "ast/async_event_types.h"
+#include "ast/bpforc/bpforc.h"
+#include "ast/codegen_helper.h"
+#include "ast/signal_bt.h"
+#include "log.h"
+#include "tracepoint_format_parser.h"
+#include "types.h"
+#include "usdt.h"
 
 namespace bpftrace {
 namespace ast {

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -6,17 +6,17 @@
 #include <ostream>
 #include <tuple>
 
-#include "ast/bpforc/bpforc.h"
-#include "bpftrace.h"
-#include "irbuilderbpf.h"
-#include "location.hh"
-#include "map.h"
-#include "visitors.h"
-
 #include <llvm/ExecutionEngine/MCJIT.h>
 #include <llvm/IR/IRBuilder.h>
 #include <llvm/IR/Module.h>
 #include <llvm/Support/raw_os_ostream.h>
+
+#include "ast/bpforc/bpforc.h"
+#include "ast/irbuilderbpf.h"
+#include "ast/visitors.h"
+#include "bpftrace.h"
+#include "location.hh"
+#include "map.h"
 
 namespace bpftrace {
 namespace ast {

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -1,9 +1,11 @@
 #include "field_analyser.h"
+
+#include <cassert>
+#include <iostream>
+
 #include "dwarf_parser.h"
 #include "log.h"
 #include "probe_matcher.h"
-#include <cassert>
-#include <iostream>
 
 namespace bpftrace {
 namespace ast {

--- a/src/ast/passes/field_analyser.h
+++ b/src/ast/passes/field_analyser.h
@@ -1,10 +1,11 @@
 #pragma once
 
-#include "bpftrace.h"
-#include "visitors.h"
 #include <iostream>
 #include <string>
 #include <unordered_set>
+
+#include "ast/visitors.h"
+#include "bpftrace.h"
 
 namespace bpftrace {
 namespace ast {

--- a/src/ast/passes/node_counter.h
+++ b/src/ast/passes/node_counter.h
@@ -1,8 +1,9 @@
 #pragma once
+
+#include "ast/pass_manager.h"
+#include "ast/visitors.h"
 #include "bpftrace.h"
 #include "log.h"
-#include "pass_manager.h"
-#include "visitors.h"
 
 namespace bpftrace {
 namespace ast {

--- a/src/ast/passes/portability_analyser.h
+++ b/src/ast/passes/portability_analyser.h
@@ -3,8 +3,8 @@
 #include <iostream>
 #include <sstream>
 
-#include "pass_manager.h"
-#include "visitors.h"
+#include "ast/pass_manager.h"
+#include "ast/visitors.h"
 
 namespace bpftrace {
 namespace ast {

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -1,10 +1,11 @@
+#include "ast/passes/printer.h"
+
 #include <cctype>
 #include <iomanip>
 #include <regex>
 #include <sstream>
 
-#include "ast.h"
-#include "printer.h"
+#include "ast/ast.h"
 
 namespace bpftrace {
 namespace ast {

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -1,7 +1,8 @@
 #pragma once
 
-#include "visitors.h"
 #include <ostream>
+
+#include "ast/visitors.h"
 
 namespace bpftrace {
 namespace ast {

--- a/src/ast/passes/resource_analyser.h
+++ b/src/ast/passes/resource_analyser.h
@@ -3,9 +3,9 @@
 #include <iostream>
 #include <sstream>
 
-#include "pass_manager.h"
+#include "ast/pass_manager.h"
+#include "ast/visitors.h"
 #include "required_resources.h"
-#include "visitors.h"
 
 namespace bpftrace {
 namespace ast {

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1,13 +1,5 @@
 #include "semantic_analyser.h"
-#include "arch/arch.h"
-#include "ast.h"
-#include "fake_map.h"
-#include "log.h"
-#include "printf.h"
-#include "probe_matcher.h"
-#include "signal_bt.h"
-#include "tracepoint_format_parser.h"
-#include "usdt.h"
+
 #include <algorithm>
 #include <cstring>
 #include <regex>
@@ -15,6 +7,16 @@
 #include <sys/stat.h>
 
 #include <bcc/libbpf.h>
+
+#include "arch/arch.h"
+#include "ast/ast.h"
+#include "ast/signal_bt.h"
+#include "fake_map.h"
+#include "log.h"
+#include "printf.h"
+#include "probe_matcher.h"
+#include "tracepoint_format_parser.h"
+#include "usdt.h"
 
 namespace bpftrace {
 namespace ast {

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -4,12 +4,12 @@
 #include <sstream>
 #include <unordered_set>
 
+#include "ast/pass_manager.h"
+#include "ast/visitors.h"
 #include "bpffeature.h"
 #include "bpftrace.h"
 #include "map.h"
-#include "pass_manager.h"
 #include "types.h"
-#include "visitors.h"
 
 namespace bpftrace {
 namespace ast {

--- a/src/ast/signal.cpp
+++ b/src/ast/signal.cpp
@@ -1,4 +1,4 @@
-#include "signal_bt.h"
+#include "ast/signal_bt.h"
 
 #include <algorithm>
 #include <map>

--- a/src/ast/visitors.cpp
+++ b/src/ast/visitors.cpp
@@ -1,5 +1,6 @@
-#include "visitors.h"
-#include "ast.h"
+#include "ast/visitors.h"
+
+#include "ast/ast.h"
 
 namespace bpftrace {
 namespace ast {

--- a/src/ast/visitors.h
+++ b/src/ast/visitors.h
@@ -1,9 +1,9 @@
 #pragma once
 
-#include "vtable.h"
 #include <string>
 
-#include "ast.h"
+#include "ast/ast.h"
+#include "ast/vtable.h"
 
 namespace bpftrace {
 namespace ast {


### PR DESCRIPTION
Cleaning up `#includes` in the ast directory.

Heads up that some of these changes are stylistic, and I'm happy to change those parts if there are other preferences. Mostly, I was shooting for consistency.

With that said, this PR offers the following:
1) Make include paths relative to `src`. Since includes can be relative, some of this is arguably optional. However, there are also instances where it is required for correctness. For example, there were cases where files in `src/ast/passes` included files from `src/ast` without giving the correct path.

2) Include order consistency: This is purely stylistic, but I went ahead and tried to make the include orders a bit more consistent across files. Current order is: (1) header for the cpp file, if applicable, (2) system includes, (3) library includes (like llvm), (4) local includes.

I limited the changes to the `ast` subdirectory for now. I can expand out to other files in a future PR if there is any desire for that.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
