### PR TITLE
Add executable permission to tools.

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,6 +1,6 @@
 file(GLOB BT_FILES *.bt)
 file(GLOB TXT_FILES *.txt)
 list(REMOVE_ITEM TXT_FILES ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt)
-install(FILES ${BT_FILES} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/bpftrace/tools)
+install(PROGRAMS ${BT_FILES} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/bpftrace/tools)
 install(FILES ${TXT_FILES} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/bpftrace/tools/doc)
 add_subdirectory(old)


### PR DESCRIPTION
It is best to add executable permissions to the toolset, which is more convenient to use.