### PR TITLE
Resolve types in parser

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -21,6 +21,7 @@ MAKE_ACCEPT(Builtin)
 MAKE_ACCEPT(Identifier)
 MAKE_ACCEPT(PositionalParameter)
 MAKE_ACCEPT(Call)
+MAKE_ACCEPT(Sizeof)
 MAKE_ACCEPT(Map)
 MAKE_ACCEPT(Variable)
 MAKE_ACCEPT(Binop)
@@ -52,6 +53,12 @@ Call::~Call()
 
   delete vargs;
   vargs = nullptr;
+}
+Sizeof::~Sizeof()
+{
+  if (expr)
+    delete expr;
+  expr = nullptr;
 }
 Map::~Map()
 {
@@ -256,6 +263,15 @@ Call::Call(const std::string &func, ExpressionList *vargs, location loc)
 {
 }
 
+Sizeof::Sizeof(SizedType type, location loc)
+    : Expression(loc), expr(nullptr), argtype(type)
+{
+}
+
+Sizeof::Sizeof(Expression *expr, location loc) : Expression(loc), expr(expr)
+{
+}
+
 Map::Map(const std::string &ident, location loc)
     : Expression(loc), ident(ident), vargs(nullptr)
 {
@@ -321,18 +337,10 @@ ArrayAccess::ArrayAccess(Expression *expr, Expression *indexpr, location loc)
 {
 }
 
-
-Cast::Cast(const std::string &type,
-           bool is_pointer,
-           bool is_double_pointer,
-           Expression *expr,
-           location loc)
-    : Expression(loc),
-      cast_type(type),
-      is_pointer(is_pointer),
-      is_double_pointer(is_double_pointer),
-      expr(expr)
+Cast::Cast(SizedType cast_type, Expression *expr, location loc)
+    : Expression(loc), expr(expr)
 {
+  type = cast_type;
 }
 
 
@@ -577,6 +585,10 @@ Call::Call(const Call &other) : Expression(other)
   func = other.func;
 }
 
+Sizeof::Sizeof(const Sizeof &other) : Expression(other)
+{
+}
+
 Binop::Binop(const Binop &other) : Expression(other)
 {
   op = other.op;
@@ -613,9 +625,6 @@ Program::Program(const Program &other) : Node(other)
 
 Cast::Cast(const Cast &other) : Expression(other)
 {
-  cast_type = other.cast_type;
-  is_pointer = other.is_pointer;
-  is_double_pointer = other.is_double_pointer;
 }
 
 Probe::Probe(const Probe &other) : Node(other)

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -210,6 +210,23 @@ private:
   Call(const Call &other);
 };
 
+class Sizeof : public Expression
+{
+public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(Sizeof)
+
+  Sizeof(SizedType type, location loc);
+  Sizeof(Expression *expr, location loc);
+  ~Sizeof();
+
+  Expression *expr;
+  SizedType argtype;
+
+private:
+  Sizeof(const Sizeof &other);
+};
+
 class Map : public Expression {
 public:
   DEFINE_ACCEPT
@@ -319,20 +336,9 @@ public:
   DEFINE_LEAFCOPY(Cast)
   DEFINE_ACCEPT
 
-  Cast(const std::string &type,
-       bool is_pointer,
-       bool is_double_pointer,
-       Expression *expr);
-  Cast(const std::string &type,
-       bool is_pointer,
-       bool is_double_pointer,
-       Expression *expr,
-       location loc);
+  Cast(SizedType type, Expression *expr, location loc);
   ~Cast();
 
-  std::string cast_type;
-  bool is_pointer;
-  bool is_double_pointer;
   Expression *expr = nullptr;
 
 private:

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1143,10 +1143,6 @@ void CodegenLLVM::visit(Call &call)
     expr_ = b_.CreateIntCast(expr_, b_.getInt32Ty(), arg.type.IsSigned());
     b_.CreateSignal(ctx_, expr_, call.loc);
   }
-  else if (call.func == "sizeof")
-  {
-    expr_ = b_.getInt64(call.vargs->at(0)->type.GetSize());
-  }
   else if (call.func == "strerror")
   {
     auto scoped_del = accept(call.vargs->front());
@@ -1287,6 +1283,11 @@ void CodegenLLVM::visit(Call &call)
   {
     LOG(FATAL) << "missing codegen for function \"" << call.func << "\"";
   }
+}
+
+void CodegenLLVM::visit(Sizeof &szof)
+{
+  expr_ = b_.getInt64(szof.argtype.GetSize());
 }
 
 void CodegenLLVM::visit(Map &map)

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -37,6 +37,7 @@ public:
   void visit(Builtin &builtin) override;
   void visit(StackMode &) override { };
   void visit(Call &call) override;
+  void visit(Sizeof &szof) override;
   void visit(Map &map) override;
   void visit(Variable &var) override;
   void visit(Binop &binop) override;

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -135,18 +135,14 @@ void FieldAnalyser::visit(FieldAccess &acc)
 void FieldAnalyser::visit(Cast &cast)
 {
   Visit(*cast.expr);
-  sized_type_ = CreateNone();
+  resolve_type(cast.type);
+}
 
-  for (auto &ap : *probe_->attach_points)
-    if (Dwarf *dwarf = bpftrace_.get_dwarf(*ap))
-      sized_type_ = dwarf->get_stype(cast.cast_type);
-
-  if (sized_type_.IsNoneTy() && bpftrace_.has_btf_data())
-    sized_type_ = bpftrace_.btf_->get_stype(cast.cast_type);
-
-  // Could not resolve destination type - let ClangParser do it
-  if (sized_type_.IsNoneTy())
-    bpftrace_.btf_set_.insert(cast.cast_type);
+void FieldAnalyser::visit(Sizeof &szof)
+{
+  if (szof.expr)
+    Visit(*szof.expr);
+  resolve_type(szof.argtype);
 }
 
 void FieldAnalyser::visit(AssignMapStatement &assignment)
@@ -313,6 +309,29 @@ void FieldAnalyser::resolve_fields(SizedType &type)
 
   if (type.GetFieldCount() == 0 && bpftrace_.has_btf_data())
     bpftrace_.btf_->resolve_fields(type);
+}
+
+void FieldAnalyser::resolve_type(SizedType &type)
+{
+  sized_type_ = CreateNone();
+
+  const SizedType *inner_type = &type;
+  while (inner_type->IsPtrTy())
+    inner_type = inner_type->GetPointeeTy();
+  if (!inner_type->IsRecordTy())
+    return;
+  auto name = inner_type->GetName();
+
+  for (auto &ap : *probe_->attach_points)
+    if (Dwarf *dwarf = bpftrace_.get_dwarf(*ap))
+      sized_type_ = dwarf->get_stype(name);
+
+  if (sized_type_.IsNoneTy() && bpftrace_.has_btf_data())
+    sized_type_ = bpftrace_.btf_->get_stype(name);
+
+  // Could not resolve destination type - let ClangParser do it
+  if (sized_type_.IsNoneTy())
+    bpftrace_.btf_set_.insert(name);
 }
 
 void FieldAnalyser::visit(Probe &probe)

