### PR TITLE
Support ringbuf output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to
 #### Changed
 - Improve attaching to uprobes with size 0
   - [#2562](https://github.com/iovisor/bpftrace/pull/2562)
+- Support ringbuf output
+  - [#2475](https://github.com/iovisor/bpftrace/pull/2475)
 #### Deprecated
 #### Removed
 #### Fixed

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -38,6 +38,14 @@
   CreateMemSet((ptr), (val), (size), (align))
 #endif
 
+#if LLVM_VERSION_MAJOR >= 13
+#define CREATE_ATOMIC_RMW(op, ptr, val, align, order)                          \
+  CreateAtomicRMW((op), (ptr), (val), MaybeAlign((align)), (order))
+#else
+#define CREATE_ATOMIC_RMW(op, ptr, val, align, order)                          \
+  CreateAtomicRMW((op), (ptr), (val), (order))
+#endif
+
 namespace bpftrace {
 namespace ast {
 
@@ -171,10 +179,11 @@ public:
                        ArrayRef<Value *> args,
                        const Twine &Name);
   void        CreateGetCurrentComm(Value *ctx, AllocaInst *buf, size_t size, const location& loc);
-  void CreatePerfEventOutput(Value *ctx,
-                             Value *data,
-                             size_t size,
-                             const location *loc = nullptr);
+  void CreateOutput(Value *ctx,
+                    Value *data,
+                    size_t size,
+                    const location *loc = nullptr);
+  void CreateAtomicIncCounter(int mapfd, uint32_t idx);
   void CreateTracePrintk(Value *fmt,
                          Value *fmt_size,
                          const std::vector<Value *> &values,
@@ -239,6 +248,13 @@ private:
 
   llvm::Type *getKernelPointerStorageTy();
   llvm::Type *getUserPointerStorageTy();
+  void CreateRingbufOutput(Value *data,
+                           size_t size,
+                           const location *loc = nullptr);
+  void CreatePerfEventOutput(Value *ctx,
+                             Value *data,
+                             size_t size,
+                             const location *loc = nullptr);
 
   std::map<std::string, StructType *> structs_;
 };

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -755,11 +755,10 @@ void CodegenLLVM::visit(Call &call)
     }
 
     // emit
-    b_.CreatePerfEventOutput(
-        ctx_,
-        perfdata,
-        8 + 8 + bpftrace_.join_argnum_ * bpftrace_.join_argsize_,
-        &call.loc);
+    b_.CreateOutput(ctx_,
+                    perfdata,
+                    8 + 8 + bpftrace_.join_argnum_ * bpftrace_.join_argsize_,
+                    &call.loc);
 
     b_.CreateBr(zero);
 
@@ -1003,7 +1002,7 @@ void CodegenLLVM::visit(Call &call)
      */
     AllocaInst *perfdata = b_.CreateAllocaBPF(b_.getInt64Ty(), "perfdata");
     b_.CreateStore(b_.getInt64(asyncactionint(AsyncAction::exit)), perfdata);
-    b_.CreatePerfEventOutput(ctx_, perfdata, sizeof(uint64_t), &call.loc);
+    b_.CreateOutput(ctx_, perfdata, sizeof(uint64_t), &call.loc);
     b_.CreateLifetimeEnd(perfdata);
     expr_ = nullptr;
     createRet();
@@ -1080,7 +1079,7 @@ void CodegenLLVM::visit(Call &call)
                                    { b_.getInt64(0), b_.getInt32(1) });
     b_.CreateStore(b_.GetIntSameSize(id, elements.at(1)), ident_ptr);
 
-    b_.CreatePerfEventOutput(ctx_, buf, getStructSize(event_struct), &call.loc);
+    b_.CreateOutput(ctx_, buf, getStructSize(event_struct), &call.loc);
     b_.CreateLifetimeEnd(buf);
     expr_ = nullptr;
   }
@@ -1102,7 +1101,7 @@ void CodegenLLVM::visit(Call &call)
         b_.CreateGEP(time_struct, buf, { b_.getInt64(0), b_.getInt32(1) }));
 
     time_id_++;
-    b_.CreatePerfEventOutput(ctx_, buf, getStructSize(time_struct), &call.loc);
+    b_.CreateOutput(ctx_, buf, getStructSize(time_struct), &call.loc);
     b_.CreateLifetimeEnd(buf);
     expr_ = nullptr;
   }
@@ -1226,7 +1225,7 @@ void CodegenLLVM::visit(Call &call)
     b_.CreateStore(
         b_.CreateIntCast(expr_, b_.getInt64Ty(), false /* unsigned */),
         b_.CreateGEP(unwatch_struct, buf, { b_.getInt64(0), b_.getInt32(1) }));
-    b_.CreatePerfEventOutput(ctx_, buf, struct_size, &call.loc);
+    b_.CreateOutput(ctx_, buf, struct_size, &call.loc);
     b_.CreateLifetimeEnd(buf);
     expr_ = nullptr;
   }
@@ -3143,7 +3142,7 @@ void CodegenLLVM::createFormatStringCall(Call &call, int &id, CallArgs &call_arg
   }
 
   id++;
-  b_.CreatePerfEventOutput(ctx_, fmt_args, struct_size, &call.loc);
+  b_.CreateOutput(ctx_, fmt_args, struct_size, &call.loc);
   b_.CreateLifetimeEnd(fmt_args);
   expr_ = nullptr;
 }
@@ -3194,7 +3193,7 @@ void CodegenLLVM::generateWatchpointSetupProbe(
   b_.CreateStore(
       addr,
       b_.CreateGEP(watchpoint_struct, buf, { b_.getInt64(0), b_.getInt32(2) }));
-  b_.CreatePerfEventOutput(ctx, buf, struct_size);
+  b_.CreateOutput(ctx, buf, struct_size);
   b_.CreateLifetimeEnd(buf);
 
   createRet();
@@ -3244,7 +3243,7 @@ void CodegenLLVM::createPrintMapCall(Call &call)
                                 { b_.getInt64(0), b_.getInt32(arg_idx + 1) }));
   }
 
-  b_.CreatePerfEventOutput(ctx_, buf, getStructSize(print_struct), &call.loc);
+  b_.CreateOutput(ctx_, buf, getStructSize(print_struct), &call.loc);
   b_.CreateLifetimeEnd(buf);
   expr_ = nullptr;
 }
@@ -3294,7 +3293,7 @@ void CodegenLLVM::createPrintNonMapCall(Call &call, int &id)
   }
 
   id++;
-  b_.CreatePerfEventOutput(ctx_, buf, struct_size, &call.loc);
+  b_.CreateOutput(ctx_, buf, struct_size, &call.loc);
   b_.CreateLifetimeEnd(buf);
   expr_ = nullptr;
 }

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -192,6 +192,7 @@ void ResourceAnalyser::visit(Call &call)
     Integer &offset = static_cast<Integer &>(offset_arg);
 
     resources_.skboutput_args_.emplace_back(file.str, offset.n);
+    resources_.needs_perf_event_map = true;
   }
 }
 

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -177,6 +177,14 @@ bool BPFfeature::detect_map(enum libbpf::bpf_map_type map_type)
     case libbpf::BPF_MAP_TYPE_STACK_TRACE:
       value_size = 8;
       break;
+    case libbpf::BPF_MAP_TYPE_RINGBUF:
+      // values from libbpf/src/libbpf_probes.c
+      // default pagesize 4KB
+      // default perf_rb_pages 64
+      key_size = 0;
+      value_size = 0;
+      max_entries = sysconf(_SC_PAGE_SIZE);
+      break;
     default:
       break;
   }
@@ -511,7 +519,7 @@ std::string BPFfeature::report(void)
       << "  percpu array: " << to_str(has_map_percpu_array())
       << "  stack_trace: " << to_str(has_map_stack_trace())
       << "  perf_event_array: " << to_str(has_map_perf_event_array())
