### PR TITLE
Improve user symbol resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to
 #### Changed
 - Make `args` a structure (instead of a pointer)
   - [#2578](https://github.com/iovisor/bpftrace/pull/2578)
+- Improve user symbol resolution
+  - [#2386](https://github.com/iovisor/bpftrace/pull/2386)
 #### Fixed
 - Fix resolving username for malformed /etc/passwd
   - [#2631](https://github.com/iovisor/bpftrace/pull/2631)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -210,12 +210,13 @@ Increasing the value will consume more memory, increase startup times and can in
 
 === BPFTRACE_CACHE_USER_SYMBOLS
 
-Default: 0 if ASLR is enabled on system and `-c` option is not given; otherwise 1
+Default: PER_PROGRAM if ASLR disabled or `-c` option given, PER_PID otherwise.
 
-By default, bpftrace caches the results of symbols resolutions only when ASLR (Address Space Layout Randomization) is disabled.
-This is because the symbol addresses change with each execution with ASLR.
-However, disabling caching may incur some performance penalty.
-Set this env variable to 1 to force bpftrace to cache.
+Caching strategy for user symbols. Valid values are:
+
+* PER_PROGRAM - each program has its own cache. If there are more processes with enabled ASLR for a single program, this might produce incorrect results.
+* PER_PID - each process has its own cache. This is accurate for processes with ASLR enabled, and enables bpftrace to preload caches for processes running at probe attachement time. If there are many processes running, it will consume a lot of a memory.
+* NONE - caching disabled. This saves the most memory, but at the cost of speed.
 
 === BPFTRACE_VMLINUX
 
@@ -1788,7 +1789,7 @@ The pointer type is left unchanged.
 
 Equal to <<functions_ksym>> but resolves user space symbols.
 
-If ASLR is enabled, it works only when the process is running at either the time of the symbol resolution or the time of the probe attachment. The latter might not work with older versions of BCC. A similar limitation also applies to dynamically loaded symbols.
+If ASLR is enabled, user space symbolication only works when the process is running at either the time of the symbol resolution or the time of the probe attachment. The latter requires `BPFTRACE_CACHE_USER_SYMBOLS` to be set to `PER_PID`, and might not work with older versions of BCC. A similar limitation also applies to dynamically loaded symbols.
 
 ----
 uprobe:/bin/bash:readline

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1786,8 +1786,9 @@ The pointer type is left unchanged.
 * uretprobes
 
 
-Equal to <<functions_ksym>> but resolves user space symbols
+Equal to <<functions_ksym>> but resolves user space symbols.
 
+If ASLR is enabled, it works only when the process is running at either the time of the symbol resolution or the time of the probe attachment. The latter might not work with older versions of BCC. A similar limitation also applies to dynamically loaded symbols.
 
 ----
 uprobe:/bin/bash:readline

--- a/src/ast/codegen_helper.h
+++ b/src/ast/codegen_helper.h
@@ -13,8 +13,8 @@ inline bool needMemcpy(const SizedType &stype)
 inline bool shouldBeOnStackAlready(const SizedType &type)
 {
   return type.IsStringTy() || type.IsBufferTy() || type.IsInetTy() ||
-         type.IsUsymTy() || type.IsTupleTy() || type.IsTimestampTy() ||
-         type.IsMacAddressTy() || type.IsCgroupPathTy();
+         type.IsUsymTy() || type.IsUstackTy() || type.IsTupleTy() ||
+         type.IsTimestampTy() || type.IsMacAddressTy() || type.IsCgroupPathTy();
 }
 
 inline bool onStack(const SizedType &type)

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -193,7 +193,7 @@ public:
   void        CreateHelperError(Value *ctx, Value *return_value, libbpf::bpf_func_id func_id, const location& loc);
   void        CreateHelperErrorCond(Value *ctx, Value *return_value, libbpf::bpf_func_id func_id, const location& loc, bool compare_zero=false);
   StructType *GetStructType(std::string name, const std::vector<llvm::Type *> & elements, bool packed = false);
-  AllocaInst *CreateUSym(llvm::Value *val, const location &loc);
+  AllocaInst *CreateUSym(llvm::Value *val, int probe_id, const location &loc);
   Value *CreateRegisterRead(Value *ctx, const std::string &builtin);
   Value *CreateRegisterRead(Value *ctx, int offset, const std::string &name);
   Value      *CreatKFuncArg(Value *ctx, SizedType& type, std::string& name);

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -162,6 +162,8 @@ private:
                      StackType stack_type,
                      const location &loc);
 
+  int get_probe_id();
+
   // Create return instruction
   //
   // If null, return value will depend on current attach point

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -65,6 +65,13 @@ void ResourceAnalyser::visit(Builtin &builtin)
   {
     resources_.stackid_maps.insert(StackType{});
   }
+
+  if (uses_usym_table(builtin.ident))
+  {
+    // mark probe as using usym, so that the symbol table can be pre-loaded
+    // and symbols resolved even when unavailable at resolution time
+    resources_.probes_using_usym.insert(probe_);
+  }
 }
 
 void ResourceAnalyser::visit(Call &call)
@@ -194,6 +201,13 @@ void ResourceAnalyser::visit(Call &call)
     resources_.skboutput_args_.emplace_back(file.str, offset.n);
     resources_.needs_perf_event_map = true;
   }
+
+  if (uses_usym_table(call.func))
+  {
+    // mark probe as using usym, so that the symbol table can be pre-loaded
+    // and symbols resolved even when unavailable at resolution time
+    resources_.probes_using_usym.insert(probe_);
+  }
 }
 
 void ResourceAnalyser::visit(Map &map)
