### PR TITLE
tools: undump: rely on BTF instead of header files

### DIFF
--- a/tools/undump.bt
+++ b/tools/undump.bt
@@ -14,7 +14,9 @@
  *
  * 22-May-2022	Rong Tao	Created this.
  */
+#ifndef BPFTRACE_HAVE_BTF
 #include <linux/skbuff.h>
+#endif
 
 BEGIN
 {


### PR DESCRIPTION
BTF, provided by most distributions nowadays, is a more robust way to provide kernel structure than the inclusion of kernel headers. Rely on BTF by default and only fall back on kernel headers if it's unavailable.
