### PR TITLE
Vendor BPF_F_KPROBE_MULTI_RETURN definition

### DIFF
--- a/src/libbpf/bpf.h
+++ b/src/libbpf/bpf.h
@@ -8,6 +8,10 @@
 #define BPF_PSEUDO_MAP_VALUE 2
 #endif
 
+#ifndef BPF_F_KPROBE_MULTI_RETURN
+#define BPF_F_KPROBE_MULTI_RETURN (1U << 0)
+#endif
+
 // clang-format off
 enum bpf_map_type {
 	BPF_MAP_TYPE_UNSPEC,


### PR DESCRIPTION
Add definition of `BPF_F_KPROBE_MULTI_RETURN` (in Linux kernel since v5.18) to the vendored `src/libbpf/bpf.h` so bpftrace can be built on a system with older kernel header.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests