### PR TITLE
Support raw tracepoint program type

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -46,17 +46,19 @@ discussion to other files in /docs, the /tools/\*\_examples.txt files, or blog p
     - [4. `uprobe`/`uretprobe`: Dynamic Tracing, User-Level Arguments](#4-uprobeuretprobe-dynamic-tracing-user-level-arguments)
     - [5. `tracepoint`: Static Tracing, Kernel-Level](#5-tracepoint-static-tracing-kernel-level)
     - [6. `tracepoint`: Static Tracing, Kernel-Level Arguments](#6-tracepoint-static-tracing-kernel-level-arguments)
-    - [7. `usdt`: Static Tracing, User-Level](#7-usdt-static-tracing-user-level)
-    - [8. `usdt`: Static Tracing, User-Level Arguments](#8-usdt-static-tracing-user-level-arguments)
-    - [9. `profile`: Timed Sampling Events](#9-profile-timed-sampling-events)
-    - [10. `interval`: Timed Output](#10-interval-timed-output)
-    - [11. `software`: Pre-defined Software Events](#11-software-pre-defined-software-events)
-    - [12. `hardware`: Pre-defined Hardware Events](#12-hardware-pre-defined-hardware-events)
-    - [13. `BEGIN`/`END`: Built-in events](#13-beginend-built-in-events)
-    - [14. `watchpoint`/`asyncwatchpoint`: Memory watchpoints](#14-watchpointasyncwatchpoint-memory-watchpoints)
-    - [15. `kfunc`/`kretfunc`: Kernel Functions Tracing](#15-kfunckretfunc-kernel-functions-tracing)
-    - [16. `kfunc`/`kretfunc`: Kernel Functions Tracing Arguments](#16-kfunckretfunc-kernel-functions-tracing-arguments)
-    - [17. `iter`: Iterators Tracing ](#17-iter-iterators-tracing)
+    - [7. `rawtracepoint`: Static Tracing, Kernel-Level](#7-rawtracepoint-static-tracing-kernel-level)
+    - [8. `rawtracepoint`: Static Tracing, Kernel-Level Arguments](#8-rawtracepoint-static-tracing-kernel-level-arguments)
+    - [9. `usdt`: Static Tracing, User-Level](#9-usdt-static-tracing-user-level)
+    - [10. `usdt`: Static Tracing, User-Level Arguments](#10-usdt-static-tracing-user-level-arguments)
+    - [11. `profile`: Timed Sampling Events](#11-profile-timed-sampling-events)
+    - [12. `interval`: Timed Output](#12-interval-timed-output)
+    - [13. `software`: Pre-defined Software Events](#13-software-pre-defined-software-events)
+    - [14. `hardware`: Pre-defined Hardware Events](#14-hardware-pre-defined-hardware-events)
+    - [15. `BEGIN`/`END`: Built-in events](#15-beginend-built-in-events)
+    - [16. `watchpoint`/`asyncwatchpoint`: Memory watchpoints](#16-watchpointasyncwatchpoint-memory-watchpoints)
+    - [17. `kfunc`/`kretfunc`: Kernel Functions Tracing](#17-kfunckretfunc-kernel-functions-tracing)
+    - [18. `kfunc`/`kretfunc`: Kernel Functions Tracing Arguments](#18-kfunckretfunc-kernel-functions-tracing-arguments)
+    - [19. `iter`: Iterators Tracing ](#19-iter-iterators-tracing)
 - [Variables](#variables)
     - [1. Builtins](#1-builtins)
     - [2. `@`, `$`: Basic Variables](#2---basic-variables)
@@ -1284,7 +1286,45 @@ listed first, the members are specific to the tracepoint.
 Examples in situ:
 [search /tools](https://github.com/iovisor/bpftrace/search?q=tracepoint%3A+path%3Atools&type=Code)
 
-## 7. `usdt`: Static Tracing, User-Level
+## 7. `rawtracepoint`: Static Tracing, Kernel-Level
+
+The hook point triggered by `tracepoint` and `rawtracepoint` is the same. The difference is that raw tracepoints are faster since no argument processing is done (see below).
+
+Syntax: `rawtracepoint:name`
+
+These use tracepoints (a Linux kernel capability).
+
+```
+# bpftrace -e 'rawtracepoint:block_rq_insert { printf("block I/O created by %d\n", tid); }'
+Attaching 1 probe...
+block I/O created by 189126
+[...]
+```
+
+## 8. `rawtracepoint`: Static Tracing, Kernel-Level Arguments
+
+`tracepoint` and `rawtracepoint` are nearly identical in terms of functionality. The only difference is in the program context. `rawtracepoint` offers raw arguments to the tracepoint while `tracepoint` applies further processing to the raw arguments. The additional processing is defined inside the kernel.
+
+Example:
+
+```
+# bpftrace -e 'rawtracepoint:block_rq_insert { printf("%llx %llx\n", arg0, arg1); }'
+Attaching 1 probe...
+ffff88810977d6f8 ffff8881097e8e80
+[...]
+```
+
+The available arguments for each tracepoint can be found in the relative path of the kernel source code include/trace/events/. For example:
+```
+include/trace/events/block.h
+DEFINE_EVENT(block_rq, block_rq_insert,
+	TP_PROTO(struct request_queue *q, struct request *rq),
+	TP_ARGS(q, rq)
+);
+```
+The individual args are accessed by their order via `argN` builtins. Each arg is a 64-bit integer.
+
+## 9. `usdt`: Static Tracing, User-Level
 
 Syntax:
 
@@ -1356,7 +1396,7 @@ matches based on file path. This means that if bpftrace runs from the root host,
 as expected if there are processes `execve`d from private mount namespaces or bind mounted directories.
 One workaround is to run bpftrace inside the appropriate namespaces (ie the container).
 
-## 8. `usdt`: Static Tracing, User-Level Arguments
+## 10. `usdt`: Static Tracing, User-Level Arguments
 
 Examples:
 
@@ -1379,7 +1419,7 @@ my string: 6
 ^C
 ```
 
-## 9. `profile`: Timed Sampling Events
+## 11. `profile`: Timed Sampling Events
 
 Syntax:
 
@@ -1403,7 +1443,7 @@ Attaching 1 probe...
 @[0]: 579
 ```
 
-## 10. `interval`: Timed Output
+## 12. `interval`: Timed Output
 
 Syntax:
 
@@ -1437,7 +1477,7 @@ This prints the rate of syscalls per second.
 Examples in situ:
 [search /tools](https://github.com/iovisor/bpftrace/search?q=interval+extension%3Abt+path%3Atools&type=Code)
 
-## 11. `software`: Pre-defined Software Events
+## 13. `software`: Pre-defined Software Events
 
 Syntax:
 
@@ -1490,7 +1530,7 @@ Attaching 1 probe...
 This roughly counts who is causing page faults, by sampling the process name for every one in one hundred
 faults.
 
-## 12. `hardware`: Pre-defined Hardware Events
+## 14. `hardware`: Pre-defined Hardware Events
 
 Syntax:
 
@@ -1526,7 +1566,7 @@ bpftrace -e 'hardware:cache-misses:1000000 { @[pid] = count(); }'
 
 That would fire once for every 1000000 cache misses. This usually indicates the last level cache (LLC).
 
-## 13. `BEGIN`/`END`: Built-in events
+## 15. `BEGIN`/`END`: Built-in events
 
 Syntax:
 
@@ -1542,7 +1582,7 @@ Examples in situ:
 [(BEGIN) search /tools](https://github.com/iovisor/bpftrace/search?q=BEGIN+extension%3Abt+path%3Atools&type=Code)
 [(END) search /tools](https://github.com/iovisor/bpftrace/search?q=END+extension%3Abt+path%3Atools&type=Code)
 
-## 14. `watchpoint`/`asyncwatchpoint`: Memory watchpoints
+## 16. `watchpoint`/`asyncwatchpoint`: Memory watchpoints
 
 **WARNING**: this feature is experimental and may be subject to interface changes. Memory watchpoints are
 also architecture dependant
@@ -1632,7 +1672,7 @@ int main()
 bpftrace will output "hit" and exit when the memory pointed to by `arg1` of `increment` is
 written.
 
-## 15. `kfunc`/`kretfunc`: Kernel Functions Tracing
+## 17. `kfunc`/`kretfunc`: Kernel Functions Tracing
 
 Syntax:
 
@@ -1669,7 +1709,7 @@ kfunc:vmlinux:ksys_mmap_pgoff
 ...
 ```
 
-## 16. `kfunc`/`kretfunc`: Kernel Functions Tracing Arguments
+## 18. `kfunc`/`kretfunc`: Kernel Functions Tracing Arguments
 
 Syntax:
 
@@ -1715,7 +1755,7 @@ fd 3 name libselinux.so.1
 ```
 And as you can see in above example it's also possible to access function arguments on `kretfunc` probes.
 
-## 17. `iter`: Iterators Tracing
+## 19. `iter`: Iterators Tracing
 
 **WARNING**: this feature is experimental and may be subject to interface changes.
 

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -2397,6 +2397,32 @@ snmpd /proc/net/dev
 .Additional information
 * https://www.kernel.org/doc/html/latest/trace/tracepoints.html
 
+[#probes-rawtracepoint]
+=== rawtracepoint
+
+.variants
+* `rawtracepoint:event`
+
+.shortnames
+* `rt`
+
+The hook point triggered by `tracepoint` and `rawtracepoint` is the same.
+`tracepoint` and `rawtracepoint` are nearly identical in terms of functionality. The only difference is in the program context. `rawtracepoint` offers raw arguments to the tracepoint while `tracepoint` applies further processing to the raw arguments. The additional processing is defined inside the kernel.
+
+Tracepoint arguments are available via the `argN` builtins. The available arguments can be found in the relative path of the kernel source code `include/trace/events/`.
+Each arg is a 64-bit integer.
+
+----
+rawtracepoint:block_rq_insert {
+  printf("%llx %llx\n", arg0, arg1);
+}
+----
+
+----
+ffff88810977d6f8 ffff8881097e8e80
+[...]
+----
+
 [#probes-uprobe]
 === uprobe, uretprobe
 

--- a/src/ast/attachpoint_parser.h
+++ b/src/ast/attachpoint_parser.h
@@ -58,6 +58,7 @@ private:
   State watchpoint_parser(bool async = false);
   State kfunc_parser();
   State iter_parser();
+  State raw_tracepoint_parser();
 
   std::optional<uint64_t> stoull(const std::string &str);
   std::optional<int64_t> stoll(const std::string &str);

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1474,6 +1474,21 @@ Value *IRBuilderBPF::CreatKFuncArg(Value *ctx,
   return expr;
 }
 
+Value *IRBuilderBPF::CreateRawTracepointArg(Value *ctx,
+                                            const std::string &builtin)
+{
+  // argX
+  int offset = atoi(builtin.substr(3).c_str());
+  llvm::Type *type = getInt64Ty();
+
+  ctx = CreatePointerCast(ctx, type->getPointerTo());
+  Value *expr = CreateLoad(type,
+                           CreateGEP(type, ctx, getInt64(offset)),
+                           builtin);
+
+  return expr;
+}
+
 Value *IRBuilderBPF::CreateRegisterRead(Value *ctx, const std::string &builtin)
 {
   int offset;

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -188,6 +188,7 @@ public:
   Value *CreateRegisterRead(Value *ctx, const std::string &builtin);
   Value *CreateRegisterRead(Value *ctx, int offset, const std::string &name);
   Value      *CreatKFuncArg(Value *ctx, SizedType& type, std::string& name);
+  Value *CreateRawTracepointArg(Value *ctx, const std::string &builtin);
   CallInst *CreateSkbOutput(Value *skb,
                             Value *len,
                             AllocaInst *data,

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -256,7 +256,11 @@ void CodegenLLVM::visit(Builtin &builtin)
       return;
     }
 
-    expr_ = b_.CreateRegisterRead(ctx_, builtin.ident);
+    if (!builtin.ident.compare(0, 3, "arg") &&
+        probetype(current_attach_point_->provider) == ProbeType::rawtracepoint)
+      expr_ = b_.CreateRawTracepointArg(ctx_, builtin.ident);
+    else
+      expr_ = b_.CreateRegisterRead(ctx_, builtin.ident);
 
     if (builtin.type.IsUsymTy())
     {
@@ -2490,6 +2494,7 @@ void CodegenLLVM::createRet(Value *value)
     case ProbeType::kfunc:
     case ProbeType::kretfunc:
     case ProbeType::iter:
+    case ProbeType::rawtracepoint:
       b_.CreateRet(b_.getInt64(0));
       break;
   }

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -189,6 +189,7 @@ AddrSpace SemanticAnalyser::find_addrspace(ProbeType pt)
     case ProbeType::kretfunc:
     case ProbeType::tracepoint:
     case ProbeType::iter:
+    case ProbeType::rawtracepoint:
       return AddrSpace::kernel;
     case ProbeType::uprobe:
     case ProbeType::uretprobe:
@@ -374,9 +375,8 @@ void SemanticAnalyser::visit(Builtin &builtin)
     for (auto &attach_point : *probe_->attach_points)
     {
       ProbeType type = probetype(attach_point->provider);
-      if (type != ProbeType::kprobe &&
-          type != ProbeType::uprobe &&
-          type != ProbeType::usdt)
+      if (type != ProbeType::kprobe && type != ProbeType::uprobe &&
+          type != ProbeType::usdt && type != ProbeType::rawtracepoint)
         LOG(ERROR, builtin.loc, err_)
             << "The " << builtin.ident << " builtin can only be used with "
             << "'kprobes', 'uprobes' and 'usdt' probes";
@@ -2684,6 +2684,14 @@ void SemanticAnalyser::visit(AttachPoint &ap)
     if (ap.target == "" || ap.func == "")
       LOG(ERROR, ap.loc, err_) << "tracepoint probe must have a target";
   }
+  else if (ap.provider == "rawtracepoint")
+  {
+    if (ap.target != "")
+      LOG(ERROR, ap.loc, err_) << "rawtracepoint should not have a target";
+    if (ap.func == "")
+      LOG(ERROR, ap.loc, err_)
+          << "rawtracepoint should be attached to a function";
+  }
   else if (ap.provider == "profile") {
     if (ap.target == "")
       LOG(ERROR, ap.loc, err_) << "profile probe must have unit of time";
@@ -3174,6 +3182,7 @@ bool SemanticAnalyser::check_available(const Call &call, const AttachPoint &ap)
       case ProbeType::kfunc:
       case ProbeType::kretfunc:
       case ProbeType::iter:
+      case ProbeType::rawtracepoint:
         return false;
     }
   }
@@ -3199,6 +3208,7 @@ bool SemanticAnalyser::check_available(const Call &call, const AttachPoint &ap)
       case ProbeType::kfunc:
       case ProbeType::kretfunc:
       case ProbeType::iter:
+      case ProbeType::rawtracepoint:
         return false;
     }
   }
@@ -3215,6 +3225,7 @@ bool SemanticAnalyser::check_available(const Call &call, const AttachPoint &ap)
       case ProbeType::profile:
       case ProbeType::kfunc:
       case ProbeType::kretfunc:
+      case ProbeType::rawtracepoint:
         return true;
       case ProbeType::invalid:
       case ProbeType::special:

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -73,6 +73,8 @@ private:
   int detach_kfunc(void);
   void attach_iter(void);
   int detach_iter(void);
+  void attach_raw_tracepoint(void);
+  int detach_raw_tracepoint(void);
 
   static std::map<std::string, int> cached_prog_fds_;
   bool use_cached_progfd(void);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -187,7 +187,8 @@ int BPFtrace::add_probe(ast::Probe &p)
                probetype(attach_point->provider) == ProbeType::uprobe ||
                probetype(attach_point->provider) == ProbeType::uretprobe ||
                probetype(attach_point->provider) == ProbeType::kfunc ||
-               probetype(attach_point->provider) == ProbeType::kretfunc)
+               probetype(attach_point->provider) == ProbeType::kretfunc ||
+               probetype(attach_point->provider) == ProbeType::rawtracepoint)
         attach_funcs.push_back(attach_point->target + ":" + attach_point->func);
       else
         attach_funcs.push_back(attach_point->func);
@@ -234,7 +235,8 @@ int BPFtrace::add_probe(ast::Probe &p)
                probetype(attach_point->provider) == ProbeType::uprobe ||
                probetype(attach_point->provider) == ProbeType::uretprobe ||
                probetype(attach_point->provider) == ProbeType::kfunc ||
-               probetype(attach_point->provider) == ProbeType::kretfunc)
+               probetype(attach_point->provider) == ProbeType::kretfunc ||
+               probetype(attach_point->provider) == ProbeType::rawtracepoint)
       {
         // tracepoint, uprobe, and k(ret)func probes specify both a target and
         // a function name.
@@ -994,6 +996,7 @@ bool attach_reverse(const Probe &p)
     case ProbeType::software:
     case ProbeType::kfunc:
     case ProbeType::iter:
+    case ProbeType::rawtracepoint:
       return true;
     case ProbeType::kretfunc:
     case ProbeType::kretprobe:

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -496,7 +496,7 @@ std::set<std::string> ProbeMatcher::get_matches_for_ap(
     case ProbeType::software:
     case ProbeType::kfunc:
     case ProbeType::kretfunc:
-    {
+    case ProbeType::rawtracepoint: {
       // Do not expand "target:" as that would match all functions in target.
       // This may occur when an absolute address is given instead of a function.
       if (attach_point.func.empty())

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -245,6 +245,7 @@ std::string probetypeName(ProbeType t)
     case ProbeType::kfunc:       return "kfunc";       break;
     case ProbeType::kretfunc:    return "kretfunc";    break;
     case ProbeType::iter:        return "iter";        break;
+    case ProbeType::rawtracepoint: return "rawtracepoint";  break;
   }
   // clang-format on
 

--- a/src/types.h
+++ b/src/types.h
@@ -452,6 +452,7 @@ enum class ProbeType
   kfunc,
   kretfunc,
   iter,
+  rawtracepoint,
 };
 
 std::ostream &operator<<(std::ostream &os, ProbeType type);
@@ -481,6 +482,7 @@ const std::vector<ProbeItem> PROBE_LIST = {
   { "kfunc", "f", ProbeType::kfunc },
   { "kretfunc", "fr", ProbeType::kretfunc },
   { "iter", "it", ProbeType::iter },
+  { "rawtracepoint", "rt", ProbeType::rawtracepoint },
 };
 
 ProbeType probetype(const std::string &type);

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -118,6 +118,16 @@ void check_tracepoint(Probe &p, const std::string &target, const std::string &fu
   EXPECT_EQ("tracepoint:" + target + ":" + func, p.name);
 }
 
+void check_rawtracepoint(Probe &p,
+                         const std::string &func,
+                         const std::string &orig_name)
+{
+  EXPECT_EQ(ProbeType::rawtracepoint, p.type);
+  EXPECT_EQ(func, p.attach_point);
+  EXPECT_EQ(orig_name, p.orig_name);
+  EXPECT_EQ("rawtracepoint:" + func, p.name);
+}
+
 void check_profile(Probe &p, const std::string &unit, int freq, const std::string &orig_name)
 {
   EXPECT_EQ(ProbeType::profile, p.type);
@@ -1029,6 +1039,21 @@ TEST_F(bpftrace_btf, add_probes_iter_task_vma)
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
 
   check_probe(bpftrace.get_probes().at(0), ProbeType::iter, "iter:task_vma");
+}
+
+TEST(bpftrace, add_probes_rawtracepoint)
+{
+  auto probe = parse_probe(("rawtracepoint:sched_switch {}"));
+  StrictMock<MockBPFtrace> bpftrace;
+
+  ASSERT_EQ(0, bpftrace.add_probe(*probe));
+  ASSERT_EQ(1U, bpftrace.get_probes().size());
+  ASSERT_EQ(0U, bpftrace.get_special_probes().size());
+
+  std::string probe_orig_name = "rawtracepoint:sched_switch";
+  check_rawtracepoint(bpftrace.get_probes().at(0),
+                      "sched_switch",
+                      probe_orig_name);
 }
 
 } // namespace bpftrace

--- a/tests/codegen/argN_rawtracepoint.cpp
+++ b/tests/codegen/argN_rawtracepoint.cpp
@@ -1,0 +1,17 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, argN_rawtracepoint)
+{
+  test("rawtracepoint:sched_switch { "
+       "@[arg0] = count(); }",
+
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/argN_rawtracepoint.ll
+++ b/tests/codegen/llvm/argN_rawtracepoint.ll
@@ -1,0 +1,61 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @"rawtracepoint:sched_switch"(i8* %0) section "s_rawtracepoint:sched_switch_1" {
+entry:
+  %"@_val" = alloca i64, align 8
+  %lookup_elem_val = alloca i64, align 8
+  %"@_key" = alloca i64, align 8
+  %1 = bitcast i8* %0 to i64*
+  %2 = getelementptr i64, i64* %1, i64 0
+  %arg0 = load i64, i64* %2, align 8
+  %3 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
+  store i64 %arg0, i64* %"@_key", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* %"@_key")
+  %4 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %cast = bitcast i8* %lookup_elem to i64*
+  %5 = load i64, i64* %cast, align 8
+  store i64 %5, i64* %lookup_elem_val, align 8
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  store i64 0, i64* %lookup_elem_val, align 8
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %6 = load i64, i64* %lookup_elem_val, align 8
+  %7 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
+  %8 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %9 = add i64 %6, 1
+  store i64 %9, i64* %"@_val", align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %"@_val", i64 0)
+  %10 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -260,6 +260,24 @@ PROG tracepoint:irq:irq_handler_entry { print(str(args->name)); exit(); }
 EXPECT ..+
 TIMEOUT 5
 
+NAME rawtracepoint
+PROG rawtracepoint:sys_exit { printf("SUCCESS %d\n", gid); exit(); }
+EXPECT SUCCESS [0-9][0-9]*
+AFTER ./testprogs/syscall nanosleep 1e8
+TIMEOUT 5
+
+NAME rawtracepoint_short_name
+PROG rt:sys_exit { printf("SUCCESS %d\n", gid); exit(); }
+EXPECT SUCCESS [0-9][0-9]*
+AFTER ./testprogs/syscall nanosleep 1e8
+TIMEOUT 5
+
+NAME rawtracepoint_missing
+PROG rawtracepoint:nonsense { printf("hit"); exit(); }
+EXPECT ERROR: Probe does not exist: rawtracepoint:nonsense
+TIMEOUT 5
+WILL_FAIL
+
 NAME profile
 PROG profile:hz:599 { @[tid] = count(); exit();}
 EXPECT \@\[[0-9]*\]\:\s[0-9]

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1460,6 +1460,12 @@ TEST(semantic_analyser, tracepoint)
   test("tracepoint:category:event { 1 }", 0);
 }
 
+TEST(semantic_analyser, rawtracepoint)
+{
+  test("rawtracepoint:event { 1 }", 0);
+  test("rawtracepoint:event { args }", 1);
+}
+
 #if defined(ARCH_X86_64) || defined(ARCH_AARCH64)
 TEST(semantic_analyser, watchpoint_invalid_modes)
 {


### PR DESCRIPTION
Complete bpftrace support for raw tracepoint.

Most of the logic follows kprobe or tracepoint. It's just that the parameters of bpf prog are specially handled, and it only needs to be simply offset according to the X of argX.

https://github.com/iovisor/bpftrace/issues/341

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
