### PR TITLE
Load program just once for wildcard probes

### DIFF
--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -68,9 +68,14 @@ private:
   void attach_iter(void);
   int detach_iter(void);
 
+  static std::map<std::string, int> cached_prog_fds_;
+  bool use_cached_progfd(void);
+  void cache_progfd(void);
+
   Probe &probe_;
   std::tuple<uint8_t *, uintptr_t> func_;
   std::vector<int> perf_event_fds_;
+  bool close_progfd_ = true;
   int progfd_ = -1;
   uint64_t offset_ = 0;
   int tracing_fd_ = -1;

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -27,6 +27,12 @@ EXPECT SUCCESS kprobe_offset [0-9][0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
+NAME kprobe_wildcard
+RUN {{BPFTRACE}} --unsafe -e 'kprobe:ksys_* { system("/usr/sbin/bpftool prog | grep kprobe | grep ksys_ | wc -l"); exit(); }'
+EXPECT 1
+TIMEOUT 5
+REQUIRES /usr/sbin/bpftool
+
 # Note: this test may fail if you've installed a new kernel but not rebooted
 # yet. Reason is b/c bpftrace will look for a vmlinux based on the running kernel's
 # version.
@@ -57,6 +63,12 @@ RUN {{BPFTRACE}} runtime/scripts/kretprobe_order.bt
 EXPECT first second
 TIMEOUT 5
 AFTER /bin/bash -c "./testprogs/syscall nanosleep 1000"; /bin/bash -c "./testprogs/syscall nanosleep 1000"
+
+NAME kretprobe_wildcard
+RUN {{BPFTRACE}} --unsafe -e 'kretprobe:ksys_* { system("/usr/sbin/bpftool prog | grep kprobe | grep ksys_ | wc -l"); exit(); }'
+EXPECT 1
+TIMEOUT 5
+REQUIRES /usr/sbin/bpftool
 
 NAME uprobe
 PROG uprobe:/bin/bash:echo_builtin { printf("arg0: %d\n", arg0); exit();}


### PR DESCRIPTION
Currently when tracing wildcard kprobes/kretprobes we load
program for each final probe. Like for:

```
  # bpftrace -e 'kprobe:kvm_a* {  }'
  Attaching 111 probes...
  ...

```
We will have:
```
  # bpftool prog | grep kprobe | wc -l
  111

```
111 loaded programs, which are the same.

Adding map of loaded programs based on their 'orig_name',
and make sure they are loaded just once. This way we prevent
multiple copies of the same program loaded for wildcard
probe and have just one.

Signed-off-by: Jiri Olsa <jolsa@kernel.org>

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests