### PR TITLE
Simplify and fix probe index assignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to
 #### Deprecated
 #### Removed
 #### Fixed
+- Simplify and fix probe index assignment
+  - [#2482](https://github.com/iovisor/bpftrace/pull/2482)
 #### Docs
 #### Tools
 

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -519,15 +519,14 @@ std::string AttachPoint::name(const std::string &attach_point) const
   return name(target, attach_point);
 }
 
-int AttachPoint::index(const std::string &name) const
+int AttachPoint::index() const
 {
-  if (index_.count(name) == 0) return 0;
-  return index_.at(name);
+  return index_;
 }
 
-void AttachPoint::set_index(const std::string &name, int index)
+void AttachPoint::set_index(int index)
 {
-  index_[name] = index;
+  index_ = index;
 }
 
 std::string Probe::name() const

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -551,13 +551,13 @@ public:
   std::string name(const std::string &attach_target,
                    const std::string &attach_point) const;
 
-  int index(const std::string &name) const;
-  void set_index(const std::string &name, int index);
+  int index() const;
+  void set_index(int index);
 
 private:
   AttachPoint(const AttachPoint &other) = default;
 
-  std::map<std::string, int> index_;
+  int index_ = 0;
 };
 using AttachPointList = std::vector<AttachPoint *>;
 

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -58,7 +58,7 @@ public:
   void visit(Probe &probe) override;
   void visit(Program &program) override;
   AllocaInst *getHistMapKey(Map &map, Value *log2);
-  int         getNextIndexForProbe(const std::string &probe_name);
+  int getNextIndexForProbe();
   Value      *createLogicalAnd(Binop &binop);
   Value      *createLogicalOr(Binop &binop);
 
@@ -221,7 +221,9 @@ private:
   std::string probefull_;
   std::string tracepoint_struct_;
   uint64_t probe_count_ = 0;
-  std::map<std::string, int> next_probe_index_;
+  // Probes and attach points are indexed from 1, 0 means no index
+  // (no index is used for probes whose attach points are indexed individually)
+  int next_probe_index_ = 1;
   // Used if there are duplicate USDT entries
   int current_usdt_location_index_{ 0 };
 

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -72,7 +72,7 @@ Probe BPFtrace::generateWatchpointSetupProbe(const std::string &func,
   setup_probe.path = ap.target;
   setup_probe.attach_point = func;
   setup_probe.orig_name = get_watchpoint_setup_probe_name(probe.name());
-  setup_probe.index = ap.index(func) > 0 ? ap.index(func) : probe.index();
+  setup_probe.index = ap.index() > 0 ? ap.index() : probe.index();
 
   return setup_probe;
 }
@@ -91,8 +91,8 @@ int BPFtrace::add_probe(ast::Probe &p)
       probe.orig_name = p.name();
       probe.name = p.name();
       probe.loc = 0;
-      probe.index = attach_point->index(probe.name) > 0 ?
-          attach_point->index(probe.name) : p.index();
+      probe.index = attach_point->index() > 0 ? attach_point->index()
+                                              : p.index();
       resources.special_probes.push_back(probe);
       continue;
     }
@@ -266,8 +266,8 @@ int BPFtrace::add_probe(ast::Probe &p)
       probe.address = attach_point->address;
       probe.func_offset = attach_point->func_offset;
       probe.loc = 0;
-      probe.index = attach_point->index(func) > 0 ? attach_point->index(func)
-                                                  : p.index();
+      probe.index = attach_point->index() > 0 ? attach_point->index()
+                                              : p.index();
       probe.len = attach_point->len;
       probe.mode = attach_point->mode;
       probe.async = attach_point->async;
@@ -282,8 +282,8 @@ int BPFtrace::add_probe(ast::Probe &p)
         {
           Probe probe_copy = probe;
           probe_copy.usdt_location_idx = i;
-          probe_copy.index = attach_point->index(func + "_loc" +
-                                                 std::to_string(i));
+          probe_copy.index = attach_point->index() > 0 ? attach_point->index()
+                                                       : p.index();
 
           resources.probes.emplace_back(std::move(probe_copy));
         }

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -61,7 +61,7 @@ TEST(codegen, populate_sections)
   auto bytecode = codegen.compile();
 
   EXPECT_NE(bytecode.find("s_kprobe:foo_1"), bytecode.end());
