### PR TITLE
Fix CI: use new version of mdflush.bt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,6 @@ jobs:
           LLVM_VERSION: 9
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
-          TOOLS_TEST_OLDVERSION: mdflush.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 9 Release
@@ -40,7 +39,6 @@ jobs:
           LLVM_VERSION: 9
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
-          TOOLS_TEST_OLDVERSION: mdflush.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 10 Debug
@@ -48,7 +46,6 @@ jobs:
           LLVM_VERSION: 10
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
-          TOOLS_TEST_OLDVERSION: mdflush.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 10 Release
@@ -56,7 +53,6 @@ jobs:
           LLVM_VERSION: 10
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
-          TOOLS_TEST_OLDVERSION: mdflush.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 10 Clang Debug
@@ -66,7 +62,6 @@ jobs:
           CXX: clang++-10
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
-          TOOLS_TEST_OLDVERSION: mdflush.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 11 Debug
@@ -74,7 +69,6 @@ jobs:
           LLVM_VERSION: 11
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
-          TOOLS_TEST_OLDVERSION: mdflush.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 11 Release
@@ -82,7 +76,6 @@ jobs:
           LLVM_VERSION: 11
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
-          TOOLS_TEST_OLDVERSION: mdflush.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 12 Release
@@ -90,7 +83,6 @@ jobs:
           LLVM_VERSION: 12
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
-          TOOLS_TEST_OLDVERSION: mdflush.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 13 Release
@@ -99,7 +91,6 @@ jobs:
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
           GTEST_FILTER: '-clang_parser.nested_struct_no_type'
-          TOOLS_TEST_OLDVERSION: mdflush.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 12 Release + libbpf
@@ -107,7 +98,6 @@ jobs:
           LLVM_VERSION: 12
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
-          TOOLS_TEST_OLDVERSION: mdflush.bt
           BASE: focal
           VENDOR_GTEST: ON
           BUILD_LIBBPF: ON

--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -16,7 +16,6 @@ jobs:
           EMBED_USE_LLVM: ON
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size
-          TOOLS_TEST_OLDVERSION: mdflush.bt
           BASE: bionic
           DISTRO: ubuntu-glibc
           VENDOR_GTEST: ON
@@ -31,7 +30,6 @@ jobs:
           EMBED_USE_LLVM: ON
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size,other.string compare map lookup
-          TOOLS_TEST_OLDVERSION: mdflush.bt
           BASE: xenial
           DISTRO: ubuntu-glibc
           CMAKE_EXTRA_FLAGS: "-DCMAKE_CXX_FLAGS='-include /usr/local/include/bcc/compat/linux/bpf.h -D__LINUX_BPF_H__'"
@@ -47,7 +45,6 @@ jobs:
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: json-output.join_delim,other.string compare map lookup,probe.kprobe_offset_fail_size,probe.uprobe_library,usdt."usdt probes - attach to fully specified probe of child",usdt."usdt probes - all probes by wildcard and file with child",usdt."usdt probes - attach to probe by wildcard and file with child",usdt."usdt probes - attach to probes by wildcard file with child",usdt."usdt probes - attach to probe on multiple files by wildcard",usdt."usdt probes - attach to probe with probe builtin and args by file with child",usdt."usdt probes - list probes by pid in separate mountns",usdt."usdt sized arguments",usdt."usdt - list probes by file with wildcarded probe type",uprobe."uprobes - list probes by pid; uprobes only",uprobe."uprobes - list probes by pid in separate mount namespace",other.positional pointer arithmetics
           TOOLS_TEST_DISABLE: gethostlatency.bt,threadsnoop.bt
-          TOOLS_TEST_OLDVERSION: mdflush.bt
           BASE: alpine
           DISTRO: alpine
           ALPINE_VERSION: 3.11
@@ -61,7 +58,6 @@ jobs:
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: other.string compare map lookup,probe.kprobe_offset_fail_size,probe.uprobe_library,usdt."usdt probes - attach to fully specified probe of child",usdt."usdt probes - all probes by wildcard and file with child",usdt."usdt probes - attach to probe by wildcard and file with child",usdt."usdt probes - attach to probes by wildcard file with child",usdt."usdt probes - attach to probe on multiple files by wildcard",usdt."usdt probes - attach to probe with probe builtin and args by file with child",usdt."usdt probes - list probes by pid in separate mountns",usdt."usdt sized arguments",usdt."usdt - list probes by file with wildcarded probe type",uprobe."uprobes - list probes by pid; uprobes only",uprobe."uprobes - list probes by pid in separate mount namespace",other.positional pointer arithmetics
           TOOLS_TEST_DISABLE: gethostlatency.bt,threadsnoop.bt
-          TOOLS_TEST_OLDVERSION: mdflush.bt
           BASE: alpine
           DISTRO: alpine
           ALPINE_VERSION: 3.11


### PR DESCRIPTION
CI container images have updated their kernels and they are now compatible with the new version of the `mdflush.bt` tool instead of the old one, which makes the CI crash. 

So, we need to drop the setting to use the old version of the tool from all CI jobs.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
