### PR TITLE
Embedded CI fix

### DIFF
--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -3,7 +3,7 @@ name: Embedded Builds
 on: [push, pull_request]
 jobs:
   llvm_clang:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         env:

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -327,7 +327,7 @@ std::unique_ptr<std::istream> ProbeMatcher::kernel_probe_list()
     if (p.type == ProbeType::kfunc)
     {
       // kfunc must be available
-      if (bpftrace_->btf_.has_data())
+      if (bpftrace_->feature_->has_prog_kfunc() && bpftrace_->btf_.has_data())
         probes += p.name + "\n";
     }
     else if (p.name.find("ret") == std::string::npos &&


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

Yet another problem with the CI - running the Docker container in embedded build fails to mount `/sys/kernel/debug`. This PR updates the CI environment to the latest Ubuntu, which fixes the problem.

It's possible that this is a bug in Ubuntu 18.04 that will be eventually fixed, but I think that it's no harm to use the latest Ubuntu even for embedded builds (as the build itself is done in a container anyway).

In addition, this also revealed a bug in `ProbeMatcher` which may break probe listing (and probe wildcards) on systems which have BTF but don't have kfuncs (or don't have `/sys/kernel/debug`). This is fixed by this PR, too.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
