### PR TITLE
Set str builin addrspace to kernel

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -696,7 +696,7 @@ void SemanticAnalyser::visit(Call &call)
       }
 
       // Required for cases like strncmp(str($1), str(2), 4))
-      call.type.SetAS(t.GetAS());
+      call.type.SetAS(AddrSpace::kernel);
     }
     has_pos_param_ = false;
   }


### PR DESCRIPTION
`str` builtin generates a probe read that reads a string from either userspace or kernel space onto the BPF stack. Hence, the call's addrspace attribute should be set to AddrSpace::kernel to reflect this.

Fixes #2480

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
