### PR TITLE
biosnoop.bt: handle Linux 5.17 block layer update

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
           LLVM_VERSION: 9
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
+          TOOLS_TEST_OLDVERSION: biosnoop.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 9 Release
@@ -39,6 +40,7 @@ jobs:
           LLVM_VERSION: 9
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
+          TOOLS_TEST_OLDVERSION: biosnoop.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 10 Debug
@@ -46,6 +48,7 @@ jobs:
           LLVM_VERSION: 10
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
+          TOOLS_TEST_OLDVERSION: biosnoop.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 10 Release
@@ -53,6 +56,7 @@ jobs:
           LLVM_VERSION: 10
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
+          TOOLS_TEST_OLDVERSION: biosnoop.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 10 Clang Debug
@@ -62,6 +66,7 @@ jobs:
           CXX: clang++-10
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
+          TOOLS_TEST_OLDVERSION: biosnoop.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 11 Debug
@@ -69,6 +74,7 @@ jobs:
           LLVM_VERSION: 11
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
+          TOOLS_TEST_OLDVERSION: biosnoop.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 11 Release
@@ -76,6 +82,7 @@ jobs:
           LLVM_VERSION: 11
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
+          TOOLS_TEST_OLDVERSION: biosnoop.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 12 Release
@@ -83,6 +90,7 @@ jobs:
           LLVM_VERSION: 12
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
+          TOOLS_TEST_OLDVERSION: biosnoop.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 13 Release
@@ -91,6 +99,7 @@ jobs:
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
           GTEST_FILTER: '-clang_parser.nested_struct_no_type'
+          TOOLS_TEST_OLDVERSION: biosnoop.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 12 Release + libbpf
@@ -98,6 +107,7 @@ jobs:
           LLVM_VERSION: 12
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
+          TOOLS_TEST_OLDVERSION: biosnoop.bt
           BASE: focal
           VENDOR_GTEST: ON
           BUILD_LIBBPF: ON

--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -16,6 +16,7 @@ jobs:
           EMBED_USE_LLVM: ON
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size
+          TOOLS_TEST_OLDVERSION: biosnoop.bt
           BASE: bionic
           DISTRO: ubuntu-glibc
           VENDOR_GTEST: ON
@@ -30,6 +31,7 @@ jobs:
           EMBED_USE_LLVM: ON
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size,other.string compare map lookup
+          TOOLS_TEST_OLDVERSION: biosnoop.bt
           BASE: xenial
           DISTRO: ubuntu-glibc
           CMAKE_EXTRA_FLAGS: "-DCMAKE_CXX_FLAGS='-include /usr/local/include/bcc/compat/linux/bpf.h -D__LINUX_BPF_H__'"
@@ -45,6 +47,7 @@ jobs:
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: json-output.join_delim,other.string compare map lookup,probe.kprobe_offset_fail_size,probe.uprobe_library,usdt."usdt probes - attach to fully specified probe of child",usdt."usdt probes - all probes by wildcard and file with child",usdt."usdt probes - attach to probe by wildcard and file with child",usdt."usdt probes - attach to probes by wildcard file with child",usdt."usdt probes - attach to probe on multiple files by wildcard",usdt."usdt probes - attach to probe with probe builtin and args by file with child",usdt."usdt probes - list probes by pid in separate mountns",usdt."usdt sized arguments",usdt."usdt - list probes by file with wildcarded probe type",uprobe."uprobes - list probes by pid; uprobes only",uprobe."uprobes - list probes by pid in separate mount namespace",other.positional pointer arithmetics
           TOOLS_TEST_DISABLE: gethostlatency.bt,threadsnoop.bt
+          TOOLS_TEST_OLDVERSION: biosnoop.bt
           BASE: alpine
           DISTRO: alpine
           ALPINE_VERSION: 3.11
@@ -58,6 +61,7 @@ jobs:
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: other.string compare map lookup,probe.kprobe_offset_fail_size,probe.uprobe_library,usdt."usdt probes - attach to fully specified probe of child",usdt."usdt probes - all probes by wildcard and file with child",usdt."usdt probes - attach to probe by wildcard and file with child",usdt."usdt probes - attach to probes by wildcard file with child",usdt."usdt probes - attach to probe on multiple files by wildcard",usdt."usdt probes - attach to probe with probe builtin and args by file with child",usdt."usdt probes - list probes by pid in separate mountns",usdt."usdt sized arguments",usdt."usdt - list probes by file with wildcarded probe type",uprobe."uprobes - list probes by pid; uprobes only",uprobe."uprobes - list probes by pid in separate mount namespace",other.positional pointer arithmetics
           TOOLS_TEST_DISABLE: gethostlatency.bt,threadsnoop.bt
+          TOOLS_TEST_OLDVERSION: biosnoop.bt
           BASE: alpine
           DISTRO: alpine
           ALPINE_VERSION: 3.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,10 @@ and this project adheres to
   - [#2164](https://github.com/iovisor/bpftrace/pull/2164)
 
 #### Tools
+
+- Update biosnoop.bt for kernel >=5.17
+  - [#2207](https://github.com/iovisor/bpftrace/pull/2207)
+
 #### Documentation
 
 ## [0.14.1] 2021-12-29

--- a/tools/old/biosnoop.bt
+++ b/tools/old/biosnoop.bt
@@ -7,6 +7,8 @@
  *
  * This is a bpftrace version of the bcc tool of the same name.
  *
+ * For Linux <= 5.16.
+ *
  * 15-Nov-2017	Brendan Gregg	Created this.
  */
 
@@ -26,7 +28,7 @@ kprobe:__blk_account_io_start
 	@start[arg0] = nsecs;
 	@iopid[arg0] = pid;
 	@iocomm[arg0] = comm;
-	@disk[arg0] = ((struct request *)arg0)->q->disk->disk_name;
+	@disk[arg0] = ((struct request *)arg0)->rq_disk->disk_name;
 }
 
 kprobe:blk_account_io_done,


### PR DESCRIPTION
The kernel upstream commit [f3fa33acc](https://github.com/torvalds/linux/commit/f3fa33acca9f0058157214800f68b10d8e71ab7a) has removed the `rq_disk` field from `struct request`. Instead, `->q->disk` should be used, so this is reflected in biosnoop.bt.

The old version of the tool (suitable for kernel <= 5.16) is backed up in tools/old and used in the CI.

Fixes #2220.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
