### PR TITLE
Add CodeQL workflow for GitHub code scanning

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,3 @@
+paths-ignore:
+  - bcc/
+  - libbpf/

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,3 +1,4 @@
 paths-ignore:
   - bcc/
   - libbpf/
+  - tests/runtime/engine/cmake_vars.py

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,64 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+  schedule:
+    - cron: "19 22 * * 1"
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ python, cpp ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Install Packages (cpp)
+        if: ${{ matrix.language == 'cpp' }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes bison cmake flex g++ git libelf-dev libgtest-dev libgmock-dev zlib1g-dev libfl-dev libcereal-dev libdw-dev libpcap-dev systemtap-sdt-dev binutils-dev llvm-11 llvm-11-dev llvm-11-runtime libllvm11 clang-11 libclang-11-dev libclang-common-11-dev libclang1-11 libbpfcc-dev systemtap-sdt-dev python3 python3-distutils xxd libssl-dev pkg-config make
+
+      - name: Configure (cpp)
+        if: ${{ matrix.language == 'cpp' }}
+        run: |
+          mkdir $GITHUB_WORKSPACE/build && cd $GITHUB_WORKSPACE/build
+          export LLVM_ROOT=/usr/lib/llvm-11; export LLVM_REQUESTED_VERSION=11;
+          ../build-libs.sh
+          cmake ..
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v2
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-and-quality
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v2
+        if: ${{ matrix.language == 'python' }}
+
+      - name: Build cpp
+        if: ${{ matrix.language == 'cpp' }}
+        run: |
+          cd $GITHUB_WORKSPACE/build
+          make -j$(nproc)
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v2
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
         with:
+          config-file: ./.github/codeql/codeql-config.yml
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,6 +32,7 @@ jobs:
         if: ${{ matrix.language == 'cpp' }}
         run: |
           sudo apt-get update
+          sudo apt-get remove 'llvm-*' 'clang-*' 'libclang-*'
           sudo apt-get install --yes bison cmake flex g++ git libelf-dev libgtest-dev libgmock-dev zlib1g-dev libfl-dev libcereal-dev libdw-dev libpcap-dev systemtap-sdt-dev binutils-dev llvm-11 llvm-11-dev llvm-11-runtime libllvm11 clang-11 libclang-11-dev libclang-common-11-dev libclang1-11 libbpfcc-dev systemtap-sdt-dev python3 python3-distutils xxd libssl-dev pkg-config make
 
       - name: Configure (cpp)

--- a/scripts/tracepoint_variable_sized_types.py
+++ b/scripts/tracepoint_variable_sized_types.py
@@ -6,28 +6,29 @@ import glob
 
 field_types = {}
 
-for format_file in glob.iglob("/sys/kernel/debug/tracing/events/*/*/format"):
-    for line in open(format_file):
-        if not line.startswith("\tfield:"):
-            continue
+for format_file_name in glob.iglob("/sys/kernel/debug/tracing/events/*/*/format"):
+    with open(format_file_name) as format_file:
+        for line in format_file:
+            if not line.startswith("\tfield:"):
+                continue
 
-        size_section = line.split(";")[2].split(":")
-        if size_section[0] != "\tsize":
-            continue
-        size_val = size_section[1]
+            size_section = line.split(";")[2].split(":")
+            if size_section[0] != "\tsize":
+                continue
+            size_val = size_section[1]
 
-        field_section = line.split(";")[0].split(":")
-        if field_section[0] != "\tfield":
-            continue
-        field_val = field_section[1]
-        if "[" in field_val or "*" in field_val:
-            continue
+            field_section = line.split(";")[0].split(":")
+            if field_section[0] != "\tfield":
+                continue
+            field_val = field_section[1]
+            if "[" in field_val or "*" in field_val:
+                continue
 
-        field_type = " ".join(field_val.split()[:-1])
+            field_type = " ".join(field_val.split()[:-1])
 
-        if field_type not in field_types:
-            field_types[field_type] = set()
-        field_types[field_type].add(size_val)
+            if field_type not in field_types:
+                field_types[field_type] = set()
+            field_types[field_type].add(size_val)
 
 for t in sorted(field_types):
     sizes = field_types[t]

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -1052,11 +1052,12 @@ void AttachedProbe::attach_usdt(int pid, BPFfeature &feature)
 
   if (err)
   {
-    std::string err;
-    err += "Error finding or enabling probe: " + probe_.name;
-    err += '\n';
-    err += "Try using -p or --usdt-file-activation if there's USDT semaphores";
-    throw std::runtime_error(err);
+    std::string errstr;
+    errstr += "Error finding or enabling probe: " + probe_.name;
+    errstr += '\n';
+    errstr +=
+        "Try using -p or --usdt-file-activation if there's USDT semaphores";
+    throw std::runtime_error(errstr);
   }
 
   int perf_event_fd =

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -742,6 +742,8 @@ __s32 BTF::find_id_in_btf(struct btf *btf,
   for (__s32 id = start_id(btf), max = (__s32)type_cnt(btf); id <= max; ++id)
   {
     const struct btf_type *t = btf__type_by_id(btf, id);
+    if (!t)
+      continue;
     if (kind && btf_kind(t) != *kind)
       continue;
 
@@ -776,6 +778,8 @@ void BTF::resolve_fields(const BTFId &type_id,
                          __u32 start_offset)
 {
   auto btf_type = btf__type_by_id(type_id.btf, type_id.id);
+  if (!btf_type)
+    return;
   auto members = btf_members(btf_type);
   for (__u32 i = 0; i < BTF_INFO_VLEN(btf_type->info); i++)
   {

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -5,15 +5,14 @@ import signal
 import sys
 import os
 import time
-from os import environ, uname, devnull
 from distutils.version import LooseVersion
 import re
 from functools import lru_cache
 
 import cmake_vars
 
-BPF_PATH = environ["BPFTRACE_RUNTIME_TEST_EXECUTABLE"]
-ENV_PATH = environ["PATH"]
+BPF_PATH = os.environ["BPFTRACE_RUNTIME_TEST_EXECUTABLE"]
+ENV_PATH = os.environ["PATH"]
 ATTACH_TIMEOUT = 5
 DEFAULT_TIMEOUT = 5
 
@@ -141,7 +140,7 @@ class Runner(object):
 
     @staticmethod
     def run_test(test):
-        current_kernel = LooseVersion(uname()[2])
+        current_kernel = LooseVersion(os.uname()[2])
         if test.kernel_min and LooseVersion(test.kernel_min) > current_kernel:
             print(warn("[   SKIP   ] ") + "%s.%s" % (test.suite, test.name))
             return Runner.SKIP_KERNEL_VERSION_MIN
@@ -167,7 +166,7 @@ class Runner(object):
             print(ok("[ RUN      ] ") + "%s.%s" % (test.suite, test.name))
             if test.requirement:
                 for req in test.requirement:
-                    with open(devnull, 'w') as dn:
+                    with open(os.devnull, 'w') as dn:
                         if subprocess.call(
                             req,
                             shell=True,
@@ -198,7 +197,7 @@ class Runner(object):
             if test.before:
                 before = subprocess.Popen(test.before, shell=True, preexec_fn=os.setsid)
                 waited=0
-                with open(devnull, 'w') as dn:
+                with open(os.devnull, 'w') as dn:
                     # This might not work for complicated cases, such as if
                     # a test program needs to accept arguments. It covers the
                     # current simple calls with no arguments

--- a/tests/testprogs/complex_struct.c
+++ b/tests/testprogs/complex_struct.c
@@ -25,7 +25,7 @@ int main()
                      .d = { 5, 6, 7, 8 },
                      .e = { 9, 10, 11, 12 },
                      .f = { 13, 14, 15, 16 } };
-  strcpy(foo.a, "\x09\x08\x07\x06");
+  memcpy(foo.a, "\x09\x08\x07\x06", 4);
   func(&foo);
   free(foo.a);
   return 0;

--- a/tests/testprogs/syscall.c
+++ b/tests/testprogs/syscall.c
@@ -44,9 +44,9 @@ int gen_nanosleep(int argc, char *argv[])
       return 1;
     }
     double time;
-    char tail = '\0';
-    sscanf(arg, "%le%c", &time, &tail);
-    if (tail != '\0')
+    char *endptr;
+    time = strtod(arg, &endptr);
+    if (endptr != arg + strlen(arg))
     {
       printf("Argument '%s' should only contain numerial characters\n", arg);
       return 1;
@@ -118,7 +118,7 @@ int gen_read()
 {
   char *file_path = get_tmp_file_path(
       "/bpftrace_runtime_test_syscall_gen_read_temp");
-  int fd = open(file_path, O_CREAT);
+  int fd = open(file_path, O_CREAT, 0644);
   if (fd < 0)
   {
     perror("Error in syscall read when creating temp file");
@@ -184,7 +184,11 @@ int gen_connect(int argc, char *argv[])
   }
 
   int port;
-  sscanf(argv[3], "%d", &port);
+  if (sscanf(argv[3], "%d", &port) <= 0)
+  {
+    printf("Argument invalid\n");
+    return 1;
+  }
   if (port < 1 || port > 65535)
   {
     printf("Argument '%s' is out of range, should be in [1, 65535]\n", argv[3]);


### PR DESCRIPTION
The PR builds on and closes #2446. CodeQL is configured to avoid scanning submodules (bcc/, libbpf/) and avoid checking the CMake template file tests/runtime/engine/cmake_vars.py. It fixes a few CodeQL errors, mainly in tests.

The remaining errors are because of CodeQL being unable to detect the pattern `switch(...) case ...: ...; case ...: ...; default: LOG(ERROR, ...)`, complaining about no return value or uninitialized variable. These have to be dismissed manually in the PR, or more comfortably in Security tab.