### PR TITLE
Fix compile warning: comparison is always true -Wtype-limits

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -634,9 +634,13 @@ std::string JsonOutput::json_escape(const std::string &str) const
         break;
 
       default:
-        if ('\x00' <= c && c <= '\x1f') {
+        // c always >= '\x00'
+        if (c <= '\x1f')
+        {
           escaped << "\\u" << std::hex << std::setw(4) << std::setfill('0') << (int)c;
-        } else {
+        }
+        else
+        {
           escaped << c;
         }
     }


### PR DESCRIPTION
WARNING:

```
src/output.cpp: In member function ‘std::__cxx11::string bpftrace::JsonOutput::json_escape(const string&) const’: 
src/output.cpp:637:20: warning: comparison is always true due to limited range of data type [-Wtype-limits]
         if ('\x00' <= c && c <= '\x1f') {
             ~~~~~~~^~~~
```

Architecture: aarch64
Vendor ID: HiSilicon
LLVM/Clang version 12.0.1
GCC Version 8.5.0