--- a/src/ast/passes/field_analyser.h
+++ b/src/ast/passes/field_analyser.h
@@ -32,6 +32,7 @@ public:
   void visit(Variable &var) override;
   void visit(FieldAccess &acc) override;
   void visit(Cast &cast) override;
+  void visit(Sizeof &szof) override;
   void visit(AssignMapStatement &assignment) override;
   void visit(AssignVarStatement &assignment) override;
   void visit(Probe &probe) override;
@@ -42,6 +43,7 @@ private:
   bool resolve_args(Probe &probe);
   bool compare_args(const ProbeArgs &args1, const ProbeArgs &args2);
   void resolve_fields(SizedType &type);
+  void resolve_type(SizedType &type);
 
   Node *root_;
   ProbeType probe_type_;

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -120,6 +120,17 @@ void Printer::visit(Call &call)
   --depth_;
 }
 
+void Printer::visit(Sizeof &szof)
+{
+  std::string indent(depth_, ' ');
+  out_ << indent << "sizeof: " << type(szof.type) << std::endl;
+
+  ++depth_;
+  if (szof.expr)
+    szof.expr->accept(*this);
+  --depth_;
+}
+
 void Printer::visit(Map &map)
 {
   std::string indent(depth_, ' ');
@@ -213,10 +224,7 @@ void Printer::visit(ArrayAccess &arr)
 void Printer::visit(Cast &cast)
 {
   std::string indent(depth_, ' ');
-  if (cast.is_pointer)
-    out_ << indent << "(" << cast.cast_type << "*)" << std::endl;
-  else
-    out_ << indent << "(" << cast.cast_type << ")" << std::endl;
+  out_ << indent << "(" << cast.type << ")" << std::endl;
 
   ++depth_;
   cast.expr->accept(*this);

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -24,6 +24,7 @@ public:
   void visit(Identifier &identifier) override;
   void visit(Builtin &builtin) override;
   void visit(Call &call) override;
+  void visit(Sizeof &szof) override;
   void visit(Map &map) override;
   void visit(Variable &var) override;
   void visit(Binop &binop) override;

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1169,15 +1169,6 @@ void SemanticAnalyser::visit(Call &call)
           << "signal only accepts string literals or integers";
     }
   }
