### PR TITLE
Fix kprobe multi compile error.

### DIFF
--- a/cmake/FindLibBpf.cmake
+++ b/cmake/FindLibBpf.cmake
@@ -85,7 +85,7 @@ CHECK_CXX_SOURCE_COMPILES("
 int main(void) {
   DECLARE_LIBBPF_OPTS(bpf_link_create_opts, opts);
 
-  opts.kprobe_multi.syms = NULL;
+  opts.kprobe_multi.syms = BPF_F_KPROBE_MULTI_RETURN;
   return 0;
 }
 " HAVE_LIBBPF_KPROBE_MULTI)


### PR DESCRIPTION
bpftrace `kprobe multi` should follow the kernel-header, not libbpf, as libbpf may be ahead of the currently installed kernel

 Env:

 * kernel 4.18 (5.15.13 also have this error when compile)
 * LLVM version 12.0.1
 * libbpf 0.8.0

 Error:

```
 /home/rongtao/Git/rtoax/bpftrace/src/bpffeature.cpp: In member function ‘bool bpftrace::BPFfeature::has_kprobe_multi()’:
 /home/rongtao/Git/rtoax/bpftrace/src/bpffeature.cpp:360:7: error: ‘BPF_TRACE_KPROBE_MULTI’ was not declared in this scope
        BPF_TRACE_KPROBE_MULTI);
        ^~~~~~~~~~~~~~~~~~~~~~
 /home/rongtao/Git/rtoax/bpftrace/src/bpffeature.cpp:360:7: note: suggested alternative:
 In file included from /home/rongtao/Git/rtoax/bpftrace/src/bpffeature.h:10,
                  from /home/rongtao/Git/rtoax/bpftrace/src/bpffeature.cpp:1:
 /home/rongtao/Git/rtoax/bpftrace/src/libbpf/bpf.h:124:2: note:   ‘BPF_TRACE_KPROBE_MULTI’
   BPF_TRACE_KPROBE_MULTI,
   ^~~~~~~~~~~~~~~~~~~~~~
 make[2]: *** [src/CMakeFiles/runtime.dir/build.make:90: src/CMakeFiles/runtime.dir/bpffeature.cpp.o] Error 1
 make[2]: *** Waiting for unfinished jobs....
 [ 77%] Linking CXX static library libbpforc.a
 /home/rongtao/Git/rtoax/bpftrace/src/attached_probe.cpp: In member function ‘void bpftrace::AttachedProbe::attach_multi_kprobe()’:
 /home/rongtao/Git/rtoax/bpftrace/src/attached_probe.cpp:847:35: error: ‘BPF_F_KPROBE_MULTI_RETURN’ was not declared in this scope
                                  ? BPF_F_KPROBE_MULTI_RETURN
                                    ^~~~~~~~~~~~~~~~~~~~~~~~~
 /home/rongtao/Git/rtoax/bpftrace/src/attached_probe.cpp:847:35: note: suggested alternative: ‘BPF_PROBE_RETURN’
                                  ? BPF_F_KPROBE_MULTI_RETURN
                                    ^~~~~~~~~~~~~~~~~~~~~~~~~
                                    BPF_PROBE_RETURN
```
