### PR TITLE
build: Fix bison deprecated directive warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,7 +122,15 @@ include_directories(SYSTEM ${LIBCEREAL_INCLUDE_DIRS})
 
 find_package(BISON REQUIRED)
 find_package(FLEX REQUIRED)
-bison_target(bison_parser src/parser.yy ${CMAKE_BINARY_DIR}/parser.tab.cc VERBOSE)
+# `parser_class_name` is deprecated and generates warnings in bison >= 3.3.
+# But `api.parser.class` is not supported in bison < 3.3. So we must inject
+# the %define based on the bison version here.
+if(${BISON_VERSION} VERSION_GREATER_EQUAL 3.3)
+  set(BISON_FLAGS "-Dapi.parser.class={Parser}")
+else()
+  set(BISON_FLAGS "-Dparser_class_name={Parser}")
+endif()
+bison_target(bison_parser src/parser.yy ${CMAKE_BINARY_DIR}/parser.tab.cc COMPILE_FLAGS ${BISON_FLAGS} VERBOSE)
 flex_target(flex_lexer src/lexer.l ${CMAKE_BINARY_DIR}/lex.yy.cc)
 add_flex_bison_dependency(flex_lexer bison_parser)
 add_library(parser ${BISON_bison_parser_OUTPUTS} ${FLEX_flex_lexer_OUTPUTS})

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -2,8 +2,9 @@
 %require "3.0.4"
 %defines
 %define api.namespace { bpftrace }
-%define parser_class_name { Parser }
-
+// Pretend like the following %define is uncommented. We set the actual
+// definition from cmake to handle older versions of bison.
+// %define api.parser.class { Parser }
 %define api.token.constructor
 %define api.value.type variant
 %define parse.assert


### PR DESCRIPTION
Previously we were getting this warning:

```
src/parser.yy:5.1-36: warning: deprecated directive: ‘%define parser_class_name { Parser }’, use ‘%define api.parser.class { Parser }’ [-Wdeprecated]
    5 | %define parser_class_name { Parser }
      | ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
      | %define api.parser.class { Parser }
```

However, we could not simply use the new directive as we support versions of bison that don't yet recognize the new directive.

Fix by using cmake to inject the correct directive based on bison version.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
