### PR TITLE
Fix CI not running unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -176,7 +176,7 @@ jobs:
         -e BUILD_LIBBPF="${BUILD_LIBBPF}"
         -e CC="${CC}"
         -e CXX="${CXX}"
-        -e GTEST_FILTER="$GTEST_FILTER"
+        -e GTEST_FILTER="${GTEST_FILTER:-*}"
         -e TOOLS_TEST_DISABLE="$TOOLS_TEST_DISABLE"
         -e TOOLS_TEST_OLDVERSION="$TOOLS_TEST_OLDVERSION"
         bpftrace-builder-$BASE-llvm-$LLVM_VERSION


### PR DESCRIPTION
Currently, CI is not running unit tests for most of the cases. The reason is that we set the `GTEST_FILTER` variable which, when set to empty value, makes no tests to be selected.

This fixes the issue by using `*` as the default  value of the variable.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
