### PR TITLE
Fix error handling for invalid providers

### DIFF
--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -176,9 +176,6 @@ AttachPointParser::State AttachPointParser::parse_attachpoint(AttachPoint &ap)
 
   switch (probetype(ap.provider))
   {
-    case ProbeType::invalid:
-      LOG(FATAL) << "Invalid probe type made it to attachpoint parser";
-      return INVALID;
     case ProbeType::special:
       return special_parser();
     case ProbeType::kprobe:
@@ -210,6 +207,9 @@ AttachPointParser::State AttachPointParser::parse_attachpoint(AttachPoint &ap)
       return kfunc_parser();
     case ProbeType::iter:
       return iter_parser();
+    case ProbeType::invalid:
+      errs_ << "Invalid probe type: " << ap.provider << std::endl;
+      return INVALID;
   }
 
   return OK;

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1857,6 +1857,13 @@ TEST(Parser, abs_knl_address)
   test(std::string(in_cstr), std::string(out_cstr));
 }
 
+TEST(Parser, invalid_provider)
+{
+  test_parse_failure("asdf { }");
+  test_parse_failure("asdf:xyz { }");
+  test_parse_failure("asdf:xyz:www { }");
+}
+
 } // namespace parser
 } // namespace test
 } // namespace bpftrace


### PR DESCRIPTION
Old behaviour:
```
  # ./bpftrace -e 'a { }'
  FATAL: Invalid probe type made it to attachpoint parser
  Aborted
```

New behaviour:
```
  # ./bpftrace -e 'a { }'
  stdin:1:1-2: ERROR: Invalid probe type: a
  a { }
  ~
```

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
