### PR TITLE
tools: Allow skipping examples

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,6 +1,11 @@
+option(INSTALL_TOOL_DOCS "Install example text files demonstrating tools" ON)
+
+if (INSTALL_TOOL_DOCS)
+  file(GLOB TXT_FILES *.txt)
+  list(REMOVE_ITEM TXT_FILES ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt)
+  install(FILES ${TXT_FILES} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/bpftrace/tools/doc)
+endif()
+
 file(GLOB BT_FILES *.bt)
-file(GLOB TXT_FILES *.txt)
-list(REMOVE_ITEM TXT_FILES ${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt)
 install(PROGRAMS ${BT_FILES} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/bpftrace/tools)
-install(FILES ${TXT_FILES} DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/bpftrace/tools/doc)
 add_subdirectory(old)


### PR DESCRIPTION
Default behaviour stays unchanged but distribution package maintainers
can now pass `-DINSTALL_TOOL_DOCS=OFF` to not ship them.
