### PR TITLE
Use unique_ptr for Driver::root_

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -32,7 +32,7 @@ int Driver::parse_str(std::string script)
 int Driver::parse()
 {
   // Reset previous state if we parse more than once
-  root_.reset();
+  root.reset();
 
   // Reset source location info on every pass
   loc.initialize();
@@ -50,14 +50,14 @@ int Driver::parse()
 
   if (!failed_)
   {
-    ast::AttachPointParser ap_parser(root_.get(), bpftrace_, out_, listing_);
+    ast::AttachPointParser ap_parser(root.get(), bpftrace_, out_, listing_);
     if (ap_parser.parse())
       failed_ = true;
   }
 
   if (failed_)
   {
-    root_.reset();
+    root.reset();
   }
 
   // Keep track of errors thrown ourselves, since the result of

--- a/src/driver.h
+++ b/src/driver.h
@@ -21,7 +21,7 @@ public:
   void error(std::ostream &, const location &, const std::string &);
   void error(const location &l, const std::string &m);
   void error(const std::string &m);
-  std::unique_ptr<ast::Program> root_;
+  std::unique_ptr<ast::Program> root;
 
   void debug()
   {

--- a/src/driver.h
+++ b/src/driver.h
@@ -14,7 +14,6 @@ class Driver
 {
 public:
   explicit Driver(BPFtrace &bpftrace, std::ostream &o = std::cerr);
-  ~Driver();
 
   int parse();
   int parse_str(std::string script);
@@ -22,7 +21,7 @@ public:
   void error(std::ostream &, const location &, const std::string &);
   void error(const location &l, const std::string &m);
   void error(const std::string &m);
-  ast::Program *root_ = nullptr;
+  std::unique_ptr<ast::Program> root_;
 
   void debug()
   {

--- a/src/fuzz_main.cpp
+++ b/src/fuzz_main.cpp
@@ -114,18 +114,18 @@ int fuzz_main(const char* data, size_t sz)
   uint64_t node_count = 0;
   ast::CallbackVisitor counter(
       [&](ast::Node* node __attribute__((unused))) { node_count += 1; });
-  driver.root_->accept(counter);
+  driver.root->accept(counter);
   if (node_count > node_max)
     return 1;
 
   // Field Analyzer
-  ast::FieldAnalyser fields(driver.root_.get(), bpftrace, devnull);
+  ast::FieldAnalyser fields(driver.root.get(), bpftrace, devnull);
   err = fields.analyse();
   if (err)
     return err;
 
   // Tracepoint parser
-  if (TracepointFormatParser::parse(driver.root_.get(), bpftrace) == false)
+  if (TracepointFormatParser::parse(driver.root.get(), bpftrace) == false)
     return 1;
 
   // ClangParser
@@ -144,14 +144,14 @@ int fuzz_main(const char* data, size_t sz)
   }
   extra_flags.push_back("-include");
   extra_flags.push_back(CLANG_WORKAROUNDS_H);
-  if (!clang.parse(driver.root_.get(), bpftrace, extra_flags))
+  if (!clang.parse(driver.root.get(), bpftrace, extra_flags))
     return 1;
   err = driver.parse();
   if (err)
     return err;
 
   // Semantic Analyzer
-  ast::SemanticAnalyser semantics(driver.root_.get(), bpftrace, devnull, false);
+  ast::SemanticAnalyser semantics(driver.root.get(), bpftrace, devnull, false);
   err = semantics.analyse();
   if (err)
     return err;
@@ -166,7 +166,7 @@ int fuzz_main(const char* data, size_t sz)
     return err;
 
   // Codegen
-  ast::CodegenLLVM llvm(driver.root_.get(), bpftrace);
+  ast::CodegenLLVM llvm(driver.root.get(), bpftrace);
   std::unique_ptr<BpfOrc> bpforc;
   try
   {

--- a/src/fuzz_main.cpp
+++ b/src/fuzz_main.cpp
@@ -119,13 +119,13 @@ int fuzz_main(const char* data, size_t sz)
     return 1;
 
   // Field Analyzer
-  ast::FieldAnalyser fields(driver.root_, bpftrace, devnull);
+  ast::FieldAnalyser fields(driver.root_.get(), bpftrace, devnull);
   err = fields.analyse();
   if (err)
     return err;
 
   // Tracepoint parser
-  if (TracepointFormatParser::parse(driver.root_, bpftrace) == false)
+  if (TracepointFormatParser::parse(driver.root_.get(), bpftrace) == false)
     return 1;
 
   // ClangParser
@@ -144,14 +144,14 @@ int fuzz_main(const char* data, size_t sz)
   }
   extra_flags.push_back("-include");
   extra_flags.push_back(CLANG_WORKAROUNDS_H);
-  if (!clang.parse(driver.root_, bpftrace, extra_flags))
+  if (!clang.parse(driver.root_.get(), bpftrace, extra_flags))
     return 1;
   err = driver.parse();
   if (err)
     return err;
 
   // Semantic Analyzer
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace, devnull, false);
+  ast::SemanticAnalyser semantics(driver.root_.get(), bpftrace, devnull, false);
   err = semantics.analyse();
   if (err)
     return err;
@@ -166,7 +166,7 @@ int fuzz_main(const char* data, size_t sz)
     return err;
 
   // Codegen
-  ast::CodegenLLVM llvm(driver.root_, bpftrace);
+  ast::CodegenLLVM llvm(driver.root_.get(), bpftrace);
   std::unique_ptr<BpfOrc> bpforc;
   try
   {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -355,12 +355,12 @@ static std::optional<struct timespec> get_boottime()
   if (err)
     return nullptr;
 
-  ast::FieldAnalyser fields(driver.root_.get(), bpftrace);
+  ast::FieldAnalyser fields(driver.root.get(), bpftrace);
   err = fields.analyse();
   if (err)
     return nullptr;
 
-  if (TracepointFormatParser::parse(driver.root_.get(), bpftrace) == false)
+  if (TracepointFormatParser::parse(driver.root.get(), bpftrace) == false)
     return nullptr;
 
   ClangParser clang;
@@ -394,17 +394,17 @@ static std::optional<struct timespec> get_boottime()
   // avoid issues in some versions. Since we're including files in the command
   // line, we want to force parsing, so we make sure C definitions are not
   // empty before going to clang parser stage.
-  if (!include_files.empty() && driver.root_->c_definitions.empty())
-    driver.root_->c_definitions = "#define __BPFTRACE_DUMMY__";
+  if (!include_files.empty() && driver.root->c_definitions.empty())
+    driver.root->c_definitions = "#define __BPFTRACE_DUMMY__";
 
-  if (!clang.parse(driver.root_.get(), bpftrace, extra_flags))
+  if (!clang.parse(driver.root.get(), bpftrace, extra_flags))
     return nullptr;
 
   err = driver.parse();
   if (err)
     return nullptr;
 
-  return std::move(driver.root_);
+  return std::move(driver.root);
 }
 
 ast::PassManager CreateDynamicPM()
@@ -705,12 +705,12 @@ int main(int argc, char* argv[])
     if (err)
       return err;
 
-    ast::SemanticAnalyser semantics(driver.root_.get(), bpftrace, false, true);
+    ast::SemanticAnalyser semantics(driver.root.get(), bpftrace, false, true);
     err = semantics.analyse();
     if (err)
       return err;
 
-    bpftrace.probe_matcher_->list_probes(driver.root_.get());
+    bpftrace.probe_matcher_->list_probes(driver.root.get());
     return 0;
   }
 

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -159,7 +159,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %%
 
 program:
-                c_definitions probes END { driver.root_ = new ast::Program($1, $2); }
+                c_definitions probes END { driver.root_ = std::make_unique<ast::Program>($1, $2); }
                 ;
 
 c_definitions:

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -159,7 +159,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %%
 
 program:
-                c_definitions probes END { driver.root_ = std::make_unique<ast::Program>($1, $2); }
+                c_definitions probes END { driver.root = std::make_unique<ast::Program>($1, $2); }
                 ;
 
 c_definitions:

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -63,8 +63,8 @@ static auto parse_probe(const std::string &str)
   {
     throw std::runtime_error("Parser failed");
   }
-  auto probe = d.root_->probes->front();
-  d.root_->probes->clear();
+  auto probe = d.root->probes->front();
+  d.root->probes->clear();
   return probe;
 }
 

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -17,11 +17,11 @@ static void parse(const std::string &input, BPFtrace &bpftrace, bool result = tr
   Driver driver(bpftrace);
   ASSERT_EQ(driver.parse_str(extended_input), 0);
 
-  ast::FieldAnalyser fields(driver.root_, bpftrace);
+  ast::FieldAnalyser fields(driver.root_.get(), bpftrace);
   EXPECT_EQ(fields.analyse(), 0);
 
   ClangParser clang;
-  ASSERT_EQ(clang.parse(driver.root_, bpftrace), result);
+  ASSERT_EQ(clang.parse(driver.root_.get(), bpftrace), result);
 }
 
 TEST(clang_parser, integers)

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -17,11 +17,11 @@ static void parse(const std::string &input, BPFtrace &bpftrace, bool result = tr
   Driver driver(bpftrace);
   ASSERT_EQ(driver.parse_str(extended_input), 0);
 
-  ast::FieldAnalyser fields(driver.root_.get(), bpftrace);
+  ast::FieldAnalyser fields(driver.root.get(), bpftrace);
   EXPECT_EQ(fields.analyse(), 0);
 
   ClangParser clang;
-  ASSERT_EQ(clang.parse(driver.root_.get(), bpftrace), result);
+  ASSERT_EQ(clang.parse(driver.root.get(), bpftrace), result);
 }
 
 TEST(clang_parser, integers)

