### PR TITLE
tools: add numasched: trace task switch between NUMA

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ bpftrace contains various tools, which also serve as examples of programming in 
 - tools/[loads.bt](tools/loads.bt): Print load averages. [Examples](tools/loads_example.txt).
 - tools/[mdflush.bt](tools/mdflush.bt): Trace md flush events. [Examples](tools/mdflush_example.txt).
 - tools/[naptime.bt](tools/naptime.bt): Show voluntary sleep calls. [Examples](tools/naptime_example.txt).
+- tools/[numasched.bt](tools/numasched.bt): Trace task switch numa node. [Examples](tools/numasched_example.txt).
 - tools/[opensnoop.bt](tools/opensnoop.bt): Trace open() syscalls showing filenames. [Examples](tools/opensnoop_example.txt).
 - tools/[oomkill.bt](tools/oomkill.bt): Trace OOM killer. [Examples](tools/oomkill_example.txt).
 - tools/[pidpersec.bt](tools/pidpersec.bt): Count new processes (via fork). [Examples](tools/pidpersec_example.txt).

--- a/man/man8/numasched.bt.8
+++ b/man/man8/numasched.bt.8
@@ -1,0 +1,52 @@
+.TH numasched.bt 8  "2022-11-24" "USER COMMANDS"
+.SH NAME
+numasched.bt \- Tracing task switch NUMA. Uses bpftrace/eBPF.
+.SH SYNOPSIS
+.B numasched.bt
+.SH DESCRIPTION
+numasched.bt tracked task switch of NUMA.
+
+This program is also a basic example of bpftrace and tracepoint.
+
+Since this uses BPF, only the root user can use this tool.
+.SH REQUIREMENTS
+CONFIG_BPF and bpftrace.
+.SH EXAMPLES
+.TP
+Tracing task switch NUMA:
+#
+.B numasched.bt
+.SH FIELDS
+.TP
+TIME
+A timestamp on the output, in "HH:MM:SS" format.
+.TP
+PID
+The process ID.
+.TP
+TID
+The thread ID.
+.TP
+SRC_NID
+Source NUMA ID.
+.TP
+DST_NID
+Target NUMA ID.
+.TP
+COMM
+The process COMM.
+.SH SOURCE
+This is from bpftrace.
+.IP
+https://github.com/iovisor/bpftrace
+.PP
+Also look in the bpftrace distribution for a companion _examples.txt file
+containing example usage, output, and commentary for this tool.
+.SH OS
+Linux
+.SH STABILITY
+Unstable - in development.
+.SH AUTHOR
+Rong Tao
+.SH SEE ALSO
+opensnoop.bt(8)

--- a/tools/numasched.bt
+++ b/tools/numasched.bt
@@ -1,0 +1,47 @@
+#!/bin/env bpftrace
+/*
+ * numasched	Trace task switch numa
+ *		For Linux, uses bpftrace and eBPF.
+ *
+ * Also a basic example of bpftrace.
+ *
+ * USAGE: numasched.bt
+ *
+ * Copyright 2022 CESTC, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License")
+ *
+ * 24-Nov-2022	Rong Tao	Created this.
+ */
+BEGIN
+{
+	printf("Tracing task numa switch.\n");
+	printf("%-8s %-8s %-8s %-8s    %-8s %-8s\n",
+			"TIME", "PID", "TID", "SRC_NID", "DST_NID", "COMM");
+}
+
+tracepoint:sched:sched_switch
+/ pid != 0 /
+{
+	$old_nid = @nid_map[tid];
+	$new_nid = numaid;
+
+	if ($old_nid != $new_nid && @mark_first[tid] == 1) {
+		time("%H:%M:%S ");
+		printf("%-8d %-8d %-8d -> %-8d %s\n",
+			pid, tid, $old_nid, $new_nid, comm);
+	}
+
+	@nid_map[tid] = $new_nid;
+
+	/* If the first time you run the above code, $old_nid equals 0,
+	 * then $old_nid is easily not equal to $new_nid, so we skip the
+	 * first time and want the @nid_map to become a valid numa */
+	@mark_first[tid] = 1;
+}
+
+END
+{
+	clear(@nid_map);
+	clear(@mark_first);
+}
+