-      << std::endl;
+      << "  ringbuf: " << to_str(has_map_ringbuf()) << std::endl;
 
   buf << "Probe types" << std::endl
       << "  kprobe: " << to_str(has_prog_kprobe())

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -94,6 +94,7 @@ public:
   DEFINE_MAP_TEST(percpu_hash, libbpf::BPF_MAP_TYPE_ARRAY);
   DEFINE_MAP_TEST(stack_trace, libbpf::BPF_MAP_TYPE_STACK_TRACE);
   DEFINE_MAP_TEST(perf_event_array, libbpf::BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+  DEFINE_MAP_TEST(ringbuf, libbpf::BPF_MAP_TYPE_RINGBUF);
   DEFINE_HELPER_TEST(send_signal, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_HELPER_TEST(override_return, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_HELPER_TEST(get_current_cgroup_id, libbpf::BPF_PROG_TYPE_KPROBE);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -30,6 +30,8 @@
 
 namespace bpftrace {
 
+const int timeout_ms = 100;
+
 struct symbol
 {
   std::string name;
@@ -198,6 +200,8 @@ public:
   uint64_t ast_max_nodes_ = 0; // Maximum AST nodes allowed for fuzzing
   std::optional<StackMode> stack_mode_;
   std::optional<struct timespec> boottime_;
+  static constexpr uint32_t rb_loss_cnt_key_ = 0;
+  static constexpr uint64_t rb_loss_cnt_val_ = 0;
 
   static void sort_by_key(
       std::vector<SizedType> key_args,
@@ -233,14 +237,33 @@ private:
       std::tuple<uint8_t *, uintptr_t> func,
       int pid,
       bool file_activation);
+  int setup_output();
   int setup_perf_events();
-  void poll_perf_events(bool drain = false);
+  int setup_ringbuf();
+  // when the ringbuf feature is available, enable ringbuf for built-ins like
+  // printf, cat.
+  bool is_ringbuf_enabled(void) const
+  {
+    return feature_->has_map_ringbuf();
+  }
+  // when the ringbuf feature is unavailable or built-in skboutput is used,
+  // enable perf_event
+  bool is_perf_event_enabled(void) const
+  {
+    return !feature_->has_map_ringbuf() || resources.needs_perf_event_map;
+  }
+  void teardown_output();
+  void poll_output(bool drain = false);
+  int poll_perf_events();
+  void handle_ringbuf_loss();
   int print_map_hist(IMap &map, uint32_t top, uint32_t div);
   int print_map_stats(IMap &map, uint32_t top, uint32_t div);
   static uint64_t read_address_from_output(std::string output);
   std::vector<uint8_t> find_empty_key(IMap &map, size_t size) const;
   bool has_iter_ = false;
   int epollfd_ = -1;
+  struct ring_buffer *ringbuf_ = nullptr;
+  uint64_t ringbuf_loss_count_ = 0;
 
   std::unordered_map<std::string, std::unique_ptr<Dwarf>> dwarves_;
 };

--- a/src/fake_map.cpp
+++ b/src/fake_map.cpp
@@ -30,5 +30,10 @@ FakeMap::FakeMap(const SizedType &type) : IMap(type)
 FakeMap::FakeMap(libbpf::bpf_map_type map_type) : IMap(map_type)
 {
 }
+FakeMap::FakeMap(libbpf::bpf_map_type map_type,
+                 uint64_t perf_rb_pages __attribute__((unused)))
+    : IMap(map_type)
+{
+}
 
 } // namespace bpftrace

--- a/src/fake_map.h
+++ b/src/fake_map.h
@@ -14,6 +14,7 @@ public:
       : FakeMap(name, type, key, 0, 0, 0, max_entries){};
   FakeMap(const SizedType &type);
   FakeMap(libbpf::bpf_map_type map_type);
+  FakeMap(libbpf::bpf_map_type map_type, uint64_t perf_rb_pages);
   FakeMap(const std::string &name,
           const SizedType &type,
           const MapKey &key,

--- a/src/imap.cpp
+++ b/src/imap.cpp
@@ -50,7 +50,8 @@ IMap::IMap(const SizedType &type)
 IMap::IMap(libbpf::bpf_map_type map_type) : map_type_(map_type)
 {
   // This constructor should only be called for perf events
-  assert(map_type == libbpf::BPF_MAP_TYPE_PERF_EVENT_ARRAY);
+  assert(map_type == libbpf::BPF_MAP_TYPE_PERF_EVENT_ARRAY ||
+         map_type == libbpf::BPF_MAP_TYPE_RINGBUF);
 }
 
 } // namespace bpftrace

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -141,6 +141,7 @@ Map::Map(const SizedType &type) : IMap(type)
 
 Map::Map(libbpf::bpf_map_type map_type) : IMap(map_type)
 {
+  assert(map_type == libbpf::BPF_MAP_TYPE_PERF_EVENT_ARRAY);
   std::vector<int> cpus = get_online_cpus();
   int key_size = 4;
   int value_size = 4;
@@ -148,7 +149,23 @@ Map::Map(libbpf::bpf_map_type map_type) : IMap(map_type)
   int flags = 0;
 
   mapfd_ = create_map(
-      map_type, "printf", key_size, value_size, max_entries, flags);
+      map_type, "perf_event", key_size, value_size, max_entries, flags);
+  if (mapfd_ < 0)
+  {
+    LOG(ERROR) << "failed to create " << name_ << " map: " << strerror(errno);
+  }
+}
+
+Map::Map(libbpf::bpf_map_type map_type, uint64_t perf_rb_pages) : IMap(map_type)
+{
+  assert(map_type == libbpf::BPF_MAP_TYPE_RINGBUF);
+  int key_size = 0;
+  int value_size = 0;
+  int max_entries = perf_rb_pages * 4096;
+  int flags = 0;
+
+  mapfd_ = create_map(
+      map_type, "ringbuf", key_size, value_size, max_entries, flags);
   if (mapfd_ < 0)
   {
     LOG(ERROR) << "failed to create " << name_ << " map: " << strerror(errno);
@@ -262,6 +279,10 @@ std::string to_string(MapManager::Type t)
       return "elapsed";
     case MapManager::Type::MappedPrintfData:
       return "mapped_printf_data";
+    case MapManager::Type::Ringbuf:
+      return "ringbuf";
+    case MapManager::Type::RingbufLossCounter:
+      return "ringbuf_loss_counter";
   }
   return {}; // unreached
 }

--- a/src/map.h
+++ b/src/map.h
@@ -27,6 +27,7 @@ public:
       int flags);
   Map(const SizedType &type);
   Map(libbpf::bpf_map_type map_type);
+  Map(libbpf::bpf_map_type map_type, uint64_t perf_rb_pages);
   virtual ~Map() override;
 };
 } // namespace bpftrace

--- a/src/mapmanager.h
+++ b/src/mapmanager.h
@@ -61,6 +61,8 @@ public:
     Join,
     Elapsed,
     MappedPrintfData,
+    Ringbuf,
+    RingbufLossCounter,
   };
 
   void Set(Type t, std::unique_ptr<IMap> map);

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -107,6 +107,7 @@ public:
   bool needs_join_map = false;
   bool needs_elapsed_map = false;
   bool needs_data_map = false;
+  bool needs_perf_event_map = false;
 
   // Probe metadata
   //
@@ -147,6 +148,7 @@ private:
             needs_join_map,
             needs_elapsed_map,
             needs_data_map,
+            needs_perf_event_map,
             probes,
             special_probes);
   }

--- a/tests/codegen/call_kstack.cpp
+++ b/tests/codegen/call_kstack.cpp
@@ -45,7 +45,7 @@ TEST(codegen, call_kstack_mapids)
   ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
   codegen.compile();
 
-  ASSERT_EQ(std::distance(bpftrace->maps.begin(), bpftrace->maps.end()), 6);
+  ASSERT_EQ(std::distance(bpftrace->maps.begin(), bpftrace->maps.end()), 7);
   ASSERT_EQ(bpftrace->maps.CountStackTypes(), 2U);
 
   StackType stack_type;
@@ -83,7 +83,7 @@ TEST(codegen, call_kstack_modes_mapids)
   ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
   codegen.compile();
 
-  ASSERT_EQ(std::distance(bpftrace->maps.begin(), bpftrace->maps.end()), 8);
+  ASSERT_EQ(std::distance(bpftrace->maps.begin(), bpftrace->maps.end()), 9);
   ASSERT_EQ(bpftrace->maps.CountStackTypes(), 3U);
 
   StackType stack_type;

--- a/tests/codegen/call_ustack.cpp
+++ b/tests/codegen/call_ustack.cpp
@@ -45,7 +45,7 @@ TEST(codegen, call_ustack_mapids)
   ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
   codegen.compile();
 
