### PR TITLE
Fix codegen for buf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,8 @@ and this project adheres to
   - [#2180](https://github.com/iovisor/bpftrace/pull/2180)
 - Improve handling of format strings
   - [#2164](https://github.com/iovisor/bpftrace/pull/2164)
+- Fix codegen for buf
+  - [#2217](https://github.com/iovisor/bpftrace/pull/2217)
 
 #### Tools
 #### Documentation

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -539,6 +539,8 @@ void CodegenLLVM::visit(Call &call)
       auto scoped_del = accept(&arg);
 
       Value *proposed_length = expr_;
+      if (arg.type.GetSize() != 8)
+        proposed_length = b_.CreateZExt(proposed_length, max_length->getType());
       Value *cmp = b_.CreateICmp(
           CmpInst::ICMP_ULE, proposed_length, max_length, "length.cmp");
       length = b_.CreateSelect(


### PR DESCRIPTION
The second parameter of `buf` specifies the number of bytes to read. Codegen generates an `icmp` instruction to compare the supplied number with the maximum length. This instruction may introduce a problem when the supplied number is not a 64-bit integer, hence this commit adds a 'zext' typecast.

Fixes #2215. Also related to #2129 and #2182.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
