### PR TITLE
Store lhist bounds inside map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to
   - [#2138](https://github.com/iovisor/bpftrace/pull/2138)
 - Fix tools to work on new kernel versions
   - [#2136](https://github.com/iovisor/bpftrace/pull/2136)
+- Fix misprinting of lhist labels
+  - [#2153](https://github.com/iovisor/bpftrace/pull/2153)
 
 #### Tools
 #### Documentation

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -116,21 +116,6 @@ void ResourceAnalyser::visit(Call &call)
     resources_.join_args.push_back(delim);
     resources_.needs_join_map = true;
   }
-  else if (call.func == "lhist")
-  {
-    Expression &min_arg = *call.vargs->at(1);
-    Expression &max_arg = *call.vargs->at(2);
-    Expression &step_arg = *call.vargs->at(3);
-    Integer &min = static_cast<Integer &>(min_arg);
-    Integer &max = static_cast<Integer &>(max_arg);
-    Integer &step = static_cast<Integer &>(step_arg);
-
-    resources_.lhist_args[call.map->ident] = LinearHistogramArgs{
-      .min = min.n,
-      .max = max.n,
-      .step = step.n,
-    };
-  }
   else if (call.func == "time")
   {
     if (call.vargs && call.vargs->size() > 0)

--- a/src/fake_map.cpp
+++ b/src/fake_map.cpp
@@ -5,11 +5,8 @@ namespace bpftrace {
 FakeMap::FakeMap(const std::string &name,
                  const SizedType &type,
                  const MapKey &key,
-                 int min,
-                 int max,
-                 int step,
                  int max_entries)
-    : IMap(name, type, key, min, max, step, max_entries)
+    : IMap(name, type, key, max_entries)
 {
 }
 

--- a/src/fake_map.h
+++ b/src/fake_map.h
@@ -10,17 +10,9 @@ public:
   FakeMap(const std::string &name,
           const SizedType &type,
           const MapKey &key,
-          int max_entries)
-      : FakeMap(name, type, key, 0, 0, 0, max_entries){};
+          int max_entries);
   FakeMap(const SizedType &type);
   FakeMap(enum bpf_map_type map_type);
-  FakeMap(const std::string &name,
-          const SizedType &type,
-          const MapKey &key,
-          int min,
-          int max,
-          int step,
-          int max_entries);
   FakeMap(const std::string &name,
           enum bpf_map_type type,
           int key_size,

--- a/src/imap.cpp
+++ b/src/imap.cpp
@@ -7,11 +7,8 @@ namespace bpftrace {
 IMap::IMap(const std::string &name,
            const SizedType &type,
            const MapKey &key,
-           int min,
-           int max,
-           int step,
            int max_entries __attribute__((unused)))
-    : name_(name), type_(type), key_(key), lqmin(min), lqmax(max), lqstep(step)
+    : name_(name), type_(type), key_(key)
 {
   if (type.IsCountTy() && !key.args_.size())
   {

--- a/src/imap.h
+++ b/src/imap.h
@@ -15,14 +15,6 @@ public:
   IMap(const std::string &name,
        const SizedType &type,
        const MapKey &key,
-       int max_entries)
-      : IMap(name, type, key, 0, 0, 0, max_entries){};
-  IMap(const std::string &name,
-       const SizedType &type,
-       const MapKey &key,
-       int min,
-       int max,
-       int step,
        int max_entries);
   IMap(const std::string &name,
        enum bpf_map_type type,
@@ -45,11 +37,6 @@ public:
   MapKey key_;
   enum bpf_map_type map_type_ = BPF_MAP_TYPE_UNSPEC;
   bool printable_ = true;
-
-  // used by lhist(). TODO: move to separate Map object.
-  int lqmin = 0;
-  int lqmax = 0;
-  int lqstep = 0;
 
   bool is_per_cpu_type()
   {

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -42,11 +42,8 @@ int create_map(enum bpf_map_type map_type,
 Map::Map(const std::string &name,
          const SizedType &type,
          const MapKey &key,
-         int min,
-         int max,
-         int step,
          int max_entries)
-    : IMap(name, type, key, min, max, step, max_entries)
+    : IMap(name, type, key, max_entries)
 {
   int key_size = key.size();
   if (type.IsHistTy() || type.IsLhistTy() || type.IsAvgTy() || type.IsStatsTy())

--- a/src/map.h
+++ b/src/map.h
@@ -10,14 +10,6 @@ public:
   Map(const std::string &name,
       const SizedType &type,
       const MapKey &key,
-      int max_entries)
-      : Map(name, type, key, 0, 0, 0, max_entries){};
-  Map(const std::string &name,
-      const SizedType &type,
-      const MapKey &key,
-      int min,
-      int max,
-      int step,
       int max_entries);
   Map(const std::string &name,
       enum bpf_map_type type,

--- a/src/output.h
+++ b/src/output.h
@@ -26,6 +26,24 @@ enum class MessageType
   lost_events
 };
 
+struct HistData
+{
+  int64_t count;
+  std::vector<uint64_t> value;
+
+  // Only valid for lhist
+  long min = -1;
+  long max = -1;
+  long step = -1;
+};
+
+enum lhist_bound_index
+{
+  lhist_bound_index_min = -1,
+  lhist_bound_index_max = -2,
+  lhist_bound_index_step = -3
+};
+
 std::ostream& operator<<(std::ostream& out, MessageType type);
 
 // Abstract class (interface) for output
@@ -51,9 +69,12 @@ public:
   // Write map histogram to output
   // Ideally, the implementation should use map_hist_to_str to convert a map
   // histogram into a string, format it properly, and print it to out_.
-  virtual void map_hist(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t div,
-                        const std::map<std::vector<uint8_t>, std::vector<uint64_t>> &values_by_key,
-                        const std::vector<std::pair<std::vector<uint8_t>, uint64_t>> &total_counts_by_key) const = 0;
+  virtual void map_hist(
+      BPFtrace &bpftrace,
+      IMap &map,
+      uint32_t top,
+      uint32_t div,
+      const std::map<std::vector<uint8_t>, HistData> &hists_by_key) const = 0;
   // Write map statistics to output
   // Ideally, the implementation should use map_stats_to_str to convert map
   // statistics into a string, format it properly, and print it to out_.
@@ -108,10 +129,7 @@ protected:
       IMap &map,
       uint32_t top,
       uint32_t div,
-      const std::map<std::vector<uint8_t>, std::vector<uint64_t>>
-          &values_by_key,
-      const std::vector<std::pair<std::vector<uint8_t>, uint64_t>>
-          &total_counts_by_key) const;
+      const std::map<std::vector<uint8_t>, HistData> &hists_by_key) const;
   // Convert map statistics into string
   // Default behaviour: format each (key, stats) pair using output-specific
   // methods and join them into a single string
@@ -170,9 +188,12 @@ public:
 
   void map(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t div,
            const std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> &values_by_key) const override;
-  void map_hist(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t div,
-                const std::map<std::vector<uint8_t>, std::vector<uint64_t>> &values_by_key,
-                const std::vector<std::pair<std::vector<uint8_t>, uint64_t>> &total_counts_by_key) const override;
+  void map_hist(BPFtrace &bpftrace,
+                IMap &map,
+                uint32_t top,
+                uint32_t div,
+                const std::map<std::vector<uint8_t>, HistData> &hists_by_key)
+      const override;
   void map_stats(
       BPFtrace &bpftrace,
       IMap &map,
@@ -220,9 +241,12 @@ public:
 
   void map(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t div,
            const std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> &values_by_key) const override;
-  void map_hist(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t div,
-                const std::map<std::vector<uint8_t>, std::vector<uint64_t>> &values_by_key,
-                const std::vector<std::pair<std::vector<uint8_t>, uint64_t>> &total_counts_by_key) const override;
+  void map_hist(BPFtrace &bpftrace,
+                IMap &map,
+                uint32_t top,
+                uint32_t div,
+                const std::map<std::vector<uint8_t>, HistData> &hists_by_key)
+      const override;
   void map_stats(
       BPFtrace &bpftrace,
       IMap &map,

--- a/src/required_resources.cpp
+++ b/src/required_resources.cpp
@@ -41,26 +41,9 @@ int RequiredResources::create_maps_impl(BPFtrace &bpftrace, bool fake)
 
     auto &key = search_args->second;
 
-    if (type.IsLhistTy())
-    {
-      auto args = lhist_args.find(map_name);
-      if (args == lhist_args.end())
-        LOG(FATAL) << "map arg \"" << map_name << "\" not found";
-
-      auto min = args->second.min;
-      auto max = args->second.max;
-      auto step = args->second.step;
-      auto map = std::make_unique<T>(
-          map_name, type, key, min, max, step, bpftrace.mapmax_);
-      failed_maps += is_invalid_map(map->mapfd_);
-      bpftrace.maps.Add(std::move(map));
-    }
-    else
-    {
-      auto map = std::make_unique<T>(map_name, type, key, bpftrace.mapmax_);
-      failed_maps += is_invalid_map(map->mapfd_);
-      bpftrace.maps.Add(std::move(map));
-    }
+    auto map = std::make_unique<T>(map_name, type, key, bpftrace.mapmax_);
+    failed_maps += is_invalid_map(map->mapfd_);
+    bpftrace.maps.Add(std::move(map));
   }
 
   for (StackType stack_type : stackid_maps)

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -26,21 +26,6 @@ struct HelperErrorInfo
   location loc;
 };
 
-struct LinearHistogramArgs
-{
-  long min = -1;
-  long max = -1;
-  long step = -1;
-
-private:
-  friend class cereal::access;
-  template <typename Archive>
-  void serialize(Archive &archive)
-  {
-    archive(min, max, step);
-  }
-};
-
 // This class contains script-specific metadata that bpftrace's runtime needs.
 //
 // This class is intended to completely encapsulate all of a script's runtime
@@ -96,7 +81,6 @@ public:
 
   // Map metadata
   std::map<std::string, SizedType> map_vals;
-  std::map<std::string, LinearHistogramArgs> lhist_args;
   std::map<std::string, MapKey> map_keys;
   std::unordered_set<StackType> stackid_maps;
   bool needs_join_map = false;
@@ -132,7 +116,6 @@ private:
             printf_args,
             probe_ids,
             map_vals,
-            lhist_args,
             map_keys,
             stackid_maps,
             needs_join_map,

--- a/tests/codegen/llvm/call_lhist.ll
+++ b/tests/codegen/llvm/call_lhist.ll
@@ -10,6 +10,12 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
+  %"@x_key8" = alloca i64, align 8
+  %"@x_step" = alloca i64, align 8
+  %"@x_key5" = alloca i64, align 8
+  %"@x_max" = alloca i64, align 8
+  %"@x_key2" = alloca i64, align 8
+  %"@x_min" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = lshr i64 %get_pid_tgid, 32
@@ -18,18 +24,54 @@ entry:
   %linear = call i64 @linear(i64 %2, i64 0, i64 100, i64 1)
   %3 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 %linear, i64* %"@x_key", align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* %"@x_key")
-  %4 = bitcast i64* %lookup_elem_val to i8*
+  store i64 -1, i64* %"@x_key", align 8
+  %4 = bitcast i64* %"@x_min" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 0, i64* %"@x_min", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_min", i64 0)
+  %5 = bitcast i64* %"@x_min" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast i64* %"@x_key2" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i64 -2, i64* %"@x_key2", align 8
+  %8 = bitcast i64* %"@x_max" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 100, i64* %"@x_max", align 8
+  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo3, i64* %"@x_key2", i64* %"@x_max", i64 0)
+  %9 = bitcast i64* %"@x_max" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@x_key2" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@x_key5" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i64 -3, i64* %"@x_key5", align 8
+  %12 = bitcast i64* %"@x_step" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  store i64 1, i64* %"@x_step", align 8
+  %pseudo6 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem7 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo6, i64* %"@x_key5", i64* %"@x_step", i64 0)
+  %13 = bitcast i64* %"@x_step" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  %14 = bitcast i64* %"@x_key5" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = bitcast i64* %"@x_key8" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  store i64 %linear, i64* %"@x_key8", align 8
+  %pseudo9 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo9, i64* %"@x_key8")
+  %16 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %5 = load i64, i64* %cast, align 8
-  store i64 %5, i64* %lookup_elem_val, align 8
+  %17 = load i64, i64* %cast, align 8
+  store i64 %17, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
@@ -37,19 +79,19 @@ lookup_failure:                                   ; preds = %entry
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %6 = load i64, i64* %lookup_elem_val, align 8
-  %7 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %9 = add i64 %6, 1
-  store i64 %9, i64* %"@x_val", align 8
-  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %18 = load i64, i64* %lookup_elem_val, align 8
+  %19 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  %20 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %20)
+  %21 = add i64 %18, 1
+  store i64 %21, i64* %"@x_val", align 8
+  %pseudo10 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem11 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo10, i64* %"@x_key8", i64* %"@x_val", i64 0)
+  %22 = bitcast i64* %"@x_key8" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
+  %23 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
   ret i64 0
 }
 

--- a/tests/required_resources.cpp
+++ b/tests/required_resources.cpp
@@ -98,33 +98,6 @@ TEST(required_resources, round_trip_map_sized_type)
   }
 }
 