@@ -215,6 +229,11 @@ void ResourceAnalyser::prepare_mapped_printf_ids()
     resources_.mapped_printf_ids.push_back({ idx, len + 1 });
     idx += len + 1;
   }
+}
+
+bool ResourceAnalyser::uses_usym_table(const std::string &fun)
+{
+  return fun == "usym" || fun == "func" || fun == "ustack";
 }
 
 Pass CreateResourcePass()

--- a/src/ast/passes/resource_analyser.h
+++ b/src/ast/passes/resource_analyser.h
@@ -37,6 +37,10 @@ private:
   // starting indicies and lengths of each format string in the data map.
   void prepare_mapped_printf_ids();
 
+  // Determines whether the given function uses userspace symbol resolution.
+  // This is used later for loading the symbol table into memory.
+  bool uses_usym_table(const std::string &fun);
+
   RequiredResources resources_;
   Node *root_;
   std::ostream &out_;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -60,7 +60,7 @@ BPFtrace::~BPFtrace()
       bcc_free_symcache(pair.second.second, pair.second.first);
   }
 
-  for (const auto& pair : pid_sym_)
+  for (const auto &pair : pid_sym_)
   {
     if (pair.second)
       bcc_free_symcache(pair.second, pair.first);
@@ -310,6 +310,18 @@ int BPFtrace::add_probe(ast::Probe &p)
       {
         resources.probes.push_back(probe);
       }
+    }
+
+    if (resources.probes_using_usym.find(&p) !=
+            resources.probes_using_usym.end() &&
+        symbol_table_cache_.find(attach_point->target) ==
+            symbol_table_cache_.end() &&
+        bcc_elf_is_exe(attach_point->target.c_str()))
+    {
+      // preload symbol table for executable to make it available even if the
+      // binary is not present at symbol resolution time
+      symbol_table_cache_[attach_point->target] = get_symbol_table_for_elf(
+          attach_point->target);
     }
   }
 
@@ -700,11 +712,10 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(const std::vec
             resolve_ksym(*reinterpret_cast<uint64_t*>(arg_data+arg.offset))));
         break;
       case Type::usym:
-        arg_values.push_back(
-          std::make_unique<PrintableString>(
-            resolve_usym(
-              *reinterpret_cast<uint64_t*>(arg_data+arg.offset),
-              *reinterpret_cast<uint64_t*>(arg_data+arg.offset + 8))));
+        arg_values.push_back(std::make_unique<PrintableString>(resolve_usym(
+            *reinterpret_cast<uint64_t *>(arg_data + arg.offset),
+            *reinterpret_cast<uint64_t *>(arg_data + arg.offset + 8),
+            *reinterpret_cast<uint64_t *>(arg_data + arg.offset + 16))));
         break;
       case Type::inet:
         arg_values.push_back(
@@ -726,20 +737,22 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(const std::vec
               *reinterpret_cast<uint64_t*>(arg_data+arg.offset))));
         break;
       case Type::kstack:
-        arg_values.push_back(
-          std::make_unique<PrintableString>(
-            get_stack(
-              *reinterpret_cast<uint64_t*>(arg_data+arg.offset),
-              false,
-              arg.type.stack_type, 8)));
+        arg_values.push_back(std::make_unique<PrintableString>(
+            get_stack(*reinterpret_cast<int64_t *>(arg_data + arg.offset),
+                      -1,
+                      -1,
+                      false,
+                      arg.type.stack_type,
+                      8)));
         break;
       case Type::ustack:
-        arg_values.push_back(
-          std::make_unique<PrintableString>(
-            get_stack(
-              *reinterpret_cast<uint64_t*>(arg_data+arg.offset),
-              true,
-              arg.type.stack_type, 8)));
+        arg_values.push_back(std::make_unique<PrintableString>(
+            get_stack(*reinterpret_cast<int64_t *>(arg_data + arg.offset),
+                      *reinterpret_cast<int32_t *>(arg_data + arg.offset + 8),
+                      *reinterpret_cast<int32_t *>(arg_data + arg.offset + 12),
+                      true,
+                      arg.type.stack_type,
+                      8)));
         break;
       case Type::timestamp:
         arg_values.push_back(
@@ -1877,10 +1890,13 @@ std::vector<uint8_t> BPFtrace::find_empty_key(IMap &map, size_t size) const
   throw std::runtime_error("Could not find empty key");
 }
 
