### PR TITLE
scripts: check_kernel_features.sh - allow overriding kernel config path

### DIFF
--- a/scripts/check_kernel_features.sh
+++ b/scripts/check_kernel_features.sh
@@ -2,7 +2,7 @@
 
 # Report missing kernel features
 #
-# Usage: ./check_kernel_features.sh
+# Usage: ./check_kernel_features.sh [PATH_TO_KERNEL_CONFIG]
 
 set -e
 set -u
@@ -11,15 +11,15 @@ err=0
 config=''
 
 # Find kernel config
-for c in "/boot/config-$(uname -r)" "/boot/config" "/proc/config.gz"; do
-    if [ -f "$c" ]; then
+for c in "$@" "/boot/config-$(uname -r)" "/boot/config" "/proc/config.gz"; do
+    if [ -r "$c" ]; then
         config="$c"
         break
     fi
 done
 
 if [ -z "$config" ]; then
-    echo "Could not find kernel config" >&2
+    echo "Could not find kernel config, please supply it as argument." >&2
     exit 1
 fi
 


### PR DESCRIPTION
Allow `check_kernel_features.sh` to get passed the path to the kernel config to look at instead of only probing a hard-coded list.

This allows to check the kernel configuration of a different but the booted kernel as well.

Also make sure the file is readable and skip it otherwise.