### PR TITLE
Fix minor sanitizer issue

### DIFF
--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -143,7 +143,6 @@ public:
   Dwarf *get_dwarf(const std::string &filename);
   Dwarf *get_dwarf(const ast::AttachPoint &attachpoint);
 
-  std::vector<std::unique_ptr<AttachedProbe>> attached_probes_;
   std::string cmd_;
   bool finalize_ = false;
   // Global variable checking if an exit signal was received
@@ -156,6 +155,7 @@ public:
   std::map<std::string, std::string> macros_;
   std::map<std::string, uint64_t> enums_;
   std::unordered_set<std::string> traceable_funcs_;
+  std::vector<std::unique_ptr<AttachedProbe>> attached_probes_;
 
   unsigned int join_argnum_ = 16;
   unsigned int join_argsize_ = 1024;


### PR DESCRIPTION
`AttachedProbe` has a reference to a `Probe` inside `RequiredResources`. Thus, strictly speaking, `RequiredResources resources` should be destroyed after `std::vector<std::unique_ptr<AttachedProbe>> attached_probes_`.

This means `std::vector<std::unique_ptr<AttachedProbe>> attached_probes_` should be declared after `RequiredResources resources;` in the struct, so that the AttachedProbes are destroyed first on `~BPFtrace`.

This was caught by an independent ASAN build. It doesn't affect much in practice, but changing it for strict correctness.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
