### PR TITLE
RFC: allow uint8 array parsed as string

### DIFF
--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -52,6 +52,7 @@ jobs:
           DISTRO: alpine
           ALPINE_VERSION: 3.11
           VENDOR_GTEST: ON
+          GTEST_FILTER: "-clang_parser.uint8_array"
         - TYPE: Release
           NAME: alpine
           LLVM_VERSION: 9
@@ -66,6 +67,7 @@ jobs:
           DISTRO: alpine
           ALPINE_VERSION: 3.11
           VENDOR_GTEST: ON
+          GTEST_FILTER: "-clang_parser.uint8_array"
     steps:
     - uses: actions/checkout@v2
     - name: Build docker container
@@ -100,6 +102,7 @@ jobs:
         -e BUILD_LIBBPF="${BUILD_LIBBPF}"
         -e TOOLS_TEST_OLDVERSION="$TOOLS_TEST_OLDVERSION"
         -e TOOLS_TEST_DISABLE="$TOOLS_TEST_DISABLE"
+        -e GTEST_FILTER="${GTEST_FILTER:-*}"
         bpftrace-embedded-${{ matrix.env['BASE'] }}
         $(pwd)/build-embedded ${TYPE}
         -j`nproc`

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -332,7 +332,8 @@ static SizedType get_sized_type(CXType clang_type, StructManager &structs)
     {
       auto elem_type = clang_getArrayElementType(clang_type);
       auto size = clang_getNumElements(clang_type);
-      if (elem_type.kind == CXType_Char_S || elem_type.kind == CXType_Char_U)
+      if (elem_type.kind == CXType_Char_S || elem_type.kind == CXType_Char_U ||
+          elem_type.kind == CXType_SChar || elem_type.kind == CXType_UChar)
       {
         return CreateString(size);
       }

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -154,6 +154,23 @@ TEST(clang_parser, string_array)
   EXPECT_EQ(foo->GetField("str").offset, 0);
 }
 
+TEST(clang_parser, uint8_array)
+{
+  BPFtrace bpftrace;
+  parse("#include <bits/types.h>\nstruct Foo { __uint8_t str[32]; }", bpftrace);
+
+  ASSERT_TRUE(bpftrace.structs.Has("struct Foo"));
+  auto foo = bpftrace.structs.Lookup("struct Foo").lock();
+
+  EXPECT_EQ(foo->size, 32);
+  ASSERT_EQ(foo->fields.size(), 1U);
+  ASSERT_TRUE(foo->HasField("str"));
+
+  EXPECT_EQ(foo->GetField("str").type.type, Type::string);
+  EXPECT_EQ(foo->GetField("str").type.GetSize(), 32U);
+  EXPECT_EQ(foo->GetField("str").offset, 0);
+}
+
 TEST(clang_parser, nested_struct_named)
 {
   BPFtrace bpftrace;

--- a/tests/codegen/llvm/call_macaddr.ll
+++ b/tests/codegen/llvm/call_macaddr.ll
@@ -9,21 +9,29 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
+  %"struct mac.addr" = alloca [6 x i8], align 1
   %macaddr = alloca [6 x i8], align 1
   %1 = bitcast [6 x i8]* %macaddr to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast [6 x i8]* %macaddr to i8*
   call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 6, i1 false)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([6 x i8]*, i32, i64)*)([6 x i8]* %macaddr, i32 6, i64 0)
-  %3 = bitcast i64* %"@x_key" to i8*
+  %3 = bitcast [6 x i8]* %"struct mac.addr" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([6 x i8]*, i32, i64)*)([6 x i8]* %"struct mac.addr", i32 6, i64 0)
+  %4 = bitcast [6 x i8]* %macaddr to i8*
+  %5 = bitcast [6 x i8]* %"struct mac.addr" to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %4, i8* align 1 %5, i64 6, i1 false)
+  %6 = bitcast [6 x i8]* %"struct mac.addr" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, [6 x i8]*, i64)*)(i64 %pseudo, i64* %"@x_key", [6 x i8]* %macaddr, i64 0)
-  %4 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
-  %5 = bitcast [6 x i8]* %macaddr to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast [6 x i8]* %macaddr to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   ret i64 0
 }
 
