### PR TITLE
RFC: Nix flake based build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,5 @@ tests/**/*.bc
 [._]sw[a-p]
 *.btaot
 
+result
 ignored/

--- a/README.md
+++ b/README.md
@@ -153,6 +153,28 @@ $ vagrant up $YOUR_CHOICE
 $ vagrant ssh $YOUR_CHOICE
 ```
 
+### Nix
+
+There is experimental support for building and testing with [Nix flakes](https://nixos.wiki/wiki/Flakes).
+The quickstart follows but more detailed documentation can be found in [nix.md](docs/nix.md).
+
+First, install `nix`: https://nixos.org/download.html. Then enable Nix flake
+support:
+
+```
+$ mkdir -p ~/.config/nix
+$ echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
+```
+
+Now build and run:
+
+```
+$ nix build
+$ sudo ./result/bin/bpftrace --info
+```
+
+The above steps are theoretically guaranteed to work on any linux x86-64/arm system.
+
 ## License
 
 Copyright 2019 Alastair Robertson

--- a/docs/nix.md
+++ b/docs/nix.md
@@ -1,0 +1,102 @@
+# Building and testing with Nix
+
+Nix flakes are, in theory, guaranteed to be 100% reproducible on (nearly) any
+system. It does this by fully managing every dependency. This also means that
+you as a developer do not need to install _any_ build / runtime packages to
+build bpftrace with Nix.
+
+Rather than explain how Nix works (which is difficult to impossible in this
+kind of document), the rest of this guide will be a series of examples.
+Learning Nix flakes and the Nix language will be an exercise left to the
+reader.
+
+## Examples
+
+These examples all assume you've already installed the `nix` CLI tool.  If not,
+see: https://nixos.org/download.html.
+
+Also note again that we require _no dependencies_ to be installed other than
+`nix` itself.
+
+### Enable flake support
+
+Nix flakes are technically an experimental feature but it's widely used and
+understood that the interface is unlikely to change. To enable flakes, run:
+
+```
+$ mkdir -p ~/.config/nix
+$ echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
+```
+
+### Build bpftrace
+
+```
+$ nix build
+$ sudo ./result/bin/bpftrace -e 'BEGIN { print("hello world!") }'
+Attaching 1 probe...
+hello world!
+^C
+```
+
+### Build bpftrace with a different LLVM version
+
+```
+$ nix build .#bpftrace-llvm13
+$ sudo ./result/bin/bpftrace --info 2>&1 | grep LLVM
+  LLVM: 13.0.1
+```
+
+### Don't use Nix to build, but rather only manage dependencies
+
+```
+$ nix develop
+[dxu@kashmir bpftrace]$ cmake -B build-nix -GNinja -DUSE_SYSTEM_BPF_BCC=1
+[...]
+
+[dxu@kashmir bpftrace]$ ninja -C build-nix
+[...]
+
+[dxu@kashmir bpftrace]$ exit
+
+$ sudo ./build-nix/src/bpftrace --version
+bpftrace v0.17.0-75-g68ea-dirty
+```
+
+`nix develop` opens a developer shell. We've configured the bpftrace flake
+to be nearly the exact same as the default build environment except with a
+few more tools available.
+
+### Build bpftrace with a different LLVM in developer shell
+
+```
+$ nix develop .#bpftrace-llvm12
+dxu@kashmir bpftrace]$ cmake -B build-nix -GNinja -DUSE_SYSTEM_BPF_BCC=1
+[...]
+-- Found LLVM 12.0.1: ///nix/store/xs06qigbqln7piypm7dfj5wqd38ndgcz-llvm-12.0.1-dev/lib/cmake/llvm/
+[...]
+```
+
+### Run test suite inside developer shell
+
+```
+$ nix develop
+[dxu@kashmir bpftrace]$ cd build-nix; sudo ctest -V
+[...]
+```
+
+## Internal examples
+
+This section has a few examples on how to interact with the Nix configuration.
+
+### Format `*.nix` files
+
+```
+$ nix fmt
+0 / 1 have been reformatted
+```
+
+### Check `*.nix` files for errors
+
+```
+$ nix flake check
+```

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,61 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1683979235,
+        "narHash": "sha256-3YXT3u8ORCoxnO6le33rLMIr74y8rtKnthFj6sxxpmo=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e28ffb8f487503362962f05718bec6b95f27a672",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "release-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,72 @@
+{
+  description = "High-level tracing language for Linux eBPF";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/release-22.11";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, flake-utils, ... }:
+    # This flake only supports 64-bit linux systems.
+    # Note bpftrace support aarch32 but for simplicity we'll omit it for now.
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" ]
+      (system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+        in
+        {
+          # Set formatter for `nix fmt` command
+          formatter = pkgs.nixpkgs-fmt;
+
+          # Define package set
+          packages = rec {
+            # Default package is bpftrace binary
+            default = bpftrace;
+
+            # Derivation for bpftrace binary
+            bpftrace =
+              with pkgs;
+              pkgs.stdenv.mkDerivation rec {
+                name = "bpftrace";
+
+                src = self;
+
+                nativeBuildInputs = [ cmake ninja bison flex gcc12 ];
+
+                # TODO: use submoduled bcc + libbpf
+                buildInputs = with llvmPackages_15;
+                  [
+                    asciidoctor
+                    bcc
+                    cereal
+                    elfutils
+                    gtest
+                    libbpf_1
+                    libbfd
+                    libclang
+                    libelf
+                    libffi
+                    libopcodes
+                    libpcap
+                    libsystemtap
+                    llvm
+                    pahole
+                    xxd
+                    zlib
+                  ];
+
+                # Release flags
+                cmakeFlags = [
+                  "-DCMAKE_BUILD_TYPE=Release"
+                  "-DUSE_SYSTEM_BPF_BCC=ON"
+                ];
+              };
+          };
+
+          # Define apps that can be run with `nix run`
+          apps.default = {
+            type = "app";
+            program = "${self.packages.${system}.default}/bin/bpftrace";
+          };
+        });
+}


### PR DESCRIPTION
This is an RFC for the nix build infra we discussed during office hours.

Attached in this PR is documentation on how to interact with the nix build.
Please see that for reference.

If we decide to move forward with this, we can at the very least replace/remove:

* All the docker based build stuff in the CI
* `build-libs.sh`
* `STATIC_BPF_BCC` in cmake config
* The vendored libbpf + bcc repos

We also get for free:

* Reproducible builds / tests (modulo kernel until `vmtest` comes) between CI
  and your development host. Ideally it'll just be `nix develop --command run-tests.sh`
  that's both run in CI and locally.
* The ability to patch libbpf, bcc, llvm, really any of our deps, completely through
  `flake.nix` configs. This is something that cannot be done through traditional,
  non-functional package managers. You can sort of see in the current `flake.nix`
  how I'm patching nixpkg's upstream libbpf and bcc. This is easily extended to
  include `.patch` as well.

Downsides:

* Nix's DSL is quite difficult to understand. You can probably already see that.
  * That being said, I got somewhat productive with it in one weekend. I'd also
    be happy to walk people through what I've learned.
  * It's also quite beautiful (the semantics, not the syntax) when you piece it all together.
* One more thing to learn (but hopefully not maintain, as we'll delete stuff if this goes in)
  * But the industry is moving towards this direction so hopefully another tool in your tool kit

What's left to do:

* Fix all the tests
* Hook up to CI
* Delete all the will-be-deprecated stuff

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
