### PR TITLE
Fix CMakeLists: include dirs for libcereal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,7 +96,7 @@ find_package(LibElf REQUIRED)
 include_directories(SYSTEM ${LIBELF_INCLUDE_DIRS})
 
 find_package(LibCereal REQUIRED)
-include_directories(SYSTEM ${CEREAL_INCLUDE_DIRS})
+include_directories(SYSTEM ${LIBCEREAL_INCLUDE_DIRS})
 
 find_package(BISON REQUIRED)
 find_package(FLEX REQUIRED)


### PR DESCRIPTION
Typo in CMakeLists meant LIBCEREAL_INCLUDE_DIRS was not taking effect properly.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
