### PR TITLE
Improve codegen for 32-bit architectures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to
 #### Deprecated
 #### Removed
 #### Fixed
+- Fix pointer/register loads on 32-bit architectures
+  - [#2361](https://github.com/iovisor/bpftrace/pull/2361)
 #### Docs
 #### Tools
 

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1340,5 +1340,30 @@ StoreInst *IRBuilderBPF::createAlignedStore(Value *val,
 #endif
 }
 
+llvm::Type *IRBuilderBPF::getPointerStorageTy(AddrSpace as)
+{
+  switch (as)
+  {
+    case AddrSpace::user:
+      return getUserPointerStorageTy();
+    default:
+      return getKernelPointerStorageTy();
+  }
+}
+
+llvm::Type *IRBuilderBPF::getKernelPointerStorageTy()
+{
+  static int ptr_width = get_kernel_ptr_width();
+
+  return getIntNTy(ptr_width);
+}
+
+llvm::Type *IRBuilderBPF::getUserPointerStorageTy()
+{
+  // TODO: we don't currently have an easy way of determining the pointer size
+  // of the uprobed process, so assume it's the same as the kernel's for now.
+  return getKernelPointerStorageTy();
+}
+
 } // namespace ast
 } // namespace bpftrace

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -481,16 +481,6 @@ void IRBuilderBPF::CreateMapDeleteElem(Value *ctx,
 
 void IRBuilderBPF::CreateProbeRead(Value *ctx,
                                    Value *dst,
-                                   size_t size,
-                                   Value *src,
-                                   AddrSpace as,
-                                   const location &loc)
-{
-  return CreateProbeRead(ctx, dst, getInt32(size), src, as, loc);
-}
-
-void IRBuilderBPF::CreateProbeRead(Value *ctx,
-                                   Value *dst,
                                    llvm::Value *size,
                                    Value *src,
                                    AddrSpace as,
@@ -672,7 +662,7 @@ Value *IRBuilderBPF::CreateUSDTReadArgument(Value *ctx,
       {
         ptr = CreateAdd(ptr, index_offset);
       }
-      CreateProbeRead(ctx, dst, abs_size, ptr, as, loc);
+      CreateProbeRead(ctx, dst, getInt32(abs_size), ptr, as, loc);
       result = CreateLoad(getIntNTy(abs_size * 8), dst);
     }
     else
@@ -1365,7 +1355,7 @@ void IRBuilderBPF::CreateProbeRead(Value *ctx,
   AddrSpace as = addrSpace ? addrSpace.value() : type.GetAS();
 
   if (!type.IsPtrTy())
-    return CreateProbeRead(ctx, dst, type.GetSize(), src, as, loc);
+    return CreateProbeRead(ctx, dst, getInt32(type.GetSize()), src, as, loc);
 
   // Pointers are internally always represented as 64-bit integers, matching the
   // BPF register size (BPF is a 64-bit ISA). This helps to avoid BPF codegen
@@ -1383,7 +1373,7 @@ void IRBuilderBPF::CreateProbeRead(Value *ctx,
   if (ptr_size != type.GetSize())
     CREATE_MEMSET(dst, getInt8(0), type.GetSize(), 1);
 
-  CreateProbeRead(ctx, dst, ptr_size, src, as, loc);
+  CreateProbeRead(ctx, dst, getInt32(ptr_size), src, as, loc);
 }
 
 llvm::Value *IRBuilderBPF::CreateDatastructElemLoad(

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1162,16 +1162,31 @@ Value *IRBuilderBPF::CreateRegisterRead(Value *ctx, const std::string &builtin)
   else // argX
     offset = arch::arg_offset(atoi(builtin.substr(3).c_str()));
 
-  Value *ctx_ptr = CreatePointerCast(ctx, getInt64Ty()->getPointerTo());
+  return CreateRegisterRead(ctx, offset, builtin);
+}
+
+Value *IRBuilderBPF::CreateRegisterRead(Value *ctx,
+                                        int offset,
+                                        const std::string &name)
+{
+  // Bitwidth of register values in struct pt_regs is the same as the kernel
+  // pointer width on all supported architectures.
+  llvm::Type *registerTy = getKernelPointerStorageTy();
+  Value *ctx_ptr = CreatePointerCast(ctx, registerTy->getPointerTo());
   // LLVM optimization is possible to transform `(uint64*)ctx` into
   // `(uint8*)ctx`, but sometimes this causes invalid context access.
   // Mark every context access to suppress any LLVM optimization.
-  Value *result = CreateLoad(getInt64Ty(),
-                             CreateGEP(getInt64Ty(), ctx_ptr, getInt64(offset)),
-                             builtin);
+  Value *result = CreateLoad(registerTy,
+                             CreateGEP(registerTy, ctx_ptr, getInt64(offset)),
+                             name);
   // LLVM 7.0 <= does not have CreateLoad(*Ty, *Ptr, isVolatile, Name),
   // so call setVolatile() manually
   dyn_cast<LoadInst>(result)->setVolatile(true);
+  // Caller expects an int64, so add a cast if the register size is different.
+  if (result->getType()->getIntegerBitWidth() != 64)
+  {
+    result = CreateIntCast(result, getInt64Ty(), false);
+  }
   return result;
 }
 

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -81,12 +81,6 @@ public:
                            const location &loc);
   void CreateProbeRead(Value *ctx,
                        Value *dst,
-                       size_t size,
-                       Value *src,
-                       AddrSpace as,
-                       const location &loc);
-  void CreateProbeRead(Value *ctx,
-                       Value *dst,
                        llvm::Value *size,
                        Value *src,
                        AddrSpace as,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -148,6 +148,7 @@ public:
   StructType *GetStructType(std::string name, const std::vector<llvm::Type *> & elements, bool packed = false);
   AllocaInst *CreateUSym(llvm::Value *val, const location &loc);
   Value *CreateRegisterRead(Value *ctx, const std::string &builtin);
+  Value *CreateRegisterRead(Value *ctx, int offset, const std::string &name);
   Value      *CreatKFuncArg(Value *ctx, SizedType& type, std::string& name);
   CallInst *CreateSkbOutput(Value *skb,
                             Value *len,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -175,6 +175,9 @@ public:
   void hoist(const std::function<void()> &functor);
   int helper_error_id_ = 0;
 
+  // Returns the integer type used to represent pointers in traced code.
+  llvm::Type *getPointerStorageTy(AddrSpace as);
+
 private:
   Module &module_;
   BPFtrace &bpftrace_;
@@ -189,6 +192,9 @@ private:
                                  llvm::Type *src,
                                  AddrSpace as);
   libbpf::bpf_func_id selectProbeReadHelper(AddrSpace as, bool str);
+
+  llvm::Type *getKernelPointerStorageTy();
+  llvm::Type *getUserPointerStorageTy();
 
   std::map<std::string, StructType *> structs_;
 };

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -271,10 +271,19 @@ void CodegenLLVM::visit(Builtin &builtin)
     int arg_num = atoi(builtin.ident.substr(4).c_str());
     Value *sp = b_.CreateRegisterRead(ctx_, sp_offset, "reg_sp");
     AllocaInst *dst = b_.CreateAllocaBPF(builtin.type, builtin.ident);
-    Value *src = b_.CreateAdd(sp,
-                              b_.getInt64((arg_num + arch::arg_stack_offset()) *
-                                          sizeof(uintptr_t)));
-    b_.CreateProbeRead(ctx_, dst, 8, src, builtin.type.GetAS(), builtin.loc);
+
+    // Pointer width is used when calculating the SP offset and the number of
+    // bytes to read from stack for each argument. We pass a pointer SizedType
+    // to CreateProbeRead to make sure it uses the correct read size while
+    // keeping builtin.type an int64.
+    size_t arg_width =
+        b_.getPointerStorageTy(builtin.type.GetAS())->getIntegerBitWidth() / 8;
+    SizedType arg_type = CreatePointer(CreateInt8(), builtin.type.GetAS());
+    assert(builtin.type.GetSize() == arg_type.GetSize());
+
+    Value *src = b_.CreateAdd(
+        sp, b_.getInt64((arg_num + arch::arg_stack_offset()) * arg_width));
+    b_.CreateProbeRead(ctx_, dst, arg_type, src, builtin.loc);
     expr_ = b_.CreateLoad(b_.GetType(builtin.type), dst);
     b_.CreateLifetimeEnd(dst);
   }
@@ -1629,10 +1638,8 @@ void CodegenLLVM::unop_ptr(Unop &unop)
       if (unop.type.IsIntegerTy() || unop.type.IsPtrTy())
       {
         auto *et = type.GetPointeeTy();
-        // Pointer always 64 bits wide
-        int size = unop.type.IsIntegerTy() ? et->GetIntBitWidth() / 8 : 8;
         AllocaInst *dst = b_.CreateAllocaBPF(*et, "deref");
-        b_.CreateProbeRead(ctx_, dst, size, expr_, type.GetAS(), unop.loc);
+        b_.CreateProbeRead(ctx_, dst, *et, expr_, unop.loc, type.GetAS());
         expr_ = b_.CreateLoad(b_.GetType(*et), dst);
         b_.CreateLifetimeEnd(dst);
       }
@@ -3396,7 +3403,8 @@ void CodegenLLVM::readDatastructElemFromStack(Value *src_data,
   if (elem_type.IsIntegerTy() || elem_type.IsPtrTy())
   {
     // Load the correct type from src
-    expr_ = b_.CreateLoad(b_.GetType(elem_type), src, true);
+    expr_ = b_.CreateDatastructElemLoad(
+        elem_type, src, true, data_type.GetAS());
   }
   else
   {
@@ -3450,9 +3458,11 @@ void CodegenLLVM::probereadDatastructElem(Value *src_data,
     // Read data onto stack
     if (data_type.IsCtxAccess())
     {
-      expr_ = b_.CreateLoad(dst_type,
-                            b_.CreateIntToPtr(src, dst_type->getPointerTo()),
-                            true);
+      expr_ = b_.CreateDatastructElemLoad(
+          elem_type,
+          b_.CreateIntToPtr(src, dst_type->getPointerTo()),
+          true,
+          data_type.GetAS());
 
       // check context access for iter probes (required by kernel)
       if (probetype(current_attach_point_->provider) == ProbeType::iter)
@@ -3479,8 +3489,7 @@ void CodegenLLVM::probereadDatastructElem(Value *src_data,
     else
     {
       AllocaInst *dst = b_.CreateAllocaBPF(elem_type, temp_name);
-      b_.CreateProbeRead(
-          ctx_, dst, elem_type.GetSize(), src, data_type.GetAS(), loc);
+      b_.CreateProbeRead(ctx_, dst, elem_type, src, loc, data_type.GetAS());
       expr_ = b_.CreateLoad(b_.GetType(elem_type), dst);
       b_.CreateLifetimeEnd(dst);
     }

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -817,9 +817,8 @@ void CodegenLLVM::visit(Call &call)
     {
       b_.CreateProbeRead(ctx_,
                          static_cast<AllocaInst *>(inet_offset),
-                         inet->type.GetSize(),
+                         inet->type,
                          expr_,
-                         inet->type.GetAS(),
                          call.loc);
     }
     else
@@ -1180,12 +1179,8 @@ void CodegenLLVM::visit(Call &call)
     if (onStack(macaddr->type))
       b_.CREATE_MEMCPY(buf, expr_, macaddr->type.GetSize(), 1);
     else
-      b_.CreateProbeRead(ctx_,
-                         static_cast<AllocaInst *>(buf),
-                         macaddr->type.GetSize(),
-                         expr_,
-                         macaddr->type.GetAS(),
-                         call.loc);
+      b_.CreateProbeRead(
+          ctx_, static_cast<AllocaInst *>(buf), macaddr->type, expr_, call.loc);
 
     expr_ = buf;
     expr_deleter_ = [this, buf]() { b_.CreateLifetimeEnd(buf); };
@@ -1610,12 +1605,9 @@ void CodegenLLVM::unop_int(Unop &unop)
     }
     case Operator::MUL: {
       // When dereferencing a 32-bit integer, only read in 32-bits, etc.
-      int size = type.GetSize();
-      auto as = type.GetAS();
-
-      auto dst_type = SizedType(type.type, size);
+      auto dst_type = SizedType(type.type, type.GetSize());
       AllocaInst *dst = b_.CreateAllocaBPF(dst_type, "deref");
-      b_.CreateProbeRead(ctx_, dst, size, expr_, as, unop.loc);
+      b_.CreateProbeRead(ctx_, dst, type, expr_, unop.loc);
       expr_ = b_.CreateIntCast(b_.CreateLoad(b_.GetType(dst_type), dst),
                                b_.getInt64Ty(),
                                type.IsSigned());
@@ -1840,8 +1832,12 @@ void CodegenLLVM::visit(FieldAccess &acc)
           // memset so verifier doesn't complain about reading uninitialized
           // stack
           b_.CREATE_MEMSET(dst, b_.getInt8(0), field.type.GetSize(), 1);
-          b_.CreateProbeRead(
-              ctx_, dst, field.bitfield.read_bytes, src, type.GetAS(), acc.loc);
+          b_.CreateProbeRead(ctx_,
+                             dst,
+                             b_.getInt32(field.bitfield.read_bytes),
+                             src,
+                             type.GetAS(),
+                             acc.loc);
           raw = b_.CreateLoad(field_type, dst);
           b_.CreateLifetimeEnd(dst);
         }
@@ -1997,12 +1993,7 @@ void CodegenLLVM::visit(Tuple &tuple)
     if (onStack(elem->type))
       b_.CREATE_MEMCPY(dst, expr_, elem->type.GetSize(), 1);
     else if (elem->type.IsArrayTy() || elem->type.IsRecordTy())
-      b_.CreateProbeRead(ctx_,
-                         dst,
-                         elem->type.GetSize(),
-                         expr_,
-                         elem->type.GetAS(),
-                         elem->loc);
+      b_.CreateProbeRead(ctx_, dst, elem->type, expr_, elem->loc);
     else
       b_.CreateStore(expr_, dst);
   }
@@ -2055,10 +2046,10 @@ void CodegenLLVM::visit(AssignMapStatement &assignment)
       AllocaInst *dst = b_.CreateAllocaBPF(map.type, map.ident + "_val");
       b_.CreateProbeRead(ctx_,
                          dst,
-                         map.type.GetSize(),
+                         map.type,
                          expr,
-                         assignment.expr->type.GetAS(),
-                         assignment.loc);
+                         assignment.loc,
+                         assignment.expr->type.GetAS());
       val = dst;
       self_alloca = true;
     }
@@ -2611,12 +2602,7 @@ std::tuple<Value *, CodegenLLVM::ScopedExprDeleter> CodegenLLVM::getMapKey(
         if (expr->type.IsArrayTy() || expr->type.IsRecordTy())
         {
           // We need to read the entire array/struct and save it
-          b_.CreateProbeRead(ctx_,
-                             key,
-                             expr->type.GetSize(),
-                             expr_,
-                             expr->type.GetAS(),
-                             expr->loc);
+          b_.CreateProbeRead(ctx_, key, expr->type, expr_, expr->loc);
         }
         else
         {
@@ -2686,12 +2672,7 @@ AllocaInst *CodegenLLVM::getMultiMapKey(Map &map,
       if (expr->type.IsArrayTy() || expr->type.IsRecordTy())
       {
         // Read the array/struct into the key
-        b_.CreateProbeRead(ctx_,
-                           offset_val,
-                           expr->type.GetSize(),
-                           expr_,
-                           expr->type.GetAS(),
-                           expr->loc);
+        b_.CreateProbeRead(ctx_, offset_val, expr->type, expr_, expr->loc);
         if ((expr->type.GetSize() % 8) != 0)
           aligned = false;
       }
@@ -3195,12 +3176,7 @@ void CodegenLLVM::createPrintNonMapCall(Call &call, int &id)
     if (onStack(arg.type))
       b_.CREATE_MEMCPY(content_offset, expr_, arg.type.GetSize(), 1);
     else
-      b_.CreateProbeRead(ctx_,
-                         content_offset,
-                         arg.type.GetSize(),
-                         expr_,
-                         arg.type.GetAS(),
-                         arg.loc);
+      b_.CreateProbeRead(ctx_, content_offset, arg.type, expr_, arg.loc);
   }
   else
   {
@@ -3446,8 +3422,7 @@ void CodegenLLVM::probereadDatastructElem(Value *src_data,
   {
     // Read data onto stack
     AllocaInst *dst = b_.CreateAllocaBPF(elem_type, temp_name);
-    b_.CreateProbeRead(
-        ctx_, dst, elem_type.GetSize(), src, data_type.GetAS(), loc);
+    b_.CreateProbeRead(ctx_, dst, elem_type, src, loc, data_type.GetAS());
     expr_ = dst;
     expr_deleter_ = [this, dst]() { b_.CreateLifetimeEnd(dst); };
   }

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1191,4 +1191,23 @@ std::string strip_symbol_module(const std::string &symbol)
   return idx != std::string::npos ? symbol.substr(0, idx) : symbol;
 }
 
+int get_kernel_ptr_width()
+{
+  // We can't assume that sizeof(void*) in bpftrace is the same as the kernel
+  // pointer size (bpftrace can be compiled as a 32-bit binary and run on a
+  // 64-bit kernel), so we guess based on the machine field of struct utsname.
+  // Note that the uname() syscall can return different values for compat mode
+  // processes (e.g. "armv8l" instead of "aarch64"; see COMPAT_UTS_MACHINE), so
+  // make sure this is taken into account.
+  struct utsname utsname;
+  if (uname(&utsname) != 0)
+    LOG(FATAL) << "uname failed: " << strerror(errno);
+
+  const char *machine = utsname.machine;
+  if (!strncmp(machine, "armv7", 5))
+    return 32;
+
+  return 64;
+}
+
 } // namespace bpftrace

--- a/src/utils.h
+++ b/src/utils.h
@@ -271,4 +271,7 @@ inline void hash_combine(std::size_t &seed, const T &value)
   seed ^= hasher(value) + 0x9e3779b9 + (seed << 6) + (seed >> 2);
 }
 
+// Returns the width in bits of kernel pointers.
+int get_kernel_ptr_width();
+
 } // namespace bpftrace


### PR DESCRIPTION
This is a follow-up to #2360. The main issues I've run into on armv7 have to do with pointers in bpftrace being 64-bit, which results in misaligned loads and/or wrong offsets; for example:
```
# bpftrace -ve 't:syscalls:sys_enter_open { printf("%p\n", args->filename); }'
0: (b7) r2 = 0
1: (7b) *(u64 *)(r10 -16) = r2
2: (79) r2 = *(u64 *)(r1 +12)
invalid bpf_context access off=12 size=8
``` 
(individual commit messages go into more details)

This changeset tackles this by modifying the size of ctx-relative pointer loads and `bpf_probe_read` calls so it depends on the target arch (4 bytes on armv7, unchanged on all other supported architectures) and adjusting ctx offsets when reading register values.

##### Checklist

- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
