### PR TITLE
parse_args: Move argument parsing into a function

### DIFF
--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -114,22 +114,22 @@ EXPECT ERROR: invalid character
 TIMEOUT 1
 
 NAME pid fails validation with leading non-number
-RUN {{BPFTRACE}} -p a1111
+RUN {{BPFTRACE}} -p a1111 file.bt
 EXPECT ERROR: pid 'a1111' is not a valid decimal number
 TIMEOUT 1
 
 NAME pid fails validation with non-number in between
-RUN {{BPFTRACE}} -p 111a1
+RUN {{BPFTRACE}} -p 111a1 file.bt
 EXPECT ERROR: pid '111a1' is not a valid decimal number
 TIMEOUT 1
 
 NAME pid fails validation with non-numeric argument
-RUN {{BPFTRACE}} -p not_a_pid
+RUN {{BPFTRACE}} -p not_a_pid file.bt
 EXPECT ERROR: pid 'not_a_pid' is not a valid decimal number
 TIMEOUT 1
 
 NAME pid outside of valid pid range
-RUN {{BPFTRACE}} -p 5000000
+RUN {{BPFTRACE}} -p 5000000 file.bt
 EXPECT ERROR: pid '5000000' out of valid pid range \[1,4194304\]
 TIMEOUT 1
 


### PR DESCRIPTION
Refactored some code to consolidate argument parsing into a `parse_args` function. Basic idea was to keep all argument parsing (including processing of `optind`) into a single function that returns a struct of all the parsed args. 

Throwing this out there to see if the maintainers want it. If you like these sort of changes, there are few other code pieces in `main()` that can be moved into functions to help with organization. Let me know what you think...I'd be happy to put out a few other contributions. 

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