-  else if (call.func == "sizeof")
-  {
-    // sizeof() is a interesting builtin because the arguments can be either
-    // an expression or a type. As a result, the only thing we'll check here
-    // is that we have a single argument.
-    check_nargs(call, 1);
-
-    call.type = CreateUInt64();
-  }
   else if (call.func == "path")
   {
     if (!bpftrace_.feature_->has_d_path())
@@ -1373,6 +1364,17 @@ void SemanticAnalyser::visit(Call &call)
   }
 }
 
+void SemanticAnalyser::visit(Sizeof &szof)
+{
+  szof.type = CreateUInt64();
+  if (szof.expr)
+  {
+    szof.expr->accept(*this);
+    szof.argtype = szof.expr->type;
+  }
+  resolve_struct_type(szof.argtype, szof.loc);
+}
+
 void SemanticAnalyser::check_stack_call(Call &call, bool kernel)
 {
   call.type = CreateStack(kernel);
@@ -1460,8 +1462,10 @@ void SemanticAnalyser::visit(Map &map)
       // a cast into the ast.
       if (expr->type.IsIntTy() && expr->type.GetSize() < 8)
       {
-        std::string type = expr->type.IsSigned() ? "int64" : "uint64";
-        Expression *cast = new ast::Cast(type, false, false, expr, map.loc);
+        Expression *cast = new ast::Cast(expr->type.IsSigned() ? CreateInt64()
+                                                               : CreateUInt64(),
+                                         expr,
+                                         map.loc);
         cast->accept(*this);
         map.vargs->at(i) = cast;
         expr = cast;
@@ -2239,82 +2243,36 @@ void SemanticAnalyser::visit(Cast &cast)
 {
   cast.expr->accept(*this);
 
-  if (cast.expr->type.IsRecordTy())
+  // cast type is synthesised in parser, if it is a struct, it needs resolving
+  resolve_struct_type(cast.type, cast.loc);
+
+  auto rhs = cast.expr->type;
+  if (rhs.IsRecordTy())
   {
     LOG(ERROR, cast.loc, err_)
         << "Cannot cast from struct type \"" << cast.expr->type << "\"";
   }
-  else if (cast.expr->type.IsNoneTy())
+  else if (rhs.IsNoneTy())
   {
     LOG(ERROR, cast.loc, err_)
         << "Cannot cast from \"" << cast.expr->type << "\" type";
   }
 
-  bool is_ctx = cast.expr->type.IsCtxAccess();
-  auto &intcasts = getIntcasts();
-  auto k_v = intcasts.find(cast.cast_type);
-
-  // Built-in int types
-  if (k_v != intcasts.end())
+  if (!cast.type.IsIntTy() && !cast.type.IsPtrTy() &&
+      !(cast.type.IsPtrTy() && !cast.type.GetElementTy()->IsIntTy() &&
+        !cast.type.GetElementTy()->IsRecordTy()))
   {
-    auto &v = k_v->second;
-    if (cast.is_pointer)
-    {
-      cast.type = CreatePointer(CreateInteger(std::get<0>(v), std::get<1>(v)));
-      if (is_ctx)
-      {
-        LOG(ERROR, cast.loc, err_)
-            << "Integer pointer casts are not supported for type: ctx";
-      }
-
-      if (cast.is_double_pointer)
-        cast.type = CreatePointer(cast.type);
-    }
-    else
-    {
-      cast.type = CreateInteger(std::get<0>(v), std::get<1>(v));
-
-      auto rhs = cast.expr->type;
-      // Casting Type::ctx to Type::integer is supported to access a
-      // tracepoint's __data_loc field. See #990 and #770
-      // In this case, the context information will be lost
-      if (!rhs.IsIntTy() && !rhs.IsRecordTy() && !rhs.IsPtrTy() &&
-          !rhs.IsCtxAccess())
-      {
-        LOG(ERROR, cast.loc, err_)
-            << "Casts are not supported for type: \"" << rhs << "\"";
-      }
-    }
-    // Consider both case *(int8)(retval) and *(int8*)retval
-    cast.type.SetAS(cast.expr->type.GetAS());
-    return;
+    LOG(ERROR, cast.loc, err_) << "Cannot cast to \"" << cast.type << "\"";
   }
-
-  if (!bpftrace_.structs.Has(cast.cast_type))
+  if (cast.type.IsIntTy() && !rhs.IsIntTy() && !rhs.IsPtrTy() &&
+      !rhs.IsCtxAccess())
   {
     LOG(ERROR, cast.loc, err_)
-        << "Unknown struct/union: '" << cast.cast_type << "'";
-    return;
+        << "Cannot cast from \"" << rhs << "\" to \"" << cast.type << "\"";
   }
 
-  SizedType struct_type = CreateRecord(
-      cast.cast_type, bpftrace_.structs.Lookup(cast.cast_type));
-
-  if (cast.is_pointer)
-  {
-    cast.type = CreatePointer(struct_type);
-
-    if (cast.is_double_pointer)
-      cast.type = CreatePointer(cast.type);
-  }
-  else
-  {
-    LOG(ERROR, cast.loc, err_)
-        << "Cannot cast to struct type \"" << cast.cast_type << "\"";
-  }
-  if (is_ctx)
+  if (cast.expr->type.IsCtxAccess() && !cast.type.IsIntTy())
     cast.type.MarkCtxAccess();
-
   cast.type.SetAS(cast.expr->type.GetAS());
   // case : BEGIN { @foo = (struct Foo)0; }
   // case : profile:hz:99 $task = (struct task_struct *)curtask.
@@ -3372,6 +3330,30 @@ bool SemanticAnalyser::update_string_size(SizedType &type,
   }
 
   return false;
+}
+
+void SemanticAnalyser::resolve_struct_type(SizedType &type, const location &loc)
+{
+  const SizedType *inner_type = &type;
+  int pointer_level = 0;
+  while (inner_type->IsPtrTy())
+  {
+    inner_type = inner_type->GetPointeeTy();
+    pointer_level++;
+  }
+  if (inner_type->IsRecordTy() && inner_type->GetStruct().expired())
+  {
+    auto struct_type = bpftrace_.structs.Lookup(inner_type->GetName());
+    if (struct_type.expired())
+      LOG(ERROR, loc, err_) << "Cannot resolve unknown type \""
+                            << inner_type->GetName() << "\"\n";
+    type = CreateRecord(inner_type->GetName(), struct_type);
+    while (pointer_level > 0)
+    {
+      type = CreatePointer(type);
+      pointer_level--;
+    }
+  }
 }
 
 Pass CreateSemanticPass()

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -50,6 +50,7 @@ public:
   void visit(Identifier &identifier) override;
   void visit(Builtin &builtin) override;
   void visit(Call &call) override;
+  void visit(Sizeof &szof) override;
   void visit(Map &map) override;
   void visit(Variable &var) override;
   void visit(Binop &binop) override;
@@ -101,6 +102,7 @@ private:
   void assign_map_type(const Map &map, const SizedType &type);
   void update_key_type(const Map &map, const MapKey &new_key);
   bool update_string_size(SizedType &type, const SizedType &new_type);
+  void resolve_struct_type(SizedType &type, const location &loc);
 
   void builtin_args_tracepoint(AttachPoint *attach_point, Builtin &builtin);
   ProbeType single_provider_type(void);

--- a/src/ast/visitors.cpp
+++ b/src/ast/visitors.cpp
@@ -40,6 +40,12 @@ void Visitor::visit(Call &call)
   }
 }
 