-std::string BPFtrace::get_stack(uint64_t stackidpid, bool ustack, StackType stack_type, int indent)
+std::string BPFtrace::get_stack(int64_t stackid,
+                                int pid,
+                                int probe_id,
+                                bool ustack,
+                                StackType stack_type,
+                                int indent)
 {
-  int32_t stackid = stackidpid & 0xffffffff;
-  int pid = stackidpid >> 32;
   auto stack_trace = std::vector<uint64_t>(stack_type.limit);
   int err = bpf_lookup_elem(maps[stack_type].value()->mapfd_,
                             &stackid,
@@ -1911,7 +1927,8 @@ std::string BPFtrace::get_stack(uint64_t stackidpid, bool ustack, StackType stac
     if (!ustack)
       sym = resolve_ksym(addr, true);
     else
-      sym = resolve_usym(addr, pid, true, stack_type.mode == StackMode::perf);
+      sym = resolve_usym(
+          addr, pid, probe_id, true, stack_type.mode == StackMode::perf);
 
     switch (stack_type.mode) {
       case StackMode::bpftrace:
@@ -2238,7 +2255,11 @@ bool BPFtrace::is_aslr_enabled(int pid)
   return false;
 }
 
-std::string BPFtrace::resolve_usym(uintptr_t addr, int pid, bool show_offset, bool show_module)
+std::string BPFtrace::resolve_usym(uintptr_t addr,
+                                   int pid,
+                                   int probe_id,
+                                   bool show_offset,
+                                   bool show_module)
 {
   struct bcc_symbol usym;
   std::ostringstream symbol;
@@ -2252,9 +2273,52 @@ std::string BPFtrace::resolve_usym(uintptr_t addr, int pid, bool show_offset, bo
 
   if (resolve_user_symbols_)
   {
+    std::string pid_exe = get_pid_exe(pid);
+    if (pid_exe.empty() && probe_id != -1)
+    {
+      // sometimes program cannot be determined from PID, typically when the
+      // process does not exist anymore; in that case, try to get program name
+      // from probe
+      // note: this fails if the probe contains a wildcard, since the probe id
+      // is not generated per match
+      auto probe_full = resolve_probe(probe_id);
+      if (probe_full.find(',') == std::string::npos &&
+          !has_wildcard(probe_full))
+      {
+        // only find program name for probes that contain one program name,
+        // to avoid incorrect symbol resolutions
+        size_t start = probe_full.find(':') + 1;
+        size_t end = probe_full.find(':', start);
+        pid_exe = probe_full.substr(start, end - start);
+      }
+    }
     if (cache_user_symbols_per_program_)
     {
-      std::string pid_exe = get_pid_exe(pid);
+      if (!pid_exe.empty())
+      {
+        // try to resolve symbol directly from program file
+        // this might work when the process does not exist anymore, but cannot
+        // resolve all symbols, e.g. those in a dynamically linked library
+        std::map<uintptr_t, elf_symbol, std::greater<>> &symbol_table =
+            symbol_table_cache_.find(pid_exe) != symbol_table_cache_.end()
+                ? symbol_table_cache_[pid_exe]
+                : (symbol_table_cache_[pid_exe] = get_symbol_table_for_elf(
+                       pid_exe));
+        auto sym = symbol_table.lower_bound(addr);
+        // address has to be either the start of the symbol (for symbols of
+        // length 0) or in [start, end)
+        if (sym != symbol_table.end() &&
+            (addr == sym->second.start ||
+             (addr >= sym->second.start && addr < sym->second.end)))
+        {
+          symbol << sym->second.name;
+          if (show_offset)
+            symbol << "+" << addr - sym->second.start;
+          if (show_module)
+            symbol << " (" << pid_exe << ")";
+          return symbol.str();
+        }
+      }
       if (exe_sym_.find(pid_exe) == exe_sym_.end())
       {
         // not cached, create new ProcSyms cache

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -192,7 +192,7 @@ public:
   uint64_t max_type_res_iterations = 0;
   bool demangle_cpp_symbols_ = true;
   bool resolve_user_symbols_ = true;
-  bool cache_user_symbols_ = true;
+  bool cache_user_symbols_per_program_ = true;
   bool safe_mode_ = true;
   bool has_usdt_ = false;
   bool usdt_file_activation_ = false;
@@ -226,7 +226,9 @@ private:
                         BpfBytecode &bytecode,
                         void (*trigger)(void));
   void* ksyms_{nullptr};
+  // note: exe_sym_ is used when layout is same for all instances of program
   std::map<std::string, std::pair<int, void *>> exe_sym_; // exe -> (pid, cache)
+  std::map<int, void *> pid_sym_; // pid -> cache
   std::vector<std::string> params_;
 
   std::vector<std::unique_ptr<void, void (*)(void *)>> open_perf_buffers_;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -118,10 +118,19 @@ public:
   int clear_map(IMap &map);
   int zero_map(IMap &map);
   int print_map(IMap &map, uint32_t top, uint32_t div);
-  std::string get_stack(uint64_t stackidpid, bool ustack, StackType stack_type, int indent=0);
+  std::string get_stack(int64_t stackid,
+                        int pid,
+                        int probe_id,
+                        bool ustack,
+                        StackType stack_type,
+                        int indent = 0);
   std::string resolve_buf(char *buf, size_t size);
   std::string resolve_ksym(uintptr_t addr, bool show_offset=false);
-  std::string resolve_usym(uintptr_t addr, int pid, bool show_offset=false, bool show_module=false);
+  std::string resolve_usym(uintptr_t addr,
+                           int pid,
+                           int probe_id,
+                           bool show_offset = false,
+                           bool show_module = false);
   std::string resolve_inet(int af, const uint8_t* inet) const;
   std::string resolve_uid(uintptr_t addr) const;
   std::string resolve_timestamp(uint32_t strftime_id, uint64_t nsecs);
@@ -228,7 +237,9 @@ private:
   void* ksyms_{nullptr};
   // note: exe_sym_ is used when layout is same for all instances of program
   std::map<std::string, std::pair<int, void *>> exe_sym_; // exe -> (pid, cache)
-  std::map<int, void *> pid_sym_; // pid -> cache
+  std::map<int, void *> pid_sym_;                         // pid -> cache
+  std::map<std::string, std::map<uintptr_t, elf_symbol, std::greater<>>>
+      symbol_table_cache_;
   std::vector<std::string> params_;
 
   std::vector<std::unique_ptr<void, void (*)(void *)>> open_perf_buffers_;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -201,7 +201,12 @@ public:
   uint64_t max_type_res_iterations = 0;
   bool demangle_cpp_symbols_ = true;
   bool resolve_user_symbols_ = true;
-  bool cache_user_symbols_per_program_ = true;
+  enum class UserSymbolCacheType
+  {
+    per_pid,
+    per_program,
+    none,
+  } user_symbol_cache_type_;
   bool safe_mode_ = true;
   bool has_usdt_ = false;
   bool usdt_file_activation_ = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -315,15 +315,16 @@ static std::optional<struct timespec> get_boottime()
     return false;
 
   if (!get_bool_env_var("BPFTRACE_CACHE_USER_SYMBOLS",
-                        bpftrace.cache_user_symbols_))
+                        bpftrace.cache_user_symbols_per_program_))
     return false;
 
   if (!std::getenv("BPFTRACE_CACHE_USER_SYMBOLS"))
   {
-    // enable user symbol cache if ASLR is disabled on system or `-c` option is
-    // given
-    bpftrace.cache_user_symbols_ = !bpftrace.cmd_.empty() ||
-                                   !bpftrace.is_aslr_enabled(-1);
+    // enable user symbol cache per program if ASLR is disabled on system
+    // or `-c` option is given
+    // otherwise, user symbol cache is indexed per process
+    bpftrace.cache_user_symbols_per_program_ = !bpftrace.cmd_.empty() ||
+                                               !bpftrace.is_aslr_enabled(-1);
   }
 
   uint64_t node_max = std::numeric_limits<uint64_t>::max();

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -81,10 +81,14 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
       break;
     case Type::kstack:
       return bpftrace.get_stack(
-          read_data<uint64_t>(data), false, arg.stack_type, 4);
+          read_data<int64_t>(data), -1, -1, false, arg.stack_type, 4);
     case Type::ustack:
-      return bpftrace.get_stack(
-          read_data<uint64_t>(data), true, arg.stack_type, 4);
+      return bpftrace.get_stack(read_data<int64_t>(data),
+                                read_data<int32_t>(arg_data + 8),
+                                read_data<int32_t>(arg_data + 12),
+                                true,
+                                arg.stack_type,
+                                4);
     case Type::timestamp:
     {
       auto p = static_cast<const AsyncEvent::Strftime *>(data);
@@ -94,7 +98,8 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
       return bpftrace.resolve_ksym(read_data<uint64_t>(data));
     case Type::usym:
       return bpftrace.resolve_usym(read_data<uint64_t>(data),
-                                   read_data<uint64_t>(arg_data + 8));
+                                   read_data<uint64_t>(arg_data + 8),
+                                   read_data<uint64_t>(arg_data + 16));
     case Type::inet:
       return bpftrace.resolve_inet(read_data<int64_t>(data),
                                    (const uint8_t *)(arg_data + 8));

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -158,15 +158,20 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
   uint32_t nvalues = is_per_cpu ? bpftrace.ncpus_ : 1;
   if (type.IsKstackTy())
     return bpftrace.get_stack(
-        read_data<uint64_t>(value.data()), false, type.stack_type, 8);
+        read_data<uint64_t>(value.data()), -1, -1, false, type.stack_type, 8);
   else if (type.IsUstackTy())
-    return bpftrace.get_stack(
-        read_data<uint64_t>(value.data()), true, type.stack_type, 8);
+    return bpftrace.get_stack(read_data<int64_t>(value.data()),
+                              read_data<int32_t>(value.data() + 8),
+                              read_data<int32_t>(value.data() + 12),
+                              true,
+                              type.stack_type,
+                              8);
   else if (type.IsKsymTy())
     return bpftrace.resolve_ksym(read_data<uintptr_t>(value.data()));
   else if (type.IsUsymTy())
     return bpftrace.resolve_usym(read_data<uintptr_t>(value.data()),
-                                 read_data<uintptr_t>(value.data() + 8));
+                                 read_data<uintptr_t>(value.data() + 8),
+                                 read_data<uint64_t>(value.data() + 16));
   else if (type.IsInetTy())
     return bpftrace.resolve_inet(read_data<uint64_t>(value.data()),
                                  (uint8_t *)(value.data() + 8));

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -117,6 +117,9 @@ public:
   std::vector<Probe> special_probes;
   std::vector<Probe> watchpoint_probes;
 
+  // List of probes using userspace symbol resolution
+  std::unordered_set<ast::Probe *> probes_using_usym;
+
 private:
   template <typename T>
   int create_maps_impl(BPFtrace &bpftrace, bool fake);

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -119,9 +119,10 @@ bool SizedType::operator==(const SizedType &t) const
 
 bool SizedType::IsByteArray() const
 {
-  return type == Type::string || type == Type::usym || type == Type::inet ||
-         type == Type::buffer || type == Type::timestamp ||
-         type == Type::mac_address || type == Type::cgroup_path;
+  return type == Type::string || type == Type::usym || type == Type::ustack ||
+         type == Type::inet || type == Type::buffer ||
+         type == Type::timestamp || type == Type::mac_address ||
+         type == Type::cgroup_path;
 }
 
 bool SizedType::IsAggregate() const
@@ -375,7 +376,7 @@ SizedType CreateRecord(const std::string &name, std::weak_ptr<Struct> record)
 
 SizedType CreateStack(bool kernel, StackType stack)
 {
-  auto st = SizedType(kernel ? Type::kstack : Type::ustack, 8);
+  auto st = SizedType(kernel ? Type::kstack : Type::ustack, kernel ? 8 : 16);
   st.stack_type = stack;
   return st;
 }
@@ -439,7 +440,7 @@ SizedType CreateHist()
 
 SizedType CreateUSym()
 {
-  return SizedType(Type::usym, 16);
+  return SizedType(Type::usym, 24);
 }
 
 SizedType CreateKSym()

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -5,7 +5,9 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <fstream>
+#include <gelf.h>
 #include <glob.h>
+#include <libelf.h>
 #include <limits>
 #include <link.h>
 #include <map>
@@ -1333,6 +1335,32 @@ std::tuple<std::string, std::string, std::string> split_addrrange_symbol_module(
            symbol.substr(idx1 + strlen("\t"), idx2 - idx1 - strlen("\t")),
            symbol.substr(idx2 + strlen(" ["),
                          symbol.length() - idx2 - strlen(" []")) };
+}
+
+std::map<uintptr_t, elf_symbol, std::greater<>> get_symbol_table_for_elf(
+    const std::string &elf_file)
+{
+  std::map<uintptr_t, elf_symbol, std::greater<>> symbol_table;
+
+  bcc_elf_symcb sym_resolve_callback = [](const char *name,
+                                          uint64_t start,
+                                          uint64_t length,
+                                          void *payload) {
+    auto *symbol_table =
+        static_cast<std::map<uintptr_t, elf_symbol, std::greater<>> *>(payload);
+    symbol_table->insert({ start,
+                           { .name = std::string(name),
+                             .start = start,
+                             .end = start + length } });
+    return 0;
+  };
+  struct bcc_symbol_option option;
+  memset(&option, 0, sizeof(option));
+  option.use_symbol_type = BCC_SYM_ALL_TYPES;
+  bcc_elf_foreach_sym(
+      elf_file.c_str(), sym_resolve_callback, &option, &symbol_table);
+
+  return symbol_table;
 }
 
 } // namespace bpftrace

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1363,4 +1363,22 @@ std::map<uintptr_t, elf_symbol, std::greater<>> get_symbol_table_for_elf(
   return symbol_table;
 }
 
