### PR TITLE
Add strerror builtin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
   - [#2289](https://github.com/iovisor/bpftrace/pull/2289)
 - Add builtin: `debugf`
   - [#2307](https://github.com/iovisor/bpftrace/pull/2307)
+- Add builtin: `strerror`
+  - [#2329](https://github.com/iovisor/bpftrace/pull/2329)
 
 #### Changed
 - Move from BCC to libbpf

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -99,6 +99,8 @@ discussion to other files in /docs, the /tools/\*\_examples.txt files, or blog p
     - [29. `cgroup_path()`: Convert cgroup id to cgroup path](#29-cgroup_path-convert-cgroup-id-to-cgroup-path)
     - [30. `bswap`: Reverse byte order](#30-bswap-reverse-byte-order)
     - [31. `skb_output`: Write `skb` 's data section into a PCAP file](#31-skb_output-write-skb-s-data-section-into-a-pcap-file)
+    - [32. `pton()`: Convert text IP address to byte array](#32-pton-convert-text-ip-address-to-byte-array)
+    - [33. `strerror`: Get error message for errno value](#33-strerror-get-error-message-for-errno-value)
 - [Map Functions](#map-functions)
     - [1. Builtins](#1-builtins-2)
     - [2. `count()`: Count](#2-count-count)
@@ -3210,6 +3212,21 @@ first octet matched
 Attaching 1 probe...
 first octet matched
 ^C
+```
+
+## 33. `strerror`: Get error message for errno code
+
+Syntax: `strerror(uint64 error)`
+
+Converts the given errno code to a string describing the error. The result can be only used for printing, since the conversion is done in userspace.
+
+Example:
+
+```
+# bpftrace -e '#include <errno.h>
+BEGIN { print(strerror(EPERM)); }'
+Attaching 1 probe...
+Operation not permitted
 ```
 
 # Map Functions

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1576,6 +1576,21 @@ In case the string is longer than the specified length only `length - 1` bytes a
 
 When available (starting from kernel 5.5, see the `--info` flag) bpftrace will automatically use the `kernel` or `user` variant of `probe_read_{kernel,user}_str` based on the address space of `data`, see <<Address-spaces>> for more information.
 
+=== strerror
+
+.variants
+* `strerror strerror(int error)`
+
+Convert errno code to string.
+This is done asynchronously in userspace when the strerror value is printed, hence the returned value can only be used for printing.
+
+----
+#include <errno.h>
+BEGIN {
+  print(strerror(EPERM));
+}
+----
+
 === strftime
 
 .variants

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1121,6 +1121,10 @@ void CodegenLLVM::visit(Call &call)
   {
     expr_ = b_.getInt64(call.vargs->at(0)->type.GetSize());
   }
+  else if (call.func == "strerror")
+  {
+    auto scoped_del = accept(call.vargs->front());
+  }
   else if (call.func == "strncmp") {
     uint64_t size = (uint64_t)*bpftrace_.get_int_literal(call.vargs->at(2));
     const auto& left_arg = call.vargs->at(0);

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1215,6 +1215,12 @@ void SemanticAnalyser::visit(Call &call)
                                    << "'kfunc', 'kretfunc', 'iter' probes";
     }
   }
+  else if (call.func == "strerror")
+  {
+    call.type = CreateStrerror();
+    if (check_nargs(call, 1))
+      check_arg(call, Type::integer, 0, false);
+  }
   else if (call.func == "strncmp") {
     if (check_nargs(call, 3)) {
       check_arg(call, Type::string, 0);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -742,6 +742,10 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(const std::vec
                                     arg_data + arg.offset)
                                     ->cgroup_id)));
         break;
+      case Type::strerror:
+        arg_values.push_back(std::make_unique<PrintableString>(
+            strerror(*reinterpret_cast<uint64_t *>(arg_data + arg.offset))));
+        break;
         // fall through
       default:
         LOG(FATAL) << "invalid argument type";

--- a/src/format_string.cpp
+++ b/src/format_string.cpp
@@ -50,7 +50,8 @@ std::string validate_format_string(const std::string &fmt,
         arg_type == Type::probe || arg_type == Type::username ||
         arg_type == Type::kstack || arg_type == Type::ustack ||
         arg_type == Type::inet || arg_type == Type::timestamp ||
-        arg_type == Type::mac_address || arg_type == Type::cgroup_path)
+        arg_type == Type::mac_address || arg_type == Type::cgroup_path ||
+        arg_type == Type::strerror)
       arg_type = Type::string; // Symbols should be printed as strings
     if (arg_type == Type::pointer)
       arg_type = Type::integer; // Casts (pointers) can be printed as integers

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -38,7 +38,7 @@ vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#\*])+
 builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ctx|curtask|elapsed|func|gid|nsecs|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
-call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|sizeof|stats|str|strftime|strncmp|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf
+call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|sizeof|stats|str|strerror|strftime|strncmp|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf
 
 /* Don't add to this! Use builtin OR call not both */
 call_and_builtin kstack|ustack

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -280,6 +280,8 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
         reinterpret_cast<AsyncEvent::CgroupPath *>(value.data())
             ->cgroup_path_id,
         reinterpret_cast<AsyncEvent::CgroupPath *>(value.data())->cgroup_id);
+  else if (type.IsStrerrorTy())
+    return strerror(read_data<uint64_t>(value.data()));
   else
     return std::to_string(read_data<int64_t>(value.data()) / div);
 }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -184,6 +184,7 @@ std::string typestr(Type t)
     case Type::timestamp:return "timestamp";break;
     case Type::mac_address: return "mac_address"; break;
     case Type::cgroup_path: return "cgroup_path"; break;
+    case Type::strerror: return "strerror"; break;
       // clang-format on
   }
 
@@ -474,6 +475,11 @@ SizedType CreateCgroupPath()
   return SizedType(Type::cgroup_path, 16);
 }
 
+SizedType CreateStrerror()
+{
+  return SizedType(Type::strerror, 8);
+}
+
 bool SizedType::IsSigned(void) const
 {
   return is_signed_;
@@ -621,6 +627,7 @@ size_t hash<bpftrace::SizedType>::operator()(
     case bpftrace::Type::timestamp:
     case bpftrace::Type::mac_address:
     case bpftrace::Type::cgroup_path:
+    case bpftrace::Type::strerror:
       break;
   }
 

--- a/src/types.h
+++ b/src/types.h
@@ -48,7 +48,8 @@ enum class Type
   tuple,
   timestamp,
   mac_address,
-  cgroup_path
+  cgroup_path,
+  strerror
   // clang-format on
 };
 
@@ -367,6 +368,10 @@ public:
   {
     return type == Type::cgroup_path;
   };
+  bool IsStrerrorTy(void) const
+  {
+    return type == Type::strerror;
+  };
 
   friend std::ostream &operator<<(std::ostream &, const SizedType &);
   friend std::ostream &operator<<(std::ostream &, Type);
@@ -426,6 +431,7 @@ SizedType CreateBuffer(size_t size);
 SizedType CreateTimestamp();
 SizedType CreateMacAddress();
 SizedType CreateCgroupPath();
+SizedType CreateStrerror();
 
 std::ostream &operator<<(std::ostream &os, const SizedType &type);
 

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -375,6 +375,11 @@ REQUIRES grep -q '^cgroup2' /proc/mounts
 TIMEOUT 5
 MIN_KERNEL 4.18
 
+NAME strerror
+RUN {{BPFTRACE}} --include "errno.h" -e 'BEGIN { print(strerror(EPERM)); exit(); }'
+EXPECT Operation not permitted
+TIMEOUT 5
+
 NAME bswap_int64
 RUN {{BPFTRACE}} -e 'BEGIN { printf("%lx", bswap(0x1122334455667788)); exit(); }'
 EXPECT 8877665544332211

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -932,6 +932,20 @@ TEST(semantic_analyser, call_cgroup_path)
   test("kprobe:f { printf(\"%d\", cgroup_path(1)) }", 10);
 }
 
+TEST(semantic_analyser, call_strerror)
+{
+  test("kprobe:f { strerror(1) }", 0);
+
+  test("kprobe:f { strerror(1, 2) }", 1);
+  test("kprobe:f { strerror(\"1\") }", 10);
+
+  test("kprobe:f { printf(\"%s\", strerror(1)) }", 0);
+  test("kprobe:f { printf(\"%s %s\", strerror(1), strerror(2)) }", 0);
+  test("kprobe:f { $var = strerror(0); printf(\"%s %s\", $var, $var) }", 0);
+
+  test("kprobe:f { printf(\"%d\", strerror(1)) }", 10);
+}
+
 TEST(semantic_analyser, map_reassignment)
 {
   test("kprobe:f { @x = 1; @x = 2; }", 0);


### PR DESCRIPTION
The new builtin behaves just like strerror in C, with the expection
of the conversion being done in userspace when the value returned
by the helper is printed.

Closes #2114

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
