### PR TITLE
Vendor stdbool.h from clang 15.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to
   - [#2315](https://github.com/iovisor/bpftrace/pull/2315)
 - Add %rh option to print buffer as hex without \x
   - [#2445](https://github.com/iovisor/bpftrace/pull/2445)
+- Add stdbool.h to built-in headers
+  - [#2380](https://github.com/iovisor/bpftrace/pull/2380)
 #### Changed
 - Raise minimum versions for libbpf and bcc and vendor them for local builds
   - [#2369](https://github.com/iovisor/bpftrace/pull/2369)

--- a/resources/stdbool.h
+++ b/resources/stdbool.h
@@ -1,0 +1,34 @@
+/*===---- stdbool.h - Standard header for booleans -------------------------===
+ *
+ * Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+ * See https://llvm.org/LICENSE.txt for license information.
+ * SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *===-----------------------------------------------------------------------===
+ */
+
+#ifndef __STDBOOL_H
+#define __STDBOOL_H
+
+#define __bool_true_false_are_defined 1
+
+#if __STDC_VERSION__ > 201710L
+/* FIXME: We should be issuing a deprecation warning here, but cannot yet due
+ * to system headers which include this header file unconditionally.
+ */
+#elif !defined(__cplusplus)
+#define bool _Bool
+#define true 1
+#define false 0
+#elif defined(__GNUC__) && !defined(__STRICT_ANSI__)
+/* Define _Bool as a GNU extension. */
+#define _Bool bool
+#if __cplusplus < 201103L
+/* For C++98, define bool, false, true as a GNU extension. */
+#define bool bool
+#define false false
+#define true true
+#endif
+#endif
+
+#endif /* __STDBOOL_H */

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -41,6 +41,11 @@ const std::vector<CXUnsavedFile> &getDefaultHeaders()
         .Length = stdarg_h_len,
     },
     {
+        .Filename = "/bpftrace/include/stdbool.h",
+        .Contents = stdbool_h,
+        .Length = stdbool_h_len,
+    },
+    {
         .Filename = "/bpftrace/include/stddef.h",
         .Contents = stddef_h,
         .Length = stddef_h_len,

--- a/src/headers.h
+++ b/src/headers.h
@@ -11,6 +11,8 @@ extern const char limits_h[];
 extern const unsigned limits_h_len;
 extern const char stdarg_h[];
 extern const unsigned stdarg_h_len;
+extern const char stdbool_h[];
+extern const unsigned stdbool_h_len;
 extern const char stddef_h[];
 extern const unsigned stddef_h_len;
 extern const char stdint_h[];


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->
This follows the example of the existing headers in `resources`, copying stdbool.h from the latest tagged release of LLVM.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
