### PR TITLE
ci: install python-distutils for bcc

### DIFF
--- a/docker/Dockerfile.ubuntu-glibc
+++ b/docker/Dockerfile.ubuntu-glibc
@@ -30,6 +30,7 @@ RUN apt-get update \
         libedit-dev \
         systemtap-sdt-dev \
         python3 \
+        python3-setuptools \
         quilt \
     && apt-get install --no-install-recommends -y \
         pkg-config


### PR DESCRIPTION
Fixes:

```
[ 56%] Linking CXX static library libclang_frontend.a
[ 56%] Built target clang_frontend
[ 56%] Building sdist for python3
Traceback (most recent call last):
  File "setup.py", line 3, in <module>
    from distutils.core import setup
ModuleNotFoundError: No module named 'distutils.core'
```
