### PR TITLE
tools: fix biosnoop for kernel v5.16+

### DIFF
--- a/tools/old/biosnoop.bt
+++ b/tools/old/biosnoop.bt
@@ -7,7 +7,7 @@
  *
  * This is a bpftrace version of the bcc tool of the same name.
  *
- * For Linux 5.16+ (see tools/old for script for lower versions).
+ * For Linux <= 5.15
  *
  * 15-Nov-2017	Brendan Gregg	Created this.
  */
@@ -28,7 +28,7 @@ kprobe:__blk_account_io_start
 	@start[arg0] = nsecs;
 	@iopid[arg0] = pid;
 	@iocomm[arg0] = comm;
-	@disk[arg0] = ((struct request *)arg0)->q->disk->disk_name;
+	@disk[arg0] = ((struct request *)arg0)->rq_disk->disk_name;
 }
 
 kprobe:blk_account_io_done,


### PR DESCRIPTION
Commit ("f3fa33acca9f block: remove the ->rq_disk field in struct
request") removed the rq_disk field of struct request. It has to be
accessed through the request_queue.

Fixes #2220

Signed-off-by: Jerome Marchand <jmarchan@redhat.com>

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
