### PR TITLE
Fix bpftrace failed to find BTF data on a low-version kernel

### DIFF
--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -52,6 +52,13 @@ BTF::BTF(const std::set<std::string> &modules) : state(NODATA)
   else
     load_kernel_btfs(modules);
 
+  if (!vmlinux_btf)
+  {
+    btf_objects.push_back(
+        BTFObj{ .btf = btf__load_vmlinux_btf(), .id = 0, .name = "vmlinux" });
+    vmlinux_btf = btf_objects.back().btf;
+  }
+
   if (btf_objects.empty())
   {
     if (bt_debug != DebugLevel::kNone)


### PR DESCRIPTION
Currently bpftraces (bpftrace -lv 'struct rq') runs on a low-version kernel, without this commit 5329722057d41aebc31e391907a501fea42f7d9 (bpf: assign ID to vmlinux BTF and return additional information for BTF in GET_OBJ_INFO), it will prompt "BTF: BTF data not found." Because it does not assign btf_idr id to vmlinux btf, it cannot be obtained through bpf_btf_get_next_id.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
