### PR TITLE
Update INSTALL.md build from source deps for later Ubuntu version

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -288,10 +288,10 @@ sudo apt-get install -y \
   systemtap-sdt-dev \
   binutils-dev \
   libcereal-dev \
-  llvm-12-dev \
-  llvm-12-runtime \
-  libclang-12-dev \
-  clang-12 \
+  llvm-dev \
+  llvm-runtime \
+  libclang-dev \
+  clang \
   libpcap-dev \
   libgtest-dev \
   libgmock-dev \


### PR DESCRIPTION
On the latest ubuntu versions, by default, clang-12 or llvm-12 related packages are not present. As an example we're using llvm-15* on ubuntu 22.04. This PR simplifies and fixes the ubuntu build steps from souce. 

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests -- Not applicable
