### PR TITLE
Add option to verify LLVM IR generated by bpftrace

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -12,6 +12,7 @@
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/LegacyPassManager.h>
 #include <llvm/IR/Metadata.h>
+#include <llvm/IR/Verifier.h>
 #if LLVM_VERSION_MAJOR >= 14
 #include <llvm/Passes/PassBuilder.h>
 #endif
@@ -3212,6 +3213,17 @@ void CodegenLLVM::optimize()
 #endif
 
   state_ = State::OPT;
+}
+
+bool CodegenLLVM::verify(void)
+{
+  bool ret = llvm::verifyModule(*module_, &errs());
+  if (ret)
+  {
+    /* verifyModule doesn't end output with end of line of line, print it now */
+    std::cerr << std::endl;
+  }
+  return !ret;
 }
 
 std::unique_ptr<BpfOrc> CodegenLLVM::emit(void)

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -75,6 +75,7 @@ public:
 
   void generate_ir(void);
   void optimize(void);
+  bool verify(void);
   std::unique_ptr<BpfOrc> emit(void);
   void emit_elf(const std::string &filename);
   // Combine generate_ir, optimize and emit into one call

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -192,6 +192,26 @@ bool get_uint64_env_var(const std::string &str, uint64_t &dest)
   return true;
 }
 
+bool get_bool_env_var(const std::string &str, bool &dest, bool neg)
+{
+  if (const char *env_p = std::getenv(str.c_str()))
+  {
+    std::string s(env_p);
+    if (s == "1")
+      dest = !neg;
+    else if (s == "0")
+      dest = neg;
+    else
+    {
+      LOG(ERROR) << "Env var '" << str
+                 << "' did not contain a "
+                    "valid value (0 or 1).";
+      return false;
+    }
+  }
+  return true;
+}
+
 std::string get_pid_exe(const std::string &pid)
 {
   std::error_code ec;

--- a/src/utils.h
+++ b/src/utils.h
@@ -138,6 +138,7 @@ static std::vector<std::string> UNSAFE_BUILTIN_FUNCS = {
 static std::vector<std::string> COMPILE_TIME_FUNCS = { "cgroupid" };
 
 bool get_uint64_env_var(const ::std::string &str, uint64_t &dest);
+bool get_bool_env_var(const ::std::string &str, bool &dest, bool neg = false);
 std::string get_pid_exe(pid_t pid);
 std::string get_pid_exe(const std::string &pid);
 bool has_wildcard(const std::string &str);


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

As proposed in #2297, this PR implements an option to verify generated LLVM IR via setting the `BPFTRACE_VERIFY_LLVM_IR` environemntal variable to `1`. An environmental variable is used to easily allow this to be set in tests.

~It also enables this option for runtime tests, detecting invalid code that has to be fixed before merging this PR to make the tests pass.~

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
