### PR TITLE
Improve handling empty attach points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to
 #### Changed
 - Use auto-resolution of library paths for tools
   - [#2181](https://github.com/iovisor/bpftrace/pull/2181)
+- Improve handling empty attach points
+  - [#2179](https://github.com/iovisor/bpftrace/pull/2179)
 
 #### Deprecated
 #### Removed

--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -86,6 +86,19 @@ int AttachPointParser::parse()
         }
       }
     }
+
+    auto new_end = std::remove_if(probe->attach_points->begin(),
+                                  probe->attach_points->end(),
+                                  [](const AttachPoint *ap) {
+                                    return ap->provider.empty();
+                                  });
+    probe->attach_points->erase(new_end, probe->attach_points->end());
+
+    if (probe->attach_points->empty())
+    {
+      LOG(ERROR, probe->loc, sink_) << "No attach points for probe";
+      failed++;
+    }
   }
 
   return failed;
@@ -103,6 +116,13 @@ AttachPointParser::State AttachPointParser::parse_attachpoint(AttachPoint &ap)
   {
     errs_ << "Invalid attachpoint definition" << std::endl;
     return INVALID;
+  }
+
+  if (parts_.front().empty())
+  {
+    // Do not fail on empty attach point, could be just a trailing comma
+    ap_->provider = "";
+    return OK;
   }
 
   std::set<std::string> probe_types;

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -727,6 +727,17 @@ TEST(bpftrace, invalid_provider)
   ASSERT_EQ(0, bpftrace.add_probe(*probe));
 }
 
+TEST(bpftrace, empty_attachpoints)
+{
+  StrictMock<MockBPFtrace> bpftrace;
+  Driver driver(bpftrace);
+
+  // Trailing comma is fine
+  ASSERT_EQ(driver.parse_str("kprobe:f1, {}"), 0);
+  // Empty attach point should fail
+  ASSERT_EQ(driver.parse_str("{}"), 1);
+}
+
 std::pair<std::vector<uint8_t>, std::vector<uint8_t>> key_value_pair_int(std::vector<uint64_t> key, int val)
 {
   std::pair<std::vector<uint8_t>, std::vector<uint8_t>> pair;


### PR DESCRIPTION
If there are empty attach points for a probe, ignore them unless there
are no other non-empty attach points. In such a case, emit error.

This allows usage of trailing commas:

    kprobe:function1,
    kprobe:function2,
    {...}

Fixes #2120.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