-  ASSERT_EQ(std::distance(bpftrace->maps.begin(), bpftrace->maps.end()), 6);
+  ASSERT_EQ(std::distance(bpftrace->maps.begin(), bpftrace->maps.end()), 7);
   ASSERT_EQ(bpftrace->maps.CountStackTypes(), 2U);
 
   StackType stack_type;
@@ -83,7 +83,7 @@ TEST(codegen, call_ustack_modes_mapids)
   ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
   codegen.compile();
 
-  ASSERT_EQ(std::distance(bpftrace->maps.begin(), bpftrace->maps.end()), 8);
+  ASSERT_EQ(std::distance(bpftrace->maps.begin(), bpftrace->maps.end()), 9);
   ASSERT_EQ(bpftrace->maps.CountStackTypes(), 3U);
 
   StackType stack_type;

--- a/tests/codegen/llvm/call_cat.ll
+++ b/tests/codegen/llvm/call_cat.ll
@@ -10,6 +10,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
+  %key = alloca i32, align 4
   %cat_args = alloca %cat_t, align 8
   %1 = bitcast %cat_t* %cat_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -18,10 +19,36 @@ entry:
   %3 = getelementptr %cat_t, %cat_t* %cat_args, i32 0, i32 0
   store i64 20000, i64* %3, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %cat_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %cat_t* %cat_args, i64 8)
-  %4 = bitcast %cat_t* %cat_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %cat_t*, i64, i64)*)(i64 %pseudo, %cat_t* %cat_args, i64 8, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %entry
+  %4 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i32 0, i32* %key, align 4
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo1, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %entry
+  %5 = bitcast %cat_t* %cat_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
   ret i64 0
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %6 = bitcast i8* %lookup_elem to i64*
+  %7 = atomicrmw add i64* %6, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %8 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  br label %counter_merge
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/call_cgroup_path.ll
+++ b/tests/codegen/llvm/call_cgroup_path.ll
@@ -11,6 +11,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
+  %key = alloca i32, align 4
   %print_cgroup_path_16_t = alloca %print_cgroup_path_16_t, align 8
   %cgroup_path_args = alloca %cgroup_path_t, align 8
   %1 = bitcast %cgroup_path_t* %cgroup_path_args to i8*
@@ -33,10 +34,36 @@ entry:
   %10 = bitcast %cgroup_path_t* %cgroup_path_args to i8*
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %9, i8* align 1 %10, i64 16, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %print_cgroup_path_16_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %print_cgroup_path_16_t* %print_cgroup_path_16_t, i64 32)
-  %11 = bitcast %print_cgroup_path_16_t* %print_cgroup_path_16_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %print_cgroup_path_16_t*, i64, i64)*)(i64 %pseudo, %print_cgroup_path_16_t* %print_cgroup_path_16_t, i64 32, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %entry
+  %11 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i32 0, i32* %key, align 4
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo1, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %entry
+  %12 = bitcast %print_cgroup_path_16_t* %print_cgroup_path_16_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %13 = bitcast i8* %lookup_elem to i64*
+  %14 = atomicrmw add i64* %13, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %15 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  br label %counter_merge
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/call_clear.ll
+++ b/tests/codegen/llvm/call_clear.ll
@@ -35,6 +35,7 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_2" {
 entry:
+  %key = alloca i32, align 4
   %"clear_@x" = alloca %clear_t, align 8
   %1 = bitcast %clear_t* %"clear_@x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -43,10 +44,36 @@ entry:
   %3 = getelementptr %clear_t, %clear_t* %"clear_@x", i64 0, i32 1
   store i32 0, i32* %3, align 4
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %clear_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %clear_t* %"clear_@x", i64 12)
-  %4 = bitcast %clear_t* %"clear_@x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %clear_t*, i64, i64)*)(i64 %pseudo, %clear_t* %"clear_@x", i64 12, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %entry
+  %4 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i32 0, i32* %key, align 4
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo1, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %entry
+  %5 = bitcast %clear_t* %"clear_@x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
   ret i64 0
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %6 = bitcast i8* %lookup_elem to i64*
+  %7 = atomicrmw add i64* %6, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %8 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  br label %counter_merge
 }
 
 attributes #0 = { nounwind }

--- a/tests/codegen/llvm/call_exit.ll
+++ b/tests/codegen/llvm/call_exit.ll
@@ -10,29 +10,56 @@ define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
+  %key = alloca i32, align 4
   %perfdata = alloca i64, align 8
   %1 = bitcast i64* %perfdata to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
   store i64 30000, i64* %perfdata, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, i64*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, i64* %perfdata, i64 8)
-  %2 = bitcast i64* %perfdata to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %2)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, i64*, i64, i64)*)(i64 %pseudo, i64* %perfdata, i64 8, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %entry
+  %2 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i32 0, i32* %key, align 4
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo1, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %entry
+  %3 = bitcast i64* %perfdata to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
   ret i64 0
 
-deadcode:                                         ; No predecessors!
-  %3 = bitcast i64* %"@_key" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
-  store i64 0, i64* %"@_key", align 8
-  %4 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
-  store i64 10, i64* %"@_val", align 8
-  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %"@_val", i64 0)
-  %5 = bitcast i64* %"@_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@_key" to i8*
+lookup_success:                                   ; preds = %event_loss_counter
+  %4 = bitcast i8* %lookup_elem to i64*
+  %5 = atomicrmw add i64* %4, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %6 = bitcast i32* %key to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  br label %counter_merge
+
+deadcode:                                         ; No predecessors!
+  %7 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i64 0, i64* %"@_key", align 8
+  %8 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 10, i64* %"@_val", align 8
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@_key", i64* %"@_val", i64 0)
+  %9 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_offsetof.ll
+++ b/tests/codegen/llvm/call_offsetof.ll
@@ -8,6 +8,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @BEGIN(i8* %0) section "s_BEGIN_1" {
 entry:
+  %key = alloca i32, align 4
   %perfdata = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
@@ -27,10 +28,36 @@ entry:
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
   store i64 30000, i64* %perfdata, align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, i64*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, i64* %perfdata, i64 8)
-  %6 = bitcast i64* %perfdata to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, i64*, i64, i64)*)(i64 %pseudo1, i64* %perfdata, i64 8, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %entry
+  %6 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  store i32 0, i32* %key, align 4
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo2, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %entry
+  %7 = bitcast i64* %perfdata to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   ret i64 0
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %8 = bitcast i8* %lookup_elem to i64*
+  %9 = atomicrmw add i64* %8, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %10 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  br label %counter_merge
 
 deadcode:                                         ; No predecessors!
   ret i64 0

--- a/tests/codegen/llvm/call_print_composit.ll
+++ b/tests/codegen/llvm/call_print_composit.ll
@@ -11,6 +11,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
+  %key = alloca i32, align 4
   %print_tuple_16_t = alloca %print_tuple_16_t, align 8
   %str = alloca [4 x i8], align 1
   %tuple = alloca %"int64_string[4]__tuple_t", align 8
@@ -42,12 +43,38 @@ entry:
   %15 = bitcast %"int64_string[4]__tuple_t"* %tuple to i8*
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %14, i8* align 1 %15, i64 16, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %print_tuple_16_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %print_tuple_16_t* %print_tuple_16_t, i64 32)
-  %16 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = bitcast %"int64_string[4]__tuple_t"* %tuple to i8*
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %print_tuple_16_t*, i64, i64)*)(i64 %pseudo, %print_tuple_16_t* %print_tuple_16_t, i64 32, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %entry
+  %16 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
+  store i32 0, i32* %key, align 4
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo1, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %entry
+  %17 = bitcast %print_tuple_16_t* %print_tuple_16_t to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %18 = bitcast %"int64_string[4]__tuple_t"* %tuple to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
   ret i64 0
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %19 = bitcast i8* %lookup_elem to i64*
+  %20 = atomicrmw add i64* %19, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %21 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %21)
+  br label %counter_merge
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/call_print_int.ll
+++ b/tests/codegen/llvm/call_print_int.ll
@@ -10,6 +10,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
+  %key = alloca i32, align 4
   %print_integer_8_t = alloca %print_integer_8_t, align 8
   %1 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -23,10 +24,36 @@ entry:
   %6 = bitcast [8 x i8]* %4 to i64*
   store i64 3, i64* %6, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %print_integer_8_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %print_integer_8_t* %print_integer_8_t, i64 24)
