### PR TITLE
Fix attaching to multiple USDT probes using the same wildcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,8 @@ and this project adheres to
   - [#2361](https://github.com/iovisor/bpftrace/pull/2361)
 - Fix kprobe multi-attachment
   - [#2381](https://github.com/iovisor/bpftrace/pull/2381)
+- Fix attaching to multiple USDT probes using the same wildcard
+  - [#2456](https://github.com/iovisor/bpftrace/pull/2456)
 - Fix pointer arithmetics codegen
   - [#2397](https://github.com/iovisor/bpftrace/pull/2397)
 - Fix segfault for invalid AssignVarStatement visit

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -221,6 +221,14 @@ int BPFtrace::add_probe(ast::Probe &p)
         attach_point->target = target;
         attach_point->ns = ns;
         attach_point->func = func_id;
+        // Necessary for correct number of locations if wildcard expands to
+        // multiple probes.
+        std::optional<usdt_probe_entry> usdt;
+        if (attach_point->need_expansion &&
+            (usdt = USDTHelper::find(this->pid(), target, ns, func_id)))
+        {
+          attach_point->usdt = *usdt;
+        }
       }
       else if (probetype(attach_point->provider) == ProbeType::tracepoint ||
                probetype(attach_point->provider) == ProbeType::uprobe ||

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -142,7 +142,7 @@ TIMEOUT 5
 
 NAME "usdt probes - attach to probe on multiple files by wildcard"
 PROG usdt:./testprogs/usdt*::* { printf("here\n" ); exit(); }
-EXPECT Attaching 41 probes...
+EXPECT Attaching 48 probes...
 TIMEOUT 5
 
 NAME "usdt probes - attach to probe on multiple providers by wildcard and pid"
@@ -151,6 +151,13 @@ EXPECT Attaching 2 probes...
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
+
+NAME "usdt probes - attach to multiple probes with different number of locations by wildcard"
+PROG usdt:./testprogs/usdt_multiple_locations:tracetest:testprobe* { printf("here\n" ); exit(); }
+BEFORE ./testprogs/usdt_multiple_locations
+EXPECT Attaching 6 probes...
+TIMEOUT 5
+REQUIRES ./testprogs/usdt_multiple_locations should_not_skip
 
 # TODO(mmarchini): re-enable this test
 # This test relies on the latest version of bcc. Before re-enabling this test,

--- a/tests/testprogs/usdt_multiple_locations.c
+++ b/tests/testprogs/usdt_multiple_locations.c
@@ -1,0 +1,38 @@
+#ifdef HAVE_SYSTEMTAP_SYS_SDT_H
+#include <sys/sdt.h>
+#else
+#define DTRACE_PROBE2(a, b, c, d) (void)0
+#endif
+#include <sys/time.h>
+#include <unistd.h>
+
+static long myclock()
+{
+  struct timeval tv;
+  gettimeofday(&tv, NULL);
+  DTRACE_PROBE2(tracetest, testprobe, tv.tv_sec, "Hello world");
+  DTRACE_PROBE2(tracetest, testprobe, tv.tv_sec, "Hello world2");
+  DTRACE_PROBE2(tracetest, testprobe2, tv.tv_sec, "Hello world3");
+  DTRACE_PROBE2(tracetest, testprobe3, tv.tv_sec, "Hello world4");
+  DTRACE_PROBE2(tracetest, testprobe3, tv.tv_sec, "Hello world5");
+  DTRACE_PROBE2(tracetest, testprobe3, tv.tv_sec, "Hello world6");
+  return tv.tv_sec;
+}
+
+int main(int argc, char **argv __attribute__((unused)))
+{
+  if (argc > 1)
+  // If we don't have Systemtap headers, we should skip USDT tests. Returning 1
+  // can be used as validation in the REQUIRE
+#ifndef HAVE_SYSTEMTAP_SYS_SDT_H
+    return 1;
+#else
+    return 0;
+#endif
+
+  while (1)
+  {
+    myclock();
+  }
+  return 0;
+}


### PR DESCRIPTION
Hi,
this is my first pull request in a public repository. Let me know what I can improve :)

Short description of the issue:
Attaching to multiple USDT probes with different number of locations by the same wildcard can produce the error 'code not generated for probe'. The reason is that a single AttachPoint has multiple matching probes in this case but we only store the USDT information for a single probe in AttachPoint. Later, the number of locations from the USDT information stored in AttachPoint is used to look up the generated code for every probe to attach to, which can differ between the USDT probes and cause the above mentioned error.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
