### PR TITLE
Better helper verifier error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to
 #### Added
 - Add builtin: `numaid`
   - [#2177](https://github.com/iovisor/bpftrace/pull/2177)
+- Add helper verifier error handling
+  - [#2279](https://github.com/iovisor/bpftrace/pull/2279)
 
 #### Changed
 - Move from BCC to libbpf

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -116,25 +116,33 @@ public:
                                 AddrSpace as,
                                 const location &loc);
   Value *CreateStrncmp(Value *val1, Value *val2, uint64_t n, bool inverse);
-  CallInst *CreateGetNs(bool boot_time);
-  CallInst   *CreateGetPidTgid();
-  CallInst   *CreateGetCurrentCgroupId();
-  CallInst   *CreateGetUidGid();
-  CallInst   *CreateGetNumaId();
-  CallInst   *CreateGetCpuId();
-  CallInst   *CreateGetCurrentTask();
-  CallInst   *CreateGetRandom();
+  CallInst *CreateGetNs(bool boot_time, const location &loc);
+  CallInst *CreateGetPidTgid(const location &loc);
+  CallInst *CreateGetCurrentCgroupId(const location &loc);
+  CallInst *CreateGetUidGid(const location &loc);
+  CallInst *CreateGetNumaId(const location &loc);
+  CallInst *CreateGetCpuId(const location &loc);
+  CallInst *CreateGetCurrentTask(const location &loc);
+  CallInst *CreateGetRandom(const location &loc);
   CallInst   *CreateGetStackId(Value *ctx, bool ustack, StackType stack_type, const location& loc);
   CallInst   *CreateGetJoinMap(Value *ctx, const location& loc);
+  CallInst *CreateHelperCall(libbpf::bpf_func_id func_id,
+                             FunctionType *helper_type,
+                             ArrayRef<Value *> args,
+                             const Twine &Name,
+                             const location *loc = nullptr);
   CallInst   *createCall(Value *callee, ArrayRef<Value *> args, const Twine &Name);
   void        CreateGetCurrentComm(Value *ctx, AllocaInst *buf, size_t size, const location& loc);
-  void        CreatePerfEventOutput(Value *ctx, Value *data, size_t size);
+  void CreatePerfEventOutput(Value *ctx,
+                             Value *data,
+                             size_t size,
+                             const location *loc = nullptr);
   void        CreateSignal(Value *ctx, Value *sig, const location &loc);
   void        CreateOverrideReturn(Value *ctx, Value *rc);
   void        CreateHelperError(Value *ctx, Value *return_value, libbpf::bpf_func_id func_id, const location& loc);
   void        CreateHelperErrorCond(Value *ctx, Value *return_value, libbpf::bpf_func_id func_id, const location& loc, bool compare_zero=false);
   StructType *GetStructType(std::string name, const std::vector<llvm::Type *> & elements, bool packed = false);
-  AllocaInst *CreateUSym(llvm::Value *val);
+  AllocaInst *CreateUSym(llvm::Value *val, const location &loc);
   Value *CreateRegisterRead(Value *ctx, const std::string &builtin);
   Value      *CreatKFuncArg(Value *ctx, SizedType& type, std::string& name);
   CallInst *CreateSkbOutput(Value *skb,

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -114,7 +114,7 @@ void CodegenLLVM::kstack_ustack(const std::string &ident,
   if (ident == "ustack")
   {
     // pack uint64_t with: (uint32_t)stack_id, (uint32_t)pid
-    Value *pidhigh = b_.CreateShl(b_.CreateGetPidTgid(), 32);
+    Value *pidhigh = b_.CreateShl(b_.CreateGetPidTgid(loc), 32);
     stackid = b_.CreateOr(stackid, pidhigh);
   }
 
@@ -125,7 +125,8 @@ void CodegenLLVM::visit(Builtin &builtin)
 {
   if (builtin.ident == "nsecs")
   {
-    expr_ = b_.CreateGetNs(bpftrace_.feature_->has_helper_ktime_get_boot_ns());
+    expr_ = b_.CreateGetNs(bpftrace_.feature_->has_helper_ktime_get_boot_ns(),
+                           builtin.loc);
   }
   else if (builtin.ident == "elapsed")
   {
@@ -135,7 +136,8 @@ void CodegenLLVM::visit(Builtin &builtin)
     auto *map = bpftrace_.maps[MapManager::Type::Elapsed].value();
     auto type = CreateUInt64();
     auto start = b_.CreateMapLookupElem(ctx_, map->id, key, type, builtin.loc);
-    expr_ = b_.CreateGetNs(bpftrace_.feature_->has_helper_ktime_get_boot_ns());
+    expr_ = b_.CreateGetNs(bpftrace_.feature_->has_helper_ktime_get_boot_ns(),
+                           builtin.loc);
     expr_ = b_.CreateSub(expr_, start);
     // start won't be on stack, no need to LifeTimeEnd it
     b_.CreateLifetimeEnd(key);
@@ -146,7 +148,7 @@ void CodegenLLVM::visit(Builtin &builtin)
   }
   else if (builtin.ident == "pid" || builtin.ident == "tid")
   {
-    Value *pidtgid = b_.CreateGetPidTgid();
+    Value *pidtgid = b_.CreateGetPidTgid(builtin.loc);
     if (builtin.ident == "pid")
     {
       expr_ = b_.CreateLShr(pidtgid, 32);
@@ -158,11 +160,11 @@ void CodegenLLVM::visit(Builtin &builtin)
   }
   else if (builtin.ident == "cgroup")
   {
-    expr_ = b_.CreateGetCurrentCgroupId();
+    expr_ = b_.CreateGetCurrentCgroupId(builtin.loc);
   }
   else if (builtin.ident == "uid" || builtin.ident == "gid" || builtin.ident == "username")
   {
-    Value *uidgid = b_.CreateGetUidGid();
+    Value *uidgid = b_.CreateGetUidGid(builtin.loc);
     if (builtin.ident == "uid"  || builtin.ident == "username")
     {
       expr_ = b_.CreateAnd(uidgid, 0xffffffff);
@@ -174,20 +176,20 @@ void CodegenLLVM::visit(Builtin &builtin)
   }
   else if (builtin.ident == "numaid")
   {
-    expr_ = b_.CreateGetNumaId();
+    expr_ = b_.CreateGetNumaId(builtin.loc);
   }
   else if (builtin.ident == "cpu")
   {
-    Value *cpu = b_.CreateGetCpuId();
+    Value *cpu = b_.CreateGetCpuId(builtin.loc);
     expr_ = b_.CreateZExt(cpu, b_.getInt64Ty());
   }
   else if (builtin.ident == "curtask")
   {
-    expr_ = b_.CreateGetCurrentTask();
+    expr_ = b_.CreateGetCurrentTask(builtin.loc);
   }
   else if (builtin.ident == "rand")
   {
-    Value *random = b_.CreateGetRandom();
+    Value *random = b_.CreateGetRandom(builtin.loc);
     expr_ = b_.CreateZExt(random, b_.getInt64Ty());
   }
   else if (builtin.ident == "comm")
@@ -228,7 +230,7 @@ void CodegenLLVM::visit(Builtin &builtin)
 
     if (builtin.type.IsUsymTy())
     {
-      expr_ = b_.CreateUSym(expr_);
+      expr_ = b_.CreateUSym(expr_, builtin.loc);
       Value *expr = expr_;
       expr_deleter_ = [this, expr]() { b_.CreateLifetimeEnd(expr); };
     }
@@ -706,7 +708,8 @@ void CodegenLLVM::visit(Call &call)
     b_.CreatePerfEventOutput(
         ctx_,
         perfdata,
-        8 + 8 + bpftrace_.join_argnum_ * bpftrace_.join_argsize_);
+        8 + 8 + bpftrace_.join_argnum_ * bpftrace_.join_argsize_,
+        &call.loc);
 
     b_.CreateBr(zero);
 
@@ -722,7 +725,7 @@ void CodegenLLVM::visit(Call &call)
   else if (call.func == "usym")
   {
     auto scoped_del = accept(call.vargs->front());
-    expr_ = b_.CreateUSym(expr_);
+    expr_ = b_.CreateUSym(expr_, call.loc);
   }
   else if (call.func == "ntop")
   {
@@ -886,7 +889,7 @@ void CodegenLLVM::visit(Call &call)
      */
     AllocaInst *perfdata = b_.CreateAllocaBPF(b_.getInt64Ty(), "perfdata");
     b_.CreateStore(b_.getInt64(asyncactionint(AsyncAction::exit)), perfdata);
-    b_.CreatePerfEventOutput(ctx_, perfdata, sizeof(uint64_t));
+    b_.CreatePerfEventOutput(ctx_, perfdata, sizeof(uint64_t), &call.loc);
     b_.CreateLifetimeEnd(perfdata);
     expr_ = nullptr;
     createRet();
@@ -963,7 +966,7 @@ void CodegenLLVM::visit(Call &call)
                                    { b_.getInt64(0), b_.getInt32(1) });
     b_.CreateStore(b_.GetIntSameSize(id, elements.at(1)), ident_ptr);
 
-    b_.CreatePerfEventOutput(ctx_, buf, getStructSize(event_struct));
+    b_.CreatePerfEventOutput(ctx_, buf, getStructSize(event_struct), &call.loc);
     b_.CreateLifetimeEnd(buf);
     expr_ = nullptr;
   }
@@ -985,7 +988,7 @@ void CodegenLLVM::visit(Call &call)
         b_.CreateGEP(time_struct, buf, { b_.getInt64(0), b_.getInt32(1) }));
 
     time_id_++;
-    b_.CreatePerfEventOutput(ctx_, buf, getStructSize(time_struct));
+    b_.CreatePerfEventOutput(ctx_, buf, getStructSize(time_struct), &call.loc);
     b_.CreateLifetimeEnd(buf);
     expr_ = nullptr;
   }
@@ -1095,7 +1098,7 @@ void CodegenLLVM::visit(Call &call)
     b_.CreateStore(
         b_.CreateIntCast(expr_, b_.getInt64Ty(), false /* unsigned */),
         b_.CreateGEP(unwatch_struct, buf, { b_.getInt64(0), b_.getInt32(1) }));
-    b_.CreatePerfEventOutput(ctx_, buf, struct_size);
+    b_.CreatePerfEventOutput(ctx_, buf, struct_size, &call.loc);
     b_.CreateLifetimeEnd(buf);
     expr_ = nullptr;
   }
@@ -1135,9 +1138,10 @@ void CodegenLLVM::visit(Call &call)
     b_.CreateStore(b_.getInt64(asyncactionint(AsyncAction::skboutput)),
                    aid_addr);
     b_.CreateStore(b_.getInt64(skb_output_id_), id_addr);
-    b_.CreateStore(b_.CreateGetNs(
-                       bpftrace_.feature_->has_helper_ktime_get_boot_ns()),
-                   time_addr);
+    b_.CreateStore(
+        b_.CreateGetNs(bpftrace_.feature_->has_helper_ktime_get_boot_ns(),
+                       call.loc),
+        time_addr);
 
     auto &arg_skb = *call.vargs->at(1);
     arg_skb.accept(*this);
@@ -2938,7 +2942,7 @@ void CodegenLLVM::createFormatStringCall(Call &call, int &id, CallArgs &call_arg
   }
 
   id++;
-  b_.CreatePerfEventOutput(ctx_, fmt_args, struct_size);
+  b_.CreatePerfEventOutput(ctx_, fmt_args, struct_size, &call.loc);
   b_.CreateLifetimeEnd(fmt_args);
   expr_ = nullptr;
 }
