### PR TITLE
support integer arrays comparison

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
 - Raise minimum versions for libbpf and bcc and vendor them for local builds
   - [#2369](https://github.com/iovisor/bpftrace/pull/2369)
   - [#2370](https://github.com/iovisor/bpftrace/pull/2370)
+- Support comparison for integer arrays
+  - [#2387](https://github.com/iovisor/bpftrace/pull/2387)
 #### Deprecated
 #### Removed
 #### Fixed

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -534,7 +534,7 @@ The following relational operators are defined for integers and pointers.
 
 |===
 
-The following relation operators are available for comparing strings.
+The following relation operators are available for comparing strings and integer arrays.
 
 [cols="~,~"]
 |===

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -136,6 +136,21 @@ public:
                            Value *val2,
                            uint64_t str2_size,
                            bool inverse);
+  Value *CreateIntegerArrayCmpUnrolled(Value *ctx,
+                                       Value *val1,
+                                       Value *val2,
+                                       const SizedType &val1_type,
+                                       const SizedType &val2_type,
+                                       const bool inverse,
+                                       const location &loc);
+  Value *CreateIntegerArrayCmp(Value *ctx,
+                               Value *val1,
+                               Value *val2,
+                               const SizedType &val1_type,
+                               const SizedType &val2_type,
+                               const bool inverse,
+                               const location &loc,
+                               MDNode *metadata);
   CallInst *CreateGetNs(bool boot_time, const location &loc);
   CallInst *CreateGetPidTgid(const location &loc);
   CallInst *CreateGetCurrentCgroupId(const location &loc);

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -148,6 +148,7 @@ private:
   std::pair<Value *, uint64_t> getString(Expression *expr);
 
   void binop_string(Binop &binop);
+  void binop_integer_array(Binop &binop);
   void binop_buf(Binop &binop);
   void binop_int(Binop &binop);
   void binop_ptr(Binop &binop);

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -108,6 +108,7 @@ private:
 
   void binop_ptr(Binop &op);
   void binop_int(Binop &op);
+  void binop_array(Binop &op);
 
   bool in_loop(void)
   {

--- a/tests/codegen/array_integer_equal_comparison.cpp
+++ b/tests/codegen/array_integer_equal_comparison.cpp
@@ -1,0 +1,31 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, array_integer_equal_comparison)
+{
+  auto bpftrace = get_mock_bpftrace();
+  if (bpftrace->has_loop())
+  {
+    return;
+  }
+
+  test("struct Foo { int arr[4]; }"
+       "kprobe:f"
+       "{"
+       "  $a = ((struct Foo *)arg0)->arr;"
+       "  $b = ((struct Foo *)arg0)->arr;"
+       "  if ($a == $b)"
+       "  {"
+       "    exit();"
+       "  }"
+       "}",
+
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/array_integer_equal_comparison_no_unroll.cpp
+++ b/tests/codegen/array_integer_equal_comparison_no_unroll.cpp
@@ -1,0 +1,31 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, array_integer_equal_comparison_no_unroll)
+{
+  auto bpftrace = get_mock_bpftrace();
+  if (!bpftrace->has_loop())
+  {
+    return;
+  }
+
+  test("struct Foo { int arr[4]; }"
+       "kprobe:f"
+       "{"
+       "  $a = ((struct Foo *)arg0)->arr;"
+       "  $b = ((struct Foo *)arg0)->arr;"
+       "  if ($a == $b)"
+       "  {"
+       "    exit();"
+       "  }"
+       "}",
+
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -40,6 +40,11 @@ public:
   {
     return feature_->has_kprobe_multi();
   }
+
+  bool has_loop(void)
+  {
+    return feature_->has_loop();
+  }
 };
 
 TEST(codegen, populate_sections)

--- a/tests/codegen/llvm/array_integer_equal_comparison.ll
+++ b/tests/codegen/llvm/array_integer_equal_comparison.ll
@@ -1,0 +1,124 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
+entry:
+  %perfdata = alloca i64, align 8
+  %arraycmp.result = alloca i1, align 1
+  %rr = alloca i32, align 4
+  %ll = alloca i32, align 4
+  %"$b" = alloca i64, align 8
+  %1 = bitcast i64* %"$b" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 0, i64* %"$b", align 8
+  %"$a" = alloca i64, align 8
+  %2 = bitcast i64* %"$a" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"$a", align 8
+  %3 = bitcast i8* %0 to i64*
+  %4 = getelementptr i64, i64* %3, i64 14
+  %arg0 = load volatile i64, i64* %4, align 8
+  %5 = add i64 %arg0, 0
+  store i64 %5, i64* %"$a", align 8
+  %6 = bitcast i8* %0 to i64*
+  %7 = getelementptr i64, i64* %6, i64 14
+  %arg01 = load volatile i64, i64* %7, align 8
+  %8 = add i64 %arg01, 0
+  store i64 %8, i64* %"$b", align 8
+  %9 = load i64, i64* %"$a", align 8
+  %10 = load i64, i64* %"$b", align 8
+  %11 = bitcast i32* %ll to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i32* %rr to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i1* %arraycmp.result to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  store i1 false, i1* %arraycmp.result, align 1
+  %14 = add i64 %9, 0
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %ll, i32 4, i64 %14)
+  %15 = load i32, i32* %ll, align 4
+  %16 = add i64 %10, 0
+  %probe_read_kernel2 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %rr, i32 4, i64 %16)
+  %17 = load i32, i32* %rr, align 4
+  %arraycmp.cmp = icmp ne i32 %15, %17
+  br i1 %arraycmp.cmp, label %arraycmp.false, label %arraycmp.loop
+
+if_body:                                          ; preds = %arraycmp.false
+  %18 = bitcast i64* %perfdata to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
+  store i64 30000, i64* %perfdata, align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, i64*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, i64* %perfdata, i64 8)
+  %19 = bitcast i64* %perfdata to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  ret i64 0
+
+if_end:                                           ; preds = %deadcode, %arraycmp.false
+  ret i64 0
+
+arraycmp.false:                                   ; preds = %arraycmp.done, %arraycmp.loop7, %arraycmp.loop3, %arraycmp.loop, %entry
+  %20 = load i1, i1* %arraycmp.result, align 1
+  %21 = bitcast i1* %arraycmp.result to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  %22 = bitcast i32* %ll to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
+  %23 = bitcast i32* %rr to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
+  %24 = zext i1 %20 to i64
+  %true_cond = icmp ne i64 %24, 0
+  br i1 %true_cond, label %if_body, label %if_end
+
+arraycmp.done:                                    ; preds = %arraycmp.loop11
+  store i1 true, i1* %arraycmp.result, align 1
+  br label %arraycmp.false
+
+arraycmp.loop:                                    ; preds = %entry
+  %25 = add i64 %9, 4
+  %probe_read_kernel4 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %ll, i32 4, i64 %25)
+  %26 = load i32, i32* %ll, align 4
+  %27 = add i64 %10, 4
+  %probe_read_kernel5 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %rr, i32 4, i64 %27)
+  %28 = load i32, i32* %rr, align 4
+  %arraycmp.cmp6 = icmp ne i32 %26, %28
+  br i1 %arraycmp.cmp6, label %arraycmp.false, label %arraycmp.loop3
+
+arraycmp.loop3:                                   ; preds = %arraycmp.loop
+  %29 = add i64 %9, 8
+  %probe_read_kernel8 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %ll, i32 4, i64 %29)
+  %30 = load i32, i32* %ll, align 4
+  %31 = add i64 %10, 8
+  %probe_read_kernel9 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %rr, i32 4, i64 %31)
+  %32 = load i32, i32* %rr, align 4
+  %arraycmp.cmp10 = icmp ne i32 %30, %32
+  br i1 %arraycmp.cmp10, label %arraycmp.false, label %arraycmp.loop7
+
+arraycmp.loop7:                                   ; preds = %arraycmp.loop3
+  %33 = add i64 %9, 12
+  %probe_read_kernel12 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %ll, i32 4, i64 %33)
+  %34 = load i32, i32* %ll, align 4
+  %35 = add i64 %10, 12
+  %probe_read_kernel13 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i64)*)(i32* %rr, i32 4, i64 %35)
+  %36 = load i32, i32* %rr, align 4
+  %arraycmp.cmp14 = icmp ne i32 %34, %36
+  br i1 %arraycmp.cmp14, label %arraycmp.false, label %arraycmp.loop11
+
+arraycmp.loop11:                                  ; preds = %arraycmp.loop7
+  br label %arraycmp.done
+
+deadcode:                                         ; No predecessors!
+  br label %if_end
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/codegen/llvm/array_integer_equal_comparison_no_unroll.ll
+++ b/tests/codegen/llvm/array_integer_equal_comparison_no_unroll.ll
@@ -1,0 +1,121 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
+entry:
+  %perfdata = alloca i64, align 8
+  %n = alloca i32, align 4
+  %i = alloca i32, align 4
+  %arraycmp.result = alloca i1, align 1
+  %v2 = alloca i32, align 4
+  %v1 = alloca i32, align 4
+  %"$b" = alloca i64, align 8
+  %1 = bitcast i64* %"$b" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 0, i64* %"$b", align 8
+  %"$a" = alloca i64, align 8
+  %2 = bitcast i64* %"$a" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"$a", align 8
+  %3 = bitcast i8* %0 to i64*
+  %4 = getelementptr i64, i64* %3, i64 14
+  %arg0 = load volatile i64, i64* %4, align 8
+  %5 = add i64 %arg0, 0
+  store i64 %5, i64* %"$a", align 8
+  %6 = bitcast i8* %0 to i64*
+  %7 = getelementptr i64, i64* %6, i64 14
+  %arg01 = load volatile i64, i64* %7, align 8
+  %8 = add i64 %arg01, 0
+  store i64 %8, i64* %"$b", align 8
+  %9 = load i64, i64* %"$a", align 8
+  %10 = load i64, i64* %"$b", align 8
+  %11 = bitcast i32* %v1 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i32* %v2 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i1* %arraycmp.result to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  store i1 true, i1* %arraycmp.result, align 1
+  %14 = inttoptr i64 %9 to [4 x i32]*
+  %15 = inttoptr i64 %10 to [4 x i32]*
+  %16 = bitcast i32* %i to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
+  %17 = bitcast i32* %n to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
+  store i32 0, i32* %i, align 4
+  store i32 4, i32* %n, align 4
+  br label %while_cond
+
+if_body:                                          ; preds = %arraycmp.done
+  %18 = bitcast i64* %perfdata to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
+  store i64 30000, i64* %perfdata, align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, i64*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, i64* %perfdata, i64 8)
+  %19 = bitcast i64* %perfdata to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  ret i64 0
+
+if_end:                                           ; preds = %deadcode, %arraycmp.done
+  ret i64 0
+
+while_cond:                                       ; preds = %arraycmp.loop, %entry
+  %20 = load i32, i32* %n, align 4
+  %21 = load i32, i32* %i, align 4
+  %size_check = icmp slt i32 %21, %20
+  br i1 %size_check, label %while_body, label %arraycmp.done, !llvm.loop !0
+
+while_body:                                       ; preds = %while_cond
+  %22 = load i32, i32* %i, align 4
+  %23 = getelementptr [4 x i32], [4 x i32]* %14, i32 0, i32 %22
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i32*, i32, i32*)*)(i32* %v1, i32 4, i32* %23)
+  %24 = load i32, i32* %v1, align 4
+  %25 = load i32, i32* %i, align 4
+  %26 = getelementptr [4 x i32], [4 x i32]* %15, i32 0, i32 %25
+  %probe_read_kernel2 = call i64 inttoptr (i64 113 to i64 (i32*, i32, i32*)*)(i32* %v2, i32 4, i32* %26)
+  %27 = load i32, i32* %v2, align 4
+  %arraycmp.cmp = icmp ne i32 %24, %27
+  br i1 %arraycmp.cmp, label %arraycmp.false, label %arraycmp.loop
+
+arraycmp.false:                                   ; preds = %while_body
+  store i1 false, i1* %arraycmp.result, align 1
+  br label %arraycmp.done
+
+arraycmp.done:                                    ; preds = %arraycmp.false, %while_cond
+  %28 = load i1, i1* %arraycmp.result, align 1
+  %29 = bitcast i1* %arraycmp.result to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %29)
+  %30 = bitcast i32* %v1 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %30)
+  %31 = bitcast i32* %v2 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %31)
+  %32 = zext i1 %28 to i64
+  %true_cond = icmp ne i64 %32, 0
+  br i1 %true_cond, label %if_body, label %if_end
+
+arraycmp.loop:                                    ; preds = %while_body
+  %33 = load i32, i32* %i, align 4
+  %34 = add i32 %33, 1
+  store i32 %34, i32* %i, align 4
+  br label %while_cond
+
+deadcode:                                         ; No predecessors!
+  br label %if_end
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+
+!0 = distinct !{!0, !1}
+!1 = !{!"llvm.loop.unroll.disable"}

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -84,6 +84,11 @@ public:
     return feature_->has_kprobe_multi();
   }
 