-TEST(required_resources, round_trip_map_lhist_args)
-{
-  std::ostringstream serialized(std::ios::binary);
-  {
-    RequiredResources r;
-    r.lhist_args.insert({ "mymap",
-                          LinearHistogramArgs{
-                              .min = 99,
-                              .max = 123,
-                              .step = 33,
-                          } });
-    r.save_state(serialized);
-  }
-
-  std::istringstream input(serialized.str());
-  {
-    RequiredResources r;
-    r.load_state(input);
-
-    ASSERT_EQ(r.lhist_args.count("mymap"), 1ul);
-    auto &args = r.lhist_args["mymap"];
-    EXPECT_EQ(args.min, 99);
-    EXPECT_EQ(args.max, 123);
-    EXPECT_EQ(args.step, 33);
-  }
-}
-
 TEST(required_resources, round_trip_set_stack_type)
 {
   std::ostringstream serialized(std::ios::binary);

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -82,3 +82,9 @@ NAME address_probe_invalid_expansion
 RUN {{BPFTRACE}} -e "uprobe:./testprogs/uprobe_test:0x$(nm ./testprogs/uprobe_test | awk '$3 == "function1" {print $1}') { @[probe] = count(); exit() }"
 EXPECT Attaching 1 probe
 TIMEOUT 1
+
+# https://github.com/iovisor/bpftrace/issues/2121
+NAME lhist_labels_misprint
+PROG BEGIN { @[0] = lhist(0, 0, 100000, 1000); @[1] = lhist(0, 0, 100000, 10000); @[1] = lhist(0, 0, 100000, 10000); exit() }
+EXPECT @\[0\]:\s*\[0, 1000\)[0123456789|@\s]*@\[1\]:\s*\[0, 10000\)
+TIMEOUT 5


### PR DESCRIPTION
Move lhist bounds (min, max, step) from map resource metadata into the
map itself. Data is stored separately for each key prefix, enabling
storing multiple histograms in one map.

Fixes #2121

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

Makes use of negative indices with the map to avoid collision with histogram buckets (which are represented only by non-negative numbers).

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
