### PR TITLE
Fix casts to typedef types

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -670,5 +670,13 @@ AssignMapStatement::AssignMapStatement(const AssignMapStatement &other)
   compound = other.compound;
 };
 
+SizedType ident_to_record(const std::string &ident, int pointer_level)
+{
+  SizedType result = CreateRecord(ident, std::weak_ptr<Struct>());
+  for (int i = 0; i < pointer_level; i++)
+    result = CreatePointer(result);
+  return result;
+}
+
 } // namespace ast
 } // namespace bpftrace

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -615,6 +615,8 @@ std::string opstr(Binop &binop);
 std::string opstr(Unop &unop);
 std::string opstr(Jump &jump);
 
+SizedType ident_to_record(const std::string &ident, int pointer_level = 0);
+
 #undef DEFINE_ACCEPT
 
 } // namespace ast

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -9,7 +9,7 @@
 %define api.value.type variant
 %define parse.assert
 %define parse.trace
-%expect 3
+%expect 5
 
 %define parse.error verbose
 
@@ -223,7 +223,7 @@ pointer_type:
                 type "*" { $$ = CreatePointer($1); }
                 ;
 struct_type:
-                STRUCT IDENT { $$ = CreateRecord($2, std::weak_ptr<Struct>()); }
+                STRUCT IDENT { $$ = ast::ident_to_record($2); }
                 ;
 
 probes:
@@ -521,6 +521,10 @@ addi_expr:
 cast_expr:
                 unary_expr                                  { $$ = $1; }
         |       LPAREN type RPAREN cast_expr                { $$ = new ast::Cast($2, $4, @1 + @3); }
+/* workaround for typedef types, see https://github.com/iovisor/bpftrace/pull/2560#issuecomment-1521783935 */
+        |       LPAREN IDENT RPAREN cast_expr               { $$ = new ast::Cast(ast::ident_to_record($2, 0), $4, @1 + @3); }
+        |       LPAREN IDENT "*" RPAREN cast_expr           { $$ = new ast::Cast(ast::ident_to_record($2, 1), $5, @1 + @4); }
+        |       LPAREN IDENT "*" "*" RPAREN cast_expr       { $$ = new ast::Cast(ast::ident_to_record($2, 2), $6, @1 + @5); }
                 ;
 
 sizeof_expr:

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1485,6 +1485,24 @@ TEST(Parser, cast_struct_ptr)
        "   builtin: arg0\n");
 }
 
+TEST(Parser, cast_typedef)
+{
+  test("kprobe:sys_read { (mytype)arg0; }",
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  (mytype)\n"
+       "   builtin: arg0\n");
+}
+
+TEST(Parser, cast_ptr_typedef)
+{
+  test("kprobe:sys_read { (mytype*)arg0; }",
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  (mytype *)\n"
+       "   builtin: arg0\n");
+}
+
 TEST(Parser, cast_multiple_pointer)
 {
   test("kprobe:sys_read { (int32 *****)arg0; }",


### PR DESCRIPTION
Fix an oversight from #2560 where casts to typedef types were removed by mistake. This workaround is done by implementing casts to typedef types in a similar way to the previous implementation of cast expressions instead of the new one using the nonterminal symbol for types.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