-  %7 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %print_integer_8_t*, i64, i64)*)(i64 %pseudo, %print_integer_8_t* %print_integer_8_t, i64 24, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %entry
+  %7 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i32 0, i32* %key, align 4
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo1, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %entry
+  %8 = bitcast %print_integer_8_t* %print_integer_8_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
   ret i64 0
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %9 = bitcast i8* %lookup_elem to i64*
+  %10 = atomicrmw add i64* %9, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %11 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  br label %counter_merge
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/call_printf.ll
+++ b/tests/codegen/llvm/call_printf.ll
@@ -10,6 +10,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
+  %key = alloca i32, align 4
   %"struct Foo.l" = alloca i64, align 8
   %"struct Foo.c" = alloca i8, align 1
   %printf_args = alloca %printf_t, align 8
@@ -47,10 +48,36 @@ entry:
   %17 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 2
   store i64 %15, i64* %17, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 24)
-  %18 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %printf_t*, i64, i64)*)(i64 %pseudo, %printf_t* %printf_args, i64 24, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %entry
+  %18 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
+  store i32 0, i32* %key, align 4
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo2, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %entry
+  %19 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
   ret i64 0
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %20 = bitcast i8* %lookup_elem to i64*
+  %21 = atomicrmw add i64* %20, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %22 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
+  br label %counter_merge
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/call_strftime.ll
+++ b/tests/codegen/llvm/call_strftime.ll
@@ -11,6 +11,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
+  %key = alloca i32, align 4
   %strftime_args = alloca %strftime_t, align 8
   %printf_args = alloca %printf_t, align 8
   %1 = bitcast %printf_t* %printf_args to i8*
@@ -31,10 +32,36 @@ entry:
   %9 = bitcast %strftime_t* %strftime_args to i8*
   call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %8, i8* align 1 %9, i64 16, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 24)
-  %10 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %printf_t*, i64, i64)*)(i64 %pseudo, %printf_t* %printf_args, i64 24, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %entry
+  %10 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i32 0, i32* %key, align 4
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo1, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %entry
+  %11 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   ret i64 0
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %12 = bitcast i8* %lookup_elem to i64*
+  %13 = atomicrmw add i64* %12, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %14 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  br label %counter_merge
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/call_system.ll
+++ b/tests/codegen/llvm/call_system.ll
@@ -10,6 +10,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
+  %key = alloca i32, align 4
   %system_args = alloca %system_t, align 8
   %1 = bitcast %system_t* %system_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -20,10 +21,36 @@ entry:
   %4 = getelementptr %system_t, %system_t* %system_args, i32 0, i32 1
   store i64 100, i64* %4, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %system_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %system_t* %system_args, i64 16)
-  %5 = bitcast %system_t* %system_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %system_t*, i64, i64)*)(i64 %pseudo, %system_t* %system_args, i64 16, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %entry
+  %5 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i32 0, i32* %key, align 4
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo1, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %entry
+  %6 = bitcast %system_t* %system_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   ret i64 0
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %7 = bitcast i8* %lookup_elem to i64*
+  %8 = atomicrmw add i64* %7, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %9 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  br label %counter_merge
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/call_time.ll
+++ b/tests/codegen/llvm/call_time.ll
@@ -10,6 +10,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
+  %key = alloca i32, align 4
   %time_t = alloca %time_t, align 8
   %1 = bitcast %time_t* %time_t to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -18,10 +19,36 @@ entry:
   %3 = getelementptr %time_t, %time_t* %time_t, i64 0, i32 1
   store i32 0, i32* %3, align 4
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %time_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %time_t* %time_t, i64 12)
-  %4 = bitcast %time_t* %time_t to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %time_t*, i64, i64)*)(i64 %pseudo, %time_t* %time_t, i64 12, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %entry
+  %4 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i32 0, i32* %key, align 4
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo1, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %entry
+  %5 = bitcast %time_t* %time_t to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
   ret i64 0
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %6 = bitcast i8* %lookup_elem to i64*
+  %7 = atomicrmw add i64* %6, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %8 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  br label %counter_merge
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/call_zero.ll
+++ b/tests/codegen/llvm/call_zero.ll
@@ -35,6 +35,7 @@ declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_2" {
 entry:
+  %key = alloca i32, align 4
   %"zero_@x" = alloca %zero_t, align 8
   %1 = bitcast %zero_t* %"zero_@x" to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -43,10 +44,36 @@ entry:
   %3 = getelementptr %zero_t, %zero_t* %"zero_@x", i64 0, i32 1
   store i32 0, i32* %3, align 4
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %zero_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %zero_t* %"zero_@x", i64 12)
-  %4 = bitcast %zero_t* %"zero_@x" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %zero_t*, i64, i64)*)(i64 %pseudo, %zero_t* %"zero_@x", i64 12, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %entry
+  %4 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i32 0, i32* %key, align 4
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo1, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %entry
+  %5 = bitcast %zero_t* %"zero_@x" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
   ret i64 0
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %6 = bitcast i8* %lookup_elem to i64*
+  %7 = atomicrmw add i64* %6, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %8 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  br label %counter_merge
 }
 
 attributes #0 = { nounwind }

--- a/tests/codegen/llvm/if_else_printf.ll
+++ b/tests/codegen/llvm/if_else_printf.ll
@@ -11,7 +11,9 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
-  %printf_args1 = alloca %printf_t.0, align 8
+  %key8 = alloca i32, align 4
+  %printf_args2 = alloca %printf_t.0, align 8
+  %key = alloca i32, align 4
   %printf_args = alloca %printf_t, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = lshr i64 %get_pid_tgid, 32
@@ -28,26 +30,78 @@ if_body:                                          ; preds = %entry
   %6 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
   store i64 0, i64* %6, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 8)
-  %7 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  br label %if_end
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %printf_t*, i64, i64)*)(i64 %pseudo, %printf_t* %printf_args, i64 8, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
-if_end:                                           ; preds = %else_body, %if_body
+if_end:                                           ; preds = %counter_merge6, %counter_merge
   ret i64 0
 
 else_body:                                        ; preds = %entry
-  %8 = bitcast %printf_t.0* %printf_args1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %9 = bitcast %printf_t.0* %printf_args1 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %9, i8 0, i64 8, i1 false)
-  %10 = getelementptr %printf_t.0, %printf_t.0* %printf_args1, i32 0, i32 0
-  store i64 1, i64* %10, align 8
-  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output3 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.0*, i64)*)(i8* %0, i64 %pseudo2, i64 4294967295, %printf_t.0* %printf_args1, i64 8)
-  %11 = bitcast %printf_t.0* %printf_args1 to i8*
+  %7 = bitcast %printf_t.0* %printf_args2 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  %8 = bitcast %printf_t.0* %printf_args2 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %8, i8 0, i64 8, i1 false)
+  %9 = getelementptr %printf_t.0, %printf_t.0* %printf_args2, i32 0, i32 0
+  store i64 1, i64* %9, align 8
+  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %ringbuf_output4 = call i64 inttoptr (i64 130 to i64 (i64, %printf_t.0*, i64, i64)*)(i64 %pseudo3, %printf_t.0* %printf_args2, i64 8, i64 0)
+  %ringbuf_loss7 = icmp slt i64 %ringbuf_output4, 0
+  br i1 %ringbuf_loss7, label %event_loss_counter5, label %counter_merge6
+
+event_loss_counter:                               ; preds = %if_body
+  %10 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i32 0, i32* %key, align 4
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo1, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %if_body
+  %11 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   br label %if_end
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %12 = bitcast i8* %lookup_elem to i64*
+  %13 = atomicrmw add i64* %12, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %14 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  br label %counter_merge
+
+event_loss_counter5:                              ; preds = %else_body
+  %15 = bitcast i32* %key8 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  store i32 0, i32* %key8, align 4
+  %pseudo9 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem10 = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo9, i32* %key8)
+  %map_lookup_cond14 = icmp ne i8* %lookup_elem10, null
+  br i1 %map_lookup_cond14, label %lookup_success11, label %lookup_failure12
+
+counter_merge6:                                   ; preds = %lookup_merge13, %else_body
+  %16 = bitcast %printf_t.0* %printf_args2 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  br label %if_end
+
+lookup_success11:                                 ; preds = %event_loss_counter5
+  %17 = bitcast i8* %lookup_elem10 to i64*
+  %18 = atomicrmw add i64* %17, i64 1 seq_cst
+  br label %lookup_merge13
+
+lookup_failure12:                                 ; preds = %event_loss_counter5
+  br label %lookup_merge13
+
+lookup_merge13:                                   ; preds = %lookup_failure12, %lookup_success11
+  %19 = bitcast i32* %key8 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  br label %counter_merge6
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/if_else_variable.ll
+++ b/tests/codegen/llvm/if_else_variable.ll
@@ -10,6 +10,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
+  %key = alloca i32, align 4
   %printf_args = alloca %printf_t, align 8
   %"$s" = alloca i64, align 8
   %1 = bitcast i64* %"$s" to i8*
