### PR TITLE
add debugf builtin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to
   - [#2279](https://github.com/iovisor/bpftrace/pull/2279)
 - Add builtin: `pton`
   - [#2289](https://github.com/iovisor/bpftrace/pull/2289)
+- Add builtin: `debugf`
+  - [#2307](https://github.com/iovisor/bpftrace/pull/2307)
 
 #### Changed
 - Move from BCC to libbpf

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1042,6 +1042,28 @@ void IRBuilderBPF::CreatePerfEventOutput(Value *ctx,
                    loc);
 }
 
+void IRBuilderBPF::CreateTracePrintk(Value *fmt_ptr,
+                                     Value *fmt_size,
+                                     const std::vector<Value *> &values,
+                                     const location &loc)
+{
+  std::vector<Value *> args = { fmt_ptr, fmt_size };
+  for (auto val : values)
+  {
+    args.push_back(val);
+  }
+
+  // long bpf_trace_printk(const char *fmt, u32 fmt_size, ...)
+  FunctionType *traceprintk_func_type = FunctionType::get(
+      getInt64Ty(), { getInt8PtrTy(), getInt32Ty() }, true);
+
+  CreateHelperCall(libbpf::BPF_FUNC_trace_printk,
+                   traceprintk_func_type,
+                   args,
+                   "trace_printk",
+                   &loc);
+}
+
 void IRBuilderBPF::CreateSignal(Value *ctx, Value *sig, const location &loc)
 {
   // long bpf_send_signal(u32 sig)

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -137,6 +137,10 @@ public:
                              Value *data,
                              size_t size,
                              const location *loc = nullptr);
+  void CreateTracePrintk(Value *fmt,
+                         Value *fmt_size,
+                         const std::vector<Value *> &values,
+                         const location &loc);
   void        CreateSignal(Value *ctx, Value *sig, const location &loc);
   void        CreateOverrideReturn(Value *ctx, Value *rc);
   void        CreateHelperError(Value *ctx, Value *return_value, libbpf::bpf_func_id func_id, const location& loc);

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -196,7 +196,7 @@ private:
   void createIncDec(Unop &unop);
 
   // Return a lambda that has captured-by-value CodegenLLVM's async id state
-  // (ie `printf_id_`, `seq_printf_id_`, etc.).  Running the returned lambda
+  // (ie `printf_id_`, `mapped_printf_id_`, etc.).  Running the returned lambda
   // will restore `CodegenLLVM`s async id state back to when this function was
   // first called.
   std::function<void()> create_reset_ids();
@@ -226,8 +226,7 @@ private:
 
   std::map<std::string, AllocaInst *> variables_;
   int printf_id_ = 0;
-  int seq_printf_id_ = 0;
-  int debugf_id_ = 0;
+  int mapped_printf_id_ = 0;
   int time_id_ = 0;
   int cat_id_ = 0;
   int strftime_id_ = 0;

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -227,6 +227,7 @@ private:
   std::map<std::string, AllocaInst *> variables_;
   int printf_id_ = 0;
   int seq_printf_id_ = 0;
+  int debugf_id_ = 0;
   int time_id_ = 0;
   int cat_id_ = 0;
   int strftime_id_ = 0;

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -38,8 +38,7 @@ ResourceAnalyser::ResourceAnalyser(Node *root, std::ostream &out)
 std::optional<RequiredResources> ResourceAnalyser::analyse()
 {
   Visit(*root_);
-  prepare_seq_printf_ids();
-  prepare_debugf_ids();
+  prepare_mapped_printf_ids();
 
   if (!err_.str().empty())
   {
@@ -103,7 +102,7 @@ void ResourceAnalyser::visit(Call &call)
     {
       if (single_provider_type_postsema(probe_) == ProbeType::iter)
       {
-        resources_.seq_printf_args.emplace_back(fmtstr, args);
+        resources_.mapped_printf_args.emplace_back(fmtstr, args);
         resources_.needs_data_map = true;
       }
       else
@@ -113,7 +112,7 @@ void ResourceAnalyser::visit(Call &call)
     }
     else if (call.func == "debugf")
     {
-      resources_.debugf_args.emplace_back(fmtstr, args);
+      resources_.mapped_printf_args.emplace_back(fmtstr, args);
       resources_.needs_data_map = true;
     }
     else if (call.func == "system")
@@ -210,28 +209,15 @@ void ResourceAnalyser::visit(Map &map)
   resources_.map_keys[map.ident] = map.key_type;
 }
 
-void ResourceAnalyser::prepare_seq_printf_ids()
+void ResourceAnalyser::prepare_mapped_printf_ids()
 {
   int idx = 0;
 
-  for (auto &arg : resources_.seq_printf_args)
+  for (auto &arg : resources_.mapped_printf_args)
   {
     assert(resources_.needs_data_map);
     auto len = std::get<0>(arg).size();
-    resources_.seq_printf_ids.push_back({ idx, len + 1 });
-    idx += len + 1;
-  }
-}
-
-void ResourceAnalyser::prepare_debugf_ids()
-{
-  int idx = 0;
-
-  for (auto &arg : resources_.debugf_args)
-  {
-    assert(resources_.needs_data_map);
-    auto len = std::get<0>(arg).size();
-    resources_.debugf_ids.push_back({ idx, len + 1 });
+    resources_.mapped_printf_ids.push_back({ idx, len + 1 });
     idx += len + 1;
   }
 }

--- a/src/ast/passes/resource_analyser.h
+++ b/src/ast/passes/resource_analyser.h
@@ -36,6 +36,7 @@ private:
   // map. This method loads `RequiredResources::seq_printf_ids` with the
   // starting indicies and lengths of each format string in the data map.
   void prepare_seq_printf_ids();
+  void prepare_debugf_ids();
 
   RequiredResources resources_;
   Node *root_;

--- a/src/ast/passes/resource_analyser.h
+++ b/src/ast/passes/resource_analyser.h
@@ -32,11 +32,10 @@ private:
   void visit(Call &call) override;
   void visit(Map &map) override;
 
-  // All the seq_printf format strings are stored head to tail in a data
-  // map. This method loads `RequiredResources::seq_printf_ids` with the
+  // seq_printf, debugf format strings are stored head to tail in a data
+  // map. This method loads `RequiredResources::mapped_printf_ids` with the
   // starting indicies and lengths of each format string in the data map.
-  void prepare_seq_printf_ids();
-  void prepare_debugf_ids();
+  void prepare_mapped_printf_ids();
 
   RequiredResources resources_;
   Node *root_;

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -955,7 +955,8 @@ void SemanticAnalyser::visit(Call &call)
     }
     call.type = CreateUInt64();
   }
-  else if (call.func == "printf" || call.func == "system" || call.func == "cat")
+  else if (call.func == "printf" || call.func == "system" ||
+           call.func == "cat" || call.func == "debugf")
   {
     check_assignment(call, false, false, false);
     if (check_varargs(call, 1, 128))
@@ -989,12 +990,18 @@ void SemanticAnalyser::visit(Call &call)
                   },
           });
         }
