### PR TITLE
CI fixes

### DIFF
--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -20,6 +20,7 @@ jobs:
           DISTRO: ubuntu-glibc
           VENDOR_GTEST: ON
           BUILD_LIBBPF: ON
+          BCC_REF: v0.23.0
         - TYPE: Release
           NAME: vanilla_llvm12+clang+glibc2.23
           LLVM_VERSION: 12
@@ -34,6 +35,7 @@ jobs:
           CMAKE_EXTRA_FLAGS: "-DCMAKE_CXX_FLAGS='-include /usr/local/include/bcc/compat/linux/bpf.h -D__LINUX_BPF_H__'"
           VENDOR_GTEST: ON
           BUILD_LIBBPF: ON
+          BCC_REF: v0.23.0
         - TYPE: Debug
           NAME: alpine
           LLVM_VERSION: 9

--- a/docker/Dockerfile.focal
+++ b/docker/Dockerfile.focal
@@ -43,6 +43,7 @@ RUN apt-get update && apt-get install -y \
       systemtap-sdt-dev \
       python3 \
       xxd
+RUN if [ "$LLVM_VERSION" -ge 13 ] ; then apt-get install -y libmlir-${LLVM_VERSION}-dev ; fi
 
 RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY build.sh /build.sh


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

Our current CI fails due to 2 issues:
1. CI build for LLVM 13 fails during CMake
```
CMake Error at /usr/lib/llvm-13/lib/cmake/llvm/LLVMExports.cmake:1529 (message):
  The imported target "MLIRSupportIndentedOstream" references the file

     "/usr/lib/llvm-13/lib/libMLIRSupportIndentedOstream.a
[...]
```
This is b/c that lib has been moved to a new package `libmlir-13-dev` in LLVM 13 Ubuntu repos.

2. The newest (unreleased) BCC breaks our static build with linker error:
```
/usr/local/lib/libbcc_bpf.a(bpf.c.o): In function `bpf_create_map_xattr':
bpf.c:(.text+0x720): multiple definition of `bpf_create_map_xattr'
/usr/local/lib/libbpf.a(bpf.o):/src/libbpf/src/bpf.c:81: first defined here
/usr/local/lib/libbcc_bpf.a(bpf.c.o): In function `bpf_create_map_node':
bpf.c:(.text+0x7c0): multiple definition of `bpf_create_map_node'
/usr/local/lib/libbpf.a(bpf.o):/src/libbpf/src/bpf.c:113: first defined here
[...]
```
This PR solves the above issues by installing the new package for LLVM 13 and by setting the BCC version to the last released version (0.23.0) in embedded CI build.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
