### PR TITLE
Probe matcher: don't fail on missing files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to
   - [#2397](https://github.com/iovisor/bpftrace/pull/2397)
 - Fix segfault for invalid AssignVarStatement visit
   - [#2423](https://github.com/iovisor/bpftrace/pull/2423)
+- Better handling of missing function trace support files
+  - [#2433](https://github.com/iovisor/bpftrace/pull/2433)
 
 #### Docs
 #### Tools

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -112,7 +112,7 @@ std::set<std::string> ProbeMatcher::get_matches_for_probetype(
     case ProbeType::kprobe:
     case ProbeType::kretprobe:
     {
-      symbol_stream = get_symbols_from_file(
+      symbol_stream = get_symbols_from_file_safe(
           tracefs::available_filter_functions());
       ignore_trailing_module = true;
       break;
@@ -127,7 +127,7 @@ std::set<std::string> ProbeMatcher::get_matches_for_probetype(
     }
     case ProbeType::tracepoint:
     {
-      symbol_stream = get_symbols_from_file(tracefs::available_events());
+      symbol_stream = get_symbols_from_file_safe(tracefs::available_events());
       break;
     }
     case ProbeType::usdt:
@@ -206,6 +206,20 @@ std::unique_ptr<std::istream> ProbeMatcher::get_symbols_from_file(
   }
 
   return file;
+}
+
+std::unique_ptr<std::istream> ProbeMatcher::get_symbols_from_file_safe(
+    const std::string& path) const
+{
+  try
+  {
+    return get_symbols_from_file(path);
+  }
+  catch (const std::runtime_error& e)
+  {
+    LOG(WARNING) << e.what();
+  }
+  return NULL;
 }
 
 std::unique_ptr<std::istream> ProbeMatcher::get_func_symbols_from_file(

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -95,6 +95,8 @@ private:
 
   virtual std::unique_ptr<std::istream> get_symbols_from_file(
       const std::string &path) const;
+  virtual std::unique_ptr<std::istream> get_symbols_from_file_safe(
+      const std::string &path) const;
   virtual std::unique_ptr<std::istream> get_func_symbols_from_file(
       const std::string &path) const;
   virtual std::unique_ptr<std::istream> get_symbols_from_usdt(


### PR DESCRIPTION
Even though we rely on ftrace's function tracing functionality to list available probe functions, bpftrace can work without these, e.g. when making use of tracepoints only.

Right now `bpftrace -l` will die with a `std::runtime_error` exception if called on a kernel that lacks `CONFIG_FUNCTION_TRACER`. This isn't exactly user friendly.

Instead of dying by throwing an exception, emit a warning and keep on going.

This makes bpftrace usable on systems that lack `CONFIG_FUNCTION_TRACER` and/or `CONFIG_EVENT_TRACING` -- with limited functionality, of course!

Signed-off-by: Mathias Krause <minipli@grsecurity.net>

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