@@ -32,6 +40,9 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly %0, i8* noalias nocapture readonly %1, i64 %2, i1 immarg %3) #1
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1

--- a/tests/codegen/llvm/call_ntop_char16.ll
+++ b/tests/codegen/llvm/call_ntop_char16.ll
@@ -11,6 +11,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
+  %"struct inet.addr" = alloca [16 x i8], align 1
   %inet = alloca %inet_t, align 8
   %1 = bitcast %inet_t* %inet to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -19,16 +20,21 @@ entry:
   %3 = getelementptr %inet_t, %inet_t* %inet, i32 0, i32 1
   %4 = bitcast [16 x i8]* %3 to i8*
   call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 16, i1 false)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* %3, i32 16, i64 0)
-  %5 = bitcast i64* %"@x_key" to i8*
+  %5 = bitcast [16 x i8]* %"struct inet.addr" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* %"struct inet.addr", i32 16, i64 0)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 ([16 x i8]*, i32, [16 x i8]*)*)([16 x i8]* %3, i32 16, [16 x i8]* %"struct inet.addr")
+  %6 = bitcast [16 x i8]* %"struct inet.addr" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %inet_t*, i64)*)(i64 %pseudo, i64* %"@x_key", %inet_t* %inet, i64 0)
-  %6 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast %inet_t* %inet to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast %inet_t* %inet to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_ntop_char4.ll
+++ b/tests/codegen/llvm/call_ntop_char4.ll
@@ -11,6 +11,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_key" = alloca i64, align 8
+  %"struct inet.addr" = alloca [4 x i8], align 1
   %inet = alloca %inet_t, align 8
   %1 = bitcast %inet_t* %inet to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -19,16 +20,21 @@ entry:
   %3 = getelementptr %inet_t, %inet_t* %inet, i32 0, i32 1
   %4 = bitcast [16 x i8]* %3 to i8*
   call void @llvm.memset.p0i8.i64(i8* align 1 %4, i8 0, i64 16, i1 false)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([16 x i8]*, i32, i64)*)([16 x i8]* %3, i32 4, i64 0)
