### PR TITLE
Fix bison warning

### DIFF
--- a/src/parser.yy
+++ b/src/parser.yy
@@ -2,7 +2,7 @@
 %require "3.0.4"
 %defines
 %define api.namespace { bpftrace }
-%define parser_class_name { Parser }
+%define api.parser.class { Parser }
 
 %define api.token.constructor
 %define api.value.type variant


### PR DESCRIPTION
Previously we were getting this warning:

```
[2/9] [BISON][bison_parser] Building parser with bison 3.8.2
src/parser.yy:5.1-36: warning: deprecated directive: ‘%define parser_class_name { Parser }’, use ‘%define api.parser.class { Parser }’ [-Wdeprecated]
    5 | %define parser_class_name { Parser }
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      | %define api.parser.class { Parser }
src/parser.yy: warning: fix-its can be applied.  Rerun with option '--update'. [-Wother]
```

Silence warning by apply suggested fix.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
