### PR TITLE
opensnoop.bt: 0 is a valid file descriptor

### DIFF
--- a/tools/opensnoop.bt
+++ b/tools/opensnoop.bt
@@ -32,8 +32,8 @@ tracepoint:syscalls:sys_exit_openat
 /@filename[tid]/
 {
 	$ret = args->ret;
-	$fd = $ret > 0 ? $ret : -1;
-	$errno = $ret > 0 ? 0 : - $ret;
+	$fd = $ret >= 0 ? $ret : -1;
+	$errno = $ret >= 0 ? 0 : - $ret;
 
 	printf("%-6d %-16s %4d %3d %s\n", pid, comm, $fd, $errno,
 	    str(@filename[tid]));


### PR DESCRIPTION
Signed-off-by: Felix Abecassis <fabecassis@nvidia.com>

Consider the following C program:
```c
#include <fcntl.h>
#include <stdio.h>
#include <string.h>
#include <unistd.h>

int main(void) {
        int fd;

        close(0);
        fd = open("/proc/self/status", O_RDONLY);
        if (fd < 0) {
                perror("open");
                return 1;
        }
        printf("fd: %d\n", fd);
}
```
The current version of opensnoop.bt prints the following, transforming `0` to `-1`:
```console
288501 a.out              -1   0 /proc/self/status
```