### PR TITLE
Fix debugf invalid LLVM IR

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -935,7 +935,7 @@ void CodegenLLVM::visit(Call &call)
     auto size = std::get<1>(ids);
 
     Value *map_data = b_.CreateBpfPseudoCallValue(mapid);
-    Value *fmt_ptr = b_.CreateAdd(map_data, b_.getInt64(idx));
+    Value *fmt = b_.CreateAdd(map_data, b_.getInt64(idx));
 
     std::vector<Value *> values;
     for (size_t i = 1; i < call.vargs->size(); i++)
@@ -945,7 +945,10 @@ void CodegenLLVM::visit(Call &call)
       values.push_back(expr_);
     }
 
-    b_.CreateTracePrintk(fmt_ptr, b_.getInt32(size), values, call.loc);
+    b_.CreateTracePrintk(b_.CreateIntToPtr(fmt, b_.getInt8PtrTy()),
+                         b_.getInt32(size),
+                         values,
+                         call.loc);
     mapped_printf_id_++;
   }
   else if (call.func == "system")


### PR DESCRIPTION
This PR fixed the `debugf`'s invalid IR detected by IR verification from https://github.com/iovisor/bpftrace/pull/2298.

Error message in CI:
```bash
stdin:1:10-26: WARNING: The debugf() builtin is not recommended for production use. For more information see bpf_trace_printk in bpf-helpers(7).
i:ms:1 { debugf("debugf"); exit();}
         ~~~~~~~~~~~~~~~~
Call parameter type does not match function signature!
  %1 = add i64 %pseudo, 0
 i8*  %trace_printk = call i64 (i8*, i32, ...) inttoptr (i64 6 to i64 (i8*, i32, ...)*)(i64 %1, i32 7)

ERROR: Verification of generated LLVM IR failed
```