### PR TITLE
Fix access variable length array failed

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1556,10 +1556,11 @@ void SemanticAnalyser::visit(ArrayAccess &arr)
         auto index = bpftrace_.get_int_literal(arr.indexpr);
         if (index.has_value())
         {
-          if ((size_t)*index >= type.GetNumElements())
-            LOG(ERROR, arr.loc, err_) << "the index " << *index
-                                      << " is out of bounds for array of size "
-                                      << type.GetNumElements();
+          size_t num = type.GetNumElements();
+          if (num != 0 && (size_t)*index >= num)
+            LOG(ERROR, arr.loc, err_)
+                << "the index " << *index
+                << " is out of bounds for array of size " << num;
         }
         else
           LOG(ERROR, arr.loc, err_) << "invalid index expression";

--- a/tests/runtime/array
+++ b/tests/runtime/array
@@ -160,3 +160,9 @@ PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_arrays { $a = (
 EXPECT two int arrays are not equal.
 TIMEOUT 5
 AFTER ./testprogs/array_access
+
+NAME variable array element access - assign to map
+PROG struct D { int x; int y[0]; } uprobe:./testprogs/array_access:test_variable_array { $a = (struct D *) arg0; @y = $a->y[0]; exit(); }
+EXPECT @y: 1
+TIMEOUT 5
+AFTER ./testprogs/array_access

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1027,6 +1027,12 @@ TEST(semantic_analyser, array_access) {
        "struct MyStruct { int y[4]; } "
        "kprobe:f { $s = ((struct MyStruct *)arg0)->y[$2]; }",
        10);
+
+  test(bpftrace,
+       "struct MyStruct { int x; int y[]; } "
+       "kprobe:f { $s = (struct MyStruct *) "
+       "arg0; @y = $s->y[0];}",
+       0);
 }
 
 TEST(semantic_analyser, array_in_map)

--- a/tests/testprogs/array_access.c
+++ b/tests/testprogs/array_access.c
@@ -13,6 +13,13 @@ struct C
   int *z[4];
 };
 
+struct D
+{
+  int x;
+  int y[0];
+  int z;
+};
+
 void test_array(int *a __attribute__((unused)))
 {
 }
@@ -28,6 +35,10 @@ void test_struct(struct A *a __attribute__((unused)),
 }
 
 void test_ptr_array(struct C *c __attribute__((unused)))
+{
+}
+
+void test_variable_array(struct D *d __attribute__((unused)))
 {
 }
 
@@ -60,4 +71,8 @@ int main(int argc __attribute__((unused)), char ** argv __attribute__((unused)))
   d.x[2] = 2;
   d.x[3] = 1;
   test_arrays(&a, &d);
+
+  struct D e;
+  e.z = 1;
+  test_variable_array(&e);
 }


### PR DESCRIPTION
After linux merged this commit:
bpf: Support variable length array in tracing programs (9c5f8a1008a121e4c6b24af211034e24b0b63081)
allows access to variable length array with BTF.

But use bpftrace to do it, get this error:
ERROR: the index 0 is out of bounds for array of size 0. So fix it.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
