### PR TITLE
Consolidate integer sizes for BPF helpers

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -421,7 +421,7 @@ void IRBuilderBPF::CreateMapUpdateElem(Value *ctx,
 
   Value *flags = getInt64(0);
 
-  // int map_update_elem(struct bpf_map * map, void *key, void * value, u64
+  // long map_update_elem(struct bpf_map * map, void *key, void * value, u64
   // flags) Return: 0 on success or negative error
   FunctionType *update_func_type = FunctionType::get(
       getInt64Ty(),
@@ -447,7 +447,7 @@ void IRBuilderBPF::CreateMapDeleteElem(Value *ctx,
   assert(key->getType()->isPointerTy());
   Value *map_ptr = CreateBpfPseudoCallId(map);
 
-  // int map_delete_elem(&map, &key)
+  // long map_delete_elem(&map, &key)
   // Return: 0 on success or negative error
   FunctionType *delete_func_type = FunctionType::get(
       getInt64Ty(), { map_ptr->getType(), key->getType() }, false);
@@ -909,7 +909,7 @@ CallInst *IRBuilderBPF::CreateGetNumaId()
 {
   // long bpf_get_numa_node_id(void)
   // Return: NUMA Node ID
-  FunctionType *numaid_func_type = FunctionType::get(getInt32Ty(), false);
+  FunctionType *numaid_func_type = FunctionType::get(getInt64Ty(), false);
   PointerType *numaid_func_ptr_type = PointerType::get(numaid_func_type, 0);
   Constant *numaid_func = ConstantExpr::getCast(
       Instruction::IntToPtr,
@@ -946,9 +946,9 @@ CallInst *IRBuilderBPF::CreateGetCurrentTask()
 
 CallInst *IRBuilderBPF::CreateGetRandom()
 {
-  // u64 bpf_get_prandom_u32(void)
+  // u32 bpf_get_prandom_u32(void)
   // Return: random
-  FunctionType *getrandom_func_type = FunctionType::get(getInt64Ty(), false);
+  FunctionType *getrandom_func_type = FunctionType::get(getInt32Ty(), false);
   PointerType *getrandom_func_ptr_type = PointerType::get(getrandom_func_type, 0);
   Constant *getrandom_func = ConstantExpr::getCast(
       Instruction::IntToPtr,
@@ -972,7 +972,7 @@ CallInst *IRBuilderBPF::CreateGetStackId(Value *ctx,
     flags |= (1<<8);
   Value *flags_val = getInt64(flags);
 
-  // int bpf_get_stackid(struct pt_regs *ctx, struct bpf_map *map, u64 flags)
+  // long bpf_get_stackid(struct pt_regs *ctx, struct bpf_map *map, u64 flags)
   // Return: >= 0 stackid on success or negative error
   FunctionType *getstackid_func_type = FunctionType::get(
       getInt64Ty(),
@@ -1001,7 +1001,7 @@ void IRBuilderBPF::CreateGetCurrentComm(Value *ctx,
          buf->getType()->getPointerElementType()->getArrayElementType() ==
              getInt8Ty());
 
-  // int bpf_get_current_comm(char *buf, int size_of_buf)
+  // long bpf_get_current_comm(char *buf, int size_of_buf)
   // Return: 0 on success or negative error
   FunctionType *getcomm_func_type = FunctionType::get(
       getInt64Ty(), { buf->getType(), getInt64Ty() }, false);
@@ -1027,8 +1027,8 @@ void IRBuilderBPF::CreatePerfEventOutput(Value *ctx, Value *data, size_t size)
   Value *flags_val = getInt64(BPF_F_CURRENT_CPU);
   Value *size_val = getInt64(size);
 
-  // int bpf_perf_event_output(struct pt_regs *ctx, struct bpf_map *map,
-  //                           u64 flags, void *data, u64 size)
+  // long bpf_perf_event_output(struct pt_regs *ctx, struct bpf_map *map,
+  //                            u64 flags, void *data, u64 size)
   FunctionType *perfoutput_func_type = FunctionType::get(getInt64Ty(),
                                                          { getInt8PtrTy(),
                                                            map_ptr->getType(),
@@ -1049,7 +1049,7 @@ void IRBuilderBPF::CreatePerfEventOutput(Value *ctx, Value *data, size_t size)
 
 void IRBuilderBPF::CreateSignal(Value *ctx, Value *sig, const location &loc)
 {
-  // int bpf_send_signal(u32 sig)
+  // long bpf_send_signal(u32 sig)
   // Return: 0 or error
   FunctionType *signal_func_type = FunctionType::get(
       getInt64Ty(),
@@ -1066,7 +1066,7 @@ void IRBuilderBPF::CreateSignal(Value *ctx, Value *sig, const location &loc)
 
 void IRBuilderBPF::CreateOverrideReturn(Value *ctx, Value *rc)
 {
-  // int bpf_override_return(struct pt_regs *regs, u64 rc)
+  // long bpf_override_return(struct pt_regs *regs, u64 rc)
   // Return: 0
   FunctionType *override_func_type = FunctionType::get(
       getInt64Ty(), { getInt8PtrTy(), getInt64Ty() }, false);
@@ -1093,8 +1093,8 @@ CallInst *IRBuilderBPF::CreateSkbOutput(Value *skb,
 
   size_val = getInt64(size);
 
-  // int bpf_skb_output(void *skb, struct bpf_map *map, u64 flags,
-  //                    void *data, u64 size)
+  // long bpf_skb_output(void *skb, struct bpf_map *map, u64 flags,
+  //                     void *data, u64 size)
   FunctionType *skb_output_func_type = FunctionType::get(getInt64Ty(),
                                                          { skb->getType(),
                                                            map_ptr->getType(),

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -174,12 +174,12 @@ void CodegenLLVM::visit(Builtin &builtin)
   }
   else if (builtin.ident == "numaid")
   {
-    Value *tmp = b_.CreateGetNumaId();
-    expr_ = b_.CreateZExt(tmp, b_.getInt64Ty());
+    expr_ = b_.CreateGetNumaId();
   }
   else if (builtin.ident == "cpu")
   {
-    expr_ = b_.CreateGetCpuId();
+    Value *cpu = b_.CreateGetCpuId();
+    expr_ = b_.CreateZExt(cpu, b_.getInt64Ty());
   }
   else if (builtin.ident == "curtask")
   {
@@ -187,7 +187,8 @@ void CodegenLLVM::visit(Builtin &builtin)
   }
   else if (builtin.ident == "rand")
   {
-    expr_ = b_.CreateGetRandom();
+    Value *random = b_.CreateGetRandom();
+    expr_ = b_.CreateZExt(random, b_.getInt64Ty());
   }
   else if (builtin.ident == "comm")
   {
@@ -1012,7 +1013,7 @@ void CodegenLLVM::visit(Call &call)
     kstack_ustack(call.func, call.type.stack_type, call.loc);
   }
   else if (call.func == "signal") {
-    // int bpf_send_signal(u32 sig)
+    // long bpf_send_signal(u32 sig)
     auto &arg = *call.vargs->at(0);
     if (arg.type.IsStringTy())
     {
@@ -1046,7 +1047,7 @@ void CodegenLLVM::visit(Call &call)
   }
   else if (call.func == "override")
   {
-    // int bpf_override(struct pt_regs *regs, u64 rc)
+    // long bpf_override(struct pt_regs *regs, u64 rc)
     // returns: 0
     auto &arg = *call.vargs->at(0);
     auto scoped_del = accept(&arg);

--- a/tests/codegen/llvm/builtin_numaid.ll
+++ b/tests/codegen/llvm/builtin_numaid.ll
@@ -10,20 +10,19 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_numa_id = call i32 inttoptr (i64 42 to i32 ()*)()
-  %1 = zext i32 %get_numa_id to i64
-  %2 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  %get_numa_id = call i64 inttoptr (i64 42 to i64 ()*)()
+  %1 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 0, i64* %"@x_key", align 8
-  %3 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 %1, i64* %"@x_val", align 8
+  %2 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 %get_numa_id, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %4 = bitcast i64* %"@x_val" to i8*
+  %3 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
+  %4 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
-  %5 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/builtin_rand.ll
+++ b/tests/codegen/llvm/builtin_rand.ll
@@ -10,19 +10,20 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %get_random = call i64 inttoptr (i64 7 to i64 ()*)()
-  %1 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 0, i64* %"@x_key", align 8
-  %2 = bitcast i64* %"@x_val" to i8*
+  %get_random = call i32 inttoptr (i64 7 to i32 ()*)()
+  %1 = zext i32 %get_random to i64
+  %2 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  store i64 %get_random, i64* %"@x_val", align 8
+  store i64 0, i64* %"@x_key", align 8
+  %3 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  store i64 %1, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %3 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
-  %4 = bitcast i64* %"@x_key" to i8*
+  %4 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  %5 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
   ret i64 0
 }
 


### PR DESCRIPTION
Checked signatures of BPF helpers from the [bpf-helpers manpage](https://man7.org/linux/man-pages/man7/bpf-helpers.7.html), updated appropriate comments in irbuilderbpf.cpp, and adjusted handling of the returned integer sizes. 

This mostly involved upcasting from u32 to u64 where necessary.

Fixes #2182.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
