### PR TITLE
Fix sizeof() reference guide.

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -2952,7 +2952,7 @@ Examples:
 Attaching 1 probe...
 8
 
-# bpftrace -e 'struct Foo { int x; char c; } BEGIN { printf("%d\n", sizeof(((struct Foo)0).c)); }'
+# bpftrace -e 'struct Foo { int x; char c; } BEGIN { printf("%d\n", sizeof(((struct Foo*)0)->c)); }'
 Attaching 1 probe...
 1
 


### PR DESCRIPTION
ERROR: Cannot cast to struct type "struct Foo"
struct Foo { int x; char c; } BEGIN { printf("%d\n", sizeof(((struct Foo)0).c)); }
                                                     ~~~~~~~~~~~~~~~~~~~~~
```
$ sudo bpftrace -e 'struct Foo { int x; char c; } BEGIN { printf("%d\n", sizeof(((struct Foo)0).c)); }'
stdin:1:54-75: ERROR: Cannot cast to struct type "struct Foo"
struct Foo { int x; char c; } BEGIN { printf("%d\n", sizeof(((struct Foo)0).c)); }
                                                     ~~~~~~~~~~~~~~~~~~~~~~
```

```
$ sudo bpftrace -e 'struct Foo { int x; char c; } BEGIN { printf("%d\n", sizeof(((struct Foo*)0)->c)); }'
Attaching 1 probe...
1
```