### PR TITLE
Runtime tests: add kfunc feature

### DIFF
--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -49,12 +49,14 @@ NAME it lists kfuncs
 RUN {{BPFTRACE}} -l | grep kfunc
 EXPECT kfunc
 REQUIRES_FEATURE btf
+REQUIRES_FEATURE kfunc
 TIMEOUT 1
 
 NAME it lists kfunc params
 RUN {{BPFTRACE}} -lv "kfunc:*" | grep kfunc
 EXPECT \s+[a-zA-Z_\*\s]+
 REQUIRES_FEATURE btf
+REQUIRES_FEATURE kfunc
 TIMEOUT 1
 
 NAME it lists kprobes with regex filter
@@ -96,12 +98,14 @@ NAME it lists kfuncs events with regex filter
 RUN {{BPFTRACE}} -l "kfunc:*"
 EXPECT kfunc
 REQUIRES_FEATURE btf
+REQUIRES_FEATURE kfunc
 TIMEOUT 1
 
 NAME it lists kretfuncs events with regex filter
 RUN {{BPFTRACE}} -l "kretfunc:*"
 EXPECT kretfunc
 REQUIRES_FEATURE btf
+REQUIRES_FEATURE kfunc
 TIMEOUT 1
 
 NAME listing with wildcarded probe type

--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -143,6 +143,7 @@ class TestParser(object):
                 features = {
                     "loop",
                     "btf",
+                    "kfunc",
                     "probe_read_kernel",
                     "dpath",
                     "uprobe_refcount",

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -121,6 +121,7 @@ class Runner(object):
         bpffeature["loop"] = output.find("Loop support: yes") != -1
         bpffeature["probe_read_kernel"] = output.find("probe_read_kernel: yes") != -1
         bpffeature["btf"] = output.find("btf (depends on Build:libbpf): yes") != -1
+        bpffeature["kfunc"] = output.find("kfunc: yes") != -1
         bpffeature["dpath"] = output.find("dpath: yes") != -1
         bpffeature["uprobe_refcount"] = \
             output.find("uprobe refcount (depends on Build:bcc bpf_attach_uprobe refcount): yes") != -1


### PR DESCRIPTION
Until now, runtime tests using kfuncs checked only availabiility of BTF. This adds a check for kfunc presence as well as it may happen that a system has BTF but does not have kfuncs (which happens in our CI when we build libbpf from source).

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
