### PR TITLE
Fix pointer arithmetics codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
   - [#2361](https://github.com/iovisor/bpftrace/pull/2361)
 - Fix kprobe multi-attachment
   - [#2381](https://github.com/iovisor/bpftrace/pull/2381)
+- Fix pointer arithmetics codegen
+  - [#2397](https://github.com/iovisor/bpftrace/pull/2397)
 
 #### Docs
 #### Tools

--- a/tests/runtime/pointers
+++ b/tests/runtime/pointers
@@ -92,3 +92,9 @@ NAME Pointer walk through struct
 RUN {{BPFTRACE}} runtime/scripts/struct_walk.bt -c ./testprogs/struct_walk
 EXPECT ^a: 45 b: 1000
 TIMEOUT 5
+
+NAME Pointer arith with int32
+PROG struct C { uint32_t a; }; uprobe:./testprogs/struct_walk:clear { $c = (struct C *)arg0; printf("ptr: %p\n", $c + $c->a); exit() }
+AFTER ./testprogs/struct_walk
+EXPECT ^ptr: 0x[0-9a-z]+
+TIMEOUT 5


### PR DESCRIPTION
Codegen for `ptr + X` creates the following instructions:

    %0 = mul sizeof(*ptr), X
    %1 = add ptr, %0

If X is not a 64-bit int, the `mul` will have incompatible operands which will cause a segfault in LLVM (at least in LLVM 14).

This fixes the problem by extending X to 64 bits, if necessary.

Fixes #2394.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
