### PR TITLE
Fix compound assignments with non-unary expr

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to
   - [#2250](https://github.com/iovisor/bpftrace/pull/2250)
 - Handle enum values in tracepoint format defs
   - [#2236](https://github.com/iovisor/bpftrace/pull/2236)
+- Fix compound assignments with non-unary expr
+  - [#2291](https://github.com/iovisor/bpftrace/pull/2293)
 
 #### Added
 #### Docs

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -319,12 +319,12 @@ assign_stmt:
                 }
         |       map ASSIGN expr      { $$ = new ast::AssignMapStatement($1, $3, false, @2); }
         |       var ASSIGN expr      { $$ = new ast::AssignVarStatement($1, $3, false, @2); }
-        |       map compound_op unary_expr
+        |       map compound_op expr
                 {
                   auto b = new ast::Binop($1, $2, $3, @2);
                   $$ = new ast::AssignMapStatement($1, b, true, @$);
                 }
-        |       var compound_op unary_expr
+        |       var compound_op expr
                 {
                   auto b = new ast::Binop($1, $2, $3, @2);
                   $$ = new ast::AssignVarStatement($1, b, true, @$);

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -381,6 +381,23 @@ TEST(semantic_analyser, compound_variable_assignments)
        "    int: 1\n");
 }
 
+TEST(Parser, compound_variable_assignment_binary_expr)
+{
+  test("kprobe:f { $a = 0; $a += 2 - 1 }",
+       "Program\n"
+       " kprobe:f\n"
+       "  =\n"
+       "   variable: $a\n"
+       "   int: 0\n"
+       "  =\n"
+       "   variable: $a\n"
+       "   +\n"
+       "    variable: $a\n"
+       "    -\n"
+       "     int: 2\n"
+       "     int: 1\n");
+}
+
 TEST(Parser, compound_map_assignments)
 {
   test("kprobe:f { @a <<= 1 }",
@@ -463,6 +480,20 @@ TEST(Parser, compound_map_assignments)
        "   ^\n"
        "    map: @a\n"
        "    int: 1\n");
+}
+
+TEST(Parser, compound_map_assignment_binary_expr)
+{
+  test("kprobe:f { @a += 2 - 1 }",
+       "Program\n"
+       " kprobe:f\n"
+       "  =\n"
+       "   map: @a\n"
+       "   +\n"
+       "    map: @a\n"
+       "    -\n"
+       "     int: 2\n"
+       "     int: 1\n");
 }
 
 TEST(Parser, integer_sizes)


### PR DESCRIPTION
Fix parser to accept any expression as the right side of a compound
operation, not only an unary expression.

Fixes #2291

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