+std::vector<int> get_pids_for_program(const std::string &program)
+{
+  std::vector<int> pids;
+  auto program_abs = std_filesystem::canonical(program);
+  for (const auto &process : std_filesystem::directory_iterator("/proc"))
+  {
+    std::string filename = process.path().filename().string();
+    if (!std::all_of(filename.begin(), filename.end(), ::isdigit))
+      continue;
+    std::error_code ec;
+    std_filesystem::path pid_program = std_filesystem::read_symlink(
+        process.path() / "exe", ec);
+    if (!ec && program_abs == pid_program)
+      pids.emplace_back(std::stoi(filename));
+  }
+  return pids;
+}
+
 } // namespace bpftrace

--- a/src/utils.h
+++ b/src/utils.h
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <exception>
 #include <iostream>
+#include <map>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -211,6 +212,19 @@ std::pair<std::string, std::string> split_symbol_module(
     const std::string &symbol);
 std::tuple<std::string, std::string, std::string> split_addrrange_symbol_module(
     const std::string &symbol);
+
+struct elf_symbol
+{
+  std::string name;
+  uintptr_t start;
+  uintptr_t end;
+};
+// Get all symbols from an ELF module together with their address ranges in
+// the form of a map sorted by start address.
+// Note: the map uses std::greater as comparator to allow resolving of an
+// address inside a range using std::map::lower_bound.
+std::map<uintptr_t, elf_symbol, std::greater<>> get_symbol_table_for_elf(
+    const std::string &elf_file);
 
 // Generate object file section name for a given probe
 inline std::string get_section_name_for_probe(

--- a/src/utils.h
+++ b/src/utils.h
@@ -225,6 +225,7 @@ struct elf_symbol
 // address inside a range using std::map::lower_bound.
 std::map<uintptr_t, elf_symbol, std::greater<>> get_symbol_table_for_elf(
     const std::string &elf_file);
+std::vector<int> get_pids_for_program(const std::string &program);
 
 // Generate object file section name for a given probe
 inline std::string get_section_name_for_probe(

--- a/tests/codegen/llvm/builtin_func_uprobe.ll
+++ b/tests/codegen/llvm/builtin_func_uprobe.ll
@@ -3,7 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf-pc-linux"
 
-%usym_t = type { i64, i64 }
+%usym_t = type { i64, i64, i64 }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -21,17 +21,19 @@ entry:
   %4 = lshr i64 %get_pid_tgid, 32
   %5 = getelementptr %usym_t, %usym_t* %usym, i64 0, i32 0
   %6 = getelementptr %usym_t, %usym_t* %usym, i64 0, i32 1
+  %7 = getelementptr %usym_t, %usym_t* %usym, i64 0, i32 2
   store i64 %func, i64* %5, align 8
   store i64 %4, i64* %6, align 8
-  %7 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i64 0, i64* %7, align 8
+  %8 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %usym_t*, i64)*)(i64 %pseudo, i64* %"@x_key", %usym_t* %usym, i64 0)
-  %8 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast %usym_t* %usym to i8*
+  %9 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast %usym_t* %usym to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/builtin_ustack.ll
+++ b/tests/codegen/llvm/builtin_ustack.ll
@@ -3,30 +3,34 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%stack_t = type { i64, i32, i32 }
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
+  %stack_args = alloca %stack_t, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 256)
+  %1 = bitcast %stack_t* %stack_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  %2 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 0
+  store i64 %get_stackid, i64* %2, align 8
+  %3 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 1
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %1 = shl i64 %get_pid_tgid, 32
-  %2 = or i64 %get_stackid, %1
-  %3 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@x_key", align 8
-  %4 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  store i64 %2, i64* %"@x_val", align 8
-  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %5 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %4 = trunc i64 %get_pid_tgid to i32
+  store i32 %4, i32* %3, align 4
+  %5 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 2
+  store i32 0, i32* %5, align 4
   %6 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  store i64 0, i64* %"@x_key", align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %stack_t*, i64)*)(i64 %pseudo1, i64* %"@x_key", %stack_t* %stack_args, i64 0)
