### PR TITLE
Add option for unconditional hex output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 ## Unreleased
 
 #### Added
+- Add option for unconditional hex output
+  - [#2200](https://github.com/iovisor/bpftrace/pull/2200)
 - Add builtin function: `cgroup_path`
   - [#2055](https://github.com/iovisor/bpftrace/pull/2055)
 - Limit number of generated BPF programs

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1268,7 +1268,7 @@ For arrays the `length` is optional, it is automatically inferred from the signa
 
 The `buf_t` object returned by `buf` can safely be printed as a hex encoded string with the `%r` format specifier.
 
-Bytes with values >=32 and \<=126 are printed using their ASCII character, other bytes are printed in hex form (e.g. `\x00`).
+Bytes with values >=32 and \<=126 are printed using their ASCII character, other bytes are printed in hex form (e.g. `\x00`). The `%rx` format specifier can be used to print everything in hex form, including ASCII characters.
 
 ----
 i:s:1 {

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -631,10 +631,10 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(const std::vec
         break;
       }
       case Type::buffer:
-        arg_values.push_back(std::make_unique<PrintableString>(resolve_buf(
+        arg_values.push_back(std::make_unique<PrintableBuffer>(
             reinterpret_cast<AsyncEvent::Buf *>(arg_data + arg.offset)->content,
             reinterpret_cast<AsyncEvent::Buf *>(arg_data + arg.offset)
-                ->length)));
+                ->length));
         break;
       case Type::ksym:
         arg_values.push_back(

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -9,6 +9,20 @@ int PrintableString::print(char *buf, size_t size, const char *fmt)
   return snprintf(buf, size, fmt, value_.c_str());
 }
 
+int PrintableBuffer::print(char *buf, size_t size, const char *fmt)
+{
+  return snprintf(
+      buf,
+      size,
+      fmt,
+      hex_format_buffer(value_.data(), value_.size(), keep_ascii_).c_str());
+}
+
+void PrintableBuffer::keep_ascii(bool value)
+{
+  keep_ascii_ = value;
+}
+
 int PrintableCString::print(char *buf, size_t size, const char *fmt)
 {
   return snprintf(buf, size, fmt, value_);

--- a/src/printf.h
+++ b/src/printf.h
@@ -42,6 +42,21 @@ private:
   std::string value_;
 };
 
+class PrintableBuffer : public virtual IPrintable
+{
+public:
+  PrintableBuffer(char* buffer, size_t size)
+      : value_(std::vector<char>(buffer, buffer + size))
+  {
+  }
+  int print(char* buf, size_t size, const char* fmt) override;
+  void keep_ascii(bool value);
+
+private:
+  std::vector<char> value_;
+  bool keep_ascii_ = true;
+};
+
 class PrintableCString : public virtual IPrintable
 {
 public:

--- a/src/printf_format_types.h
+++ b/src/printf_format_types.h
@@ -21,6 +21,7 @@ namespace bpftrace {
 const std::unordered_map<std::string, Type> printf_format_types = {
   {"s", Type::string},
   {"r", Type::buffer},
+  {"rx", Type::buffer},
   {"c", Type::integer},
   {"d", Type::integer},
   {"u", Type::integer},

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -925,14 +925,14 @@ pid_t parse_pid(const std::string &str)
   }
 }
 
-std::string hex_format_buffer(const char *buf, size_t size)
+std::string hex_format_buffer(const char *buf, size_t size, bool keep_ascii)
 {
   // Allow enough space for every byte to be sanitized in the form "\x00"
   char s[size * 4 + 1];
 
   size_t offset = 0;
   for (size_t i = 0; i < size; i++)
-    if (buf[i] >= 32 && buf[i] <= 126)
+    if (keep_ascii && buf[i] >= 32 && buf[i] <= 126)
       offset += sprintf(s + offset, "%c", ((const uint8_t *)buf)[i]);
     else
       offset += sprintf(s + offset, "\\x%02x", ((const uint8_t *)buf)[i]);

--- a/src/utils.h
+++ b/src/utils.h
@@ -181,7 +181,9 @@ std::string str_join(const std::vector<std::string> &list,
 bool is_numeric(const std::string &str);
 bool symbol_has_cpp_mangled_signature(const std::string &sym_name);
 pid_t parse_pid(const std::string &str);
-std::string hex_format_buffer(const char *buf, size_t size);
+std::string hex_format_buffer(const char *buf,
+                              size_t size,
+                              bool keep_ascii = true);
 std::optional<std::string> abs_path(const std::string &rel_path);
 bool symbol_has_module(const std::string &symbol);
 std::string strip_symbol_module(const std::string &symbol);

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -86,6 +86,11 @@ PROG i:ms:100 { @ = buf("ok_value", 8); exit(); }
 EXPECT @: ok_value
 TIMEOUT 5
 
+NAME buf_no_ascii
+PROG BEGIN { printf("%rx", buf("Hello\0", 6)); exit(); }
+EXPECT \\x48\\x65\\x6c\\x6c\\x6f\\x00
+TIMEOUT 5
+
 NAME ksym
 PROG kprobe:do_nanosleep { printf("%s\n", ksym(reg("ip"))); exit();}
 EXPECT do_nanosleep

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1264,6 +1264,17 @@ TEST(semantic_analyser, printf_bad_format_buf)
   test("kprobe:f { printf(\"%r\", arg0) }", 10);
 }
 
+TEST(semantic_analyser, printf_format_buf_no_ascii)
+{
+  test("kprobe:f { printf(\"%rx\", buf(\"mystr\", 5)) }", 0);
+}
+
+TEST(semantic_analyser, printf_bad_format_buf_no_ascii)
+{
+  test("kprobe:f { printf(\"%rx\", \"mystr\") }", 10);
+  test("kprobe:f { printf(\"%rx\", arg0) }", 10);
+}
+
 TEST(semantic_analyser, printf_format_multi)
 {
   test("kprobe:f { printf(\"%d %d %s\", 1, 2, \"mystr\") }", 0);


### PR DESCRIPTION
Implement hex output without converting ASCII characters by introducing
a parameter to hex_format_buffer. A new class derived from IPrintable is
introduced to pass the option to the string formatting logic.

Fixes #2130

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [X] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
