### PR TITLE
Implement strstr

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -87,20 +87,21 @@ discussion to other files in /docs, the /tools/\*\_examples.txt files, or blog p
     - [17. `cat()`: Print file content](#17-cat-print-file-content)
     - [18. `signal()`: Send a signal to the current task](#18-signal-send-a-signal-to-current-task)
     - [19. `strncmp()`: Compare first n characters of two strings](#19-strncmp-compare-first-n-characters-of-two-strings)
-    - [20. `override()`: Override return value](#20-override-override-return-value)
-    - [21. `buf()`: Buffers](#21-buf-buffers)
-    - [22. `sizeof()`: Size of type or expression](#22-sizeof-size-of-type-or-expression)
-    - [23. `print()`: Print Value](#23-print-print-value)
-    - [24. `strftime()`: Formatted timestamp](#24-strftime-formatted-timestamp)
-    - [25. `path()`: Return full path](#25-path-return-full-path)
-    - [26. `uptr()`: Annotate userspace pointer](#26-uptr-annotate-userspace-pointer)
-    - [27. `kptr()`: Annotate kernelspace pointer](#27-kptr-annotate-kernelspace-pointer)
-    - [28. `macaddr()`: Convert MAC address data to text](#28-macaddr-convert-mac-address-data-to-text)
-    - [29. `cgroup_path()`: Convert cgroup id to cgroup path](#29-cgroup_path-convert-cgroup-id-to-cgroup-path)
-    - [30. `bswap`: Reverse byte order](#30-bswap-reverse-byte-order)
-    - [31. `skb_output`: Write `skb` 's data section into a PCAP file](#31-skb_output-write-skb-s-data-section-into-a-pcap-file)
-    - [32. `pton()`: Convert text IP address to byte array](#32-pton-convert-text-ip-address-to-byte-array)
-    - [33. `strerror`: Get error message for errno value](#33-strerror-get-error-message-for-errno-value)
+    - [20. `strcontains()`: Compares whether the string haystack contains the string needle.](#20-Compare-whether-the-string-haystack-contains-the-string-needle)
+    - [21. `override()`: Override return value](#20-override-override-return-value)
+    - [22. `buf()`: Buffers](#21-buf-buffers)
+    - [23. `sizeof()`: Size of type or expression](#22-sizeof-size-of-type-or-expression)
+    - [24. `print()`: Print Value](#23-print-print-value)
+    - [25. `strftime()`: Formatted timestamp](#24-strftime-formatted-timestamp)
+    - [26. `path()`: Return full path](#25-path-return-full-path)
+    - [27. `uptr()`: Annotate userspace pointer](#26-uptr-annotate-userspace-pointer)
+    - [28. `kptr()`: Annotate kernelspace pointer](#27-kptr-annotate-kernelspace-pointer)
+    - [29. `macaddr()`: Convert MAC address data to text](#28-macaddr-convert-mac-address-data-to-text)
+    - [30. `cgroup_path()`: Convert cgroup id to cgroup path](#29-cgroup_path-convert-cgroup-id-to-cgroup-path)
+    - [31. `bswap`: Reverse byte order](#30-bswap-reverse-byte-order)
+    - [32. `skb_output`: Write `skb` 's data section into a PCAP file](#31-skb_output-write-skb-s-data-section-into-a-pcap-file)
+    - [33. `pton()`: Convert text IP address to byte array](#32-pton-convert-text-ip-address-to-byte-array)
+    - [34. `strerror`: Get error message for errno value](#33-strerror-get-error-message-for-errno-value)
 - [Map Functions](#map-functions)
     - [1. Builtins](#1-builtins-2)
     - [2. `count()`: Count](#2-count-count)
@@ -2218,6 +2219,7 @@ Tracing block I/O sizes > 0 bytes
 - `cat(char *filename)` - Print file content
 - `signal(char[] signal | u32 signal)` - Send a signal to the current task
 - `strncmp(char *s1, char *s2, int length)` - Compare first n characters of two strings
+- `strcontains(const char *haystack, const char *needle)` - Compares whether the string haystack contains the string needle.
 - `override(u64 rc)` - Override return value
 - `buf(void *d [, int length])` - Returns a hex-formatted string of the data pointed to by d
 - `sizeof(...)` - Return size of a type or expression
@@ -2884,7 +2886,28 @@ Attaching 320 probes...
 @[mpv, tracepoint:syscalls:sys_enter_futex]: 403868
 ```
 
-## 20. `override()`: Override return value
+## 20. `strcontains()`: Compare whether the string haystack contains the string needle.
+
+Syntax: `strcontains(const char *haystack, const char *needle)`
+
+Return true if the string haystack contains the string needle, and zero otherwise.
+
+Examples:
+
+```
+bpftrace -e 't:syscalls:sys_enter_execve /strcontains(str(args->filename),"bin")/ { @[comm, str(args->filename)] = count(); }'  
+Attaching 1 probe...
+
+@[sh, /usr/bin/which]: 2
+@[sh, /home/liuting.0xffff/.vscode-server/bin/3b889b090b5ad5793f524b5]: 2
+@[cpuUsage.sh, /usr/bin/sleep]: 2
+@[sh, /usr/bin/ps]: 2
+@[cpuUsage.sh, /usr/bin/sed]: 4
+@[node, /bin/sh]: 6
+@[cpuUsage.sh, /usr/bin/cat]: 12
+```
+
+## 21. `override()`: Override return value
 
 Syntax: `override(u64 rc)`
 
@@ -2911,7 +2934,7 @@ ioctl(PERF_EVENT_IOC_SET_BPF): Invalid argument
 Error attaching probe: 'kprobe:vfs_read'
 ```
 
-## 21. `buf()`: Buffers
+## 22. `buf()`: Buffers
 
 Syntax: `buf(void *d [, int length])`
 
@@ -2942,7 +2965,7 @@ Datagram bytes: \x08\x00+\xb9\x06b\x00\x01Aen^\x00\x00\x00\x00KM\x0c\x00\x00\x00
 rtt min/avg/max/mdev = 19.426/19.426/19.426/0.000 ms
 ```
 
-## 22. `sizeof()`: Size of type or expression
+## 23. `sizeof()`: Size of type or expression
 
 Syntax:
 - `sizeof(TYPE)`
@@ -2975,7 +2998,7 @@ Attaching 1 probe...
 8
 ```
 
-## 23. `print()`: Print Value
+## 24. `print()`: Print Value
 
 Syntax: ```print(value)```
 
@@ -2999,7 +3022,7 @@ contains the memcopy'd value so the value at `print()` invocation time will be
 printed.  However for maps, only the handle to the map is queued up, so the
 printed map may be different than the map at `print()` invocation.
 
-## 24. `strftime()`: Formatted timestamp
+## 25. `strftime()`: Formatted timestamp
 
 Syntax:
 - `strftime(const char *format, int nsecs)`
@@ -3036,7 +3059,7 @@ Attaching 1 probe...
 ^C
 ```
 
-## 25. `path()`: Return full path
+## 26. `path()`: Return full path
 
 Syntax:
 - `path(struct path *path)`
@@ -3063,7 +3086,7 @@ Attaching 1 probe...
 /dev/pts/1 -> /dev/pts/1
 ```
 
-## 26. `uptr()`: Annotate userspace pointer
+## 27. `uptr()`: Annotate userspace pointer
 
 Syntax:
 - `uptr(void *p)`
@@ -3085,7 +3108,7 @@ state
 ^C
 ```
 
-## 27. `kptr()`: Annotate kernelspace pointer
+## 28. `kptr()`: Annotate kernelspace pointer
 
 Syntax:
 - `kptr(void *p)`
@@ -3095,7 +3118,7 @@ Annotate `p` as a pointer belonging to kernel address space.
 Just like `uptr`, you'll generally only need this if bpftrace has inferred the
 pointer address space incorrectly.
 
-## 28. `macaddr()`: Convert MAC address data to text
+## 29. `macaddr()`: Convert MAC address data to text
 
 Syntax: `macaddr(char[6] addr)`
 
@@ -3109,7 +3132,7 @@ SRC 18:C0:4D:08:2E:BB, DST 74:83:C2:7F:8C:FF
 ^C
 ```
 
-## 29. `cgroup_path`: Convert cgroup id to cgroup path
+## 30. `cgroup_path`: Convert cgroup id to cgroup path
 
 Syntax: `cgroup_path(int cgroupid, string filter)`
 
@@ -3128,7 +3151,7 @@ Attaching 1 probe...
 unified:/user.slice/user-1000.slice/session-3.scope
 ```
 
-## 30. `bswap`: Reverse byte order
+## 31. `bswap`: Reverse byte order
 
 Syntax: `bswap(uint[8|16|32|64] n)`
 
@@ -3143,7 +3166,7 @@ Attaching 1 probe...
 Reversing byte order of 0x12345678 ==> 0x78563412
 ```
 
-## 31. `skb_output`: Write `skb` 's data section into a PCAP file
+## 32. `skb_output`: Write `skb` 's data section into a PCAP file
 
 Syntax: `uint32 skboutput(const string path, struct sk_buff *skb, uint64 length, const uint64 offset)`
 
@@ -3184,7 +3207,7 @@ dropped privs to tcpdump
 10:23:45.823229 IP 100.101.2.146.53 > 192.168.0.23.46158: 45799 1/0/0 A 100.100.45.106 (60)
 ```
 
-## 32. `pton()`: Convert text IP address to byte array
+## 33. `pton()`: Convert text IP address to byte array
 
 Syntax: `pton(const string *addr)`
 
@@ -3214,7 +3237,7 @@ first octet matched
 ^C
 ```
 
-## 33. `strerror`: Get error message for errno code
+## 34. `strerror`: Get error message for errno code
 
 Syntax: `strerror(uint64 error)`
 

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1633,6 +1633,16 @@ bpftrace doesn't read past the length of the shortest string.
 
 The use of the `==` and `!=` operators is recommended over calling `strncmp` directly.
 
+=== strcontains
+
+.variants
+* `int64 strcontains(const char *haystack, const char *needle)`
+
+`strcontains` compares whether the string haystack contains the string needle.
+If needle is contained `1` is returned, else zero is returned.
+
+bpftrace doesn't read past the length of the shortest string.
+
 === system
 
 .variants

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -131,6 +131,11 @@ public:
                        uint64_t str2_size,
                        uint64_t n,
                        bool inverse);
+  Value *CreateStrcontains(Value *val1,
+                           uint64_t str1_size,
+                           Value *val2,
+                           uint64_t str2_size,
+                           bool inverse);
   CallInst *CreateGetNs(bool boot_time, const location &loc);
   CallInst *CreateGetPidTgid(const location &loc);
   CallInst *CreateGetCurrentCgroupId(const location &loc);

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1159,6 +1159,20 @@ void CodegenLLVM::visit(Call &call)
                              size,
                              false);
   }
+  else if (call.func == "strcontains")
+  {
+    const auto &left_arg = call.vargs->at(0);
+    const auto &right_arg = call.vargs->at(1);
+
+    auto left_string = getString(left_arg);
+    auto right_string = getString(right_arg);
+
+    expr_ = b_.CreateStrcontains(left_string.first,
+                                 left_string.second,
+                                 right_string.first,
+                                 right_string.second,
+                                 false);
+  }
   else if (call.func == "override")
   {
     // long bpf_override(struct pt_regs *regs, u64 rc)

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1239,6 +1239,15 @@ void SemanticAnalyser::visit(Call &call)
     }
     call.type = CreateUInt64();
   }
+  else if (call.func == "strcontains")
+  {
+    if (check_nargs(call, 2))
+    {
+      check_arg(call, Type::string, 0);
+      check_arg(call, Type::string, 1);
+    }
+    call.type = CreateUInt64();
+  }
   else if (call.func == "override")
   {
     if (!bpftrace_.feature_->has_helper_override_return())

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -38,7 +38,7 @@ vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#\*])+
 builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ctx|curtask|elapsed|func|gid|nsecs|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
-call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|sizeof|stats|str|strerror|strftime|strncmp|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf
+call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|sizeof|stats|str|strerror|strftime|strncmp|strcontains|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf
 
 /* Don't add to this! Use builtin OR call not both */
 call_and_builtin kstack|ustack

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -326,6 +326,18 @@ REQUIRES_FEATURE dpath kfunc
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
+NAME strcontains
+RUN {{BPFTRACE}} -ve 'kfunc:filp_close { $f = path(args->filp->f_path); if (strcontains($f, "tmp")) { printf("OK\n"); exit(); } }'
+EXPECT OK
+REQUIRES_FEATURE dpath kfunc
+TIMEOUT 5
+AFTER ./testprogs/syscall read
+
+NAME strcontains literals
+RUN {{BPFTRACE}} -e 'BEGIN { if (strcontains("abc", "a")) { printf("OK\n"); exit(); } }'
+EXPECT OK
+TIMEOUT 1
+
 NAME path_in_unsupported_kfunc
 PROG kfunc:vfs_read { print(path(args->file->f_path)); }
 EXPECT \nstdin:1:18-48: ERROR: helper bpf_d_path not supported in probe\n

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2035,6 +2035,23 @@ TEST(semantic_analyser, strncmp_posparam)
   test(bpftrace, "i:s:1 { strncmp(\"foo\", \"bar\", $2) }", 1);
 }
 
+TEST(semantic_analyser, strconrtains)
+{
+  // Test strcontains builtin
+  test("i:s:1 { $a = \"bar\"; strcontains(\"foo\", $a) }", 0);
+  test("i:s:1 { strcontains(\"foo\", \"bar\") }", 0);
+  test("i:s:1 { strcontains(1) }", 1);
+  test("i:s:1 { strcontains(1,1) }", 10);
+  test("i:s:1 { strcontains(\"a\",1) }", 10);
+}
+
+TEST(semantic_analyser, strcontains_posparam)
+{
+  BPFtrace bpftrace;
+  bpftrace.add_param("hello");
+  test(bpftrace, "i:s:1 { strcontains(\"foo\", str($1)) }", 0);
+}
+
 TEST(semantic_analyser, override)
 {
   // literals


### PR DESCRIPTION
<!--
 Add a new built-in func like strstr()
-->
 Add a new built-in func like strstr()

Add the strstr () function to make fuzzy comparisons when there is no way to confirm the absolute path of the file or the full name of the process or

usage:
`sudo bpftrace -e 't:syscalls:sys_enter_execve /strstr(comm,"sh") == 0/ { printf("%s called %s\n", comm, str(args->filename));}'`

Problem background: https://github.com/iovisor/bpftrace/issues/2306

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
