### PR TITLE
tools/old/mdflush.bt: fix BPFTRACE_HAVE_BTF macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to
   - [#2439](https://github.com/iovisor/bpftrace/pull/2439)
 - Support profile and interval probes in probe matcher
   - [#2443](https://github.com/iovisor/bpftrace/pull/2443)
+- Fix BTF detection macro in tools/old/mdflush.bt
+  - [#2444](https://github.com/iovisor/bpftrace/pull/2444)
 
 #### Docs
 #### Tools

--- a/tools/old/mdflush.bt
+++ b/tools/old/mdflush.bt
@@ -15,7 +15,7 @@
  * 08-Sep-2018	Brendan Gregg	Created this.
  */
 
-#ifndef __BPFTRACE_HAVE_BTF
+#ifndef BPFTRACE_HAVE_BTF
 #include <linux/genhd.h>
 #include <linux/bio.h>
 #endif


### PR DESCRIPTION
The correct macro to use is called `BPFTRACE_HAVE_BTF`, not `__BPFTRACE_HAVE_BTF`.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
