### PR TITLE
github: set up CODEOWNERS to auto-request reviews

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Request reviews automatically to speed up the PR workflow
+
+*   @ajor @viktormalik @danobi @fbs @burntbrunch


### PR DESCRIPTION
As discussed in the office hours meeting, let's set up a CODEOWNERS file so GitHub is a little more pushy on new PRs.