### PR TITLE
Add BPFTRACE_STACK_MODE env variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to
   - [#2579](https://github.com/iovisor/bpftrace/pull/2579)
 - Add 'StackMode::raw' for ustack and kstack formatting
   - [#2581](https://github.com/iovisor/bpftrace/pull/2581)
+- Add 'BPFTRACE_STACK_MODE' env variable
+  - [#2586](https://github.com/iovisor/bpftrace/pull/2586)
 #### Changed
 - Improve attaching to uprobes with size 0
   - [#2562](https://github.com/iovisor/bpftrace/pull/2562)

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -176,6 +176,7 @@ ENVIRONMENT:
     BPFTRACE_CACHE_USER_SYMBOLS [default: auto] enable user symbol cache
     BPFTRACE_VMLINUX            [default: none] vmlinux path used for kernel symbol resolution
     BPFTRACE_BTF                [default: none] BTF file
+    BPFTRACE_STACK_MODE         [default: bpftrace] Output format for ustack and kstack builtins
 
 EXAMPLES:
 bpftrace -l '*sleep*'
@@ -553,6 +554,12 @@ Default: `..`
 
 Trailer to add to strings that were truncated. Set to empty string to disable truncation trailers.
 
+### 9.11 `BPFTRACE_STACK_MODE`
+
+Default: bpftrace
+
+Output format for ustack and kstack builtins. Available modes/formats: `bpftrace`, `perf`, and `raw`.
+This can be overwritten at the call site.
 
 ## 10. Clang Environment Variables
 

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -258,6 +258,13 @@ Default: `..`
 
 Trailer to add to strings that were truncated. Set to empty string to disable truncation trailers.
 
+=== BPFTRACE_STACK_MODE
+
+Default: bpftrace
+
+Output format for ustack and kstack builtins. Available modes/formats: `bpftrace`, `perf`, and `raw`.
+This can be overwritten at the call site.
+
 ////
 !
 !

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1417,6 +1417,12 @@ void SemanticAnalyser::check_stack_call(Call &call, bool kernel)
   }
 
   StackType stack_type;
+
+  if (bpftrace_.stack_mode_.has_value())
+  {
+    stack_type.mode = *bpftrace_.stack_mode_;
+  }
+
   if (call.vargs)
   {
     switch (call.vargs->size())

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -195,6 +195,7 @@ public:
   bool usdt_file_activation_ = false;
   int helper_check_level_ = 0;
   uint64_t ast_max_nodes_ = 0; // Maximum AST nodes allowed for fuzzing
+  std::optional<StackMode> stack_mode_;
   std::optional<struct timespec> boottime_;
 
   static void sort_by_key(

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -128,6 +128,7 @@ void usage()
   std::cerr << "    BPFTRACE_VMLINUX            [default: none] vmlinux path used for kernel symbol resolution" << std::endl;
   std::cerr << "    BPFTRACE_BTF                [default: none] BTF file" << std::endl;
   std::cerr << "    BPFTRACE_STR_TRUNC_TRAILER  [default: '..'] string truncation trailer" << std::endl;
+  std::cerr << "    BPFTRACE_STACK_MODE         [default: bpftrace] Output format for ustack and kstack builtins" << std::endl;
   std::cerr << std::endl;
   std::cerr << "EXAMPLES:" << std::endl;
   std::cerr << "bpftrace -l '*sleep*'" << std::endl;
@@ -333,6 +334,21 @@ static std::optional<struct timespec> get_boottime()
 
   if (!get_bool_env_var("BPFTRACE_VERIFY_LLVM_IR", verify_llvm_ir))
     return false;
+
+  if (const char* stack_mode = std::getenv("BPFTRACE_STACK_MODE"))
+  {
+    auto found = STACK_MODE_MAP.find(stack_mode);
+    if (found != STACK_MODE_MAP.end())
+    {
+      bpftrace.stack_mode_ = found->second;
+    }
+    else
+    {
+      LOG(ERROR) << "Env var 'BPFTRACE_STACK_MODE' did not contain a valid "
+                    "StackMode: "
+                 << stack_mode;
+    }
+  }
 
   return true;
 }

--- a/src/types.h
+++ b/src/types.h
@@ -69,6 +69,12 @@ enum class StackMode
   raw,
 };
 
+const std::map<std::string, StackMode> STACK_MODE_MAP = {
+  { "bpftrace", StackMode::bpftrace },
+  { "perf", StackMode::perf },
+  { "raw", StackMode::raw },
+};
+
 struct StackType
 {
   size_t limit = DEFAULT_STACK_SIZE;

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -207,10 +207,37 @@ EXPECT Attaching 1 probe
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8
 
-
 NAME ustack
 PROG k:do_nanosleep { printf("%s\n%s\n", ustack(), ustack(1)); exit(); }
 EXPECT Attaching 1 probe
+TIMEOUT 5
+AFTER ./testprogs/syscall nanosleep  1e8
+
+NAME ustack_stack_mode_env_bpftrace
+PROG k:do_nanosleep { printf("%s", ustack(1)); exit(); }
+ENV BPFTRACE_STACK_MODE=bpftrace
+EXPECT ^\s+[a-zA-Z0-9_]+
+TIMEOUT 5
+AFTER ./testprogs/syscall nanosleep  1e8
+
+NAME ustack_stack_mode_env_perf
+PROG k:do_nanosleep { printf("%s", ustack(1)); exit(); }
+ENV BPFTRACE_STACK_MODE=perf
+EXPECT ^\s+[0-9a-f]+ [a-zA-Z0-9_]+
+TIMEOUT 5
+AFTER ./testprogs/syscall nanosleep  1e8
+
+NAME ustack_stack_mode_env_raw
+PROG k:do_nanosleep { printf("%s", ustack(1)); exit(); }
+ENV BPFTRACE_STACK_MODE=raw
+EXPECT ^\s+[0-9a-f]+$
+TIMEOUT 5
+AFTER ./testprogs/syscall nanosleep  1e8
+
+NAME ustack_stack_mode_env_override
+PROG k:do_nanosleep { printf("%s", ustack(raw, 1)); exit(); }
+ENV BPFTRACE_STACK_MODE=perf
+EXPECT ^\s+[0-9a-f]+$
 TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep  1e8
 


### PR DESCRIPTION
Summary:
This is so users can more easily set the global output for their stacks rather than repeating the same string for every invocation of ustack or kstack

Test Plan:
Tested locally.
```
BPFTRACE_STACK_MODE=tomato sudo ./src/bpftrace -e 'kprobe:do_nanosleep {
printf("Jordan\n%s\n", ustack());  }'
ERROR: Env var 'BPFTRACE_STACK_MODE' did not contain a valid StackMode:
tomato
```

```
BPFTRACE_STACK_MODE=perf sudo ./src/bpftrace -e 'kprobe:do_nanosleep {
printf("Jordan\n%s\n", ustack());  }'
Attaching 1 probe...
Jordan

	7f088cae85b3 __clock_nanosleep+99
(/usr/local/fbcode/platform010-compat/lib/libc.so.6)
	7f088caed253 __nanosleep+19
(/usr/local/fbcode/platform010-compat/lib/libc.so.6)
	1f3418b
scribe::common::sink::QueueSink::sendLoop(scribe::common::sink::detail::BatchQueue*,
int)+2971 (/usr/local/fbprojects/scribe/bin/scribed)
	6187e12 folly::ThreadedExecutor::work(folly::Function<void
()>&)+82 (/usr/local/fbprojects/scribe/bin/scribed)
	7f088cedf2e5 execute_native_thread_routine+21
(/usr/local/fbcode/platform010-compat/lib/libstdc++.so.6.0.29)
	7f088ca979bf start_thread+559
(/usr/local/fbcode/platform010-compat/lib/libc.so.6)
	7f088cb288ac __GI___clone3+44
(/usr/local/fbcode/platform010-compat/lib/libc.so.6)
```

Reviewers:

Subscribers:

Tasks:

Tags:

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
