### PR TITLE
Use blacklist to filter unavailable kprobes

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,6 +36,7 @@ add_library(runtime
   required_resources.cpp
   struct.cpp
   tracefs.cpp
+  debugfs.cpp
   types.cpp
   usdt.cpp
   utils.cpp

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -10,6 +10,7 @@
 #include <unistd.h>
 
 #include "btf.h"
+#include "debugfs.h"
 #include "probe_matcher.h"
 #include "tracefs.h"
 #include "utils.h"

--- a/src/debugfs.cpp
+++ b/src/debugfs.cpp
@@ -1,0 +1,20 @@
+#include "debugfs.h"
+#include <unistd.h>
+
+namespace bpftrace {
+namespace debugfs {
+
+#define DEBUGFS "/sys/kernel/debug"
+
+std::string path()
+{
+  return DEBUGFS;
+}
+
+std::string path(const std::string &file)
+{
+  return path() + "/" + file;
+}
+
+} // namespace debugfs
+} // namespace bpftrace

--- a/src/debugfs.h
+++ b/src/debugfs.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <string>
+
+namespace bpftrace {
+namespace debugfs {
+
+std::string path();
+
+std::string path(const std::string &file);
+
+inline std::string kprobes_blacklist()
+{
+  return path("kprobes/blacklist");
+}
+
+} // namespace debugfs
+} // namespace bpftrace

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -112,8 +112,7 @@ std::set<std::string> ProbeMatcher::get_matches_for_probetype(
     case ProbeType::kprobe:
     case ProbeType::kretprobe:
     {
-      symbol_stream = get_symbols_from_file_safe(
-          tracefs::available_filter_functions());
+      symbol_stream = get_symbols_from_traceable_funcs();
       ignore_trailing_module = true;
       break;
     }
@@ -206,6 +205,24 @@ std::unique_ptr<std::istream> ProbeMatcher::get_symbols_from_file(
   }
 
   return file;
+}
+
+std::unique_ptr<std::istream> ProbeMatcher::get_symbols_from_traceable_funcs(
+    void) const
+{
+  std::string funcs;
+  for (auto& func_mod : bpftrace_->traceable_funcs_)
+  {
+    if (func_mod.second.empty() || *func_mod.second.begin() == "vmlinux")
+    {
+      funcs += func_mod.first + "\n";
+    }
+    else
+    {
+      funcs += func_mod.first + " [" + *func_mod.second.begin() + "]\n";
+    }
+  }
+  return std::make_unique<std::istringstream>(funcs);
 }
 
 std::unique_ptr<std::istream> ProbeMatcher::get_symbols_from_file_safe(

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -95,6 +95,8 @@ private:
 
   virtual std::unique_ptr<std::istream> get_symbols_from_file(
       const std::string &path) const;
+  virtual std::unique_ptr<std::istream> get_symbols_from_traceable_funcs(
+      void) const;
   virtual std::unique_ptr<std::istream> get_symbols_from_file_safe(
       const std::string &path) const;
   virtual std::unique_ptr<std::istream> get_func_symbols_from_file(

--- a/src/utils.h
+++ b/src/utils.h
@@ -209,6 +209,8 @@ bool symbol_has_module(const std::string &symbol);
 std::string strip_symbol_module(const std::string &symbol);
 std::pair<std::string, std::string> split_symbol_module(
     const std::string &symbol);
+std::tuple<std::string, std::string, std::string> split_addrrange_symbol_module(
+    const std::string &symbol);
 
 // Generate object file section name for a given probe
 inline std::string get_section_name_for_probe(

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -212,8 +212,7 @@ TEST(bpftrace, add_probes_wildcard)
       "kprobe:sys_read,kprobe:my_*,kprobe:sys_write{}");
 
   auto bpftrace = get_strict_mock_bpftrace();
-  EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_symbols_from_file(tracefs::available_filter_functions()))
+  EXPECT_CALL(*bpftrace->mock_probe_matcher, get_symbols_from_traceable_funcs())
       .Times(1);
 
   if (bpftrace->has_kprobe_multi())
@@ -249,8 +248,7 @@ TEST(bpftrace, add_probes_wildcard_no_matches)
       "kprobe:sys_read,kprobe:not_here_*,kprobe:sys_write{}");
 
   auto bpftrace = get_strict_mock_bpftrace();
-  EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_symbols_from_file(tracefs::available_filter_functions()))
+  EXPECT_CALL(*bpftrace->mock_probe_matcher, get_symbols_from_traceable_funcs())
       .Times(1);
 
   ASSERT_EQ(0, bpftrace->add_probe(*probe));
