### PR TITLE
Tool documentation fixes

### DIFF
--- a/man/man8/syscount.8
+++ b/man/man8/syscount.8
@@ -16,7 +16,7 @@ Since this uses BPF, only the root user can use this tool.
 CONFIG_BPF and bpftrace.
 .SH EXAMPLES
 .TP
-Count all VFS calls until Ctrl-C is hit:
+Count system calls until Ctrl-C is hit:
 #
 .B syscount.bt
 .SH OUTPUT

--- a/tools/tcpretrans_example.txt
+++ b/tools/tcpretrans_example.txt
@@ -5,10 +5,10 @@ This tool traces the kernel TCP retransmit function to show details of these
 retransmits. For example:
 
 # ./tcpretrans.bt
-TIME     PID               LADDR:LPORT          RADDR:RPORT  STATE
-00:43:54 0          10.229.20.82:46654    153.2.224.76:443    SYN_SENT
-00:43:55 0           10.232.0.49:57678    10.229.20.99:24231  SYN_SENT
-00:43:57 100       10.229.20.175:54224   10.201.76.122:443    ESTABLISHED
+TIME     PID               LADDR:LPORT           RADDR:RPORT  STATE
+01:55:05 0        10.153.223.157:22       69.53.245.40:34619  ESTABLISHED
+01:55:05 0        10.153.223.157:22       69.53.245.40:34619  ESTABLISHED
+01:55:17 0        10.153.223.157:22       69.53.245.40:22957  ESTABLISHED
 [...]
 
 This output shows three TCP retransmits, the first two were for an IPv4


### PR DESCRIPTION
Fixes two problems
- `syscount.bt` manpage has wrong example description,
- `tcpretrans_example.txt` has mismatch between tool output and description.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
