### PR TITLE
Clang parser: resolve unknown enum values from BTF

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,8 @@ and this project adheres to
   - [#2443](https://github.com/iovisor/bpftrace/pull/2443)
 - Fix BTF detection macro in tools/old/mdflush.bt
   - [#2444](https://github.com/iovisor/bpftrace/pull/2444)
+- Clang parser: resolve unknown enum values from BTF
+  - [#2472](https://github.com/iovisor/bpftrace/pull/2472)
 
 #### Docs
 #### Tools

--- a/src/clang_parser.h
+++ b/src/clang_parser.h
@@ -45,12 +45,12 @@ private:
    * Collect names of types defined by typedefs that are in non-included
    * headers as they may pose problems for clang parser.
    */
-  std::unordered_set<std::string> get_unknown_typedefs();
+  std::unordered_set<std::string> get_unknown_types();
   /*
    * Iteratively check for unknown typedefs, pull their definitions from BTF,
    * and update the input files with the definitions.
    */
-  void resolve_unknown_typedefs_from_btf(BPFtrace &bpftrace);
+  void resolve_unknown_types_from_btf(BPFtrace &bpftrace);
 
   static std::optional<std::string> get_unknown_type(
       const std::string &diagnostic_msg);

--- a/tests/data/data_source.c
+++ b/tests/data/data_source.c
@@ -24,6 +24,12 @@ struct Foo3
   const volatile struct Foo2 *restrict foo2;
 };
 
+enum FooBar
+{
+  FOO = 0,
+  BAR
+};
+
 struct Foo3 foo3;
 
 struct Foo3 *func_1(int a, struct Foo1 *foo1, struct Foo2 *foo2)
@@ -85,6 +91,7 @@ int main(void)
   struct bpf_iter__task iter_task;
   struct bpf_iter__task_file iter_task_file;
   struct bpf_iter__task_vma iter_task_vma;
+  enum FooBar foobar;
 
   func_1(0, 0, 0);
   return 0;


### PR DESCRIPTION
When user-defined types/includes are used but some types are missing, we try to resolve the types from BTF so that the user doesn't have to search for the missing headers to include. This works fine for incomplete struct types and unknown typedefs, but doesn't work for missing enum values.

This PR adds support for parsing the missing enum value names from Clang diagnostic messages and retrieving them from BTF.

This fixes the following, currently failing, example (latest bpftrace, kernel `6.0.11-200.fc36.x86_64`):
```
# cat test.bt
#include <linux/skbuff.h>
BEGIN { exit(); }

# bpftrace test.bt
/lib/modules/6.0.11-200.fc36.x86_64/source/include/linux/compiler-clang.h:41:9: warning: '__HAVE_BUILTIN_BSWAP32__' macro redefined [-Wmacro-redefined]
note: previous definition is here
/lib/modules/6.0.11-200.fc36.x86_64/source/include/linux/compiler-clang.h:42:9: warning: '__HAVE_BUILTIN_BSWAP64__' macro redefined [-Wmacro-redefined]
note: previous definition is here
/lib/modules/6.0.11-200.fc36.x86_64/source/include/linux/compiler-clang.h:43:9: warning: '__HAVE_BUILTIN_BSWAP16__' macro redefined [-Wmacro-redefined]
note: previous definition is here
/lib/modules/6.0.11-200.fc36.x86_64/source/include/linux/kasan-checks.h:24:9: error: use of undeclared identifier 'true'
/lib/modules/6.0.11-200.fc36.x86_64/source/include/linux/kasan-checks.h:28:9: error: use of undeclared identifier 'true'
/lib/modules/6.0.11-200.fc36.x86_64/source/include/linux/kasan-checks.h:42:9: error: use of undeclared identifier 'true'
/lib/modules/6.0.11-200.fc36.x86_64/source/include/linux/kasan-checks.h:46:9: error: use of undeclared identifier 'true'
/lib/modules/6.0.11-200.fc36.x86_64/source/arch/x86/include/asm/ibt.h:101:47: error: use of undeclared identifier 'false'
/lib/modules/6.0.11-200.fc36.x86_64/source/include/asm-generic/bitops/le.h:21:9: error: use of undeclared identifier 'uintptr_t'
/lib/modules/6.0.11-200.fc36.x86_64/source/include/asm-generic/bitops/le.h:21:9: error: use of undeclared identifier 'uintptr_t'
/lib/modules/6.0.11-200.fc36.x86_64/source/include/asm-generic/bitops/le.h:21:9: error: use of undeclared identifier 'uintptr_t'
/lib/modules/6.0.11-200.fc36.x86_64/source/include/asm-generic/bitops/le.h:21:9: error: use of undeclared identifier 'uintptr_t'
/lib/modules/6.0.11-200.fc36.x86_64/source/include/asm-generic/bitops/le.h:36:2: error: use of undeclared identifier 'uintptr_t'
/lib/modules/6.0.11-200.fc36.x86_64/source/include/asm-generic/bitops/le.h:36:2: error: use of undeclared identifier 'uintptr_t'
/lib/modules/6.0.11-200.fc36.x86_64/source/include/asm-generic/bitops/le.h:36:2: error: use of undeclared identifier 'uintptr_t'
/lib/modules/6.0.11-200.fc36.x86_64/source/include/asm-generic/bitops/le.h:36:2: error: use of undeclared identifier 'uintptr_t'
/lib/modules/6.0.11-200.fc36.x86_64/source/include/asm-generic/bitops/le.h:41:2: error: use of undeclared identifier 'uintptr_t'
/lib/modules/6.0.11-200.fc36.x86_64/source/include/asm-generic/bitops/le.h:41:2: error: use of undeclared identifier 'uintptr_t'
/lib/modules/6.0.11-200.fc36.x86_64/source/include/asm-generic/bitops/le.h:41:2: error: use of undeclared identifier 'uintptr_t'
/lib/modules/6.0.11-200.fc36.x86_64/source/include/asm-generic/bitops/le.h:41:2: error: use of undeclared identifier 'uintptr_t'
/lib/modules/6.0.11-200.fc36.x86_64/source/include/asm-generic/bitops/le.h:56:9: error: use of undeclared identifier 'uintptr_t'
/lib/modules/6.0.11-200.fc36.x86_64/source/include/asm-generic/bitops/le.h:56:9: error: use of undeclared identifier 'uintptr_t'
fatal error: too many errors emitted, stopping now [-ferror-limit=]
```

The reason why this fails is that we override `<linux/types.h>` (included by `<linux/skbuff.h>`) with BTF-pulled definitions but are not able to detect that we're missing some enum values (`true`/`false` in this case).

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
