### PR TITLE
Fix bpftrace_test ERROR for LLVM-13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,6 @@ jobs:
           LLVM_VERSION: 13
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
-          GTEST_FILTER: '-clang_parser.nested_struct_no_type'
           TOOLS_TEST_OLDVERSION: biosnoop.bt
           BASE: focal
           VENDOR_GTEST: ON

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -202,8 +202,13 @@ TEST(clang_parser, nested_struct_no_type)
   // since they are called bar and baz
   parse("struct Foo { struct { int x; } bar; union { int y; } baz; }", bpftrace);
 
+#if LLVM_VERSION_MAJOR >= 13
+  std::string bar_name = "struct Foo::(unnamed at definitions.h:2:14)";
+  std::string baz_name = "union Foo::(unnamed at definitions.h:2:37)";
+#else
   std::string bar_name = "struct Foo::(anonymous at definitions.h:2:14)";
   std::string baz_name = "union Foo::(anonymous at definitions.h:2:37)";
+#endif
 
   ASSERT_TRUE(bpftrace.structs.Has("struct Foo"));
   ASSERT_TRUE(bpftrace.structs.Has(bar_name));


### PR DESCRIPTION
Rename 'anonymous' to 'unnamed' for LLVM-13.

```
  $ sudo ./bpftrace_test --gtest_filter=clang_parser.nested_struct_no_type
  Note: Google Test filter = clang_parser.nested_struct_no_type
  [==========] Running 1 test from 1 test suite.
  [----------] Global test environment set-up.
  [----------] 1 test from clang_parser
  [ RUN      ] clang_parser.nested_struct_no_type
  /home/rongtao/Git/rtoax/bpftrace/tests/clang_parser.cpp:209: Failure
  Value of: bpftrace.structs.Has(bar_name)
    Actual: false
  Expected: true
  [  FAILED  ] clang_parser.nested_struct_no_type (272 ms)
  [----------] 1 test from clang_parser (272 ms total)

  [----------] Global test environment tear-down
  [==========] 1 test from 1 test suite ran. (272 ms total)
  [  PASSED  ] 0 tests.
  [  FAILED  ] 1 test, listed below:
  [  FAILED  ] clang_parser.nested_struct_no_type

   1 FAILED TEST
```

Check it in 'llvm-project' commit 50542d504dd869fe1241a9cc987b72ead5a56073
rename 'anonymous' to 'unnamed', and it's belongs to 'release/13.x'.

https://github.com/llvm/llvm-project/commit/50542d504dd869fe1241a9cc987b72ead5a56073

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->