@@ -279,8 +277,7 @@ TEST(bpftrace, add_probes_kernel_module_wildcard)
 {
   ast::Probe *probe = parse_probe("kprobe:func_in_mo*{}");
   auto bpftrace = get_strict_mock_bpftrace();
-  EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_symbols_from_file(tracefs::available_filter_functions()))
+  EXPECT_CALL(*bpftrace->mock_probe_matcher, get_symbols_from_traceable_funcs())
       .Times(1);
 
   ASSERT_EQ(0, bpftrace->add_probe(*probe));

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -11,17 +11,16 @@ using ::testing::StrictMock;
 
 void setup_mock_probe_matcher(MockProbeMatcher &matcher)
 {
-  ON_CALL(matcher, get_symbols_from_file(tracefs::available_filter_functions()))
-      .WillByDefault([](const std::string &) {
-        std::string ksyms = "SyS_read\n"
-                            "sys_read\n"
-                            "sys_write\n"
-                            "my_one\n"
-                            "my_two\n"
-                            "func_in_mod [kernel_mod]\n";
-        auto myval = std::unique_ptr<std::istream>(new std::istringstream(ksyms));
-        return myval;
-      });
+  ON_CALL(matcher, get_symbols_from_traceable_funcs()).WillByDefault([](void) {
+    std::string ksyms = "SyS_read\n"
+                        "sys_read\n"
+                        "sys_write\n"
+                        "my_one\n"
+                        "my_two\n"
+                        "func_in_mod [kernel_mod]\n";
+    auto myval = std::unique_ptr<std::istream>(new std::istringstream(ksyms));
+    return myval;
+  });
 
   ON_CALL(matcher, get_symbols_from_file(tracefs::available_events()))
       .WillByDefault([](const std::string &) {

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -23,6 +23,8 @@ public:
 #endif
   MOCK_CONST_METHOD1(get_symbols_from_file,
                      std::unique_ptr<std::istream>(const std::string &path));
+  MOCK_CONST_METHOD0(get_symbols_from_traceable_funcs,
+                     std::unique_ptr<std::istream>(void));
   MOCK_CONST_METHOD2(get_symbols_from_usdt,
                      std::unique_ptr<std::istream>(int pid,
                                                    const std::string &target));

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -46,6 +46,24 @@ TEST(utils, split_string)
   EXPECT_EQ(split_string("foo-bar", '-'), tokens_foo_bar);
 }
 
+TEST(utils, split_addrrange_symbol_module)
+{
+  std::tuple<std::string, std::string, std::string> tokens_ar_sym = {
+    "0xffffffff85201511-0xffffffff8520152f", "first_nmi", ""
+  };
+  std::tuple<std::string, std::string, std::string> tokens_ar_sym_mod = {
+    "0xffffffffc17e9373-0xffffffffc17e94ff", "vmx_vmexit", "kvm_intel"
+  };
+
+  EXPECT_EQ(split_addrrange_symbol_module(
+                "0xffffffff85201511-0xffffffff8520152f	first_nmi"),
+            tokens_ar_sym);
+  EXPECT_EQ(split_addrrange_symbol_module(
+                "0xffffffffc17e9373-0xffffffffc17e94ff	vmx_vmexit "
+                "[kvm_intel]"),
+            tokens_ar_sym_mod);
+}
+
 TEST(utils, wildcard_match)
 {
   std::vector<std::string> tokens_not = {"not"};


### PR DESCRIPTION
Some functions in the kernel are explicitly designated as non-kprobe, such as do_trap() in the kernel with such a declaration:

  NOKPROBE_SYMBOL(do_trap);

So the file /sys/kernel/debug/kprobes/blacklist contains the do_trap() function. Now, the -l parameter of bpftrace can be found in this kprobe:

  $ sudo bpftrace -l | grep do_trap
  kprobe:do_trap

If attach kprobe:do_trap will report an error directly, which is not the result we are seeing. We should filter out this kprobe as early as possible.

  $ sudo bpftrace -e 'kprobe:do_trap {}'
  Attaching 1 probe...
  cannot attach kprobe, Invalid argument
  ERROR: Error attaching probe: 'kprobe:do_trap'

Because do_trap() is in the available_filter_functions:

  $ sudo grep do_trap /sys/kernel/debug/tracing/available_filter_functions
  do_trap

So using a blacklist to filter out do_trap() is a good solution:

  $ sudo grep do_trap /sys/kernel/debug/kprobes/blacklist
  0xffffffff846258d0-0xffffffff846259f0	do_trap