--- a/tests/codegen/call_kstack.cpp
+++ b/tests/codegen/call_kstack.cpp
@@ -27,19 +27,19 @@ TEST(codegen, call_kstack_mapids)
             0);
 
   ClangParser clang;
-  clang.parse(driver.root_.get(), *bpftrace);
+  clang.parse(driver.root.get(), *bpftrace);
 
   // Override to mockbpffeature.
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_.get(), *bpftrace);
+  ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root_.get());
+  ast::ResourceAnalyser resource_analyser(driver.root.get());
   auto resources = resource_analyser.analyse();
   ASSERT_EQ(resources.create_maps(*bpftrace, true), 0);
   bpftrace->resources = resources;
 
-  ast::CodegenLLVM codegen(driver.root_.get(), *bpftrace);
+  ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
   codegen.compile();
 
   ASSERT_EQ(std::distance(bpftrace->maps.begin(), bpftrace->maps.end()), 6);
@@ -62,19 +62,19 @@ TEST(codegen, call_kstack_modes_mapids)
             0);
 
   ClangParser clang;
-  clang.parse(driver.root_.get(), *bpftrace);
+  clang.parse(driver.root.get(), *bpftrace);
 
   // Override to mockbpffeature.
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_.get(), *bpftrace);
+  ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root_.get());
+  ast::ResourceAnalyser resource_analyser(driver.root.get());
   auto resources = resource_analyser.analyse();
   ASSERT_EQ(resources.create_maps(*bpftrace, true), 0);
   bpftrace->resources = resources;
 