+void Visitor::visit(Sizeof &szof)
+{
+  if (szof.expr)
+    Visit(*szof.expr);
+}
+
 void Visitor::visit(Map &map)
 {
   if (map.vargs)
@@ -231,6 +237,14 @@ Node *Mutator::visit(Call &call)
   if (call.vargs)
     c->vargs = mutateExprList(call.vargs);
   return c;
+}
+
+Node *Mutator::visit(Sizeof &szof)
+{
+  auto s = szof.leafcopy();
+  if (szof.expr)
+    s->expr = Value<Expression>(szof.expr);
+  return s;
 }
 
 Node *Mutator::visit(Map &map)

--- a/src/ast/visitors.h
+++ b/src/ast/visitors.h
@@ -22,6 +22,7 @@ public:
   virtual void visit(Identifier &identifier) = 0;
   virtual void visit(StackMode &mode) = 0;
   virtual void visit(Call &call) = 0;
+  virtual void visit(Sizeof &szof) = 0;
   virtual void visit(Map &map) = 0;
   virtual void visit(Variable &var) = 0;
   virtual void visit(Binop &binop) = 0;
@@ -84,6 +85,7 @@ public:
   void visit(Identifier &identifier) override;
   void visit(Builtin &builtin) override;
   void visit(Call &call) override;
