### PR TITLE
Runtime tests: allow multiple REQUIRES

### DIFF
--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -105,7 +105,7 @@ class TestParser(object):
         after = ''
         kernel_min = ''
         kernel_max = ''
-        requirement = ''
+        requirement = []
         env = {}
         arch = []
         feature_requirement = set()
@@ -136,7 +136,7 @@ class TestParser(object):
             elif item_name == 'MAX_KERNEL':
                 kernel_max = line
             elif item_name == 'REQUIRES':
-                requirement = line
+                requirement.append(line)
             elif item_name == 'ENV':
                 for e in line.split():
                     k, v = e.split('=')

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -72,7 +72,7 @@ class Runner(object):
         if status == Runner.SKIP_KERNEL_VERSION_MAX:
             return "max Kernel: %s" % test.kernel_max
         elif status == Runner.SKIP_REQUIREMENT_UNSATISFIED:
-            return "unmet condition: '%s'" % test.requirement
+            return "unmet condition: '%s'" % ' && '.join(test.requirement)
         elif status == Runner.SKIP_FEATURE_REQUIREMENT_UNSATISFIED:
             neg_reqs = { "!{}".format(f) for f in test.neg_feature_requirement }
             return "missed feature: '%s'" % ','.join(
@@ -166,16 +166,17 @@ class Runner(object):
 
             print(ok("[ RUN      ] ") + "%s.%s" % (test.suite, test.name))
             if test.requirement:
-                with open(devnull, 'w') as dn:
-                    if subprocess.call(
-                        test.requirement,
-                        shell=True,
-                        stdout=dn,
-                        stderr=dn,
-                        env={'PATH': "{}:{}".format(BPF_PATH, ENV_PATH)},
-                    ) != 0:
-                        print(warn("[   SKIP   ] ") + "%s.%s" % (test.suite, test.name))
-                        return Runner.SKIP_REQUIREMENT_UNSATISFIED
+                for req in test.requirement:
+                    with open(devnull, 'w') as dn:
+                        if subprocess.call(
+                            req,
+                            shell=True,
+                            stdout=dn,
+                            stderr=dn,
+                            env={'PATH': "{}:{}".format(BPF_PATH, ENV_PATH)},
+                        ) != 0:
+                            print(warn("[   SKIP   ] ") + "%s.%s" % (test.suite, test.name))
+                            return Runner.SKIP_REQUIREMENT_UNSATISFIED
 
             if test.feature_requirement or test.neg_feature_requirement:
                 bpffeature = Runner.__get_bpffeature()


### PR DESCRIPTION
Some tests may require multiple conditions to be run. Using multiple `REQUIRES` fields is more convenient than just a single `REQUIRES` with multiple commands joint with `&&`.

This was originally a part of #2315 but #2332 will need it earlier, so extracting it as a separate PR.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
