### PR TITLE
Add offsetof() builtin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to
   - [#2166](https://github.com/iovisor/bpftrace/pull/2166)
 - Print all maps to stdout on `SIGUSR1`
   - [#2203](https://github.com/iovisor/bpftrace/pull/2203)
+- Add new function, `offsetof`, get the offset of the element in the struct
+  - [#2216](https://github.com/iovisor/bpftrace/pull/2216)
 
 #### Changed
 - Use auto-resolution of library paths for tools

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -2222,6 +2222,7 @@ Tracing block I/O sizes > 0 bytes
 - `kptr(void *p)` - Annotate as kernelspace pointer
 - `macaddr(char[6] addr)` - Convert MAC address data
 - `bswap(uint[8|16|32|64] n)` - Reverse byte order
+- `offsetof(struct, element)` - Offset of element in structure
 
 Some of these are asynchronous: the kernel queues the event, but some time later (milliseconds) it is
 processed in user-space. The asynchronous actions are: `printf()`, `time()`, and `join()`. Both `ksym()`
@@ -3135,6 +3136,32 @@ Example:
 # bpftrace -e 'BEGIN { $i = (uint32)0x12345678; printf("Reversing byte order of 0x%x ==> 0x%x\n", $i, bswap($i)); }'
 Attaching 1 probe...
 Reversing byte order of 0x12345678 ==> 0x78563412
+```
+
+# 31. `offsetof`: Offset of element in structure
+
+Syntax: `offsetof(struct, element)`
+
+Get the offset of the element in the struct.
+
+Examples:
+
+```
+#!/usr/bin/env bpftrace
+#include <linux/sched.h>
+
+BEGIN
+{
+    printf("Offsetof %ld\n", offsetof(struct task_struct, flags));
+    printf("Offsetof %ld\n", offsetof(struct task_struct, comm));
+    exit();
+}
+```
+
+```
+Attaching 1 probe...
+Offsetof 44
+Offsetof 3216
 ```
 
 # Map Functions

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1026,6 +1026,13 @@ void CodegenLLVM::visit(Call &call)
   {
     expr_ = b_.getInt64(call.vargs->at(0)->type.GetSize());
   }
+  else if (call.func == "offsetof")
+  {
+    auto &element_arg = *call.vargs->at(1);
+    String &element = static_cast<String&>(element_arg);
+    auto &field = call.vargs->at(0)->type.GetField(element.str);
+    expr_ = b_.getInt64(field.offset);
+  }
   else if (call.func == "strncmp") {
     uint64_t size = (uint64_t)*bpftrace_.get_int_literal(call.vargs->at(2));
     const auto& left_arg = call.vargs->at(0);

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -38,7 +38,7 @@ vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#\*])+
 builtin  arg[0-9]|args|cgroup|comm|cpid|cpu|ctx|curtask|elapsed|func|gid|nsecs|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
-call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|sizeof|stats|str|strftime|strncmp|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap
+call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|sizeof|stats|str|strftime|strncmp|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|offsetof
 
 /* Don't add to this! Use builtin OR call not both */
 call_and_builtin kstack|ustack
@@ -170,10 +170,10 @@ bpftrace|perf           { return Parser::make_STACK_MODE(yytext, loc); }
 
 struct|union|enum       yy_push_state(STRUCT, yyscanner); buffer.clear(); struct_type = yytext;
 <STRUCT,BRACE>{
-  "*"|")"               {
+  "*"|")"|","           {
                           if (YY_START == STRUCT)
                           {
-                            // Finished parsing the typename of a cast
+                            // Finished parsing the typename of a cast or a call arg
                             // Put the cast type into a canonical form by trimming
                             // and then inserting a single space.
                             yy_pop_state(yyscanner);

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -336,6 +336,7 @@ primary_expr:
         |       int                { $$ = $1; }
         |       STRING             { $$ = new ast::String($1, @$); }
         |       STACK_MODE         { $$ = new ast::StackMode($1, @$); }
+        |       CALL               { $$ = new ast::String($1, @$); }
         |       BUILTIN            { $$ = new ast::Builtin($1, @$); }
         |       CALL_BUILTIN       { $$ = new ast::Builtin($1, @$); }
         |       LPAREN expr RPAREN { $$ = $2; }

--- a/tests/codegen/call_offsetof.cpp
+++ b/tests/codegen/call_offsetof.cpp
@@ -1,0 +1,16 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, call_offsetof)
+{
+  test("struct Foo { int x; long l; char c; } BEGIN { @x = offsetof(struct Foo, x); }",
+
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/call_offsetof.ll
+++ b/tests/codegen/llvm/call_offsetof.ll
@@ -1,0 +1,45 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @BEGIN(i8* nocapture readnone %0) local_unnamed_addr section "s_BEGIN_1" {
+entry:
+  %"@c_val" = alloca i64, align 8
+  %"@c_key" = alloca i64, align 8
+  %"@x_val" = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  %1 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %1)
+  store i64 0, i64* %"@x_key", align 8
+  %2 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %2)
+  store i64 0, i64* %"@x_val", align 8
+  %pseudo = tail call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* nonnull %"@x_key", i64* nonnull %"@x_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %2)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %1)
+  %3 = bitcast i64* %"@c_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %3)
+  store i64 0, i64* %"@c_key", align 8
+  %4 = bitcast i64* %"@c_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* nonnull %4)
+  store i64 16, i64* %"@c_val", align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem2 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* nonnull %"@c_key", i64* nonnull %"@c_val", i64 0)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %4)
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* nonnull %3)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly mustprogress nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly mustprogress nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly mustprogress nofree nosync nounwind willreturn }

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -193,3 +193,8 @@ PROG BEGIN { printf("size=%d\n", sizeof(struct task_struct)); exit(); }
 EXPECT ^size=
 TIMEOUT 5
 REQUIRES_FEATURE btf
+
+NAME offsetof
+PROG struct Foo { int x; long l; char c; } BEGIN { printf("%ld\n", offsetof(struct Foo, x)); exit(); }
+EXPECT ^0$
+TIMEOUT 5

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2492,6 +2492,36 @@ TEST(semantic_analyser, string_size)
   ASSERT_EQ(var_assign->var->type.GetField(0).type.GetSize(), 6UL);
 }
 
+TEST(semantic_analyser, call_offsetof)
+{
+  test("struct Foo { int x; long l; char c; } \
+        BEGIN { @x = offsetof(struct Foo, x); }", 0);
+  test("struct Foo { int x; long l; char c; } \
+        BEGIN { @x = offsetof(struct Foo, z); }", 1);
+  test("struct Foo { int x; long l; char c; } \
+        struct Bar { struct Foo foo; int x; } \
+        BEGIN { @x = offsetof(struct Bar, x); }", 0);
+  test("struct Foo { int x; long l; char c; } \
+        union Bar { struct Foo foo; int x; } \
+        BEGIN { @x = offsetof(union Bar, x); }", 0);
+  test("struct Foo { int x; long l; char c; } \
+        struct Fun { struct Foo foo; int (*call)(void); } \
+        BEGIN { @x = offsetof(struct Fun, call); }", 0);
+  test("struct Foo { int x; long l; char c; } \
+        struct Ano { \
+          struct { \
+            struct Foo foo; \
+            int a; \
+          }; \
+          long l; \
+        } \
+        BEGIN { @x = offsetof(struct Ano, a); }", 0);
+  test("struct offsetof { int offsetof; int bswap;} \
+        BEGIN { \
+          @x = offsetof(struct offsetof, offsetof); \
+        }", 0);
+}
+
 #ifdef HAVE_LIBBPF_BTF_DUMP
 
 #include "btf_common.h"


### PR DESCRIPTION
Get the offset of the element in the struct.

```
struct Foo {
    int x;
    long l;
    char c;
}
BEGIN
{
    printf("%ld, %ld\n", offsetof(struct Foo, c), sizeof(struct Foo));
    printf("%ld\n", offsetof(struct Foo, c));
    printf("%ld\n", offsetof(struct Foo, x));
    printf("%ld\n", offsetof(struct task_struct, comm));
    printf("%ld\n", offsetof(struct task_struct, flags));
    printf("%ld\n", offsetof(struct task_struct, mm));
    printf("%ld\n", offsetof(struct list_head, next));
    printf("%ld\n", offsetof(struct list_head, prev));
}
```

Result:

```
Attaching 1 probe...
16, 24
16
0
3216
44
2504
0
8
```