### PR TITLE
Make aot build depend on parser target

### DIFF
--- a/src/aot/CMakeLists.txt
+++ b/src/aot/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_library(aot aot.cpp)
+add_dependencies(aot parser)
 target_include_directories(aot PUBLIC ${CMAKE_SOURCE_DIR}/src)
 target_include_directories(aot PUBLIC ${CMAKE_BINARY_DIR})
 target_compile_definitions(aot PRIVATE ${BPFTRACE_FLAGS})


### PR DESCRIPTION
There were a race condition that would sporadically pop up where we
would try to build `aot` and it would fail to find `location.hh`.

The error was:
```
In file included from /home/chantra/devel/bpftrace/src/bpftrace.h:12,
                 from /home/chantra/devel/bpftrace/src/aot/aot.h:6,
                 from /home/chantra/devel/bpftrace/src/aot/aot.cpp:1:
/home/chantra/devel/bpftrace/src/ast/ast.h:7:10: fatal error: location.hh: No such file or directory
    7 | #include "location.hh"
      |          ^~~~~~~~~~~~~
compilation terminated.
make[2]: *** [src/aot/CMakeFiles/aot.dir/build.make:76: src/aot/CMakeFiles/aot.dir/aot.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:1397: src/aot/CMakeFiles/aot.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
```

This symptom had already be mentioned in https://github.com/iovisor/bpftrace/issues/2026#issuecomment-946945350

`location.hh` is produced by yacc/lex through the `parser` target.

In order to exacerbate the behaviour, I introduce a `sleep 60`
dependency before we run `bison` and could reproduce build failure.
Logs are available at https://gist.github.com/chantra/9d8be621f91764fd1231ea314c493a28
The bottom of the gist shows the diff apply to repro.

After adding the dependency from aot on the parser, the issue does not
reproduce.
See https://gist.github.com/chantra/45b491b1691380043daf4bdd61ba5162
(diff at the top this type ¯\_(ツ)_/¯.

I checked if this dependency would be missing in any other places, but
it seems to be OK:
```
[12:21:46] chantra@worktop:bpftrace git:(aot_deps_on_parser) $ PAGER=cat git grep parser | grep dependenc
CMakeLists.txt:add_flex_bison_dependency(flex_lexer bison_parser)
src/CMakeLists.txt:add_dependencies(runtime parser)
src/aot/CMakeLists.txt:add_dependencies(aot parser)
src/ast/CMakeLists.txt:add_dependencies(ast_defs parser)
[12:22:00] chantra@worktop:bpftrace git:(aot_deps_on_parser) $ PAGER=cat git grep location.hh
src/ast/ast.h:#include "location.hh"
src/ast/passes/codegen_llvm.h:#include "location.hh"
src/log.h:#include "location.hh"
src/required_resources.h:#include "location.hh"
```

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