+  %7 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_ustack.ll
+++ b/tests/codegen/llvm/call_ustack.ll
@@ -3,49 +3,55 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf-pc-linux"
 
+%stack_t = type { i64, i32, i32 }
+
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
-  %"@y_val" = alloca i64, align 8
   %"@y_key" = alloca i64, align 8
-  %"@x_val" = alloca i64, align 8
+  %stack_args4 = alloca %stack_t, align 8
   %"@x_key" = alloca i64, align 8
+  %stack_args = alloca %stack_t, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 3)
   %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 256)
+  %1 = bitcast %stack_t* %stack_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  %2 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 0
+  store i64 %get_stackid, i64* %2, align 8
+  %3 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 1
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %1 = shl i64 %get_pid_tgid, 32
-  %2 = or i64 %get_stackid, %1
-  %3 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@x_key", align 8
-  %4 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  store i64 %2, i64* %"@x_val", align 8
-  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_val", i64 0)
-  %5 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %4 = trunc i64 %get_pid_tgid to i32
+  store i32 %4, i32* %3, align 4
+  %5 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 2
+  store i32 0, i32* %5, align 4
   %6 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  store i64 0, i64* %"@x_key", align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %stack_t*, i64)*)(i64 %pseudo1, i64* %"@x_key", %stack_t* %stack_args, i64 0)
