### PR TITLE
Fix invalid LLVM IR in join builtin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
           TYPE: Release
           LLVM_VERSION: 14
           RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,call.join,call.join_delim,intptrcast.Casting ints,json-output.join_delim,variable.32-bit tracepoint arg
+          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,intptrcast.Casting ints,variable.32-bit tracepoint arg
           TOOLS_TEST_OLDVERSION: biosnoop.bt
           BASE: focal
           VENDOR_GTEST: ON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to
   - [#2236](https://github.com/iovisor/bpftrace/pull/2236)
 - Fix compound assignments with non-unary expr
   - [#2291](https://github.com/iovisor/bpftrace/pull/2293)
+- Fix invalid LLVM IR in join builtin
+  - [#2296](https://github.com/iovisor/bpftrace/pull/2296)
 
 #### Added
 #### Docs


### PR DESCRIPTION
Add pointer casts to store instruction where required and use GEP
instructions to do pointer arithmetic instead of incorrect use of
add instruction.

Fixes #2222

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
