### PR TITLE
Fix invalid LLVM IR as detected by tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
           TYPE: Release
           LLVM_VERSION: 14
           RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,intptrcast.Casting ints,variable.32-bit tracepoint arg
+          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
           TOOLS_TEST_OLDVERSION: biosnoop.bt
           BASE: focal
           VENDOR_GTEST: ON

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to
   - [#2296](https://github.com/iovisor/bpftrace/pull/2296)
 - Fix lexer buffer size check
   - [#2313](https://github.com/iovisor/bpftrace/pull/2313)
+- Fix invalid LLVM IR as detected by tests
+  - [#2316](https://github.com/iovisor/bpftrace/pull/2316)
 
 #### Added
 #### Docs

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1267,7 +1267,7 @@ void IRBuilderBPF::CreatePath(Value *ctx,
 void IRBuilderBPF::CreateSeqPrintf(Value *ctx,
                                    Value *fmt,
                                    Value *fmt_size,
-                                   AllocaInst *data,
+                                   Value *data,
                                    Value *data_len,
                                    const location &loc)
 {

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -156,7 +156,7 @@ public:
   void CreateSeqPrintf(Value *ctx,
                        Value *fmt,
                        Value *fmt_size,
-                       AllocaInst *data,
+                       Value *data,
                        Value *data_len,
                        const location &loc);
 

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -612,7 +612,14 @@ void CodegenLLVM::visit(Call &call)
     AllocaInst *buf = b_.CreateAllocaBPF(bpftrace_.strlen_, "path");
     b_.CREATE_MEMSET(buf, b_.getInt8(0), bpftrace_.strlen_, 1);
     call.vargs->front()->accept(*this);
-    b_.CreatePath(ctx_, buf, expr_, call.loc);
+    b_.CreatePath(ctx_,
+                  buf,
+                  b_.CreateCast(expr_->getType()->isPointerTy()
+                                    ? Instruction::BitCast
+                                    : Instruction::IntToPtr,
+                                expr_,
+                                b_.getInt8PtrTy()),
+                  call.loc);
     expr_ = buf;
     expr_deleter_ = [this, buf]() { b_.CreateLifetimeEnd(buf); };
   }

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -3431,7 +3431,6 @@ void CodegenLLVM::probereadDatastructElem(Value *src_data,
       expr_ = b_.CreateLoad(dst_type,
                             b_.CreateIntToPtr(src, dst_type->getPointerTo()),
                             true);
-      expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), elem_type.IsSigned());
 
       // check context access for iter probes (required by kernel)
       if (probetype(current_attach_point_->provider) == ProbeType::iter)

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1590,9 +1590,7 @@ void CodegenLLVM::unop_ptr(Unop &unop)
         int size = unop.type.IsIntegerTy() ? et->GetIntBitWidth() / 8 : 8;
         AllocaInst *dst = b_.CreateAllocaBPF(*et, "deref");
         b_.CreateProbeRead(ctx_, dst, size, expr_, type.GetAS(), unop.loc);
-        expr_ = b_.CreateIntCast(b_.CreateLoad(b_.GetType(*et), dst),
-                                 b_.getInt64Ty(),
-                                 unop.type.IsSigned());
+        expr_ = b_.CreateLoad(b_.GetType(*et), dst);
         b_.CreateLifetimeEnd(dst);
       }
       break;

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2657,10 +2657,13 @@ AllocaInst *CodegenLLVM::getMultiMapKey(Map &map,
     Value *offset_val = b_.CreateGEP(key_type,
                                      key,
                                      { b_.getInt64(0), b_.getInt64(offset) });
+    Value *offset_val_cast = b_.CreatePointerCast(
+        offset_val, extra_key->getType()->getPointerTo());
+
     if (aligned)
-      b_.CreateStore(extra_key, offset_val);
+      b_.CreateStore(extra_key, offset_val_cast);
     else
-      b_.createAlignedStore(extra_key, offset_val, 1);
+      b_.createAlignedStore(extra_key, offset_val_cast, 1);
   }
 
   return key;

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -900,8 +900,12 @@ void CodegenLLVM::visit(Call &call)
       Value *fmt = b_.CreateAdd(map_data, b_.getInt64(idx));
 
       // and finally the seq_printf call
-      b_.CreateSeqPrintf(
-          ctx_, fmt, b_.getInt64(size), data, b_.getInt64(data_size), call.loc);
+      b_.CreateSeqPrintf(ctx_,
+                         b_.CreateIntToPtr(fmt, b_.getInt8PtrTy()),
+                         b_.getInt32(size),
+                         b_.CreatePointerCast(data, b_.getInt8PtrTy()),
+                         b_.getInt32(data_size),
+                         call.loc);
 
       seq_printf_id_++;
     }

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -136,9 +136,7 @@ private:
 
   [[nodiscard]] ScopedExprDeleter accept(Node *node);
   [[nodiscard]] std::tuple<Value *, ScopedExprDeleter> getMapKey(Map &map);
-  AllocaInst *getMultiMapKey(Map &map,
-                             const std::vector<Value *> &extra_keys,
-                             size_t extra_keys_size);
+  AllocaInst *getMultiMapKey(Map &map, const std::vector<Value *> &extra_keys);
 
   void compareStructure(SizedType &our_type, llvm::Type *llvm_type);
 

--- a/tests/codegen/llvm/builtin_ctx_field.ll
+++ b/tests/codegen/llvm/builtin_ctx_field.ll
@@ -46,13 +46,13 @@ entry:
   %13 = add i64 %12, 0
   %14 = inttoptr i64 %13 to i16*
   %15 = load volatile i16, i16* %14, align 2
-  %16 = sext i16 %15 to i64
-  %17 = bitcast i64* %"@b_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
+  %16 = bitcast i64* %"@b_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
   store i64 0, i64* %"@b_key", align 8
+  %17 = sext i16 %15 to i64
   %18 = bitcast i64* %"@b_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
-  store i64 %16, i64* %"@b_val", align 8
+  store i64 %17, i64* %"@b_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %update_elem2 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@b_key", i64* %"@b_val", i64 0)
   %19 = bitcast i64* %"@b_val" to i8*