+  %7 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %get_stackid3 = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo2, i64 256)
-  %get_pid_tgid4 = call i64 inttoptr (i64 14 to i64 ()*)()
-  %7 = shl i64 %get_pid_tgid4, 32
-  %8 = or i64 %get_stackid3, %7
-  %9 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %8 = bitcast %stack_t* %stack_args4 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %9 = getelementptr %stack_t, %stack_t* %stack_args4, i64 0, i32 0
+  store i64 %get_stackid3, i64* %9, align 8
+  %10 = getelementptr %stack_t, %stack_t* %stack_args4, i64 0, i32 1
+  %get_pid_tgid5 = call i64 inttoptr (i64 14 to i64 ()*)()
+  %11 = trunc i64 %get_pid_tgid5 to i32
+  store i32 %11, i32* %10, align 4
+  %12 = getelementptr %stack_t, %stack_t* %stack_args4, i64 0, i32 2
+  store i32 0, i32* %12, align 4
+  %13 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
   store i64 0, i64* %"@y_key", align 8
-  %10 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
-  store i64 %8, i64* %"@y_val", align 8
-  %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %update_elem6 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo5, i64* %"@y_key", i64* %"@y_val", i64 0)
-  %11 = bitcast i64* %"@y_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast i64* %"@y_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %pseudo6 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %update_elem7 = call i64 inttoptr (i64 2 to i64 (i64, i64*, %stack_t*, i64)*)(i64 %pseudo6, i64* %"@y_key", %stack_t* %stack_args4, i64 0)
+  %14 = bitcast i64* %"@y_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_usym_key.ll
+++ b/tests/codegen/llvm/call_usym_key.ll
@@ -3,7 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf-pc-linux"
 
-%usym_t = type { i64, i64 }
+%usym_t = type { i64, i64, i64 }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -19,19 +19,21 @@ entry:
   %2 = lshr i64 %get_pid_tgid, 32
   %3 = getelementptr %usym_t, %usym_t* %usym, i64 0, i32 0
   %4 = getelementptr %usym_t, %usym_t* %usym, i64 0, i32 1
+  %5 = getelementptr %usym_t, %usym_t* %usym, i64 0, i32 2
   store i64 0, i64* %3, align 8
   store i64 %2, i64* %4, align 8
+  store i64 0, i64* %5, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, %usym_t*)*)(i64 %pseudo, %usym_t* %usym)
-  %5 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  %6 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %6 = load i64, i64* %cast, align 8
-  store i64 %6, i64* %lookup_elem_val, align 8
+  %7 = load i64, i64* %cast, align 8
+  store i64 %7, i64* %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
@@ -39,19 +41,19 @@ lookup_failure:                                   ; preds = %entry
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %7 = load i64, i64* %lookup_elem_val, align 8
-  %8 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %10 = add i64 %7, 1
-  store i64 %10, i64* %"@x_val", align 8
+  %8 = load i64, i64* %lookup_elem_val, align 8
+  %9 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = add i64 %8, 1
+  store i64 %11, i64* %"@x_val", align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, %usym_t*, i64*, i64)*)(i64 %pseudo1, %usym_t* %usym, i64* %"@x_val", i64 0)
-  %11 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
-  %12 = bitcast %usym_t* %usym to i8*
+  %12 = bitcast i64* %"@x_val" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast %usym_t* %usym to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/struct_semicolon_1.ll
+++ b/tests/codegen/llvm/struct_semicolon_1.ll
@@ -3,7 +3,8 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf-pc-linux"
 
-%printf_t = type { i64, i64 }
+%stack_t = type { i64, i32, i32 }
+%printf_t = type { i64, [16 x i8] }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -11,28 +12,38 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %key = alloca i32, align 4
+  %stack_args = alloca %stack_t, align 8
   %printf_args = alloca %printf_t, align 8
   %1 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 16, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 24, i1 false)
   %3 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
   store i64 0, i64* %3, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 256)
