### PR TITLE
Fix libbtf 0.6.0 build

### DIFF
--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -24,6 +24,15 @@
 #pragma GCC diagnostic pop
 #include <bpf/libbpf.h>
 
+/*
+ * Since libbtf 0.6, btf_dump__new() has been overloaded and now can design
+ * either btf_dump__new_v0_6_0() or btf_dump__new_deprecated(), which is the
+ * same as btf_dump__new() for libbtf < 0.6, and the one we still use.
+ */
+#if LIBBPF_MAJOR_VERSION == 0 && LIBBPF_MINOR_VERSION >= 6
+#define btf_dump__new(a1, a2, a3, a4) btf_dump__new_deprecated(a1, a2, a3, a4)
+#endif
+
 #include "bpftrace.h"
 
 namespace bpftrace {


### PR DESCRIPTION
Libbpf 0.6.0 introduced a new version of btf_dump__new(). The new
version is btf_dump__new_v0_6_0() while the old version was renamed
btf_dump__new_deprecated(). btf_dump__new() is now overloaded,
unfortunately the macro doesn't work on cpp.

Let's call btf_dump__new_deprecated() explicitely when libbpbf version
is above 0.6.0. That should work till support for the deprecated
function is removed in libbpf 1.0.0.

Fixes #2068

Signed-off-by: Jerome Marchand <jmarchan@redhat.com>

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
