### PR TITLE
Install libbpf in update_codegen_tests.sh

### DIFF
--- a/scripts/update_codegen_tests.sh
+++ b/scripts/update_codegen_tests.sh
@@ -28,4 +28,5 @@ docker run                                \
   -e BPFTRACE_UPDATE_TESTS=1              \
   -e TEST_ARGS="--gtest_filter=codegen.*" \
   -e VENDOR_GTEST="ON"                    \
+  -e BUILD_LIBBPF="ON"                    \
   bpftrace-builder-focal "$(pwd)/build-codegen-update" Debug "$@"


### PR DESCRIPTION
Since libbpf is now required, it has to be installed in the container when doing codegen update, otherwise bpftrace does not compile.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