+  %4 = bitcast %stack_t* %stack_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  %5 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 0
+  store i64 %get_stackid, i64* %5, align 8
+  %6 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 1
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %4 = shl i64 %get_pid_tgid, 32
-  %5 = or i64 %get_stackid, %4
-  %6 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %5, i64* %6, align 8
+  %7 = trunc i64 %get_pid_tgid to i32
+  store i32 %7, i32* %6, align 4
+  %8 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 2
+  store i32 0, i32* %8, align 4
+  %9 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
+  %10 = bitcast [16 x i8]* %9 to i8*
+  %11 = bitcast %stack_t* %stack_args to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %10, i8* align 1 %11, i64 16, i1 false)
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %printf_t*, i64, i64)*)(i64 %pseudo1, %printf_t* %printf_args, i64 16, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %printf_t*, i64, i64)*)(i64 %pseudo1, %printf_t* %printf_args, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 event_loss_counter:                               ; preds = %entry
-  %7 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %12 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
   store i32 0, i32* %key, align 4
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo2, i32* %key)
@@ -40,21 +51,21 @@ event_loss_counter:                               ; preds = %entry
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 counter_merge:                                    ; preds = %lookup_merge, %entry
-  %8 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %13 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %9 = bitcast i8* %lookup_elem to i64*
-  %10 = atomicrmw add i64* %9, i64 1 seq_cst
+  %14 = bitcast i8* %lookup_elem to i64*
+  %15 = atomicrmw add i64* %14, i64 1 seq_cst
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %11 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %16 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
   br label %counter_merge
 }
 
@@ -63,6 +74,9 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly %0, i8* noalias nocapture readonly %1, i64 %2, i1 immarg %3) #1
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1

--- a/tests/codegen/llvm/struct_semicolon_2.ll
+++ b/tests/codegen/llvm/struct_semicolon_2.ll
@@ -3,7 +3,8 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf-pc-linux"
 
-%printf_t = type { i64, i64 }
+%stack_t = type { i64, i32, i32 }
+%printf_t = type { i64, [16 x i8] }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -11,28 +12,38 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %key = alloca i32, align 4
+  %stack_args = alloca %stack_t, align 8
   %printf_args = alloca %printf_t, align 8
   %1 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 16, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 24, i1 false)
   %3 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
   store i64 0, i64* %3, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %get_stackid = call i64 inttoptr (i64 27 to i64 (i8*, i64, i64)*)(i8* %0, i64 %pseudo, i64 256)
+  %4 = bitcast %stack_t* %stack_args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  %5 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 0
+  store i64 %get_stackid, i64* %5, align 8
+  %6 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 1
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %4 = shl i64 %get_pid_tgid, 32
-  %5 = or i64 %get_stackid, %4
-  %6 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  store i64 %5, i64* %6, align 8
+  %7 = trunc i64 %get_pid_tgid to i32
+  store i32 %7, i32* %6, align 4
+  %8 = getelementptr %stack_t, %stack_t* %stack_args, i64 0, i32 2
+  store i32 0, i32* %8, align 4
+  %9 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
+  %10 = bitcast [16 x i8]* %9 to i8*
+  %11 = bitcast %stack_t* %stack_args to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %10, i8* align 1 %11, i64 16, i1 false)
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %printf_t*, i64, i64)*)(i64 %pseudo1, %printf_t* %printf_args, i64 16, i64 0)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %printf_t*, i64, i64)*)(i64 %pseudo1, %printf_t* %printf_args, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 event_loss_counter:                               ; preds = %entry
-  %7 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %12 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
   store i32 0, i32* %key, align 4
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo2, i32* %key)
@@ -40,21 +51,21 @@ event_loss_counter:                               ; preds = %entry
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 counter_merge:                                    ; preds = %lookup_merge, %entry
-  %8 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %13 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %9 = bitcast i8* %lookup_elem to i64*
-  %10 = atomicrmw add i64* %9, i64 1 seq_cst
+  %14 = bitcast i8* %lookup_elem to i64*
+  %15 = atomicrmw add i64* %14, i64 1 seq_cst
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %11 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %16 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
   br label %counter_merge
 }
 
@@ -63,6 +74,9 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
 declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.memcpy.p0i8.p0i8.i64(i8* noalias nocapture writeonly %0, i8* noalias nocapture readonly %1, i64 %2, i1 immarg %3) #1
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1

--- a/tests/codegen/llvm/tuple_bytearray.ll
+++ b/tests/codegen/llvm/tuple_bytearray.ll
@@ -3,8 +3,8 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf-pc-linux"
 
-%usym_t = type { i64, i64 }
-%"unsigned int8_usym_int64__tuple_t" = type { i8, [16 x i8], i64 }
+%usym_t = type { i64, i64, i64 }
+%"unsigned int8_usym_int64__tuple_t" = type { i8, [24 x i8], i64 }
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
@@ -17,7 +17,7 @@ entry:
   %1 = bitcast %"unsigned int8_usym_int64__tuple_t"* %tuple to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   %2 = bitcast %"unsigned int8_usym_int64__tuple_t"* %tuple to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 32, i1 false)
+  call void @llvm.memset.p0i8.i64(i8* align 1 %2, i8 0, i64 40, i1 false)
   %3 = getelementptr %"unsigned int8_usym_int64__tuple_t", %"unsigned int8_usym_int64__tuple_t"* %tuple, i32 0, i32 0
   store i8 1, i8* %3, align 1
   %4 = bitcast i8* %0 to i64*
