### PR TITLE
Fix the problem of kfunc loading failure in 5.10 kernel which doesn't support module btf

### DIFF
--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -499,6 +499,7 @@ std::string BPFfeature::report(void)
       << "  Instruction limit: " << instruction_limit() << std::endl
       << "  Loop support: " << to_str(has_loop())
       << "  btf: " << to_str(has_btf())
+      << "  module btf: " << to_str(has_module_btf())
       << "  map batch: " << to_str(has_map_batch())
       << "  uprobe refcount (depends on Build:bcc bpf_attach_uprobe refcount): "
       << to_str(has_uprobe_refcnt()) << std::endl;
@@ -552,6 +553,39 @@ out_false:
 bool BPFfeature::has_kfunc()
 {
   return has_prog_kfunc() && btf_.has_data();
+}
+
+bool BPFfeature::has_module_btf()
+{
+  if (has_module_btf_.has_value())
+    return *has_module_btf_;
+
+  char name[64];
+  struct bpf_btf_info info = {};
+  info.name = (__u64)name;
+  info.name_len = sizeof(name);
+  __u32 id = 0, info_len = sizeof(info);
+  int err = 0, fd = -1;
+
+  err = bpf_btf_get_next_id(id, &id);
+  if (err)
+    goto not_support;
+
+  fd = bpf_btf_get_fd_by_id(id);
+  if (fd < 0)
+    goto not_support;
+
+  err = bpf_obj_get_info_by_fd(fd, &info, &info_len);
+  close(fd);
+  if (err)
+    goto not_support;
+
+  has_module_btf_ = true;
+  return *has_module_btf_;
+
+not_support:
+  has_module_btf_ = false;
+  return *has_module_btf_;
 }
 
 } // namespace bpftrace

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -84,6 +84,7 @@ public:
   bool has_skb_output();
   bool has_raw_tp_special();
   bool has_prog_kfunc();
+  bool has_module_btf();
 
   std::string report(void);
 
@@ -129,6 +130,7 @@ protected:
   std::optional<bool> has_skb_output_;
   std::optional<bool> has_raw_tp_special_;
   std::optional<bool> has_prog_kfunc_;
+  std::optional<bool> has_module_btf_;
 
 private:
   bool detect_map(libbpf::bpf_map_type map_type);

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -82,6 +82,9 @@ void BTF::load_kernel_btfs(const std::set<std::string> &modules)
   btf_objects.push_back(
       BTFObj{ .btf = vmlinux_btf, .id = 0, .name = "vmlinux" });
 
+  if (bpftrace_ && !bpftrace_->feature_->has_module_btf())
+    return;
+
   // Note that we cannot parse BTFs from /sys/kernel/btf/ as we need BTF object
   // IDs, so the only way is to iterate through all loaded BTF objects
   __u32 id = 0;
@@ -723,7 +726,7 @@ std::pair<int, int> BTF::get_btf_id_fd(const std::string &func,
 
     auto id = find_id_in_btf(btf_obj.btf, func, BTF_KIND_FUNC);
     if (id >= 0)
-      return { id, bpf_btf_get_fd_by_id(btf_obj.id) };
+      return { id, btf_obj.id ? bpf_btf_get_fd_by_id(btf_obj.id) : 0 };
   }
 
   return { -1, -1 };


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

The first patch add function has_module_btf to check if the kernel supports module btf.
 
The second patch fix the problem of kfunc loading failure in 5.10 kernel which doesn't support module btf. And this patch does two things:

- Modified the load_kernel_btfs function: when the kernel does not support the module btf feature,
    it is not necessary to read the module btf.
   
 - The get_btf_id_fd function is modified: when the number of btfojb is 0, it is not necessary to
  obtain its fd through bpf_btf_get_fd_by_id. This avoids assigning wrong values to attach_btf_obj_fd.
  When the value of attach_btf_obj_fd is 0, the kernel will find the corresponding kernel symbol
  from the vmlinux btf according to the btf id.

Best regards and thank you in advance.

##### Checklist

- [] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [] The new behaviour is covered by tests
