### PR TITLE
Add pahole dep to ubuntu build requirements.

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -295,7 +295,8 @@ sudo apt-get install -y \
   libpcap-dev \
   libgtest-dev \
   libgmock-dev \
-  asciidoctor
+  asciidoctor \
+  pahole
 git clone https://github.com/iovisor/bpftrace --recurse-submodules
 mkdir bpftrace/build; cd bpftrace/build;
 ../build-libs.sh
@@ -331,7 +332,8 @@ sudo dnf install -y bison \
   gtest-devel \
   gmock-devel \
   cereal-devel \
-  asciidoctor
+  asciidoctor \
+  dwarves
 git clone https://github.com/iovisor/bpftrace --recurse-submodules
 cd bpftrace
 mkdir build; cd build


### PR DESCRIPTION
Building `main` on Ubuntu 22.04 ARM gave me:

```
CMake Error at tests/CMakeLists.txt:50 (find_program):
  Could not find PAHOLE using the following names: pahole
```

`apt install pahole` resolved it.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
