### PR TITLE
Replace commas in BPF program name

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -680,8 +680,9 @@ void AttachedProbe::load_prog(BPFfeature &feature)
     // start the name after the probe type, after ':'
     if (auto last_colon = name.rfind(':'); last_colon != std::string::npos)
       name = name.substr(last_colon + 1);
-    // replace '+' by '.'
+    // replace '+' and ',' by '.'
     std::replace(name.begin(), name.end(), '+', '.');
+    std::replace(name.begin(), name.end(), ',', '.');
     // remove quotes
     name.erase(std::remove(name.begin(), name.end(), '"'), name.end());
 

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -256,6 +256,11 @@ PROG interval:s:1 { exit(); } END { printf("end"); }
 EXPECT end
 TIMEOUT 2
 
+NAME BEGIN,END
+PROG BEGIN,END { printf("Hello\n"); exit(); }
+EXPECT Hello\nHello
+TIMEOUT 2
+
 # The "probe" builtin forces bpftrace to generate one BPF function for each
 # match and so we should fail on exceeding BPFTRACE_MAX_BPF_PROGS.
 NAME bpf_programs_limit


### PR DESCRIPTION
`bpf_prog_load` does not accept commas in the program name, which may cause failures when attaching, e.g. to `BEGIN,END`. This fixes the issue by replacing commas by dots, which are accepted.

Fixes #2294.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
