### PR TITLE
Preliminary support for 32-bit ARM systems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 ## Unreleased
 
 #### Added
+- Support for 32-bit ARM systems
+  - [#2360](https://github.com/iovisor/bpftrace/pull/2360)
 #### Changed
 #### Deprecated
 #### Removed

--- a/src/arch/CMakeLists.txt
+++ b/src/arch/CMakeLists.txt
@@ -1,5 +1,7 @@
 if(CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
     add_library(arch aarch64.cpp)
+elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "armv7-a")
+    add_library(arch arm.cpp)
 elseif(CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64" OR
        CMAKE_SYSTEM_PROCESSOR STREQUAL "ppc64le")
     add_library(arch ppc64.cpp)

--- a/src/arch/arm.cpp
+++ b/src/arch/arm.cpp
@@ -1,0 +1,95 @@
+#include "arch.h"
+
+#include <algorithm>
+#include <array>
+
+// SP points to the first argument that is passed on the stack
+#define ARG0_STACK 0
+
+namespace bpftrace {
+namespace arch {
+
+// clang-format off
+static std::array<std::string, 17> registers = {
+  "r0",
+  "r1",
+  "r2",
+  "r3",
+  "r4",
+  "r5",
+  "r6",
+  "r7",
+  "r8",
+  "r9",
+  "r10",
+  "fp",
+  "ip",
+  "sp",
+  "lr",
+  "pc",
+  "cpsr",
+};
+
+static std::array<std::string, 4> arg_registers = {
+  "r0",
+  "r1",
+  "r2",
+  "r3",
+};
+// clang-format on
+
+int offset(std::string reg_name)
+{
+  auto it = find(registers.begin(), registers.end(), reg_name);
+  if (it == registers.end())
+    return -1;
+  return distance(registers.begin(), it);
+}
+
+int max_arg()
+{
+  return arg_registers.size() - 1;
+}
+
+int arg_offset(int arg_num)
+{
+  return offset(arg_registers.at(arg_num));
+}
+
+int ret_offset()
+{
+  return offset("r0");
+}
+
+int pc_offset()
+{
+  return offset("pc");
+}
+
+int sp_offset()
+{
+  return offset("sp");
+}
+
+int arg_stack_offset()
+{
+  return ARG0_STACK / 4;
+}
+
+std::string name()
+{
+  return std::string("arm");
+}
+
+std::vector<std::string> invalid_watchpoint_modes()
+{
+  // See arch/arm/kernel/hw_breakpoint.c:arch_build_bp_info in kernel source
+  return std::vector<std::string>{
+    "rx",
+    "wx",
+    "rwx",
+  };
+}
+
+} // namespace arch
+} // namespace bpftrace

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -126,7 +126,7 @@ Map::Map(const std::string &name,
 Map::Map(const SizedType &type) : IMap(type)
 {
   int key_size = 4;
-  int value_size = sizeof(uintptr_t) * type.stack_type.limit;
+  int value_size = sizeof(uint64_t) * type.stack_type.limit;
   int max_entries = 128 << 10;
   int flags = 0;
 

--- a/src/triggers.h
+++ b/src/triggers.h
@@ -1,7 +1,22 @@
 #pragma once
 
+#if defined(__arm__)
+// Force the compiler to generate A32 instructions for the two trigger functions
+// to ensure they end up being 4-byte (UPROBE_SWBP_INSN_SIZE) aligned, otherwise
+// uprobe_register() fails with EINVAL (see kernel/events/uprobes.c).
+#define __target_attr __attribute__((target("arm")))
+#else
+#define __target_attr
+#endif
+
 extern "C"
 {
-  void __attribute__((noinline)) BEGIN_trigger() { asm (""); }
-  void __attribute__((noinline)) END_trigger() { asm (""); }
+  void __attribute__((noinline)) __target_attr BEGIN_trigger()
+  {
+    asm("");
+  }
+  void __attribute__((noinline)) __target_attr END_trigger()
+  {
+    asm("");
+  }
 }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -377,6 +377,12 @@ std::vector<std::string> get_kernel_cflags(
   if (archenv)
     cflags.push_back("-D__TARGET_ARCH_" + arch);
 
+  if (arch == "arm")
+  {
+    // Required by several header files in arch/arm/include
+    cflags.push_back("-D__LINUX_ARM_ARCH__=7");
+  }
+
   return cflags;
 }
 

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -83,6 +83,13 @@ ARCH s390x
 TIMEOUT 5
 AFTER ./testprogs/stack_args
 
+NAME sarg
+PROG uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS %d %d\n", sarg0, sarg1); exit(); }
+EXPECT SUCCESS 8 16
+ARCH armv7l
+TIMEOUT 5
+AFTER ./testprogs/stack_args
+
 NAME retval
 PROG kretprobe:vfs_read { printf("SUCCESS %d\n", retval); exit(); }
 EXPECT SUCCESS .*

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -58,7 +58,7 @@ NAME buf
 RUN {{BPFTRACE}} -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s->a, 4), buf($s->b, 4), buf($s->c), buf($s->d), buf($s->e), buf($s->f)); exit(); }' -c ./testprogs/complex_struct
 EXPECT P: \\x09\\x08\\x07\\x06-\\x05\\x04\\x03\\x02-\\x01\\x02\\x03\\x04-\\x05\\x00\\x00\\x00\\x06\\x00\\x00\\x00\\x07\\x00\\x00\\x00\\x08\\x00\\x00\\x00-\\x09\\x00\\x0a\\x00\\x0b\\x00\\x0c\\x00-\\x0d\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0e\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x0f\\x00\\x00\\x00\\x00\\x00\\x00\\x00\\x10\\x00\\x00\\x00\\x00\\x00\\x00\\x00
 TIMEOUT 5