@@ -37,14 +38,40 @@ if_end:                                           ; preds = %else_body, %if_body
   %9 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
   store i64 %8, i64* %9, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 16)
-  %10 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  ret i64 0
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %printf_t*, i64, i64)*)(i64 %pseudo, %printf_t* %printf_args, i64 16, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 else_body:                                        ; preds = %entry
   store i64 20, i64* %"$s", align 8
   br label %if_end
+
+event_loss_counter:                               ; preds = %if_end
+  %10 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i32 0, i32* %key, align 4
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo1, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %if_end
+  %11 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  ret i64 0
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %12 = bitcast i8* %lookup_elem to i64*
+  %13 = atomicrmw add i64* %12, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %14 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  br label %counter_merge
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/if_nested_printf.ll
+++ b/tests/codegen/llvm/if_nested_printf.ll
@@ -10,6 +10,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
+  %key = alloca i32, align 4
   %printf_args = alloca %printf_t, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = lshr i64 %get_pid_tgid, 32
@@ -38,13 +39,39 @@ if_body1:                                         ; preds = %if_body
   %10 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
   store i64 0, i64* %10, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 8)
-  %11 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %printf_t*, i64, i64)*)(i64 %pseudo, %printf_t* %printf_args, i64 8, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+if_end2:                                          ; preds = %counter_merge, %if_body
+  br label %if_end
+
+event_loss_counter:                               ; preds = %if_body1
+  %11 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i32 0, i32* %key, align 4
+  %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo5, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %if_body1
+  %12 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   br label %if_end2
 
-if_end2:                                          ; preds = %if_body1, %if_body
-  br label %if_end
+lookup_success:                                   ; preds = %event_loss_counter
+  %13 = bitcast i8* %lookup_elem to i64*
+  %14 = atomicrmw add i64* %13, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %15 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  br label %counter_merge
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/if_printf.ll
+++ b/tests/codegen/llvm/if_printf.ll
@@ -10,6 +10,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
+  %key = alloca i32, align 4
   %printf_args = alloca %printf_t, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = lshr i64 %get_pid_tgid, 32
@@ -30,13 +31,39 @@ if_body:                                          ; preds = %entry
   %8 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
   store i64 %7, i64* %8, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 16)
-  %9 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %printf_t*, i64, i64)*)(i64 %pseudo, %printf_t* %printf_args, i64 16, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+if_end:                                           ; preds = %counter_merge, %entry
+  ret i64 0
+
+event_loss_counter:                               ; preds = %if_body
+  %9 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i32 0, i32* %key, align 4
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo2, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %if_body
+  %10 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   br label %if_end
 
-if_end:                                           ; preds = %if_body, %entry
-  ret i64 0
+lookup_success:                                   ; preds = %event_loss_counter
+  %11 = bitcast i8* %lookup_elem to i64*
+  %12 = atomicrmw add i64* %11, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %13 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  br label %counter_merge
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/if_variable.ll
+++ b/tests/codegen/llvm/if_variable.ll
@@ -10,6 +10,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
+  %key = alloca i32, align 4
   %printf_args = alloca %printf_t, align 8
   %"$s" = alloca i64, align 8
   %1 = bitcast i64* %"$s" to i8*
@@ -37,10 +38,36 @@ if_end:                                           ; preds = %if_body, %entry
   %9 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
   store i64 %8, i64* %9, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 16)
-  %10 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %printf_t*, i64, i64)*)(i64 %pseudo, %printf_t* %printf_args, i64 16, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %if_end
+  %10 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  store i32 0, i32* %key, align 4
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo1, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %if_end
+  %11 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   ret i64 0
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %12 = bitcast i8* %lookup_elem to i64*
+  %13 = atomicrmw add i64* %12, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %14 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  br label %counter_merge
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/ptr_to_ptr.ll
+++ b/tests/codegen/llvm/ptr_to_ptr.ll
@@ -10,6 +10,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
+  %key = alloca i32, align 4
   %deref1 = alloca i32, align 4
   %deref = alloca i64, align 8
   %printf_args = alloca %printf_t, align 8
@@ -41,10 +42,36 @@ entry:
   %13 = sext i32 %10 to i64
   store i64 %13, i64* %12, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 16)
-  %14 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %printf_t*, i64, i64)*)(i64 %pseudo, %printf_t* %printf_args, i64 16, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %entry
+  %14 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  store i32 0, i32* %key, align 4
+  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo3, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %entry
+  %15 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
   ret i64 0
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %16 = bitcast i8* %lookup_elem to i64*
+  %17 = atomicrmw add i64* %16, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %18 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  br label %counter_merge
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/struct_semicolon_1.ll
+++ b/tests/codegen/llvm/struct_semicolon_1.ll
@@ -10,6 +10,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
+  %key = alloca i32, align 4
   %printf_args = alloca %printf_t, align 8
   %1 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -25,10 +26,36 @@ entry:
   %6 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
   store i64 %5, i64* %6, align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %printf_t* %printf_args, i64 16)
-  %7 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %printf_t*, i64, i64)*)(i64 %pseudo1, %printf_t* %printf_args, i64 16, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %entry
+  %7 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i32 0, i32* %key, align 4
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo2, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %entry
+  %8 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
   ret i64 0
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %9 = bitcast i8* %lookup_elem to i64*
+  %10 = atomicrmw add i64* %9, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %11 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  br label %counter_merge
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/struct_semicolon_2.ll
+++ b/tests/codegen/llvm/struct_semicolon_2.ll
@@ -10,6 +10,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
+  %key = alloca i32, align 4
   %printf_args = alloca %printf_t, align 8
   %1 = bitcast %printf_t* %printf_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
@@ -25,10 +26,36 @@ entry:
   %6 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
   store i64 %5, i64* %6, align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %printf_t* %printf_args, i64 16)
-  %7 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %printf_t*, i64, i64)*)(i64 %pseudo1, %printf_t* %printf_args, i64 16, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %entry
+  %7 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i32 0, i32* %key, align 4
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo2, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %entry
+  %8 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
   ret i64 0
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %9 = bitcast i8* %lookup_elem to i64*
+  %10 = atomicrmw add i64* %9, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %11 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  br label %counter_merge
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/ternary_none.ll
+++ b/tests/codegen/llvm/ternary_none.ll
@@ -10,7 +10,9 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
+  %key7 = alloca i32, align 4
   %perfdata = alloca i64, align 8
+  %key = alloca i32, align 4
   %printf_args = alloca %printf_t, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
   %1 = lshr i64 %get_pid_tgid, 32
@@ -27,23 +29,75 @@ left:                                             ; preds = %entry
   %6 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
   store i64 0, i64* %6, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 8)
-  %7 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  br label %done
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %printf_t*, i64, i64)*)(i64 %pseudo, %printf_t* %printf_args, i64 8, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 right:                                            ; preds = %entry
-  %8 = bitcast i64* %perfdata to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %7 = bitcast i64* %perfdata to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   store i64 30000, i64* %perfdata, align 8
-  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output2 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, i64*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, i64* %perfdata, i64 8)
-  %9 = bitcast i64* %perfdata to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %ringbuf_output3 = call i64 inttoptr (i64 130 to i64 (i64, i64*, i64, i64)*)(i64 %pseudo2, i64* %perfdata, i64 8, i64 0)
+  %ringbuf_loss6 = icmp slt i64 %ringbuf_output3, 0
+  br i1 %ringbuf_loss6, label %event_loss_counter4, label %counter_merge5
+
+done:                                             ; preds = %deadcode, %counter_merge
   ret i64 0
 
