### PR TITLE
Add missing Expected<T> error checks

### DIFF
--- a/src/ast/bpforc/bpforcv2.cpp
+++ b/src/ast/bpforc/bpforcv2.cpp
@@ -37,8 +37,8 @@ std::unique_ptr<BpfOrc> BpfOrc::Create()
   auto DL = cantFail(JTMB.getDefaultDataLayoutForTarget());
   auto TM = cantFail(JTMB.createTargetMachine());
 #if LLVM_VERSION_MAJOR >= 13
-  auto EPC = SelfExecutorProcessControl::Create();
-  auto ES = std::make_unique<ExecutionSession>(std::move(*EPC));
+  auto EPC = cantFail(SelfExecutorProcessControl::Create());
+  auto ES = std::make_unique<ExecutionSession>(std::move(EPC));
 #else
   auto ES = std::make_unique<ExecutionSession>();
 #endif


### PR DESCRIPTION
Fixes a couple of places where `llvm::Expected<T>` values were not properly checked for errors, triggering asserts in debug builds of LLVM.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