-        std::string msg = validate_format_string(fmt.str, args);
+        std::string msg = validate_format_string(fmt.str, args, call.func);
         if (msg != "")
         {
           LOG(ERROR, call.loc, err_) << msg;
         }
       }
+    }
+    if (call.func == "debugf" && is_final_pass())
+    {
+      LOG(WARNING, call.loc, out_)
+          << "The debugf() builtin is not recommended for production use. For "
+             "more information see bpf_trace_printk in bpf-helpers(7).";
     }
 
     call.type = CreateNone();

--- a/src/format_string.h
+++ b/src/format_string.h
@@ -12,7 +12,8 @@ namespace bpftrace {
  * validate_fmt makes sure that the type are valid for the format specifiers
  */
 std::string validate_format_string(const std::string &fmt,
-                                   std::vector<Field> args);
+                                   std::vector<Field> args,
+                                   const std::string call_func);
 
 struct Field;
 /*

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -38,7 +38,7 @@ vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#\*])+
 builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ctx|curtask|elapsed|func|gid|nsecs|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
-call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|sizeof|stats|str|strftime|strncmp|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton
+call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|sizeof|stats|str|strftime|strncmp|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf
 
 /* Don't add to this! Use builtin OR call not both */
 call_and_builtin kstack|ustack

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -265,10 +265,8 @@ std::string to_string(MapManager::Type t)
       return "join";
     case MapManager::Type::Elapsed:
       return "elapsed";
