### PR TITLE
Improve resolution of Clang system include paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to
   - [#2141](https://github.com/iovisor/bpftrace/pull/2141)
 - Support the octal format specifier (`%o`) in `printf`
   - [#2147](https://github.com/iovisor/bpftrace/pull/2147)
+- Improve include paths resolution
+  - [#2149](https://github.com/iovisor/bpftrace/pull/2149)
 
 #### Changed
 #### Deprecated

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -722,6 +722,10 @@ bool ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<s
     "-isystem", "/usr/include",
   };
   // clang-format on
+  std::string arch_path = get_arch_include_path();
+  args.push_back("-isystem");
+  args.push_back(arch_path.c_str());
+
   for (auto &flag : extra_flags)
   {
     args.push_back(flag.c_str());
@@ -884,6 +888,13 @@ CXUnsavedFile ClangParser::get_empty_btf_generated_header()
     .Contents = btf_cdef.c_str(),
     .Length = btf_cdef.size(),
   };
+}
+
+std::string ClangParser::get_arch_include_path()
+{
+  struct utsname utsname;
+  uname(&utsname);
+  return "/usr/include/" + std::string(utsname.machine) + "-linux-gnu";
 }
 
 } // namespace bpftrace

--- a/src/clang_parser.h
+++ b/src/clang_parser.h
@@ -59,6 +59,7 @@ private:
   CXUnsavedFile get_empty_btf_generated_header();
 
   std::string get_arch_include_path();
+  std::vector<std::string> system_include_paths();
 
   std::string input;
   std::vector<const char *> args;

--- a/src/clang_parser.h
+++ b/src/clang_parser.h
@@ -58,6 +58,8 @@ private:
   CXUnsavedFile get_btf_generated_header(BPFtrace &bpftrace);
   CXUnsavedFile get_empty_btf_generated_header();
 
+  std::string get_arch_include_path();
+
   std::string input;
   std::vector<const char *> args;
   std::vector<CXUnsavedFile> input_files;


### PR DESCRIPTION
Ubuntu and other Debian-like systems use arch-specific directories for their system include paths. This adds the default path (`/usr/include/<arch>-linux-gnu`) to Clang include directories so that ClangParser can locate system headers.

At the same time, this also adds automatic detection of system include paths (returned by `clang`). Resolves #2150.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
