### PR TITLE
Utilized tracepoints instead of kprobes for probing block IO actions.…

### DIFF
--- a/man/man8/biolatency.bt.8
+++ b/man/man8/biolatency.bt.8
@@ -10,9 +10,14 @@ including modes and outliers. There are often two modes, one for device cache
 hits and one for cache misses, which can be shown by this tool. Latency
 outliers will also be shown.
 
-This tool currently works by dynamic tracing of the blk_account*() kernel
-functions, which will need updating to match any changes to these functions
-in future kernels versions.
+The original tool, which is retained as "biolatency-kp.bt", currently
+works by dynamic tracing of the blk_account*() kernel functions, which
+will need updating to match any changes to these functions in future
+kernels versions.
+
+The updated version of the tool utilizes tracepoints instead of
+kprobes so that it can be compatible with a wide range of kernel
+versions.
 
 Since this uses BPF, only the root user can use this tool.
 .SH REQUIREMENTS

--- a/tools/biolatency-kp.bt
+++ b/tools/biolatency-kp.bt
@@ -16,17 +16,18 @@ BEGIN
 	printf("Tracing block device I/O... Hit Ctrl-C to end.\n");
 }
 
-tracepoint:block:block_bio_queue
+kprobe:blk_account_io_start,
+kprobe:__blk_account_io_start
 {
-	@start[args->sector] = nsecs;
+	@start[arg0] = nsecs;
 }
 
-tracepoint:block:block_rq_complete,
-tracepoint:block:block_bio_complete
-/@start[args->sector]/
+kprobe:blk_account_io_done,
+kprobe:__blk_account_io_done
+/@start[arg0]/
 {
-	@usecs = hist((nsecs - @start[args->sector]) / 1000);
-	delete(@start[args->sector]);
+	@usecs = hist((nsecs - @start[arg0]) / 1000);
+	delete(@start[arg0]);
 }
 
 END

--- a/tools/biolatency_example.txt
+++ b/tools/biolatency_example.txt
@@ -3,7 +3,7 @@ Demonstrations of biolatency, the Linux BPF/bpftrace version.
 
 This traces block I/O, and shows latency as a power-of-2 histogram. For example:
 
-# ./biolatency.bt
+# ./biolatency-kp.bt
 Attaching 3 probes...
 Tracing block device I/O... Hit Ctrl-C to end.
 ^C
@@ -30,3 +30,6 @@ instrumentation, like biosnoop.bt, can shed more light on those outliers.
 
 There is another version of this tool in bcc: https://github.com/iovisor/bcc
 The bcc version provides options to customize the output.
+
+"biolatency.bt" is an updated version of "biolatency-kp.bt" and does basically
+the same thing utilizing the tracepoints instead of kprobes.


### PR DESCRIPTION
… The results displayed in usecs are equivalent of the Q2C metrics in blktrace.


Descriptions of the change
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

In some environment like follows,
/usr/share/bpftrace/tools/biolatency.bt fails due to the lack of
the specified kprobe entries.

```
   [root@enaga tools]# uname -ra
   Linux enaga.mihalabo.com 6.1.9-100.fc36.x86_64 #1 SMP PREEMPT_DYNAMIC Thu Feb  2 03:27:13 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux

   [root@enaga tools]# /usr/share/bpftrace/tools/biolatency.bt 
   /usr/share/bpftrace/tools/biolatency.bt:17-19: WARNING: blk_account_io_start is not traceable (either non-existing, inlined, or marked as "notrace"); attaching to it will likely fail
   /usr/share/bpftrace/tools/biolatency.bt:19-20: WARNING: __blk_account_io_start is not traceable (either non-existing, inlined, or marked as "notrace"); attaching to it will likely fail
   /usr/share/bpftrace/tools/biolatency.bt:23-25: WARNING: blk_account_io_done is not traceable (either non-existing, inlined, or marked as "notrace"); attaching to it will likely fail
   Attaching 6 probes...
   cannot attach kprobe, probe entry may not exist
   WARNING: could not attach probe kprobe:blk_account_io_done, skipping.
   cannot attach kprobe, probe entry may not exist
   WARNING: could not attach probe kprobe:__blk_account_io_start, skipping.
   cannot attach kprobe, probe entry may not exist
   WARNING: could not attach probe kprobe:blk_account_io_start, skipping.
   Tracing block device I/O... Hit Ctrl-C to end.
   ^C
```

The tracepoints in the block I/O layer of Linux kernel utilized for
blktrace are more stable probe points through different versions of
the Linux kernel.

The tracepoints proposed in this pull request represents the 'Q' and
the 'C' TRACE ACTIONS described in the 'man 1 blkparse'.
As a result, @usecs displayed are equivalent of the Q2C metrics in the blktrace.



Tests on kernel 6.1.9 and 4.18-0
^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

```
   [root@enaga tools]# cat ./biolatency.bt 
   #!/usr/bin/env bpftrace
   /*
    * biolatency.bt	Block I/O latency as a histogram.
    *			For Linux, uses bpftrace, eBPF.
    *
    * This is a bpftrace version of the bcc tool of the same name.
    *
    * Copyright 2018 Netflix, Inc.
    * Licensed under the Apache License, Version 2.0 (the "License")
    *
    * 13-Sep-2018	Brendan Gregg	Created this.
    */
   
   BEGIN
   {
   	printf("Tracing block device I/O... Hit Ctrl-C to end.\n");
   }
   
   tracepoint:block:block_bio_queue
   {
   	@start[args->sector] = nsecs;
   }
   
   tracepoint:block:block_rq_complete,
   tracepoint:block:block_bio_complete
   /@start[args->sector]/
   {
   	@usecs = hist((nsecs - @start[args->sector]) / 1000);
   	delete(@start[args->sector]);
   }
   
   END
   {
   	clear(@start);
   }
```

On Fedora36 (kernel 6.1.9)

```
   [root@enaga tools]# uname -ra
   Linux enaga.mihalabo.com 6.1.9-100.fc36.x86_64 #1 SMP PREEMPT_DYNAMIC Thu Feb  2 03:27:13 UTC 2023 x86_64 x86_64 x86_64 GNU/Linux

   [root@enaga tools]# ./biolatency.bt 
   Attaching 5 probes...
   Tracing block device I/O... Hit Ctrl-C to end.
   ^C


   @usecs: 
   [64, 128)              2 |@@                                                  |
   [128, 256)             3 |@@@@                                                |
   [256, 512)             7 |@@@@@@@@@                                           |
   [512, 1K)              0 |                                                    |
   [1K, 2K)               0 |                                                    |
   [2K, 4K)               0 |                                                    |
   [4K, 8K)               0 |                                                    |
   [8K, 16K)             38 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
```

On RHEL8.7 (kernel 4.18.0)
```   
   [root@akagera mihara]# uname -ra
   Linux akagera.mihalabo.com 4.18.0-425.10.1.el8_7.x86_64 #1 SMP Wed Dec 14 16:00:01 EST 2022 x86_64 x86_64 x86_64 GNU/Linux

   [root@akagera mihara]# ./biolatency.bt 
   Attaching 5 probes...
   ^C


   @usecs: 
   [256, 512)             1 |@@@@                                                |
   [512, 1K)              0 |                                                    |
   [1K, 2K)               4 |@@@@@@@@@@@@@@@@@@                                  |
   [2K, 4K)               0 |                                                    |
   [4K, 8K)               0 |                                                    |
   [8K, 16K)              0 |                                                    |
   [16K, 32K)            11 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
   [32K, 64K)             1 |@@@@                                                |
```

##### Checklist

- [ none ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ none ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ done ] The new behaviour is covered by tests
