### PR TITLE
Sanitise program names

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -690,11 +690,7 @@ void AttachedProbe::load_prog(BPFfeature &feature)
     // start the name after the probe type, after ':'
     if (auto last_colon = name.rfind(':'); last_colon != std::string::npos)
       name = name.substr(last_colon + 1);
-    // replace '+' and ',' by '.'
-    std::replace(name.begin(), name.end(), '+', '.');
-    std::replace(name.begin(), name.end(), ',', '.');
-    // remove quotes
-    name.erase(std::remove(name.begin(), name.end(), '"'), name.end());
+    name = sanitise(name);
 
     auto prog_type = progtype(probe_.type);
     if (probe_.type == ProbeType::special && !feature.has_raw_tp_special())

--- a/tests/runtime/uprobe
+++ b/tests/runtime/uprobe
@@ -61,3 +61,9 @@ NAME "uprobes - probe function in non-executable library"
 PROG uprobe:./testlibs/libsimple.so:fun {}
 EXPECT Attaching 1 probe...
 TIMEOUT 5
+
+NAME "uprobes - attach probe to golang program"
+RUN {{BPFTRACE}} -e 'uprobe:/usr/bin/docker:"os.(*File).Read" {}'
+EXPECT Attaching 1 probe...
+TIMEOUT 5
+REQUIRES command -v /usr/bin/docker


### PR DESCRIPTION

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

bpf objects may only have names containing alphanumeric characters, '.' and '_'. Golang programs, in particular, have symbol names which cause problems e.g. "os.(*File).Read".

Fixes #2388.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
