### PR TITLE
fix skb_output feature detection and func type

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1436,7 +1436,7 @@ CallInst *IRBuilderBPF::CreateSkbOutput(Value *skb,
 
   // long bpf_skb_output(void *skb, struct bpf_map *map, u64 flags,
   //                     void *data, u64 size)
-  FunctionType *skb_output_func_type = FunctionType::get(getInt64Ty(),
+  FunctionType *skb_output_func_type = FunctionType::get(getInt32Ty(),
                                                          { skb->getType(),
                                                            map_ptr->getType(),
                                                            getInt64Ty(),

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -426,7 +426,8 @@ bool BPFfeature::has_skb_output(void)
       try_load(libbpf::BPF_PROG_TYPE_TRACING,
                insns,
                ARRAY_SIZE(insns),
-               "kfunc__kfree_skb"));
+               "__kfree_skb",
+               libbpf::BPF_TRACE_FENTRY));
 
   close(map_fd);
   return *has_skb_output_;


### PR DESCRIPTION
This PR fixes two bugs:
1. skboutput feature detection failed after PR #2265 
2. bpf_skb_output func return type is incorrect, causing "Stored value type does not match pointer operand type" ci error

Before:
```bash
root@node:~# bpftrace --info
System
  OS: Linux 5.15.0-56-generic #62-Ubuntu SMP Tue Nov 22 19:54:14 UTC 2022
  Arch: x86_64

Build
  version: v0.16.0
  LLVM: 12.0.1
  unsafe uprobe: no
  bfd: yes
  libdw (DWARF support): yes

Kernel helpers
  ...
  skboutput: no
```

After:
```bash
root@node:~# bpftrace --info
System
  OS: Linux 5.15.0-56-generic #62-Ubuntu SMP Tue Nov 22 19:54:14 UTC 2022
  Arch: x86_64

Build
  version: v0.16.0
  LLVM: 12.0.1
  unsafe uprobe: no
  bfd: yes
  libdw (DWARF support): yes

Kernel helpers
  ...
  skboutput: yes
``` 

The test script works after this change.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
