### PR TITLE
Fix: warning: deprecated directive.

### DIFF
--- a/src/parser.yy
+++ b/src/parser.yy
@@ -2,7 +2,7 @@
 %require "3.0.4"
 %defines
 %define api.namespace { bpftrace }
-%define parser_class_name { Parser }
+%define api.parser.class { Parser }
 
 %define api.token.constructor
 %define api.value.type variant


### PR DESCRIPTION
When compile:

```
src/parser.yy:5.1-36: warning: deprecated directive: ‘%define parser_class_name { Parser }’, use ‘%define api.parser.class { Parser }’ [-Wdeprecated]
    5 | %define parser_class_name { Parser }
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      | %define api.parser.class { Parser }
```