### PR TITLE
Use a full number instead of "1e6" 

### DIFF
--- a/tools/biosnoop.bt
+++ b/tools/biosnoop.bt
@@ -35,8 +35,8 @@ kprobe:__blk_account_io_done
 {
 	$now = nsecs;
 	printf("%-12u %-7s %-16s %-6d %7d\n",
-	    elapsed / 1e6, @disk[arg0], @iocomm[arg0], @iopid[arg0],
-	    ($now - @start[arg0]) / 1e6);
+	    elapsed / 100000, @disk[arg0], @iocomm[arg0], @iopid[arg0],
+	    ($now - @start[arg0]) / 100000);
 
 	delete(@start[arg0]);
 	delete(@iopid[arg0]);


### PR DESCRIPTION
These `1e6` numbers didn't work on Amazon Linux 2, but this did:
```
[root@ip-10-201-20-193 tools]# bpftrace biosnoop.bt 
biosnoop.bt:38:16-19: ERROR: syntax error, unexpected identifier, expecting ) or ","
        elapsed / 1e6, @disk[arg0], @iocomm[arg0], @iopid[arg0],
```

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