@@ -29,23 +29,25 @@ entry:
   %7 = lshr i64 %get_pid_tgid, 32
   %8 = getelementptr %usym_t, %usym_t* %usym, i64 0, i32 0
   %9 = getelementptr %usym_t, %usym_t* %usym, i64 0, i32 1
+  %10 = getelementptr %usym_t, %usym_t* %usym, i64 0, i32 2
   store i64 %reg_ip, i64* %8, align 8
   store i64 %7, i64* %9, align 8
-  %10 = getelementptr %"unsigned int8_usym_int64__tuple_t", %"unsigned int8_usym_int64__tuple_t"* %tuple, i32 0, i32 1
-  %11 = bitcast [16 x i8]* %10 to i8*
-  %12 = bitcast %usym_t* %usym to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %11, i8* align 1 %12, i64 16, i1 false)
-  %13 = getelementptr %"unsigned int8_usym_int64__tuple_t", %"unsigned int8_usym_int64__tuple_t"* %tuple, i32 0, i32 2
-  store i64 10, i64* %13, align 8
-  %14 = bitcast i64* %"@t_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  store i64 0, i64* %10, align 8
+  %11 = getelementptr %"unsigned int8_usym_int64__tuple_t", %"unsigned int8_usym_int64__tuple_t"* %tuple, i32 0, i32 1
+  %12 = bitcast [24 x i8]* %11 to i8*
+  %13 = bitcast %usym_t* %usym to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %12, i8* align 1 %13, i64 24, i1 false)
+  %14 = getelementptr %"unsigned int8_usym_int64__tuple_t", %"unsigned int8_usym_int64__tuple_t"* %tuple, i32 0, i32 2
+  store i64 10, i64* %14, align 8
+  %15 = bitcast i64* %"@t_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
   store i64 0, i64* %"@t_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %"unsigned int8_usym_int64__tuple_t"*, i64)*)(i64 %pseudo, i64* %"@t_key", %"unsigned int8_usym_int64__tuple_t"* %tuple, i64 0)
-  %15 = bitcast i64* %"@t_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
-  %16 = bitcast %"unsigned int8_usym_int64__tuple_t"* %tuple to i8*
+  %16 = bitcast i64* %"@t_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = bitcast %"unsigned int8_usym_int64__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
   ret i64 0
 }
 

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -108,6 +108,23 @@ EXPECT SUCCESS .*
 AFTER ./testprogs/uprobe_negative_retval
 TIMEOUT 5
 
+# Disabled, since BCC code it depends on is prone to race condition,
+# (https://github.com/iovisor/bcc/pull/4319#issuecomment-1321731687)
+NAME func_uprobe_symcache_preload
+ENV BPFTRACE_CACHE_USER_SYMBOLS=PER_PID
+PROG uprobe:./testprogs/uprobe_symres_exited_process:test { print(func); exit(); }
+EXPECT test
+BEFORE ./testprogs/uprobe_symres_exited_process
+TIMEOUT 5
+REQUIRES bash -c "exit 1"
+
+NAME func_uprobe_elf_symtable
+ENV BPFTRACE_CACHE_USER_SYMBOLS=PER_PROGRAM
+PROG uprobe:./testprogs/uprobe_symres_exited_process:test { print(func); exit(); }
+EXPECT test
+AFTER ./testprogs/disable_aslr ./testprogs/uprobe_symres_exited_process
+TIMEOUT 5
+
 NAME username
 PROG i:ms:1 { printf("SUCCESS %s\n", username); exit(); }
 EXPECT SUCCESS .*

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -241,6 +241,13 @@ EXPECT ^\s+[0-9a-f]+$
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8
 
+NAME ustack_elf_symtable
+ENV BPFTRACE_CACHE_USER_SYMBOLS=PER_PROGRAM
+PROG uprobe:./testprogs/uprobe_symres_exited_process:test { print(ustack); exit(); }
+EXPECT ^\s+test\+0\s+main\+[1-9][0-9]*
+AFTER ./testprogs/disable_aslr ./testprogs/uprobe_symres_exited_process
+TIMEOUT 5
+
 NAME cat
 PROG i:ms:1 { cat("/proc/uptime"); exit();}
 EXPECT [0-9]*.[0-9]* [0-9]*.[0-9]*

--- a/tests/testprogs/disable_aslr.c
+++ b/tests/testprogs/disable_aslr.c
@@ -1,0 +1,8 @@
+#include <sys/personality.h>
+#include <unistd.h>
+
+int main(int argc __attribute__((unused)), char **argv)
+{
+  personality(ADDR_NO_RANDOMIZE);
+  execv(argv[1], argv + 1);
+}

--- a/tests/testprogs/uprobe_symres_exited_process.c
+++ b/tests/testprogs/uprobe_symres_exited_process.c
@@ -1,0 +1,17 @@
+#include <unistd.h>
+
+__attribute__((noinline)) int test()
+{
+  return 42;
+}
+
+__attribute__((noinline)) int test2()
+{
+  return test();
+}
+
+int main()
+{
+  sleep(3);
+  test2();
+}


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->
This PR contains three related improvements of usym resolution (edit: added purpose of the changes):
- Caching BCC symcache per process if ASLR is enabled (edit: optional after changes, by default disabled)
  - Enables faster symbol resolution and symcache preloading (see below)
- Resolving symbols directly from ELF (only if ASLR is disabled)
  - Enables resolving symbols that are not dynamically loaded even after process exit
- Preloading BCC symcache for running instances of program
  - Enables resolving symbols after program exists even with ASLR enabled, given that the process exists at probe attachment time.

The latter two provide a partial fix of #2284. 

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
