### PR TITLE
softirqstat

### DIFF
--- a/tools/softirqstat.bt
+++ b/tools/softirqstat.bt
@@ -1,0 +1,80 @@
+#!/usr/bin/bpftrace --unsafe
+/**
+ * softirqstat	Stat softirq like /proc/softirqs with better display.
+ *				For Linux, uses bpftrace and eBPF.
+ *
+ * Written as a basic example of counting softirqs and printing a
+ * per-second Statistic.
+ *
+ * USAGE: softirqstat.bt
+ *
+ * This is a bpftrace version of the bcc tool of the same name.
+ *
+ * Copyright 2022 CESTC, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ *
+ * 24-Mar-2022	Rong Tao <rongtao@cestc.cn> Create this.
+ */
+
+#include <linux/interrupt.h>
+
+BEGIN
+{
+	@softirqname[HI_SOFTIRQ] = "HI";
+	@softirqname[TIMER_SOFTIRQ] = "TIMER";
+	@softirqname[NET_TX_SOFTIRQ] = "NET_TX";
+	@softirqname[NET_RX_SOFTIRQ] = "NET_RX";
+	@softirqname[BLOCK_SOFTIRQ] = "BLOCK";
+	@softirqname[IRQ_POLL_SOFTIRQ] = "IRQ_POLL";
+	@softirqname[TASKLET_SOFTIRQ] = "TASKLET";
+	@softirqname[SCHED_SOFTIRQ] = "SCHED";
+	@softirqname[HRTIMER_SOFTIRQ] = "HRTIMER";
+	@softirqname[RCU_SOFTIRQ] = "RCU";
+
+	if ($# < 1) {
+		printf("Input max CPU id.\n");
+		exit();
+	}
+	printf("Tracing softirq_entry, hit ctrl+c to end.\n");
+}
+
+tracepoint:irq:softirq_entry
+{
+	$vec_nr = args->vec;
+
+	@vec_count[cpu, @softirqname[$vec_nr]] += 1;
+}
+
+interval:s:1
+{
+	system("clear");
+	printf("Statistic Softirq...\n");
+	printf("\033[1;32m%-4s\033[m\033[1;33m %-10s %-10s %-10s %-10s %-10s ",
+		"CPU", "HI", "TIMER", "NET_TX", "NET_RX", "BLOCK");
+	printf("%-10s %-10s %-10s %-10s %-10s\033[m\n",
+		"IRQ_POLL", "TASKLET", "SCHED", "HRTIMER", "RCU");
+
+	$i = 0;
+	unroll($1) {
+	printf("%-4d %-10ld %-10d %-10d %-10d %-10d %-10d %-10d %-10d %-10d %-10d\n",
+		$i,
+		@vec_count[$i, "HI"],
+		@vec_count[$i, "TIMER"],
+		@vec_count[$i, "NET_TX"],
+		@vec_count[$i, "NET_RX"],
+		@vec_count[$i, "BLOCK"],
+		@vec_count[$i, "IRQ_POLL"],
+		@vec_count[$i, "TASKLET"],
+		@vec_count[$i, "SCHED"],
+		@vec_count[$i, "HRTIMER"],
+		@vec_count[$i, "RCU"]);
+
+		$i = $i + 1;
+	}
+}
+
+END
+{
+	clear(@softirqname);
+	clear(@vec_count);
+}

--- a/tools/softirqstat_examples.bt
+++ b/tools/softirqstat_examples.bt
@@ -1,0 +1,23 @@
+Demonstrations of softirqstat, the Linux bpftrace/eBPF version.
+
+Written as a basic example of counting softirqs and printing a
+per-second Statistic.
+
+$ sudo ./softirqstat.bt $(nproc)
+
+Statistic Softirq...
+CPU  HI         TIMER      NET_TX     NET_RX     BLOCK      IRQ_POLL   TASKLET    SCHED      HRTIMER    RCU
+0    0          8          0          0          0          0          0          35         0          50
+1    0          10         0          0          0          0          0          24         0          22
+2    0          21         0          0          0          0          0          41         0          35
+3    0          140        1          0          0          0          0          147        0          136
+4    0          4          0          0          0          0          0          37         0          52
+5    0          9          0          0          0          0          0          18         0          19
+6    219        6          0          0          0          0          0          9          0          13
+7    36         119        0          40         0          0          0          384        0          272
+8    224        69         0          0          0          0          67         79         0          31
+9    0          18         0          0          0          0          0          71         0          66
+10   147        218        0          0          0          0          0          284        0          203
+11   0          3          0          0          0          0          0          24         0          34
+
+Each second, show softirq Statistics.


### PR DESCRIPTION
Print softirq information every second, and better display, like:

```
$ sudo ./softirqstat.bt $(nproc)
Statistic Softirq...
CPU  HI         TIMER      NET_TX     NET_RX     BLOCK      IRQ_POLL   TASKLET    SCHED      HRTIMER    RCU
0    0          6          0          0          0          0          0          37         0          54
1    0          129        0          0          0          0          0          145        0          70
2    0          4          0          0          0          0          0          6          0          5
3    0          4          1          0          0          0          0          10         0          12
4    0          3          0          0          0          0          0          6          0          7
5    0          7          0          0          0          0          0          13         0          13
6    156        41         0          0          0          0          0          49         0          46
7    0          2          0          18         0          0          0          23         0          30
8    103        80         0          0          0          0          78         122        0          65
9    0          12         0          0          0          0          0          33         0          26
10   107        105        0          0          0          0          0          186        0          162
11   24         72         0          0          0          0          0          179        0          142
```

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
