### PR TITLE
Allow working with all probe params (kfunc, uprobe)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to
   - [#2588](https://github.com/iovisor/bpftrace/pull/2588)
 - Support all iterators
   - [#2630](https://github.com/iovisor/bpftrace/pull/2630)
+- Improve working with all probe params (kfunc, uprobe)
+  - [#2477](https://github.com/iovisor/bpftrace/pull/2477)
 #### Changed
 - Make `args` a structure (instead of a pointer)
   - [#2578](https://github.com/iovisor/bpftrace/pull/2578)

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1902,6 +1902,9 @@ NetworkManager:1155 /var/lib/sss/mc/passwd (deleted)
 - `sarg0`, `sarg1`, ..., `sargN`. - Arguments to the traced function (for programs that store arguments
   on the stack); assumed to be 64 bits wide
 - `retval` - Return value from traced function
+- `args` - The struct with all arguments of the traced function.
+  Available in `tracepoint`, `kfunc`, and `uprobe` (with DWARF) probes. Use
+  `args.x` to access argument `x` or `args` to get a record with all arguments.
 - `func` - Name of the traced function
 - `probe` - Full name of the probe
 - `curtask` - Current task struct as a u64

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -932,6 +932,12 @@ For string arguments use the `str()` call to retrieve the value.
 | n/a
 | nth argument passed to the function being traced. These are extracted from the CPU registers. The amount of args passed in registers depends on the CPU architecture. (kprobes, uprobes, usdt).
 
+| `args`
+| struct args
+| n/a
+| n/a
+| The struct of all arguments of the traced function. Available in `tracepoint`, `kfunc`, and `uprobe` (with DWARF) probes. Use `args.x` to access argument `x` or `args` to get a record with all arguments.
+
 | cgroup
 | uint64
 | 4.18

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1589,6 +1589,40 @@ Value *IRBuilderBPF::CreateRawTracepointArg(Value *ctx,
   return expr;
 }
 
+Value *IRBuilderBPF::CreateUprobeArgsRecord(Value *ctx,
+                                            const SizedType &args_type)
+{
+  assert(args_type.IsRecordTy());
+
+  auto *args_t = UprobeArgsType(args_type);
+  AllocaInst *result = CreateAllocaBPF(args_t, "args");
+
+  for (auto &arg : args_type.GetFields())
+  {
+    assert(arg.type.is_funcarg);
+    Value *arg_read = CreateRegisterRead(
+        ctx, "arg" + std::to_string(arg.type.funcarg_idx));
+    if (arg.type.GetSize() != 8)
+      arg_read = CreateTrunc(arg_read, GetType(arg.type));
+    CreateStore(arg_read,
+                CreateGEP(args_t,
+                          result,
+                          { getInt64(0), getInt32(arg.type.funcarg_idx) }));
+  }
+  return result;
+}
+
+llvm::Type *IRBuilderBPF::UprobeArgsType(const SizedType &args_type)
+{
+  auto type_name = args_type.GetName();
+  type_name.erase(0, strlen("struct "));
+
+  std::vector<llvm::Type *> arg_types;
+  for (auto &arg : args_type.GetFields())
+    arg_types.push_back(GetType(arg.type));
+  return GetStructType(type_name, arg_types, false);
+}
+
 Value *IRBuilderBPF::CreateRegisterRead(Value *ctx, const std::string &builtin)
 {
   int offset;

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -198,6 +198,8 @@ public:
   Value *CreateRegisterRead(Value *ctx, int offset, const std::string &name);
   Value      *CreatKFuncArg(Value *ctx, SizedType& type, std::string& name);
   Value *CreateRawTracepointArg(Value *ctx, const std::string &builtin);
+  Value *CreateUprobeArgsRecord(Value *ctx, const SizedType &args_type);
+  llvm::Type *UprobeArgsType(const SizedType &args_type);
   CallInst *CreateSkbOutput(Value *skb,
                             Value *len,
                             AllocaInst *data,

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -337,6 +337,12 @@ void CodegenLLVM::visit(Builtin &builtin)
     builtin.probe_id = get_probe_id();
     expr_ = b_.getInt64(builtin.probe_id);
   }
+  else if (builtin.ident == "args" &&
+           probetype(current_attach_point_->provider) == ProbeType::uprobe)
+  {
+    // uprobe args record is built on stack
+    expr_ = b_.CreateUprobeArgsRecord(ctx_, builtin.type);
+  }
   else if (builtin.ident == "args" || builtin.ident == "ctx")
   {
     // ctx is undocumented builtin: for debugging
@@ -1888,10 +1894,25 @@ void CodegenLLVM::visit(FieldAccess &acc)
     auto probe_type = probetype(current_attach_point_->provider);
     if (probe_type == ProbeType::kfunc || probe_type == ProbeType::kretfunc)
       expr_ = b_.CreatKFuncArg(ctx_, acc.type, acc.field);
-    else
-      expr_ = b_.CreateRegisterRead(ctx_,
-                                    "arg" +
-                                        std::to_string(acc.type.funcarg_idx));
+    else if (probe_type == ProbeType::uprobe)
+    {
+      Value *args = expr_;
+      llvm::Type *args_type = b_.UprobeArgsType(type);
+#if LLVM_VERSION_MAJOR <= 14
+      // LLVM <= 14 doesn't have opaque pointers, so we need to cast args to the
+      // correct pointer type
+      if (auto *ptr_ty = dyn_cast<PointerType>(args->getType()))
+      {
+        if (ptr_ty->getPointerElementType() != args_type->getPointerTo())
+          args = b_.CreatePointerCast(args, args_type->getPointerTo());
+      }
+#endif
+      readDatastructElemFromStack(args,
+                                  b_.getInt32(acc.type.funcarg_idx),
+                                  args_type,
+                                  acc.type,
+                                  scoped_del);
+    }
     return;
   }
   else if (type.IsTupleTy())
@@ -3492,19 +3513,16 @@ CodegenLLVM::ScopedExprDeleter CodegenLLVM::accept(Node *node)
 //   scoped_del scope deleter for the data structure
 void CodegenLLVM::readDatastructElemFromStack(Value *src_data,
                                               Value *index,
-                                              const SizedType &data_type,
+                                              llvm::Type *data_type,
                                               const SizedType &elem_type,
                                               ScopedExprDeleter &scoped_del)
 {
   // src_data should contain a pointer to the data structure, but it may be
   // internally represented as an integer and then we need to cast it
   if (src_data->getType()->isIntegerTy())
-    src_data = b_.CreateIntToPtr(src_data,
-                                 b_.GetType(data_type)->getPointerTo());
+    src_data = b_.CreateIntToPtr(src_data, data_type->getPointerTo());
 
-  Value *src = b_.CreateGEP(b_.GetType(data_type),
-                            src_data,
-                            { b_.getInt32(0), index });
+  Value *src = b_.CreateGEP(data_type, src_data, { b_.getInt32(0), index });
 
   // It may happen that the result pointer type is not correct, in such case
   // do a typecast
@@ -3516,7 +3534,7 @@ void CodegenLLVM::readDatastructElemFromStack(Value *src_data,
   {
     // Load the correct type from src
     expr_ = b_.CreateDatastructElemLoad(
-        elem_type, src, true, data_type.GetAS());
+        elem_type, src, true, elem_type.GetAS());
   }
   else
   {
@@ -3525,6 +3543,16 @@ void CodegenLLVM::readDatastructElemFromStack(Value *src_data,
     expr_ = src;
     expr_deleter_ = scoped_del.disarm();
   }
+}
+
+void CodegenLLVM::readDatastructElemFromStack(Value *src_data,
+                                              Value *index,
+                                              const SizedType &data_type,
+                                              const SizedType &elem_type,
+                                              ScopedExprDeleter &scoped_del)
+{
+  return readDatastructElemFromStack(
+      src_data, index, b_.GetType(data_type), elem_type, scoped_del);
 }
 
 // Read a single element from a compound data structure (i.e. an array or

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -189,6 +189,11 @@ private:
                                    const SizedType &data_type,
                                    const SizedType &elem_type,
                                    ScopedExprDeleter &scoped_del);
+  void readDatastructElemFromStack(Value *src_data,
+                                   Value *index,
+                                   llvm::Type *data_type,
+                                   const SizedType &elem_type,
+                                   ScopedExprDeleter &scoped_del);
   void probereadDatastructElem(Value *src_data,
                                Value *offset,
                                const SizedType &data_type,

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -3,6 +3,7 @@
 #include <cassert>
 #include <iostream>
 
+#include "arch/arch.h"
 #include "dwarf_parser.h"
 #include "log.h"
 #include "probe_matcher.h"
@@ -259,6 +260,11 @@ bool FieldAnalyser::resolve_args(Probe &probe)
         else
         {
           LOG(ERROR, ap->loc, err_) << "No debuginfo found for " << ap->target;
+        }
+        if ((int)probe_args.fields.size() > (arch::max_arg() + 1))
+        {
+          LOG(ERROR, ap->loc, err_) << "\'args\' builtin is not supported for "
+                                       "probes with stack-passed arguments.";
         }
       }
     }

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -436,6 +436,9 @@ void SemanticAnalyser::visit(Builtin &builtin)
       auto type_name = probe_->args_typename();
       builtin.type = CreateRecord(type_name,
                                   bpftrace_.structs.Lookup(type_name));
+      if (builtin.type.GetFieldCount() == 0)
+        LOG(ERROR, builtin.loc, err_) << "Cannot read function parameters";
+
       builtin.type.MarkCtxAccess();
       builtin.type.is_funcarg = true;
       builtin.type.SetAS(type == ProbeType::uprobe ? AddrSpace::user

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1483,7 +1483,7 @@ void SemanticAnalyser::visit(Map &map)
         map.vargs->at(i) = cast;
         expr = cast;
       }
-      else if (expr->type.IsCtxAccess())
+      else if (expr->type.IsPtrTy() && expr->type.IsCtxAccess())
       {
         // map functions only accepts a pointer to a element in the stack
         LOG(ERROR, map.loc, err_) << "context cannot be used as a map key";
@@ -3204,8 +3204,11 @@ void SemanticAnalyser::assign_map_type(const Map &map, const SizedType &type)
 {
   const std::string &map_ident = map.ident;
 
-  if (type.IsRecordTy() && (type.is_funcarg || type.is_tparg))
-    LOG(ERROR, map.loc, err_) << "Storing args in maps is not supported";
+  if (type.IsRecordTy() && type.is_tparg)
+  {
+    LOG(ERROR, map.loc, err_)
+        << "Storing tracepoint args in maps is not supported";
+  }
 
   auto *maptype = get_map_type(map);
   if (maptype)

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2445,12 +2445,6 @@ void SemanticAnalyser::visit(AssignVarStatement &assignment)
 
   auto &assignTy = assignment.expr->type;
 
-  auto *builtin = dynamic_cast<Builtin *>(assignment.expr);
-  if (builtin && builtin->ident == "args" && builtin->type.is_funcarg)
-  {
-    LOG(ERROR, assignment.loc, err_) << "args cannot be assigned to a variable";
-  }
-
   if (search != variable_val_[probe_].end())
   {
     if (search->second.IsNoneTy())

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -443,6 +443,9 @@ void SemanticAnalyser::visit(Builtin &builtin)
       builtin.type.is_funcarg = true;
       builtin.type.SetAS(type == ProbeType::uprobe ? AddrSpace::user
                                                    : AddrSpace::kernel);
+      // We'll build uprobe args struct on stack
+      if (type == ProbeType::uprobe)
+        builtin.type.is_internal = true;
     }
     else if (type != ProbeType::tracepoint) // no special action for tracepoint
     {
@@ -1966,6 +1969,7 @@ void SemanticAnalyser::visit(Unop &unop)
       if (type.IsCtxAccess())
         unop.type.MarkCtxAccess();
       unop.type.is_btftype = type.is_btftype;
+      unop.type.is_internal = type.is_internal;
       unop.type.SetAS(type.GetAS());
     }
     else if (type.IsRecordTy())

--- a/tests/codegen/llvm/map_args.ll
+++ b/tests/codegen/llvm/map_args.ll
@@ -1,0 +1,50 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args" = type { i32, i64, i64 }
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @"uprobe:/tmp/bpftrace-test-dwarf-data:func_1"(i8* %0) section "s_uprobe:/tmp/bpftrace-test-dwarf-data:func_1_1" {
+entry:
+  %"@_key" = alloca i64, align 8
+  %args = alloca %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", align 8
+  %1 = bitcast %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args"* %args to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  %2 = bitcast i8* %0 to i64*
+  %3 = getelementptr i64, i64* %2, i64 14
+  %arg0 = load volatile i64, i64* %3, align 8
+  %4 = trunc i64 %arg0 to i32
+  %5 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args"* %args, i64 0, i32 0
+  store i32 %4, i32* %5, align 4
+  %6 = bitcast i8* %0 to i64*
+  %7 = getelementptr i64, i64* %6, i64 13
+  %arg1 = load volatile i64, i64* %7, align 8
+  %8 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args"* %args, i64 0, i32 1
+  store i64 %arg1, i64* %8, align 8
+  %9 = bitcast i8* %0 to i64*
+  %10 = getelementptr i64, i64* %9, i64 12
+  %arg2 = load volatile i64, i64* %10, align 8
+  %11 = getelementptr %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args", %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args"* %args, i64 0, i32 2
+  store i64 %arg2, i64* %11, align 8
+  %12 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  store i64 0, i64* %"@_key", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args"*, i64)*)(i64 %pseudo, i64* %"@_key", %"uprobe:/tmp/bpftrace-test-dwarf-data:func_1_args"* %args, i64 0)
+  %13 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/codegen/map_args.cpp
+++ b/tests/codegen/map_args.cpp
@@ -1,0 +1,24 @@
+#if HAVE_LIBDW
+
+#include "../dwarf_common.h"
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+class codegen_dwarf : public test_dwarf
+{
+};
+
+TEST_F(codegen_dwarf, map_args)
+{
+  std::string uprobe = "uprobe:" + bin_ + ":func_1";
+  test(uprobe + "{ @ = args }", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace
+
+#endif // HAVE_LIBDW

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -234,3 +234,17 @@ EXPECT { .path = 0x[0-9a-f]+, .file = 0x[0-9a-f]+ }
 REQUIRES_FEATURE btf
 TIMEOUT 5
 AFTER ./testprogs/syscall open
+
+NAME args in kfunc store in map
+PROG kfunc:vfs_open { @= args; exit(); }
+EXPECT @: { .path = 0x[0-9a-f]+, .file = 0x[0-9a-f]+ }
+REQUIRES_FEATURE btf
+TIMEOUT 5
+AFTER ./testprogs/syscall open
+
+NAME args in kfunc as a map key
+PROG kfunc:vfs_open { @[args] = 1; exit(); }
+EXPECT @[{.path=0x[0-9a-f]+,.file=0x[0-9a-f]+}]: 1
+REQUIRES_FEATURE btf
+TIMEOUT 5
+AFTER ./testprogs/syscall open

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -248,3 +248,31 @@ EXPECT @[{.path=0x[0-9a-f]+,.file=0x[0-9a-f]+}]: 1
 REQUIRES_FEATURE btf
 TIMEOUT 5
 AFTER ./testprogs/syscall open
+
+NAME args in uprobe print
+PROG uprobe:./testprogs/uprobe_test:function1 { print(args); exit(); }
+EXPECT { .n = 0x[0-9a-f]+, .c = 120 }
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+
+NAME args in uprobe store in map
+PROG uprobe:./testprogs/uprobe_test:function1 { @ = args; exit(); }
+EXPECT @: { .n = 0x[0-9a-f]+, .c = 120 }
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+
+NAME args in uprobe store in map and access field
+PROG uprobe:./testprogs/uprobe_test:function1 { @ = args; print(@.c); exit(); }
+EXPECT 120
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+
+NAME args in uprobe as a map key
+PROG uprobe:./testprogs/uprobe_test:function1 { @[args] = 1; exit(); }
+EXPECT @[{.n=0x[0-9a-f]+,.c=120}]: 1
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2716,7 +2716,7 @@ TEST_F(semantic_analyser_btf, kfunc)
   test("kfunc:*:func_1 { 1 }", 0);
 
   test("kretfunc:func_1 { $x = args.foo; }", 1);
-  test("kretfunc:func_1 { $x = args; }", 1);
+  test("kretfunc:func_1 { $x = args; }", 0);
   // reg() is not available in kfunc
 #ifdef ARCH_X86_64
   test("kfunc:func_1 { reg(\"ip\") }", 1);

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2717,6 +2717,8 @@ TEST_F(semantic_analyser_btf, kfunc)
 
   test("kretfunc:func_1 { $x = args.foo; }", 1);
   test("kretfunc:func_1 { $x = args; }", 0);
+  test("kfunc:func_1 { @ = args; }", 0);
+  test("kfunc:func_1 { @[args] = 1; }", 0);
   // reg() is not available in kfunc
 #ifdef ARCH_X86_64
   test("kfunc:func_1 { reg(\"ip\") }", 1);


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.
 
Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

Allows to use `*args` in multiple constructions such as:
- printing (resolves #2436)
```
# bpftrace -e 'kfunc:vfs_read { print(*args); exit(); }'
Attaching 1 probe...
{ .file = 0xffff9fbe928a7e00, .buf = 0x7ffddb859ee0, .count = 16, .pos = 0xffffb203068afee0 }
```
- storing in map
```
# bpftrace -e 'kfunc:vfs_read { @ = *args; exit(); }'
Attaching 1 probe...

@: { .file = 0xffff9fbe928a7e00, .buf = 0x7ffddb859ee0, .count = 16, .pos = 0xffffb203068afe88 }
```
- map keys
```
# bpftrace -e 'kfunc:vfs_read { @[*args] = count(); } i:ms:100 { exit(); }'
Attaching 2 probes...

[...]
@[{.file=0xffff9fbe8164df00,.buf=0x3434008bd400,.count=1024,.pos=0xffffb2030f24ff00}]: 1
@[{.file=0xffff9fbe4496e400,.buf=0x7ffe84009f10,.count=64,.pos=0xffffb20300757e60}]: 2
@[{.file=0xffff9fbf0c666100,.buf=0x7fff1d7d8577,.count=1,.pos=0x0}]: 2

```

The main change is that probe args are now represented using a special record with `struct <probename>_args` type and hence can be treated as any other record type. Construction of the type is different for kfuncs and uprobes:
- kfunc: the `ctx` pointer points to the struct of args which has exactly the same layout as our representation, so the implementation is straightforward.
- uprobes: args are stored in registers, so when `*args` occurs in the code, the args record is constructed on BPF stack and filled from registers. Note: this is done every time, even when only `args->x` is used (and it would be sufficient to read one register). The reason for this is that creating entire `*args` elegantly fits the current implementation and since there are at most 6 args supported, this should be quite a cheap operation.

This required some minor changes, especially to codegen tests, see commit messages for more details.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
