### PR TITLE
Add StackMode::raw for unsymbolized addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to
   - [#2577](https://github.com/iovisor/bpftrace/pull/2577)
 - Add new function, `offsetof`, get the offset of the element in the struct
   - [#2579](https://github.com/iovisor/bpftrace/pull/2579)
+- Add 'StackMode::raw' for ustack and kstack formatting
+  - [#2581](https://github.com/iovisor/bpftrace/pull/2581)
 #### Changed
 - Improve attaching to uprobes with size 0
   - [#2562](https://github.com/iovisor/bpftrace/pull/2562)

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -2693,7 +2693,7 @@ Attaching 1 probe...
 ]: 22186
 ```
 
-You can also choose a different output format. Available formats are `bpftrace` and `perf`:
+You can also choose a different output format. Available formats are `bpftrace`, `perf`, and `raw` (no symbolization):
 
 ```
 # bpftrace -e 'kprobe:do_mmap { @[kstack(perf)] = count(); }'
@@ -2705,6 +2705,20 @@ Attaching 1 probe...
 	ffffffffb3e334eb sys_mmap+27
 	ffffffffb3e03ae3 do_syscall_64+115
 	ffffffffb4800081 entry_SYSCALL_64_after_hwframe+61
+
+]: 22186
+```
+
+```
+# bpftrace -e 'kprobe:do_mmap { @[kstack(raw)] = count(); }'
+Attaching 1 probe...
+[...]
+@[
+	ffffffffb4019501
+	ffffffffb401700a
+	ffffffffb3e334eb
+	ffffffffb3e03ae3
+	ffffffffb4800081
 
 ]: 22186
 ```
@@ -2813,7 +2827,7 @@ Attaching 1 probe...
 ]: 27
 ```
 
-You can also choose a different output format. Available formats are `bpftrace` and `perf`:
+You can also choose a different output format. Available formats are `bpftrace`, `perf`, and `raw` (no symbolization):
 
 ```
 # bpftrace -e 'uprobe:bash:readline { printf("%s\n", ustack(perf)); }'
@@ -2839,6 +2853,15 @@ Attaching 1 probe...
 	5649feec4090 readline+0 (/home/mmarchini/bash/bash/bash)
 	5649fee2bfa6 yy_readline_get+451 (/home/mmarchini/bash/bash/bash)
 	5649fee2bdc6 yy_getc+13 (/home/mmarchini/bash/bash/bash)
+```
+
+```
+# bpftrace -e 'uprobe:bash:readline { printf("%s\n", ustack(raw, 3)); }'
+Attaching 1 probe...
+
+	5649feec4090
+	5649fee2bfa6
+	5649fee2bdc6
 ```
 
 Note that for these examples to work, bash had to be recompiled with frame pointers.

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -105,7 +105,13 @@ void SemanticAnalyser::visit(StackMode &mode)
     mode.type.stack_type.mode = bpftrace::StackMode::bpftrace;
   } else if (mode.mode == "perf") {
     mode.type.stack_type.mode = bpftrace::StackMode::perf;
-  } else {
+  }
+  else if (mode.mode == "raw")
+  {
+    mode.type.stack_type.mode = bpftrace::StackMode::raw;
+  }
+  else
+  {
     mode.type = CreateNone();
     LOG(ERROR, mode.loc, err_) << "Unknown stack mode: '" + mode.mode + "'";
   }

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1777,6 +1777,11 @@ std::string BPFtrace::get_stack(uint64_t stackidpid, bool ustack, StackType stac
   {
     if (addr == 0)
       break;
+    if (stack_type.mode == StackMode::raw)
+    {
+      stack << std::hex << addr << std::endl;
+      continue;
+    }
     std::string sym;
     if (!ustack)
       sym = resolve_ksym(addr, true);
@@ -1789,6 +1794,10 @@ std::string BPFtrace::get_stack(uint64_t stackidpid, bool ustack, StackType stac
         break;
       case StackMode::perf:
         stack << "\t" << std::hex << addr << std::dec << " " << sym << std::endl;
+        break;
+      case StackMode::raw:
+        LOG(BUG) << "StackMode::raw should have been processed before "
+                    "symbolication.";
         break;
     }
   }

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -71,7 +71,7 @@ oct_esc  [0-7]{1,3}
   <<EOF>>               yy_pop_state(yyscanner); driver.error(loc, "end of file during comment");
 }
 
-bpftrace|perf           { return Parser::make_STACK_MODE(yytext, loc); }
+bpftrace|perf|raw       { return Parser::make_STACK_MODE(yytext, loc); }
 {builtin}               { return Parser::make_BUILTIN(yytext, loc); }
 {call}                  { return Parser::make_CALL(yytext, loc); }
 {call_and_builtin}      { return Parser::make_CALL_BUILTIN(yytext, loc); }

--- a/src/types.h
+++ b/src/types.h
@@ -66,6 +66,7 @@ enum class StackMode
 {
   bpftrace,
   perf,
+  raw,
 };
 
 struct StackType
@@ -592,6 +593,8 @@ struct hash<bpftrace::StackType>
         return std::hash<std::string>()("bpftrace#" + to_string(obj.limit));
       case bpftrace::StackMode::perf:
         return std::hash<std::string>()("perf#" + to_string(obj.limit));
+      case bpftrace::StackMode::raw:
+        return std::hash<std::string>()("raw#" + to_string(obj.limit));
     }
 
     return {}; // unreached

