### PR TITLE
Fix crash in BPFfeature on kernels that don't support BTF

### DIFF
--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -101,7 +101,7 @@ bool BPFfeature::try_load(enum libbpf::bpf_prog_type prog_type,
   char logbuf[log_size] = {};
 
   std::optional<unsigned> btf_id;
-  if (prog_type == libbpf::BPF_PROG_TYPE_TRACING)
+  if (prog_type == libbpf::BPF_PROG_TYPE_TRACING && has_btf())
     btf_id = btf_.get_btf_id(name);
 
   if (prog_type == libbpf::BPF_PROG_TYPE_TRACING)


### PR DESCRIPTION
`BPFfeature::try_load` calls `get_btf_id` even if loading BTF data failed, which causes `bpftrace --info` and `bpftrace -l` to crash on older kernels that don't support BTF:

```
  Program received signal SIGSEGV, Segmentation fault.
  (gdb) bt
  #0  0x95101db8 in btf_find_by_name_kind (btf=0x0, start_id=1, [...])
  #1  0x0a74695e in bpftrace::BTF::get_btf_id
  #2  0x0a716fe8 in bpftrace::BPFfeature::try_load
  #3  0x0a717546 in bpftrace::BPFfeature::detect_prog_type
  #4  0x0a71963c in bpftrace::BPFfeature::has_prog_kfunc
  #5  0x0a7181e8 in bpftrace::BPFfeature::has_kfunc
  [...]
```

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
