### PR TITLE
Add a static build script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 build/
 build-*/
 tests/runtime/*.pyc

--- a/README.md
+++ b/README.md
@@ -111,6 +111,24 @@ For additional help / discussion, please use our [discussions](https://github.co
 
 ## Development
 
+### Docker
+
+For build & test directly in docker
+
+```
+$ ./build.sh
+```
+
+For build in docker then test directly on host
+
+```
+$ ./build-static.sh
+$ ./build-static/src/bpftrace
+$ ./build-static/testing/bpftrace_test
+```
+
+### Vagrant
+
 For development and testing a [Vagrantfile](Vagrantfile) is available.
 
 Make sure you have the `vbguest` plugin installed, it is required to correctly

--- a/build-static.sh
+++ b/build-static.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eu
+export BASE=ubuntu-glibc
+export LLVM_VERSION=12
+export RUN_TESTS=0
+./build-docker-image.sh
+docker run --network host --rm -it -u $(id -u):$(id -g) -v $(pwd):$(pwd) -e STATIC_LINKING=ON -e STATIC_LIBC=OFF -e ALLOW_UNSAFE_PROBE=OFF -e VENDOR_GTEST=ON -e RUN_TESTS=${RUN_TESTS} -e EMBED_USE_LLVM=ON bpftrace-builder-${BASE} "$(pwd)/build-static" Release "$@"


### PR DESCRIPTION
This PR adds a static (embed) build script that can be used locally to generate static linked binaries through docker.

Also adds instructions in README.md.