### PR TITLE
Fix LLVM install dir path

### DIFF
--- a/.github/workflows/embedded_llvm.yml
+++ b/.github/workflows/embedded_llvm.yml
@@ -3,12 +3,12 @@ on:
   push:
     paths:
       - docker/Dockerfile.llvm
-      - cmake/embedded/*
+      - cmake/embed/*
       - .github/workflows/embedded_llvm.yml
   pull_request:
     paths:
       - docker/Dockerfile.llvm
-      - cmake/embedded/*
+      - cmake/embed/*
       - .github/workflows/embedded_llvm.yml
   schedule:
     - cron: '0 0 1 * *'

--- a/cmake/embed/embed_llvm.cmake
+++ b/cmake/embed/embed_llvm.cmake
@@ -165,7 +165,7 @@ if(EMBED_BUILD_LLVM)
 
   # Set up build targets and map to embedded paths
   ExternalProject_Get_Property(embedded_llvm INSTALL_DIR)
-  set(EMBEDDED_LLVM_INSTALL_DIR "${INSTALL_DIR}/lib")
+  set(EMBEDDED_LLVM_INSTALL_DIR "${INSTALL_DIR}")
 else()
   set(EMBEDDED_LLVM_INSTALL_DIR "${EMBED_LLVM_PATH}")
 endif()


### PR DESCRIPTION
Found the below error while I'm trying to build a static binary for arm64.

```bash
[ 50%] Built target embedded_llvm
[ 57%] Performing configure step for 'embedded_clang'
CMake Error at CMakeLists.txt:66 (find_package):
  Could not find a package configuration file provided by "LLVM" with any of
  the following names:

    LLVMConfig.cmake
    llvm-config.cmake

  Add the installation prefix of "LLVM" to CMAKE_PREFIX_PATH or set
  "LLVM_DIR" to a directory containing one of the above files.  If "LLVM"
  provides a separate development package or SDK, be sure it has been
  installed.
```

I don't know CMake well,
but seems the [LLVM_DIR](https://github.com/iovisor/bpftrace/blob/master/cmake/embed/embed_clang.cmake#L95) has the wrong value. 

Could be related to the PR https://github.com/iovisor/bpftrace/pull/2088

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
