### PR TITLE
TCP NAT tracking tool that displays SNAT and DNAT records

### DIFF
--- a/tools/tcpnat.bt
+++ b/tools/tcpnat.bt
@@ -1,0 +1,69 @@
+#!/usr/bin/env bpftrace
+/*
+ * tcpnat.bt     TCP NAT tracking tool that displays SNAT and DNAT records, attempt to reduce duplicate NAT records.
+ *               For Linux, uses bpftrace, eBPF.
+ *
+ * 12-May-2023   Weiyang Wang	Created this.
+ */
+
+#include <net/netfilter/nf_nat.h>
+#include <linux/socket.h>
+#include <linux/skbuff.h>
+#include <linux/tcp.h>
+#include <linux/ip.h>
+
+BEGIN
+{
+    printf("Tracing TCP NAT... Hit Ctrl-C to end.\n");
+}
+
+kprobe:nf_nat_ipv4_manip_pkt
+{
+    $skb = (struct sk_buff *)arg0;
+    $iph = (struct iphdr *)($skb->head + $skb->network_header);
+
+    if ($iph->protocol == IPPROTO_TCP) {
+        $th = (struct tcphdr *)($skb->head + $skb->transport_header);
+        // before nat
+        $saddr = ntop($iph->saddr);
+        $sport = (uint16)($th->source << 8) | ($th->source >> 8);
+        $daddr = ntop($iph->daddr);
+        $dport = (uint16)($th->dest << 8) | ($th->dest >> 8);
+
+        if (@nat[$saddr, $sport, $daddr, $dport] == 0) {
+            $type = arg3;
+            $tuple = (struct nf_conntrack_tuple *)arg2;
+
+            if ($type == NF_NAT_MANIP_SRC) {
+                // after nat
+                $nat_saddr = ntop(AF_INET, $tuple->src.u3.ip);
+                $nat_sport = $tuple->src.u.tcp.port;
+                $nat_sport = ($nat_sport >> 8) | (($nat_sport << 8) & 0xff00);
+                printf("[snat] saddr=%s sport=%d daddr=%s dport=%d -> saddr=%s sport=%d daddr=%s dport=%d\n", 
+                    $saddr, $sport, $daddr, $dport,
+                    $nat_saddr, $nat_sport, $daddr, $dport);
+            } else {
+                // after nat
+                $nat_daddr = ntop(AF_INET, $tuple->dst.u3.ip);
+                $nat_dport = $tuple->dst.u.tcp.port;
+                $nat_dport = ($nat_dport >> 8) | (($nat_dport << 8) & 0xff00);
+                printf("[dnat] saddr=%s sport=%d daddr=%s dport=%d -> saddr=%s sport=%d daddr=%s dport=%d\n", 
+                    $saddr, $sport, $daddr, $dport,
+                    $saddr, $sport, $nat_daddr, $nat_dport);
+            }
+
+            @nat[$saddr, $sport, $daddr, $dport] = 1;
+            @count++;
+        }
+    }
+
+    if (@count > 1000) {
+        clear(@nat);
+        @count = 0;
+    }
+}
+
+END
+{
+    clear(@nat); clear(@count);
+}

--- a/tools/tcpnat_example.txt
+++ b/tools/tcpnat_example.txt
@@ -1,0 +1,27 @@
+Trace TCP NAT, the Linux BPF/bpftrace version.
+
+TCP NAT tracking tool that displays SNAT and DNAT records, attempt to reduce duplicate NAT records. For Linux, uses bpftrace, eBPF. For example:
+
+# tcpnat.bt 
+Attaching 3 probes...
+Tracing TCP NAT... Hit Ctrl-C to end.
+[dnat] saddr=10.206.65.152 sport=6443 daddr=10.206.65.155 dport=49702 -> saddr=10.206.65.152 sport=6443 daddr=10.233.69.23 dport=51298
+[dnat] saddr=10.206.65.152 sport=6443 daddr=10.206.65.155 dport=9389 -> saddr=10.206.65.152 sport=6443 daddr=10.233.0.1 dport=58024
+[snat] saddr=10.233.69.23 sport=51298 daddr=10.206.65.152 dport=6443 -> saddr=10.206.65.155 sport=49702 daddr=10.206.65.152 dport=6443
+[snat] saddr=10.233.0.1 sport=58024 daddr=10.206.65.152 dport=6443 -> saddr=10.206.65.155 sport=9389 daddr=10.206.65.152 dport=6443
+[dnat] saddr=10.206.65.152 sport=6443 daddr=10.206.65.155 dport=9358 -> saddr=10.206.65.152 sport=6443 daddr=10.233.0.1 dport=50472
+[snat] saddr=10.233.0.1 sport=50472 daddr=10.206.65.152 dport=6443 -> saddr=10.206.65.155 sport=9358 daddr=10.206.65.152 dport=6443
+[dnat] saddr=10.206.65.152 sport=6443 daddr=10.206.65.155 dport=59590 -> saddr=10.206.65.152 sport=6443 daddr=10.233.0.1 dport=57974
+[snat] saddr=10.233.0.1 sport=57974 daddr=10.206.65.152 dport=6443 -> saddr=10.206.65.155 sport=59590 daddr=10.206.65.152 dport=6443
+[dnat] saddr=10.206.65.152 sport=6443 daddr=10.206.65.155 dport=37230 -> saddr=10.206.65.152 sport=6443 daddr=10.233.0.1 dport=57980
+[snat] saddr=10.233.0.1 sport=57980 daddr=10.206.65.152 dport=6443 -> saddr=10.206.65.155 sport=37230 daddr=10.206.65.152 dport=6443
+[dnat] saddr=10.206.65.152 sport=6443 daddr=10.206.65.155 dport=1751 -> saddr=10.206.65.152 sport=6443 daddr=10.233.0.1 dport=58058
+[snat] saddr=10.233.0.1 sport=58058 daddr=10.206.65.152 dport=6443 -> saddr=10.206.65.155 sport=1751 daddr=10.206.65.152 dport=6443
+[dnat] saddr=10.233.80.233 sport=4222 daddr=10.206.65.155 dport=41551 -> saddr=10.233.80.233 sport=4222 daddr=10.233.57.43 dport=55362
+[snat] saddr=10.233.57.43 sport=55362 daddr=10.233.80.233 dport=4222 -> saddr=10.206.65.155 sport=41551 daddr=10.233.80.233 dport=4222
+^C
+
+While tracing, this shows many DNAT and SNAT behaviors in Linux, The content before the -> symbol is the pre-translation address information, 
+and the content after is the post-translation address information.
+This tool can be used as a Linux system TCP NAT tracker, similar to `tcplife.bt`, to record operating system NAT behavior.
+For example, on a Kubernetes data node, this tool can be used to record access to pods via nodeport.


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

`tcpnat.bt`: TCP NAT tracking tool that displays SNAT and DNAT records, attempt to reduce duplicate NAT records.
For Linux, uses bpftrace, eBPF.

While tracing, this shows many DNAT and SNAT behaviors in Linux, The content before the -> symbol is the pre-translation address information, and the content after is the post-translation address information.

This tool can be used as a Linux system TCP NAT tracker, similar to `tcplife.bt`, to record operating system NAT behavior.

For example, on a Kubernetes data node, this tool can be used to record access to pods via nodeport.