-  ast::CodegenLLVM codegen(driver.root_.get(), *bpftrace);
+  ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
   codegen.compile();
 
   ASSERT_EQ(std::distance(bpftrace->maps.begin(), bpftrace->maps.end()), 6);

--- a/tests/codegen/call_kstack.cpp
+++ b/tests/codegen/call_kstack.cpp
@@ -27,19 +27,19 @@ TEST(codegen, call_kstack_mapids)
             0);
 
   ClangParser clang;
-  clang.parse(driver.root_, *bpftrace);
+  clang.parse(driver.root_.get(), *bpftrace);
 
   // Override to mockbpffeature.
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_, *bpftrace);
+  ast::SemanticAnalyser semantics(driver.root_.get(), *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root_);
+  ast::ResourceAnalyser resource_analyser(driver.root_.get());
   auto resources = resource_analyser.analyse();
   ASSERT_EQ(resources.create_maps(*bpftrace, true), 0);
   bpftrace->resources = resources;
 
-  ast::CodegenLLVM codegen(driver.root_, *bpftrace);
+  ast::CodegenLLVM codegen(driver.root_.get(), *bpftrace);
   codegen.compile();
 
   ASSERT_EQ(std::distance(bpftrace->maps.begin(), bpftrace->maps.end()), 6);
@@ -62,19 +62,19 @@ TEST(codegen, call_kstack_modes_mapids)
             0);
 
   ClangParser clang;
