### PR TITLE
Runtime tests: Fix failure when "pidof -s" is not available

### DIFF
--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -203,7 +203,7 @@ class Runner(object):
                     # a test program needs to accept arguments. It covers the
                     # current simple calls with no arguments
                     child_name = os.path.basename(test.before.split()[-1])
-                    while subprocess.call(["pidof", "-s", child_name], stdout=dn, stderr=dn) != 0:
+                    while subprocess.call(["pidof", child_name], stdout=dn, stderr=dn) != 0:
                         time.sleep(0.1)
                         waited+=0.1
                         if waited > test.timeout:
@@ -211,7 +211,7 @@ class Runner(object):
 
             bpf_call = Runner.prepare_bpf_call(test)
             if test.before:
-                childpid = subprocess.Popen(["pidof", "-s", child_name], stdout=subprocess.PIPE, universal_newlines=True).communicate()[0].strip()
+                childpid = subprocess.Popen(["pidof", child_name], stdout=subprocess.PIPE, universal_newlines=True).communicate()[0].split()[0]
                 bpf_call = re.sub("{{BEFORE_PID}}", str(childpid), bpf_call)
             env = {
                 'test': test.name,


### PR DESCRIPTION
On some busybox builds "pidof -s" is not available that results in unexpected TimeoutError and fails runtime test. Use first element of "pidof" output to workaround this.

Signed-off-by: Michal Wojcik <michal.wojcik@linaro.org>

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
