### PR TITLE
Workaround OpaquePointers for LLVM 15

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -123,6 +123,9 @@ IRBuilderBPF::IRBuilderBPF(LLVMContext &context,
     module_(module),
     bpftrace_(bpftrace)
 {
+#if LLVM_VERSION_MAJOR == 15
+  context.setOpaquePointers(false);
+#endif
   // Declare external LLVM function
   FunctionType *pseudo_func_type = FunctionType::get(
       getInt64Ty(),


### PR DESCRIPTION
This workaround allows bpftrace to be compiled against LLVM-15.  This will have to be address properly before LLVM-16
More details from LLVM here: https://llvm.org/docs/OpaquePointers.html

Open issues here:
https://github.com/iovisor/bpftrace/issues/2366
https://github.com/iovisor/bpftrace/issues/2365
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
