### PR TITLE
Add sslsnoop and ssllatency tools

### DIFF
--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -46,7 +46,7 @@ jobs:
           EMBED_BUILD_LLVM: OFF
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: json-output.join_delim,other.string compare map lookup,probe.kprobe_offset_fail_size,probe.uprobe_library,usdt."usdt probes - attach to fully specified probe of child",usdt."usdt probes - all probes by wildcard and file with child",usdt."usdt probes - attach to probe by wildcard and file with child",usdt."usdt probes - attach to probes by wildcard file with child",usdt."usdt probes - attach to probe on multiple files by wildcard",usdt."usdt probes - attach to probe with probe builtin and args by file with child",usdt."usdt probes - list probes by pid in separate mountns",usdt."usdt sized arguments",usdt."usdt - list probes by file with wildcarded probe type",uprobe."uprobes - list probes by pid; uprobes only",uprobe."uprobes - list probes by pid in separate mount namespace",other.positional pointer arithmetics
-          TOOLS_TEST_DISABLE: gethostlatency.bt,threadsnoop.bt
+          TOOLS_TEST_DISABLE: gethostlatency.bt,threadsnoop.bt,ssllatency.bt,sslsnoop.bt
           TOOLS_TEST_OLDVERSION: biosnoop.bt
           BASE: alpine
           DISTRO: alpine
@@ -60,7 +60,7 @@ jobs:
           EMBED_BUILD_LLVM: OFF
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: other.string compare map lookup,probe.kprobe_offset_fail_size,probe.uprobe_library,usdt."usdt probes - attach to fully specified probe of child",usdt."usdt probes - all probes by wildcard and file with child",usdt."usdt probes - attach to probe by wildcard and file with child",usdt."usdt probes - attach to probes by wildcard file with child",usdt."usdt probes - attach to probe on multiple files by wildcard",usdt."usdt probes - attach to probe with probe builtin and args by file with child",usdt."usdt probes - list probes by pid in separate mountns",usdt."usdt sized arguments",usdt."usdt - list probes by file with wildcarded probe type",uprobe."uprobes - list probes by pid; uprobes only",uprobe."uprobes - list probes by pid in separate mount namespace",other.positional pointer arithmetics
-          TOOLS_TEST_DISABLE: gethostlatency.bt,threadsnoop.bt
+          TOOLS_TEST_DISABLE: gethostlatency.bt,threadsnoop.bt,ssllatency.bt,sslsnoop.bt
           TOOLS_TEST_OLDVERSION: biosnoop.bt
           BASE: alpine
           DISTRO: alpine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
 #### Added
 #### Docs
 #### Tools
