### PR TITLE
Handle BPF load errors for multi-attachpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
   - [#2482](https://github.com/iovisor/bpftrace/pull/2482)
 - Handle colon in positional param used in attachpoint
   - [#2514](https://github.com/iovisor/bpftrace/pull/2514)
+- Handle BPF load errors for multi-attachpoints
+  - [#2521](https://github.com/iovisor/bpftrace/pull/2521)
 #### Docs
 #### Tools
 


### PR DESCRIPTION
If `bpf_prog_load` fails, do not fail hard when user is trying to attach to multiple attachpoints at once. In such a case, just print a warning but continue with attaching the remaining probes.

This fixes the following issue:

Before:

    # bpftrace -e 'kfunc:audit* { printf("hit\n"); exit(); }'
    ERROR: Error loading program: kfunc:vmlinux:audit_log_format (try -v)

After:

    # bpftrace -e 'kfunc:audit* { printf("hit\n"); exit(); }'
    Attaching 116 probes...
    WARNING: Error loading program: kfunc:vmlinux:audit_log_format (try -v), skipping.
    WARNING: Error loading program: kfunc:vmlinux:audit_log (try -v), skipping.
    hit

Note: `audit_log` and `audit_log_format` have a variable number of arguments and attaching k(ret)func to such functions is not supported by the current kernel.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
