### PR TITLE
CMake: detect presence of 'xxd' command

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -45,12 +45,15 @@ add_executable(bpftrace_test
 )
 
 # Regenerate DWARF data for unit tests
-add_custom_target(testing_debuginfo_data
-        COMMAND
-        ${CMAKE_COMMAND}
-        -DDATA_SOURCE_DIR="${CMAKE_SOURCE_DIR}/tests/data"
-        -P ${CMAKE_SOURCE_DIR}/tests/data/generate_debuginfo_data.cmake)
-add_dependencies(bpftrace_test testing_debuginfo_data)
+if (LIBDW_FOUND)
+  find_program(XXD xxd REQUIRED)
+  add_custom_target(testing_debuginfo_data
+          COMMAND
+          ${CMAKE_COMMAND}
+          -DDATA_SOURCE_DIR="${CMAKE_SOURCE_DIR}/tests/data"
+          -P ${CMAKE_SOURCE_DIR}/tests/data/generate_debuginfo_data.cmake)
+  add_dependencies(bpftrace_test testing_debuginfo_data)
+endif()
 
 target_compile_definitions(bpftrace_test PRIVATE TEST_CODEGEN_LOCATION="${CMAKE_SOURCE_DIR}/tests/codegen/llvm/")
 target_link_libraries(bpftrace_test libbpftrace)


### PR DESCRIPTION
Coming from issue reported in discussion #2290.

`xxd` is used to create DWARF data for unit testing. It is used inside `add_custom_target`, which, in case `xxd` doesn't exist, fails silently.

This fixes the issue by requiring presence of `xxd` from CMake to report a message to the user.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
