### PR TITLE
Fix segfault for invalid AssignVarStatement visit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to
   - [#2381](https://github.com/iovisor/bpftrace/pull/2381)
 - Fix pointer arithmetics codegen
   - [#2397](https://github.com/iovisor/bpftrace/pull/2397)
+- Fix segfault for invalid AssignVarStatement visit
+  - [#2423](https://github.com/iovisor/bpftrace/pull/2423)
 
 #### Docs
 #### Tools

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2208,6 +2208,11 @@ void SemanticAnalyser::visit(Cast &cast)
     LOG(ERROR, cast.loc, err_)
         << "Cannot cast from struct type \"" << cast.expr->type << "\"";
   }
+  else if (cast.expr->type.IsNoneTy())
+  {
+    LOG(ERROR, cast.loc, err_)
+        << "Cannot cast from \"" << cast.expr->type << "\" type";
+  }
 
   bool is_ctx = cast.expr->type.IsCtxAccess();
   auto &intcasts = getIntcasts();


### PR DESCRIPTION
When CodegenLLVM::visit calls CreateStore() with NULL expr_ as parameter, segfault is generated, for example:

```
  #include <linux/fs.h>
  kprobe:vfs_open {
    $file = (struct file *)
    printf("Hello\n");
  }
```

Acctually, we want to '`$file = (struct file *)arg1;`' here. When writing incorrectly '`$file = (struct file *)`', printf() make `expr_ == nullptr`, when call CreateStore(NULL, ...), segfault has occurred, and the stack backtrace is as follows:

```
  (gdb) bt
  #0  0x00000000007098c6 in llvm::Value::getType (this=0x0) at /usr/include/llvm/IR/Value.h:255
  #1  0x000000000070cc76 in llvm::IRBuilderBase::CreateAlignedStore (this=0x7fffffffbe40, Val=0x0,
      Ptr=0x15e2340, Align=..., isVolatile=false) at /usr/include/llvm/IR/IRBuilder.h:1689
  #2  0x000000000070cab3 in llvm::IRBuilderBase::CreateStore (this=0x7fffffffbe40, Val=0x0, Ptr=0x15e2340,
      isVolatile=false) at /usr/include/llvm/IR/IRBuilder.h:1663
  #3  0x00000000006f6948 in bpftrace::ast::CodegenLLVM::visit (this=0x7fffffffbe10, assignment=...)
      at /home/rongtao/Git/bpftrace/src/ast/passes/codegen_llvm.cpp:2140
  #4  0x0000000000751258 in bpftrace::ast::AssignVarStatement::accept (this=0x7fffe99b9a30, v=...)
      at /home/rongtao/Git/bpftrace/src/ast/ast.cpp:35
  #5  0x00000000006ff6ea in bpftrace::ast::CodegenLLVM::accept (this=0x7fffffffbe10, node=0x7fffe99b9a30)
      at /home/rongtao/Git/bpftrace/src/ast/passes/codegen_llvm.cpp:3360
```

We should prompt the user for some useful information, like:

```
  $ sudo ./sample.bt
  ./t3-call.bt:4:9-10: FATAL: Invalid expression for "$file"
    $file = (struct file *)
          ~
  Aborted
```

We can't solve this problem semantic_analyser because the syntax is correct. Maybe in the future we can solve it by modifying parser.yy, but this modification is not considered because it is more complicated. In any case, the CreateStore() parameter should not be NULL during the codegen phase.

LLVM/Clang Version: 15.0.1

