### PR TITLE
tools: Add filelife tools to track the lifecycle of a file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to
 
 #### Docs
 #### Tools
+- Add filelife tool
+  - [#2424](https://github.com/iovisor/bpftrace/pull/2424)
 
 ## [0.16.0] 2022-08-30
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ bpftrace contains various tools, which also serve as examples of programming in 
 - tools/[cpuwalk.bt](tools/cpuwalk.bt): Sample which CPUs are executing processes. [Examples](tools/cpuwalk_example.txt).
 - tools/[dcsnoop.bt](tools/dcsnoop.bt): Trace directory entry cache (dcache) lookups. [Examples](tools/dcsnoop_example.txt).
 - tools/[execsnoop.bt](tools/execsnoop.bt): Trace new processes via exec() syscalls. [Examples](tools/execsnoop_example.txt).
+- tools/[filelife.bt](tools/filelife.bt): Trace the lifespan of short-lived files. [Examples](tools/filelife_example.txt).
 - tools/[gethostlatency.bt](tools/gethostlatency.bt): Show latency for getaddrinfo/gethostbyname[2] calls. [Examples](tools/gethostlatency_example.txt).
 - tools/[killsnoop.bt](tools/killsnoop.bt): Trace signals issued by the kill() syscall. [Examples](tools/killsnoop_example.txt).
 - tools/[loads.bt](tools/loads.bt): Print load averages. [Examples](tools/loads_example.txt).

--- a/man/man8/filelife.bt.8
+++ b/man/man8/filelife.bt.8
@@ -1,0 +1,54 @@
+.TH filelife.bt 8  "2022-11-13" "USER COMMANDS"
+.SH NAME
+filelife \- Tracing the lifespan of short-lived files, Uses bpftrace/eBPF.
+.SH SYNOPSIS
+.B filelife.bt
+.SH DESCRIPTION
+filelife.bt tracked the lifespan of short-lived files
+
+This program is also a basic example of bpftrace and kprobes.
+
+Since this uses BPF, only the root user can use this tool.
+.SH REQUIREMENTS
+CONFIG_BPF and bpftrace.
+.SH EXAMPLES
+.TP
+Tracing the lifespan of short-lived files:
+#
+.B filelife.bt
+.SH FIELDS
+.TP
+TIME
+A timestamp on the output, in "HH:MM:SS" format.
+.TP
+PID
+The process ID.
+.TP
+COMM
+The process COMM.
+.TP
+AGE(us)
+Display the lifetime of the file (microseconds).
+.TP
+FILE
+The file name.
+.SH SOURCE
+This is from bpftrace.
+.IP
+https://github.com/iovisor/bpftrace
+.PP
+Also look in the bpftrace distribution for a companion _examples.txt file
+containing example usage, output, and commentary for this tool.
+
+This is a bpftrace version of the bcc tools of the same name.
+The bcc tool may provide more options and customizations.
+.IP
+https://github.com/iovisor/bcc
+.SH OS
+Linux
+.SH STABILITY
+Unstable - in development.
+.SH AUTHOR
+Rong Tao
+.SH SEE ALSO
+undump.bt(8)

--- a/tools/filelife.bt
+++ b/tools/filelife.bt
@@ -1,0 +1,71 @@
+#!/usr/bin/env bpftrace
+/*
+ * filelife	Tracing the lifespan of short-lived files.
+ *		For Linux, uses bpftrace and eBPF.
+ *
+ * Also a basic example of bpftrace.
+ *
+ * This is a bpftrace version of the bcc tools of the same name.
+ *
+ * USAGE: filelife.bt
+ *
+ * Copyright 2022 CESTC, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ *
+ * 13-Nov-2022	Rong Tao	Created this.
+ */
+#include <linux/fs.h>
+// linux: include/linux/fs.h
+#define FMODE_CREATED 0x100000
+
+BEGIN
+{
+	printf("Tracing the lifespan of short-lived files, Hit Ctrl-C to end\n");
+	printf("%-8s %-8s %-16s %-14s %-8s\n",
+		"TIME", "PID", "COMM", "AGE(us)", "FILE");
+}
+
+kprobe:vfs_create
+{
+	$dentry = (struct dentry *)arg2;
+	@dentry_map[$dentry] = 1;
+	@start[$dentry] = nsecs;
+}
+
+kprobe:security_inode_create
+{
+	$dentry = (struct dentry *)arg1;
+	@dentry_map[$dentry] = 1;
+	@start[$dentry] = nsecs;
+}
+
+kprobe:vfs_open
+{
+	$path = (struct path *)arg0;
+	$file = (struct file *)arg1;
+
+	if ($file->f_mode & FMODE_CREATED) {
+		$dentry = $path->dentry;
+		@dentry_map[$dentry] = 1;
+		@start[$dentry] = nsecs;
+	}
+}
+
+kprobe:vfs_unlink
+{
+	$dentry = (struct dentry *)arg2;
+	$d_name = $dentry->d_name;
+
+	if (@dentry_map[$dentry] == 1) {
+		$age = (nsecs - @start[$dentry]) / 1000;
+		time("%H:%M:%S ");
+		printf("%-8d %-16s %-14d %s\n", pid, comm, $age, str($d_name.name));
+		delete(@dentry_map[$dentry]);
+	}
+}
+
+END
+{
+	clear(@dentry_map);
+	clear(@start);
+}

--- a/tools/filelife_example.txt
+++ b/tools/filelife_example.txt
@@ -1,0 +1,36 @@
+Demonstrations of filelife.bt, the Linux eBPF/bpftrace version.
+
+This example trace the kernel function performing receive AP_UNIX socket
+packet. Some example output:
+
+Terminal 1, running filelife.bt:
+
+```
+$ sudo ./filelife.bt
+```
+
+Terminal 2, create and remove a file, run the following command line serial
+times:
+
+```
+$ touch a.txt && sleep 0.5 && rm a.txt
+```
+
+Terminal 1 shows:
+
+```
+$ sudo ./filelife.bt 
+Attaching 6 probes...
+Tracing the lifespan of short-lived files, Hit Ctrl-C to end
+TIME     PID      COMM             AGE(us)        FILE    
+19:45:58 106199   rm               507770         a.txt
+19:46:00 4046     kalendarac       7825           kalendaracrc.lock
+19:46:02 106208   rm               507581         a.txt
+19:46:03 106215   rm               507693         a.txt
+19:46:05 106223   rm               507504         a.txt
+19:46:06 106231   rm               507558         a.txt
+19:46:07 106238   rm               507553         a.txt
+```
+
+We can clearly see the life cycle of the A.txt file.
+


### PR DESCRIPTION
Usage:

```
  $ sudo ./filelife.bt
  Attaching 6 probes...
  Tracing the lifespan of short-lived files, Hit Ctrl-C to end
  TIME     PID      COMM             AGE(us)        FILE
  20:01:26 109927   rm               507814         a.txt
  20:01:28 109934   rm               507448         a.txt
  ^C
```

  Test command line:

```
  $ touch a.txt && sleep 0.5 && rm a.txt
  ...
```

