### PR TITLE
ci: 'fix' libbpf build

### DIFF
--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -19,6 +19,7 @@ jobs:
           BASE: bionic
           DISTRO: ubuntu-glibc
           VENDOR_GTEST: ON
+          BUILD_LIBBPF: ON
         - TYPE: Release
           NAME: vanilla_llvm12+clang+glibc2.23
           LLVM_VERSION: 12
@@ -32,6 +33,7 @@ jobs:
           DISTRO: ubuntu-glibc
           CMAKE_EXTRA_FLAGS: "-DCMAKE_CXX_FLAGS='-include /usr/local/include/bcc/compat/linux/bpf.h -D__LINUX_BPF_H__'"
           VENDOR_GTEST: ON
+          BUILD_LIBBPF: ON
         - TYPE: Debug
           NAME: alpine
           LLVM_VERSION: 9
@@ -88,6 +90,7 @@ jobs:
         -e TEST_GROUPS_DISABLE="${TEST_GROUPS_DISABLE}"
         -e RUNTIME_TEST_DISABLE="${RUNTIME_TEST_DISABLE}"
         -e VENDOR_GTEST="${VENDOR_GTEST}"
+        -e BUILD_LIBBPF="${BUILD_LIBBPF}"
         bpftrace-embedded-${{ matrix.env['BASE'] }}
         $(pwd)/build-embedded ${TYPE}
         -j`nproc`

--- a/docker/Dockerfile.ubuntu-glibc
+++ b/docker/Dockerfile.ubuntu-glibc
@@ -9,7 +9,6 @@ ARG CMAKE_VER="3.16"
 ARG CMAKE_BUILD="2"
 ARG bcc_ref="v0.22.0"
 ARG bcc_org="iovisor"
-ARG libbpf_ref="092a606856"
 
 ENV LLVM_VERSION=$LLVM_VERSION
 ENV CMAKE_VER=${CMAKE_VER}
@@ -54,11 +53,6 @@ RUN mkdir -p /src \
     && cp src/cc/libbcc-loader-static.a /usr/local/lib/libbcc-loader-static.a \
     && cp ./src/cc/libbcc_bpf.a /usr/local/lib/libbpf.a \
     && cp ./src/cc/libbcc_bpf.a /usr/local/lib/libbcc_bpf.a
-
-RUN git clone https://github.com/libbpf/libbpf.git /src/libbpf \
-    && cd /src/libbpf/src \
-    && git checkout $libbpf_ref \
-    && CC=gcc make -j$(nproc) install install_uapi_headers
 
 COPY build.sh /build.sh
 RUN chmod 755 /build.sh

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -23,9 +23,10 @@ if [[ $LLVM_VERSION -eq 13 ]]; then
 fi
 
 if [[ $BUILD_LIBBPF = ON ]]; then
-  mkdir /src
+  mkdir -p /src
   git clone https://github.com/libbpf/libbpf.git /src/libbpf
   cd /src/libbpf/src
+  git checkout v0.5.0
   CC=gcc make -j$(nproc)
   # libbpf defaults to /usr/lib64 which doesn't work on debian like systems
   # this should work on both


### PR DESCRIPTION
The LLVM 12 + libbpf build breaks in the ci, pinning to a version that
should work.

Bit hacky but proper fix can come later, this unblocks the CI for other
PRs

fixes #2068
