### PR TITLE
Fix GCC 11 build

### DIFF
--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -202,9 +202,9 @@ TEST(utils, get_cgroup_path_in_hierarchy)
   {
     throw std::runtime_error("creating subdirectory for tests failed");
   }
-  static_cast<std::ofstream &>(std::ofstream(file_1) << "File 1 content")
+  static_cast<std::ofstream &&>(std::ofstream(file_1) << "File 1 content")
       .close();
-  static_cast<std::ofstream &>(std::ofstream(file_2) << "File 2 content")
+  static_cast<std::ofstream &&>(std::ofstream(file_2) << "File 2 content")
       .close();
   struct stat file_1_st, file_2_st;
   if (stat(file_1.c_str(), &file_1_st) < 0 ||


### PR DESCRIPTION
Currently, bpftrace cannot be built with newest GCC 11. Compilation fails with error:
```
/bpftrace/tests/utils.cpp: In member function 'virtual void bpftrace::test::utils::utils_get_cgroup_path_in_hierarchy_Test::TestBody()':
/bpftrace/tests/utils.cpp:205:3: error: invalid 'static_cast' from type 'std::basic_ofstream<char>' to type 'std::ofstream&' {aka 'std::basic_ofstream<char>&'}
  205 |   static_cast<std::ofstream &>(std::ofstream(file_1) << "File 1 content")
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/bpftrace/tests/utils.cpp:207:3: error: invalid 'static_cast' from type 'std::basic_ofstream<char>' to type 'std::ofstream&' {aka 'std::basic_ofstream<char>&'}
  207 |   static_cast<std::ofstream &>(std::ofstream(file_2) << "File 2 content")
      |   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

IIUC, C++ standard doesn't allow to typecast a temporary to a non-const lvalue reference, which is done in one of our new tests for `cgroup_path`.

This fixes the problem by using an rvalue reference.

cc @lenticularis39 

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