-done:                                             ; preds = %deadcode, %left
+event_loss_counter:                               ; preds = %left
+  %8 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i32 0, i32* %key, align 4
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo1, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %left
+  %9 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  br label %done
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %10 = bitcast i8* %lookup_elem to i64*
+  %11 = atomicrmw add i64* %10, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %12 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  br label %counter_merge
+
+event_loss_counter4:                              ; preds = %right
+  %13 = bitcast i32* %key7 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  store i32 0, i32* %key7, align 4
+  %pseudo8 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem9 = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo8, i32* %key7)
+  %map_lookup_cond13 = icmp ne i8* %lookup_elem9, null
+  br i1 %map_lookup_cond13, label %lookup_success10, label %lookup_failure11
+
+counter_merge5:                                   ; preds = %lookup_merge12, %right
+  %14 = bitcast i64* %perfdata to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
   ret i64 0
+
+lookup_success10:                                 ; preds = %event_loss_counter4
+  %15 = bitcast i8* %lookup_elem9 to i64*
+  %16 = atomicrmw add i64* %15, i64 1 seq_cst
+  br label %lookup_merge12
+
+lookup_failure11:                                 ; preds = %event_loss_counter4
+  br label %lookup_merge12
+
+lookup_merge12:                                   ; preds = %lookup_failure11, %lookup_success10
+  %17 = bitcast i32* %key7 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  br label %counter_merge5
 
 deadcode:                                         ; No predecessors!
   br label %done

--- a/tests/codegen/llvm/unroll_async_id.ll
+++ b/tests/codegen/llvm/unroll_async_id.ll
@@ -14,10 +14,15 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @BEGIN(i8* %0) section "s_BEGIN_1" {
 entry:
-  %printf_args11 = alloca %printf_t.3, align 8
-  %printf_args8 = alloca %printf_t.2, align 8
-  %printf_args5 = alloca %printf_t.1, align 8
-  %printf_args2 = alloca %printf_t.0, align 8
+  %key48 = alloca i32, align 4
+  %printf_args42 = alloca %printf_t.3, align 8
+  %key35 = alloca i32, align 4
+  %printf_args29 = alloca %printf_t.2, align 8
+  %key22 = alloca i32, align 4
+  %printf_args16 = alloca %printf_t.1, align 8
+  %key9 = alloca i32, align 4
+  %printf_args3 = alloca %printf_t.0, align 8
+  %key = alloca i32, align 4
   %printf_args = alloca %printf_t, align 8
   %"@i_val" = alloca i64, align 8
   %"@i_key" = alloca i64, align 8
@@ -40,50 +45,180 @@ entry:
   %7 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 0
   store i64 0, i64* %7, align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, %printf_t* %printf_args, i64 8)
-  %8 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast %printf_t.0* %printf_args2 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %10 = bitcast %printf_t.0* %printf_args2 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %10, i8 0, i64 8, i1 false)
-  %11 = getelementptr %printf_t.0, %printf_t.0* %printf_args2, i32 0, i32 0
-  store i64 0, i64* %11, align 8
-  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %perf_event_output4 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.0*, i64)*)(i8* %0, i64 %pseudo3, i64 4294967295, %printf_t.0* %printf_args2, i64 8)
-  %12 = bitcast %printf_t.0* %printf_args2 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
-  %13 = bitcast %printf_t.1* %printf_args5 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
-  %14 = bitcast %printf_t.1* %printf_args5 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %14, i8 0, i64 8, i1 false)
-  %15 = getelementptr %printf_t.1, %printf_t.1* %printf_args5, i32 0, i32 0
-  store i64 0, i64* %15, align 8
-  %pseudo6 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %perf_event_output7 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.1*, i64)*)(i8* %0, i64 %pseudo6, i64 4294967295, %printf_t.1* %printf_args5, i64 8)
-  %16 = bitcast %printf_t.1* %printf_args5 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
-  %17 = bitcast %printf_t.2* %printf_args8 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
-  %18 = bitcast %printf_t.2* %printf_args8 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %18, i8 0, i64 8, i1 false)
-  %19 = getelementptr %printf_t.2, %printf_t.2* %printf_args8, i32 0, i32 0
-  store i64 0, i64* %19, align 8
-  %pseudo9 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %perf_event_output10 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.2*, i64)*)(i8* %0, i64 %pseudo9, i64 4294967295, %printf_t.2* %printf_args8, i64 8)
-  %20 = bitcast %printf_t.2* %printf_args8 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
-  %21 = bitcast %printf_t.3* %printf_args11 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21)
-  %22 = bitcast %printf_t.3* %printf_args11 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %22, i8 0, i64 8, i1 false)
-  %23 = getelementptr %printf_t.3, %printf_t.3* %printf_args11, i32 0, i32 0
-  store i64 0, i64* %23, align 8
-  %pseudo12 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
-  %perf_event_output13 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.3*, i64)*)(i8* %0, i64 %pseudo12, i64 4294967295, %printf_t.3* %printf_args11, i64 8)
-  %24 = bitcast %printf_t.3* %printf_args11 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %printf_t*, i64, i64)*)(i64 %pseudo1, %printf_t* %printf_args, i64 8, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %entry
+  %8 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i32 0, i32* %key, align 4
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo2, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %entry
+  %9 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast %printf_t.0* %printf_args3 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = bitcast %printf_t.0* %printf_args3 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 8, i1 false)
+  %12 = getelementptr %printf_t.0, %printf_t.0* %printf_args3, i32 0, i32 0
+  store i64 0, i64* %12, align 8
+  %pseudo4 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %ringbuf_output5 = call i64 inttoptr (i64 130 to i64 (i64, %printf_t.0*, i64, i64)*)(i64 %pseudo4, %printf_t.0* %printf_args3, i64 8, i64 0)
+  %ringbuf_loss8 = icmp slt i64 %ringbuf_output5, 0
+  br i1 %ringbuf_loss8, label %event_loss_counter6, label %counter_merge7
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %13 = bitcast i8* %lookup_elem to i64*
+  %14 = atomicrmw add i64* %13, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %15 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  br label %counter_merge
+
+event_loss_counter6:                              ; preds = %counter_merge
+  %16 = bitcast i32* %key9 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
+  store i32 0, i32* %key9, align 4
+  %pseudo10 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_elem11 = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo10, i32* %key9)
+  %map_lookup_cond15 = icmp ne i8* %lookup_elem11, null
+  br i1 %map_lookup_cond15, label %lookup_success12, label %lookup_failure13
+
+counter_merge7:                                   ; preds = %lookup_merge14, %counter_merge
+  %17 = bitcast %printf_t.0* %printf_args3 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
+  %18 = bitcast %printf_t.1* %printf_args16 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %18)
+  %19 = bitcast %printf_t.1* %printf_args16 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %19, i8 0, i64 8, i1 false)
+  %20 = getelementptr %printf_t.1, %printf_t.1* %printf_args16, i32 0, i32 0
+  store i64 0, i64* %20, align 8
+  %pseudo17 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %ringbuf_output18 = call i64 inttoptr (i64 130 to i64 (i64, %printf_t.1*, i64, i64)*)(i64 %pseudo17, %printf_t.1* %printf_args16, i64 8, i64 0)
+  %ringbuf_loss21 = icmp slt i64 %ringbuf_output18, 0
+  br i1 %ringbuf_loss21, label %event_loss_counter19, label %counter_merge20
+
+lookup_success12:                                 ; preds = %event_loss_counter6
+  %21 = bitcast i8* %lookup_elem11 to i64*
+  %22 = atomicrmw add i64* %21, i64 1 seq_cst
+  br label %lookup_merge14
+
+lookup_failure13:                                 ; preds = %event_loss_counter6
+  br label %lookup_merge14
+
+lookup_merge14:                                   ; preds = %lookup_failure13, %lookup_success12
+  %23 = bitcast i32* %key9 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %23)
+  br label %counter_merge7
+
+event_loss_counter19:                             ; preds = %counter_merge7
+  %24 = bitcast i32* %key22 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %24)
+  store i32 0, i32* %key22, align 4
+  %pseudo23 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_elem24 = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo23, i32* %key22)
+  %map_lookup_cond28 = icmp ne i8* %lookup_elem24, null
+  br i1 %map_lookup_cond28, label %lookup_success25, label %lookup_failure26
+
+counter_merge20:                                  ; preds = %lookup_merge27, %counter_merge7
+  %25 = bitcast %printf_t.1* %printf_args16 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %25)
+  %26 = bitcast %printf_t.2* %printf_args29 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %26)
+  %27 = bitcast %printf_t.2* %printf_args29 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %27, i8 0, i64 8, i1 false)
+  %28 = getelementptr %printf_t.2, %printf_t.2* %printf_args29, i32 0, i32 0
+  store i64 0, i64* %28, align 8
+  %pseudo30 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %ringbuf_output31 = call i64 inttoptr (i64 130 to i64 (i64, %printf_t.2*, i64, i64)*)(i64 %pseudo30, %printf_t.2* %printf_args29, i64 8, i64 0)
+  %ringbuf_loss34 = icmp slt i64 %ringbuf_output31, 0
+  br i1 %ringbuf_loss34, label %event_loss_counter32, label %counter_merge33
+
+lookup_success25:                                 ; preds = %event_loss_counter19
+  %29 = bitcast i8* %lookup_elem24 to i64*
+  %30 = atomicrmw add i64* %29, i64 1 seq_cst
+  br label %lookup_merge27
+
+lookup_failure26:                                 ; preds = %event_loss_counter19
+  br label %lookup_merge27
+
+lookup_merge27:                                   ; preds = %lookup_failure26, %lookup_success25
+  %31 = bitcast i32* %key22 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %31)
+  br label %counter_merge20
+
+event_loss_counter32:                             ; preds = %counter_merge20
+  %32 = bitcast i32* %key35 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %32)
+  store i32 0, i32* %key35, align 4
+  %pseudo36 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_elem37 = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo36, i32* %key35)
+  %map_lookup_cond41 = icmp ne i8* %lookup_elem37, null
+  br i1 %map_lookup_cond41, label %lookup_success38, label %lookup_failure39
+
+counter_merge33:                                  ; preds = %lookup_merge40, %counter_merge20
+  %33 = bitcast %printf_t.2* %printf_args29 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %33)
+  %34 = bitcast %printf_t.3* %printf_args42 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %34)
+  %35 = bitcast %printf_t.3* %printf_args42 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %35, i8 0, i64 8, i1 false)
+  %36 = getelementptr %printf_t.3, %printf_t.3* %printf_args42, i32 0, i32 0
+  store i64 0, i64* %36, align 8
+  %pseudo43 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %ringbuf_output44 = call i64 inttoptr (i64 130 to i64 (i64, %printf_t.3*, i64, i64)*)(i64 %pseudo43, %printf_t.3* %printf_args42, i64 8, i64 0)
+  %ringbuf_loss47 = icmp slt i64 %ringbuf_output44, 0
+  br i1 %ringbuf_loss47, label %event_loss_counter45, label %counter_merge46
+
+lookup_success38:                                 ; preds = %event_loss_counter32
+  %37 = bitcast i8* %lookup_elem37 to i64*
+  %38 = atomicrmw add i64* %37, i64 1 seq_cst
+  br label %lookup_merge40
+
+lookup_failure39:                                 ; preds = %event_loss_counter32
+  br label %lookup_merge40
+
+lookup_merge40:                                   ; preds = %lookup_failure39, %lookup_success38
+  %39 = bitcast i32* %key35 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %39)
+  br label %counter_merge33
+
+event_loss_counter45:                             ; preds = %counter_merge33
+  %40 = bitcast i32* %key48 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %40)
+  store i32 0, i32* %key48, align 4
+  %pseudo49 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_elem50 = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo49, i32* %key48)
+  %map_lookup_cond54 = icmp ne i8* %lookup_elem50, null
+  br i1 %map_lookup_cond54, label %lookup_success51, label %lookup_failure52
+
+counter_merge46:                                  ; preds = %lookup_merge53, %counter_merge33
+  %41 = bitcast %printf_t.3* %printf_args42 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %41)
   ret i64 0
