### PR TITLE
Support printing entire structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to
   - [#2524](https://github.com/iovisor/bpftrace/pull/2524)
 - Support parsing bitfields from BTF/DWARF
   - [#2505](https://github.com/iovisor/bpftrace/pull/2505)
+- Support printing entire structs
+  - [#2557](https://github.com/iovisor/bpftrace/pull/2557)
 #### Changed
 #### Deprecated
 #### Removed

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -105,12 +105,6 @@ void FieldAnalyser::visit(FieldAccess &acc)
   }
   else if (!sized_type_.IsNoneTy())
   {
-    if (sized_type_.IsPtrTy())
-    {
-      sized_type_ = *sized_type_.GetPointeeTy();
-      resolve_fields(sized_type_);
-    }
-
     // If the struct type or the field type has not been resolved, add the type
     // to the BTF set to let ClangParser resolve it
     if (bpftrace_.has_btf_data() && sized_type_.IsRecordTy())
@@ -160,6 +154,16 @@ void FieldAnalyser::visit(AssignVarStatement &assignment)
 {
   Visit(*assignment.expr);
   var_types_.emplace(assignment.var->ident, sized_type_);
+}
+
+void FieldAnalyser::visit(Unop &unop)
+{
+  Visit(*unop.expr);
+  if (unop.op == Operator::MUL && sized_type_.IsPtrTy())
+  {
+    sized_type_ = *sized_type_.GetPointeeTy();
+    resolve_fields(sized_type_);
+  }
 }
 
 bool FieldAnalyser::compare_args(const ProbeArgs &args1, const ProbeArgs &args2)

--- a/src/ast/passes/field_analyser.h
+++ b/src/ast/passes/field_analyser.h
@@ -34,6 +34,7 @@ public:
   void visit(Cast &cast) override;
   void visit(AssignMapStatement &assignment) override;
   void visit(AssignVarStatement &assignment) override;
+  void visit(Unop &unop) override;
   void visit(Probe &probe) override;
 
   int analyse();

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -282,6 +282,12 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
         reinterpret_cast<AsyncEvent::CgroupPath *>(value.data())->cgroup_id);
   else if (type.IsStrerrorTy())
     return strerror(read_data<uint64_t>(value.data()));
+  else if (type.IsPtrTy())
+  {
+    std::ostringstream res;
+    res << "0x" << std::hex << read_data<uint64_t>(value.data());
+    return res.str();
+  }
   else
     return std::to_string(read_data<int64_t>(value.data()) / div);
 }

--- a/src/types.h
+++ b/src/types.h
@@ -199,8 +199,7 @@ public:
 
   bool IsPrintableTy()
   {
-    return type != Type::none && type != Type::pointer &&
-           type != Type::stack_mode && !IsCtxAccess();
+    return type != Type::none && type != Type::stack_mode && !IsCtxAccess();
   }
 
   bool IsSigned(void) const;

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -275,6 +275,13 @@ EXPECT { .m = 2, .n = 3 }
 TIMEOUT 5
 AFTER ./testprogs/simple_struct
 
+NAME print_non_map_struct_kfunc
+PROG kfunc:vfs_open { print(*args->path); exit(); }
+EXPECT { .mnt = 0x[0-9a-f]+, .dentry = 0x[0-9a-f]+ }
+REQUIRES_FEATURE btf
+TIMEOUT 5
+AFTER ./testprogs/syscall open
+
 NAME strftime
 PROG BEGIN { $ts = strftime("%m/%d/%y", nsecs); printf("%s\n", $ts); exit(); }
 EXPECT [0-9]{2}\/[0-9]{2}\/[0-9]{2}

--- a/tests/runtime/pointers
+++ b/tests/runtime/pointers
@@ -1,81 +1,81 @@
 NAME u8 pointer increment
-PROG BEGIN { @=(int8*) 32; @+=1; exit(); }
-EXPECT ^@: 33
+PROG BEGIN { @=(int8*) 0x32; @+=1; exit(); }
+EXPECT ^@: 0x33
 TIMEOUT 5
 
 NAME u16 pointer increment
-PROG BEGIN { @=(int16*) 32; @+=1; exit(); }
-EXPECT ^@: 34
+PROG BEGIN { @=(int16*) 0x32; @+=1; exit(); }
+EXPECT ^@: 0x34
 TIMEOUT 5
 
 NAME u32 pointer increment
-PROG BEGIN { @=(int32*) 32; @+=1; exit(); }
-EXPECT ^@: 36
+PROG BEGIN { @=(int32*) 0x32; @+=1; exit(); }
+EXPECT ^@: 0x36
 TIMEOUT 5
 
 NAME u64 pointer increment
-PROG BEGIN { @=(int64*) 32; @+=1; exit(); }
-EXPECT ^@: 40
+PROG BEGIN { @=(int64*) 0x32; @+=1; exit(); }
+EXPECT ^@: 0x3a
 TIMEOUT 5
 
 NAME u8 pointer unop post increment
-PROG BEGIN { @=(int8*) 32; @++; exit(); }
-EXPECT ^@: 33
+PROG BEGIN { @=(int8*) 0x32; @++; exit(); }
+EXPECT ^@: 0x33
 TIMEOUT 5
 
 NAME u16 pointer unop post increment
-PROG BEGIN { @=(int16*) 32; @++; exit(); }
-EXPECT ^@: 34
+PROG BEGIN { @=(int16*) 0x32; @++; exit(); }
+EXPECT ^@: 0x34
 TIMEOUT 5
 
 NAME u32 pointer unop post increment
-PROG BEGIN { @=(int32*) 32; @++; exit(); }
-EXPECT ^@: 36
+PROG BEGIN { @=(int32*) 0x32; @++; exit(); }
+EXPECT ^@: 0x36
 TIMEOUT 5
 
 NAME u64 pointer unop post increment
-PROG BEGIN { @=(int64*) 32; @++; exit(); }
-EXPECT ^@: 40
+PROG BEGIN { @=(int64*) 0x32; @++; exit(); }
+EXPECT ^@: 0x3a
 TIMEOUT 5
 
 NAME u8 pointer unop pre increment
-PROG BEGIN { @=(int8*) 32; @++; exit(); }
-EXPECT ^@: 33
+PROG BEGIN { @=(int8*) 0x32; @++; exit(); }
+EXPECT ^@: 0x33
 TIMEOUT 5
 
 NAME u16 pointer unop pre increment
-PROG BEGIN { @=(int16*) 32; @++; exit(); }
-EXPECT ^@: 34
+PROG BEGIN { @=(int16*) 0x32; @++; exit(); }
+EXPECT ^@: 0x34
 TIMEOUT 5
 
 NAME u32 pointer unop pre increment
-PROG BEGIN { @=(int32*) 32; @++; exit(); }
-EXPECT ^@: 36
+PROG BEGIN { @=(int32*) 0x32; @++; exit(); }
+EXPECT ^@: 0x36
 TIMEOUT 5
 
 NAME u64 pointer unop pre increment
-PROG BEGIN { @=(int64*) 32; @++; exit(); }
-EXPECT ^@: 40
+PROG BEGIN { @=(int64*) 0x32; @++; exit(); }
+EXPECT ^@: 0x3a
 TIMEOUT 5
 
 NAME Pointer decrement 1
-PROG BEGIN { @=(int32*) 32; @-=1; exit(); }
-EXPECT ^@: 28
+PROG BEGIN { @=(int32*) 0x32; @-=1; exit(); }
+EXPECT ^@: 0x2e
 TIMEOUT 5
 
 NAME Pointer decrement
-PROG BEGIN { @=(int32*) 32; @--; exit(); }
-EXPECT ^@: 28
+PROG BEGIN { @=(int32*) 0x32; @--; exit(); }
+EXPECT ^@: 0x2e
 TIMEOUT 5
 
 NAME Pointer increment 6
-PROG BEGIN { @=(int32*) 32; @+=6; exit(); }
-EXPECT ^@: 56
+PROG BEGIN { @=(int32*) 0x32; @+=6; exit(); }
+EXPECT ^@: 0x4a
 TIMEOUT 5
 
 NAME Pointer decrement 6
-PROG BEGIN { @=(int32*) 32; @-=6; exit(); }
-EXPECT ^@: 8
+PROG BEGIN { @=(int32*) 0x32; @-=6; exit(); }
+EXPECT ^@: 0x1a
 TIMEOUT 5
 
 NAME Struct pointer math
@@ -84,8 +84,8 @@ EXPECT 1024 - 5 x 36 = 844
 TIMEOUT 5
 
 NAME Pointer decrement with map
-PROG BEGIN { @dec = 4; @=(int32*) 32; @-=@dec; exit(); }
-EXPECT ^@: 16
+PROG BEGIN { @dec = 4; @=(int32*) 0x32; @-=@dec; exit(); }
+EXPECT ^@: 0x22
 TIMEOUT 5
 
 NAME Pointer walk through struct

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -502,6 +502,7 @@ TEST(semantic_analyser, call_print_non_map)
   test(R"_(BEGIN { print((1, 2, "tuple")) })_", 0);
   test(R"_(BEGIN { $x = 1; print($x) })_", 0);
   test(R"_(BEGIN { $x = 1; $y = $x + 3; print($y) })_", 0);
+  test(R"_(BEGIN { print((int8 *)0) })_", 0);
 
   test(R"_(BEGIN { print(3, 5) })_", 1);
   test(R"_(BEGIN { print(3, 5, 2) })_", 1);
@@ -509,7 +510,6 @@ TEST(semantic_analyser, call_print_non_map)
   test(R"_(BEGIN { print(exit()) })_", 10);
   test(R"_(BEGIN { print(count()) })_", 1);
   test(R"_(BEGIN { print(ctx) })_", 1);
-  test(R"_(BEGIN { print((int8 *)0) })_", 10);
 }
 
 TEST(semantic_analyser, call_clear)


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

Until now, field analyser resolved struct fields for structs accessed via a pointer only when the pointer dereference was followed by a field access, i.e. for cases like `p->field`.
    
This does the field resolution on every dereference, particularly allowing to print the entire struct using `print(*p)`.

Also improves printing of pointers as they are often members of kernel structs.


##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
