### PR TITLE
Codegen tests: allow using DWARF-based features

### DIFF
--- a/scripts/update_codegen_tests.sh
+++ b/scripts/update_codegen_tests.sh
@@ -26,7 +26,7 @@ docker run                                \
   -it                                     \
   -v $(pwd):$(pwd)                        \
   -e BPFTRACE_UPDATE_TESTS=1              \
-  -e TEST_ARGS="--gtest_filter=codegen.*" \
+  -e TEST_ARGS="--gtest_filter=codegen*" \
   -e VENDOR_GTEST="ON"                    \
   -e BUILD_LIBBPF="ON"                    \
   bpftrace-builder-focal "$(pwd)/build-codegen-update" Debug "$@"

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -8,6 +8,7 @@
 #include "../mocks.h"
 
 #include "ast/passes/codegen_llvm.h"
+#include "ast/passes/field_analyser.h"
 #include "ast/passes/resource_analyser.h"
 #include "ast/passes/semantic_analyser.h"
 
@@ -43,6 +44,9 @@ static void test(BPFtrace &bpftrace,
 {
   Driver driver(bpftrace);
   ASSERT_EQ(driver.parse_str(input), 0);
+
+  ast::FieldAnalyser fields(driver.root.get(), bpftrace);
+  ASSERT_EQ(fields.analyse(), 0);
 
   ClangParser clang;
   clang.parse(driver.root.get(), bpftrace);

--- a/tests/dwarf_common.h
+++ b/tests/dwarf_common.h
@@ -8,30 +8,20 @@ class test_dwarf : public ::testing::Test
 protected:
   void SetUp() override
   {
-    char *bin = strdup("/tmp/dwarf_dataXXXXXX");
-    int fd = mkstemp(bin);
-    if (fd < 0)
-      return;
+    std::string bin = "/tmp/bpftrace-test-dwarf-data";
+    std::ofstream file(bin, std::ios::trunc | std::ios::binary);
+    file.write(reinterpret_cast<const char *>(dwarf_data), dwarf_data_len);
+    file.close();
 
-    fchmod(fd, S_IRUSR | S_IWUSR | S_IXUSR);
-
-    if (write(fd, dwarf_data, dwarf_data_len) != dwarf_data_len)
-    {
-      close(fd);
-      std::remove(bin);
-      return;
-    }
-
-    close(fd);
-    bin_ = bin;
+    if (file)
+      bin_ = bin;
   }
 
   void TearDown() override
   {
-    if (bin_)
-      std::remove(bin_);
+    bin_.clear();
   }
 
 public:
-  char *bin_ = nullptr;
+  std::string bin_;
 };

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -209,7 +209,7 @@ class field_analyser_dwarf : public test_dwarf
 
 TEST_F(field_analyser_dwarf, uprobe_args)
 {
-  std::string uprobe = "uprobe:" + std::string(bin_);
+  std::string uprobe = "uprobe:" + bin_;
   test(uprobe + ":func_1 { $x = args->a; }", 0);
   test(uprobe + ":func_2 { $x = args->b; }", 0);
 
@@ -236,7 +236,7 @@ TEST_F(field_analyser_dwarf, uprobe_args)
 TEST_F(field_analyser_dwarf, parse_struct)
 {
   BPFtrace bpftrace;
-  std::string uprobe = "uprobe:" + std::string(bin_);
+  std::string uprobe = "uprobe:" + bin_;
   test(bpftrace, uprobe + ":func_1 { $x = args->foo1->a; }", 0);
 
   ASSERT_TRUE(bpftrace.structs.Has("struct Foo1"));


### PR DESCRIPTION
Several changes to allow codegen tests use features depending on DWARF:

- run `FieldAnalyser` in tests as it is necessary to read DWARF data and parse uprobe args and struct field accesses

- store mock DWARF data in a binary with a deterministic name (instead of a unique name) as the binary name will appear in the codegen LLVM (in the attachpoint name) and we're checking the LLVM files for exact text equality

- update the test execution filter in `scripts/update_codegen_tests.sh` to use `codegen*` rather than `codegen.*` as DWARF-based tests will need to introduce a test fixture called `codegen_dwarf`

Actual tests depending on this will be added in following PRs.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
