### PR TITLE
Add bswap built-in function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
   - [#2147](https://github.com/iovisor/bpftrace/pull/2147)
 - Improve include paths resolution
   - [#2149](https://github.com/iovisor/bpftrace/pull/2149)
+- Add builtin function: `bswap`
+  - [#2166](https://github.com/iovisor/bpftrace/pull/2166)
 
 #### Changed
 #### Deprecated

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -2221,6 +2221,7 @@ Tracing block I/O sizes > 0 bytes
 - `uptr(void *p)` - Annotate as userspace pointer
 - `kptr(void *p)` - Annotate as kernelspace pointer
 - `macaddr(char[6] addr)` - Convert MAC address data
+- `bswap(uint[8|16|32|64] n)` - Reverse byte order
 
 Some of these are asynchronous: the kernel queues the event, but some time later (milliseconds) it is
 processed in user-space. The asynchronous actions are: `printf()`, `time()`, and `join()`. Both `ksym()`
@@ -3119,6 +3120,21 @@ Example:
 # bpftrace -e 'BEGIN { print(cgroup_path(5386)); }'
 Attaching 1 probe...
 unified:/user.slice/user-1000.slice/session-3.scope
+```
+
+## 30. `bswap`: Reverse byte order
+
+Syntax: `bswap(uint[8|16|32|64] n)`
+
+Reverses the order of the bytes in integer `n`. In case of 8 bit integers, `n` is returned without being modified.
+The return type is an unsigned integer of the same width as `n`.
+
+Example:
+
+```
+# bpftrace -e 'BEGIN { $i = (uint32)0x12345678; printf("Reversing byte order of 0x%x ==> 0x%x\n", $i, bswap($i)); }'
+Attaching 1 probe...
+Reversing byte order of 0x12345678 ==> 0x78563412
 ```
 
 # Map Functions

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1244,6 +1244,17 @@ Functions that are marked *async* are asynchronous which can lead to unexpected 
 
 *unsafe* functions can have dangerous side effects and should be used with care, the `--unsafe` flag is required for use.
 
+=== bswap
+
+.variants
+* `uint8 bswap(uint8 n)`
+* `uint16 bswap(uint16 n)`
+* `uint32 bswap(uint32 n)`
+* `uint64 bswap(uint64 n)`
+
+`bswap` reverses the order of the bytes in integer `n`. In case of 8 bit integers, `n` is returned without being modified.
+The return type is an unsigned integer of the same width as `n`.
+
 === buf
 
 .variants

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1260,6 +1260,22 @@ void SemanticAnalyser::visit(Call &call)
     // Return type cannot be used
     call.type = SizedType(Type::none, 0);
   }
+  else if (call.func == "bswap")
+  {
+    if (!check_nargs(call, 1))
+      return;
+
+    Expression *arg = call.vargs->at(0);
+    if (arg->type.type != Type::integer)
+    {
+      LOG(ERROR, call.loc, err_)
+          << call.func << "() only supports integer arguments ("
+          << arg->type.type << " provided)";
+      return;
+    }
+
+    call.type = CreateUInt(arg->type.GetIntBitWidth());
+  }
   else
   {
     LOG(ERROR, call.loc, err_) << "Unknown function: '" << call.func << "'";

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -38,7 +38,7 @@ vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#\*])+
 builtin  arg[0-9]|args|cgroup|comm|cpid|cpu|ctx|curtask|elapsed|func|gid|nsecs|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
-call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|sizeof|stats|str|strftime|strncmp|sum|system|time|uaddr|uptr|usym|zero|path|unwatch
+call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|sizeof|stats|str|strftime|strncmp|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap
 
 /* Don't add to this! Use builtin OR call not both */
 call_and_builtin kstack|ustack

--- a/tests/codegen/llvm/builtin_ctx_field.ll
+++ b/tests/codegen/llvm/builtin_ctx_field.ll
@@ -85,14 +85,14 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"struct c.c")
   %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct c.c", i32 1, i64 %35)
   %36 = load i8, i8* %"struct c.c", align 1
-  %37 = sext i8 %36 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct c.c")
-  %38 = bitcast i64* %"@d_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %38)
+  %37 = bitcast i64* %"@d_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %37)
   store i64 0, i64* %"@d_key", align 8
+  %38 = sext i8 %36 to i64
   %39 = bitcast i64* %"@d_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %39)
-  store i64 %37, i64* %"@d_val", align 8
+  store i64 %38, i64* %"@d_val", align 8
   %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
   %update_elem6 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo5, i64* %"@d_key", i64* %"@d_val", i64 0)
   %40 = bitcast i64* %"@d_val" to i8*

--- a/tests/codegen/llvm/call_printf.ll
+++ b/tests/codegen/llvm/call_printf.ll
@@ -32,10 +32,10 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"struct Foo.c")
   %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.c", i32 1, i64 %8)
   %9 = load i8, i8* %"struct Foo.c", align 1
-  %10 = sext i8 %9 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct Foo.c")
-  %11 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %10, i64* %11, align 8
+  %10 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
+  %11 = sext i8 %9 to i64
+  store i64 %11, i64* %10, align 8
   %12 = load i64, i64* %"$foo", align 8
   %13 = add i64 %12, 8
   %14 = bitcast i64* %"struct Foo.l" to i8*

--- a/tests/codegen/llvm/logical_and_or_different_type.ll
+++ b/tests/codegen/llvm/logical_and_or_different_type.ll
@@ -41,10 +41,9 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   %probe_read_user = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.m", i32 4, i64 %9)
   %11 = load i32, i32* %"struct Foo.m", align 4
-  %12 = sext i32 %11 to i64
-  %13 = bitcast i32* %"struct Foo.m" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %lhs_true_cond = icmp ne i64 %12, 0
+  %12 = bitcast i32* %"struct Foo.m" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %lhs_true_cond = icmp ne i32 %11, 0
   br i1 %lhs_true_cond, label %"&&_lhs_true", label %"&&_false"
 
 "&&_lhs_true":                                    ; preds = %entry
@@ -59,24 +58,23 @@ entry:
   br label %"&&_merge"
 
 "&&_merge":                                       ; preds = %"&&_false", %"&&_true"
-  %14 = load i64, i64* %"&&_result", align 8
-  %15 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %14, i64* %15, align 8
-  %16 = bitcast i64* %"&&_result5" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
+  %13 = load i64, i64* %"&&_result", align 8
+  %14 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
+  store i64 %13, i64* %14, align 8
+  %15 = bitcast i64* %"&&_result5" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
   br i1 true, label %"&&_lhs_true1", label %"&&_false3"
 
 "&&_lhs_true1":                                   ; preds = %"&&_merge"
-  %17 = load i64, i64* %"$foo", align 8
-  %18 = add i64 %17, 0
-  %19 = bitcast i32* %"struct Foo.m6" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
-  %probe_read_user7 = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.m6", i32 4, i64 %18)
-  %20 = load i32, i32* %"struct Foo.m6", align 4
-  %21 = sext i32 %20 to i64
-  %22 = bitcast i32* %"struct Foo.m6" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
-  %rhs_true_cond = icmp ne i64 %21, 0
+  %16 = load i64, i64* %"$foo", align 8
+  %17 = add i64 %16, 0
+  %18 = bitcast i32* %"struct Foo.m6" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
+  %probe_read_user7 = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.m6", i32 4, i64 %17)
+  %19 = load i32, i32* %"struct Foo.m6", align 4
+  %20 = bitcast i32* %"struct Foo.m6" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
+  %rhs_true_cond = icmp ne i32 %19, 0
   br i1 %rhs_true_cond, label %"&&_true2", label %"&&_false3"
 
 "&&_true2":                                       ; preds = %"&&_lhs_true1"
@@ -88,21 +86,20 @@ entry:
   br label %"&&_merge4"
 
 "&&_merge4":                                      ; preds = %"&&_false3", %"&&_true2"
-  %23 = load i64, i64* %"&&_result5", align 8
-  %24 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 2
-  store i64 %23, i64* %24, align 8
-  %25 = bitcast i64* %"||_result" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %25)
-  %26 = load i64, i64* %"$foo", align 8
-  %27 = add i64 %26, 0
+  %21 = load i64, i64* %"&&_result5", align 8
+  %22 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 2
+  store i64 %21, i64* %22, align 8
+  %23 = bitcast i64* %"||_result" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
+  %24 = load i64, i64* %"$foo", align 8
+  %25 = add i64 %24, 0
+  %26 = bitcast i32* %"struct Foo.m8" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %26)
+  %probe_read_user9 = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.m8", i32 4, i64 %25)
+  %27 = load i32, i32* %"struct Foo.m8", align 4
   %28 = bitcast i32* %"struct Foo.m8" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %28)
-  %probe_read_user9 = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.m8", i32 4, i64 %27)
-  %29 = load i32, i32* %"struct Foo.m8", align 4
-  %30 = sext i32 %29 to i64
-  %31 = bitcast i32* %"struct Foo.m8" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %31)
-  %lhs_true_cond10 = icmp ne i64 %30, 0
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %28)
+  %lhs_true_cond10 = icmp ne i32 %27, 0
   br i1 %lhs_true_cond10, label %"||_true", label %"||_lhs_false"
 
 "||_lhs_false":                                   ; preds = %"&&_merge4"
@@ -117,24 +114,23 @@ entry:
   br label %"||_merge"
 
 "||_merge":                                       ; preds = %"||_true", %"||_false"
-  %32 = load i64, i64* %"||_result", align 8
-  %33 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 3
-  store i64 %32, i64* %33, align 8
-  %34 = bitcast i64* %"||_result15" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %34)
+  %29 = load i64, i64* %"||_result", align 8
+  %30 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 3
+  store i64 %29, i64* %30, align 8
+  %31 = bitcast i64* %"||_result15" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %31)
   br i1 false, label %"||_true13", label %"||_lhs_false11"
 
 "||_lhs_false11":                                 ; preds = %"||_merge"
-  %35 = load i64, i64* %"$foo", align 8
-  %36 = add i64 %35, 0
-  %37 = bitcast i32* %"struct Foo.m16" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %37)
-  %probe_read_user17 = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.m16", i32 4, i64 %36)
-  %38 = load i32, i32* %"struct Foo.m16", align 4
-  %39 = sext i32 %38 to i64
-  %40 = bitcast i32* %"struct Foo.m16" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %40)
-  %rhs_true_cond18 = icmp ne i64 %39, 0
+  %32 = load i64, i64* %"$foo", align 8
+  %33 = add i64 %32, 0
+  %34 = bitcast i32* %"struct Foo.m16" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %34)
+  %probe_read_user17 = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.m16", i32 4, i64 %33)
+  %35 = load i32, i32* %"struct Foo.m16", align 4
+  %36 = bitcast i32* %"struct Foo.m16" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %36)
+  %rhs_true_cond18 = icmp ne i32 %35, 0
   br i1 %rhs_true_cond18, label %"||_true13", label %"||_false12"
 
 "||_false12":                                     ; preds = %"||_lhs_false11"
@@ -146,13 +142,13 @@ entry:
   br label %"||_merge14"
 
 "||_merge14":                                     ; preds = %"||_true13", %"||_false12"
-  %41 = load i64, i64* %"||_result15", align 8
-  %42 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 4
-  store i64 %41, i64* %42, align 8
+  %37 = load i64, i64* %"||_result15", align 8
+  %38 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 4
+  store i64 %37, i64* %38, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 40)
-  %43 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %43)
+  %39 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %39)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_char_1.ll
+++ b/tests/codegen/llvm/struct_char_1.ll
@@ -24,14 +24,14 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"struct Foo.x")
   %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.x", i32 1, i64 %5)
   %6 = load i8, i8* %"struct Foo.x", align 1
-  %7 = sext i8 %6 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct Foo.x")
-  %8 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %7 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   store i64 0, i64* %"@x_key", align 8
+  %8 = sext i8 %6 to i64
   %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store i64 %7, i64* %"@x_val", align 8
+  store i64 %8, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
   %10 = bitcast i64* %"@x_val" to i8*

--- a/tests/codegen/llvm/struct_char_2.ll
+++ b/tests/codegen/llvm/struct_char_2.ll
@@ -24,14 +24,14 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"struct Foo.x")
   %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.x", i32 1, i64 %5)
   %6 = load i8, i8* %"struct Foo.x", align 1
-  %7 = sext i8 %6 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct Foo.x")
-  %8 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %7 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   store i64 0, i64* %"@x_key", align 8
+  %8 = sext i8 %6 to i64
   %9 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store i64 %7, i64* %"@x_val", align 8
+  store i64 %8, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
   %10 = bitcast i64* %"@x_val" to i8*

--- a/tests/codegen/llvm/struct_integers_1.ll
+++ b/tests/codegen/llvm/struct_integers_1.ll
@@ -25,15 +25,15 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.x", i32 4, i64 %5)
   %7 = load i32, i32* %"struct Foo.x", align 4
-  %8 = sext i32 %7 to i64
-  %9 = bitcast i32* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %8 = bitcast i32* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 0, i64* %"@x_key", align 8
+  %10 = sext i32 %7 to i64
   %11 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  store i64 %8, i64* %"@x_val", align 8
+  store i64 %10, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
   %12 = bitcast i64* %"@x_val" to i8*

--- a/tests/codegen/llvm/struct_integers_2.ll
+++ b/tests/codegen/llvm/struct_integers_2.ll
@@ -25,15 +25,15 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Foo.x", i32 4, i64 %5)
   %7 = load i32, i32* %"struct Foo.x", align 4
-  %8 = sext i32 %7 to i64
-  %9 = bitcast i32* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %8 = bitcast i32* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 0, i64* %"@x_key", align 8
+  %10 = sext i32 %7 to i64
   %11 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  store i64 %8, i64* %"@x_val", align 8
+  store i64 %10, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
   %12 = bitcast i64* %"@x_val" to i8*

--- a/tests/codegen/llvm/struct_nested_struct_anon_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_1.ll
@@ -26,15 +26,15 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Foo::(anonymous at definitions.h:2:14).x", i32 4, i64 %6)
   %8 = load i32, i32* %"struct Foo::(anonymous at definitions.h:2:14).x", align 4
-  %9 = sext i32 %8 to i64
-  %10 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %9 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 0, i64* %"@x_key", align 8
+  %11 = sext i32 %8 to i64
   %12 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  store i64 %9, i64* %"@x_val", align 8
+  store i64 %11, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
   %13 = bitcast i64* %"@x_val" to i8*

--- a/tests/codegen/llvm/struct_nested_struct_anon_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_2.ll
@@ -26,15 +26,15 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Foo::(anonymous at definitions.h:2:14).x", i32 4, i64 %6)
   %8 = load i32, i32* %"struct Foo::(anonymous at definitions.h:2:14).x", align 4
-  %9 = sext i32 %8 to i64
-  %10 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %9 = bitcast i32* %"struct Foo::(anonymous at definitions.h:2:14).x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 0, i64* %"@x_key", align 8
+  %11 = sext i32 %8 to i64
   %12 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  store i64 %9, i64* %"@x_val", align 8
+  store i64 %11, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
   %13 = bitcast i64* %"@x_val" to i8*

--- a/tests/codegen/llvm/struct_nested_struct_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_1.ll
@@ -26,15 +26,15 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %6)
   %8 = load i32, i32* %"struct Bar.x", align 4
-  %9 = sext i32 %8 to i64
-  %10 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %9 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 0, i64* %"@x_key", align 8
+  %11 = sext i32 %8 to i64
   %12 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  store i64 %9, i64* %"@x_val", align 8
+  store i64 %11, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
   %13 = bitcast i64* %"@x_val" to i8*

--- a/tests/codegen/llvm/struct_nested_struct_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_2.ll
@@ -26,15 +26,15 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %6)
   %8 = load i32, i32* %"struct Bar.x", align 4
-  %9 = sext i32 %8 to i64
-  %10 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %9 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 0, i64* %"@x_key", align 8
+  %11 = sext i32 %8 to i64
   %12 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  store i64 %9, i64* %"@x_val", align 8
+  store i64 %11, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
   %13 = bitcast i64* %"@x_val" to i8*

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
@@ -33,15 +33,15 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %9)
   %11 = load i32, i32* %"struct Bar.x", align 4
-  %12 = sext i32 %11 to i64
-  %13 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  %12 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
   store i64 0, i64* %"@x_key", align 8
+  %14 = sext i32 %11 to i64
   %15 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
-  store i64 %12, i64* %"@x_val", align 8
+  store i64 %14, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
   %16 = bitcast i64* %"@x_val" to i8*

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
@@ -33,15 +33,15 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %"struct Bar.x", i32 4, i64 %9)
   %11 = load i32, i32* %"struct Bar.x", align 4
-  %12 = sext i32 %11 to i64
-  %13 = bitcast i32* %"struct Bar.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
-  %14 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  %12 = bitcast i32* %"struct Bar.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
   store i64 0, i64* %"@x_key", align 8
+  %14 = sext i32 %11 to i64
   %15 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
-  store i64 %12, i64* %"@x_val", align 8
+  store i64 %14, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
   %16 = bitcast i64* %"@x_val" to i8*

--- a/tests/codegen/llvm/struct_short_1.ll
+++ b/tests/codegen/llvm/struct_short_1.ll
@@ -25,15 +25,15 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i16*, i32, i64)*)(i16* %"struct Foo.x", i32 2, i64 %5)
   %7 = load i16, i16* %"struct Foo.x", align 2
-  %8 = sext i16 %7 to i64
-  %9 = bitcast i16* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %8 = bitcast i16* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 0, i64* %"@x_key", align 8
+  %10 = sext i16 %7 to i64
   %11 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  store i64 %8, i64* %"@x_val", align 8
+  store i64 %10, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
   %12 = bitcast i64* %"@x_val" to i8*

--- a/tests/codegen/llvm/struct_short_2.ll
+++ b/tests/codegen/llvm/struct_short_2.ll
@@ -25,15 +25,15 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i16*, i32, i64)*)(i16* %"struct Foo.x", i32 2, i64 %5)
   %7 = load i16, i16* %"struct Foo.x", align 2
-  %8 = sext i16 %7 to i64
-  %9 = bitcast i16* %"struct Foo.x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %8 = bitcast i16* %"struct Foo.x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 0, i64* %"@x_key", align 8
+  %10 = sext i16 %7 to i64
   %11 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
-  store i64 %8, i64* %"@x_val", align 8
+  store i64 %10, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
   %12 = bitcast i64* %"@x_val" to i8*

--- a/tests/codegen/llvm/variable_assign_array.ll
+++ b/tests/codegen/llvm/variable_assign_array.ll
@@ -26,15 +26,15 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %array_access, i32 4, i64 %6)
   %8 = load i32, i32* %array_access, align 4
-  %9 = sext i32 %8 to i64
-  %10 = bitcast i32* %array_access to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %9 = bitcast i32* %array_access to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 0, i64* %"@x_key", align 8
+  %11 = sext i32 %8 to i64
   %12 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
-  store i64 %9, i64* %"@x_val", align 8
+  store i64 %11, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
   %13 = bitcast i64* %"@x_val" to i8*

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -351,3 +351,33 @@ EXPECT path: ([a-z]*:\/.*;)*[a-z]*:\/.*
 REQUIRES grep -q '^cgroup2' /proc/mounts
 TIMEOUT 5
 MIN_KERNEL 4.18
+
+NAME bswap_int64
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%lx", bswap(0x1122334455667788)); exit(); }'
+EXPECT 8877665544332211
+TIMEOUT 1
+
+NAME bswap_int32
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%x", bswap((int32)0x12345678)); exit(); }'
+EXPECT 78563412
+TIMEOUT 1
+
+NAME bswap_int16
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%x", bswap((int16)0x1234)); exit(); }'
+EXPECT 3412
+TIMEOUT 1
+
+NAME bswap_int8
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%x", bswap((int8)0x12)); exit(); }'
+EXPECT 12
+TIMEOUT 1
+
+NAME bswap_int64_op
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%lx", bswap(0x12340000 + 0x5678)); exit(); }'
+EXPECT 7856341200000000
+TIMEOUT 1
+
+NAME bswap_twice
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%x", bswap(bswap(0x1234))); exit(); }'
+EXPECT 1234
+TIMEOUT 1

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -868,6 +868,24 @@ TEST(semantic_analyser, call_macaddr)
   test("kprobe:f { macaddr(\"hello\"); }", 1);
 }
 
+TEST(semantic_analyser, call_bswap)
+{
+  test("kprobe:f { bswap(arg0); }", 0);
+
+  test("kprobe:f { bswap(0x12); }", 0);
+  test("kprobe:f { bswap(0x12 + 0x34); }", 0);
+
+  test("kprobe:f { bswap((int8)0x12); }", 0);
+  test("kprobe:f { bswap((int16)0x12); }", 0);
+  test("kprobe:f { bswap((int32)0x12); }", 0);
+  test("kprobe:f { bswap((int64)0x12); }", 0);
+
+  test("kprobe:f { bswap(); }", 1);
+  test("kprobe:f { bswap(0x12, 0x34); }", 1);
+
+  test("kprobe:f { bswap(\"hello\"); }", 1);
+}
+
 TEST(semantic_analyser, call_cgroup_path)
 {
   test("kprobe:f { cgroup_path(1) }", 0);

--- a/tools/tcpaccept.bt
+++ b/tools/tcpaccept.bt
@@ -55,7 +55,7 @@ kretprobe:inet_csk_accept
 		$qmax  = $sk->sk_max_ack_backlog;
 
 		// Destination port is big endian, it must be flipped
-		$dport = ($dport >> 8) | (($dport << 8) & 0x00FF00);
+		$dport = bswap($dport);
 
 		time("%H:%M:%S ");
 		printf("%-6d %-14s ", pid, comm);

--- a/tools/tcpconnect.bt
+++ b/tools/tcpconnect.bt
@@ -50,7 +50,7 @@ kprobe:tcp_connect
     $dport = $sk->__sk_common.skc_dport;
 
     // Destination port is big endian, it must be flipped
-    $dport = ($dport >> 8) | (($dport << 8) & 0x00FF00);
+    $dport = bswap($dport);
 
     time("%H:%M:%S ");
     printf("%-8d %-16s ", pid, comm);

--- a/tools/tcpdrop.bt
+++ b/tools/tcpdrop.bt
@@ -65,7 +65,7 @@ kprobe:tcp_drop
     $dport = $sk->__sk_common.skc_dport;
 
     // Destination port is big endian, it must be flipped
-    $dport = ($dport >> 8) | (($dport << 8) & 0x00FF00);
+    $dport = bswap($dport);
 
     $state = $sk->__sk_common.skc_state;
     $statestr = @tcp_states[$state];

--- a/tools/tcplife.bt
+++ b/tools/tcplife.bt
@@ -62,7 +62,7 @@ kprobe:tcp_set_state
 		$delta_ms = (nsecs - @birth[$sk]) / 1e6;
 		$lport = $sk->__sk_common.skc_num;
 		$dport = $sk->__sk_common.skc_dport;
-		$dport = ($dport >> 8) | (($dport << 8) & 0xff00);
+		$dport = bswap($dport);
 		$tp = (struct tcp_sock *)$sk;
 		$pid = @skpid[$sk];
 		$comm = @skcomm[$sk];

--- a/tools/tcpretrans.bt
+++ b/tools/tcpretrans.bt
@@ -67,7 +67,7 @@ kprobe:tcp_retransmit_skb
 		$dport = $sk->__sk_common.skc_dport;
 
 		// Destination port is big endian, it must be flipped
-		$dport = ($dport >> 8) | (($dport << 8) & 0x00FF00);
+		$dport = bswap($dport);
 
 		$state = $sk->__sk_common.skc_state;
 		$statestr = @tcp_states[$state];


### PR DESCRIPTION
The function takes an unsigned integer and returns an unsigned
integer of the same width, but with the byte order reversed.

Resolves #1875 

One thing I'd like to draw your attention is the integer type promotion / demotion in order to fix a strange behaviour when 16 bit arguments were received. Since I am not really competent in LLVM, it is possible that something is escaping me....

Also, I have updated TCP related programs (e.g. `tcpconnect.bt`) to use the new bswap function, instead of the manual byte reordering.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
