### PR TITLE
Add %rh option to print buffer as hex without \x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to
   - [#2360](https://github.com/iovisor/bpftrace/pull/2360)
 - Support BTF for kernel modules
   - [#2315](https://github.com/iovisor/bpftrace/pull/2315)
+- Add %rh option to print buffer as hex without \x
+  - [#2445](https://github.com/iovisor/bpftrace/pull/2445)
 #### Changed
 - Raise minimum versions for libbpf and bcc and vendor them for local builds
   - [#2369](https://github.com/iovisor/bpftrace/pull/2369)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1274,7 +1274,7 @@ For arrays the `length` is optional, it is automatically inferred from the signa
 
 The `buf_t` object returned by `buf` can safely be printed as a hex encoded string with the `%r` format specifier.
 
-Bytes with values >=32 and \<=126 are printed using their ASCII character, other bytes are printed in hex form (e.g. `\x00`). The `%rx` format specifier can be used to print everything in hex form, including ASCII characters.
+Bytes with values >=32 and \<=126 are printed using their ASCII character, other bytes are printed in hex form (e.g. `\x00`). The `%rx` format specifier can be used to print everything in hex form, including ASCII characters. The similar `%rh` format specifier prints everything in hex form without `\x` and with spaces between bytes (e.g. `0a fe`).
 
 ----
 i:s:1 {

--- a/src/format_string.cpp
+++ b/src/format_string.cpp
@@ -136,17 +136,21 @@ void FormatString::format(std::ostream &out,
                                    ? parts_[i].substr(last_percent_sign)
                                    : "";
       std::string printf_fmt;
-      if (fmt_string == "%r" || fmt_string == "%rx")
+      if (fmt_string == "%r" || fmt_string == "%rx" || fmt_string == "%rh")
       {
-        if (fmt_string == "%rx")
+        if (fmt_string == "%rx" || fmt_string == "%rh")
         {
           auto printable_buffer = dynamic_cast<PrintableBuffer *>(&*args.at(i));
           // this is checked by semantic analyzer
           assert(printable_buffer);
           printable_buffer->keep_ascii(false);
+          if (fmt_string == "%rh")
+            printable_buffer->escape_hex(false);
         }
         // replace nonstandard format specifier with %s
-        printf_fmt = std::regex_replace(parts_[i], std::regex("%rx?"), "%s");
+        printf_fmt = std::regex_replace(parts_[i],
+                                        std::regex("%r[x|h]?"),
+                                        "%s");
       }
       else
       {

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -15,12 +15,18 @@ int PrintableBuffer::print(char *buf, size_t size, const char *fmt)
       buf,
       size,
       fmt,
-      hex_format_buffer(value_.data(), value_.size(), keep_ascii_).c_str());
+      hex_format_buffer(value_.data(), value_.size(), keep_ascii_, escape_hex_)
+          .c_str());
 }
 
 void PrintableBuffer::keep_ascii(bool value)
 {
   keep_ascii_ = value;
+}
+
+void PrintableBuffer::escape_hex(bool value)
+{
+  escape_hex_ = value;
 }
 
 int PrintableCString::print(char *buf, size_t size, const char *fmt)

--- a/src/printf.h
+++ b/src/printf.h
@@ -51,10 +51,12 @@ public:
   }
   int print(char* buf, size_t size, const char* fmt) override;
   void keep_ascii(bool value);
+  void escape_hex(bool value);
 
 private:
   std::vector<char> value_;
   bool keep_ascii_ = true;
+  bool escape_hex_ = true;
 };
 
 class PrintableCString : public virtual IPrintable

--- a/src/printf_format_types.h
+++ b/src/printf_format_types.h
@@ -22,6 +22,7 @@ const std::unordered_map<std::string, Type> printf_format_types = {
   {"s", Type::string},
   {"r", Type::buffer},
   {"rx", Type::buffer},
+  {"rh", Type::buffer},
   {"c", Type::integer},
   {"d", Type::integer},
   {"u", Type::integer},

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -952,7 +952,10 @@ pid_t parse_pid(const std::string &str)
   }
 }
 
-std::string hex_format_buffer(const char *buf, size_t size, bool keep_ascii)
+std::string hex_format_buffer(const char *buf,
+                              size_t size,
+                              bool keep_ascii,
+                              bool escape_hex)
 {
   // Allow enough space for every byte to be sanitized in the form "\x00"
   char s[size * 4 + 1];
@@ -961,8 +964,12 @@ std::string hex_format_buffer(const char *buf, size_t size, bool keep_ascii)
   for (size_t i = 0; i < size; i++)
     if (keep_ascii && buf[i] >= 32 && buf[i] <= 126)
       offset += sprintf(s + offset, "%c", ((const uint8_t *)buf)[i]);
-    else
+    else if (escape_hex)
       offset += sprintf(s + offset, "\\x%02x", ((const uint8_t *)buf)[i]);
+    else
+      offset += sprintf(s + offset,
+                        i == size - 1 ? "%02x" : "%02x ",
+                        ((const uint8_t *)buf)[i]);
 
   s[offset] = '\0';
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -188,7 +188,8 @@ bool symbol_has_cpp_mangled_signature(const std::string &sym_name);
 pid_t parse_pid(const std::string &str);
 std::string hex_format_buffer(const char *buf,
                               size_t size,
-                              bool keep_ascii = true);
+                              bool keep_ascii = true,
+                              bool escape_hex = true);
 std::optional<std::string> abs_path(const std::string &rel_path);
 bool symbol_has_module(const std::string &symbol);
 std::string strip_symbol_module(const std::string &symbol);

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -91,6 +91,11 @@ PROG BEGIN { printf("%rx", buf("Hello\0", 6)); exit(); }
 EXPECT \\x48\\x65\\x6c\\x6c\\x6f\\x00
 TIMEOUT 5
 
+NAME buf_no_ascii_no_escaping
+PROG BEGIN { printf("%rh", buf("Hello\0", 6)); exit(); }
+EXPECT 48 65 6c 6c 6f 00
+TIMEOUT 5
+
 NAME ksym
 PROG kprobe:do_nanosleep { printf("%s\n", ksym(reg("ip"))); exit();}
 EXPECT do_nanosleep

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1336,6 +1336,17 @@ TEST(semantic_analyser, printf_bad_format_buf_no_ascii)
   test("kprobe:f { printf(\"%rx\", arg0) }", 10);
 }
 
+TEST(semantic_analyser, printf_format_buf_nonescaped_hex)
+{
+  test("kprobe:f { printf(\"%rh\", buf(\"mystr\", 5)) }", 0);
+}
+
+TEST(semantic_analyser, printf_bad_format_buf_nonescaped_hex)
+{
+  test("kprobe:f { printf(\"%rh\", \"mystr\") }", 10);
+  test("kprobe:f { printf(\"%rh\", arg0) }", 10);
+}
+
 TEST(semantic_analyser, printf_format_multi)
 {
   test("kprobe:f { printf(\"%d %d %s\", 1, 2, \"mystr\") }", 0);


### PR DESCRIPTION
The new option serves as a more readable variant of %rx. In addition to omitting `%rx`, it puts spaces between the bytes.

Closes #2305

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

Example:
```
# bpftrace -e 'BEGIN { printf("%rh", buf("Hello world", 11)); }'
Attaching 1 probe...
48 65 6c 6c 6f 20 77 6f 72 6c 64
```

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
