### PR TITLE
Fix runtime test color display

### DIFF
--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -2,6 +2,7 @@
 
 import subprocess
 import signal
+import sys
 import os
 import time
 from os import environ, uname, devnull
@@ -24,7 +25,7 @@ NO_COLOR = '\033[0m'
 
 # TODO(mmarchini) only add colors if terminal supports it
 def colorify(s, color):
-    return "%s%s%s" % (color, s, NO_COLOR)
+    return "%s%s%s" % (color, s, NO_COLOR) if sys.stdout.isatty() else s
 
 def ok(s):
     return colorify(s, OK_COLOR)


### PR DESCRIPTION
Don't display colors in runtime test output when stdout is not a tty.
This works because only the stdout output messages are colored.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

Just a quick workaround of a probably forgotten todo I noticed. This doesn't handle the uncommon case of a terminal without color support, but it does handle the much more common case of stdout redirection.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
