### PR TITLE
AttachPointParser cleanups

### DIFF
--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -172,7 +172,7 @@ AttachPointParser::State AttachPointParser::parse_attachpoint(AttachPoint &ap)
     return NEW_APS;
   }
 
-  ap_->provider = probetypeName(*probe_types.begin());
+  ap.provider = expand_probe_name(*probe_types.begin());
 
   switch (probetype(ap.provider))
   {
@@ -212,7 +212,7 @@ AttachPointParser::State AttachPointParser::parse_attachpoint(AttachPoint &ap)
       return iter_parser();
   }
 
-  return OK;
+  __builtin_unreachable();
 }
 
 AttachPointParser::State AttachPointParser::lex_attachpoint(

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2579,8 +2579,6 @@ void SemanticAnalyser::visit(Predicate &pred)
 
 void SemanticAnalyser::visit(AttachPoint &ap)
 {
-  ap.provider = probetypeName(ap.provider);
-
   if (ap.provider == "kprobe" || ap.provider == "kretprobe") {
     if (ap.target != "")
       LOG(ERROR, ap.loc, err_) << "kprobes should not have a target";

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -207,20 +207,20 @@ ProbeType probetype(const std::string &probeName)
   return retType;
 }
 
-std::string probetypeName(const std::string &probeName)
+std::string expand_probe_name(const std::string &orig_name)
 {
-  std::string res = probeName;
+  std::string expanded_name = orig_name;
 
-  auto v = std::find_if(PROBE_LIST.begin(), PROBE_LIST.end(),
-                          [&probeName] (const ProbeItem& p) {
-                            return (p.name == probeName ||
-                                    p.abbr == probeName);
-                          });
+  auto v = std::find_if(PROBE_LIST.begin(),
+                        PROBE_LIST.end(),
+                        [&orig_name](const ProbeItem &p) {
+                          return (p.name == orig_name || p.abbr == orig_name);
+                        });
 
   if (v != PROBE_LIST.end())
-    res = v->name;
+    expanded_name = v->name;
 
-  return res;
+  return expanded_name;
 }
 
 std::string probetypeName(ProbeType t)

--- a/src/types.h
+++ b/src/types.h
@@ -489,7 +489,7 @@ ProbeType probetype(const std::string &type);
 bool is_userspace_probe(const ProbeType &probe_type);
 std::string addrspacestr(AddrSpace as);
 std::string typestr(Type t);
-std::string probetypeName(const std::string &type);
+std::string expand_probe_name(const std::string &orig_name);
 std::string probetypeName(ProbeType t);
 
 struct Probe


### PR DESCRIPTION
Rename probetypeName(string) to expand_probe_name(string) to be clearer about what it's doing. Remove it from SemanticAnalyser as provider names have already been expanded by that point.