+  void visit(Sizeof &szof) override;
   void visit(Map &map) override;
   void visit(Variable &var) override;
   void visit(Binop &binop) override;
@@ -145,6 +147,7 @@ public:
   virtual R visit(Identifier &node) DEFAULT_FN;
   virtual R visit(StackMode &node) DEFAULT_FN;
   virtual R visit(Call &node) DEFAULT_FN;
+  virtual R visit(Sizeof &node) DEFAULT_FN;
   virtual R visit(Map &node) DEFAULT_FN;
   virtual R visit(Variable &node) DEFAULT_FN;
   virtual R visit(Binop &node) DEFAULT_FN;
@@ -190,6 +193,7 @@ private:
     DEFINE_DISPATCH(Identifier);
     DEFINE_DISPATCH(Builtin);
     DEFINE_DISPATCH(Call);
+    DEFINE_DISPATCH(Sizeof);
     DEFINE_DISPATCH(Map);
     DEFINE_DISPATCH(Variable);
     DEFINE_DISPATCH(Binop);
@@ -238,6 +242,7 @@ public:
   Node *visit(Identifier &) override;
   Node *visit(StackMode &) override;
   Node *visit(Call &) override;
+  Node *visit(Sizeof &) override;
   Node *visit(Map &) override;
   Node *visit(Variable &) override;
   Node *visit(Binop &) override;

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -38,7 +38,10 @@ vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#\*])+
 builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ctx|curtask|elapsed|func|gid|nsecs|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
-call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|sizeof|stats|str|strerror|strftime|strncmp|strcontains|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf
+call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|stats|str|strerror|strftime|strncmp|strcontains|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf
+
+simple_type     bool|(u)?int(8|16|32|64)|(u)?(min|max|sum|count|avg|stats)_t|probe_t|username_t|lhist_t|hist_t|usym_t|ksym_t|timestamp_t|macaddr_t|cgroup_path_t|strerror_t
+sized_type      str_t|inet_t|buf_t
 
 /* Don't add to this! Use builtin OR call not both */
 call_and_builtin kstack|ustack
@@ -143,6 +146,11 @@ bpftrace|perf           { return Parser::make_STACK_MODE(yytext, loc); }
 "return"                { return Parser::make_RETURN(loc); }
 "continue"              { return Parser::make_CONTINUE(loc); }
 "break"                 { return Parser::make_BREAK(loc); }
+"sizeof"                { return Parser::make_SIZEOF(loc); }
+
+{simple_type}           { return Parser::make_SIMPLE_TYPE(yytext, loc); }
+{sized_type}            { return Parser::make_SIZED_TYPE(yytext, loc); }
+
 
 \"                      { yy_push_state(STR, yyscanner); buffer.clear(); }
 <STR>{
@@ -168,7 +176,12 @@ bpftrace|perf           { return Parser::make_STACK_MODE(yytext, loc); }
   .                     driver.error(loc, "invalid character"); yy_pop_state(yyscanner);
 }
 
-struct|union|enum       yy_push_state(STRUCT, yyscanner); buffer.clear(); struct_type = yytext;
+struct|union|enum       {
+                            yy_push_state(STRUCT, yyscanner);
+                            buffer.clear();
+                            struct_type = yytext;
+                            return Parser::make_STRUCT(loc);
+                        }
 <STRUCT,BRACE>{
   "*"|")"               {
                           if (YY_START == STRUCT)

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1421,7 +1421,43 @@ TEST(Parser, brackets)
       "   builtin: arg1\n");
 }
 