-    case MapManager::Type::SeqPrintfData:
-      return "seq_printf_data";
-    case MapManager::Type::DebugfData:
-      return "debugf_data";
+    case MapManager::Type::MappedPrintfData:
+      return "mapped_printf_data";
   }
   return {}; // unreached
 }

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -267,6 +267,8 @@ std::string to_string(MapManager::Type t)
       return "elapsed";
     case MapManager::Type::SeqPrintfData:
       return "seq_printf_data";
+    case MapManager::Type::DebugfData:
+      return "debugf_data";
   }
   return {}; // unreached
 }

--- a/src/mapmanager.h
+++ b/src/mapmanager.h
@@ -60,8 +60,7 @@ public:
     PerfEvent,
     Join,
     Elapsed,
-    SeqPrintfData,
-    DebugfData,
+    MappedPrintfData,
   };
 
   void Set(Type t, std::unique_ptr<IMap> map);

--- a/src/mapmanager.h
+++ b/src/mapmanager.h
@@ -61,6 +61,7 @@ public:
     Join,
     Elapsed,
     SeqPrintfData,
+    DebugfData,
   };
 
   void Set(Type t, std::unique_ptr<IMap> map);

--- a/src/printf_format_types.h
+++ b/src/printf_format_types.h
@@ -73,6 +73,22 @@ const std::unordered_map<std::string, Type> printf_format_types = {
   {"tp", Type::integer}
 };
 
+// bpf_trace_printk_format_types is a subset of printf_format_types that contains valid types for bpf_trace_printk()
+// see iovisor/bcc BTypeVisitor::checkFormatSpecifiers
+const std::unordered_map<std::string, Type> bpf_trace_printk_format_types = {
+    {"d", Type::integer},
+    {"u", Type::integer},
+    {"x", Type::integer},
+    {"ld", Type::integer},
+    {"lu", Type::integer},
+    {"lx", Type::integer},
+    {"lld", Type::integer},
+    {"llu", Type::integer},
+    {"llx", Type::integer},
+    {"p", Type::integer},
+    {"s", Type::string}
+};
+
 // clang-format on
 
 } // namespace bpftrace

