### PR TITLE
Fix kprobe program caching

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -635,9 +635,9 @@ bool AttachedProbe::use_cached_progfd(void)
   if (probe_.type != ProbeType::kprobe && probe_.type != ProbeType::kretprobe)
     return false;
 
-  // Only for the wildcard probe, because we can have multiple
-  // programs attached to single probe
-  if (!has_wildcard(probe_.orig_name))
+  // Only for a wildcard probe which does not need expansion,
+  // because we can have multiple programs attached to a single probe
+  if (!has_wildcard(probe_.orig_name) || probe_.need_expansion)
     return false;
 
   // Keep map of loaded programs based on their 'orig_name',

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -235,6 +235,7 @@ int BPFtrace::add_probe(ast::Probe &p)
       probe.orig_name = p.name();
       probe.ns = attach_point->ns;
       probe.name = attach_point->name(target, func_id);
+      probe.need_expansion = p.need_expansion;
       probe.freq = attach_point->freq;
       probe.address = attach_point->address;
       probe.func_offset = attach_point->func_offset;

--- a/src/types.h
+++ b/src/types.h
@@ -493,6 +493,7 @@ struct Probe
   std::string orig_name;        // original full probe name,
                                 // before wildcard expansion
   std::string name;             // full probe name
+  bool need_expansion;
   std::string pin;              // pin file for iterator probes
   std::string ns;               // for USDT probes, if provider namespace not from path
   uint64_t loc = 0;             // for USDT probes

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -34,6 +34,12 @@ EXPECT progs: 1
 TIMEOUT 5
 REQUIRES /usr/sbin/bpftool
 
+NAME kprobe_wildcard probe builtin
+RUN {{BPFTRACE}} --unsafe -e 'kprobe:ksys_* { @ = probe; printf("progs: "); system("/usr/sbin/bpftool prog | grep kprobe | grep ksys_ | wc -l"); exit(); }'
+EXPECT progs: [1-9][0-9]+
+TIMEOUT 5
+REQUIRES /usr/sbin/bpftool
+
 # Note: this test may fail if you've installed a new kernel but not rebooted
 # yet. Reason is b/c bpftrace will look for a vmlinux based on the running kernel's
 # version.

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -29,8 +29,8 @@ TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME kprobe_wildcard
-RUN {{BPFTRACE}} --unsafe -e 'kprobe:ksys_* { system("/usr/sbin/bpftool prog | grep kprobe | grep ksys_ | wc -l"); exit(); }'
-EXPECT 1
+RUN {{BPFTRACE}} --unsafe -e 'kprobe:ksys_* { printf("progs: "); system("/usr/sbin/bpftool prog | grep kprobe | grep ksys_ | wc -l"); exit(); }'
+EXPECT progs: 1
 TIMEOUT 5
 REQUIRES /usr/sbin/bpftool
 


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

When using the `probe` builtin in combination with wildcards, a single program must be generated for each attach point. This also prevents re-using loaded programs for multiple kprobe attach points.

Fixes #2209.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
