### PR TITLE
Use int64_t instead of long to represent int literals

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -221,7 +221,7 @@ Program::~Program()
   probes = nullptr;
 }
 
-Integer::Integer(long n, location loc) : Expression(loc), n(n)
+Integer::Integer(int64_t n, location loc) : Expression(loc), n(n)
 {
   is_literal = true;
 }

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>
@@ -111,9 +112,9 @@ public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(Integer)
 
-  explicit Integer(long n, location loc);
+  explicit Integer(int64_t n, location loc);
 
-  long n;
+  int64_t n;
 
 private:
   Integer(const Integer &other) = default;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -2256,7 +2256,8 @@ std::string BPFtrace::get_string_literal(const ast::Expression *expr) const
   return "";
 }
 
-std::optional<long> BPFtrace::get_int_literal(const ast::Expression *expr) const
+std::optional<int64_t> BPFtrace::get_int_literal(
+    const ast::Expression *expr) const
 {
   if (expr->is_literal)
   {
@@ -2269,7 +2270,7 @@ std::optional<long> BPFtrace::get_int_literal(const ast::Expression *expr) const
       {
         auto param_str = get_param(pos_param->n, false);
         if (is_numeric(param_str))
-          return std::stol(param_str);
+          return std::stoll(param_str);
         else
         {
           LOG(ERROR, pos_param->loc)
@@ -2279,7 +2280,7 @@ std::optional<long> BPFtrace::get_int_literal(const ast::Expression *expr) const
         }
       }
       else
-        return (long)num_params();
+        return (int64_t)num_params();
     }
   }
 

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstdint>
 #include <iostream>
 #include <map>
 #include <memory>
@@ -139,7 +140,7 @@ public:
   void request_finalize();
   bool is_aslr_enabled(int pid);
   std::string get_string_literal(const ast::Expression *expr) const;
-  std::optional<long> get_int_literal(const ast::Expression *expr) const;
+  std::optional<int64_t> get_int_literal(const ast::Expression *expr) const;
   std::optional<std::string> get_watchpoint_binary_path() const;
   virtual bool is_traceable_func(const std::string &func_name) const;
   std::unordered_set<std::string> get_func_modules(

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -20,6 +20,7 @@
 // Forward declarations of classes referenced in the parser
 %code requires
 {
+#include <cstdint>
 #include <limits>
 #include <regex>
 
@@ -120,7 +121,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %token <std::string> MAP "map"
 %token <std::string> VAR "variable"
 %token <std::string> PARAM "positional parameter"
-%token <long> INT "integer"
+%token <int64_t> INT "integer"
 %token <std::string> STACK_MODE "stack_mode"
 
 
@@ -542,7 +543,7 @@ offsetof_expr:
                 ;
 
 int:
-                MINUS INT    { $$ = new ast::Integer((long)(~(unsigned long)($2) + 1), @$); }
+                MINUS INT    { $$ = new ast::Integer((int64_t)(~(uint64_t)($2) + 1), @$); }
         |       INT          { $$ = new ast::Integer($1, @$); }
                 ;
 

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -452,7 +452,7 @@ EXPECT Operation not permitted
 TIMEOUT 5
 
 NAME bswap_int64
-RUN {{BPFTRACE}} -e 'BEGIN { printf("%lx", bswap(0x1122334455667788)); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%llx", bswap(0x1122334455667788)); exit(); }'
 EXPECT 8877665544332211
 TIMEOUT 1
 
@@ -472,7 +472,7 @@ EXPECT 12
 TIMEOUT 1
 
 NAME bswap_int64_op
-RUN {{BPFTRACE}} -e 'BEGIN { printf("%lx", bswap(0x12340000 + 0x5678)); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%llx", bswap(0x12340000 + 0x5678)); exit(); }'
 EXPECT 7856341200000000
 TIMEOUT 1
 


### PR DESCRIPTION
Integer literals are internally represented as int64s, but the `ast::Integer` constructor takes a `long` argument. Fix the inconsistency by switching to `int64_t`.

This allows bpftrace to correctly handle 64-bit constants on systems where `sizeof(long) == 4`.

Test: `call.bswap*` runtime tests on armv7
Test: `bpftrace -e 'BEGIN { print(0xdeadbeef12345678) }'`

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
