### PR TITLE
Disable runtime test failing in CI

### DIFF
--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -46,13 +46,6 @@ TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME 32-bit tracepoint arg
-PROG tracepoint:random:urandom_read { $i = args->got_bits; printf("bits: %d\n", $i); if ($i == 24) { exit() } }
-EXPECT bits: 24
-TIMEOUT 5
-MAX_KERNEL 5.16
-AFTER dd if=/dev/urandom bs=3 count=1
-
-NAME 32-bit tracepoint arg openat_flags
 PROG tracepoint:syscalls:sys_enter_openat /comm == "syscall"/ { $i = args->flags; printf("openflags: %d\n", $i); if ($i == 64) { exit() } }
 EXPECT openflags: 64
 TIMEOUT 5


### PR DESCRIPTION
Runtime test `variable.32-bit tracepoint arg` requires max kernel 5.16. It is currently failing in the CI since it has the kernel version 5.15.0-1029-azure (i.e. <= 5.16) which doesn't have the required tracepoint.

This disables the test in the CI until a better solution is found.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
