### PR TITLE
[RFC] Add docker image to build and run bpftrace for both amd64, arm64 and powerpc

### DIFF
--- a/cmake/embed/embed_llvm.cmake
+++ b/cmake/embed/embed_llvm.cmake
@@ -173,7 +173,11 @@ endif()
 
 set(LLVM_EMBEDDED_CMAKE_TARGETS "")
 
-include_directories(SYSTEM ${EMBEDDED_LLVM_INSTALL_DIR}/include)
+# The below .. is needed otherwise the Demangle header is not found:
+#0 81.26 /bpftrace/src/cxxdemangler/cxxdemangler_llvm.cpp:3:10: fatal error: llvm/Demangle/Demangle.h: No such file or directory
+#0 81.26     3 | #include <llvm/Demangle/Demangle.h>
+#0 81.26       |
+include_directories(SYSTEM ${EMBEDDED_LLVM_INSTALL_DIR}/../include)
 
 foreach(llvm_target IN LISTS LLVM_LIBRARY_TARGETS)
   list(APPEND LLVM_EMBEDDED_CMAKE_TARGETS ${llvm_target})

--- a/docker/Dockerfile.cross
+++ b/docker/Dockerfile.cross
@@ -1,0 +1,79 @@
+ARG BUILDER_IMAGE=debian:bullseye
+ARG BASE_IMAGE=debian:bullseye
+ARG LLVM=ghcr.io/iovisor/llvm
+FROM ${LLVM} as llvm
+FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder
+ARG LLVM_VERSION=12
+ARG BUILD_TYPE=Release
+ARG TARGETARCH
+ARG BUILDARCH
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ENV TARGETARCH=${TARGETARCH}
+ENV BUILDARCH=${BUILDARCH}
+
+COPY --from=llvm /usr/local /usr/local
+
+RUN if [ "${TARGETARCH}" != "${BUILDARCH}" ]; then \
+    PACKAGEARCH="${TARGETARCH}"; \
+    if [ "${TARGETARCH}" = 'ppc64le' ]; then \
+      PACKAGEARCH='ppc64el'; \
+    fi; \
+    dpkg --add-architecture ${PACKAGEARCH}; \
+  fi \
+  && apt-get update \
+  && apt-get install -y \
+    bison \
+    cmake \
+    flex \
+    libcereal-dev:${PACKAGEARCH} \
+    libelf-dev:${PACKAGEARCH} \
+    libiberty-dev:${PACKAGEARCH} \
+    make \
+    pkg-config \
+  && if [ "${TARGETARCH}" == "${BUILDARCH}" ]; then \
+    apt-get install -y gcc g++; \
+  elif [ "${TARGETARCH}" = 'arm64' ]; then \
+    apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu; \
+  elif [ "${TARGETARCH}" = 'ppc64le' ]; then \
+    apt-get install -y gcc-powerpc64le-linux-gnu g++-powerpc64le-linux-gnu; \
+  elif [ "${TARGETARCH}" = 'amd64' ]; then \
+    apt-get install -y gcc-x86-64-linux-gnu g++-x86-64-linux-gnu; \
+  else \
+    echo "${TARGETARCH} is not supported" 1>&2; \
+    exit 1;\
+  fi
+
+COPY ./ /bpftrace
+
+RUN mkdir /bpftrace/build \
+  && cd /bpftrace/build \
+  && if [ "${TARGETARCH}" = 'arm64' -a "${BUILDARCH}" != 'arm64' ]; then \
+    export CC=aarch64-linux-gnu-gcc; \
+    export AR=aarch64-linux-gnu-ar; \
+    export CXX=aarch64-linux-gnu-g++; \
+  elif [ "${TARGETARCH}" = 'ppc64le' -a "${BUILDARCH}" != 'ppc64le' ]; then \
+    export CC=powerpc64le-linux-gnu-gcc; \
+    export AR=powerpc64le-linux-gnu-ar; \
+    export CXX=powerpc64le-linux-gnu-g++; \
+  elif [ "${TARGETARCH}" = 'amd64' -a "${BUILDARCH}" != 'amd64' ]; then \
+    export CC=x86_64-linux-gnu-gcc; \
+    export AR=x86_64-linux-gnu-ar; \
+    export CXX=x86_64-linux-gnu-g++; \
+  fi \
+  && bash /bpftrace/build-libs.sh \
+  && cmake -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+    -DSTATIC_LINKING:BOOL=ON \
+    -DEMBED_USE_LLVM:BOOL=ON \
+    -DEMBED_BUILD_LLVM:BOOL=OFF \
+    -DEMBED_LLVM_VERSION=${LLVM_VERSION} \
+    -DALLOW_UNSAFE_PROBE:BOOL=OFF \
+    -DBUILD_TESTING:BOOL=OFF \
+    -DCMAKE_VERBOSE_MAKEFILE:BOOL=ON \
+    -DENABLE_SKB_OUTPUT:BOOL=OFF \
+    ../ \
+  && make -j$(nproc)
+
+FROM ${BASE_IMAGE}
+COPY --from=builder /bpftrace/build/src/bpftrace /usr/bin/bpftrace

