### PR TITLE
Replace with correct macro HAVE_UNSAFE_PROBE

### DIFF
--- a/src/build_info.cpp
+++ b/src/build_info.cpp
@@ -12,8 +12,8 @@ std::string BuildInfo::report()
       << "  version: " << BPFTRACE_VERSION << std::endl
       << "  LLVM: " << LLVM_VERSION_MAJOR << "." << LLVM_VERSION_MINOR << "."
       << LLVM_VERSION_PATCH << std::endl
-      << "  unsafe uprobe: "
-#ifdef HAVE_UNSAFE_UPROBE
+      << "  unsafe probe: "
+#ifdef HAVE_UNSAFE_PROBE
       << "yes" << std::endl;
 #else
       << "no" << std::endl;


### PR DESCRIPTION
With reference to change e31e398f4, "bpftrace --info" was always reporting 'no' for 'Build: unsafe uprobe'.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->
