### PR TITLE
Fix typos in runqlat and vfscount documentation

### DIFF
--- a/tools/runqlat_example.txt
+++ b/tools/runqlat_example.txt
@@ -119,7 +119,7 @@ There's now a second mode between 8 and 16 milliseconds, as each thread must
 wait its turn on the one CPU.
 
 
-Now I'l run 10 CPU-bound throuds on one CPU:
+Now I'll run 10 CPU-bound threads on one CPU:
 
 # ./runqlat.bt
 Attaching 5 probes...

--- a/tools/vfscount_example.txt
+++ b/tools/vfscount_example.txt
@@ -29,7 +29,7 @@ resources that expose a file system interface. Much of VFS maps directly to the
 syscall interface. Tracing VFS calls gives you a high level breakdown of the
 kernel workload, and starting points for further investigation.
 
-Notet that a warning was printed: "Warning: could not attach probe
+Note that a warning was printed: "Warning: could not attach probe
 kprobe:vfs_dedupe_get_page.isra.21": these are not currently instrumentable by
 bpftrace/kprobes, so a warning is printed to let you know that they will be
 missed.


### PR DESCRIPTION
Spotted while creating some exercises based on these scripts.

Signed-off-by: Rik van Riel <riel@surriel.com>

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
