### PR TITLE
Pipe helper errors into normal text and json output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
   - [#2265](https://github.com/iovisor/bpftrace/pull/2265)
 - Add non-uprobe based BEGIN/END implementation
   - [#2264](https://github.com/iovisor/bpftrace/pull/2264)
+- Helper errors (-k, -kk options) are now emitted to text or json output
+  - [#2326](https://github.com/iovisor/bpftrace/pull/2326)
 
 #### Deprecated
 #### Removed

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -435,13 +435,9 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
     auto error_id = helpererror->error_id;
     auto return_value = helpererror->return_value;
     auto &info = bpftrace->resources.helper_error_info[error_id];
-    std::stringstream msg;
-    msg << "Failed to " << libbpf::bpf_func_name[info.func_id] << ": ";
-    if (return_value < 0)
-      msg << strerror(-return_value) << " (" << return_value << ")";
-    else
-      msg << return_value;
-    LOG(WARNING, info.loc, std::cerr) << msg.str();
+    bpftrace->out_->helper_error(libbpf::bpf_func_name[info.func_id],
+                                 return_value,
+                                 info.loc);
     return;
   }
   else if (printf_id == asyncactionint(AsyncAction::watchpoint_attach))

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -542,6 +542,19 @@ void TextOutput::attached_probes(uint64_t num_probes) const
     out_ << "Attaching " << num_probes << " probes..." << std::endl;
 }
 
+void TextOutput::helper_error(const std::string &helper,
+                              int retcode,
+                              const location &loc) const
+{
+  std::stringstream msg;
+  msg << "Failed to " << helper << ": ";
+  if (retcode < 0)
+    msg << strerror(-retcode) << " (" << retcode << ")";
+  else
+    msg << retcode;
+  LOG(WARNING, loc, out_) << msg.str();
+}
+
 std::string TextOutput::field_to_str(const std::string &name,
                                      const std::string &value) const
 {
@@ -807,6 +820,15 @@ void JsonOutput::lost_events(uint64_t lost) const
 void JsonOutput::attached_probes(uint64_t num_probes) const
 {
   message(MessageType::attached_probes, "probes", num_probes);
+}
+
+void JsonOutput::helper_error(const std::string &helper,
+                              int retcode,
+                              const location &loc) const
+{
+  out_ << "{\"type\": \"helper_error\", \"helper\": \"" << helper
+       << "\", \"retcode\": " << retcode << ", \"line\": " << loc.begin.line
+       << ", \"col\": " << loc.begin.column << "}" << std::endl;
 }
 
 std::string JsonOutput::field_to_str(const std::string &name,

--- a/src/output.h
+++ b/src/output.h
@@ -6,6 +6,7 @@
 #include <vector>
 
 #include "imap.h"
+#include "location.hh"
 
 namespace bpftrace {
 
@@ -23,7 +24,8 @@ enum class MessageType
   join,
   syscall,
   attached_probes,
-  lost_events
+  lost_events,
+  helper_error,
 };
 
 std::ostream& operator<<(std::ostream& out, MessageType type);
@@ -75,6 +77,9 @@ public:
   virtual void message(MessageType type, const std::string& msg, bool nl = true) const = 0;
   virtual void lost_events(uint64_t lost) const = 0;
   virtual void attached_probes(uint64_t num_probes) const = 0;
+  virtual void helper_error(const std::string &helper,
+                            int retcode,
+                            const location &loc) const = 0;
 
 protected:
   std::ostream &out_;
@@ -188,6 +193,9 @@ public:
   void message(MessageType type, const std::string& msg, bool nl = true) const override;
   void lost_events(uint64_t lost) const override;
   void attached_probes(uint64_t num_probes) const override;
+  void helper_error(const std::string &helper,
+                    int retcode,
+                    const location &loc) const override;
 
 protected:
   static std::string hist_index_label(int power);
@@ -239,6 +247,9 @@ public:
   void message(MessageType type, const std::string& field, uint64_t value) const;
   void lost_events(uint64_t lost) const override;
   void attached_probes(uint64_t num_probes) const override;
+  void helper_error(const std::string &helper,
+                    int retcode,
+                    const location &loc) const override;
 
 private:
   std::string json_escape(const std::string &str) const;

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -158,3 +158,8 @@ NAME print_hist_with_large_top_arg
 RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 10); clear(@); exit(); }'
 EXPECT {"type": "hist", "data": {"@": {"1": \[{"min": 8, "max": 15, "count": 1}\], "2": \[{"min": 16, "max": 31, "count": 1}\], "3": \[{"min": 16, "max": 31, "count": 1}\]}}}
 TIMEOUT 1
+
+NAME helper_error
+RUN {{BPFTRACE}} -kk -q -f json -e 'struct foo {int a;}; BEGIN { $tmp = ((struct foo*) 0)->a; exit(); }'
+EXPECT {"type": "helper_error", "helper": "probe_read", "retcode": -14, "line": 1, "col": 37}
+TIMEOUT 1


### PR DESCRIPTION
Helper errors (-k or -kk) are currently only visible on stderr.
Change that behavior to emit them to text output (-o) and in JSON
format.

This allows tools that process the JSON output to account for the
errors, similarly to lost perf events.

##### Checklist

- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
