### PR TITLE
Treat str() builtin's len parameter as int64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to
   - [#2521](https://github.com/iovisor/bpftrace/pull/2521)
 - Respect BPFTRACE_STRLEN environment variable for all strings
   - [#2545](https://github.com/iovisor/bpftrace/pull/2545)
+- Treat str() builtin's len parameter as int64
+  - [#2546](https://github.com/iovisor/bpftrace/pull/2546)
 #### Docs
 #### Tools
 

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -540,6 +540,7 @@ void CodegenLLVM::visit(Call &call)
     b_.CREATE_MEMSET(strlen, b_.getInt8(0), sizeof(uint64_t), 1);
     if (call.vargs->size() > 1) {
       auto scoped_del = accept(call.vargs->at(1));
+      expr_ = b_.CreateIntCast(expr_, b_.getInt64Ty(), true);
       Value *proposed_strlen = b_.CreateAdd(expr_, b_.getInt64(1)); // add 1 to accommodate probe_read_str's null byte
 
       // largest read we'll allow = our global string buffer size


### PR DESCRIPTION
The len parameter to str() should be treated as int64,
so that the LHS and RHS to IRBuilder::CreateICmp() is of
the same type. Otherwise, this would trigger an assertion
failure in the ICmpInst constructor.

Closes #2544.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
