### PR TITLE
BTF support for tracepoints defined in modules

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,8 +153,10 @@ jobs:
       run: >
         docker load --input /tmp/docker-save/i.tar
     - name: Load kernel modules
-      # nf_tables is necessary for testing kernel modules BTF support
-      run: sudo modprobe nf_tables
+      # nf_tables and xfs are necessary for testing kernel modules BTF support
+      run: |
+        sudo modprobe nf_tables
+        sudo modprobe xfs
     - name: Build and test
       env: ${{matrix.env}}
       run: >

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to
   - [#2505](https://github.com/iovisor/bpftrace/pull/2505)
 - Support printing entire structs
   - [#2557](https://github.com/iovisor/bpftrace/pull/2557)
+- BTF support for tracepoints defined in modules
+  - [#2479](https://github.com/iovisor/bpftrace/pull/2479)
 #### Changed
 #### Deprecated
 #### Removed

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -251,9 +251,16 @@ std::string BTF::c_def(const std::unordered_set<std::string> &set) const
   if (!has_data())
     return std::string("");
 
-  // Definition dumping from modules would require to resolve type conflicts,
-  // so we dump from vmlinux only for now.
+  // Definition dumping from multiple modules would require to resolve type
+  // conflicts, so we allow dumping from a single module or from vmlinux only.
   std::unordered_set<std::string> to_dump(set);
+  if (btf_objects.size() == 2)
+  {
+    auto *mod_btf = btf_objects[0].btf == vmlinux_btf ? btf_objects[1].btf
+                                                      : btf_objects[0].btf;
+    return dump_defs_from_btf(mod_btf, to_dump);
+  }
+
   return dump_defs_from_btf(vmlinux_btf, to_dump);
 }
 

--- a/src/btf.h
+++ b/src/btf.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "types.h"
+#include <cstddef>
 #include <linux/types.h>
 #include <map>
 #include <optional>
@@ -51,6 +52,10 @@ public:
   ~BTF();
 
   bool has_data(void) const;
+  size_t objects_cnt() const
+  {
+    return btf_objects.size();
+  }
   std::string c_def(const std::unordered_set<std::string>& set) const;
   std::string type_of(const std::string& name, const std::string& field);
   std::string type_of(const BTFId& type_id, const std::string& field);

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -776,6 +776,13 @@ bool ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<s
     {
       LOG(ERROR) << "Include headers with missing type definitions or install "
                     "BTF information to your system.";
+      if (bpftrace.btf_->objects_cnt() > 2)
+      {
+        LOG(WARNING)
+            << "Trying to dump BTF from multiple kernel modules at once. "
+            << "This is currently not possible, use probes from a single module"
+            << " (and/or vmlinux) only.";
+      }
     }
     return false;
   }

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -78,8 +78,9 @@ void Driver::error(const std::string &m)
   failed_ = true;
 }
 
-// Retrieves the list of kernel modules for all attached-to functions.
-// Currently modules are only important for k(ret)func probes.
+// Retrieves the list of kernel modules for all attachpoints. Will be used to
+// identify modules whose BTF we need to parse.
+// Currently, this is useful for k(ret)func and tracepoint probes.
 std::set<std::string> Driver::list_modules() const
 {
   std::set<std::string> modules;
@@ -101,6 +102,13 @@ std::set<std::string> Driver::list_modules() const
         }
         else
           modules.insert(ap->target);
+      }
+      else if (probe_type == ProbeType::tracepoint)
+      {
+        // For now, we support this for a single target only since tracepoints
+        // need dumping of C definitions BTF and that is not available for
+        // multiple modules at once.
+        modules.insert(ap->target);
       }
     }
   }

--- a/tests/runtime/btf
+++ b/tests/runtime/btf
@@ -62,6 +62,13 @@ REQUIRES lsmod | grep '^nf_tables'
 REQUIRES /usr/sbin/nft --help
 AFTER nft delete table bpftrace
 
+NAME kernel_module_tracepoint
+PROG tracepoint:xfs:xfs_setfilesize { print(args->offset) } i:ms:1 { exit(); }
+EXPECT Attaching 2 probes...
+TIMEOUT 5
+REQUIRES_FEATURE btf
+REQUIRES lsmod | grep "^xfs"
+
 # args->ctxt has type 'struct x86_emulate_ctxt' which is forward-defined in
 # 'vmlinux' BTF and fully defined in 'kvm' BTF.
 # This tests checks that the correct BTF definition is pulled from 'kvm'.


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

For tracepoints defined in vmlinux, we support usage of BTF for type parsing which can automatically resolve types from tracepoint defs. Thanks to this feature, users do not have to include headers with necessary types manually.
    
This PR enables the same for tracepoints defined in kernel modules. Since parsing of BTF for modules is already supported for kfuncs (#2315) , this change is as simple as adding the subsystem name to the list of modules whose BTF is parsed.

At the moment, this is not supported for tracepoints using wildcarded subsystems. The reason is that tracepoints require dumping of C definitions from BTF which is not possible for multiple modules at once (as it could introduce type redefinitions) so this feature is limited to single-subsystem tracepoints only.

Check #2094 to see where this is useful.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
