### PR TITLE
Always set libbpf print function

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -668,11 +668,27 @@ Args parse_args(int argc, char* argv[])
   return args;
 }
 
+static const char* libbpf_print_level_string(enum libbpf_print_level level)
+{
+  switch (level)
+  {
+    case LIBBPF_WARN:
+      return "WARN";
+    case LIBBPF_INFO:
+      return "INFO";
+    default:
+      return "DEBUG";
+  }
+}
+
 static int libbpf_print(enum libbpf_print_level level,
                         const char* msg,
                         va_list ap)
 {
-  fprintf(stderr, "libbpf: (%d) ", level);
+  if (bt_debug == DebugLevel::kNone)
+    return 0;
+
+  fprintf(stderr, "[%s] ", libbpf_print_level_string(level));
   return vfprintf(stderr, msg, ap);
 }
 
@@ -724,8 +740,7 @@ int main(int argc, char* argv[])
       break;
   }
 
-  if (bt_debug != DebugLevel::kNone)
-    libbpf_set_print(libbpf_print);
+  libbpf_set_print(libbpf_print);
 
   BPFtrace bpftrace(std::move(output));
   bool verify_llvm_ir = false;


### PR DESCRIPTION
Libbpf's default print function writes all non-debug messages to stderr[1], which can be noisy: for example, as of cd8c1b188 ("bpftrace: Load vmlinux BTF using btf__load_vmlinux_btf()"), bpftrace logs a warning[2] on startup every time on older kernels that don't have BTF support.

Move the debug level check into libbpf_print() and set it unconditionally; this way libbpf messages are printed only if -d is specified.

[1] https://github.com/libbpf/libbpf/blob/v1.0.0/src/libbpf.c#L209
[2] https://github.com/libbpf/libbpf/blob/v1.0.0/src/btf.c#L4685

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
