### PR TITLE
ast: Use std::optional in CodegenLLVM::CodegenLLVM call

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -56,11 +56,17 @@ CodegenLLVM::CodegenLLVM(Node *root, BPFtrace &bpftrace)
     throw std::runtime_error(
         "Could not find bpf llvm target, does your llvm support it?");
 
-  target_machine_.reset(target->createTargetMachine(LLVMTargetTriple,
-                                                    "generic",
-                                                    "",
-                                                    TargetOptions(),
-                                                    Optional<Reloc::Model>()));
+  target_machine_.reset(
+      target->createTargetMachine(LLVMTargetTriple,
+                                  "generic",
+                                  "",
+                                  TargetOptions(),
+#if LLVM_VERSION_MAJOR >= 16
+                                  std::optional<Reloc::Model>()
+#else
+                                  Optional<Reloc::Model>()
+#endif
+                                      ));
   target_machine_->setOptLevel(llvm::CodeGenOpt::Aggressive);
 
   module_->setTargetTriple(LLVMTargetTriple);


### PR DESCRIPTION
Fixes build with clang-16

src/ast/passes/codegen_llvm.cpp:63:53: error: use of undeclared identifier 'Optional'; did you mean 'std::optional'?

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