@@ -3042,7 +3046,7 @@ void CodegenLLVM::createPrintMapCall(Call &call)
                                 { b_.getInt64(0), b_.getInt32(arg_idx + 1) }));
   }
 
-  b_.CreatePerfEventOutput(ctx_, buf, getStructSize(print_struct));
+  b_.CreatePerfEventOutput(ctx_, buf, getStructSize(print_struct), &call.loc);
   b_.CreateLifetimeEnd(buf);
   expr_ = nullptr;
 }
@@ -3097,7 +3101,7 @@ void CodegenLLVM::createPrintNonMapCall(Call &call, int &id)
   }
 
   id++;
-  b_.CreatePerfEventOutput(ctx_, buf, struct_size);
+  b_.CreatePerfEventOutput(ctx_, buf, struct_size, &call.loc);
   b_.CreateLifetimeEnd(buf);
   expr_ = nullptr;
 }

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -89,4 +89,18 @@ private:
   BTF &btf_;
 };
 
+class HelperVerifierError : public std::runtime_error
+{
+public:
+  const libbpf::bpf_func_id func_id_;
+  const std::string helper_name_;
+  explicit HelperVerifierError(libbpf::bpf_func_id func_id,
+                               std::string helper_name)
+      : std::runtime_error("helper invalid in probe"),
+        func_id_(func_id),
+        helper_name_(helper_name)
+  {
+  }
+};
+
 } // namespace bpftrace

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -953,6 +953,18 @@ std::vector<std::unique_ptr<AttachedProbe>> BPFtrace::attach_probe(
     // Caller will handle
     throw e;
   }
