### PR TITLE
ci: publish images for focal as well

### DIFF
--- a/.github/workflows/embedded_llvm.yml
+++ b/.github/workflows/embedded_llvm.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         llvm_version: [12]
-        base: [xenial, bionic]
+        base: [xenial, bionic, focal]
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2


### PR DESCRIPTION
xenial is out of standard support AND it doesn't have linux/btf.h, which libbpf is now expecting. To make our lives easier, let's also publish embedded images for focal and switch the builds away from [xenial, bionic] to [bionic, focal].