### PR TITLE
Add offsetof()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
   - [#2559](https://github.com/iovisor/bpftrace/pull/2559)
 - Enable watchpoint support for PowerPC
   - [#2577](https://github.com/iovisor/bpftrace/pull/2577)
+- Add new function, `offsetof`, get the offset of the element in the struct
+  - [#2579](https://github.com/iovisor/bpftrace/pull/2579)
 #### Changed
 - Improve attaching to uprobes with size 0
   - [#2562](https://github.com/iovisor/bpftrace/pull/2562)

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -2280,6 +2280,7 @@ Tracing block I/O sizes > 0 bytes
 - `kptr(void *p)` - Annotate as kernelspace pointer
 - `macaddr(char[6] addr)` - Convert MAC address data
 - `bswap(uint[8|16|32|64] n)` - Reverse byte order
+- `offsetof(struct, element)` - Offset of element in structure
 
 Some of these are asynchronous: the kernel queues the event, but some time later (milliseconds) it is
 processed in user-space. The asynchronous actions are: `printf()`, `time()`, and `join()`. Both `ksym()`
@@ -3300,6 +3301,33 @@ Example:
 BEGIN { print(strerror(EPERM)); }'
 Attaching 1 probe...
 Operation not permitted
+```
+
+# 35. `offsetof`: Offset of element in structure
+
+Syntax:
+- `offsetof(struct, element)`
+- `offsetof(expression, element)`
+
+Get the offset of the element in the struct.
+
+Examples:
+
+```
+#!/usr/bin/env bpftrace
+
+BEGIN
+{
+	printf("Offset of flags: %ld\n", offsetof(struct task_struct, flags));
+	printf("Offset of comm: %ld\n", offsetof(*curtask, comm));
+	exit();
+}
+```
+
+```
+Attaching 1 probe...
+Offset of flags: 44
+Offset of comm: 3216
 ```
 
 # Map Functions

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1569,6 +1569,18 @@ Returns size of the argument in bytes.
 Similar to C/C++ `sizeof` operator.
 Note that the expression does not get evaluated.
 
+=== offsetof
+
+.variants
+* `offsetof(STRUCT, FIELD)`
+* `offsetof(EXPRESSION, FIELD)`
+
+*compile time*
+
+Returns offset of the field offset bytes in struct.
+Similar to kernel `offsetof` operator.
+Note that subfields are not yet supported.
+
 === str
 
 .variants

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -22,6 +22,7 @@ MAKE_ACCEPT(Identifier)
 MAKE_ACCEPT(PositionalParameter)
 MAKE_ACCEPT(Call)
 MAKE_ACCEPT(Sizeof)
+MAKE_ACCEPT(Offsetof)
 MAKE_ACCEPT(Map)
 MAKE_ACCEPT(Variable)
 MAKE_ACCEPT(Binop)
@@ -55,6 +56,12 @@ Call::~Call()
   vargs = nullptr;
 }
 Sizeof::~Sizeof()
+{
+  if (expr)
+    delete expr;
+  expr = nullptr;
+}
+Offsetof::~Offsetof()
 {
   if (expr)
     delete expr;
@@ -269,6 +276,16 @@ Sizeof::Sizeof(SizedType type, location loc)
 }
 
 Sizeof::Sizeof(Expression *expr, location loc) : Expression(loc), expr(expr)
+{
+}
+
+Offsetof::Offsetof(SizedType record, std::string &field, location loc)
+    : Expression(loc), record(record), expr(nullptr), field(field)
+{
+}
+
+Offsetof::Offsetof(Expression *expr, std::string &field, location loc)
+    : Expression(loc), expr(expr), field(field)
 {
 }
 
@@ -586,6 +603,10 @@ Call::Call(const Call &other) : Expression(other)
 }
 
 Sizeof::Sizeof(const Sizeof &other) : Expression(other)
+{
+}
+
+Offsetof::Offsetof(const Offsetof &other) : Expression(other)
 {
 }
 

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -227,6 +227,24 @@ private:
   Sizeof(const Sizeof &other);
 };
 
+class Offsetof : public Expression
+{
+public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(Offsetof)
+
+  Offsetof(SizedType record, std::string &field, location loc);
+  Offsetof(Expression *expr, std::string &field, location loc);
+  ~Offsetof();
+
+  SizedType record;
+  Expression *expr;
+  std::string field;
+
+private:
+  Offsetof(const Offsetof &other);
+};
+
 class Map : public Expression {
 public:
   DEFINE_ACCEPT

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1294,6 +1294,12 @@ void CodegenLLVM::visit(Sizeof &szof)
   expr_ = b_.getInt64(szof.argtype.GetSize());
 }
 
+void CodegenLLVM::visit(Offsetof &ofof)
+{
+  auto &field = ofof.record.GetField(ofof.field);
+  expr_ = b_.getInt64(field.offset);
+}
+
 void CodegenLLVM::visit(Map &map)
 {
   auto [key, scoped_key_deleter] = getMapKey(map);

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -38,6 +38,7 @@ public:
   void visit(StackMode &) override { };
   void visit(Call &call) override;
   void visit(Sizeof &szof) override;
+  void visit(Offsetof &ofof) override;
   void visit(Map &map) override;
   void visit(Variable &var) override;
   void visit(Binop &binop) override;

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -139,6 +139,13 @@ void FieldAnalyser::visit(Sizeof &szof)
   resolve_type(szof.argtype);
 }
 
+void FieldAnalyser::visit(Offsetof &ofof)
+{
+  if (ofof.expr)
+    Visit(*ofof.expr);
+  resolve_type(ofof.record);
+}
+
 void FieldAnalyser::visit(AssignMapStatement &assignment)
 {
   Visit(*assignment.map);

--- a/src/ast/passes/field_analyser.h
+++ b/src/ast/passes/field_analyser.h
@@ -33,6 +33,7 @@ public:
   void visit(FieldAccess &acc) override;
   void visit(Cast &cast) override;
   void visit(Sizeof &szof) override;
+  void visit(Offsetof &ofof) override;
   void visit(AssignMapStatement &assignment) override;
   void visit(AssignVarStatement &assignment) override;
   void visit(Unop &unop) override;

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -131,6 +131,17 @@ void Printer::visit(Sizeof &szof)
   --depth_;
 }
 
+void Printer::visit(Offsetof &ofof)
+{
+  std::string indent(depth_, ' ');
+  out_ << indent << "offsetof: " << type(ofof.type) << std::endl;
+
+  ++depth_;
+  if (ofof.expr)
+    ofof.expr->accept(*this);
+  --depth_;
+}
+
 void Printer::visit(Map &map)
 {
   std::string indent(depth_, ' ');

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -25,6 +25,7 @@ public:
   void visit(Builtin &builtin) override;
   void visit(Call &call) override;
   void visit(Sizeof &szof) override;
+  void visit(Offsetof &ofof) override;
   void visit(Map &map) override;
   void visit(Variable &var) override;
   void visit(Binop &binop) override;

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -51,6 +51,7 @@ public:
   void visit(Builtin &builtin) override;
   void visit(Call &call) override;
   void visit(Sizeof &szof) override;
+  void visit(Offsetof &ofof) override;
   void visit(Map &map) override;
   void visit(Variable &var) override;
   void visit(Binop &binop) override;

--- a/src/ast/visitors.cpp
+++ b/src/ast/visitors.cpp
@@ -46,6 +46,12 @@ void Visitor::visit(Sizeof &szof)
     Visit(*szof.expr);
 }
 
+void Visitor::visit(Offsetof &ofof)
+{
+  if (ofof.expr)
+    Visit(*ofof.expr);
+}
+
 void Visitor::visit(Map &map)
 {
   if (map.vargs)
@@ -244,6 +250,14 @@ Node *Mutator::visit(Sizeof &szof)
   auto s = szof.leafcopy();
   if (szof.expr)
     s->expr = Value<Expression>(szof.expr);
+  return s;
+}
+
+Node *Mutator::visit(Offsetof &ofof)
+{
+  auto s = ofof.leafcopy();
+  if (ofof.expr)
+    s->expr = Value<Expression>(ofof.expr);
   return s;
 }
 

--- a/src/ast/visitors.h
+++ b/src/ast/visitors.h
@@ -23,6 +23,7 @@ public:
   virtual void visit(StackMode &mode) = 0;
   virtual void visit(Call &call) = 0;
   virtual void visit(Sizeof &szof) = 0;
+  virtual void visit(Offsetof &ofof) = 0;
   virtual void visit(Map &map) = 0;
   virtual void visit(Variable &var) = 0;
   virtual void visit(Binop &binop) = 0;
@@ -86,6 +87,7 @@ public:
   void visit(Builtin &builtin) override;
   void visit(Call &call) override;
   void visit(Sizeof &szof) override;
+  void visit(Offsetof &ofof) override;
   void visit(Map &map) override;
   void visit(Variable &var) override;
   void visit(Binop &binop) override;
@@ -148,6 +150,7 @@ public:
   virtual R visit(StackMode &node) DEFAULT_FN;
   virtual R visit(Call &node) DEFAULT_FN;
   virtual R visit(Sizeof &node) DEFAULT_FN;
+  virtual R visit(Offsetof &node) DEFAULT_FN;
   virtual R visit(Map &node) DEFAULT_FN;
   virtual R visit(Variable &node) DEFAULT_FN;
   virtual R visit(Binop &node) DEFAULT_FN;
@@ -194,6 +197,7 @@ private:
     DEFINE_DISPATCH(Builtin);
     DEFINE_DISPATCH(Call);
     DEFINE_DISPATCH(Sizeof);
+    DEFINE_DISPATCH(Offsetof);
     DEFINE_DISPATCH(Map);
     DEFINE_DISPATCH(Variable);
     DEFINE_DISPATCH(Binop);
@@ -243,6 +247,7 @@ public:
   Node *visit(StackMode &) override;
   Node *visit(Call &) override;
   Node *visit(Sizeof &) override;
+  Node *visit(Offsetof &) override;
   Node *visit(Map &) override;
   Node *visit(Variable &) override;
   Node *visit(Binop &) override;

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -147,6 +147,7 @@ bpftrace|perf           { return Parser::make_STACK_MODE(yytext, loc); }
 "continue"              { return Parser::make_CONTINUE(loc); }
 "break"                 { return Parser::make_BREAK(loc); }
 "sizeof"                { return Parser::make_SIZEOF(loc); }
+"offsetof"              { return Parser::make_OFFSETOF(loc); }
 
 {simple_type}           { return Parser::make_SIMPLE_TYPE(yytext, loc); }
 {sized_type}            { return Parser::make_SIZED_TYPE(yytext, loc); }
@@ -183,10 +184,10 @@ struct|union|enum       {
                             return Parser::make_STRUCT(loc);
                         }
 <STRUCT,BRACE>{
-  "*"|")"               {
+  "*"|")"|","           {
                           if (YY_START == STRUCT)
                           {
-                            // Finished parsing the typename of a cast
+                            // Finished parsing the typename of a cast or a call arg
                             // Put the cast type into a canonical form by trimming
                             // and then inserting a single space.
                             yy_pop_state(yyscanner);

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -103,6 +103,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
   CONTINUE   "continue"
   BREAK      "break"
   SIZEOF     "sizeof"
+  OFFSETOF   "offsetof"
 ;
 
 %token <std::string> BUILTIN "builtin"
@@ -130,6 +131,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %type <ast::AttachPointList *> attach_points
 %type <ast::Call *> call
 %type <ast::Sizeof *> sizeof_expr
+%type <ast::Offsetof *> offsetof_expr
 %type <ast::Expression *> and_expr addi_expr primary_expr cast_expr conditional_expr equality_expr expr logical_and_expr muli_expr
 %type <ast::Expression *> logical_or_expr map_or_var or_expr postfix_expr relational_expr shift_expr tuple_access_expr unary_expr xor_expr
 %type <ast::ExpressionList *> vargs
@@ -418,6 +420,7 @@ postfix_expr:
         |       postfix_expr "[" expr "]" { $$ = new ast::ArrayAccess($1, $3, @2 + @4); }
         |       call                      { $$ = $1; }
         |       sizeof_expr               { $$ = $1; }
+        |       offsetof_expr             { $$ = $1; }
         |       map_or_var INCREMENT      { $$ = new ast::Unop(ast::Operator::INCREMENT, $1, true, @2); }
         |       map_or_var DECREMENT      { $$ = new ast::Unop(ast::Operator::DECREMENT, $1, true, @2); }
 /* errors */
@@ -526,6 +529,12 @@ cast_expr:
 sizeof_expr:
                 SIZEOF "(" type ")"                         { $$ = new ast::Sizeof($3, @$); }
         |       SIZEOF "(" expr ")"                         { $$ = new ast::Sizeof($3, @$); }
+                ;
+
+offsetof_expr:
+                OFFSETOF "(" struct_type "," ident ")"      { $$ = new ast::Offsetof($3, $5, @$); }
+/* For example: offsetof(*curtask, comm) */
+        |       OFFSETOF "(" expr "," ident ")"             { $$ = new ast::Offsetof($3, $5, @$); }
                 ;
 
 int:

--- a/tests/codegen/call_offsetof.cpp
+++ b/tests/codegen/call_offsetof.cpp
@@ -1,0 +1,16 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, call_offsetof)
+{
+  test("struct Foo { int x; long l; char c; }"
+       "BEGIN { @x = offsetof(struct Foo, x); exit(); }",
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/call_offsetof.ll
+++ b/tests/codegen/llvm/call_offsetof.ll
@@ -1,0 +1,46 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @BEGIN(i8* %0) section "s_BEGIN_1" {
+entry:
+  %perfdata = alloca i64, align 8
+  %"@x_val" = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  %1 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 0, i64* %"@x_key", align 8
+  %2 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 0, i64* %"@x_val", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
+  %3 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  %5 = bitcast i64* %perfdata to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i64 30000, i64* %perfdata, align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %perf_event_output = call i64 inttoptr (i64 25 to i64 (i8*, i64, i64, i64*, i64)*)(i8* %0, i64 %pseudo1, i64 4294967295, i64* %perfdata, i64 8)
+  %6 = bitcast i64* %perfdata to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  ret i64 0
+
+deadcode:                                         ; No predecessors!
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1559,6 +1559,33 @@ TEST(Parser, sizeof_type)
        "  sizeof: \n");
 }
 
+TEST(Parser, offsetof_type)
+{
+  test("struct Foo { int x; } BEGIN { offsetof(struct Foo, x); }",
+       "struct Foo { int x; };\n"
+       "\n"
+       "Program\n"
+       " BEGIN\n"
+       "  offsetof: \n");
+}
+
+TEST(Parser, offsetof_expression)
+{
+  test("struct Foo { int x; }; "
+       "BEGIN { $foo = (struct Foo *)0; offsetof(*$foo, x); }",
+       "struct Foo { int x; };;\n"
+       "\n"
+       "Program\n"
+       " BEGIN\n"
+       "  =\n"
+       "   variable: $foo\n"
+       "   (struct Foo *)\n"
+       "    int: 0\n"
+       "  offsetof: \n"
+       "   dereference\n"
+       "    variable: $foo\n");
+}
+
 TEST(Parser, dereference_precedence)
 {
   test("kprobe:sys_read { *@x+1 }",

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -205,3 +205,8 @@ PROG BEGIN { printf("size=%d\n", sizeof(struct task_struct)); exit(); }
 EXPECT ^size=
 TIMEOUT 5
 REQUIRES_FEATURE btf
+
+NAME offsetof
+PROG struct Foo { int x; long l; char c; } BEGIN { printf("%ld\n", offsetof(struct Foo, x)); exit(); }
+EXPECT ^0$
+TIMEOUT 5

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2569,6 +2569,53 @@ TEST(semantic_analyser, call_path)
   test("END { $k = path( 1 ) }", 1);
 }
 
+TEST(semantic_analyser, call_offsetof)
+{
+  test("struct Foo { int x; long l; char c; } \
+        BEGIN { @x = offsetof(struct Foo, x); }",
+       0);
+  test("struct Foo { int comm; } \
+        BEGIN { @x = offsetof(struct Foo, comm); }",
+       0);
+  test("struct Foo { int ctx; } \
+        BEGIN { @x = offsetof(struct Foo, ctx); }",
+       0);
+  test("struct Foo { int args; } \
+        BEGIN { @x = offsetof(struct Foo, args); }",
+       0);
+  test("struct Foo { int x; long l; char c; } \
+        struct Bar { struct Foo foo; int x; } \
+        BEGIN { @x = offsetof(struct Bar, x); }",
+       0);
+  test("struct Foo { int x; long l; char c; } \
+        union Bar { struct Foo foo; int x; } \
+        BEGIN { @x = offsetof(union Bar, x); }",
+       0);
+  test("struct Foo { int x; long l; char c; } \
+        struct Fun { struct Foo foo; int (*call)(void); } \
+        BEGIN { @x = offsetof(struct Fun, call); }",
+       0);
+  test("struct Foo { int x; long l; char c; } \
+        BEGIN { $foo = (struct Foo *)0; \
+        @x = offsetof(*$foo, x); }",
+       0);
+  test("struct Foo { int x; long l; char c; } \
+        struct Ano { \
+          struct { \
+            struct Foo foo; \
+            int a; \
+          }; \
+          long l; \
+        } \
+        BEGIN { @x = offsetof(struct Ano, a); }",
+       0);
+  test("struct Foo { int x; long l; char c; } \
+        BEGIN { @x = offsetof(struct Foo, __notexistfield__); }",
+       1);
+  test("BEGIN { @x = offsetof(__passident__, x); }", 1);
+  test("BEGIN { @x = offsetof(struct __notexiststruct__, x); }", 1);
+}
+
 TEST(semantic_analyser, int_ident)
 {
   test("BEGIN { sizeof(int32) }", 0);


### PR DESCRIPTION
Add the offsetof() function, the syntax follows the kernel offsetof() macro definition, and currently only supports single-member format parameters such as offsetof(struct task_struct, comm). The function returns a long integer with the output format '%ld'.

This is the second PR for offsetof(), v1[0] and v2[1] was not merged, and the discussion of offsetof() can be found in [0][1].

Basic use:
```
    struct Foo {
        int a;
        long b;
        char c;
        struct {
            int d;
        };
        struct {
            int a;
        } e;
    }
    struct offsetof {
        int bswap;
	int comm;
	int kstack;
	int ustack;
	int pid;
	int ctx;
	int arg;
    }

    BEGIN {
        printf("%ld\n", offsetof(struct Foo, c));
        printf("%ld\n", offsetof(struct Foo, d));

        printf("%ld\n", offsetof(struct offsetof, bswap));

        printf("%ld\n", offsetof(struct task_struct, comm));
        printf("%ld\n", offsetof(*curtask, comm));

        exit();
    }
```

  Get offset:
```
    16
    20
    0
    3240
    3240
```

[0] v1: https://github.com/iovisor/bpftrace/pull/2216
[1] v2: https://github.com/iovisor/bpftrace/pull/2565
