### PR TITLE
use tracefs directly when debugfs is not available

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(runtime
   resolve_cgroupid.cpp
   required_resources.cpp
   struct.cpp
+  tracefs.cpp
   types.cpp
   usdt.cpp
   utils.cpp

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -13,6 +13,7 @@
 
 #include "btf.h"
 #include "probe_matcher.h"
+#include "tracefs.h"
 #include "utils.h"
 
 namespace bpftrace {
@@ -106,7 +107,7 @@ bool BPFfeature::try_load(enum libbpf::bpf_prog_type prog_type,
   if (prog_type == libbpf::BPF_PROG_TYPE_TRACING)
   {
     // List of available functions must be readable
-    std::ifstream traceable_funcs(kprobe_path);
+    std::ifstream traceable_funcs(tracefs::available_filter_functions());
     if (!traceable_funcs.good())
       return false;
   }

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -3,6 +3,7 @@
 #include "bpftrace.h"
 #include "log.h"
 #include "probe_matcher.h"
+#include "tracefs.h"
 #include "types.h"
 #include "utils.h"
 #include <cstring>
@@ -478,7 +479,8 @@ int BTF::resolve_args(const std::string &func,
     {
       if (bpftrace_->traceable_funcs_.empty())
         throw std::runtime_error("could not read traceable functions from " +
-                                 kprobe_path + " (is debugfs mounted?)");
+                                 tracefs::available_filter_functions() +
+                                 " (is debugfs mounted?)");
       else
         throw std::runtime_error("function not traceable (probably it is "
                                  "inlined or marked as \"notrace\")");

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -480,7 +480,7 @@ int BTF::resolve_args(const std::string &func,
       if (bpftrace_->traceable_funcs_.empty())
         throw std::runtime_error("could not read traceable functions from " +
                                  tracefs::available_filter_functions() +
-                                 " (is debugfs mounted?)");
+                                 " (is tracefs mounted?)");
       else
         throw std::runtime_error("function not traceable (probably it is "
                                  "inlined or marked as \"notrace\")");

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -11,6 +11,7 @@
 #include "dwarf_parser.h"
 #include "log.h"
 #include "probe_matcher.h"
+#include "tracefs.h"
 #include "utils.h"
 
 #include <bcc/bcc_syms.h>
@@ -116,7 +117,8 @@ std::set<std::string> ProbeMatcher::get_matches_for_probetype(
     case ProbeType::kprobe:
     case ProbeType::kretprobe:
     {
-      symbol_stream = get_symbols_from_file(kprobe_path);
+      symbol_stream = get_symbols_from_file(
+          tracefs::available_filter_functions());
       ignore_trailing_module = true;
       break;
     }
@@ -130,7 +132,7 @@ std::set<std::string> ProbeMatcher::get_matches_for_probetype(
     }
     case ProbeType::tracepoint:
     {
-      symbol_stream = get_symbols_from_file(tp_avail_path);
+      symbol_stream = get_symbols_from_file(tracefs::available_events());
       break;
     }
     case ProbeType::usdt:
@@ -349,8 +351,7 @@ FuncParamLists ProbeMatcher::get_tracepoints_params(
     auto event = tracepoint;
     auto category = erase_prefix(event);
 
-    std::string format_file_path = tp_path + "/" + category + "/" + event +
-                                   "/format";
+    std::string format_file_path = tracefs::event_format_file(category, event);
     std::ifstream format_file(format_file_path.c_str());
     std::string line;
 

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -9,11 +9,6 @@
 
 namespace bpftrace {
 
-const std::string kprobe_path =
-    "/sys/kernel/debug/tracing/available_filter_functions";
-const std::string tp_avail_path = "/sys/kernel/debug/tracing/available_events";
-const std::string tp_path = "/sys/kernel/debug/tracing/events";
-
 struct ProbeListItem
 {
   std::string path;

--- a/src/tracefs.cpp
+++ b/src/tracefs.cpp
@@ -1,0 +1,28 @@
+#include "tracefs.h"
+#include <unistd.h>
+
+namespace bpftrace {
+namespace tracefs {
+
+#define DEBUGFS_TRACEFS "/sys/kernel/debug/tracing"
+#define TRACEFS "/sys/kernel/tracing"
+
+std::string path()
+{
+  static bool use_debugfs = access(DEBUGFS_TRACEFS, F_OK) == 0;
+  return use_debugfs ? DEBUGFS_TRACEFS : TRACEFS;
+}
+
+std::string path(const std::string &file)
+{
+  return path() + "/" + file;
+}
+
+std::string event_format_file(const std::string &category,
+                              const std::string &event)
+{
+  return path("events/" + category + "/" + event + "/format");
+}
+
+} // namespace tracefs
+} // namespace bpftrace

--- a/src/tracefs.h
+++ b/src/tracefs.h
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <string>
+
+namespace bpftrace {
+namespace tracefs {
+
+std::string path();
+
+std::string path(const std::string &file);
+
+inline std::string available_events()
+{
+  return path("available_events");
+}
+
+inline std::string events()
+{
+  return path("events");
+}
+
+inline std::string available_filter_functions()
+{
+  return path("available_filter_functions");
+}
+
+std::string event_format_file(const std::string &category,
+                              const std::string &event);
+
+} // namespace tracefs
+} // namespace bpftrace

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -7,6 +7,7 @@
 #include "bpftrace.h"
 #include "log.h"
 #include "struct.h"
+#include "tracefs.h"
 #include "tracepoint_format_parser.h"
 
 namespace bpftrace {
@@ -38,7 +39,8 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
       {
         std::string &category = ap->target;
         std::string &event_name = ap->func;
-        std::string format_file_path = "/sys/kernel/debug/tracing/events/" + category + "/" + event_name + "/format";
+        std::string format_file_path = tracefs::event_format_file(category,
+                                                                  event_name);
         glob_t glob_result;
 
         if (has_wildcard(category) || has_wildcard(event_name))
@@ -78,7 +80,7 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
           for (size_t i = 0; i < glob_result.gl_pathc; ++i) {
             std::string filename(glob_result.gl_pathv[i]);
             std::ifstream format_file(filename);
-            std::string prefix("/sys/kernel/debug/tracing/events/");
+            const std::string prefix = tracefs::events() + "/";
             size_t pos = prefix.length();
             std::string real_category = filename.substr(
                 pos, filename.find('/', pos) - pos);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -22,6 +22,7 @@
 #include "bpftrace.h"
 #include "log.h"
 #include "probe_matcher.h"
+#include "tracefs.h"
 #include "utils.h"
 #include <bcc/bcc_elf.h>
 #include <bcc/bcc_syms.h>
@@ -968,13 +969,12 @@ std::unordered_set<std::string> get_traceable_funcs()
   return {};
 #else
   // Try to get the list of functions from BPFTRACE_AVAILABLE_FUNCTIONS_TEST env
-  const char *path = std::getenv("BPFTRACE_AVAILABLE_FUNCTIONS_TEST");
+  const char *path_env = std::getenv("BPFTRACE_AVAILABLE_FUNCTIONS_TEST");
+  const std::string kprobe_path = path_env
+                                      ? path_env
+                                      : tracefs::available_filter_functions();
 
-  // Use kprobe list as default
-  if (!path)
-    path = kprobe_path.c_str();
-
-  std::ifstream available_funs(path);
+  std::ifstream available_funs(kprobe_path);
   if (available_funs.fail())
   {
     if (bt_debug != DebugLevel::kNone)


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

On some platforms tracefs is available as "/sys/kernel/tracing" and not "/sys/kernel/debug/tracing". This pull request makes bpftrace use "/sys/kernel/tracing" when "/sys/kernel/debug/tracing" is not accessible.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