-  %5 = bitcast i64* %"@x_key" to i8*
+  %5 = bitcast [4 x i8]* %"struct inet.addr" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 ([4 x i8]*, i32, i64)*)([4 x i8]* %"struct inet.addr", i32 4, i64 0)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 ([16 x i8]*, i32, [4 x i8]*)*)([16 x i8]* %3, i32 4, [4 x i8]* %"struct inet.addr")
+  %6 = bitcast [4 x i8]* %"struct inet.addr" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %inet_t*, i64)*)(i64 %pseudo, i64* %"@x_key", %inet_t* %inet, i64 0)
-  %6 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast %inet_t* %inet to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast %inet_t* %inet to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   ret i64 0
 }
 

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -55,13 +55,13 @@ EXPECT P: /*.
 TIMEOUT 5
 
 NAME buf
-RUN {{BPFTRACE}} -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s->a, 4), buf($s->b, 4), buf($s->c), buf($s->d), buf($s->e), buf($s->f)); exit(); }' -c ./testprogs/complex_struct
+RUN {{BPFTRACE}} -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s->a, 4), buf($s->b, 4), buf($s->c, 4), buf($s->d), buf($s->e), buf($s->f)); exit(); }' -c ./testprogs/complex_struct
 EXPECT P: \\x09\\x08\\x07\\x06-\\x05\\x04\\x03\\x02-\\x01\\x02\\x03\\x04-\\x05\\x00\\x00\\x00\\x06\\x00\\x00\\x00\\x07\\x00\\x00\\x00\\x08\\x00\\x00\\x00-\\x09\\x00\\x0a\\x00\\x0b\\x00\\x0c\\x00-\\x0d\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0e\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0f\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x10\\x00\\x00\\x00\\x00\\x00\\x00\\x00
 TIMEOUT 5
 ARCH x86_64|ppc64le|aarch64
 
 NAME buf
-RUN {{BPFTRACE}} -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s->a, 4), buf($s->b, 4), buf($s->c), buf($s->d), buf($s->e), buf($s->f)); exit(); }' -c ./testprogs/complex_struct
+RUN {{BPFTRACE}} -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s->a, 4), buf($s->b, 4), buf($s->c, 4), buf($s->d), buf($s->e), buf($s->f)); exit(); }' -c ./testprogs/complex_struct
 EXPECT P: \\x09\\x08\\x07\\x06-\\x05\\x04\\x03\\x02-\\x01\\x02\\x03\\x04-\\x00\\x00\\x00\\x05\\x00\\x00\\x00\\x06\\x00\\x00\\x00\\x07\\x00\\x00\\x00\\x08-\\x00\\x09\\x00\\x0a\\x00\\x0b\\x00\\x0c-\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0d\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0e\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0f\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x10
 TIMEOUT 5
 ARCH s390x|ppc64

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -24,8 +24,8 @@ EXPECT 0
 TIMEOUT 5
 
 NAME c_array_indexing
-RUN {{BPFTRACE}} -e 'struct Foo { int a; uint8_t b[10]; } uprobe:testprogs/uprobe_test:function2 { $foo = (struct Foo *)arg0; printf("%c %c %c %c %c\n", $foo->b[0], $foo->b[1], $foo->b[2], $foo->b[3], $foo->b[4]) }' -c ./testprogs/uprobe_test
-EXPECT h e l l o
+RUN {{BPFTRACE}} -e 'struct Foo { int a; uint8_t b[10]; int c[3]; } uprobe:testprogs/uprobe_test:function2 { $foo = (struct Foo *)arg0; printf("%d %d %d\n", $foo->c[0], $foo->c[1], $foo->c[2]) }' -c ./testprogs/uprobe_test
+EXPECT 1 2 3
 TIMEOUT 5
 
 # https://github.com/iovisor/bpftrace/issues/1773


### PR DESCRIPTION
Context: https://github.com/iovisor/bpftrace/issues/2248#issuecomment-1144512575

I'm looking for ways to compare two char array in bpftrace, some idea:
1. use `str()` convert two char array to string, and do `strncmp()` on them, it works, but seems cumbersome
2. implement char array binop comparison
3. parse char array as string, and compare them directly by `==` or `strncmp()`

This PR is a try of **the 3rd idea**, not sure if this is appropriate, please leave your comments. :)

In the following example, the `daddr_v6` is defined as `__u8 daddr_v6[16]` in the tracepoint format. 
```
tracepoint:tcp:tcp_retransmit_skb {
  $addr = args->daddr_v6;
}
```

When clang_parser parses this field, it firstly recognize this `daddr_v6[16]` field as `CXType_ConstantArray`, then its element type is `CXType_UChar`, a similar but different type from `CXType_Char_U`.

https://github.com/iovisor/bpftrace/blob/master/src/clang_parser.cpp#L333-L338

To achieve my goal with the 3rd idea, I added the `CXType_UChar` and `CXType_SChar` to the if-statement before `CreateString()`. Now the `args->daddr_v6` can be recognized as a `Type:string`.

I don't think there is much difference between `CXType_UChar` and `CXType_Char_U`, how do you think?

Some info found: https://lists.llvm.org/pipermail/cfe-dev/2012-February/019902.html

##### Side effect
This pr may cause some of the existing char array becoming strings, as the changes in the test files shown.
There are other cases may fail, e.g., c_array_indexing https://github.com/iovisor/bpftrace/blob/master/tests/runtime/regression#L26

##### Checklist

- [-] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [-] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [*] The new behaviour is covered by tests
