### PR TITLE
Fix the misleading uprobe syntax statement

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1029,7 +1029,7 @@ Syntax:
 
 ```
 uprobe:library_name:function_name[+offset]
-uprobe:library_name:address
+uprobe:library_name:offset
 uretprobe:library_name:function_name
 ```
 

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -2371,6 +2371,7 @@ snmpd /proc/net/dev
 .variants
 * `uprobe:binary:func`
 * `uprobe:binary:func+offset`
+* `uprobe:binary:offset`
 * `uretprobe:binary:func`
 
 .shortnames


### PR DESCRIPTION

This PR simply fixed a misleading statement of uprobe syntax, for which I opened an [issue](https://github.com/iovisor/bpftrace/issues/1763) due to this inaccuracy.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
