### PR TITLE
Fix accessing ctx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to
   - [#2316](https://github.com/iovisor/bpftrace/pull/2316)
 - Fix builds against libbfd(binutils) >=2.39
   - [#2328](https://github.com/iovisor/bpftrace/pull/2328)
+- Fix access to ctx
+  - [#2343](https://github.com/iovisor/bpftrace/pull/2343)
 
 #### Added
 #### Docs

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -232,7 +232,7 @@ void SemanticAnalyser::visit(Builtin &builtin)
       case libbpf::BPF_PROG_TYPE_KPROBE:
         builtin.type = CreatePointer(CreateRecord("struct pt_regs",
                                                   bpftrace_.structs.Lookup(
-                                                      "structs pt_regs")),
+                                                      "struct pt_regs")),
                                      AddrSpace::kernel);
         builtin.type.MarkCtxAccess();
         break;


### PR DESCRIPTION
There was a typo when assigning type of the `ctx` builtin which caused a segfault when trying to access its fields.

Fixes #2342.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
