### PR TITLE
Fix compile with GCC 13

### DIFF
--- a/src/ast/int_parser.h
+++ b/src/ast/int_parser.h
@@ -1,3 +1,4 @@
+#include <cstdint>
 #include <string>
 
 namespace bpftrace {

--- a/src/pcap_writer.h
+++ b/src/pcap_writer.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 struct pcap;

--- a/src/usdt.h
+++ b/src/usdt.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <vector>

--- a/src/utils.h
+++ b/src/utils.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <cstring>
 #include <exception>
 #include <iostream>


### PR DESCRIPTION
This fixes the compile of bpftrace with the forthcoming GCC 13, as currently found in Fedora rawhide, and explained in [the porting docs](https://gcc.gnu.org/gcc-13/porting_to.html).

Please note that this is the bare minimum changes needed to compile; for stylistic reasons, you may wish to add `#include <cstdint>` in all headers and sources which use `[u]int*_t`.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
