### PR TITLE
Remove unsupported "--test semantic" command line option

### DIFF
--- a/scripts/compare_tool_speed.sh
+++ b/scripts/compare_tool_speed.sh
@@ -36,7 +36,7 @@ cd $TMPDIR
 set +e
 
 TESTMODE=${4:-codegen}
-if [[ $TESTMODE != "codegen" && $TESTMODE != "semantic" ]]; then
+if [[ $TESTMODE != "codegen" ]]; then
     echo invalid testmode: $TESTMODE
     exit 20
 fi

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -50,7 +50,6 @@ enum class OutputBufferConfig {
 enum class TestMode
 {
   UNSET = 0,
-  SEMANTIC,
   CODEGEN,
 };
 
@@ -493,13 +492,11 @@ Args parse_args(int argc, char* argv[])
         DISABLE_LOG(WARNING);
         break;
       case Options::TEST: // --test
-        if (std::strcmp(optarg, "semantic") == 0)
-          args.test_mode = TestMode::SEMANTIC;
-        else if (std::strcmp(optarg, "codegen") == 0)
+        if (std::strcmp(optarg, "codegen") == 0)
           args.test_mode = TestMode::CODEGEN;
         else
         {
-          LOG(ERROR) << "USAGE: --test must be either 'semantic' or 'codegen'.";
+          LOG(ERROR) << "USAGE: --test can only be 'codegen'.";
           exit(1);
         }
         break;


### PR DESCRIPTION
##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
