### PR TITLE
tcpdrop: Fix: ERROR: Error attaching probe: 'kprobe:tcp_drop'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           LLVM_VERSION: 10
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
-          TOOLS_TEST_OLDVERSION: biosnoop.bt
+          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 10 Release
@@ -42,7 +42,7 @@ jobs:
           LLVM_VERSION: 10
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
-          TOOLS_TEST_OLDVERSION: biosnoop.bt
+          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 10 Clang Debug
@@ -52,7 +52,7 @@ jobs:
           CXX: clang++-10
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
-          TOOLS_TEST_OLDVERSION: biosnoop.bt
+          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 11 Debug
@@ -60,7 +60,7 @@ jobs:
           LLVM_VERSION: 11
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
-          TOOLS_TEST_OLDVERSION: biosnoop.bt
+          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 11 Release
@@ -68,7 +68,7 @@ jobs:
           LLVM_VERSION: 11
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
-          TOOLS_TEST_OLDVERSION: biosnoop.bt
+          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 12 Release
@@ -76,7 +76,7 @@ jobs:
           LLVM_VERSION: 12
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
-          TOOLS_TEST_OLDVERSION: biosnoop.bt
+          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 13 Release
@@ -84,7 +84,7 @@ jobs:
           LLVM_VERSION: 13
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
-          TOOLS_TEST_OLDVERSION: biosnoop.bt
+          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 14 Release
@@ -92,7 +92,7 @@ jobs:
           LLVM_VERSION: 14
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
-          TOOLS_TEST_OLDVERSION: biosnoop.bt
+          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: LLVM 15 Release
@@ -100,7 +100,7 @@ jobs:
           LLVM_VERSION: 15
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
-          TOOLS_TEST_OLDVERSION: biosnoop.bt
+          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: focal
           VENDOR_GTEST: ON
         - NAME: Memleak test (LLVM 11 Debug)

--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -16,7 +16,7 @@ jobs:
           EMBED_USE_LLVM: ON
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size
-          TOOLS_TEST_OLDVERSION: biosnoop.bt
+          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: bionic
           DISTRO: ubuntu-glibc
           VENDOR_GTEST: ON
@@ -30,7 +30,7 @@ jobs:
           EMBED_USE_LLVM: ON
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size,other."string compare map lookup",call.skboutput
-          TOOLS_TEST_OLDVERSION: biosnoop.bt
+          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: focal
           DISTRO: ubuntu-glibc
           VENDOR_GTEST: ON
@@ -44,7 +44,7 @@ jobs:
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: json-output.join_delim,other.string compare map lookup,probe.kprobe_offset_fail_size,probe.uprobe_library,usdt."usdt probes - attach to fully specified probe of child",usdt."usdt probes - all probes by wildcard and file with child",usdt."usdt probes - attach to probe by wildcard and file with child",usdt."usdt probes - attach to probes by wildcard file with child",usdt."usdt probes - attach to probe on multiple files by wildcard",usdt."usdt probes - attach to probe with probe builtin and args by file with child",usdt."usdt probes - list probes by pid in separate mountns",usdt."usdt sized arguments",usdt."usdt - list probes by file with wildcarded probe type",uprobe."uprobes - list probes by pid; uprobes only",uprobe."uprobes - list probes by pid in separate mount namespace",other."positional pointer arithmetics",call.skboutput
           TOOLS_TEST_DISABLE: gethostlatency.bt,threadsnoop.bt,ssllatency.bt,sslsnoop.bt
-          TOOLS_TEST_OLDVERSION: biosnoop.bt
+          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: alpine
           DISTRO: alpine
           ALPINE_VERSION: 3.12
@@ -59,7 +59,7 @@ jobs:
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: other.string compare map lookup,probe.kprobe_offset_fail_size,probe.uprobe_library,usdt."usdt probes - attach to fully specified probe of child",usdt."usdt probes - all probes by wildcard and file with child",usdt."usdt probes - attach to probe by wildcard and file with child",usdt."usdt probes - attach to probes by wildcard file with child",usdt."usdt probes - attach to probe on multiple files by wildcard",usdt."usdt probes - attach to probe with probe builtin and args by file with child",usdt."usdt probes - list probes by pid in separate mountns",usdt."usdt sized arguments",usdt."usdt - list probes by file with wildcarded probe type",uprobe."uprobes - list probes by pid; uprobes only",uprobe."uprobes - list probes by pid in separate mount namespace",other."positional pointer arithmetics",call.skboutput
           TOOLS_TEST_DISABLE: gethostlatency.bt,threadsnoop.bt,ssllatency.bt,sslsnoop.bt
-          TOOLS_TEST_OLDVERSION: biosnoop.bt
+          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: alpine
           DISTRO: alpine
           ALPINE_VERSION: 3.12

--- a/tools/old/tcpdrop.bt
+++ b/tools/old/tcpdrop.bt
@@ -9,15 +9,18 @@
  * It is limited to ipv4 addresses, and cannot show tcp flags.
  *
  * This provides information such as packet details, socket state, and kernel
- * stack trace for packets/segments that were dropped via kfree_skb.
+ * stack trace for packets/segments that were dropped via tcp_drop().
+
+ * WARNING: this script attaches to the tcp_drop kprobe which is likely inlined
+ *          on newer kernels and not replaced by anything else, therefore
+ *          the script will stop working
  *
- * For Linux 5.17+ (see tools/old for script for lower versions).
+ * For Linux <= 5.18.
  *
  * Copyright (c) 2018 Dale Hamel.
  * Licensed under the Apache License, Version 2.0 (the "License")
  *
  * 23-Nov-2018	Dale Hamel	created this.
- * 01-Oct-2022	Rong Tao	use tracepoint:skb:kfree_skb
  */
 
 #ifndef BPFTRACE_HAVE_BTF
@@ -47,15 +50,12 @@ BEGIN
   @tcp_states[12] = "NEW_SYN_RECV";
 }
 
-tracepoint:skb:kfree_skb
+kprobe:tcp_drop
 {
-  $reason = args->reason;
-  $skb = (struct sk_buff *)args->skbaddr;
-  $sk = ((struct sock *) $skb->sk);
+  $sk = ((struct sock *) arg0);
   $inet_family = $sk->__sk_common.skc_family;
 
-  if ($reason > SKB_DROP_REASON_NOT_SPECIFIED &&
-      ($inet_family == AF_INET || $inet_family == AF_INET6)) {
+  if ($inet_family == AF_INET || $inet_family == AF_INET6) {
     if ($inet_family == AF_INET) {
       $daddr = ntop($sk->__sk_common.skc_daddr);
       $saddr = ntop($sk->__sk_common.skc_rcv_saddr);


### PR DESCRIPTION
kernel commit 8fbf195798b5('tcp_drop() is no longer needed.') remove the kprobe:tcp_drop, bcc commit 16eab39171eb('Add
tracepoint:skb:kfree_skb if no tcp_drop() kprobe.') already fix this problem.

CI old kernel is too old and not support the 'reason' field, move the old tools/tcpdrop.bt into tools/old/tcpdrop.bt and set the CI to use it.

ERROR log:
```bash
 $ sudo ./tcpdrop.bt
 ./tcpdrop.bt:49-51: WARNING: tcp_drop is not traceable (either non-existing, inlined, or marked as "notrace"); attaching to it will likely fail
 Attaching 3 probes...
 cannot attach kprobe, probe entry may not exist
 ERROR: Error attaching probe: 'kprobe:tcp_drop'
```