### PR TITLE
Support profile and interval probes in probe matcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to
   - [#2433](https://github.com/iovisor/bpftrace/pull/2433)
 - Fix unroll ID reset
   - [#2439](https://github.com/iovisor/bpftrace/pull/2439)
+- Support profile and interval probes in probe matcher
+  - [#2443](https://github.com/iovisor/bpftrace/pull/2443)
 
 #### Docs
 #### Tools

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -521,11 +521,14 @@ std::set<std::string> ProbeMatcher::get_matches_for_ap(
       break;
     }
     case ProbeType::invalid:
-    case ProbeType::profile:
-    case ProbeType::interval:
       throw WildcardException(
           "Wildcard matches aren't available on probe type '" +
           attach_point.provider + "'");
+    case ProbeType::profile:
+    case ProbeType::interval:
+      // Wildcard matches are not supported on these probe types, however
+      // expansion can still happen when the probe builtin is used
+      return { "" };
   }
 
   return get_matches_for_probetype(probetype(attach_point.provider),

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -249,6 +249,11 @@ PROG p:hz:599 { @[tid] = count(); exit();}
 EXPECT \@\[[0-9]*\]\:\s[0-9]
 TIMEOUT 5
 
+NAME profile_probe_builtin
+PROG profile:hz:599 { print(probe); exit();}
+EXPECT profile:hz:599
+TIMEOUT 5
+
 NAME interval
 PROG t:raw_syscalls:sys_enter { @syscalls = count(); } interval:ms:1{ print(@syscalls); clear(@syscalls); exit();}
 EXPECT @syscalls\:\s[0-9]*
@@ -257,6 +262,11 @@ TIMEOUT 5
 NAME interval_short_name
 PROG t:raw_syscalls:sys_enter { @syscalls = count(); } i:ms:1{ print(@syscalls); clear(@syscalls); exit();}
 EXPECT @syscalls\:\s[0-9]*
+TIMEOUT 5
+
+NAME interval_probe_builtin
+PROG interval:ms:1 { print(probe); exit();}
+EXPECT interval:ms:1
 TIMEOUT 5
 
 NAME software


### PR DESCRIPTION
Profile and interval probes don't support wildcards, however they can still be expanded when the probe builtin is used. Hence, return a set containing an empty string instead of failing (which will expand to the original probe name) in ProbeMatcher::get_matches_for_ap.

Fixes #2362

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

This is the second attempt at fixing the issue (the first one #2363 used a wrong approach).

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
