### PR TITLE
Support octal format specifier for printf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to
   - [#2055](https://github.com/iovisor/bpftrace/pull/2055)
 - Limit number of generated BPF programs
   - [#2141](https://github.com/iovisor/bpftrace/pull/2141)
+- Support the octal format specifier (`%o`) in `printf`
+  - [#2147](https://github.com/iovisor/bpftrace/pull/2147)
 
 #### Changed
 #### Deprecated

--- a/src/printf_format_types.h
+++ b/src/printf_format_types.h
@@ -12,10 +12,11 @@ namespace bpftrace {
 // compile time string concatenation. here is the Python 3 code that generates this map:
 // #!/usr/bin/python3
 // lengths = ("", "hh", "h", "l", "ll", "j", "z", "t")
-// specifiers = ("d", "u", "x", "X", "p")
+// specifiers = ("d", "u", "o", "x", "X", "p")
 //
 // print("{\"s\", Type::string},")
 // print("{\"r\", Type::buffer},")
+// print("{\"c\", Type::integer},")
 // print(",\n".join([f"{{\"{l+s}\", Type::integer}}" for l in lengths for s in specifiers]))
 const std::unordered_map<std::string, Type> printf_format_types = {
   {"s", Type::string},
@@ -23,41 +24,49 @@ const std::unordered_map<std::string, Type> printf_format_types = {
   {"c", Type::integer},
   {"d", Type::integer},
   {"u", Type::integer},
+  {"o", Type::integer},
   {"x", Type::integer},
   {"X", Type::integer},
   {"p", Type::integer},
   {"hhd", Type::integer},
   {"hhu", Type::integer},
+  {"hho", Type::integer},
   {"hhx", Type::integer},
   {"hhX", Type::integer},
   {"hhp", Type::integer},
   {"hd", Type::integer},
   {"hu", Type::integer},
+  {"ho", Type::integer},
   {"hx", Type::integer},
   {"hX", Type::integer},
   {"hp", Type::integer},
   {"ld", Type::integer},
   {"lu", Type::integer},
+  {"lo", Type::integer},
   {"lx", Type::integer},
   {"lX", Type::integer},
   {"lp", Type::integer},
   {"lld", Type::integer},
   {"llu", Type::integer},
+  {"llo", Type::integer},
   {"llx", Type::integer},
   {"llX", Type::integer},
   {"llp", Type::integer},
   {"jd", Type::integer},
   {"ju", Type::integer},
+  {"jo", Type::integer},
   {"jx", Type::integer},
   {"jX", Type::integer},
   {"jp", Type::integer},
   {"zd", Type::integer},
   {"zu", Type::integer},
+  {"zo", Type::integer},
   {"zx", Type::integer},
   {"zX", Type::integer},
   {"zp", Type::integer},
   {"td", Type::integer},
   {"tu", Type::integer},
+  {"to", Type::integer},
   {"tx", Type::integer},
   {"tX", Type::integer},
   {"tp", Type::integer}

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -166,8 +166,8 @@ EXPECT got 2 args: one 2
 TIMEOUT 5
 
 NAME positional multiple bases
-RUN {{BPFTRACE}} -e 'BEGIN { printf("got: %d %d 0x%x\n", $1, $2, $3); exit() }' 123 0775 0x123
-EXPECT got: 123 509 0x123
+RUN {{BPFTRACE}} -e 'BEGIN { printf("got: %d %o 0x%x\n", $1, $2, $3); exit() }' 123 0775 0x123
+EXPECT got: 123 775 0x123
 TIMEOUT 5
 
 NAME positional pointer arithmetics

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1153,6 +1153,7 @@ TEST(semantic_analyser, printf_format_int)
   test("kprobe:f { $x = 123; printf(\"int: %d\", $x) }", 0);
 
   test("kprobe:f { printf(\"int: %u\", 1234) }", 0);
+  test("kprobe:f { printf(\"int: %o\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %x\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %X\", 1234) }", 0);
 }
@@ -1161,48 +1162,56 @@ TEST(semantic_analyser, printf_format_int_with_length)
 {
   test("kprobe:f { printf(\"int: %d\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %u\", 1234) }", 0);
+  test("kprobe:f { printf(\"int: %o\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %x\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %X\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %p\", 1234) }", 0);
 
   test("kprobe:f { printf(\"int: %hhd\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %hhu\", 1234) }", 0);
+  test("kprobe:f { printf(\"int: %hho\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %hhx\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %hhX\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %hhp\", 1234) }", 0);
 
   test("kprobe:f { printf(\"int: %hd\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %hu\", 1234) }", 0);
+  test("kprobe:f { printf(\"int: %ho\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %hx\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %hX\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %hp\", 1234) }", 0);
 
   test("kprobe:f { printf(\"int: %ld\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %lu\", 1234) }", 0);
+  test("kprobe:f { printf(\"int: %lo\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %lx\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %lX\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %lp\", 1234) }", 0);
 
   test("kprobe:f { printf(\"int: %lld\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %llu\", 1234) }", 0);
+  test("kprobe:f { printf(\"int: %llo\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %llx\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %llX\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %llp\", 1234) }", 0);
 
   test("kprobe:f { printf(\"int: %jd\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %ju\", 1234) }", 0);
+  test("kprobe:f { printf(\"int: %jo\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %jx\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %jX\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %jp\", 1234) }", 0);
 
   test("kprobe:f { printf(\"int: %zd\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %zu\", 1234) }", 0);
+  test("kprobe:f { printf(\"int: %zo\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %zx\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %zX\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %zp\", 1234) }", 0);
 
   test("kprobe:f { printf(\"int: %td\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %tu\", 1234) }", 0);
+  test("kprobe:f { printf(\"int: %to\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %tx\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %tX\", 1234) }", 0);
   test("kprobe:f { printf(\"int: %tp\", 1234) }", 0);


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

The %o format specifier (together with the different length prefixes) is now supported for printf. The python script in the comments of `printf_format_types.h` was also accordingly updated (plus added a seemingly missing line for `%c`).

Resolves #1985 

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
