### PR TITLE
runtime tests: improve test for probe name sanitization

### DIFF
--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -285,3 +285,9 @@ PROG k:* { @[probe] = count(); }
 EXPECT BPFTRACE_MAX_BPF_PROGS
 WILL_FAIL
 TIMEOUT 2
+
+NAME sanitise probe name
+PROG uprobe:./testprogs/uprobe_namesan:fn* { printf("ok\n"); exit(); }
+EXPECT ^ok
+AFTER ./testprogs/uprobe_namesan
+TIMEOUT 5

--- a/tests/runtime/uprobe
+++ b/tests/runtime/uprobe
@@ -61,9 +61,3 @@ NAME "uprobes - probe function in non-executable library"
 PROG uprobe:./testlibs/libsimple.so:fun {}
 EXPECT Attaching 1 probe...
 TIMEOUT 5
-
-NAME "uprobes - attach probe to golang program"
-RUN {{BPFTRACE}} -e 'uprobe:/usr/bin/docker:"os.(*File).Read" {}'
-EXPECT Attaching 1 probe...
-TIMEOUT 5
-REQUIRES command -v /usr/bin/docker

--- a/tests/testprogs/uprobe_namesan.c
+++ b/tests/testprogs/uprobe_namesan.c
@@ -1,0 +1,9 @@
+int __attribute__((noinline)) fn$()
+{
+  return 0;
+}
+
+int main(void)
+{
+  return fn$();
+}


### PR DESCRIPTION
#2390 introduced a runtime test attaching to a uprobe of `/usr/bin/docker` which is normally a Golang program.

That is not always the case, as Fedora uses Podman and `/usr/bin/docker` is just a compatibility shell script. So, this PR improves the test requirement that `/usr/bin/docker` is an ELF file (instead of just checking that it exists).

The test still depends on a non-standard binary (it's not run in the CI either) so it'd be probably better implement our own Golang program to test the functionality.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