@@ -64,13 +64,13 @@ entry:
   %23 = add i64 %22, 0
   %24 = inttoptr i64 %23 to i8*
   %25 = load volatile i8, i8* %24, align 1
-  %26 = sext i8 %25 to i64
-  %27 = bitcast i64* %"@c_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %27)
+  %26 = bitcast i64* %"@c_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %26)
   store i64 0, i64* %"@c_key", align 8
+  %27 = sext i8 %25 to i64
   %28 = bitcast i64* %"@c_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %28)
-  store i64 %26, i64* %"@c_val", align 8
+  store i64 %27, i64* %"@c_val", align 8
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %update_elem4 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo3, i64* %"@c_key", i64* %"@c_val", i64 0)
   %29 = bitcast i64* %"@c_val" to i8*

--- a/tests/codegen/llvm/call_uptr_1.ll
+++ b/tests/codegen/llvm/call_uptr_1.ll
@@ -18,15 +18,15 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   %probe_read_user = call i64 inttoptr (i64 112 to i64 (i16*, i32, i64)*)(i16* %deref, i32 2, i64 %arg0)
   %4 = load i16, i16* %deref, align 2
-  %5 = sext i16 %4 to i64
-  %6 = bitcast i16* %deref to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %5 = bitcast i16* %deref to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   store i64 0, i64* %"@_key", align 8
+  %7 = sext i16 %4 to i64
   %8 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  store i64 %5, i64* %"@_val", align 8
+  store i64 %7, i64* %"@_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
   %9 = bitcast i64* %"@_val" to i8*

--- a/tests/codegen/llvm/call_uptr_2.ll
+++ b/tests/codegen/llvm/call_uptr_2.ll
@@ -18,15 +18,15 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   %probe_read_user = call i64 inttoptr (i64 112 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %arg0)
   %4 = load i32, i32* %deref, align 4