-  clang.parse(driver.root_, *bpftrace);
+  clang.parse(driver.root_.get(), *bpftrace);
 
   // Override to mockbpffeature.
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_, *bpftrace);
+  ast::SemanticAnalyser semantics(driver.root_.get(), *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root_);
+  ast::ResourceAnalyser resource_analyser(driver.root_.get());
   auto resources = resource_analyser.analyse();
   ASSERT_EQ(resources.create_maps(*bpftrace, true), 0);
   bpftrace->resources = resources;
 
-  ast::CodegenLLVM codegen(driver.root_, *bpftrace);
+  ast::CodegenLLVM codegen(driver.root_.get(), *bpftrace);
   codegen.compile();
 
   ASSERT_EQ(std::distance(bpftrace->maps.begin(), bpftrace->maps.end()), 6);

--- a/tests/codegen/call_ustack.cpp
+++ b/tests/codegen/call_ustack.cpp
@@ -27,19 +27,19 @@ TEST(codegen, call_ustack_mapids)
             0);
 
   ClangParser clang;
-  clang.parse(driver.root_.get(), *bpftrace);
+  clang.parse(driver.root.get(), *bpftrace);
 
   // Override to mockbpffeature.
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_.get(), *bpftrace);
+  ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root_.get());
+  ast::ResourceAnalyser resource_analyser(driver.root.get());
   auto resources = resource_analyser.analyse();
   ASSERT_EQ(resources.create_maps(*bpftrace, true), 0);
   bpftrace->resources = resources;
 
-  ast::CodegenLLVM codegen(driver.root_.get(), *bpftrace);
+  ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
   codegen.compile();
 
   ASSERT_EQ(std::distance(bpftrace->maps.begin(), bpftrace->maps.end()), 6);
@@ -62,19 +62,19 @@ TEST(codegen, call_ustack_modes_mapids)
             0);
 
   ClangParser clang;
-  clang.parse(driver.root_.get(), *bpftrace);
+  clang.parse(driver.root.get(), *bpftrace);
 
   // Override to mockbpffeature.
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_.get(), *bpftrace);
+  ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root_.get());
+  ast::ResourceAnalyser resource_analyser(driver.root.get());
   auto resources = resource_analyser.analyse();
   ASSERT_EQ(resources.create_maps(*bpftrace, true), 0);
   bpftrace->resources = resources;
 
-  ast::CodegenLLVM codegen(driver.root_.get(), *bpftrace);
+  ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
   codegen.compile();
 
   ASSERT_EQ(std::distance(bpftrace->maps.begin(), bpftrace->maps.end()), 6);

--- a/tests/codegen/call_ustack.cpp
+++ b/tests/codegen/call_ustack.cpp
@@ -27,19 +27,19 @@ TEST(codegen, call_ustack_mapids)
             0);
 
   ClangParser clang;
-  clang.parse(driver.root_, *bpftrace);
+  clang.parse(driver.root_.get(), *bpftrace);
 
   // Override to mockbpffeature.
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_, *bpftrace);
+  ast::SemanticAnalyser semantics(driver.root_.get(), *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root_);
+  ast::ResourceAnalyser resource_analyser(driver.root_.get());
   auto resources = resource_analyser.analyse();
   ASSERT_EQ(resources.create_maps(*bpftrace, true), 0);
   bpftrace->resources = resources;
 
-  ast::CodegenLLVM codegen(driver.root_, *bpftrace);
+  ast::CodegenLLVM codegen(driver.root_.get(), *bpftrace);
   codegen.compile();
 
   ASSERT_EQ(std::distance(bpftrace->maps.begin(), bpftrace->maps.end()), 6);
@@ -62,19 +62,19 @@ TEST(codegen, call_ustack_modes_mapids)
             0);
 
   ClangParser clang;
-  clang.parse(driver.root_, *bpftrace);
+  clang.parse(driver.root_.get(), *bpftrace);
 
   // Override to mockbpffeature.
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_, *bpftrace);
+  ast::SemanticAnalyser semantics(driver.root_.get(), *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root_);
+  ast::ResourceAnalyser resource_analyser(driver.root_.get());
   auto resources = resource_analyser.analyse();
   ASSERT_EQ(resources.create_maps(*bpftrace, true), 0);
   bpftrace->resources = resources;
 
