### PR TITLE
Add offsetof() builtin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
   - [#2479](https://github.com/iovisor/bpftrace/pull/2479)
 - Add trailer to truncated strings
   - [#2559](https://github.com/iovisor/bpftrace/pull/2559)
+- Add new function, `offsetof`, get the offset of the element in the struct
+  - [#2565](https://github.com/iovisor/bpftrace/pull/2565)
 #### Changed
 - Improve attaching to uprobes with size 0
   - [#2562](https://github.com/iovisor/bpftrace/pull/2562)

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -2240,6 +2240,7 @@ Tracing block I/O sizes > 0 bytes
 - `kptr(void *p)` - Annotate as kernelspace pointer
 - `macaddr(char[6] addr)` - Convert MAC address data
 - `bswap(uint[8|16|32|64] n)` - Reverse byte order
+- `offsetof(struct, element)` - Offset of element in structure
 
 Some of these are asynchronous: the kernel queues the event, but some time later (milliseconds) it is
 processed in user-space. The asynchronous actions are: `printf()`, `time()`, and `join()`. Both `ksym()`
@@ -3260,6 +3261,31 @@ Example:
 BEGIN { print(strerror(EPERM)); }'
 Attaching 1 probe...
 Operation not permitted
+```
+
+# 35. `offsetof`: Offset of element in structure
+
+Syntax: `offsetof(struct, element)`
+
+Get the offset of the element in the struct.
+
+Examples:
+
+```
+#!/usr/bin/env bpftrace
+
+BEGIN
+{
+	printf("Offset of flags: %ld\n", offsetof(struct task_struct, flags));
+	printf("Offset of comm: %ld\n", offsetof(struct task_struct, comm));
+	exit();
+}
+```
+
+```
+Attaching 1 probe...
+Offset of flags: 44
+Offset of comm: 3216
 ```
 
 # Map Functions

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1569,6 +1569,17 @@ Returns size of the argument in bytes.
 Similar to C/C++ `sizeof` operator.
 Note that the expression does not get evaluated.
 
+=== offsetof
+
+.variants
+* `offsetof(STRUCT, FIELD)`
+
+*compile time*
+
+Returns offset of the field offset bytes in struct.
+Similar to kernel `offsetof` operator.
+Note that subfields are not yet supported.
+
 === str
 
 .variants

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1147,6 +1147,14 @@ void CodegenLLVM::visit(Call &call)
   {
     expr_ = b_.getInt64(call.vargs->at(0)->type.GetSize());
   }
+  else if (call.func == "offsetof")
+  {
+    auto identifier = dynamic_cast<Identifier *>(call.vargs->at(1));
+    assert(identifier && "offsetof() 2nd argument not an identifier");
+
+    auto &field = call.vargs->at(0)->type.GetField(identifier->ident);
+    expr_ = b_.getInt64(field.offset);
+  }
   else if (call.func == "strerror")
   {
     auto scoped_del = accept(call.vargs->front());

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -38,7 +38,7 @@ vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#\*])+
 builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ctx|curtask|elapsed|func|gid|nsecs|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
-call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|sizeof|stats|str|strerror|strftime|strncmp|strcontains|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf
+call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|sizeof|stats|str|strerror|strftime|strncmp|strcontains|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf|offsetof
 
 /* Don't add to this! Use builtin OR call not both */
 call_and_builtin kstack|ustack
@@ -170,10 +170,10 @@ bpftrace|perf           { return Parser::make_STACK_MODE(yytext, loc); }
 
 struct|union|enum       yy_push_state(STRUCT, yyscanner); buffer.clear(); struct_type = yytext;
 <STRUCT,BRACE>{
-  "*"|")"               {
+  "*"|")"|","           {
                           if (YY_START == STRUCT)
                           {
-                            // Finished parsing the typename of a cast
+                            // Finished parsing the typename of a cast or a call arg
                             // Put the cast type into a canonical form by trimming
                             // and then inserting a single space.
                             yy_pop_state(yyscanner);

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -337,6 +337,7 @@ primary_expr:
         |       int                { $$ = $1; }
         |       STRING             { $$ = new ast::String($1, @$); }
         |       STACK_MODE         { $$ = new ast::StackMode($1, @$); }
+        |       CALL               { $$ = new ast::Call($1, @$); }
         |       BUILTIN            { $$ = new ast::Builtin($1, @$); }
         |       CALL_BUILTIN       { $$ = new ast::Builtin($1, @$); }
         |       LPAREN expr RPAREN { $$ = $2; }

--- a/tests/codegen/call_offsetof.cpp
+++ b/tests/codegen/call_offsetof.cpp
@@ -1,0 +1,16 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, call_offsetof)
+{
+  test("struct Foo { int x; long l; char c; } BEGIN { @x = offsetof(struct "
+       "Foo, x); exit(); }",
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/call_offsetof.ll
+++ b/tests/codegen/llvm/call_offsetof.ll
@@ -1,0 +1,46 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @BEGIN(i8* %0) section "s_BEGIN_1" {
+entry:
+  %perfdata = alloca i64, align 8
+  %"@x_val" = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  %1 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 0, i64* %"@x_key", align 8
+  %2 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_val", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
+  %3 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  %5 = bitcast i64* %perfdata to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i64 30000, i64* %perfdata, align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, i64*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, i64* %perfdata, i64 8)
+  %6 = bitcast i64* %perfdata to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  ret i64 0
+
+deadcode:                                         ; No predecessors!
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -205,3 +205,8 @@ PROG BEGIN { printf("size=%d\n", sizeof(struct task_struct)); exit(); }
 EXPECT ^size=
 TIMEOUT 5
 REQUIRES_FEATURE btf
+
+NAME offsetof
+PROG struct Foo { int x; long l; char c; } BEGIN { printf("%ld\n", offsetof(struct Foo, x)); exit(); }
+EXPECT ^0$
+TIMEOUT 5

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2571,6 +2571,59 @@ TEST(semantic_analyser, call_path)
   test("END { $k = path( 1 ) }", 1);
 }
 
+TEST(semantic_analyser, call_offsetof)
+{
+  test("struct Foo { int x; long l; char c; } \
+        BEGIN { @x = offsetof(struct Foo, x); }",
+       0);
+  test("struct Foo { int x; long l; char c; } \
+        BEGIN { @x = offsetof(struct Foo, z); }",
+       1);
+  test("struct Foo { int offsetof; } \
+        BEGIN { @x = offsetof(struct Foo, offsetof); }",
+       0);
+  test("struct Foo { int comm; } \
+        BEGIN { @x = offsetof(struct Foo, comm); }",
+       0);
+  test("struct Foo { int ctx; } \
+        BEGIN { @x = offsetof(struct Foo, ctx); }",
+       0);
+  test("struct Foo { int args; } \
+        BEGIN { @x = offsetof(struct Foo, args); }",
+       0);
+  test("struct Foo { int x; long l; char c; } \
+        BEGIN { @x = offsetof(struct Foo); }",
+       1);
+  test("BEGIN { @x = offsetof(struct _NonExistStruct_, z); }", 1);
+  test("struct Foo { int x; long l; char c; } \
+        struct Bar { struct Foo foo; int x; } \
+        BEGIN { @x = offsetof(struct Bar, x); }",
+       0);
+  test("struct Foo { int x; long l; char c; } \
+        union Bar { struct Foo foo; int x; } \
+        BEGIN { @x = offsetof(union Bar, x); }",
+       0);
+  test("struct Foo { int x; long l; char c; } \
+        struct Fun { struct Foo foo; int (*call)(void); } \
+        BEGIN { @x = offsetof(struct Fun, call); }",
+       0);
+  test("struct Foo { int x; long l; char c; } \
+        struct Ano { \
+          struct { \
+            struct Foo foo; \
+            int a; \
+          }; \
+          long l; \
+        } \
+        BEGIN { @x = offsetof(struct Ano, a); }",
+       0);
+  test("struct offsetof { int offsetof; int bswap;} \
+        BEGIN { \
+          @x = offsetof(struct offsetof, offsetof); \
+        }",
+       0);
+}
+
 TEST(semantic_analyser, int_ident)
 {
   test("BEGIN { sizeof(int32) }", 0);


### PR DESCRIPTION
Add the offsetof() function, the syntax follows the kernel offsetof() macro definition, and currently only supports single-member format parameters such as offsetof(struct task_struct, comm). The function returns a long integer with the output format '%ld'.

This is the second PR for offsetof(), the first version was not merged, and the discussion of offsetof() can be found in the first PR [0].

Basic use:

```
    #include <linux/sched.h>

    struct Foo {
        int a;
        long b;
        char c;
        struct {
            int d;
        };
        struct {
            int a;
        } e;
        int offsetof;
    }
    struct offsetof {
        int offsetof;
        int bswap;
	int comm;
	int kstack;
	int ustack;
	int pid;
	int ctx;
	int arg;
    }

    BEGIN {
        printf("%ld\n", offsetof(struct Foo, c));
        printf("%ld\n", offsetof(struct Foo, d));
        printf("%ld\n", offsetof(struct Foo, offsetof));

        printf("%ld\n", offsetof(struct offsetof, offsetof));
        printf("%ld\n", offsetof(struct offsetof, bswap));

        printf("%ld\n", offsetof(struct task_struct, comm));
        printf("%ld\n", offsetof(*curtask, comm));

        exit();
    }
```

  Get offset:
```
    16
    20
    28
    0
    4
    3240
    3240
```

Wrong use:

```
    # ERROR: offsetof() requires 2 arguments (1 provided)
    printf("%ld\n", offsetof(struct Foo));

    # ERROR: The first argument of offsetof() only supports record (pointer provided)
    printf("%ld\n", offsetof(curtask, d));

    # ERROR: struct 'struct Foo' has no field 'xyz'
    printf("%ld\n", offsetof(struct Foo, xyz));

    # ERROR: The first argument of offsetof() only supports record (none provided)
    printf("%ld\n", offsetof(c, struct Foo));

    # ERROR: offsetof() unsupport subfield format.
    printf("%ld\n", offsetof(struct Foo, e.a));

    # ERROR: offsetof() unsupport subfield format.
    printf("%ld\n", offsetof(struct Foo, e->a));

    # ERROR: struct 'struct Foo' has no field '@e'
    printf("%ld\n", offsetof(struct Foo, @e));

    # ERROR: struct 'struct Foo' has no field '$e'
    printf("%ld\n", offsetof(struct Foo, $e));

    # ERROR: offsetof() unsupport expression format.
    printf("%ld\n", offsetof(struct Foo, e+a));
```

[0] https://github.com/iovisor/bpftrace/pull/2216
