### PR TITLE
Userspace kprobe offset verification can now fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to
   - [#2264](https://github.com/iovisor/bpftrace/pull/2264)
 - Helper errors (-k, -kk options) are now emitted to text or json output
   - [#2326](https://github.com/iovisor/bpftrace/pull/2326)
+- kprobe offset verification is now optional, without requiring --unsafe
+  - [#2332](https://github.com/iovisor/bpftrace/pull/2332)
 
 #### Deprecated
 #### Removed

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -76,6 +76,23 @@ EXPECT Offset outside the function bounds \('vfs_read' size is*
 TIMEOUT 5
 WILL_FAIL
 
+NAME kprobe_offset_module
+RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x5 { printf("hit\n"); exit(); }' -c '/usr/sbin/nft add table bpftrace'
+EXPECT hit
+TIMEOUT 5
+REQUIRES lsmod | grep '^nf_tables'
+REQUIRES /usr/sbin/nft --help
+AFTER nft delete table bpftrace
+
+NAME kprobe_offset_module_error
+RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x1 { printf("hit\n"); exit(); }' -c '/usr/sbin/nft add table bpftrace'
+EXPECT Possible attachment attempt in the middle of an instruction, try a different offset.
+TIMEOUT 5
+REQUIRES lsmod | grep '^nf_tables'
+REQUIRES /usr/sbin/nft --help
+AFTER nft delete table bpftrace
+WILL_FAIL
+
 NAME kretprobe
 PROG kretprobe:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT SUCCESS [0-9][0-9]*


### PR DESCRIPTION
Previously, this logic could only fail in unsafe mode. Unfortunately,
this prevented attachment to module functions with an offset, as
the module binary would never be examined.

This PR makes the logic entirely optional and improves the error
messages to provide a similar user experience.

Fixes #2327 

##### Checklist

- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by runtime tests using the nf_tables module that #2315 uses as well