-  ast::CodegenLLVM codegen(driver.root_, *bpftrace);
+  ast::CodegenLLVM codegen(driver.root_.get(), *bpftrace);
   codegen.compile();
 
   ASSERT_EQ(std::distance(bpftrace->maps.begin(), bpftrace->maps.end()), 6);

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -46,22 +46,22 @@ static void test(BPFtrace &bpftrace,
   ASSERT_EQ(driver.parse_str(input), 0);
 
   ClangParser clang;
-  clang.parse(driver.root_, bpftrace);
+  clang.parse(driver.root_.get(), bpftrace);
 
   ASSERT_EQ(driver.parse_str(input), 0);
 
   // Override to mockbpffeature.
   bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace);
+  ast::SemanticAnalyser semantics(driver.root_.get(), bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root_);
+  ast::ResourceAnalyser resource_analyser(driver.root_.get());
   auto resources = resource_analyser.analyse();
   ASSERT_EQ(resources.create_maps(bpftrace, true), 0);
   bpftrace.resources = resources;
 
   std::stringstream out;
-  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  ast::CodegenLLVM codegen(driver.root_.get(), bpftrace);
   codegen.generate_ir();
   codegen.DumpIR(out);
   // Test that generated code compiles cleanly

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -46,22 +46,22 @@ static void test(BPFtrace &bpftrace,
   ASSERT_EQ(driver.parse_str(input), 0);
 
   ClangParser clang;
-  clang.parse(driver.root_.get(), bpftrace);
+  clang.parse(driver.root.get(), bpftrace);
 
   ASSERT_EQ(driver.parse_str(input), 0);
 
   // Override to mockbpffeature.
   bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_.get(), bpftrace);
+  ast::SemanticAnalyser semantics(driver.root.get(), bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root_.get());
+  ast::ResourceAnalyser resource_analyser(driver.root.get());
   auto resources = resource_analyser.analyse();
   ASSERT_EQ(resources.create_maps(bpftrace, true), 0);
   bpftrace.resources = resources;
 
   std::stringstream out;
-  ast::CodegenLLVM codegen(driver.root_.get(), bpftrace);
+  ast::CodegenLLVM codegen(driver.root.get(), bpftrace);
   codegen.generate_ir();
   codegen.DumpIR(out);
   // Test that generated code compiles cleanly

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -45,9 +45,9 @@ TEST(codegen, populate_sections)
   ASSERT_EQ(driver.parse_str("kprobe:foo { 1 } kprobe:bar { 1 }"), 0);
   // Override to mockbpffeature.
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_.get(), *bpftrace);
+  ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
-  ast::CodegenLLVM codegen(driver.root_.get(), *bpftrace);
+  ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
   auto bpforc = codegen.compile();
 
   EXPECT_TRUE(bpforc->getSection("s_kprobe:foo_1").has_value());
@@ -68,19 +68,19 @@ TEST(codegen, printf_offsets)
                 "}"),
             0);
   ClangParser clang;
-  clang.parse(driver.root_.get(), *bpftrace);
+  clang.parse(driver.root.get(), *bpftrace);
 
   // Override to mockbpffeature.
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_.get(), *bpftrace);
+  ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root_.get());
+  ast::ResourceAnalyser resource_analyser(driver.root.get());
   auto resources = resource_analyser.analyse();
   ASSERT_EQ(resources.create_maps(*bpftrace, true), 0);
   bpftrace->resources = resources;
 
-  ast::CodegenLLVM codegen(driver.root_.get(), *bpftrace);
+  ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
   codegen.generate_ir();
 
   EXPECT_EQ(resources.printf_args.size(), 1U);
@@ -120,9 +120,9 @@ TEST(codegen, probe_count)
   ASSERT_EQ(driver.parse_str("kprobe:f { 1; } kprobe:d { 1; }"), 0);
   // Override to mockbpffeature.
   bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_.get(), bpftrace);
