### PR TITLE
CI: re-enable tests depending on BTF

### DIFF
--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -124,7 +124,7 @@ class Runner(object):
         bpffeature = {}
         bpffeature["loop"] = output.find("Loop support: yes") != -1
         bpffeature["probe_read_kernel"] = output.find("probe_read_kernel: yes") != -1
-        bpffeature["btf"] = output.find("btf (depends on Build:libbpf): yes") != -1
+        bpffeature["btf"] = output.find("btf: yes") != -1
         bpffeature["kfunc"] = output.find("kfunc: yes") != -1
         bpffeature["dpath"] = output.find("dpath: yes") != -1
         bpffeature["uprobe_refcount"] = \


### PR DESCRIPTION
#2265 changed the format of `bpftrace --info` but the change hasn't been reflected in the runtime test suite which greps info's output to determine enabled features. Due to this, all runtime tests depending on BTF were skipped.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
