### PR TITLE
Fix probe builtin probe expansion bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to
 #### Deprecated
 #### Removed
 #### Fixed
+- Fix probe builtin probe expansion bug
+  - [#2363](https://github.com/iovisor/bpftrace/pull/2363)
+
 #### Docs
 #### Tools
 

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -408,7 +408,8 @@ void SemanticAnalyser::visit(Builtin &builtin)
   }
   else if (builtin.ident == "probe") {
     builtin.type = CreateProbe();
-    probe_->need_expansion = true;
+    if (has_wildcard(probe_->name()))
+      probe_->need_expansion = true;
   }
   else if (builtin.ident == "username") {
     builtin.type = CreateUsername();

--- a/tests/codegen/llvm/map_key_probe.ll
+++ b/tests/codegen/llvm/map_key_probe.ll
@@ -6,7 +6,7 @@ target triple = "bpf-pc-linux"
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @"tracepoint:sched:sched_one"(i8* %0) section "s_tracepoint:sched:sched_one_1" {
+define i64 @"tracepoint:sched:sched_one,tracepoint:sched:sched_two"(i8* %0) section "s_tracepoint:sched:sched_one,tracepoint:sched:sched_two_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key1" = alloca i64, align 8
@@ -59,54 +59,6 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
-
-define i64 @"tracepoint:sched:sched_two"(i8* %0) section "s_tracepoint:sched:sched_two_2" {
-entry:
-  %"@x_val" = alloca i64, align 8
-  %"@x_key1" = alloca i64, align 8
-  %lookup_elem_val = alloca i64, align 8
-  %"@x_key" = alloca i64, align 8
-  %1 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
-  store i64 1, i64* %"@x_key", align 8
-  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* %"@x_key")
-  %2 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
-  %map_lookup_cond = icmp ne i8* %lookup_elem, null
-  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
-
-lookup_success:                                   ; preds = %entry
-  %cast = bitcast i8* %lookup_elem to i64*
-  %3 = load i64, i64* %cast, align 8
-  store i64 %3, i64* %lookup_elem_val, align 8
-  br label %lookup_merge
-
-lookup_failure:                                   ; preds = %entry
-  store i64 0, i64* %lookup_elem_val, align 8
-  br label %lookup_merge
-
-lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %4 = load i64, i64* %lookup_elem_val, align 8
-  %5 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = add i64 %4, 1
-  %8 = bitcast i64* %"@x_key1" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  store i64 1, i64* %"@x_key1", align 8
-  %9 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  store i64 %7, i64* %"@x_val", align 8
-  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@x_key1", i64* %"@x_val", i64 0)
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_key1" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  ret i64 1
-}
 
 attributes #0 = { nounwind }
 attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -118,6 +118,11 @@ EXPECT ^BEGIN-END$
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep 1e8
 
+NAME interval probe
+PROG interval:ms:2000 { print(probe); exit(); }
+EXPECT ^interval:ms:2000$
+TIMEOUT 5
+
 NAME curtask
 PROG i:ms:1 { printf("SUCCESS %d\n", curtask); exit(); }
 EXPECT SUCCESS -?[0-9][0-9]*

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -41,7 +41,7 @@ TIMEOUT 1
 
 # https://github.com/iovisor/bpftrace/issues/1952
 NAME async_id_invalid_probe_expansion
-PROG kprobe:zzzzz { probe; printf("asdf\n") } BEGIN { printf("_%s_\n", "success"); exit() }
+PROG kprobe:zzzzz* { probe; printf("asdf\n") } BEGIN { printf("_%s_\n", "success"); exit() }
 EXPECT _success_
 TIMEOUT 1
 


### PR DESCRIPTION
Expand probes using probe builtin only when they contain a wildcard. This prevents an error in cases where the probe builtin is used in a probe that cannot be expanded, e.g. interval probe.

Fixes #2362

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
