### PR TITLE
Handle colon in positional param used in attachpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to
 #### Fixed
 - Simplify and fix probe index assignment
   - [#2482](https://github.com/iovisor/bpftrace/pull/2482)
+- Handle colon in positional param used in attachpoint
+  - [#2514](https://github.com/iovisor/bpftrace/pull/2514)
 #### Docs
 #### Tools
 

--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -218,7 +218,7 @@ AttachPointParser::State AttachPointParser::parse_attachpoint(AttachPoint &ap)
 AttachPointParser::State AttachPointParser::lex_attachpoint(
     const AttachPoint &ap)
 {
-  const auto &raw = ap.raw_input;
+  std::string raw = ap.raw_input;
   std::vector<std::string> ret;
   bool in_quotes = false;
   std::string argument;
@@ -266,10 +266,11 @@ AttachPointParser::State AttachPointParser::lex_attachpoint(
         return State::INVALID;
       }
 
-      argument += bpftrace_.get_param(param_idx, true);
-      // NB the for loop will then do idx++ so while we consumed
-      // (len + 1) characters, we only increment by (len).
-      idx += len;
+      // Expand the positional param in-place and decrement idx so that the next
+      // iteration takes the first char of the expansion
+      raw = raw.substr(0, idx) + bpftrace_.get_param(param_idx, true) +
+            raw.substr(i);
+      idx--;
     }
     else
       argument += raw[idx];

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -120,6 +120,11 @@ RUN {{BPFTRACE}} -e 'BEG$1 { printf("hello world\n"); exit(); }' IN
 EXPECT hello world
 TIMEOUT 1
 
+NAME positional attachpoint full
+RUN {{BPFTRACE}} -e '$1 { printf("hello world\n"); exit(); }' i:ms:1
+EXPECT hello world
+TIMEOUT 1
+
 NAME string compare map lookup
 RUN {{BPFTRACE}} -e 't:syscalls:sys_enter_openat /comm == "syscall"/ { @[comm] = 1; }' -c "./testprogs/syscall openat"
 EXPECT @\[syscall\]: 1


### PR DESCRIPTION
We allow to use positional parameters in attachpoints, however, when the parameter contains a colon (i.e. multiple attachpoint parts), bpftrace will fail:

    # bpftrace -e '$1 {printf("%s\n", probe);}' kprobe:vfs_read
    FATAL: Invalid probe type made it to attachpoint parser

The problem is that AttachPointParser expands the positional parameter into the string with the current part. Fix this by expanding it into the string holding the entire attachpoint.

Fixes #2513.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
