### PR TITLE
Add 'has_field()' and 'get_field' call.

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1261,6 +1261,26 @@ Functions that are marked *async* are asynchronous which can lead to unexpected 
 `bswap` reverses the order of the bytes in integer `n`. In case of 8 bit integers, `n` is returned without being modified.
 The return type is an unsigned integer of the same width as `n`.
 
+=== has_field
+
+.variants
+* `has_field(STRUCT, "x")`
+* `has_field(UNION, "x")`
+
+*compile time*
+
+Returns true if field exists in struct/union.
+
+=== get_field
+
+.variants
+* `get_field(STRUCT, "x")`
+* `get_field(UNION, "x")`
+
+*compile time*
+
+Get elements of struct/union.
+
 === buf
 
 .variants

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1114,6 +1114,21 @@ void CodegenLLVM::visit(Call &call)
       expr_ = b_.CreateCall(swap_fun, { expr_ });
     }
   }
+  else if (call.func == "has_field")
+  {
+    auto &element_arg = *call.vargs->at(1);
+    String &element = static_cast<String &>(element_arg);
+    expr_ = b_.getInt32(call.vargs->at(0)->type.HasField(element.str));
+  }
+  else if (call.func == "get_field")
+  {
+    auto &element_arg = *call.vargs->at(1);
+    String &element = static_cast<String &>(element_arg);
+    FieldAccess *acc = new FieldAccess(call.vargs->at(0),
+                                       element.str,
+                                       call.loc);
+    visit(*acc);
+  }
   else
   {
     LOG(FATAL) << "missing codegen for function \"" << call.func << "\"";

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -38,7 +38,7 @@ vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#\*])+
 builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ctx|curtask|elapsed|func|gid|nsecs|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
-call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|sizeof|stats|str|strftime|strncmp|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap
+call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|sizeof|stats|str|strftime|strncmp|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|has_field|get_field
 
 /* Don't add to this! Use builtin OR call not both */
 call_and_builtin kstack|ustack
@@ -170,7 +170,7 @@ bpftrace|perf           { return Parser::make_STACK_MODE(yytext, loc); }
 
 struct|union|enum       yy_push_state(STRUCT, yyscanner); buffer.clear(); struct_type = yytext;
 <STRUCT,BRACE>{
-  "*"|")"               {
+  "*"|")"|","           {
                           if (YY_START == STRUCT)
                           {
                             // Finished parsing the typename of a cast

--- a/tests/codegen/call_get_field.cpp
+++ b/tests/codegen/call_get_field.cpp
@@ -1,0 +1,20 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, call_get_field)
+{
+  test("struct Foo { char c; long l; } kprobe:f { $foo = (struct Foo*)arg0; "
+       "if (has_field(struct Foo, \"c\")) {"
+       "  $c = get_field(*$foo, \"c\");"
+       "}"
+       "}",
+
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/call_has_field.cpp
+++ b/tests/codegen/call_has_field.cpp
@@ -1,0 +1,17 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, call_has_field)
+{
+  test("struct Foo { int x; char c; } BEGIN { @x = has_field(struct Foo,
+       \"x\") }",
+
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/call_get_field.ll
+++ b/tests/codegen/llvm/call_get_field.ll
@@ -1,0 +1,46 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @"kprobe:do_nanosleep"(i8* %0) section "s_kprobe:do_nanosleep_1" {
+entry:
+  %"$c" = alloca i8, align 1
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"$c")
+  store i8 0, i8* %"$c", align 1
+  %"struct Foo.c" = alloca i8, align 1
+  %"$foo" = alloca i64, align 8
+  %1 = bitcast i64* %"$foo" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 0, i64* %"$foo", align 8
+  %2 = bitcast i8* %0 to i64*
+  %3 = getelementptr i64, i64* %2, i64 14
+  %arg0 = load volatile i64, i64* %3, align 8
+  store i64 %arg0, i64* %"$foo", align 8
+  br i1 true, label %if_body, label %if_end
+
+if_body:                                          ; preds = %entry
+  %4 = load i64, i64* %"$foo", align 8
+  %5 = add i64 %4, 0
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %"struct Foo.c")
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %"struct Foo.c", i32 1, i64 %5)
+  %6 = load i8, i8* %"struct Foo.c", align 1
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %"struct Foo.c")
+  store i8 %6, i8* %"$c", align 1
+  br label %if_end
+
+if_end:                                           ; preds = %if_body, %entry
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/codegen/llvm/call_has_field.ll
+++ b/tests/codegen/llvm/call_has_field.ll
@@ -1,0 +1,35 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @BEGIN(i8* %0) section "s_BEGIN_1" {
+entry:
+  %"@x_val" = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  %1 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 0, i64* %"@x_key", align 8
+  %2 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 1, i64* %"@x_val", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
+  %3 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -198,3 +198,8 @@ PROG BEGIN { printf("size=%d\n", sizeof(struct task_struct)); exit(); }
 EXPECT ^size=
 TIMEOUT 5
 REQUIRES_FEATURE btf
+
+NAME has_field
+PROG struct Foo { int x; struct { char c; }; } BEGIN { printf("%d %d %d\n", has_field(struct Foo, "x"), has_field(struct Foo, "c"), has_field(struct Foo, "d")); exit(); }
+EXPECT ^1 1 0$
+TIMEOUT 5

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2441,6 +2441,26 @@ TEST(semantic_analyser, call_path)
   test("END { $k = path( 1 ) }", 1);
 }
 
+TEST(semantic_analyser, call_has_field)
+{
+  test("struct Foo { int a; struct { char c; }; }; \
+        BEGIN { $a = has_field(struct Foo, \"a\"); \
+               $c = has_field(struct Foo, \"c\"); }",
+        0);
+}
+
+TEST(semantic_analyser, call_get_field)
+{
+  test("struct Foo { char c; long l; } "
+	   "kprobe:f { $foo = (struct Foo*)arg0; "
+       "if (has_field(struct Foo, \"c\")) {"
+       "  $c = get_field(*$foo, \"c\");"
+       "}"
+       "printf(\"%d\\n\", $c);"
+       "}",
+       0);
+}
+
 TEST(semantic_analyser, int_ident)
 {
   test("BEGIN { sizeof(int32) }", 0);


### PR DESCRIPTION
##  `get_field`: Get elements of struct/union

Syntax: `get_field(struct/union X, field)`

Get elements of struct/union, `get_field()` usually used with `has_field()`.
This interface adapts to CO-RE, This interface is adapted to `CO-RE`,
For example: since linux-5.14, the process state field of the `task_struct` structure has changed from
`state` to `__state`, and this interface can adapt to the change of this kernel structure field.

Note that when field does not exist, `get_field` will return `none`, so when __state does not exist,
`printf("%d.\n", get_field(*$task, "__state"))` will report an error, which should be avoided.

Examples:

```
$task = (struct task_struct *)curtask;
if (has_field(struct task_struct, "state")) {
  $state = get_field(*$task, "state");
} else if (has_field(struct task_struct, "__state")) {
  $state = get_field(*$task, "__state");
}
```

##  `has_field`: Returns true if field exists in struct/union

Syntax: `has_field(struct/union X, field)`

Returns true if field exists in struct/union.

Examples:

```
$ sudo bpftrace -e 'struct Foo { int x; char c; } BEGIN { @x = has_field(struct Foo, "x"); exit(); }'
Attaching 1 probe...

@x: 1
```
