### PR TITLE
Static build: install libbpf headers

### DIFF
--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -20,7 +20,6 @@ jobs:
           BASE: bionic
           DISTRO: ubuntu-glibc
           VENDOR_GTEST: ON
-          BUILD_LIBBPF: ON
           BCC_REF: v0.23.0
           ENABLE_SKB_OUTPUT: ON
         - TYPE: Release
@@ -37,7 +36,6 @@ jobs:
           DISTRO: ubuntu-glibc
           CMAKE_EXTRA_FLAGS: "-DCMAKE_CXX_FLAGS='-include /usr/local/include/bcc/compat/linux/bpf.h -D__LINUX_BPF_H__'"
           VENDOR_GTEST: ON
-          BUILD_LIBBPF: ON
           BCC_REF: v0.23.0
           ENABLE_SKB_OUTPUT: OFF
         - TYPE: Debug

--- a/docker/Dockerfile.ubuntu-glibc
+++ b/docker/Dockerfile.ubuntu-glibc
@@ -51,6 +51,7 @@ RUN mkdir -p /src \
          -DENABLE_LLVM_NATIVECODEGEN=0 \
     && make -j$(nproc) \
     && make install \
+    && make -C ../src/cc/libbpf/src install_headers install_uapi_headers \
     && mkdir -p /usr/local/lib \
     && cp src/cc/libbcc.a /usr/local/lib/libbcc.a \
     && cp src/cc/libbcc-loader-static.a /usr/local/lib/libbcc-loader-static.a \


### PR DESCRIPTION
Static builds use the `ubuntu-glibc` container image which builds BCC (and libbpf as a part of that) from source. As reported in #2317, this currently doesn't work (when running `build-static.sh`) as CMake cannot find libbpf. The problem is that the image build misses installation of libbpf headers, which is fixed by this PR.

Fixes #2317.

Also, thanks to this, embedded CI runs based on the `ubuntu-glibc` image do not need to build libbpf anymore.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
