### PR TITLE
Add LLVM 14 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,15 @@ jobs:
           BASE: focal
           VENDOR_GTEST: ON
           BUILD_LIBBPF: ON
+        - NAME: LLVM 14 Release
+          TYPE: Release
+          LLVM_VERSION: 14
+          RUN_ALL_TESTS: 1
+          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,call.join,call.join_delim,intptrcast.Casting ints,json-output.join_delim,variable.32-bit tracepoint arg
+          TOOLS_TEST_OLDVERSION: biosnoop.bt
+          BASE: focal
+          VENDOR_GTEST: ON
+          BUILD_LIBBPF: ON
         - NAME: LLVM 12 Release + old libbpf
           TYPE: Release
           LLVM_VERSION: 12


### PR DESCRIPTION
`join` and some other features are broken on LLVM, but we still should have it in the CI to catch possible errors as early as possible (e.g. LLVM 14 doesn't support some deprecated variants of `createGEP` and `createLoad`).

The failing tests are disabled for the moment.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
