### PR TITLE
docker: fall back to a known bpftool version

### DIFF
--- a/docker/Dockerfile.focal
+++ b/docker/Dockerfile.focal
@@ -41,11 +41,17 @@ RUN apt-get update && apt-get install -y \
       llvm-${LLVM_VERSION}-dev \
       llvm-${LLVM_VERSION}-runtime \
       libllvm${LLVM_VERSION} \
-      linux-tools-$(uname -r) \
       systemtap-sdt-dev \
       python3 \
       xxd \
       libssl-dev
+
+# linux-tools on Ubuntu is versioned per-kernel but in reality we can just pull
+# bpftool from any release and we'll be fine. That said, try the exact kernel
+# release first just in case the host is running Ubuntu.
+RUN apt-get install -y linux-tools-$(uname -r) 2>/dev/null || apt-get install -y linux-tools-5.15.0-50-generic
+RUN /sbin/bpftool &>/dev/null || (rm -f /sbin/bpftool && ln -s /usr/lib/linux-tools/5.15.0-50-generic/bpftool /sbin/bpftool && bpftool)
+
 RUN if [ "$LLVM_VERSION" -ge 13 ] ; then apt-get install -y libmlir-${LLVM_VERSION}-dev ; fi
 
 RUN ln -s /usr/bin/python3 /usr/bin/python


### PR DESCRIPTION
The `linux-tools-$(uname -r)` construct that 1f0ff4c6 added only works if the host kernel is one of Ubuntu's.

If the install fails, fall back to a known package version and replace the /sbin/bpftool script with a direct symlink.

@viktormalik