### PR TITLE
add pton builtin

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -2212,6 +2212,7 @@ Tracing block I/O sizes > 0 bytes
 - `kstack([StackMode mode, ][int level])` - Kernel stack trace
 - `ustack([StackMode mode, ][int level])` - User stack trace
 - `ntop([int af, ]int|char[4|16] addr)` - Convert IP address data to text
+- `pton(const string *addr)` - Convert text IP address to byte array
 - `cat(char *filename)` - Print file content
 - `signal(char[] signal | u32 signal)` - Send a signal to the current task
 - `strncmp(char *s1, char *s2, int length)` - Compare first n characters of two strings
@@ -3179,6 +3180,36 @@ dropped privs to tcpdump
 10:23:44.674087 IP 22.128.74.231.63175 > 192.168.0.23.22: Flags [.], ack 3513221061, win 14009, options [nop,nop,TS val 721277750 ecr 3115333619], length 0
 10:23:45.823194 IP 100.101.2.146.53 > 192.168.0.23.46619: 17273 0/1/0 (130)
 10:23:45.823229 IP 100.101.2.146.53 > 192.168.0.23.46158: 45799 1/0/0 A 100.100.45.106 (60)
+```
+
+## 32. `pton()`: Convert text IP address to byte array
+
+Syntax: `pton(const string *addr)`
+
+This converts a text representation of an IPv4 or IPv6 address to byte array.
+`pton` infers the address family based on `.` or `:` in the given argument.
+`pton` comes in handy when we need to select packets with certain IP addresses.
+
+Examples:
+
+```
+# bpftrace -e 'tracepoint:tcp:tcp_retransmit_skb {
+  if (args->daddr_v6[0] == pton("::1")[0]) {
+    printf("first octet matched\n");
+  }
+}'
+Attaching 1 probe...
+first octet matched
+^C
+
+# bpftrace -e 'tracepoint:tcp:tcp_retransmit_skb {
+  if (args->daddr[0] == pton("127.0.0.1")[0]) {
+    printf("first octet matched\n");
+  }
+}'
+Attaching 1 probe...
+first octet matched
+^C
 ```
 
 # Map Functions

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1461,6 +1461,18 @@ SRC 18:C0:4D:08:2E:BB, DST 74:83:C2:7F:8C:FF
 If an integer or `char[4]` is given, ntop assumes IPv4, if a `char[16]` is given, ntop assumes IPv6.
 You can also pass the address type (e.g. AF_INET) explicitly as the first parameter.
 
+=== pton
+
+.variants
+* `char addr[4] pton(const string *addr_v4)`
+* `char addr[16] pton(const string *addr_v6)`
+
+*compile time*
+
+`pton` converts a text representation of an IPv4 or IPv6 address to byte array.
+`pton` infers the address family based on `.` or `:` in the given argument.
+`pton` comes in handy when we need to select packets with certain IP addresses.
+
 === override
 
 .variants

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1,4 +1,5 @@
 #include "semantic_analyser.h"
+#include <arpa/inet.h>
 
 #include <algorithm>
 #include <cstring>
@@ -816,6 +817,45 @@ void SemanticAnalyser::visit(Call &call)
           << call.func << "() argument must be 4 or 16 bytes in size";
 
     call.type = CreateInet(buffer_size);
+  }
+  else if (call.func == "pton")
+  {
+    if (!check_nargs(call, 1))
+      return;
+    std::string addr = bpftrace_.get_string_literal(call.vargs->at(0));
+    int af_type, addr_size;
+    // use '.' and ':' to determine the address family
+    if (addr.find(".") != std::string::npos)
+    {
+      af_type = AF_INET;
+      addr_size = 4;
+    }
+    else if (addr.find(":") != std::string::npos)
+    {
+      af_type = AF_INET6;
+      addr_size = 16;
+    }
+    else
+    {
+      LOG(ERROR, call.loc, err_)
+          << call.func
+          << "() expects an string argument of an IPv4/IPv6 address, got "
+          << addr;
+      return;
+    }
+
+    char dst[addr_size];
+    auto ret = inet_pton(af_type, addr.c_str(), &dst);
+    if (ret != 1)
+    {
+      LOG(ERROR, call.loc, err_)
+          << call.func << "() expects a valid IPv4/IPv6 address, got " << addr;
+      return;
+    }
+
+    auto elem_type = CreateUInt8();
+    call.type = CreateArray(addr_size, elem_type);
+    call.type.SetAS(AddrSpace::kernel);
   }
   else if (call.func == "join") {
     check_assignment(call, false, false, false);

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -38,7 +38,7 @@ vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#\*])+
 builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ctx|curtask|elapsed|func|gid|nsecs|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
-call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|sizeof|stats|str|strftime|strncmp|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput
+call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|sizeof|stats|str|strftime|strncmp|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton
 
 /* Don't add to this! Use builtin OR call not both */
 call_and_builtin kstack|ustack

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -222,6 +222,16 @@ EXPECT IP: 1.0.0.0, 127.0.0.1, 0.0.255.255, 255.255.0.0
 ARCH s390x|ppc64
 TIMEOUT 5
 
+NAME pton ipv4
+PROG i:ms:100 { printf("IP: %s\n", ntop(2, pton("127.0.0.1"))); exit(); }
+EXPECT IP: 127.0.0.1
+TIMEOUT 5
+
+NAME pton ipv6
+PROG i:ms:100 { printf("IP: %s\n", ntop(10, pton("::1"))); exit(); }
+EXPECT IP: ::1
+TIMEOUT 5
+
 NAME usym
 PROG i:ms:100 { @=usym(1); @a=@; exit(); }
 EXPECT ^@a: 0x1$


### PR DESCRIPTION
##### Description 

This pull request addressed the proposal in https://github.com/iovisor/bpftrace/issues/2248, added a new built-in function `pton`.

The `pton` converts text-formatted IP addresses to byte arrays, which is exactly reversed-version of `ntop`. It should come in handy when we need to select packets with certain IP addresses.


##### Plan

The current implementation only support comparison byte by byte, direct byte array comparison will be implemented in future pull requests. 

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