+- Add sslsnoop and ssllatency tools
+  - [#2117](https://github.com/iovisor/bpftrace/pull/2117)
 
 ## [0.15.0] 2022-05-24
 

--- a/README.md
+++ b/README.md
@@ -74,6 +74,8 @@ bpftrace contains various tools, which also serve as examples of programming in 
 - tools/[runqlat.bt](tools/runqlat.bt): CPU scheduler run queue latency as a histogram. [Examples](tools/runqlat_example.txt).
 - tools/[runqlen.bt](tools/runqlen.bt): CPU scheduler run queue length as a histogram. [Examples](tools/runqlen_example.txt).
 - tools/[setuids.bt](tools/setuids.bt): Trace the setuid syscalls: privilege escalation. [Examples](tools/setuids_example.txt).
+- tools/[ssllatency.bt](tools/ssllatency.bt): Summarize SSL/TLS handshake latency as a histogram. [Examples](tools/ssllatency_example.txt)
+- tools/[sslsnoop.bt](tools/sslsnoop.bt): Trace SSL/TLS handshake, showing latency and return value. [Examples](tools/sslsnoop_example.txt)
 - tools/[statsnoop.bt](tools/statsnoop.bt): Trace stat() syscalls for general debugging. [Examples](tools/statsnoop_example.txt).
 - tools/[swapin.bt](tools/swapin.bt): Show swapins by process. [Examples](tools/swapin_example.txt).
 - tools/[syncsnoop.bt](tools/syncsnoop.bt): Trace sync() variety of syscalls. [Examples](tools/syncsnoop_example.txt).

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -26,7 +26,8 @@ RUN apk add --update \
   python3 \
   wget \
   zlib-dev \
-  zlib-static
+  zlib-static \
+  openssl-dev
 
 WORKDIR /
 

--- a/docker/Dockerfile.focal
+++ b/docker/Dockerfile.focal
@@ -42,7 +42,8 @@ RUN apt-get update && apt-get install -y \
       libllvm${LLVM_VERSION} \
       systemtap-sdt-dev \
       python3 \
-      xxd
+      xxd \
+      libssl-dev
 RUN if [ "$LLVM_VERSION" -ge 13 ] ; then apt-get install -y libmlir-${LLVM_VERSION}-dev ; fi
 
 RUN ln -s /usr/bin/python3 /usr/bin/python

--- a/docker/Dockerfile.ubuntu-glibc
+++ b/docker/Dockerfile.ubuntu-glibc
@@ -32,6 +32,7 @@ RUN apt-get update \
         python3 \
         python3-setuptools \
         quilt \
+        libssl-dev \
     && apt-get install --no-install-recommends -y \
         pkg-config
 

--- a/man/man8/ssllatency.8
+++ b/man/man8/ssllatency.8
@@ -1,0 +1,62 @@
+.TH ssllatency 8  "2021-12-28" "USER COMMANDS"
+.SH NAME
+ssllatency.bt \- Show SSL/TLS handshake latency histogram. Uses bpftrace/eBPF.
+.SH SYNOPSIS
+.B ssllatency.bt
+.SH DESCRIPTION
+ssllatency shows latency distribution for OpenSSL handshake functions. This is
+useful for performance analysis with different crypto cipher suite, async SSL
+acceleration by CPU or offload device, etc.
+
+This tool works by dynamic tracing the uprobes in OpenSSL and related crypto
+libs, and may need updating to match future changes to these functions.
+
+Since this uses BPF, only the root user can use this tool.
+.SH REQUIREMENTS
+CONFIG_BPF and bpftrace.
+.SH EXAMPLES
+.TP
+Trace SSL/TLS handshake latency, and print a histogram on Ctrl-C:
+#
+.B ssllatency.bt
+.SH FIELDS
+.TP
+0th
+A function name is shown in "@hist[...]" followed by latency histogram and
+"@stat[...]" followed by total call count, average, total latency in
+microseconds. Non-zero failed calls are traced separately (in "@histF[]" and
+"@statF[]") for some functions.
+.TP
+1st, 2nd
+This is a range of latency, in microseconds (shown in "[...)" set notation).
+.TP
+3rd
+A column showing the count of operations in this range.
+.TP
+4th
+This is an ASCII histogram representing the count column.
+.SH OVERHEAD
+SSL/TLS handshake usually contains network latency and the traced crypto
+functions are CPU intensive tasks, so call frequency should be low and the
+overhead of this tool is expected to be negligible.
+.SH SOURCE
+This is from bpftrace.
+.IP
+https://github.com/iovisor/bpftrace
+.PP
+Also look in the bpftrace distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+
+There is a bcc tool sslsniff that can show SSL/TLS handshake event latency
+before sniffing the plaintext in SSL_read/write. This tool provides more
+detailed crypto latency distribution during the handshake event.
+.IP
+https://github.com/iovisor/bcc
+.SH OS
+Linux
+.SH STABILITY
+Unstable - in development.
+.SH AUTHOR
+Tao Xu
+.SH SEE ALSO
+sslsnoop(8)

--- a/man/man8/sslsnoop.8
+++ b/man/man8/sslsnoop.8
@@ -1,0 +1,64 @@
+.TH sslsnoop 8  "2021-12-28" "USER COMMANDS"
+.SH NAME
+sslsnoop.bt \- Show SSL/TLS handshake events. Uses bpftrace/eBPF.
+.SH SYNOPSIS
+.B sslsnoop.bt
+.SH DESCRIPTION
+sslsnoop traces OpenSSL handshake functions, and shows latency and return
+value. This can be used to analyze SSL/TLS performance.
+
+This tool works by dynamic tracing the uprobes in OpenSSL and related crypto
+libs, and may need updating to match future changes to these functions.
+
+Since this uses BPF, only the root user can use this tool.
+.SH REQUIREMENTS
+CONFIG_BPF and bpftrace.
+.SH EXAMPLES
+.TP
+Trace SSL/TLS handshake events, printing per-line summaries:
+#
+.B sslsnoop.bt
+.SH FIELDS
+.TP
+TIME(us)
+Time of the call completion, in microseconds since program start.
+.TP
+TID
+Thread ID.
+.TP
+COMM
+Process name.
+.TP
+LAT(us)
+Latency of the call, in microseconds.
+.TP
+RET
+Return value of the call.
+.TP
+FUNC
+Function name.
+.SH OVERHEAD
+SSL/TLS handshake usually contains network latency and the traced crypto
+functions are CPU intensive tasks, so call frequency should be low and the
+overhead of this tool is expected to be negligible.
+.SH SOURCE
+This is from bpftrace.
+.IP
+https://github.com/iovisor/bpftrace
+.PP
+Also look in the bpftrace distribution for a companion _examples.txt file containing
+example usage, output, and commentary for this tool.
+
+There is a bcc tool sslsniff that can show SSL/TLS handshake event latency
+before sniffing the plaintext in SSL_read/write. This tool provides more
+detailed crypto latency distribution during the handshake event.
+.IP
+https://github.com/iovisor/bcc
+.SH OS
+Linux
+.SH STABILITY
+Unstable - in development.
+.SH AUTHOR
+Tao Xu
+.SH SEE ALSO
+biosnoop(8)

--- a/tools/ssllatency.bt
+++ b/tools/ssllatency.bt
@@ -1,0 +1,78 @@
+#!/usr/bin/bpftrace
+/*
+ * ssllatency	Trace SSL/TLS handshake for OpenSSL.
+ * 		For Linux, uses bpftrace and eBPF.
+ *
+ * ssllatency shows handshake latency stats and distribution.
+ *
+ * Copyright (c) 2021 Tao Xu.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ *
+ * 17-Dec-2021	Tao Xu	created this.
+ */
+
+BEGIN
+{
+	printf("Tracing SSL/TLS handshake... Hit Ctrl-C to end.\n");
+}
+
+uprobe:libssl:SSL_read,
+uprobe:libssl:SSL_write,
+uprobe:libssl:SSL_do_handshake
+{
+	@start_ssl[tid] = nsecs;
+	@func_ssl[tid] = func; // store for uretprobe
+}
+
+uretprobe:libssl:SSL_read,
+uretprobe:libssl:SSL_write,
+uretprobe:libssl:SSL_do_handshake
+/@start_ssl[tid] != 0/
+{
+	$lat_us = (nsecs - @start_ssl[tid]) / 1000;
+	if ((int8)retval >= 1) {
+		@hist[@func_ssl[tid]] = lhist($lat_us, 0, 1000, 200);
+		@stat[@func_ssl[tid]] = stats($lat_us);
+	} else {
+		@histF[@func_ssl[tid]] = lhist($lat_us, 0, 1000, 200);
+		@statF[@func_ssl[tid]] = stats($lat_us);
+	}
+	delete(@start_ssl[tid]); delete(@func_ssl[tid]);
+}
+
+// need debug symbol for ossl local functions
+uprobe:libcrypto:rsa_ossl_public_encrypt,
+uprobe:libcrypto:rsa_ossl_public_decrypt,
+uprobe:libcrypto:rsa_ossl_private_encrypt,
+uprobe:libcrypto:rsa_ossl_private_decrypt,
+uprobe:libcrypto:RSA_sign,
+uprobe:libcrypto:RSA_verify,
+uprobe:libcrypto:ossl_ecdsa_sign,
+uprobe:libcrypto:ossl_ecdsa_verify,
+uprobe:libcrypto:ecdh_simple_compute_key
+{
+	@start_crypto[tid] = nsecs;
+	@func_crypto[tid] = func; // store for uretprobe
+}
+
+uretprobe:libcrypto:rsa_ossl_public_encrypt,
+uretprobe:libcrypto:rsa_ossl_public_decrypt,
+uretprobe:libcrypto:rsa_ossl_private_encrypt,
+uretprobe:libcrypto:rsa_ossl_private_decrypt,
+uretprobe:libcrypto:RSA_sign,
+uretprobe:libcrypto:RSA_verify,
+uretprobe:libcrypto:ossl_ecdsa_sign,
+uretprobe:libcrypto:ossl_ecdsa_verify,
+uretprobe:libcrypto:ecdh_simple_compute_key
+/@start_crypto[tid] != 0/
+{
+	$lat_us = (nsecs - @start_crypto[tid]) / 1000;
+	@hist[@func_crypto[tid]] = lhist($lat_us, 0, 1000, 200);
+	@stat[@func_crypto[tid]] = stats($lat_us);
+	delete(@start_crypto[tid]); delete(@func_crypto[tid]);
+}
+
+END
+{
+	printf("\nLatency distribution in microsecond:");
+}

--- a/tools/ssllatency_example.txt
+++ b/tools/ssllatency_example.txt
@@ -1,0 +1,102 @@
+Demonstrations of ssllatency, the Linux bpftrace/eBPF version.
+
+ssllatency traces OpenSSL handshake functions. It's the statistical summary
+version of sslsnoop. This is useful for performance analysis with different
+crypto algorithms or async SSL acceleration by CPU or offload device.
+For example:
+
+# wrk -t 1 -c 10 -d 1s -H 'Connection: close' https://localhost:443/0kb.bin
+Running 1s test @ https://localhost:443/0kb.bin
+  1 threads and 10 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency   839.94us  323.68us   5.98ms   98.50%
+    Req/Sec     1.28k     9.05     1.29k    54.55%
+  1400 requests in 1.10s, 414.26KB read
+  Non-2xx or 3xx responses: 1400
+Requests/sec:   1272.97
+Transfer/sec:    376.67KB
+
+# ./ssllatency.bt
+Attaching 26 probes...
+Tracing SSL/TLS handshake... Hit Ctrl-C to end.
+^C
+Latency distribution in microsecond:
+
+@hist[SSL_write]:
+[0, 200)            1401 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+@hist[SSL_read]:
+[0, 200)            1401 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+@hist[SSL_do_handshake]:
+[600, 800)          1359 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+[800, 1000)           12 |                                                    |
+[1000, ...)           32 |@                                                   |
+@hist[rsa_ossl_private_decrypt]:
+[600, 800)          1359 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+[800, 1000)           44 |@                                                   |
+@histF[SSL_do_handshake]:
+[0, 200)            1410 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+@histF[SSL_read]:
+[0, 200)            2804 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+
+@stat[SSL_read]: count 1401, average 2, total 2834
+@stat[SSL_write]: count 1401, average 5, total 7062
+@stat[rsa_ossl_private_decrypt]: count 1403, average 643, total 902780
+@stat[SSL_do_handshake]: count 1403, average 706, total 991605
+
+@statF[SSL_read]: count 2804, average 1, total 3951
+@statF[SSL_do_handshake]: count 1410, average 29, total 41964
+
+This output shows latency distribution for wrk benchmark which saturated
+one CPU core used by nginx server. wrk issued 1400 requests in 1.10s, and
+req/s is 1272. Server side RSA function is counted 1403 times averaging
+643us latency. And there's same amount(1410/1403) of failed/successful
+SSL_do_handshake calls for the round trip. This is the default behavior.
+
+# wrk -t 1 -c 10 -d 1s -H 'Connection: close' https://localhost:443/0kb.bin
+Running 1s test @ https://localhost:443/0kb.bin
+  1 threads and 10 connections
+  Thread Stats   Avg      Stdev     Max   +/- Stdev
+    Latency   448.67us  148.67us   1.28ms   82.00%
+    Req/Sec     2.95k    43.03     2.99k    80.00%
+  2933 requests in 1.00s, 867.87KB read
+  Non-2xx or 3xx responses: 2933
+Requests/sec:   2930.53
+Transfer/sec:    867.14KB
+
+# ./ssllatency.bt
+Attaching 26 probes...
+Tracing SSL/TLS handshake... Hit Ctrl-C to end.
+^C
+Latency distribution in microsecond:
+
+@hist[SSL_write]:
+[0, 200)            2933 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+@hist[SSL_read]:
+[0, 200)            2933 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+@hist[SSL_do_handshake]:
+[0, 200)            2941 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+@histF[SSL_read]:
+[0, 200)            5873 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+@histF[SSL_do_handshake]:
+[0, 200)            5884 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
+
+@stat[SSL_read]: count 2933, average 4, total 12088
+@stat[SSL_write]: count 2933, average 7, total 20683
+@stat[SSL_do_handshake]: count 2941, average 51, total 151149
+
+@statF[SSL_read]: count 5873, average 2, total 13942
+@statF[SSL_do_handshake]: count 5884, average 19, total 113061
+
+This is the hardware accelerated result by using async SSL and CPU crypto
+SIMD. req/s is more than doubled under same wkr workload. Peak throughput
+can be more than 3x if adding more wrk connections. Keep using same
+workload for comparison.
+
+libcrypto_mb.so is used instead of libcrypto.so, to batch process multiple
+async requets simultaniously by SIMD. As a result, wrk issued 2933 requests
+in 1s. Failed SSL_do_handshake calls has doubled(5884), and successful
+calls(2941) returned quickly(51us). This is expected from async routines.
+
+The above effect is based on the huge bottleneck of RSA which is very CPU
+intensive. If change to ECDSA, the overhead would be much less, and overall
+improvement is less obvious.

--- a/tools/sslsnoop.bt
+++ b/tools/sslsnoop.bt
@@ -1,0 +1,69 @@
+#!/usr/bin/bpftrace
+/*
+ * sslsnoop	Trace SSL/TLS handshake for OpenSSL.
+ * 		For Linux, uses bpftrace and eBPF.
+ *
+ * sslsnoop shows handshake latency and retval. This is useful for SSL/TLS
+ * performance analysis.
+ *
+ * Copyright (c) 2021 Tao Xu.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ *
+ * 15-Dec-2021	Tao Xu	created this.
+ */
+
+BEGIN
+{
+	printf("Tracing SSL/TLS handshake... Hit Ctrl-C to end.\n");
+	printf("%-10s %-8s %-8s %7s %5s %s\n", "TIME(us)", "TID",
+	       "COMM", "LAT(us)", "RET", "FUNC");
+}
+
+uprobe:libssl:SSL_read,
+uprobe:libssl:SSL_write,
+uprobe:libssl:SSL_do_handshake
+{
+	@start_ssl[tid] = nsecs;
+	@func_ssl[tid] = func; // store for uretprobe
+}
+
+uretprobe:libssl:SSL_read,
+uretprobe:libssl:SSL_write,
+uretprobe:libssl:SSL_do_handshake
+/@start_ssl[tid] != 0/
+{
+	printf("%-10u %-8d %-8s %7u %5d %s\n", elapsed/1000, tid, comm,
+	       (nsecs - @start_ssl[tid])/1000, retval, @func_ssl[tid]);
+	delete(@start_ssl[tid]); delete(@func_ssl[tid]);
+}
+
+// need debug symbol for ossl local functions
+uprobe:libcrypto:rsa_ossl_public_encrypt,
+uprobe:libcrypto:rsa_ossl_public_decrypt,
+uprobe:libcrypto:rsa_ossl_private_encrypt,
+uprobe:libcrypto:rsa_ossl_private_decrypt,
+uprobe:libcrypto:RSA_sign,
+uprobe:libcrypto:RSA_verify,
+uprobe:libcrypto:ossl_ecdsa_sign,
+uprobe:libcrypto:ossl_ecdsa_verify,
+uprobe:libcrypto:ossl_ecdh_compute_key
+{
+	@start_crypto[tid] = nsecs;
+	@func_crypto[tid] = func; // store for uretprobe
+}
+
+uretprobe:libcrypto:rsa_ossl_public_encrypt,
+uretprobe:libcrypto:rsa_ossl_public_decrypt,
+uretprobe:libcrypto:rsa_ossl_private_encrypt,
+uretprobe:libcrypto:rsa_ossl_private_decrypt,
+uretprobe:libcrypto:RSA_sign,
+uretprobe:libcrypto:RSA_verify,
+uretprobe:libcrypto:ossl_ecdsa_sign,
+uretprobe:libcrypto:ossl_ecdsa_verify,
+uretprobe:libcrypto:ossl_ecdh_compute_key
+/@start_crypto[tid] != 0/
+{
+	printf("%-10u %-8d %-8s %7u %5d %s\n", elapsed/1000, tid, comm,
+	       (nsecs - @start_crypto[tid])/1000, retval, @func_crypto[tid]);
+	delete(@start_crypto[tid]); delete(@func_crypto[tid]);
+}

--- a/tools/sslsnoop_example.txt
+++ b/tools/sslsnoop_example.txt
@@ -1,0 +1,42 @@
+Demonstrations of sslsnoop, the Linux bpftrace/eBPF version.
+
+sslsnoop shows OpenSSL handshake function latency and return value. This
+can be used to analyzea SSL/TLS performance. For example:
+
+# ./sslsnoop.bt
+Attaching 25 probes...
+Tracing SSL/TLS handshake... Hit Ctrl-C to end.
+TIME(us)   TID      COMM     LAT(us)   RET FUNC
+1623016    2834695  openssl       71     1 ossl_ecdh_compute_key
+1623319    2834695  openssl       32    51 rsa_ossl_public_decrypt
+1623418    2834695  openssl       31    51 rsa_ossl_public_decrypt
+1623547    2834695  openssl       27   256 rsa_ossl_public_decrypt
+1623612    2834695  openssl   361150     0 SSL_write
+1804646    2834695  openssl       92    -1 SSL_read
+1804730    2834695  openssl       76    -1 SSL_read
+^C
+
+Above shows the output of 'openssl s_client -connect example.com:443'.
+The first SSL_write call returned after 361ms that is the TLS handshake
+time. Local ECDH and RSA crypto calculation is fast at client side. Most
+time is spent at server side including crypto and network latency.
+
+# ./sslsnoop.bt
+Attaching 25 probes...
+Tracing SSL/TLS handshake... Hit Ctrl-C to end.
+TIME(us)   TID      COMM     LAT(us)   RET FUNC
+1133960    2826460  nginx         81    -1 SSL_do_handshake
+1134910    2826460  nginx        631   256 rsa_ossl_private_decrypt
+1134977    2826460  nginx        709     1 SSL_do_handshake
+1134984    2826460  nginx          3    -1 SSL_read
+1134209    2834970  openssl       37   256 rsa_ossl_public_encrypt
+1134994    2834970  openssl     1244     0 SSL_write
+^C
+
+Change example.com to localhost to exclude network latency. Output above
+shows 1.2ms overall handshake time, and RSA calculation took 0.7ms at nginx
+server. As event print is asynchronous, timestamp is not guaranteed to show
+in order.
+
+The bcc tool sslsniff shows similar event latency, and additional plaintext
+and ciphertext in SSL_read/wirte: https://github.com/iovisor/bcc


### PR DESCRIPTION
Add sslsnoop and ssllatency tools for SSL/TLS handshake performance analysis.

Use case and background is described here: https://xutao323.github.io/2022/01/06/tls-acceleration-with-new-CPU.html