### PR TITLE
poll_perf_buffers: make epollfd_ member variable

### DIFF
--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -214,12 +214,13 @@ private:
       int pid,
       bool file_activation);
   int setup_perf_events();
-  void poll_perf_events(int epollfd, bool drain = false);
+  void poll_perf_events(bool drain = false);
   int print_map_hist(IMap &map, uint32_t top, uint32_t div);
   int print_map_stats(IMap &map, uint32_t top, uint32_t div);
   static uint64_t read_address_from_output(std::string output);
   std::vector<uint8_t> find_empty_key(IMap &map, size_t size) const;
   bool has_iter_ = false;
+  int epollfd_ = -1;
 
   std::unordered_map<std::string, std::unique_ptr<Dwarf>> dwarves_;
 };


### PR DESCRIPTION
Two items around `poll_perf_events`:
1) Make epollfd a member variable. It's state that is used in multiple functions, so seems like a good candidate for that.
2) Expose poll_perf_events interface polling period via `timeout_ms`

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
