### PR TITLE
Add undump tool to tracing UNIX domain socket packages receive.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to
 #### Tools
 - Add sslsnoop and ssllatency tools
   - [#2117](https://github.com/iovisor/bpftrace/pull/2117)
+- Add undump tool.
+  - [#2225](https://github.com/iovisor/bpftrace/pull/2225)
 
 ## [0.15.0] 2022-05-24
 

--- a/man/man8/undump.bt.8
+++ b/man/man8/undump.bt.8
@@ -1,0 +1,57 @@
+.TH undump.bt 8  "2022-06-03" "USER COMMANDS"
+.SH NAME
+undump.bt \- Catch UNIX domain socket packages. Uses bpftrace/eBPF.
+.SH SYNOPSIS
+.B undump.bt
+.SH DESCRIPTION
+undump.bt tracked reception of UNIX domain sockets.
+
+This program is also a basic example of bpftrace and kprobes.
+
+Since this uses BPF, only the root user can use this tool.
+.SH REQUIREMENTS
+CONFIG_BPF and bpftrace.
+.SH EXAMPLES
+.TP
+Trace reception of UNIX domain sockets:
+#
+.B undump.bt
+.SH FIELDS
+.TP
+TIME
+A timestamp on the output, in "HH:MM:SS" format.
+.TP
+COMM
+The process COMM.
+.TP
+PID
+The process ID.
+.TP
+SIZE
+The size of the received packet, in bytes.
+.TP
+DATA
+Display received packets in hex or string.
+.SH OVERHEAD
+The overhead of this program mainly comes from the data packets received
+by the terminal output.
+.SH SOURCE
+This is from bpftrace.
+.IP
+https://github.com/iovisor/bpftrace
+.PP
+Also look in the bpftrace distribution for a companion _examples.txt file
+containing example usage, output, and commentary for this tool.
+
+This is a bpftrace version of the bcc examples/tracing of the same name.
+The bcc tool may provide more options and customizations.
+.IP
+https://github.com/iovisor/bcc
+.SH OS
+Linux
+.SH STABILITY
+Unstable - in development.
+.SH AUTHOR
+Rong Tao
+.SH SEE ALSO
+opensnoop(8)

--- a/tools/undump.bt
+++ b/tools/undump.bt
@@ -1,0 +1,34 @@
+#!/usr/bin/env bpftrace
+/*
+ * undump	Trace unix domain socket package receive.
+ *		For Linux, uses bpftrace and eBPF.
+ *
+ * Also a basic example of bpftrace.
+ *
+ * This is a bpftrace version of the bcc examples/tracing of the same name.
+ *
+ * USAGE: undump.bt
+ *
+ * Copyright 2022 CESTC, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ *
+ * 22-May-2022	Rong Tao	Created this.
+ */
+#include <linux/skbuff.h>
+
+BEGIN
+{
+	printf("Dump UNIX socket packages RX. Ctrl-C to end\n");
+	printf("%-8s %-16s %-8s %-8s %-s\n", "TIME", "COMM", "PID", "SIZE", "DATA");
+}
+
+kprobe:unix_stream_read_actor
+{
+	$skb = (struct sk_buff *)arg0;
+	time("%H:%M:%S ");
+	printf("%-16s %-8d %-8d %r\n", comm, pid, $skb->len, buf($skb->data, $skb->len));
+}
+
+END
+{
+}

--- a/tools/undump_example.txt
+++ b/tools/undump_example.txt
@@ -1,0 +1,35 @@
+Demonstrations of undump.py, the Linux eBPF/bpftrace version.
+
+This example trace the kernel function performing receive AP_UNIX socket
+packet. Some example output:
+
+Terminal 1, UNIX Socket Server:
+
+```
+$ nc -lU /var/tmp/unixsocket
+# receive from Client
+Hello, world
+123abc
+```
+
+Terminal 2, UNIX socket Client:
+
+```
+$ nc -U /var/tmp/unixsocket
+# Input some lines
+Hello, world
+123abc
+```
+
+Terminal 3, receive tracing:
+
+```
+$ sudo ./undump.bt
+Attaching 3 probes...
+Dump UNIX socket packages RX. Ctrl-C to end
+TIME     COMM             PID      SIZE     DATA
+20:40:11 nc               139071   13       Hello, world\x0a
+20:40:14 nc               139071   7        123abc\x0a
+^C
+```
+


### PR DESCRIPTION
This is a bpftrace version of the bcc examples/tracing of the same name, [undump](https://github.com/iovisor/bcc/blob/master/examples/tracing/undump.py)

* `tcpdump` not support `unix domain socket`;
* first tool use `buf()` builtin;

# Usage

Terminal 1, UNIX Socket Server:

```
$ nc -lU /var/tmp/unixsocket
# receive from Client
Hello, world
123abc
```

Terminal 2, UNIX socket Client:

```
$ nc -U /var/tmp/unixsocket
# Input some lines
Hello, world
123abc
```

Terminal 3, receive tracing:

```
$ sudo ./undump.bt
Attaching 3 probes...
Dump UNIX socket packages RX. Ctrl-C to end
TIME     COMM             PID      SIZE     DATA
20:40:11 nc               139071   13       Hello, world\x0a
20:40:14 nc               139071   7        123abc\x0a
^C
```