-  %5 = sext i32 %4 to i64
-  %6 = bitcast i32* %deref to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %5 = bitcast i32* %deref to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %6 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   store i64 0, i64* %"@_key", align 8
+  %7 = sext i32 %4 to i64
   %8 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  store i64 %5, i64* %"@_val", align 8
+  store i64 %7, i64* %"@_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
   %9 = bitcast i64* %"@_val" to i8*

--- a/tests/codegen/llvm/intptrcast_assign_var.ll
+++ b/tests/codegen/llvm/intptrcast_assign_var.ll
@@ -18,14 +18,14 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %deref)
   %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %deref, i32 1, i64 %3)
   %4 = load i8, i8* %deref, align 1
-  %5 = sext i8 %4 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %deref)
-  %6 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  %5 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
   store i64 0, i64* %"@_key", align 8
+  %6 = sext i8 %4 to i64
   %7 = bitcast i64* %"@_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  store i64 %5, i64* %"@_val", align 8
+  store i64 %6, i64* %"@_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
   %8 = bitcast i64* %"@_val" to i8*

--- a/tests/codegen/llvm/intptrcast_call.ll
+++ b/tests/codegen/llvm/intptrcast_call.ll
@@ -45,8 +45,8 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %deref)
   %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i8*, i32, i64)*)(i8* %deref, i32 1, i64 %9)
   %10 = load i8, i8* %deref, align 1
-  %11 = sext i8 %10 to i64
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %deref)
+  %11 = sext i8 %10 to i64
   %12 = add i64 %11, %4
   store i64 %12, i64* %"@_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)

--- a/tests/codegen/llvm/ptr_to_ptr.ll
+++ b/tests/codegen/llvm/ptr_to_ptr.ll
@@ -35,11 +35,11 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   %probe_read_kernel2 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %deref1, i32 4, i64 %7)
   %10 = load i32, i32* %deref1, align 4
-  %11 = sext i32 %10 to i64
-  %12 = bitcast i32* %deref1 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %11, i64* %13, align 8
+  %11 = bitcast i32* %deref1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
+  %13 = sext i32 %10 to i64
+  store i64 %13, i64* %12, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 16)
   %14 = bitcast %printf_t* %printf_args to i8*

--- a/tests/codegen/llvm/struct_integer_ptr_1.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_1.ll
@@ -32,15 +32,15 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %7)
   %10 = load i32, i32* %deref, align 4
-  %11 = sext i32 %10 to i64
-  %12 = bitcast i32* %deref to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %11 = bitcast i32* %deref to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
   store i64 0, i64* %"@x_key", align 8
+  %13 = sext i32 %10 to i64
   %14 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
-  store i64 %11, i64* %"@x_val", align 8
+  store i64 %13, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
   %15 = bitcast i64* %"@x_val" to i8*

--- a/tests/codegen/llvm/struct_integer_ptr_2.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_2.ll
@@ -32,15 +32,15 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %deref, i32 4, i64 %7)
   %10 = load i32, i32* %deref, align 4
-  %11 = sext i32 %10 to i64
-  %12 = bitcast i32* %deref to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %11 = bitcast i32* %deref to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
   store i64 0, i64* %"@x_key", align 8
+  %13 = sext i32 %10 to i64
   %14 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
-  store i64 %11, i64* %"@x_val", align 8
+  store i64 %13, i64* %"@x_val", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
   %15 = bitcast i64* %"@x_val" to i8*

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -216,6 +216,7 @@ class Runner(object):
                 'test': test.name,
                 '__BPFTRACE_NOTIFY_PROBES_ATTACHED': '1',
                 '__BPFTRACE_NOTIFY_AOT_PORTABILITY_DISABLED': '1',
+                'BPFTRACE_VERIFY_LLVM_IR': '1',
             }
             env.update(test.env)
             p = subprocess.Popen(


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->
With the option to verify LLVM IR generated by runtime tests (implemented in #2298), several issues with codegen were found. This PR includes commits to fix them, along with enabling LLVM IR verification in tests and enabling remaining failing LLVM 14 tests. The reasoning behind each fix is explained in the individual commits.

Closes #2297

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