+  bool has_loop(void)
+  {
+    return feature_->has_loop();
+  }
+
   MockProbeMatcher *mock_probe_matcher;
 };
 

--- a/tests/runtime/array
+++ b/tests/runtime/array
@@ -148,3 +148,15 @@ PROG struct C { int *z[4]; } uprobe:./testprogs/array_access:test_ptr_array { @x
 EXPECT @x: 2
 TIMEOUT 5
 AFTER ./testprogs/array_access
+
+NAME array compare eq
+PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_arrays { $a = (struct A *) arg0; $b = (struct A *) arg0; if ($a->x == $b->x) { printf("two int arrays are equal.\n"); } exit(); }
+EXPECT two int arrays are equal.
+TIMEOUT 5
+AFTER ./testprogs/array_access
+
+NAME array compare ne
+PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_arrays { $a = (struct A *) arg0; $b = (struct A *) arg1; if ($a->x != $b->x) { printf("two int arrays are not equal.\n"); } exit(); }
+EXPECT two int arrays are not equal.
+TIMEOUT 5
+AFTER ./testprogs/array_access

--- a/tests/testprogs/array_access.c
+++ b/tests/testprogs/array_access.c
@@ -17,6 +17,11 @@ void test_array(int *a __attribute__((unused)))
 {
 }
 
+void test_arrays(struct A *a __attribute__((unused)),
+                 struct A *d __attribute__((unused)))
+{
+}
+
 void test_struct(struct A *a __attribute__((unused)),
                  struct B *b __attribute__((unused)))
 {
@@ -48,4 +53,11 @@ int main(int argc __attribute__((unused)), char ** argv __attribute__((unused)))
   c.z[2] = &a.x[2];
   c.z[3] = &a.x[3];
   test_ptr_array(&c);
+
+  struct A d;
+  d.x[0] = 4;
+  d.x[1] = 3;
+  d.x[2] = 2;
+  d.x[3] = 1;
+  test_arrays(&a, &d);
 }


### PR DESCRIPTION
This PR implements the binop comparison for integer arrays, it is a part of #2248 , a follow-up to #2261 .

By using this binop and the `pton` built-in together, we can now select packets filtered by addresses. Example:

```
tracepoint:tcp:tcp_retransmit_skb {
  $addr = pton("::1");
  if (args->daddr_v6 == $addr) {
    printf("localhost ipv6 retransmit\n");
  } else {
    printf("non-localhost ipv6 retransmit\n");
  }
  return;
}
```

Comments are welcome.

##### Checklist
- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