+
+lookup_success51:                                 ; preds = %event_loss_counter45
+  %42 = bitcast i8* %lookup_elem50 to i64*
+  %43 = atomicrmw add i64* %42, i64 1 seq_cst
+  br label %lookup_merge53
+
+lookup_failure52:                                 ; preds = %event_loss_counter45
+  br label %lookup_merge53
+
+lookup_merge53:                                   ; preds = %lookup_failure52, %lookup_success51
+  %44 = bitcast i32* %key48 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %44)
+  br label %counter_merge46
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/variable_increment_decrement.ll
+++ b/tests/codegen/llvm/variable_increment_decrement.ll
@@ -13,9 +13,13 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @BEGIN(i8* %0) section "s_BEGIN_1" {
 entry:
-  %printf_args7 = alloca %printf_t.2, align 8
-  %printf_args4 = alloca %printf_t.1, align 8
-  %printf_args1 = alloca %printf_t.0, align 8
+  %key34 = alloca i32, align 4
+  %printf_args28 = alloca %printf_t.2, align 8
+  %key21 = alloca i32, align 4
+  %printf_args15 = alloca %printf_t.1, align 8
+  %key8 = alloca i32, align 4
+  %printf_args2 = alloca %printf_t.0, align 8
+  %key = alloca i32, align 4
   %printf_args = alloca %printf_t, align 8
   %"$x" = alloca i64, align 8
   %1 = bitcast i64* %"$x" to i8*
@@ -34,55 +38,159 @@ entry:
   %7 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
   store i64 %5, i64* %7, align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t*, i64)*)(i8* %0, i64 %pseudo, i64 4294967295, %printf_t* %printf_args, i64 16)
