### PR TITLE
Fixed the issue when using wildcards in kfunc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ and this project adheres to
   - [#2136](https://github.com/iovisor/bpftrace/pull/2136)
 - Fix uprobe target resolution
   - [#2180](https://github.com/iovisor/bpftrace/pull/2180)
+- Fix using wildcards in kfunc
+  - [#2208](https://github.com/iovisor/bpftrace/pull/2208)
 - Improve handling of format strings
   - [#2164](https://github.com/iovisor/bpftrace/pull/2164)
 

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -691,19 +691,15 @@ void AttachedProbe::load_prog()
     if (bt_verbose)
       log_level = 1;
 
-    if (probe_.type == ProbeType::kfunc || probe_.type == ProbeType::kretfunc)
-    {
-      // Use attach_point for program name when probe type is kfunc or
-      // kretfunc, otherwise will get a ENOENT when using a wildcard
-      name = probe_.attach_point;
-    }
-    else
+    if (probe_.type == ProbeType::kprobe || probe_.type == ProbeType::kretprobe)
     {
       // Use orig_name for program name so we get proper name for
       // wildcard probes, replace wildcards with '.'
       name = probe_.orig_name;
       std::replace(name.begin(), name.end(), '*', '.');
     }
+    else
+      name = probe_.name;
 
     // bpf_prog_load rejects colons in the probe name,
     // so start the name after the probe type, after ':'

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -691,10 +691,19 @@ void AttachedProbe::load_prog()
     if (bt_verbose)
       log_level = 1;
 
-    // Use orig_name for program name so we get proper name for
-    // wildcard probes, replace wildcards with '.'
-    name = probe_.orig_name;
-    std::replace(name.begin(), name.end(), '*', '.');
+    if (probe_.type == ProbeType::kfunc || probe_.type == ProbeType::kretfunc)
+    {
+      // Use attach_point for program name when probe type is kfunc or
+      // kretfunc, otherwise will get a ENOENT when using a wildcard
+      name = probe_.attach_point;
+    }
+    else
+    {
+      // Use orig_name for program name so we get proper name for
+      // wildcard probes, replace wildcards with '.'
+      name = probe_.orig_name;
+      std::replace(name.begin(), name.end(), '*', '.');
+    }
 
     // bpf_prog_load rejects colons in the probe name,
     // so start the name after the probe type, after ':'

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -1,6 +1,8 @@
 NAME kfunc_wildcard
 PROG kfunc:vfs_re*ad { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT SUCCESS [0-9][0-9]*
+REQUIRES_FEATURE btf
+REQUIRES_FEATURE kfunc
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -1,3 +1,9 @@
+NAME kfunc_wildcard
+PROG kfunc:vfs_re*ad { printf("SUCCESS %d\n", pid); exit(); }
+EXPECT SUCCESS [0-9][0-9]*
+TIMEOUT 5
+AFTER ./testprogs/syscall read
+
 NAME kprobe
 PROG kprobe:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT SUCCESS [0-9][0-9]*


### PR DESCRIPTION
The kfunc and kretfunc probes that contains a wildcard always failed to attach:

```
$ sudo src/bpftrace -ve 'kfunc:vfs_* { @[probe] = count(); }'
INFO: node count: 7
Attaching 67 probes...

Error log: 

ERROR: Error loading program: kfunc:vfs_writev
$ sudo src/bpftrace -ve 'kfunc:vfs_writev* { @[probe] = count(); }'
INFO: node count: 7
Attaching 1 probe...

Error log: 

ERROR: Error loading program: kfunc:vfs_writev
```

The [bcc_prog_load_xattr](https://github.com/iovisor/bpftrace/blob/38c099dff9100bafeaaa7cee865f4dfda58134ac/src/attached_probe.cpp#L746) function internally rely on the [libbpf_find_vmlinux_btf_id](https://github.com/iovisor/bcc/blob/0064febd47972cc6c79de64639790f5889387d03/src/cc/libbpf.c#L736) function to find btf id for the kfunc and kretfunc probe, which need a exact probe name. So, I use the attach_point as program name when probe type is kfunc or kretfunc.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
