### PR TITLE
Enable watchpoint support for PowerPC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
   - [#2479](https://github.com/iovisor/bpftrace/pull/2479)
 - Add trailer to truncated strings
   - [#2559](https://github.com/iovisor/bpftrace/pull/2559)
+- Enable watchpoint support for PowerPC
+  - [#2577](https://github.com/iovisor/bpftrace/pull/2577)
 #### Changed
 - Improve attaching to uprobes with size 0
   - [#2562](https://github.com/iovisor/bpftrace/pull/2562)

--- a/src/arch/ppc64.cpp
+++ b/src/arch/ppc64.cpp
@@ -129,8 +129,13 @@ std::string name()
 
 std::vector<std::string> invalid_watchpoint_modes()
 {
-  throw std::runtime_error(
-      "Watchpoints are not supported on this architecture");
+  // See PowerISA Book III v3.1B, Section 5.4.4 and 10.4
+  return std::vector<std::string>{
+    "x",
+    "rx",
+    "wx",
+    "rwx",
+  };
 }
 
 } // namespace arch


### PR DESCRIPTION
PowerPC supports data watchpoint through DAWR register. The invalid watchpoint modes referenced from
PowerISA Book III v3.1B, Section 5.4.4 and 10.4

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->
