### PR TITLE
Fix unused-variable warning

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -525,7 +525,7 @@ CallInst *IRBuilderBPF::CreateProbeReadStr(Value *ctx,
 {
   assert(ctx && ctx->getType() == getInt8PtrTy());
   assert(size && size->getType()->isIntegerTy());
-  if (auto *dst_alloca = dyn_cast<AllocaInst>(dst))
+  if ([[maybe_unused]] auto *dst_alloca = dyn_cast<AllocaInst>(dst))
   {
     assert(dst_alloca->getAllocatedType()->isArrayTy() &&
            dst_alloca->getAllocatedType()->getArrayElementType() ==


### PR DESCRIPTION
This PR fixes the warning below.

```bash
[ 90%] Building CXX object src/ast/CMakeFiles/ast.dir/passes/semantic_analyser.cpp.o
/root/bpftrace/src/ast/irbuilderbpf.cpp: In member function 'llvm::CallInst* bpftrace::ast::IRBuilderBPF::CreateProbeReadStr(llvm::Value*, llvm::Value*, llvm::Value*, llvm::Value*, bpftrace::AddrSpace, const bpftrace::location&)':
/root/bpftrace/src/ast/irbuilderbpf.cpp:528:13: warning: unused variable 'dst_alloca' [-Wunused-variable]
  528 |   if (auto *dst_alloca = dyn_cast<AllocaInst>(dst))
      |             ^~~~~~~~~~
```

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
