### PR TITLE
src: fuzz_main.cpp: Fix includes

### DIFF
--- a/src/fuzz_main.cpp
+++ b/src/fuzz_main.cpp
@@ -17,12 +17,12 @@
 #include <unistd.h>
 
 #include "ast/bpforc/bpforc.h"
-#include "ast/clang_parser.h"
 #include "ast/passes/callback_visitor.h"
+#include "ast/passes/codegen_llvm.h"
 #include "ast/passes/field_analyser.h"
 #include "ast/passes/semantic_analyser.h"
 #include "bpftrace.h"
-#include "codegen_llvm.h"
+#include "clang_parser.h"
 #include "driver.h"
 #include "log.h"
 #include "output.h"
@@ -135,7 +135,7 @@ int fuzz_main(const char* data, size_t sz)
     struct utsname utsname;
     uname(&utsname);
     std::string ksrc, kobj;
-    auto kdirs = get_kernel_dirs(utsname, !bpftrace.features_->has_btf());
+    auto kdirs = get_kernel_dirs(utsname, !bpftrace.feature_->has_btf());
     ksrc = std::get<0>(kdirs);
     kobj = std::get<1>(kdirs);
 


### PR DESCRIPTION
This fixes the following build issues:
```
fuzz_main.cpp:20:10: fatal error: ast/clang_parser.h: No such file or
directory
fuzz_main.cpp:25:10: fatal error: codegen_llvm.h: No such file or
director
```
Bug: https://bugs.gentoo.org/801385

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
