### PR TITLE
Fix fd leak from bpf_btf_get_fd_by_id()

### DIFF
--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -86,7 +86,12 @@ bool BPFfeature::try_load(enum libbpf::bpf_prog_type prog_type,
 
   std::optional<unsigned> btf_id;
   if (prog_type == libbpf::BPF_PROG_TYPE_TRACING && has_btf())
-    btf_id = btf_.get_btf_id_fd(name, "vmlinux").first;
+  {
+    auto id_fd = btf_.get_btf_id_fd(name, "vmlinux");
+    btf_id = id_fd.first;
+    if (id_fd.second >= 0)
+      close(id_fd.second);
+  }
 
   if (prog_type == libbpf::BPF_PROG_TYPE_TRACING)
   {


### PR DESCRIPTION
The fd returned from BTF::get_btf_id_fd() is unused and leaked. Close it properly.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
