### PR TITLE
Drop Ubuntu 19.10 lockdown detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to
   - [#2387](https://github.com/iovisor/bpftrace/pull/2387)
 #### Deprecated
 #### Removed
+- Drop Ubuntu 19.10 lockdown detection
+  - [#2467](https://github.com/iovisor/bpftrace/pull/2467)
 #### Fixed
 - Fix pointer/register loads on 32-bit architectures
   - [#2361](https://github.com/iovisor/bpftrace/pull/2361)

--- a/src/lockdown.cpp
+++ b/src/lockdown.cpp
@@ -26,22 +26,6 @@ static LockdownState from_string(const std::string &s)
   return LockdownState::Unknown;
 }
 
-static bool is_ubuntu(void)
-{
-  // If ubuntu is somewhere in uname it is probably ubuntu
-  struct utsname name = {};
-  uname(&name);
-
-  std::string version(name.version);
-
-  std::transform(version.begin(),
-                 version.end(),
-                 version.begin(),
-                 [](unsigned char c) { return std::tolower(c); });
-
-  return (version.find("ubuntu") != std::string::npos);
-}
-
 static LockdownState read_security_lockdown(void)
 {
   std::ifstream file("/sys/kernel/security/lockdown");
@@ -73,14 +57,6 @@ void emit_warning(std::ostream &out)
 
 LockdownState detect(std::unique_ptr<BPFfeature> &feature)
 {
-  // Ubuntu (19.10 at least) ships a lockdown version that fully blocks the bpf
-  // syscall
-  if (is_ubuntu() && !feature->has_map_array() &&
-      !feature->has_helper_probe_read())
-  {
-    return LockdownState::Confidentiality;
-  }
-
   return read_security_lockdown();
 }
 


### PR DESCRIPTION
Commit 37d28c261a29962b9db8bafc3da866f07ce38d8b ("detect lockdown mode") introduced a specific lockdown detection for Ubuntu 19.10 which was different from the upstream.

Now that the lockdown mode can be detected by reading `/sys/kernel/security/lockdown` on all currently supported Ubuntu versions, we may remove this hack.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

Resolves #2455.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