+  ast::SemanticAnalyser semantics(driver.root.get(), bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
-  ast::CodegenLLVM codegen(driver.root_.get(), bpftrace);
+  ast::CodegenLLVM codegen(driver.root.get(), bpftrace);
   codegen.generate_ir();
 }
 } // namespace codegen

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -45,9 +45,9 @@ TEST(codegen, populate_sections)
   ASSERT_EQ(driver.parse_str("kprobe:foo { 1 } kprobe:bar { 1 }"), 0);
   // Override to mockbpffeature.
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_, *bpftrace);
+  ast::SemanticAnalyser semantics(driver.root_.get(), *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
-  ast::CodegenLLVM codegen(driver.root_, *bpftrace);
+  ast::CodegenLLVM codegen(driver.root_.get(), *bpftrace);
   auto bpforc = codegen.compile();
 
   EXPECT_TRUE(bpforc->getSection("s_kprobe:foo_1").has_value());
@@ -68,19 +68,19 @@ TEST(codegen, printf_offsets)
                 "}"),
             0);
   ClangParser clang;
-  clang.parse(driver.root_, *bpftrace);
+  clang.parse(driver.root_.get(), *bpftrace);
 
   // Override to mockbpffeature.
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_, *bpftrace);
+  ast::SemanticAnalyser semantics(driver.root_.get(), *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root_);
+  ast::ResourceAnalyser resource_analyser(driver.root_.get());
   auto resources = resource_analyser.analyse();
   ASSERT_EQ(resources.create_maps(*bpftrace, true), 0);
   bpftrace->resources = resources;
 
-  ast::CodegenLLVM codegen(driver.root_, *bpftrace);
+  ast::CodegenLLVM codegen(driver.root_.get(), *bpftrace);
   codegen.generate_ir();
 
   EXPECT_EQ(resources.printf_args.size(), 1U);
@@ -120,9 +120,9 @@ TEST(codegen, probe_count)
   ASSERT_EQ(driver.parse_str("kprobe:f { 1; } kprobe:d { 1; }"), 0);
   // Override to mockbpffeature.
   bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace);
+  ast::SemanticAnalyser semantics(driver.root_.get(), bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
-  ast::CodegenLLVM codegen(driver.root_, bpftrace);
+  ast::CodegenLLVM codegen(driver.root_.get(), bpftrace);
   codegen.generate_ir();
 }
 } // namespace codegen

--- a/tests/codegen/regression.cpp
+++ b/tests/codegen/regression.cpp
@@ -16,15 +16,15 @@ TEST(codegen, regression_957)
 
   ASSERT_EQ(driver.parse_str("t:sched:sched_one* { cat(\"%s\", probe); }"), 0);
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_, *bpftrace);
+  ast::SemanticAnalyser semantics(driver.root_.get(), *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root_);
+  ast::ResourceAnalyser resource_analyser(driver.root_.get());
   auto resources = resource_analyser.analyse();
   ASSERT_EQ(resources.create_maps(*bpftrace, true), 0);
   bpftrace->resources = resources;
 
-  ast::CodegenLLVM codegen(driver.root_, *bpftrace);
+  ast::CodegenLLVM codegen(driver.root_.get(), *bpftrace);
   codegen.compile();
 }
 

--- a/tests/codegen/regression.cpp
+++ b/tests/codegen/regression.cpp
@@ -16,15 +16,15 @@ TEST(codegen, regression_957)
 
   ASSERT_EQ(driver.parse_str("t:sched:sched_one* { cat(\"%s\", probe); }"), 0);
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_.get(), *bpftrace);
+  ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root_.get());
+  ast::ResourceAnalyser resource_analyser(driver.root.get());
   auto resources = resource_analyser.analyse();
   ASSERT_EQ(resources.create_maps(*bpftrace, true), 0);
   bpftrace->resources = resources;
 
-  ast::CodegenLLVM codegen(driver.root_.get(), *bpftrace);
+  ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
   codegen.compile();
 }
 

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -33,7 +33,7 @@ void test(BPFtrace &bpftrace,
 
   std::ostringstream out;
   Printer printer(out);
-  printer.print(driver.root_);
+  printer.print(driver.root_.get());
   EXPECT_EQ(output, out.str());
 }
 

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -33,7 +33,7 @@ void test(BPFtrace &bpftrace,
 
   std::ostringstream out;
   Printer printer(out);
-  printer.print(driver.root_.get());
+  printer.print(driver.root.get());
   EXPECT_EQ(output, out.str());
 }
 

