### PR TITLE
add skb-output runtime check

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1331,6 +1331,13 @@ void SemanticAnalyser::visit(Call &call)
   }
   else if (call.func == "skboutput")
   {
+    if (!bpftrace_.feature_->has_skb_output())
+    {
+      LOG(ERROR, call.loc, err_)
+          << "BPF_FUNC_skb_output is not available for your kernel "
+             "version";
+    }
+
     check_assignment(call, false, true, false);
     if (check_nargs(call, 4))
     {

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -107,6 +107,7 @@ public:
     has_d_path_ = std::make_optional<bool>(has_features);
     has_ktime_get_boot_ns_ = std::make_optional<bool>(has_features);
     has_kprobe_multi_ = std::make_optional<bool>(has_features);
+    has_skb_output_ = std::make_optional<bool>(has_features);
   };
   bool has_features_;
 };


### PR DESCRIPTION
The built-in function `skboutput` should have a runtime feature check, to prevent issues like #2403 

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
