### PR TITLE
Support opaque pointers (LLVM 15)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,15 @@ jobs:
           BASE: focal
           VENDOR_GTEST: ON
           BUILD_LIBBPF: ON
+        - NAME: LLVM 15 Release
+          TYPE: Release
+          LLVM_VERSION: 15
+          RUN_ALL_TESTS: 1
+          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size
+          TOOLS_TEST_OLDVERSION: biosnoop.bt
+          BASE: focal
+          VENDOR_GTEST: ON
+          BUILD_LIBBPF: ON
         - NAME: LLVM 12 Release + old libbpf
           TYPE: Release
           LLVM_VERSION: 12

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -123,9 +123,6 @@ IRBuilderBPF::IRBuilderBPF(LLVMContext &context,
     module_(module),
     bpftrace_(bpftrace)
 {
-#if LLVM_VERSION_MAJOR == 15
-  context.setOpaquePointers(false);
-#endif
   // Declare external LLVM function
   FunctionType *pseudo_func_type = FunctionType::get(
       getInt64Ty(),

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -90,14 +90,8 @@ public:
                        AddrSpace as,
                        const location &loc);
   CallInst *CreateProbeReadStr(Value *ctx,
-                               AllocaInst *dst,
+                               Value *dst,
                                llvm::Value *size,
-                               Value *src,
-                               AddrSpace as,
-                               const location &loc);
-  CallInst *CreateProbeReadStr(Value *ctx,
-                               AllocaInst *dst,
-                               size_t size,
                                Value *src,
                                AddrSpace as,
                                const location &loc);
@@ -115,7 +109,12 @@ public:
                                 pid_t pid,
                                 AddrSpace as,
                                 const location &loc);
-  Value *CreateStrncmp(Value *val1, Value *val2, uint64_t n, bool inverse);
+  Value *CreateStrncmp(Value *str1,
+                       uint64_t str1_size,
+                       Value *str2,
+                       uint64_t str2_size,
+                       uint64_t n,
+                       bool inverse);
   CallInst *CreateGetNs(bool boot_time, const location &loc);
   CallInst *CreateGetPidTgid(const location &loc);
   CallInst *CreateGetCurrentCgroupId(const location &loc);
@@ -131,7 +130,10 @@ public:
                              ArrayRef<Value *> args,
                              const Twine &Name,
                              const location *loc = nullptr);
-  CallInst   *createCall(Value *callee, ArrayRef<Value *> args, const Twine &Name);
+  CallInst *createCall(FunctionType *callee_type,
+                       Value *callee,
+                       ArrayRef<Value *> args,
+                       const Twine &Name);
   void        CreateGetCurrentComm(Value *ctx, AllocaInst *buf, size_t size, const location& loc);
   void CreatePerfEventOutput(Value *ctx,
                              Value *data,
@@ -185,9 +187,6 @@ private:
                                 AddrSpace as,
                                 const location &loc);
   CallInst *createMapLookup(int mapid, Value *key);
-  Constant *createProbeReadStrFn(llvm::Type *dst,
-                                 llvm::Type *src,
-                                 AddrSpace as);
   libbpf::bpf_func_id selectProbeReadHelper(AddrSpace as, bool str);
 
   std::map<std::string, StructType *> structs_;


### PR DESCRIPTION
LLVM moves to opaque pointers, starting from version 15 (see [here](https://llvm.org/docs/OpaquePointers.html) for details). They can be disabled in 15 (which is what #2367 did) but that won't be an option for LLVM 16.

This PR removes all the remaining dependencies on explicit pointers, in particular the `Value::getPointerElementType` method. With that, opaque pointers are properly supported and #2367 is reverted.

Closes #2368, fixes #2365 and #2366.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
