### PR TITLE
Add BPFTRACE_KERNEL_BUILD env var for out-of-tree kernel build

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -3631,4 +3631,5 @@ bpftrace requires kernel headers for certain features, which are searched for by
 /lib/modules/$(uname -r)
 ```
 
-The default search directory can be overridden using the environment variable `BPFTRACE_KERNEL_SOURCE`.
+The default search directory can be overridden using the environment variable `BPFTRACE_KERNEL_SOURCE`, and
+also `BPFTRACE_KERNEL_BUILD` if it is out-of-tree Linux kernel build.

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -551,7 +551,14 @@ std::tuple<std::string, std::string> get_kernel_dirs(
 
   const char *kpath_env = ::getenv("BPFTRACE_KERNEL_SOURCE");
   if (kpath_env)
-    return std::make_tuple(kpath_env, kpath_env);
+  {
+    const char *kpath_build_env = ::getenv("BPFTRACE_KERNEL_BUILD");
+    if (!kpath_build_env)
+    {
+      kpath_build_env = kpath_env;
+    }
+    return std::make_tuple(kpath_env, kpath_build_env);
+  }
 
   std::string kdir = std::string("/lib/modules/") + utsname.release;
   auto ksrc = kdir + "/source";


### PR DESCRIPTION
The existing BPFTRACE_KERNEL_SOURCE supports passing kernel source tree
from environment variable to bpftrace, but it assumes in-tree build as
it returns the previous env var value as both ksrc and kobj, which
causes compilation error for out-of-tree Linux kernel build when loading
BTF.

This PR adds optional BPFTRACE_KERNEL_BUILD to pass out-of-tree build
dir, and fallback to BPFTRACE_KERNEL_SOURCE if it is not provided which
makes it still work for in-tree build.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
