### PR TITLE
Fix ScopedExprDeleter

### DIFF
--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -89,8 +89,17 @@ private:
 
     ScopedExprDeleter(const ScopedExprDeleter &other) = delete;
     ScopedExprDeleter &operator=(const ScopedExprDeleter &other) = delete;
-    ScopedExprDeleter(ScopedExprDeleter &&other) = default;
-    ScopedExprDeleter &operator=(ScopedExprDeleter &&other) = default;
+
+    ScopedExprDeleter(ScopedExprDeleter &&other)
+    {
+      *this = std::move(other);
+    }
+
+    ScopedExprDeleter &operator=(ScopedExprDeleter &&other)
+    {
+      deleter_ = other.disarm();
+      return *this;
+    }
 
     ~ScopedExprDeleter()
     {


### PR DESCRIPTION
When move assigning/constructing std::function the function moved from
is left in a valid but unspecified state. Care needs to be taken to make
sure ScopedExprDeleter accounts for that.

This commit fixes lifetime issues I observed in bpftrace compiled with
Android's r23 ndk.

<!--
Please provide a description of your change below this comment.

The default move constructor/assignment operator does not need to nullify
the `deleter_` of `ScopedExprDeleter`. I learned about this while debugging
erroneous `llvm.lifetime.end.p0i8` calls in ir emitted when running bpftrace
on Android. Here is an example:
```
bpftrace -e 'tracepoint:raw_syscalls:sys_enter { @ = count(); }' -dd
```
gives:
```
define i64 @"tracepoint:raw_syscalls:sys_enter"(i8* %0) section "s_tracepoint:raw_syscalls:sys_enter_1" {
entry:
  %"@_val" = alloca i64
  %lookup_elem_val = alloca i64
  %"@_key" = alloca i64
  %1 = bitcast i64* %"@_key" to i8*
  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
  store i64 0, i64* %"@_key"
  %2 = bitcast i64* %"@_key" to i8*
  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* %"@_key")
  %3 = bitcast i64* %lookup_elem_val to i8*
  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
  %map_lookup_cond = icmp ne i8* %lookup_elem, null
  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure

lookup_success:                                   ; preds = %entry
  %cast = bitcast i8* %lookup_elem to i64*
  %4 = load i64, i64* %cast
  store i64 %4, i64* %lookup_elem_val
  br label %lookup_merge

lookup_failure:                                   ; preds = %entry
  store i64 0, i64* %lookup_elem_val
  br label %lookup_merge

lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
  %5 = load i64, i64* %lookup_elem_val
  %6 = bitcast i64* %lookup_elem_val to i8*
  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
  %7 = bitcast i64* %"@_val" to i8*
  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
  %8 = add i64 %5, 1
  store i64 %8, i64* %"@_val"
  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %"@_val", i64 0)
  %9 = bitcast i64* %"@_val" to i8*
  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
  %10 = bitcast i64* %"@_key" to i8*
  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
  ret i64 1
}
```
where lifetime of @_key ends prematurely in the entry block. This has consequences
for the sequence of BPF instructions:
```
0: (b7) r1 = 0
1: (7b) *(u64 *)(r10 -8) = r1
2: (18) r1 = 0xffffffee20165a00
4: (bf) r2 = r10
5: (07) r2 += -8
6: (85) call 1
7: (b7) r1 = 1
8: (15) if r0 == 0x0 goto pc+2
 R0=map_value(ks=4,vs=8,id=0),min_value=0,max_value=0 R1=imm1,min_value=1,max_value=1 R10=fp
9: (79) r1 = *(u64 *)(r0 +0)
10: (07) r1 += 1
11: (7b) *(u64 *)(r10 -8) = r1
12: (18) r1 = 0xffffffee20165a00
14: (bf) r2 = r10
15: (07) r2 += -8
16: (bf) r3 = r10
17: (07) r3 += -8
18: (b7) r4 = 0
19: (85) call 2
20: (b7) r0 = 1
21: (95) exit
```
Instructions 14-15 and 16-17 set addresses of a key and a value for map_update_elem
and both are set to r10 - 8.


Then please complete the checklist.
-->

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
