### PR TITLE
[cli] add --emit-llvm iption to write IR to file

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -3206,6 +3206,15 @@ void CodegenLLVM::DumpIR(std::ostream &out)
   module_->print(os, nullptr, false, true);
 }
 
+void CodegenLLVM::DumpIR(const std::string filename)
+{
+  assert(module_.get() != nullptr);
+  std::ofstream file;
+  file.open(filename);
+  raw_os_ostream os(file);
+  module_->print(os, nullptr, false, true);
+}
+
 CodegenLLVM::ScopedExprDeleter CodegenLLVM::accept(Node *node)
 {
   expr_deleter_ = nullptr;

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -66,6 +66,7 @@ public:
   // Exists to make calling from a debugger easier
   void DumpIR(void);
   void DumpIR(std::ostream &out);
+  void DumpIR(const std::string filename);
   void createFormatStringCall(Call &call, int &id, CallArgs &call_args,
                               const std::string &call_name, AsyncAction async_action);
 


### PR DESCRIPTION
Adding a new CLI option to write LLVM IR to files so those can be opened
in editors with syntax highlight.

In theory the new option could be used on `compare_tool_codegen.sh` and `update_codegen_tests.sh`, not sure if that's worth it though.