### PR TITLE
BEGIN/END: Feature test for BPF_PROG_RUN

### DIFF
--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -117,7 +117,6 @@ public:
                         libbpf::BPF_PROG_TYPE_TRACING,
                         "bpf_iter_task_file",
                         libbpf::BPF_TRACE_ITER);
-  DEFINE_PROG_TEST(raw_tracepoint, libbpf::BPF_PROG_TYPE_RAW_TRACEPOINT);
 
 protected:
   std::optional<bool> has_loop_;
@@ -142,7 +141,8 @@ private:
       struct bpf_insn* insns,
       size_t len,
       const char* name = nullptr,
-      std::optional<libbpf::bpf_attach_type> attach_type = std::nullopt);
+      std::optional<libbpf::bpf_attach_type> attach_type = std::nullopt,
+      int* outfd = nullptr);
 
   BTF btf_;
 };


### PR DESCRIPTION
Before, we checked that we could load a prog of type
BPF_PROG_TYPE_RAW_TRACEPOINT and assumed success meant BPF_PROG_RUN
support also existed. It turns out that assumption was false.

Fix incorrect feature detection by also checking for BPF_PROG_RUN
support.

This closes #2318.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
