### PR TITLE
docker: Add xz-utils to the release docker image

### DIFF
--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -4,7 +4,7 @@ FROM ubuntu:$BASE
 ARG build_dir=build-embedded
 
 # Run security updates
-RUN apt-get update && apt-get upgrade -y && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get upgrade -y && apt-get install -y xz-utils && rm -rf /var/lib/apt/lists/*
 
 COPY /$build_dir/src/bpftrace /usr/bin/bpftrace
 COPY /tools/*.bt /usr/local/bin/


### PR DESCRIPTION
This doesn't bloat the image too much and allows bpftrace to extract the
kernel headers from /sys/kernel/kheaders.tar.xz when IKHEADERS is
enabled.