--- a/tests/portability_analyser.cpp
+++ b/tests/portability_analyser.cpp
@@ -23,18 +23,18 @@ void test(BPFtrace &bpftrace, const std::string &input, int expected_result = 0)
 
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.root_, bpftrace, out);
+  ast::FieldAnalyser fields(driver.root_.get(), bpftrace, out);
   ASSERT_EQ(fields.analyse(), 0) << msg.str() << out.str();
 
   ClangParser clang;
-  ASSERT_TRUE(clang.parse(driver.root_, bpftrace));
+  ASSERT_TRUE(clang.parse(driver.root_.get(), bpftrace));
 
   ASSERT_EQ(driver.parse_str(input), 0);
   out.str("");
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace, out, false);
+  ast::SemanticAnalyser semantics(driver.root_.get(), bpftrace, out, false);
   ASSERT_EQ(semantics.analyse(), 0) << msg.str() << out.str();
 
-  ast::PortabilityAnalyser portability(driver.root_, out);
+  ast::PortabilityAnalyser portability(driver.root_.get(), out);
   EXPECT_EQ(portability.analyse(), expected_result) << msg.str() << out.str();
 }
 

--- a/tests/portability_analyser.cpp
+++ b/tests/portability_analyser.cpp
@@ -23,18 +23,18 @@ void test(BPFtrace &bpftrace, const std::string &input, int expected_result = 0)
 
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.root_.get(), bpftrace, out);
+  ast::FieldAnalyser fields(driver.root.get(), bpftrace, out);
   ASSERT_EQ(fields.analyse(), 0) << msg.str() << out.str();
 
   ClangParser clang;
-  ASSERT_TRUE(clang.parse(driver.root_.get(), bpftrace));
+  ASSERT_TRUE(clang.parse(driver.root.get(), bpftrace));
 
   ASSERT_EQ(driver.parse_str(input), 0);
   out.str("");
-  ast::SemanticAnalyser semantics(driver.root_.get(), bpftrace, out, false);
+  ast::SemanticAnalyser semantics(driver.root.get(), bpftrace, out, false);
   ASSERT_EQ(semantics.analyse(), 0) << msg.str() << out.str();
 
-  ast::PortabilityAnalyser portability(driver.root_.get(), out);
+  ast::PortabilityAnalyser portability(driver.root.get(), out);
   EXPECT_EQ(portability.analyse(), expected_result) << msg.str() << out.str();
 }
 

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -28,23 +28,23 @@ void gen_bytecode(const std::string &input, std::stringstream &out)
 
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.root_.get(), *bpftrace);
+  ast::FieldAnalyser fields(driver.root.get(), *bpftrace);
   EXPECT_EQ(fields.analyse(), 0);
 
   ClangParser clang;
-  clang.parse(driver.root_.get(), *bpftrace);
+  clang.parse(driver.root.get(), *bpftrace);
 
   // Override to mockbpffeature.
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_.get(), *bpftrace);
+  ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root_.get());
+  ast::ResourceAnalyser resource_analyser(driver.root.get());
   auto resources = resource_analyser.analyse();
   ASSERT_EQ(resources.create_maps(*bpftrace, true), 0);
   bpftrace->resources = resources;
 
-  ast::CodegenLLVM codegen(driver.root_.get(), *bpftrace);
+  ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
   codegen.generate_ir();
   codegen.DumpIR(out);
 }

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -28,23 +28,23 @@ void gen_bytecode(const std::string &input, std::stringstream &out)
 
   ASSERT_EQ(driver.parse_str(input), 0);
 
-  ast::FieldAnalyser fields(driver.root_, *bpftrace);
+  ast::FieldAnalyser fields(driver.root_.get(), *bpftrace);
   EXPECT_EQ(fields.analyse(), 0);
 
   ClangParser clang;
-  clang.parse(driver.root_, *bpftrace);
+  clang.parse(driver.root_.get(), *bpftrace);
 
   // Override to mockbpffeature.
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_, *bpftrace);
+  ast::SemanticAnalyser semantics(driver.root_.get(), *bpftrace);
   ASSERT_EQ(semantics.analyse(), 0);
 
-  ast::ResourceAnalyser resource_analyser(driver.root_);
+  ast::ResourceAnalyser resource_analyser(driver.root_.get());
   auto resources = resource_analyser.analyse();
   ASSERT_EQ(resources.create_maps(*bpftrace, true), 0);
   bpftrace->resources = resources;
 
