### PR TITLE
Fix lexer buffer size check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ and this project adheres to
   - [#2291](https://github.com/iovisor/bpftrace/pull/2293)
 - Fix invalid LLVM IR in join builtin
   - [#2296](https://github.com/iovisor/bpftrace/pull/2296)
+- Fix lexer buffer size check
+  - [#2313](https://github.com/iovisor/bpftrace/pull/2313)
 
 #### Added
 #### Docs

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -218,7 +218,7 @@ struct|union|enum       yy_push_state(STRUCT, yyscanner); buffer.clear(); struct
                             }
                             else
                             {
-                              int leng = yyleng;
+                              int leng = YY_BUF_SIZE;
                               std::string original_s(s);
                               std::string original_yytext(yytext);
                               for (z=strlen(s) - 1; z >= 0; z--){


### PR DESCRIPTION
Use YY_BUF_SIZE instead of yyleng to correctly get the size of flex
buffer in recursive macro processing.

Fixes #2304

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
