### PR TITLE
CMake: make libebl independent of libdw

### DIFF
--- a/cmake/FindLibDw.cmake
+++ b/cmake/FindLibDw.cmake
@@ -31,21 +31,11 @@ find_library (LIBDW_LIBRARIES
     ENV LIBRARY_PATH
     ENV LD_LIBRARY_PATH)
 
-find_library (LIBEBL_LIBRARIES
-  NAMES
-    ebl
-  PATH_SUFFIXES
-    libebl
-  PATHS
-    ENV LIBRARY_PATH
-    ENV LD_LIBRARY_PATH)
-
 include (FindPackageHandleStandardArgs)
 
 # handle the QUIETLY and REQUIRED arguments and set LIBDW_FOUND to TRUE if all listed variables are TRUE
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibDw "Please install the libdw development package"
   LIBDW_LIBRARIES
-  LIBEBL_LIBRARIES
   LIBDW_INCLUDE_DIRS)
 
-mark_as_advanced(LIBDW_INCLUDE_DIRS LIBEBL_LIBRARIES LIBDW_LIBRARIES)
+mark_as_advanced(LIBDW_INCLUDE_DIRS LIBDW_LIBRARIES)

--- a/cmake/FindLibEbl.cmake
+++ b/cmake/FindLibEbl.cmake
@@ -1,0 +1,21 @@
+# - Try to find libebl static library
+# Once done this will define
+#
+#  LIBEBL_FOUND - system has libebl
+#  LIBEBL_LIBRARIES - Link these to use libebl
+
+find_library(LIBEBL_LIBRARIES
+  NAMES
+    ebl
+  PATH_SUFFIXES
+    libebl
+  PATHS
+    ENV LIBRARY_PATH
+    ENV LD_LIBRARY_PATH)
+
+include (FindPackageHandleStandardArgs)
+
+FIND_PACKAGE_HANDLE_STANDARD_ARGS(LibEbl "Please install the libebl static library"
+  LIBEBL_LIBRARIES)
+
+mark_as_advanced(LIBEBL_LIBRARIES)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -171,19 +171,28 @@ endif(STATIC_BPF_BCC)
 if (LIBDW_FOUND)
   if(STATIC_LINKING)
     find_package(LibBz2)
+    find_package(LibLzma)
+    find_package(LibEbl)
+
     add_library(LIBBZ2 STATIC IMPORTED)
     set_property(TARGET LIBBZ2 PROPERTY IMPORTED_LOCATION ${LIBBZ2_LIBRARIES})
 
-    find_package(LibLzma)
     add_library(LIBLZMA STATIC IMPORTED)
     set_property(TARGET LIBLZMA PROPERTY IMPORTED_LOCATION ${LIBLZMA_LIBRARIES})
 
-    add_library(LIBEBL STATIC IMPORTED)
-    set_property(TARGET LIBEBL PROPERTY IMPORTED_LOCATION ${LIBEBL_LIBRARIES})
-
     add_library(LIBDW STATIC IMPORTED)
     set_property(TARGET LIBDW PROPERTY IMPORTED_LOCATION ${LIBDW_LIBRARIES})
-    target_link_libraries(LIBDW INTERFACE LIBBZ2 LIBELF LIBLZMA LIBEBL)
+
+    set(LIBDW_LIBS LIBBZ2 LIBELF LIBLZMA)
+
+    if (${LIBEBL_FOUND})
+      # libebl is not necessary on some systems (e.g. Alpine)
+      add_library(LIBEBL STATIC IMPORTED)
+      set_property(TARGET LIBEBL PROPERTY IMPORTED_LOCATION ${LIBEBL_LIBRARIES})
+      set(LIBDW_LIBS ${LIBDW_LIBS} LIBEBL)
+    endif()
+
+    target_link_libraries(LIBDW INTERFACE ${LIBDW_LIBS})
 
     target_link_libraries(runtime LIBDW)
   else()
@@ -221,7 +230,7 @@ if (STATIC_LINKING)
     target_link_libraries(libbpftrace "-Wl,-Bdynamic" "-lrt" "-lpthread" "-ldl" "-lm")
     target_link_libraries(libbpftrace "-Wl,-Bstatic" "-lz")
     target_link_libraries(runtime "-Wl,-Bdynamic" "-lrt" "-lpthread" "-ldl" "-lm")
-    target_link_libraries(runtime "-Wl,-Bstatic" "-lz")  
+    target_link_libraries(runtime "-Wl,-Bstatic" "-lz")
   endif()
 elseif(STATIC_BPF_BCC)
   # partial static build, libbpf needs zlib


### PR DESCRIPTION
#2555 added a search for libebl into `FindLibDw.cmake`. The problem is that distros only provide libebl as a static library which makes the search for libdw fail when linking dynamically.

Since libebl is necessary for static builds only, this separates its search into `FindLibEbl.cmake` and require it from static builds.

In addition, libebl is not necessary on all systems (e.g. Alpine doesn't have it), so we make its requirement optional. This may cause some trouble when running a static build on a system *with* libdw but *without* libebl but since those two are usually packaged in the same package, that shouldn't occur often.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
