### PR TITLE
Do not pass ProbeArgs entries by value in predicate function

### DIFF
--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -156,7 +156,10 @@ void FieldAnalyser::visit(AssignVarStatement &assignment)
 
 bool FieldAnalyser::compare_args(const ProbeArgs &args1, const ProbeArgs &args2)
 {
-  auto pred = [](auto a, auto b) { return a.first == b.first; };
+  using ProbeArgsValue = ProbeArgs::value_type;
+  auto pred = [](const ProbeArgsValue &a, const ProbeArgsValue &b) {
+    return a.first == b.first;
+  };
 
   return args1.size() == args2.size() &&
          std::equal(args1.begin(), args1.end(), args2.begin(), pred);


### PR DESCRIPTION
Fixes alert reported by lgtm:
> This parameter of type pair<const basic_string<char, char_traits<char>, allocator<char>>, SizedType> is 168 bytes - consider passing a const pointer/reference instead.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
