### PR TITLE
Ignore non-existing tracepoints for multi-attach probes

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -626,6 +626,18 @@ Probe::Probe(const Probe &other) : Node(other)
   index_ = other.index_;
 }
 
+bool Probe::has_ap_of_probetype(ProbeType probe_type)
+{
+  if (!attach_points)
+    return false;
+  for (auto ap : *attach_points)
+  {
+    if (probetype(ap->provider) == probe_type)
+      return true;
+  }
+  return false;
+}
+
 While::While(const While &other) : Statement(other)
 {
 }

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -581,6 +581,8 @@ public:
   int index() const;
   void set_index(int index);
 
+  bool has_ap_of_probetype(ProbeType probe_type);
+
 private:
   Probe(const Probe &other);
   int index_ = 0;

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -1018,8 +1018,11 @@ void AttachedProbe::attach_tracepoint()
   int perf_event_fd = bpf_attach_tracepoint(progfd_, probe_.path.c_str(),
       eventname().c_str());
 
-  if (perf_event_fd < 0)
+  if (perf_event_fd < 0 && probe_.name == probe_.orig_name)
+  {
+    // do not fail if there are other attach points where attaching may succeed
     throw std::runtime_error("Error attaching probe: " + probe_.name);
+  }
 
   perf_event_fds_.push_back(perf_event_fd);
 }

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -17,11 +17,10 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
 {
   std::vector<ast::Probe*> probes_with_tracepoint;
   for (ast::Probe *probe : *program->probes)
-    for (ast::AttachPoint *ap : *probe->attach_points)
-      if (ap->provider == "tracepoint") {
-        probes_with_tracepoint.push_back(probe);
-        continue;
-      }
+  {
+    if (probe->has_ap_of_probetype(ProbeType::tracepoint))
+      probes_with_tracepoint.push_back(probe);
+  }
 
   if (probes_with_tracepoint.empty())
     return true;

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -134,6 +134,17 @@ RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_*_nanosleep { printf("hit "); }' -c
 EXPECT hit hit
 TIMEOUT 5
 
+NAME tracepoint_missing
+PROG t:syscalls:nonsense { printf("hit"); exit(); }
+EXPECT ERROR: tracepoint not found: syscalls:nonsense
+TIMEOUT 5
+
+NAME tracepoint_multiattach_missing
+PROG t:syscalls:sys_exit_nanosleep,t:syscalls:nonsense { printf("hit"); exit(); }
+EXPECT hit
+AFTER ./testprogs/syscall nanosleep 1e8
+TIMEOUT 5
+
 # Test that we get at least two characters out
 NAME tracepoint_data_loc
 PROG tracepoint:irq:irq_handler_entry { print(str(args->name)); exit(); }


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

The set of available tracepoints is not the same on each system and therefore some scripts may not be portable as bpftrace always fails on a non-existing tracepoint. For example, aarch64 kernel does not have some syscalls and lets libc emulate them - one of the missing syscalls is `sys_enter_newstat` which causes `statsnoop.bt` to fail on aarch64.

This PR resolves the above issue by not failing on non-existing tracepoints, if the same probe is attached to other tracepoints. Instead of failing, just a warning is printed (this is a behaviour similar to kprobes).

An alternative solution to the above problem could be to add a bpftrace syntax option to check if the given attachpoint exists.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