-  %8 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast %printf_t.0* %printf_args1 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
-  %10 = bitcast %printf_t.0* %printf_args1 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %10, i8 0, i64 16, i1 false)
-  %11 = getelementptr %printf_t.0, %printf_t.0* %printf_args1, i32 0, i32 0
-  store i64 1, i64* %11, align 8
-  %12 = load i64, i64* %"$x", align 8
-  %13 = add i64 %12, 1
-  store i64 %13, i64* %"$x", align 8
-  %14 = getelementptr %printf_t.0, %printf_t.0* %printf_args1, i32 0, i32 1
-  store i64 %13, i64* %14, align 8
-  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output3 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.0*, i64)*)(i8* %0, i64 %pseudo2, i64 4294967295, %printf_t.0* %printf_args1, i64 16)
-  %15 = bitcast %printf_t.0* %printf_args1 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
-  %16 = bitcast %printf_t.1* %printf_args4 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %16)
-  %17 = bitcast %printf_t.1* %printf_args4 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %17, i8 0, i64 16, i1 false)
-  %18 = getelementptr %printf_t.1, %printf_t.1* %printf_args4, i32 0, i32 0
-  store i64 2, i64* %18, align 8
-  %19 = load i64, i64* %"$x", align 8
-  %20 = sub i64 %19, 1
-  store i64 %20, i64* %"$x", align 8
-  %21 = getelementptr %printf_t.1, %printf_t.1* %printf_args4, i32 0, i32 1
-  store i64 %19, i64* %21, align 8
-  %pseudo5 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output6 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.1*, i64)*)(i8* %0, i64 %pseudo5, i64 4294967295, %printf_t.1* %printf_args4, i64 16)
-  %22 = bitcast %printf_t.1* %printf_args4 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %22)
-  %23 = bitcast %printf_t.2* %printf_args7 to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
-  %24 = bitcast %printf_t.2* %printf_args7 to i8*
-  call void @llvm.memset.p0i8.i64(i8* align 1 %24, i8 0, i64 16, i1 false)
-  %25 = getelementptr %printf_t.2, %printf_t.2* %printf_args7, i32 0, i32 0
-  store i64 3, i64* %25, align 8
-  %26 = load i64, i64* %"$x", align 8
-  %27 = sub i64 %26, 1
-  store i64 %27, i64* %"$x", align 8
-  %28 = getelementptr %printf_t.2, %printf_t.2* %printf_args7, i32 0, i32 1
-  store i64 %27, i64* %28, align 8
-  %pseudo8 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %perf_event_output9 = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, %printf_t.2*, i64)*)(i8* %0, i64 %pseudo8, i64 4294967295, %printf_t.2* %printf_args7, i64 16)
-  %29 = bitcast %printf_t.2* %printf_args7 to i8*
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %printf_t*, i64, i64)*)(i64 %pseudo, %printf_t* %printf_args, i64 16, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %entry
+  %8 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i32 0, i32* %key, align 4
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo1, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %entry
+  %9 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
+  %10 = bitcast %printf_t.0* %printf_args2 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = bitcast %printf_t.0* %printf_args2 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %11, i8 0, i64 16, i1 false)
+  %12 = getelementptr %printf_t.0, %printf_t.0* %printf_args2, i32 0, i32 0
+  store i64 1, i64* %12, align 8
+  %13 = load i64, i64* %"$x", align 8
+  %14 = add i64 %13, 1
+  store i64 %14, i64* %"$x", align 8
+  %15 = getelementptr %printf_t.0, %printf_t.0* %printf_args2, i32 0, i32 1
+  store i64 %14, i64* %15, align 8
+  %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %ringbuf_output4 = call i64 inttoptr (i64 130 to i64 (i64, %printf_t.0*, i64, i64)*)(i64 %pseudo3, %printf_t.0* %printf_args2, i64 16, i64 0)
+  %ringbuf_loss7 = icmp slt i64 %ringbuf_output4, 0
+  br i1 %ringbuf_loss7, label %event_loss_counter5, label %counter_merge6
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %16 = bitcast i8* %lookup_elem to i64*
+  %17 = atomicrmw add i64* %16, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %18 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
+  br label %counter_merge
+
+event_loss_counter5:                              ; preds = %counter_merge
+  %19 = bitcast i32* %key8 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %19)
+  store i32 0, i32* %key8, align 4
+  %pseudo9 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem10 = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo9, i32* %key8)
+  %map_lookup_cond14 = icmp ne i8* %lookup_elem10, null
+  br i1 %map_lookup_cond14, label %lookup_success11, label %lookup_failure12
+
+counter_merge6:                                   ; preds = %lookup_merge13, %counter_merge
+  %20 = bitcast %printf_t.0* %printf_args2 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %20)
+  %21 = bitcast %printf_t.1* %printf_args15 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %21)
+  %22 = bitcast %printf_t.1* %printf_args15 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %22, i8 0, i64 16, i1 false)
+  %23 = getelementptr %printf_t.1, %printf_t.1* %printf_args15, i32 0, i32 0
+  store i64 2, i64* %23, align 8
+  %24 = load i64, i64* %"$x", align 8
+  %25 = sub i64 %24, 1
+  store i64 %25, i64* %"$x", align 8
+  %26 = getelementptr %printf_t.1, %printf_t.1* %printf_args15, i32 0, i32 1
+  store i64 %24, i64* %26, align 8
+  %pseudo16 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %ringbuf_output17 = call i64 inttoptr (i64 130 to i64 (i64, %printf_t.1*, i64, i64)*)(i64 %pseudo16, %printf_t.1* %printf_args15, i64 16, i64 0)
+  %ringbuf_loss20 = icmp slt i64 %ringbuf_output17, 0
+  br i1 %ringbuf_loss20, label %event_loss_counter18, label %counter_merge19
+
+lookup_success11:                                 ; preds = %event_loss_counter5
+  %27 = bitcast i8* %lookup_elem10 to i64*
+  %28 = atomicrmw add i64* %27, i64 1 seq_cst
+  br label %lookup_merge13
+
+lookup_failure12:                                 ; preds = %event_loss_counter5
+  br label %lookup_merge13
+
+lookup_merge13:                                   ; preds = %lookup_failure12, %lookup_success11
+  %29 = bitcast i32* %key8 to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %29)
+  br label %counter_merge6
+
+event_loss_counter18:                             ; preds = %counter_merge6
+  %30 = bitcast i32* %key21 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %30)
+  store i32 0, i32* %key21, align 4
+  %pseudo22 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem23 = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo22, i32* %key21)
+  %map_lookup_cond27 = icmp ne i8* %lookup_elem23, null
+  br i1 %map_lookup_cond27, label %lookup_success24, label %lookup_failure25
+
+counter_merge19:                                  ; preds = %lookup_merge26, %counter_merge6
+  %31 = bitcast %printf_t.1* %printf_args15 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %31)
+  %32 = bitcast %printf_t.2* %printf_args28 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %32)
+  %33 = bitcast %printf_t.2* %printf_args28 to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %33, i8 0, i64 16, i1 false)
+  %34 = getelementptr %printf_t.2, %printf_t.2* %printf_args28, i32 0, i32 0
+  store i64 3, i64* %34, align 8
+  %35 = load i64, i64* %"$x", align 8
+  %36 = sub i64 %35, 1
+  store i64 %36, i64* %"$x", align 8
+  %37 = getelementptr %printf_t.2, %printf_t.2* %printf_args28, i32 0, i32 1
+  store i64 %36, i64* %37, align 8
+  %pseudo29 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %ringbuf_output30 = call i64 inttoptr (i64 130 to i64 (i64, %printf_t.2*, i64, i64)*)(i64 %pseudo29, %printf_t.2* %printf_args28, i64 16, i64 0)
+  %ringbuf_loss33 = icmp slt i64 %ringbuf_output30, 0
+  br i1 %ringbuf_loss33, label %event_loss_counter31, label %counter_merge32
+
+lookup_success24:                                 ; preds = %event_loss_counter18
+  %38 = bitcast i8* %lookup_elem23 to i64*
+  %39 = atomicrmw add i64* %38, i64 1 seq_cst
+  br label %lookup_merge26
+
+lookup_failure25:                                 ; preds = %event_loss_counter18
+  br label %lookup_merge26
+
+lookup_merge26:                                   ; preds = %lookup_failure25, %lookup_success24
+  %40 = bitcast i32* %key21 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %40)
+  br label %counter_merge19
+
+event_loss_counter31:                             ; preds = %counter_merge19
+  %41 = bitcast i32* %key34 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %41)
+  store i32 0, i32* %key34, align 4
+  %pseudo35 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %lookup_elem36 = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo35, i32* %key34)
+  %map_lookup_cond40 = icmp ne i8* %lookup_elem36, null
+  br i1 %map_lookup_cond40, label %lookup_success37, label %lookup_failure38
+
+counter_merge32:                                  ; preds = %lookup_merge39, %counter_merge19
+  %42 = bitcast %printf_t.2* %printf_args28 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %42)
   ret i64 0
+
+lookup_success37:                                 ; preds = %event_loss_counter31
+  %43 = bitcast i8* %lookup_elem36 to i64*
+  %44 = atomicrmw add i64* %43, i64 1 seq_cst
+  br label %lookup_merge39
+
+lookup_failure38:                                 ; preds = %event_loss_counter31
+  br label %lookup_merge39
+
+lookup_merge39:                                   ; preds = %lookup_failure38, %lookup_success37
+  %45 = bitcast i32* %key34 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %45)
+  br label %counter_merge32
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -116,6 +116,7 @@ public:
     has_ktime_get_boot_ns_ = std::make_optional<bool>(has_features);
     has_kprobe_multi_ = std::make_optional<bool>(has_features);
     has_skb_output_ = std::make_optional<bool>(has_features);
+    map_ringbuf_ = std::make_optional<bool>(has_features);
   };
   bool has_features_;
 };


### PR DESCRIPTION
This PR supports `bpf_ringbuf_output` in bpftrace, as a continuation of PR #1458 .

For most async builtins, it uses feature detection to decide whether use perf-event or ringbuf. However, `bpf_skb_output` cannot send to ringbuf, so we have to keep ringbuf and perf-event both running to consume events. In this case, I use a thread to poll events from ringbuf.

A couple of details we should discuss beforehand:
1. Should we have a event_loss_counter like the former PR does? One alternative is to add return value for functions like printf(), so user can use it on their own.
2. There are a bunch of codegen tests need to be updated, I updated one of them as an example in the commit, is it okay? One alternative is to add feature variation to codegen tests, like [this branch](https://github.com/xh4n3/bpftrace/tree/codegen-tests-variation) does.

##### Checklist
- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
