### PR TITLE
Fix offset calculation for arrays of pointers on 32-bit architectures

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1363,6 +1363,17 @@ llvm::Value *IRBuilderBPF::CreateDatastructElemLoad(
   return CreateIntCast(expr, getInt64Ty(), false);
 }
 
+llvm::Value *IRBuilderBPF::CreatePtrOffset(const SizedType &type,
+                                           llvm::Value *index,
+                                           AddrSpace as)
+{
+  size_t elem_size = type.IsPtrTy()
+                         ? getPointerStorageTy(as)->getIntegerBitWidth() / 8
+                         : type.GetSize();
+
+  return CreateMul(index, getInt64(elem_size));
+}
+
 llvm::Type *IRBuilderBPF::getPointerStorageTy(AddrSpace as)
 {
   switch (as)

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -183,6 +183,13 @@ public:
                        Value *data_len,
                        const location &loc);
 
+  // For a type T, creates an integer expression representing the byte offset
+  // of the element at the given index in T[]. Used for array dereferences and
+  // pointer arithmetic.
+  llvm::Value *CreatePtrOffset(const SizedType &type,
+                               llvm::Value *index,
+                               AddrSpace as);
+
   StoreInst *createAlignedStore(Value *val, Value *ptr, unsigned align);
   // moves the insertion point to the start of the function you're inside,
   // invokes functor, then moves the insertion point back to its original

--- a/tests/runtime/array
+++ b/tests/runtime/array
@@ -142,3 +142,9 @@ RUN {{BPFTRACE}} -e 'struct A { int x[4]; } uprobe:./testprogs/array_access:test
 EXPECT Result: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
+
+NAME array of pointers element access
+PROG struct C { int *z[4]; } uprobe:./testprogs/array_access:test_ptr_array { @x = *((struct C*)arg0)->z[1]; exit(); }
+EXPECT @x: 2
+TIMEOUT 5
+AFTER ./testprogs/array_access

--- a/tests/runtime/pointers
+++ b/tests/runtime/pointers
@@ -98,3 +98,9 @@ PROG struct C { uint32_t a; }; uprobe:./testprogs/struct_walk:clear { $c = (stru
 AFTER ./testprogs/struct_walk
 EXPECT ^ptr: 0x[0-9a-z]+
 TIMEOUT 5
+
+NAME Pointer to pointer arithmetic and dereference
+PROG uprobe:./testprogs/array_access:test_ptr_array { $p = (int32 **)arg0; @x = **($p + 1); exit(); }
+EXPECT @x: 2
+AFTER ./testprogs/array_access
+TIMEOUT 5

--- a/tests/testprogs/array_access.c
+++ b/tests/testprogs/array_access.c
@@ -8,12 +8,21 @@ struct B
   int y[2][2];
 };
 
+struct C
+{
+  int *z[4];
+};
+
 void test_array(int *a __attribute__((unused)))
 {
 }
 
 void test_struct(struct A *a __attribute__((unused)),
                  struct B *b __attribute__((unused)))
+{
+}
+
+void test_ptr_array(struct C *c __attribute__((unused)))
 {
 }
 
@@ -32,4 +41,11 @@ int main(int argc __attribute__((unused)), char ** argv __attribute__((unused)))
   b.y[1][1] = 8;
   test_struct(&a, &b);
   test_array(a.x);
+
+  struct C c;
+  c.z[0] = &a.x[0];
+  c.z[1] = &a.x[1];
+  c.z[2] = &a.x[2];
+  c.z[3] = &a.x[3];
+  test_ptr_array(&c);
 }


### PR DESCRIPTION
When indexing into an array of pointers, or doing arithmetic on pointers to pointers, make sure the correct element/pointee size is used for offset calculation. For example, `*((int32 **)$ptr + 1)` should generate a read at offset 4 from `$ptr` on a 32-bit system.

This is a follow-up to 02b0f077 ("Use arch-dependent size when reading pointers from kernel/user memory").

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
