### PR TITLE
Add test max kernel option

### DIFF
--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -28,7 +28,8 @@ TestStruct = namedtuple(
         'before',
         'after',
         'suite',
-        'kernel',
+        'kernel_min',
+        'kernel_max',
         'requirement',
         'env',
         'arch',
@@ -102,7 +103,8 @@ class TestParser(object):
         timeout = ''
         before = ''
         after = ''
-        kernel = ''
+        kernel_min = ''
+        kernel_max = ''
         requirement = ''
         env = {}
         arch = []
@@ -130,7 +132,9 @@ class TestParser(object):
             elif item_name == 'AFTER':
                 after = line
             elif item_name == 'MIN_KERNEL':
-                kernel = line
+                kernel_min = line
+            elif item_name == 'MAX_KERNEL':
+                kernel_max = line
             elif item_name == 'REQUIRES':
                 requirement = line
             elif item_name == 'ENV':
@@ -191,7 +195,8 @@ class TestParser(object):
             before,
             after,
             test_suite,
-            kernel,
+            kernel_min,
+            kernel_max,
             requirement,
             env,
             arch,

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -52,6 +52,12 @@ TIMEOUT 5
 MAX_KERNEL 5.16
 AFTER dd if=/dev/urandom bs=3 count=1
 
+NAME 32-bit tracepoint arg openat_flags
+PROG tracepoint:syscalls:sys_enter_openat /comm == "syscall"/ { $i = args->flags; printf("openflags: %d\n", $i); if ($i == 64) { exit() } }
+EXPECT openflags: 64
+TIMEOUT 5
+AFTER ./testprogs/syscall openat
+
 NAME tracepoint arg casts in predicates
 RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_enter_wait4 /args->ru/ { @ru[tid] = args->ru; } tracepoint:syscalls:sys_exit_wait4 /@ru[tid]/ { @++; exit(); }' -c ./testprogs/wait4_ru
 EXPECT @: 1

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -49,6 +49,7 @@ NAME 32-bit tracepoint arg
 PROG tracepoint:random:urandom_read { $i = args->got_bits; printf("bits: %d\n", $i); if ($i == 24) { exit() } }
 EXPECT bits: 24
 TIMEOUT 5
+MAX_KERNEL 5.16
 AFTER dd if=/dev/urandom bs=3 count=1
 
 NAME tracepoint arg casts in predicates


### PR DESCRIPTION
Add MAX_KERNEL option to ensure that testcases are still executed for older kernels, but skipped for newer kernels.

Usecase:
urandom_read tracepoint is no longer present since kernel v5.17-rc5. Ensure testing is performed until kernel 5.17.