### PR TITLE
Fix flex build warning

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -1,4 +1,4 @@
-%option yylineno nodefault noyywrap noinput
+%option yylineno noyywrap noinput
 %option never-interactive
 %option reentrant
 %option stack


### PR DESCRIPTION
Before, we were getting this flex build warning:

```
[1/6] [FLEX][flex_lexer] Building scanner with flex 2.6.4
src/lexer.l:244: warning, -s option given but default rule can be matched
```

Since flex seems convinced `nodefault` is unnecessary, remove it.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
