### PR TITLE
tests/runtime: Restrict kfunc attach test to x86.

### DIFF
--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -308,6 +308,7 @@ NAME path
 RUN {{BPFTRACE}} -ve 'kfunc:filp_close { $f = path(args->filp->f_path); if (!strncmp($f, "/tmp/bpftrace_runtime_test_syscall_gen_read_temp", 49)) { printf("OK\n"); exit(); } }'
 EXPECT OK
 REQUIRES_FEATURE dpath
+ARCH x86_64
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 


### PR DESCRIPTION
The kernel function arch_prepare_bpf_trampoline() is implemented only for x86.

kfunc attach tests would fail irrespective of whether has_prog_kfunc()
is true or false on non-x86 platforms

Signed-off-by: Sumanth Korikkar <sumanthk@linux.ibm.com>

