### PR TITLE
Fix tests mocking tracefs accesses.

### DIFF
--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -3,6 +3,7 @@
 #include "bpftrace.h"
 #include "driver.h"
 #include "mocks.h"
+#include "tracefs.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -210,8 +211,7 @@ TEST(bpftrace, add_probes_wildcard)
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_symbols_from_file(
-                  "/sys/kernel/debug/tracing/available_filter_functions"))
+              get_symbols_from_file(tracefs::available_filter_functions()))
       .Times(1);
 
   if (bpftrace->has_kprobe_multi())
@@ -248,8 +248,7 @@ TEST(bpftrace, add_probes_wildcard_no_matches)
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_symbols_from_file(
-                  "/sys/kernel/debug/tracing/available_filter_functions"))
+              get_symbols_from_file(tracefs::available_filter_functions()))
       .Times(1);
 
   ASSERT_EQ(0, bpftrace->add_probe(*probe));
@@ -279,8 +278,7 @@ TEST(bpftrace, add_probes_kernel_module_wildcard)
   ast::Probe *probe = parse_probe("kprobe:func_in_mo*{}");
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_symbols_from_file(
-                  "/sys/kernel/debug/tracing/available_filter_functions"))
+              get_symbols_from_file(tracefs::available_filter_functions()))
       .Times(1);
 
   ASSERT_EQ(0, bpftrace->add_probe(*probe));
@@ -598,8 +596,7 @@ TEST(bpftrace, add_probes_tracepoint_wildcard)
   auto bpftrace = get_strict_mock_bpftrace();
   std::set<std::string> matches = { "sched_one", "sched_two" };
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_symbols_from_file(
-                  "/sys/kernel/debug/tracing/available_events"))
+              get_symbols_from_file(tracefs::available_events()))
       .Times(1);
 
   ASSERT_EQ(0, bpftrace->add_probe(*probe));
@@ -616,8 +613,7 @@ TEST(bpftrace, add_probes_tracepoint_category_wildcard)
   auto probe = parse_probe(("tracepoint:sched*:sched_* {}"));
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_symbols_from_file(
-                  "/sys/kernel/debug/tracing/available_events"))
+              get_symbols_from_file(tracefs::available_events()))
       .Times(1);
 
   ASSERT_EQ(0, bpftrace->add_probe(*probe));
@@ -649,8 +645,7 @@ TEST(bpftrace, add_probes_tracepoint_wildcard_no_matches)
 */
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_symbols_from_file(
-                  "/sys/kernel/debug/tracing/available_events"))
+              get_symbols_from_file(tracefs::available_events()))
       .Times(1);
 
   ASSERT_EQ(0, bpftrace->add_probe(*probe));

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -1,4 +1,5 @@
 #include "mocks.h"
+#include "tracefs.h"
 
 namespace bpftrace {
 namespace test {
@@ -10,9 +11,7 @@ using ::testing::StrictMock;
 
 void setup_mock_probe_matcher(MockProbeMatcher &matcher)
 {
-  ON_CALL(matcher,
-          get_symbols_from_file(
-              "/sys/kernel/debug/tracing/available_filter_functions"))
+  ON_CALL(matcher, get_symbols_from_file(tracefs::available_filter_functions()))
       .WillByDefault([](const std::string &) {
         std::string ksyms = "SyS_read\n"
                             "sys_read\n"
@@ -24,8 +23,7 @@ void setup_mock_probe_matcher(MockProbeMatcher &matcher)
         return myval;
       });
 
-  ON_CALL(matcher,
-          get_symbols_from_file("/sys/kernel/debug/tracing/available_events"))
+  ON_CALL(matcher, get_symbols_from_file(tracefs::available_events()))
       .WillByDefault([](const std::string &) {
         std::string tracepoints = "sched:sched_one\n"
                                   "sched:sched_two\n"


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.
-->

If /sys/kernel/debug/tracing directory does not exist, then bpftrace assumes tracefs is available under /sys/kernel/tracing. This breaks mocks and results in test failures when /sys/kernel/debug/tracing does not exist. This pull request replaces tracefs paths in tests with tracefs::* function calls to use the same tracefs detection logic as bpftrace.

This fixes following tests:
[  FAILED  ] 17 tests, listed below:
[  FAILED  ] bpftrace.add_probes_wildcard
[  FAILED  ] bpftrace.add_probes_wildcard_no_matches
[  FAILED  ] bpftrace.add_probes_kernel_module_wildcard
[  FAILED  ] bpftrace.add_probes_tracepoint_wildcard
[  FAILED  ] bpftrace.add_probes_tracepoint_category_wildcard
[  FAILED  ] bpftrace.add_probes_tracepoint_wildcard_no_matches
[  FAILED  ] semantic_analyser.call_ntop
[  FAILED  ] semantic_analyser.builtin_args
[  FAILED  ] semantic_analyser.tracepoint_common_field
[  FAILED  ] portability_analyser.tracepoint_field_access
[  FAILED  ] codegen.args_multiple_tracepoints
[  FAILED  ] codegen.args_multiple_tracepoints_category_wild
[  FAILED  ] codegen.args_multiple_tracepoints_wild
[  FAILED  ] codegen.builtin_probe
[  FAILED  ] codegen.builtin_probe_wild
[  FAILED  ] codegen.map_key_probe
[  FAILED  ] codegen.strncmp

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
