### PR TITLE
tools: use auto-resolution of library paths

### DIFF
--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -45,8 +45,8 @@ jobs:
           STATIC_LIBC: ON
           EMBED_BUILD_LLVM: OFF
           RUN_ALL_TESTS: 1
-          TEST_GROUPS_DISABLE: "tools-parsing-test"
           RUNTIME_TEST_DISABLE: json-output.join_delim,other.string compare map lookup,probe.kprobe_offset_fail_size,probe.uprobe_library,usdt."usdt probes - attach to fully specified probe of child",usdt."usdt probes - all probes by wildcard and file with child",usdt."usdt probes - attach to probe by wildcard and file with child",usdt."usdt probes - attach to probes by wildcard file with child",usdt."usdt probes - attach to probe on multiple files by wildcard",usdt."usdt probes - attach to probe with probe builtin and args by file with child",usdt."usdt probes - list probes by pid in separate mountns",usdt."usdt sized arguments",usdt."usdt - list probes by file with wildcarded probe type",uprobe."uprobes - list probes by pid; uprobes only",uprobe."uprobes - list probes by pid in separate mount namespace",other.positional pointer arithmetics
+          TOOLS_TEST_DISABLE: gethostlatency.bt,threadsnoop.bt
           TOOLS_TEST_OLDVERSION: mdflush.bt
           BASE: alpine
           DISTRO: alpine
@@ -60,6 +60,7 @@ jobs:
           EMBED_BUILD_LLVM: OFF
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: other.string compare map lookup,probe.kprobe_offset_fail_size,probe.uprobe_library,usdt."usdt probes - attach to fully specified probe of child",usdt."usdt probes - all probes by wildcard and file with child",usdt."usdt probes - attach to probe by wildcard and file with child",usdt."usdt probes - attach to probes by wildcard file with child",usdt."usdt probes - attach to probe on multiple files by wildcard",usdt."usdt probes - attach to probe with probe builtin and args by file with child",usdt."usdt probes - list probes by pid in separate mountns",usdt."usdt sized arguments",usdt."usdt - list probes by file with wildcarded probe type",uprobe."uprobes - list probes by pid; uprobes only",uprobe."uprobes - list probes by pid in separate mount namespace",other.positional pointer arithmetics
+          TOOLS_TEST_DISABLE: gethostlatency.bt,threadsnoop.bt
           TOOLS_TEST_OLDVERSION: mdflush.bt
           BASE: alpine
           DISTRO: alpine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to
   - [#2166](https://github.com/iovisor/bpftrace/pull/2166)
 
 #### Changed
+- Use auto-resolution of library paths for tools
+  - [#2181](https://github.com/iovisor/bpftrace/pull/2181)
+
 #### Deprecated
 #### Removed
 #### Fixed

--- a/tools/gethostlatency.bt
+++ b/tools/gethostlatency.bt
@@ -26,17 +26,17 @@ BEGIN
 	    "HOST");
 }
 
-uprobe:/lib/x86_64-linux-gnu/libc.so.6:getaddrinfo,
-uprobe:/lib/x86_64-linux-gnu/libc.so.6:gethostbyname,
-uprobe:/lib/x86_64-linux-gnu/libc.so.6:gethostbyname2
+uprobe:libc:getaddrinfo,
+uprobe:libc:gethostbyname,
+uprobe:libc:gethostbyname2
 {
 	@start[tid] = nsecs;
 	@name[tid] = arg0;
 }
 
-uretprobe:/lib/x86_64-linux-gnu/libc.so.6:getaddrinfo,
-uretprobe:/lib/x86_64-linux-gnu/libc.so.6:gethostbyname,
-uretprobe:/lib/x86_64-linux-gnu/libc.so.6:gethostbyname2
+uretprobe:libc:getaddrinfo,
+uretprobe:libc:gethostbyname,
+uretprobe:libc:gethostbyname2
 /@start[tid]/
 {
 	$latms = (nsecs - @start[tid]) / 1e6;

--- a/tools/threadsnoop.bt
+++ b/tools/threadsnoop.bt
@@ -18,7 +18,7 @@ BEGIN
 	printf("%-10s %-6s %-16s %s\n", "TIME(ms)", "PID", "COMM", "FUNC");
 }
 
-uprobe:/lib/x86_64-linux-gnu/libpthread.so.0:pthread_create
+uprobe:libpthread:pthread_create
 {
 	printf("%-10u %-6d %-16s %s\n", elapsed / 1e6, pid, comm,
 	    usym(arg2));


### PR DESCRIPTION
With BCC being updated to newer versions in the CI, we can finally make our tools use automatic resolution of library paths. This makes them portable across various distros.

There's just a problem with `ldconfig` on Alpine which struggles to find the correct paths, so we disable the relevant tests there.

Resolves #2075.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