-ARCH x86_64|ppc64le|aarch64
+ARCH x86_64|ppc64le|aarch64|armv7l
 
 NAME buf
 RUN {{BPFTRACE}} -e 'struct MyStruct { const char* a; char b[4]; uint8_t c[4]; int d[4]; uint16_t e[4]; uint64_t f[4] }; u:./testprogs/complex_struct:func { $s = (struct MyStruct *)arg0; printf("P: %r-%r-%r-%r-%r-%r\n", buf($s->a, 4), buf($s->b, 4), buf($s->c), buf($s->d), buf($s->e), buf($s->f)); exit(); }' -c ./testprogs/complex_struct
@@ -109,7 +109,7 @@ NAME ksym
 PROG kprobe:do_nanosleep { printf("%s\n", ksym(reg("pc"))); exit();}
 EXPECT do_nanosleep
 TIMEOUT 5
-ARCH aarch64
+ARCH aarch64|armv7l
 AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME ksym
@@ -213,7 +213,7 @@ TIMEOUT 5
 NAME ntop static ip
 PROG i:ms:100 { printf("IP: %s, %s, %s, %s\n", ntop(1), ntop(0x0100007f), ntop(0xffff0000), ntop(0x0000ffff)); exit() }
 EXPECT IP: 1.0.0.0, 127.0.0.1, 0.0.255.255, 255.255.0.0
-ARCH x86_64|aarch64|ppc64le
+ARCH x86_64|aarch64|ppc64le|armv7l
 TIMEOUT 5
 
 NAME ntop static ip

--- a/tests/runtime/intptrcast
+++ b/tests/runtime/intptrcast
@@ -13,6 +13,13 @@ ARCH aarch64
 AFTER ./testprogs/intptrcast
 
 NAME Sum casted value
+PROG uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("sp")+0)); exit();}
+EXPECT ^@: 3567
+TIMEOUT 5
+ARCH armv7l
+AFTER ./testprogs/intptrcast
+
+NAME Sum casted value
 PROG uprobe:./testprogs/intptrcast:fn { @=sum(*(uint16*)(reg("r1")+96)); exit();}
 EXPECT ^@: 3258
 TIMEOUT 5
@@ -45,6 +52,13 @@ PROG uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("sp")+0); printf("%d\n
 EXPECT 3258
 TIMEOUT 5
 ARCH aarch64
+AFTER ./testprogs/intptrcast
+
+NAME Casting ints
+PROG uprobe:./testprogs/intptrcast:fn { $a=*(uint16*)(reg("sp")+4); printf("0x%x\n", $a); exit();}
+EXPECT 0x4321
+TIMEOUT 5
+ARCH armv7l
 AFTER ./testprogs/intptrcast
 
 NAME Casting ints


### PR DESCRIPTION
Adds basic support for ARMv7. 

The main part of this PR is the implementation of the arch interface in `arch/arm.cpp`. It also includes fixes for a few issues I've encountered while using bpftrace on my Android device running an old (4.14) armv7 kernel:
- failing to create stack maps
- errors when including kernel headers
- broken BEGIN/END probes

While many programs work on armv7 out of the box, there's one big remaining class of issues related to all pointers internally being represented as `int64`s; this can lead to unaligned loads, wrong offset calculations, etc. I'll submit a separate PR with changes to codegen to keep both easier to review.

This (aims to) resolve #1688.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
