### PR TITLE
Fix uprobe:address expansion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
 
 - Fix precedence of multiplicative operations
   - [#2096](https://github.com/iovisor/bpftrace/pull/2096)
+- Fix probe matching for uprobes with absolute address
+  - [#2138](https://github.com/iovisor/bpftrace/pull/2138)
 
 #### Tools
 #### Documentation

--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -432,6 +432,11 @@ AttachPointParser::State AttachPointParser::uprobe_parser(bool allow_offset,
       auto res = stoll(parts_[2]);
       if (res)
       {
+        if (has_wildcard(ap_->target))
+        {
+          errs_ << "Cannot use wildcards with absolute address" << std::endl;
+          return INVALID;
+        }
         ap_->address = *res;
       }
       else

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -483,6 +483,11 @@ std::set<std::string> ProbeMatcher::get_matches_for_ap(
     case ProbeType::hardware:
     case ProbeType::software:
     {
+      // Do not expand "target:" as that would match all functions in target.
+      // This may occur when an absolute address is given instead of a function.
+      if (attach_point.func.empty())
+        return { attach_point.target + ":" };
+
       search_input = attach_point.target + ":" + attach_point.func;
       break;
     }

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -990,6 +990,7 @@ TEST(Parser, uprobe)
 
   test_parse_failure("uprobe:f { 1 }");
   test_parse_failure("uprobe { 1 }");
+  test_parse_failure("uprobe:/my/program*:0x1234 { 1 }");
 }
 
 TEST(Parser, usdt)

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -76,3 +76,9 @@ NAME access ctx struct field twice
 PROG tracepoint:sched:sched_wakeup { if (args->comm == "asdf") { print(args->comm) } exit(); }
 EXPECT Attaching 1 probe
 TIMEOUT 1
+
+# https://github.com/iovisor/bpftrace/issues/2135
+NAME address_probe_invalid_expansion
+RUN {{BPFTRACE}} -e "uprobe:./testprogs/uprobe_test:0x$(nm ./testprogs/uprobe_test | awk '$3 == "function1" {print $1}') { @[probe] = count(); exit() }"
+EXPECT Attaching 1 probe
+TIMEOUT 1


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

`uprobe:target:address` should never be expanded - neither when `target` contains a wildcard, nor when, e.g., `probe` builtin is used within the probe. This makes sure expansion doesn't happen. See individual commits for more details.

Fixes #2135.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