-  ast::CodegenLLVM codegen(driver.root_, *bpftrace);
+  ast::CodegenLLVM codegen(driver.root_.get(), *bpftrace);
   codegen.generate_ir();
   codegen.DumpIR(out);
 }

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -27,13 +27,13 @@ void test_for_warning(
   ASSERT_EQ(driver.parse_str(input), 0);
 
   ClangParser clang;
-  clang.parse(driver.root_, bpftrace);
+  clang.parse(driver.root_.get(), bpftrace);
 
   ASSERT_EQ(driver.parse_str(input), 0);
   std::stringstream out;
   // Override to mockbpffeature.
   bpftrace.feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace, out);
+  ast::SemanticAnalyser semantics(driver.root_.get(), bpftrace, out);
   semantics.analyse();
   if (invert)
     EXPECT_THAT(out.str(), Not(HasSubstr(warning)));
@@ -72,17 +72,17 @@ void test(BPFtrace &bpftrace,
   if (expected_parse)
     return;
 
-  ast::FieldAnalyser fields(driver.root_, bpftrace, out);
+  ast::FieldAnalyser fields(driver.root_.get(), bpftrace, out);
   EXPECT_EQ(fields.analyse(), expected_field_analyser) << msg.str() + out.str();
 
   ClangParser clang;
-  clang.parse(driver.root_, bpftrace);
+  clang.parse(driver.root_.get(), bpftrace);
 
   ASSERT_EQ(driver.parse_str(input), 0);
   out.str("");
   // Override to mockbpffeature.
   bpftrace.feature_ = std::make_unique<MockBPFfeature>(mock_has_features);
-  ast::SemanticAnalyser semantics(driver.root_, bpftrace, out, has_child);
+  ast::SemanticAnalyser semantics(driver.root_.get(), bpftrace, out, has_child);
   EXPECT_EQ(expected_result, semantics.analyse()) << msg.str() + out.str();
 }
 

--- a/tests/tracepoint_format_parser.cpp
+++ b/tests/tracepoint_format_parser.cpp
@@ -260,23 +260,23 @@ TEST(tracepoint_format_parser, args_field_access)
   ast::TracepointArgsVisitor visitor;
 
   EXPECT_EQ(driver.parse_str("BEGIN { args->f1->f2->f3 }"), 0);
-  visitor.visit(*driver.root_->probes->at(0));
-  EXPECT_EQ(driver.root_->probes->at(0)->tp_args_structs_level, 3);
+  visitor.visit(*driver.root->probes->at(0));
+  EXPECT_EQ(driver.root->probes->at(0)->tp_args_structs_level, 3);
 
   // Should work via intermediary variable, too
   EXPECT_EQ(driver.parse_str("BEGIN { $x = args->f1; $x->f2->f3 }"), 0);
-  visitor.visit(*driver.root_->probes->at(0));
-  EXPECT_EQ(driver.root_->probes->at(0)->tp_args_structs_level, 3);
+  visitor.visit(*driver.root->probes->at(0));
+  EXPECT_EQ(driver.root->probes->at(0)->tp_args_structs_level, 3);
 
   // "args" used without field access => level should be 0
   EXPECT_EQ(driver.parse_str("BEGIN { args }"), 0);
-  visitor.visit(*driver.root_->probes->at(0));
-  EXPECT_EQ(driver.root_->probes->at(0)->tp_args_structs_level, 0);
+  visitor.visit(*driver.root->probes->at(0));
+  EXPECT_EQ(driver.root->probes->at(0)->tp_args_structs_level, 0);
 
   // "args" not used => level should be -1
   EXPECT_EQ(driver.parse_str("BEGIN { x->f1->f2->f3 }"), 0);
-  visitor.visit(*driver.root_->probes->at(0));
-  EXPECT_EQ(driver.root_->probes->at(0)->tp_args_structs_level, -1);
+  visitor.visit(*driver.root->probes->at(0));
+  EXPECT_EQ(driver.root->probes->at(0)->tp_args_structs_level, -1);
 }
 
 } // namespace tracepoint_format_parser


### PR DESCRIPTION
Change to use `std::unique_ptr` instead of raw pointer for `Driver::root_`, for the sake of more modern memory management.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