--- a/docker/Dockerfile.llvm-cross
+++ b/docker/Dockerfile.llvm-cross
@@ -1,0 +1,74 @@
+ARG BUILDER_IMAGE=debian:bullseye
+ARG BASE_IMAGE=debian:bullseye
+FROM --platform=${BUILDPLATFORM} ${BUILDER_IMAGE} as builder
+ARG LLVM_VERSION=12
+ARG BUILD_TYPE=Release
+ARG TARGETARCH
+ARG BUILDARCH
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+ENV TARGETARCH=${TARGETARCH}
+ENV BUILDARCH=${BUILDARCH}
+
+RUN if [ "${TARGETARCH}" != "${BUILDARCH}" ]; then \
+    PACKAGEARCH="${TARGETARCH}"; \
+    if [ "${TARGETARCH}" = 'ppc64le' ]; then \
+      PACKAGEARCH='ppc64el'; \
+    fi; \
+    dpkg --add-architecture ${PACKAGEARCH}; \
+  fi \
+  && apt-get update \
+  && apt-get install -y \
+    binutils-dev:${PACKAGEARCH} \
+    cmake \
+    libelf-dev:${PACKAGEARCH} \
+    make \
+    pkg-config \
+    python3 \
+    rsync \
+  && if [ "${TARGETARCH}" == "${BUILDARCH}" ]; then \
+    apt-get install -y gcc g++; \
+  elif [ "${TARGETARCH}" = 'arm64' ]; then \
+    cp /usr/include/plugin-api.h /tmp; \
+    apt-get install -y gcc-aarch64-linux-gnu g++-aarch64-linux-gnu; \
+    cp /tmp/plugin-api.h /usr/include; \
+  elif [ "${TARGETARCH}" = 'ppc64le' ]; then \
+    cp /usr/include/plugin-api.h /tmp; \
+    apt-get install -y gcc-powerpc64le-linux-gnu g++-powerpc64le-linux-gnu; \
+    cp /tmp/plugin-api.h /usr/include; \
+  elif [ "${TARGETARCH}" = 'amd64' ]; then \
+    apt-get install -y gcc-x86-64-linux-gnu g++-x86-64-linux-gnu; \
+  else \
+    echo "${TARGETARCH} is not supported" 1>&2; \
+    exit 1;\
+  fi
+
+COPY ./ /bpftrace
+
+RUN mkdir /bpftrace/build \
+  && mkdir /bpftrace/build/llvm \
+  && cp -r /bpftrace/cmake /bpftrace/build/llvm \
+  && cp /bpftrace/CMakeLists-LLVM.txt /bpftrace/build/llvm/CMakeLists.txt \
+  && cd /bpftrace/build/llvm \
+  && if [ "${TARGETARCH}" = 'arm64' -a "${BUILDARCH}" != 'arm64' ]; then \
+    export CC=aarch64-linux-gnu-gcc; \
+    export AR=aarch64-linux-gnu-ar; \
+    export CXX=aarch64-linux-gnu-g++; \
+  elif [ "${TARGETARCH}" = 'ppc64le' -a "${BUILDARCH}" != 'ppc64le' ]; then \
+    export CC=powerpc64le-linux-gnu-gcc; \
+    export AR=powerpc64le-linux-gnu-ar; \
+    export CXX=powerpc64le-linux-gnu-g++; \
+  elif [ "${TARGETARCH}" = 'amd64' -a "${BUILDARCH}" != 'amd64' ]; then \
+    export CC=x86_64-linux-gnu-gcc; \
+    export AR=x86_64-linux-gnu-ar; \
+    export CXX=x86_64-linux-gnu-g++; \
+  fi \
+  && cmake . -DLLVM_VERSION=${LLVM_VERSION} \
+    -DCMAKE_BUILD_TYPE=${BUILD_TYPE} \
+  && make embedded_llvm -j$(nproc) \
+  && make embedded_clang -j$(nproc) \
+  && rm -rf embedded_llvm-prefix/src embedded_clang-prefix/src \
+  && rm -rf embedded_llvm-prefix/tmp embedded_clang-prefix/tmp \
+  && rsync -a embedded_clang-prefix/ embedded_llvm-prefix/ /usr/local \
+  && rm -rf /bpftrace/build/llvm

