### PR TITLE
Log when BPF_MAP_TYPE_STACK_TRACE creation fails with ENOMEM

### DIFF
--- a/src/map.cpp
+++ b/src/map.cpp
@@ -134,13 +134,19 @@ Map::Map(const SizedType &type) : IMap(type)
       map_type_, "stack", key_size, value_size, max_entries, flags);
   if (mapfd_ < 0)
   {
-    LOG(ERROR)
-        << "failed to create stack id map\n"
-        // TODO (mmarchini): Check perf_event_max_stack in the semantic_analyzer
-        << "This might have happened because kernel.perf_event_max_stack "
-        << "is smaller than " << type.stack_type.limit
-        << ". Try to tweak this value with "
-        << "sysctl kernel.perf_event_max_stack=<new value>";
+    LOG(ERROR) << "failed to create stack id map: " << strerror(errno);
+    if (errno == ENOMEM)
+      LOG(ERROR) << "Tried to allocate " << max_entries << " entries of size "
+                 << value_size
+                 << ". Consider limiting the number of stack frames captured.";
+    else
+      LOG(ERROR)
+          // TODO (mmarchini): Check perf_event_max_stack in the
+          // semantic_analyzer
+          << "This might have happened because kernel.perf_event_max_stack "
+          << "is smaller than " << type.stack_type.limit
+          << ". Try to tweak this value with "
+          << "sysctl kernel.perf_event_max_stack=<new value>";
   }
 }
 


### PR DESCRIPTION
Commit dfa3f090d ("Reduce frequency of lost stack traces") increased the max number of map entries to 128K, which with the default limit of 127 frames requires a total of 129 MB:

```
# bpftrace -e 'kprobe:bpf_map_area_alloc { print(arg0); }'
[...]
135266304
```
On memory-constrained systems (e.g. low-end Android devices) such allocations can fail, particularly on older kernels that don't have f01a7dbe98ae4 ("bpf: Try harder when allocating memory for large maps"). Log a better error when this happens and suggest a workaround.


##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
