### PR TITLE
Remove unused paramter in lockdown::detect()

### DIFF
--- a/src/lockdown.cpp
+++ b/src/lockdown.cpp
@@ -55,7 +55,7 @@ void emit_warning(std::ostream &out)
   // clang-format on
 }
 
-LockdownState detect(std::unique_ptr<BPFfeature> &feature)
+LockdownState detect()
 {
   return read_security_lockdown();
 }

--- a/src/lockdown.h
+++ b/src/lockdown.h
@@ -15,7 +15,7 @@ enum class LockdownState
   Unknown, // Could not determine whether lockdown is enabled or not
 };
 
-LockdownState detect(std::unique_ptr<BPFfeature> &feature);
+LockdownState detect();
 void emit_warning(std::ostream &out);
 
 } //  namespace lockdown

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -853,7 +853,7 @@ int main(int argc, char* argv[])
   if (!is_root())
     return 1;
 
-  auto lockdown_state = lockdown::detect(bpftrace.feature_);
+  auto lockdown_state = lockdown::detect();
   if (lockdown_state == lockdown::LockdownState::Confidentiality)
   {
     lockdown::emit_warning(std::cerr);


### PR DESCRIPTION
Previously we were getting this warning:

```
[2/5] Building CXX object src/CMakeFiles/libbpftrace.dir/lockdown.cpp.o
/home/dxu/dev/bpftrace/src/lockdown.cpp: In function ‘bpftrace::lockdown::LockdownState bpftrace::lockdown::detect(std::unique_ptr<bpftrace::BPFfeature>&)’:
/home/dxu/dev/bpftrace/src/lockdown.cpp:58:51: warning: unused parameter ‘feature’ [-Wunused-parameter]
   58 | LockdownState detect(std::unique_ptr<BPFfeature> &feature)
      |
```

Commit e8b9ca7e ("Drop Ubuntu 19.10 lockdown detection") deleted the code that used BPFfeature parameter. Stop passing the parameter if there's no use for it.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