--- a/src/required_resources.cpp
+++ b/src/required_resources.cpp
@@ -94,15 +94,10 @@ int RequiredResources::create_maps_impl(BPFtrace &bpftrace, bool fake)
   if (needs_data_map)
   {
     int ret;
-    auto map = prepareFormatStringDataMap<T>(seq_printf_args, &ret);
+    auto map = prepareFormatStringDataMap<T>(mapped_printf_args, &ret);
     if (is_invalid_map(map->mapfd_) || (!fake && ret == -1))
       failed_maps += 1;
-    bpftrace.maps.Set(MapManager::Type::SeqPrintfData, std::move(map));
-
-    map = prepareFormatStringDataMap<T>(debugf_args, &ret);
-    if (is_invalid_map(map->mapfd_) || (!fake && ret == -1))
-      failed_maps += 1;
-    bpftrace.maps.Set(MapManager::Type::DebugfData, std::move(map));
+    bpftrace.maps.Set(MapManager::Type::MappedPrintfData, std::move(map));
   }
   {
     auto map = std::make_unique<T>(libbpf::BPF_MAP_TYPE_PERF_EVENT_ARRAY);

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -78,6 +78,8 @@ public:
   std::vector<std::tuple<FormatString, std::vector<Field>>> system_args;
   std::vector<std::tuple<FormatString, std::vector<Field>>> seq_printf_args;
   std::vector<std::tuple<int, int>> seq_printf_ids;
+  std::vector<std::tuple<FormatString, std::vector<Field>>> debugf_args;
+  std::vector<std::tuple<int, int>> debugf_ids;
   std::vector<std::string> join_args;
   std::vector<std::string> time_args;
   std::vector<std::string> strftime_args;
@@ -116,6 +118,10 @@ public:
 private:
   template <typename T>
   int create_maps_impl(BPFtrace &bpftrace, bool fake);
+  template <typename T>
+  std::unique_ptr<T> prepareFormatStringDataMap(
+      const std::vector<std::tuple<FormatString, std::vector<Field>>> &args,
+      int *ret);
 
   friend class cereal::access;
   template <typename Archive>
@@ -132,6 +138,8 @@ private:
             // Hard to annotate flex types, so skip
             // helper_error_info,
             printf_args,
+            debugf_args,
+            debugf_ids,
             probe_ids,
             map_vals,
             lhist_args,

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -76,10 +76,11 @@ public:
 
   // Async argument metadata
   std::vector<std::tuple<FormatString, std::vector<Field>>> system_args;
-  std::vector<std::tuple<FormatString, std::vector<Field>>> seq_printf_args;
-  std::vector<std::tuple<int, int>> seq_printf_ids;
-  std::vector<std::tuple<FormatString, std::vector<Field>>> debugf_args;
-  std::vector<std::tuple<int, int>> debugf_ids;
+  // mapped_printf_args stores seq_printf, debugf arguments
+  std::vector<std::tuple<FormatString, std::vector<Field>>> mapped_printf_args;
+  // mapped_printf_ids stores the starting indices and length of each format
+  // string in the data map of MapManager::Type::MappedPrintfData
+  std::vector<std::tuple<int, int>> mapped_printf_ids;
   std::vector<std::string> join_args;
   std::vector<std::string> time_args;
   std::vector<std::string> strftime_args;
@@ -128,8 +129,8 @@ private:
   void serialize(Archive &archive)
   {
     archive(system_args,
-            seq_printf_args,
-            seq_printf_ids,
+            mapped_printf_args,
+            mapped_printf_ids,
             join_args,
             time_args,
             strftime_args,
@@ -138,8 +139,6 @@ private:
             // Hard to annotate flex types, so skip
             // helper_error_info,
             printf_args,
-            debugf_args,
-            debugf_ids,
             probe_ids,
             map_vals,
             lhist_args,

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -412,3 +412,18 @@ EXPECT OK
 REQUIRES_FEATURE skboutput
 TIMEOUT 5
 MIN_KERNEL 5.5
+
+NAME debugf
+RUN echo > /sys/kernel/debug/tracing/trace; {{BPFTRACE}} -e 'i:ms:1 { debugf("debugf"); exit();}'; cat /sys/kernel/debug/tracing/trace
+EXPECT bpf_trace_printk: debugf
+TIMEOUT 3
+
+NAME debugf_with_arguments
+RUN echo > /sys/kernel/debug/tracing/trace; {{BPFTRACE}} -e 'i:ms:1 { debugf("debugf %s %d %x", "a", 1, 16); exit();}'; cat /sys/kernel/debug/tracing/trace
+EXPECT bpf_trace_printk: debugf a 1 10
+TIMEOUT 3
+
+NAME debugf_with_seq_printf
+RUN echo > /sys/kernel/debug/tracing/trace; {{BPFTRACE}} -e 'i:ms:1 { printf("printf %d", 0); debugf("debugf %d", 1); exit();}'; cat /sys/kernel/debug/tracing/trace
+EXPECT bpf_trace_printk: debugf 1
+TIMEOUT 3


### PR DESCRIPTION
This PR implements the builtin function `debugf`, which we've discussed earlier in https://github.com/iovisor/bpftrace/issues/2300

This PR is currently in RFC status, comments are welcomed. At least we should decide whether documentation is needed.

##### Example
```bash
[root@test build]# bpftrace -e 'i:s:1 { debugf("hello"); exit();}'
stdin:1:9-24: WARNING: The debugf() builtin is not recommended for production use. For more information see bpf_trace_printk in bpf-helpers(7).
i:s:1 { debugf("hello"); exit();}
        ~~~~~~~~~~~~~~~
Attaching 1 probe...


[root@test build]# cat /sys/kernel/debug/tracing/trace
          <idle>-0       [000] d.h. 880121.845861: bpf_trace_printk: hello
```

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
