### PR TITLE
Adding the command to clone the submodules in the readme file

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -332,7 +332,7 @@ sudo dnf install -y bison \
   gmock-devel \
   cereal-devel \
   asciidoctor
-git clone https://github.com/iovisor/bpftrace
+git clone https://github.com/iovisor/bpftrace --recurse-submodules
 cd bpftrace
 mkdir build; cd build
 ../build-libs.sh


### PR DESCRIPTION
Signed-off-by: rajeeshckr <rajeesh.ckr@gmail.com>

Updating the readme to include `--recurse-submodules` when cloning the repo. Without this, `../build-libs.sh` step in [building bpftrace](https://github.com/rajeeshckr/bpftrace/blob/master/INSTALL.md#building-bpftrace-1) was failing.

##### Checklist
These checklists does not apply to the change since it is a readme change.

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
