### PR TITLE
Fix unroll ID reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to
   - [#2423](https://github.com/iovisor/bpftrace/pull/2423)
 - Better handling of missing function trace support files
   - [#2433](https://github.com/iovisor/bpftrace/pull/2433)
+- Fix unroll ID reset
+  - [#2439](https://github.com/iovisor/bpftrace/pull/2439)
 
 #### Docs
 #### Tools

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2207,7 +2207,8 @@ void CodegenLLVM::visit(Unroll &unroll)
       auto scoped_del = accept(stmt);
     }
 
-    reset_ids();
+    if (i != unroll.var - 1)
+      reset_ids();
   }
 }
 

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -75,6 +75,11 @@ RUN {{BPFTRACE}} -e 'i:ms:1 {$a = 1; unroll ($1) { $a = $a + 1; } printf("a=%d\n
 EXPECT a=11
 TIMEOUT 5
 
+NAME unroll_printf
+PROG BEGIN { unroll (1) { printf("a"); } printf("b\n"); exit(); }
+EXPECT ab\n
+TIMEOUT 5
+
 NAME if_compare_and_print_string
 PROG BEGIN { if (comm == "bpftrace") { printf("comm: %s\n", comm);} exit();}
 EXPECT comm: bpftrace


### PR DESCRIPTION
Do not reset at last iteration. Fixes #2430.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