--- a/tools/numasched_example.txt
+++ b/tools/numasched_example.txt
@@ -1,0 +1,56 @@
+Demonstrations of numasched.bt, the Linux eBPF/bpftrace version.
+
+This example trace the task switch numa. Some example output:
+
+NUMA Information:
+
+  $ numactl --hardware
+  available: 4 nodes (0-3)
+  node 0 cpus: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23
+  node 0 size: 97373 MB
+  node 0 free: 1756 MB
+  node 1 cpus: 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47
+  node 1 size: 98192 MB
+  node 1 free: 1269 MB
+  node 2 cpus: 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71
+  node 2 size: 98192 MB
+  node 2 free: 4811 MB
+  node 3 cpus: 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95
+  node 3 size: 98135 MB
+  node 3 free: 1617 MB
+  node distances:
+  node   0   1   2   3
+    0:  10  12  20  22
+    1:  12  10  22  24
+    2:  20  22  10  12
+    3:  22  24  12  10
+
+
+Terminal 1, start a task running on NUMA0:
+
+  $ taskset -c 1 yes >/dev/null
+
+
+Terminal 2, start tracing:
+
+  $ sudo ./numasched.bt
+
+
+Terminal 3
+
+  # taskset 'yes' task to NUMA1(cpu=24):
+  $ taskset -p 0x1000000 $(pidof yes)
+
+  # taskset 'yes' task to NUMA2(cpu=48):
+  $ taskset -p 0x1000000000000 $(pidof yes)
+
+
+Then, Terminal 2 shows:
+
+  $ sudo ./numasched.bt
+  Attaching 3 probes...
+  Tracing task numa switch.
+  TIME     PID      TID      SRC_NID     DST_NID  COMM
+  16:19:08 915188   915188   0        -> 1        yes
+  16:19:14 915188   915188   1        -> 2        yes
+


### PR DESCRIPTION
Tasks frequently switch between NUMA, often resulting in poor performance.

since commit 121f73df1cb8("Add builtin 'numaid'") bpftrace support 'numaid' builtin. As described in the commit notes that introduced 'numaid', programs running on the same NUMA will have better performance (usually at the memory level). If processes are migrating between different CPUs and these CPUs belong to different NUMAs, this tool provides an effective means of tracing to optimize the program or configuration.

For example:

 NUMA info:
```
  $ numactl --hardware
  available: 4 nodes (0-3)
  node 0 cpus: 0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23
  node 0 size: 97373 MB
  node 0 free: 1756 MB
  node 1 cpus: 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47
  node 1 size: 98192 MB
  node 1 free: 1269 MB
  node 2 cpus: 48 49 50 51 52 53 54 55 56 57 58 59 60 61 62 63 64 65 66 67 68 69 70 71
  node 2 size: 98192 MB
  node 2 free: 4811 MB
  node 3 cpus: 72 73 74 75 76 77 78 79 80 81 82 83 84 85 86 87 88 89 90 91 92 93 94 95
  node 3 size: 98135 MB
  node 3 free: 1617 MB
  node distances:
  node   0   1   2   3
    0:  10  12  20  22
    1:  12  10  22  24
    2:  20  22  10  12
    3:  22  24  12  10
```

 Running 'yes' task:

```
  $ taskset -c 1 yes >/dev/null                   # running on NUMA0
```

 Then, taskset 'yes' to other NUMA:

```
  $ taskset -p 0x1000000 $(pidof yes)             # NUMA0 -> NUMA1
  $ taskset -p 0x1000000000000 $(pidof yes)       # NUMA1 -> NUMA2
  $ taskset -p 0x1000000000000000000 $(pidof yes) # NUMA2 -> NUMA3
```

 numasched.bt shows:

```
  $ sudo ./numasched.bt
  Attaching 3 probes...
  Tracing task numa switch.
  TIME     PID      SRC_NID     DST_NID  COMM
  16:30:43 915504   0        -> 1        yes
  16:30:44 915504   1        -> 2        yes
  16:30:46 915504   2        -> 3        yes
```
