### PR TITLE
Fix error on accessing field of struct request when without BTF

### DIFF
--- a/tools/biosnoop.bt
+++ b/tools/biosnoop.bt
@@ -12,6 +12,7 @@
 
 #ifndef BPFTRACE_HAVE_BTF
 #include <linux/blkdev.h>
+#include <linux/blk-mq.h>
 #endif
 
 BEGIN


### PR DESCRIPTION
Without including blk-mq.h, we will get: ERROR: Struct/union
of type 'struct request' does not contain a field named 'rq_disk'

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
