### PR TITLE
Ubuntu Focal: force-install libpolly for LLVM >=14

### DIFF
--- a/docker/Dockerfile.focal
+++ b/docker/Dockerfile.focal
@@ -57,6 +57,11 @@ RUN /sbin/bpftool &>/dev/null || (rm -f /sbin/bpftool && ln -s /usr/lib/linux-to
 
 RUN if [ "$LLVM_VERSION" -ge 13 ] ; then apt-get install -y libmlir-${LLVM_VERSION}-dev ; fi
 
+RUN if [ "$LLVM_VERSION" -ge 14 ] ; then \
+      apt download libpolly-${LLVM_VERSION}-dev && \
+      dpkg --force-all -i libpolly-${LLVM_VERSION}-dev*.deb ; \
+    fi
+
 RUN ln -s /usr/bin/python3 /usr/bin/python
 COPY build.sh /build.sh
 RUN chmod 755 /build.sh


### PR DESCRIPTION
Recently, LLVM moved the static polly libraries from libclang-common-dev into the libpolly-dev package for LLVM 14 and 15. Unfortunately, libpolly-dev cannot be installed due to broken dependencies, as reported in https://github.com/llvm/llvm-project/issues/59903. This breaks building of BCC which requires libPolly.a.

To fix this, manually download and force-install libpolly-dev as suggested in https://github.com/llvm/llvm-project/issues/59903#issuecomment-1378634639.

Fixes #2474.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