+  catch (const HelperVerifierError &e)
+  {
+    if (helper_use_loc_.find(e.func_id_) != helper_use_loc_.end())
+    {
+      LOG(ERROR, helper_use_loc_[e.func_id_], std::cerr)
+          << "helper " << e.helper_name_ << " not supported in probe";
+    }
+    else
+    {
+      LOG(ERROR) << "helper " << e.helper_name_ << " not supported in probe";
+    }
+  }
   catch (const std::runtime_error &e)
   {
     LOG(ERROR) << e.what();

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -162,6 +162,7 @@ public:
   StructManager structs;
   std::map<std::string, std::string> macros_;
   std::map<std::string, uint64_t> enums_;
+  std::map<libbpf::bpf_func_id, location> helper_use_loc_;
   std::unordered_set<std::string> traceable_funcs_;
   std::vector<std::unique_ptr<AttachedProbe>> attached_probes_;
 

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -316,6 +316,14 @@ REQUIRES_FEATURE dpath kfunc
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
+NAME path_in_unsupported_kfunc
+PROG kfunc:vfs_read { print(path(args->file->f_path)); }
+EXPECT \nstdin:1:18-48: ERROR: helper bpf_d_path not supported in probe\n
+REQUIRES_FEATURE dpath
+TIMEOUT 5
+WILL_FAIL
+AFTER ./testprogs/syscall read
+
 NAME macaddr
 RUN {{BPFTRACE}} -e 'struct MyStruct { const char* ignore; char mac[6]; }; u:./testprogs/complex_struct:func { $s = ((struct MyStruct *)arg0); printf("P: %s\n", macaddr($s->mac)); exit(); }' -c ./testprogs/complex_struct
 EXPECT P: 05:04:03:02:01:02


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

Currently, if a helper is rejected by the verifier, bpftrace displays a generic message:

```
# bpftrace -e 'kfunc:vfs_read { print(path(args->file->f_path)); }'
Attaching 1 probe...
ERROR: Error loading program: kfunc:vfs_read (try -v)
```

If run in verbose mode, the message includes the name of the unallowed helper, including its location in the compiled BPF program. This patch improves the error message to point to the location in the source core causing the generation of the helper:

```
# bpftrace -e 'kfunc:vfs_read { print(path(args->file->f_path)); }'
Attaching 1 probe...
stdin:1:18-48: ERROR: helper bpf_d_path not supported in probe
kfunc:vfs_read { print(path(args->file->f_path)); }
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

In addition to this user-visible improvement, helper call generation in `IRBuilderBPF` was refactored to go through a single `CreateHelperCall` function, which optionally takes a location argument. The location at which the first call of a helper function is generated is recorded into a map, hence it can be displayed to the user should the helper call be rejected by the verifier.

All helper creating methods were extended to pass down the location (in case of `CreatePerfEventOutput`, having no location is permitted, since that function is also used outside of parser code).

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
