### PR TITLE
Fix kprobe multi-attachment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to
 #### Fixed
 - Fix pointer/register loads on 32-bit architectures
   - [#2361](https://github.com/iovisor/bpftrace/pull/2361)
+- Fix kprobe multi-attachment
+  - [#2381](https://github.com/iovisor/bpftrace/pull/2381)
+
 #### Docs
 #### Tools
 

--- a/docker/Dockerfile.focal
+++ b/docker/Dockerfile.focal
@@ -41,6 +41,7 @@ RUN apt-get update && apt-get install -y \
       llvm-${LLVM_VERSION}-dev \
       llvm-${LLVM_VERSION}-runtime \
       libllvm${LLVM_VERSION} \
+      linux-tools-$(uname -r) \
       systemtap-sdt-dev \
       python3 \
       xxd \

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -835,8 +835,7 @@ void AttachedProbe::attach_multi_kprobe(void)
   opts.kprobe_multi.syms = syms.data();
   opts.kprobe_multi.cnt = syms.size();
   opts.kprobe_multi.flags = probe_.type == ProbeType::kretprobe
-                                ? static_cast<enum ::bpf_attach_type>(
-                                      libbpf::BPF_TRACE_KPROBE_MULTI)
+                                ? BPF_F_KPROBE_MULTI_RETURN
                                 : 0;
 
   if (bt_verbose)

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -138,7 +138,7 @@ int BPFtrace::add_probe(ast::Probe &p)
       attach_funcs.insert(attach_funcs.end(), matches.begin(), matches.end());
 
       if (feature_->has_kprobe_multi() && has_wildcard(attach_point->func) &&
-          attach_funcs.size() &&
+          !p.need_expansion && attach_funcs.size() &&
           (probetype(attach_point->provider) == ProbeType::kprobe ||
            probetype(attach_point->provider) == ProbeType::kretprobe))
       {

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -55,7 +55,7 @@ TIMEOUT 5
 REQUIRES /usr/sbin/bpftool
 
 NAME kprobe_multi_wildcard
-RUN {{BPFTRACE}} --unsafe -e 'kprobe:ksys_* { printf("link: "); system("/usr/sbin/bpftool link | grep type | grep 8 | wc -l"); exit(); }'
+RUN {{BPFTRACE}} --unsafe -e 'kprobe:ksys_* { printf("link: "); system("/usr/sbin/bpftool link | grep kprobe_multi | wc -l"); exit(); }'
 EXPECT link: 1
 TIMEOUT 5
 REQUIRES /usr/sbin/bpftool
@@ -124,7 +124,7 @@ TIMEOUT 5
 REQUIRES /usr/sbin/bpftool
 
 NAME kretprobe_multi_wildcard
-RUN {{BPFTRACE}} --unsafe -e 'kretprobe:ksys_* { printf("link: "); system("/usr/sbin/bpftool link | grep type | grep 8 | wc -l"); exit(); }'
+RUN {{BPFTRACE}} --unsafe -e 'kretprobe:ksys_* { printf("link: "); system("/usr/sbin/bpftool link | grep kprobe_multi | wc -l"); exit(); }'
 EXPECT link: 1
 TIMEOUT 5
 REQUIRES /usr/sbin/bpftool


### PR DESCRIPTION
Tests for kprobe multi-attachment are not executed in the CI, so we missed a couple of bugs. This PR fixes them (see individual commits for details).

Also, some runtime tests (including those for kprobe multi) require bpftool, so it is now installed in Docker. Unfortunately, kprobe_multi is stilll not available in the CI kernel.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
