### PR TITLE
Codegen: initialize LLVM targets

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -24,6 +24,8 @@
 #include <llvm/Support/TargetRegistry.h>
 #endif
 
+#include <llvm/Support/TargetSelect.h>
+
 #include "arch/arch.h"
 #include "ast.h"
 #include "ast/async_event_types.h"
@@ -45,6 +47,9 @@ CodegenLLVM::CodegenLLVM(Node *root, BPFtrace &bpftrace)
       module_(std::make_unique<Module>("bpftrace", *context_)),
       b_(*context_, *module_, bpftrace)
 {
+  llvm::InitializeAllTargets();
+  llvm::InitializeAllTargetMCs();
+  llvm::InitializeAllAsmPrinters();
   std::string error_str;
   auto target = llvm::TargetRegistry::lookupTarget(LLVMTargetTriple, error_str);
   if (!target)


### PR DESCRIPTION
The initialization is required by the new in-memory ELF parsing that has replaced ORC usage (#2376). At this point, it is executed inside `clang_createIndex` but if ClangParser did not run for some reason (as #2315 proposes), codegen would fail.

This PR does the initialization transparently from codegen.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