--- a/scripts/build-docker-bpftrace.sh
+++ b/scripts/build-docker-bpftrace.sh
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+
+docker buildx build -t ghcr.io/iovisor/bpftrace --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.cross .

--- a/scripts/build-docker-llvm.sh
+++ b/scripts/build-docker-llvm.sh
@@ -1,0 +1,3 @@
+#! /usr/bin/env bash
+
+docker buildx build --push -t ghcr.io/iovisor/llvm --platform=linux/arm64,linux/amd64 -f docker/Dockerfile.llvm-cross .


### PR DESCRIPTION
Hi.


With this PR, I added a new `dockerfile` which is used to first build `bpftrace` and then make it usable for both `amd64` and `arm64`.
Note that, for `arm64`, `bpftrace` is cross-compiled so it does not take more than time than building it for `amd64`.

You can build the image for both architecture with:

```bash
$ docker buildx build --platform=linux/amd64,linux/arm64 -t bpftrace -f docker/Dockerfile.cross
```

Then you can run it with:

```bash
$ docker buildx build --load --platform=linux/amd64 -t bpftrace-amd -f docker/Dockerfile.cross
$ docker run --rm -ti --privileged bpftrace-amd
root@d32016dabfb4:/# bpftrace -e 'kprobe:do_nanosleep { printf("PID %d sleeping...\n", pid); }'
PID 2209 sleeping...
PID 62649 sleeping...
PID 2209 sleeping...
^C
```

You can of course test the `bpftrace-arm64` with the same way on an `arm64` computer:

```bash
$ lscpu | head -1
Architecture:           aarch64
$ docker run --rm --privileged -ti bpftrace-arm
root@78893e525312:/# bpftrace -e 'kprobe:do_nanosleep { printf("PID %d sleeping...\n", pid); }'
PID 4581 sleeping...
PID 3754 sleeping...
^C
```

I would like to get your opinion on this contribution as I think it can replace several dockerfiles here.
Nonetheless, I also would like to get specific reviews, particularly on the `cmake` changes and also on how to use `STATIC_LINKING` as I failed to use it with both `libclang-dev` installed from `debian` repo as I should miss including some static libraries and with `EMBED_USE_LLVM` and `LLVM_VERSION=12` as I got an error regarding missing `clang-c/Index.h`.


Best regards and thank you in advance.