-TEST(Parser, cast)
+TEST(Parser, cast_simple_type)
+{
+  test("kprobe:sys_read { (int32)arg0; }",
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  (int32)\n"
+       "   builtin: arg0\n");
+}
+
+TEST(Parser, cast_simple_type_pointer)
+{
+  test("kprobe:sys_read { (int32 *)arg0; }",
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  (int32 *)\n"
+       "   builtin: arg0\n");
+}
+
+TEST(Parser, cast_sized_type)
+{
+  test("kprobe:sys_read { (str_t[1])arg0; }",
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  (string[1])\n"
+       "   builtin: arg0\n");
+}
+
+TEST(Parser, cast_sized_type_pointer)
+{
+  test("kprobe:sys_read { (str_t[1] *)arg0; }",
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  (string[1] *)\n"
+       "   builtin: arg0\n");
+}
+
+TEST(Parser, cast_struct)
 {
   test("kprobe:sys_read { (struct mytype)arg0; }",
       "Program\n"
@@ -1435,7 +1471,7 @@ TEST(Parser, cast)
       "   builtin: arg0\n");
 }
 
-TEST(Parser, cast_ptr)
+TEST(Parser, cast_struct_ptr)
 {
   test("kprobe:sys_read { (struct mytype*)arg0; }",
        "Program\n"
@@ -1449,21 +1485,12 @@ TEST(Parser, cast_ptr)
        "   builtin: arg0\n");
 }
 
-TEST(Parser, cast_typedef)
+TEST(Parser, cast_multiple_pointer)
 {
-  test("kprobe:sys_read { (struct mytype)arg0; }",
+  test("kprobe:sys_read { (int32 *****)arg0; }",
        "Program\n"
        " kprobe:sys_read\n"
-       "  (struct mytype)\n"
-       "   builtin: arg0\n");
-}
-
-TEST(Parser, cast_ptr_typedef)
-{
-  test("kprobe:sys_read { (struct mytype*)arg0; }",
-       "Program\n"
-       " kprobe:sys_read\n"
-       "  (struct mytype *)\n"
+       "  (int32 * * * * *)\n"
        "   builtin: arg0\n");
 }
 
@@ -1513,6 +1540,23 @@ TEST(Parser, cast_precedence)
        "   (struct mytype)\n"
        "    builtin: arg0\n"
        "   int: 123\n");
+}
+
+TEST(Parser, sizeof_expression)
+{
+  test("kprobe:sys_read { sizeof(arg0); }",
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  sizeof: \n"
+       "   builtin: arg0\n");
+}
+
+TEST(Parser, sizeof_type)
+{
+  test("kprobe:sys_read { sizeof(int32); }",
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  sizeof: \n");
 }
 
 TEST(Parser, dereference_precedence)

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1438,43 +1438,43 @@ TEST(Parser, cast)
 TEST(Parser, cast_ptr)
 {
   test("kprobe:sys_read { (struct mytype*)arg0; }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  (struct mytype*)\n"
-      "   builtin: arg0\n");
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  (struct mytype *)\n"
+       "   builtin: arg0\n");
   test("kprobe:sys_read { (union mytype*)arg0; }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  (union mytype*)\n"
-      "   builtin: arg0\n");
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  (union mytype *)\n"
+       "   builtin: arg0\n");
 }
 
 TEST(Parser, cast_typedef)
 {
-  test("kprobe:sys_read { (mytype)arg0; }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  (mytype)\n"
-      "   builtin: arg0\n");
+  test("kprobe:sys_read { (struct mytype)arg0; }",
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  (struct mytype)\n"
+       "   builtin: arg0\n");
 }
 
 TEST(Parser, cast_ptr_typedef)
 {
-  test("kprobe:sys_read { (mytype*)arg0; }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  (mytype*)\n"
-      "   builtin: arg0\n");
+  test("kprobe:sys_read { (struct mytype*)arg0; }",
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  (struct mytype *)\n"
+       "   builtin: arg0\n");
 }
 
 TEST(Parser, cast_or_expr1)
 {
-  test("kprobe:sys_read { (mytype)*arg0; }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  (mytype)\n"
-      "   dereference\n"
-      "    builtin: arg0\n");
+  test("kprobe:sys_read { (struct mytype)*arg0; }",
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  (struct mytype)\n"
+       "   dereference\n"
+       "    builtin: arg0\n");
 }
 
 TEST(Parser, cast_or_expr2)