-  EXPECT_NE(bytecode.find("s_kprobe:bar_1"), bytecode.end());
+  EXPECT_NE(bytecode.find("s_kprobe:bar_2"), bytecode.end());
 }
 
 TEST(codegen, printf_offsets)

--- a/tests/codegen/llvm/args_multiple_tracepoints_category_wild.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints_category_wild.ll
@@ -58,7 +58,7 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-define i64 @"tracepoint:sched:sched_two"(i8* %0) section "s_tracepoint:sched:sched_two_2" {
+define i64 @"tracepoint:sched:sched_two"(i8* %0) section "s_tracepoint:sched:sched_two_1" {
 entry:
   %"@_val" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
@@ -104,7 +104,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   ret i64 1
 }
 
-define i64 @"tracepoint:sched_extra:sched_extra"(i8* %0) section "s_tracepoint:sched_extra:sched_extra_3" {
+define i64 @"tracepoint:sched_extra:sched_extra"(i8* %0) section "s_tracepoint:sched_extra:sched_extra_1" {
 entry:
   %"@_val" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8

--- a/tests/codegen/llvm/args_multiple_tracepoints_wild.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints_wild.ll
@@ -58,7 +58,7 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-define i64 @"tracepoint:sched:sched_two"(i8* %0) section "s_tracepoint:sched:sched_two_2" {
+define i64 @"tracepoint:sched:sched_two"(i8* %0) section "s_tracepoint:sched:sched_two_1" {
 entry:
   %"@_val" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8

--- a/tests/codegen/llvm/call_clear.ll
+++ b/tests/codegen/llvm/call_clear.ll
@@ -33,7 +33,7 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_2" {
 entry:
   %"clear_@x" = alloca %clear_t, align 8
   %1 = bitcast %clear_t* %"clear_@x" to i8*

--- a/tests/codegen/llvm/call_print.ll
+++ b/tests/codegen/llvm/call_print.ll
@@ -33,7 +33,7 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_2" {
 entry:
   %"print_@x" = alloca %print_t, align 8
   %1 = bitcast %print_t* %"print_@x" to i8*

--- a/tests/codegen/llvm/call_zero.ll
+++ b/tests/codegen/llvm/call_zero.ll
@@ -33,7 +33,7 @@ declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn
 declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
 
-define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_2" {
 entry:
   %"zero_@x" = alloca %zero_t, align 8
   %1 = bitcast %zero_t* %"zero_@x" to i8*

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -30,6 +30,15 @@ EXPECT SUCCESS [0-9][0-9]*
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
+# https://github.com/iovisor/bpftrace/issues/2447
+NAME kfunc_multiple_attach_point_multiple_functions
+PROG BEGIN { @a = 2; @b = 1; @c = 1 } i:s:1 { exit() } kfunc:vfs_read, kfunc:vfs_open /@a != 0/ { @a -= 1 } kfunc:vfs_read /@b == 1/ { @b = 0 } kfunc:vfs_open /@c == 1/ { @c = 0 }
+EXPECT @a: 0\n@b: 0\n@c: 0
+TIMEOUT 5
+REQUIRES_FEATURE btf
+# Note: this calls both vfs_read and vfs_open
+AFTER ./testprogs/syscall read
+
 NAME kprobe
 PROG kprobe:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT SUCCESS [0-9][0-9]*


### PR DESCRIPTION
Assign a unique index for each probe or attach point in generateProbe (the latter if expansion field is set to true). A new index is generated per each call of generateProbe, unless the probe/attach point already has an index; in the case, the old index is kept and used for the section. (this case happens when a wildcard is expanded).

This makes sure that each section in the generated bytecode is uniquely paired to a pair of AST probe/attach point and the actual probe name, preventing the program being attached to a wrong probe.

Fixes #2447

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

See the included test for a more minimal example of the issue. 

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