--- a/tests/codegen/call_ustack.cpp
+++ b/tests/codegen/call_ustack.cpp
@@ -14,6 +14,7 @@ TEST(codegen, call_ustack)
   // program
   test("kprobe:f { @x = ustack(); @y = ustack(6) }", result);
   test("kprobe:f { @x = ustack(perf); @y = ustack(perf, 6) }", result);
+  test("kprobe:f { @x = ustack(raw); @y = ustack(raw, 6) }", result);
   test("kprobe:f { @x = ustack(perf); @y = ustack(bpftrace) }", result);
 }
 
@@ -59,8 +60,9 @@ TEST(codegen, call_ustack_modes_mapids)
   auto bpftrace = get_mock_bpftrace();
   Driver driver(*bpftrace);
 
-  ASSERT_EQ(driver.parse_str("kprobe:f { @x = ustack(perf); @y = "
-                             "ustack(bpftrace); @z = ustack() }"),
+  ASSERT_EQ(driver.parse_str(
+                "kprobe:f { @w = ustack(raw); @x = ustack(perf); @y = "
+                "ustack(bpftrace); @z = ustack() }"),
             0);
 
   ClangParser clang;
@@ -81,13 +83,15 @@ TEST(codegen, call_ustack_modes_mapids)
   ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
   codegen.compile();
 
-  ASSERT_EQ(std::distance(bpftrace->maps.begin(), bpftrace->maps.end()), 6);
-  ASSERT_EQ(bpftrace->maps.CountStackTypes(), 2U);
+  ASSERT_EQ(std::distance(bpftrace->maps.begin(), bpftrace->maps.end()), 8);
+  ASSERT_EQ(bpftrace->maps.CountStackTypes(), 3U);
 
   StackType stack_type;
   stack_type.mode = StackMode::perf;
   ASSERT_TRUE(bpftrace->maps.Has(stack_type));
   stack_type.mode = StackMode::bpftrace;
+  ASSERT_TRUE(bpftrace->maps.Has(stack_type));
+  stack_type.mode = StackMode::raw;
   ASSERT_TRUE(bpftrace->maps.Has(stack_type));
 }
 

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1346,9 +1346,27 @@ TEST(Parser, wildcard_func)
        "  int: 1\n");
 
   std::string keywords[] = {
-    "arg0", "args", "curtask", "func", "gid" "rand", "uid",
-    "avg", "cat", "exit", "kaddr", "min", "printf", "usym",
-    "kstack", "ustack", "bpftrace", "perf", "uprobe", "kprobe",
+    "arg0",
+    "args",
+    "curtask",
+    "func",
+    "gid"
+    "rand",
+    "uid",
+    "avg",
+    "cat",
+    "exit",
+    "kaddr",
+    "min",
+    "printf",
+    "usym",
+    "kstack",
+    "ustack",
+    "bpftrace",
+    "perf",
+    "raw",
+    "uprobe",
+    "kprobe",
   };
   for(auto kw : keywords)
   {

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -825,6 +825,8 @@ TEST(semantic_analyser, call_stack)
   test("kprobe:f { ustack(3) }", 0);
   test("kprobe:f { kstack(perf, 3) }", 0);
   test("kprobe:f { ustack(perf, 3) }", 0);
+  test("kprobe:f { kstack(raw, 3) }", 0);
+  test("kprobe:f { ustack(raw, 3) }", 0);
 
   // Wrong arguments
   test("kprobe:f { kstack(3, perf) }", 1);
@@ -2125,9 +2127,27 @@ TEST(semantic_analyser, unwatch)
 TEST(semantic_analyser, struct_member_keywords)
 {
   std::string keywords[] = {
-    "arg0", "args", "curtask", "func", "gid" "rand", "uid",
-    "avg", "cat", "exit", "kaddr", "min", "printf", "usym",
-    "kstack", "ustack", "bpftrace", "perf", "uprobe", "kprobe",
+    "arg0",
+    "args",
+    "curtask",
+    "func",
+    "gid"
+    "rand",
+    "uid",
+    "avg",
+    "cat",
+    "exit",
+    "kaddr",
+    "min",
+    "printf",
+    "usym",
+    "kstack",
+    "ustack",
+    "bpftrace",
+    "perf",
+    "raw",
+    "uprobe",
+    "kprobe",
   };
   for(auto kw : keywords)
   {


### PR DESCRIPTION
Summary:
Some tools that use bpftrace would rather do their own symbolication (e.g. with llvm or a symbolication service). Using 'raw' as a StackMode outputs just the raw addresses without bpftrace doing the symbolication.

Test Plan:
Updated unit tests and tested locally:
```
sudo ./src/bpftrace -e 'kprobe:do_nanosleep { printf("Jordan\n%s\n",
ustack(raw));  }'
```
Example output:
```
Attaching 1 probe...
Jordan

7f058de12155

Jordan

7f088cae85b3
7f088caed253
1f3418b
6187e12
7f088cedf2e5
7f088ca979bf
7f088cb288ac
```

Reviewers:

Subscribers:

Tasks:

Tags:

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
