### PR TITLE
Fix segfaults in dwarf_parser

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to
   - [#2546](https://github.com/iovisor/bpftrace/pull/2546)
 - arm64: define the KASAN_SHADOW_SCALE_SHIFT macro
   - [#2518](https://github.com/iovisor/bpftrace/pull/2518)
+- Fix segfaults in dwarf_parser
+  - [#2587](https://github.com/iovisor/bpftrace/pull/2587)
 #### Docs
 #### Tools
 


### PR DESCRIPTION
Programs may contain DWARF entities with no name (missing DW_AT_name attribute). This fixes segfaults for programs containing two kinds of such entities:
- subprogram entries (unnamed functions),
- function parameters.

Fixes the following issue (taken from https://github.com/iovisor/bpftrace/pull/2578#pullrequestreview-1405996930):
bpftest.cpp:
```
extern "C" {
void foo(int, int) { }
}
int main() { }
```
`g++ -g bpftest.cpp -O0`
```
# ./build/src/bpftrace -e 'uprobe:/tmp/a.out:foo { @ = args }' -d
libbpf: (2) libbpf: loading kernel BTF '/sys/kernel/btf/vmlinux': 0
libbpf: (2) libbpf: loading kernel BTF '/sys/kernel/btf/vmlinux': 0
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string::_M_construct null not valid
Aborted
```

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