@@ -1489,30 +1489,30 @@ TEST(Parser, cast_or_expr2)
 
 TEST(Parser, cast_precedence)
 {
-  test("kprobe:sys_read { (mytype)arg0.field; }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  (mytype)\n"
-      "   .\n"
-      "    builtin: arg0\n"
-      "    field\n");
+  test("kprobe:sys_read { (struct mytype)arg0.field; }",
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  (struct mytype)\n"
+       "   .\n"
+       "    builtin: arg0\n"
+       "    field\n");
 
-  test("kprobe:sys_read { (mytype*)arg0->field; }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  (mytype*)\n"
-      "   .\n"
-      "    dereference\n"
-      "     builtin: arg0\n"
-      "    field\n");
+  test("kprobe:sys_read { (struct mytype*)arg0->field; }",
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  (struct mytype *)\n"
+       "   .\n"
+       "    dereference\n"
+       "     builtin: arg0\n"
+       "    field\n");
 
-  test("kprobe:sys_read { (mytype)arg0+123; }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  +\n"
-      "   (mytype)\n"
-      "    builtin: arg0\n"
-      "   int: 123\n");
+  test("kprobe:sys_read { (struct mytype)arg0+123; }",
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  +\n"
+       "   (struct mytype)\n"
+       "    builtin: arg0\n"
+       "   int: 123\n");
 }
 
 TEST(Parser, dereference_precedence)

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1959,9 +1959,6 @@ TEST(semantic_analyser, int_cast_types)
   test("kretprobe:f { @ = (uint16)retval }", 0);
   test("kretprobe:f { @ = (uint32)retval }", 0);
   test("kretprobe:f { @ = (uint64)retval }", 0);
-
-  test("kretprobe:f { @ = (int2)retval }", 1);
-  test("kretprobe:f { @ = (uint2)retval }", 1);
 }
 
 TEST(semantic_analyser, int_cast_usage)
@@ -1985,9 +1982,6 @@ TEST(semantic_analyser, intptr_cast_types)
   test("kretprobe:f { @ = *(uint16*)retval }", 0);
   test("kretprobe:f { @ = *(uint32*)retval }", 0);
   test("kretprobe:f { @ = *(uint64*)retval }", 0);
-
-  test("kretprobe:f { @ = *(int2*)retval }", 1);
-  test("kretprobe:f { @ = *(uint2*)retval }", 1);
 }
 
 TEST(semantic_analyser, intptr_cast_usage)
@@ -2434,8 +2428,6 @@ TEST(semantic_analyser, tuple)
   test(R"_(BEGIN { @t = (1, 2); @t = (4, "other"); })_", 10);
   test(R"_(BEGIN { @t = (1, 2); @t = 5; })_", 1);
   test(R"_(BEGIN { @t = (1, count()) })_", 1);
-  test(R"_(BEGIN { @t = (1, (aaa)0) })_", 1);
-  test(R"_(BEGIN { @t = (1, !(aaa)0) })_", 1);
 }
 
 TEST(semantic_analyser, tuple_indexing)
@@ -2568,7 +2560,6 @@ TEST(semantic_analyser, call_path)
 TEST(semantic_analyser, int_ident)
 {
   test("BEGIN { sizeof(int32) }", 0);
-  test("BEGIN { print(int32) }", 1);
 }
 
 TEST(semantic_analyser, tracepoint_common_field)


### PR DESCRIPTION
Instead of parsing types in casts as identifiers, implement separate tokens for type identifiers and parse type expressions. Simple types, parametric size types (like strings) and struct types are all supported. For types whose names collide with builtin functions the _t suffix is used (e.g. min_t).

The main purpose of this is preparation for typing arguments of user-defined functions (see #2516). Currently, it adds arbitrary pointer type nesting and sizeofs of arbitrary types; no new types are supported for casts.

Implementation notes:
- Struct types are generated with empty pointers in the parser and completed in SemanticAnalyser after the types are fetched by FieldAnalyser.
- sizeof is now a special kind of expression instead of being a call, since type arguments are now not treated as expressions.
- unit tests using invalid types had to be changed to use valid ones or removed, otherwise the code would be rejected by the parser

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
