### PR TITLE
Support identifying btf type for btf-based tracing

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1846,6 +1846,7 @@ void CodegenLLVM::visit(FieldAccess &acc)
   bool is_tparg = type.is_tparg;
   bool is_internal = type.is_internal;
   bool is_funcarg = type.is_funcarg;
+  bool is_btftype = type.is_btftype;
   assert(type.IsRecordTy() || type.IsTupleTy());
 
   if (type.is_funcarg)
@@ -1887,6 +1888,7 @@ void CodegenLLVM::visit(FieldAccess &acc)
   type.is_tparg = is_tparg;
   type.is_internal = is_internal;
   type.is_funcarg = is_funcarg;
+  type.is_btftype = is_btftype;
   // Restore the addrspace info
   // struct MyStruct { const int* a; };  $s = (struct MyStruct *)arg0;  $s->a
   type.SetAS(addrspace);
@@ -3524,23 +3526,30 @@ void CodegenLLVM::probereadDatastructElem(Value *src_data,
   {
     // Read data onto stack
     AllocaInst *dst = b_.CreateAllocaBPF(elem_type, temp_name);
-    b_.CreateProbeRead(ctx_, dst, elem_type, src, loc, data_type.GetAS());
+    if (elem_type.IsStringTy() && data_type.is_btftype)
+    {
+      b_.CREATE_MEMCPY(dst, src, elem_type.GetSize(), 1);
+    }
+    else
+    {
+      b_.CreateProbeRead(ctx_, dst, elem_type, src, loc, data_type.GetAS());
+    }
     expr_ = dst;
     expr_deleter_ = [this, dst]() { b_.CreateLifetimeEnd(dst); };
   }
   else
   {
     // Read data onto stack
-    if (data_type.IsCtxAccess())
+    if (data_type.IsCtxAccess() || data_type.is_btftype)
     {
       expr_ = b_.CreateDatastructElemLoad(
           elem_type,
           b_.CreateIntToPtr(src, dst_type->getPointerTo()),
           true,
           data_type.GetAS());
-
       // check context access for iter probes (required by kernel)
-      if (probetype(current_attach_point_->provider) == ProbeType::iter)
+      if (data_type.IsCtxAccess() &&
+          probetype(current_attach_point_->provider) == ProbeType::iter)
       {
         Function *parent = b_.GetInsertBlock()->getParent();
         BasicBlock *pred_false_block = BasicBlock::Create(module_->getContext(),

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -276,6 +276,7 @@ void SemanticAnalyser::visit(Builtin &builtin)
               CreateRecord(type, bpftrace_.structs.Lookup(type)),
               AddrSpace::kernel);
           builtin.type.MarkCtxAccess();
+          builtin.type.is_btftype = true;
         }
         else
         {
@@ -325,7 +326,10 @@ void SemanticAnalyser::visit(Builtin &builtin)
       auto it = ap_args_.find("$retval");
 
       if (it != ap_args_.end())
+      {
         builtin.type = it->second;
+        builtin.type.is_btftype = true;
+      }
       else
         LOG(ERROR, builtin.loc, err_) << "Can't find a field $retval";
     }
@@ -1583,6 +1587,7 @@ void SemanticAnalyser::visit(ArrayAccess &arr)
   else
     arr.type = CreateNone();
   arr.type.is_internal = type.is_internal;
+  arr.type.is_btftype = type.is_btftype;
   arr.type.SetAS(type.GetAS());
 }
 
@@ -1953,6 +1958,7 @@ void SemanticAnalyser::visit(Unop &unop)
         unop.type.is_funcarg = type.is_funcarg;
         unop.type.is_tparg = type.is_tparg;
       }
+      unop.type.is_btftype = type.is_btftype;
       unop.type.SetAS(type.GetAS());
     }
     else if (type.IsRecordTy())
@@ -2139,6 +2145,12 @@ void SemanticAnalyser::visit(FieldAccess &acc)
       {
         if (acc.type.IsNoneTy())
           LOG(ERROR, acc.loc, err_) << acc.field << " has unsupported type";
+
+        ProbeType probetype = single_provider_type();
+        if (probetype == ProbeType::kfunc || probetype == ProbeType::kretfunc)
+        {
+          acc.type.is_btftype = true;
+        }
       }
     }
     else
@@ -2229,6 +2241,7 @@ void SemanticAnalyser::visit(FieldAccess &acc)
         acc.type.MarkCtxAccess();
       }
       acc.type.is_internal = type.is_internal;
+      acc.type.is_btftype = type.is_btftype;
       acc.type.SetAS(acc.expr->type.GetAS());
 
       // The kernel uses the first 8 bytes to store `struct pt_regs`. Any

--- a/src/types.h
+++ b/src/types.h
@@ -108,6 +108,7 @@ public:
   bool is_internal = false;
   bool is_tparg = false;
   bool is_funcarg = false;
+  bool is_btftype = false;
   int funcarg_idx = -1;
 
 private:
@@ -134,6 +135,7 @@ private:
             is_internal,
             is_tparg,
             is_funcarg,
+            is_btftype,
             funcarg_idx,
             size_,
             is_signed_,

--- a/tests/codegen/iter_dereference.cpp
+++ b/tests/codegen/iter_dereference.cpp
@@ -1,0 +1,14 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, iter_dereference)
+{
+  test("iter:task_file { @[ctx->meta->session_id] = count()}", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/kfunc_dereference.cpp
+++ b/tests/codegen/kfunc_dereference.cpp
@@ -1,0 +1,15 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, kfunc_dereference)
+{
+  test("kfunc:tcp_sendmsg { @[args->sk->__sk_common.skc_daddr] = count(); }",
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/kretfunc_dereference.cpp
+++ b/tests/codegen/kretfunc_dereference.cpp
@@ -1,0 +1,15 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, kretfunc_dereference)
+{
+  test("kretfunc:sk_alloc { @[retval->__sk_common.skc_daddr] = count(); }",
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/iter_dereference.ll
+++ b/tests/codegen/llvm/iter_dereference.ll
@@ -1,0 +1,72 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @"iter:task_file"(i8* %0) section "s_iter:task_file_1" {
+entry:
+  %"@_val" = alloca i64, align 8
+  %lookup_elem_val = alloca i64, align 8
+  %"@_key" = alloca i64, align 8
+  %1 = ptrtoint i8* %0 to i64
+  %2 = add i64 %1, 0
+  %3 = inttoptr i64 %2 to i64*
+  %4 = load volatile i64, i64* %3, align 8
+  %predcond = icmp eq i64 %4, 0
+  br i1 %predcond, label %pred_false, label %pred_true
+
+pred_false:                                       ; preds = %entry
+  ret i64 0
+
+pred_true:                                        ; preds = %entry
+  %5 = add i64 %4, 8
+  %6 = inttoptr i64 %5 to i64*
+  %7 = load volatile i64, i64* %6, align 8
+  %8 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 %7, i64* %"@_key", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* %"@_key")
+  %9 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %pred_true
+  %cast = bitcast i8* %lookup_elem to i64*
+  %10 = load i64, i64* %cast, align 8
+  store i64 %10, i64* %lookup_elem_val, align 8
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %pred_true
+  store i64 0, i64* %lookup_elem_val, align 8
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %11 = load i64, i64* %lookup_elem_val, align 8
+  %12 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %14 = add i64 %11, 1
+  store i64 %14, i64* %"@_val", align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %"@_val", i64 0)
+  %15 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %16 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/codegen/llvm/kfunc_dereference.ll
+++ b/tests/codegen/llvm/kfunc_dereference.ll
@@ -1,0 +1,67 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @"kfunc:vmlinux:tcp_sendmsg"(i8* %0) section "s_kfunc:vmlinux:tcp_sendmsg_1" {
+entry:
+  %"@_val" = alloca i64, align 8
+  %lookup_elem_val = alloca i64, align 8
+  %"@_key" = alloca i64, align 8
+  %1 = ptrtoint i8* %0 to i64
+  %2 = bitcast i8* %0 to i64*
+  %3 = getelementptr i64, i64* %2, i64 0
+  %sk = load volatile i64, i64* %3, align 8
+  %4 = add i64 %sk, 0
+  %5 = add i64 %4, 0
+  %6 = inttoptr i64 %5 to i32*
+  %7 = load volatile i32, i32* %6, align 4
+  %cast = zext i32 %7 to i64
+  %8 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  store i64 %cast, i64* %"@_key", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* %"@_key")
+  %9 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %cast1 = bitcast i8* %lookup_elem to i64*
+  %10 = load i64, i64* %cast1, align 8
+  store i64 %10, i64* %lookup_elem_val, align 8
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  store i64 0, i64* %lookup_elem_val, align 8
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %11 = load i64, i64* %lookup_elem_val, align 8
+  %12 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  %14 = add i64 %11, 1
+  store i64 %14, i64* %"@_val", align 8
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@_key", i64* %"@_val", i64 0)
+  %15 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  %16 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/codegen/llvm/kretfunc_dereference.ll
+++ b/tests/codegen/llvm/kretfunc_dereference.ll
@@ -1,0 +1,66 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @"kretfunc:vmlinux:sk_alloc"(i8* %0) section "s_kretfunc:vmlinux:sk_alloc_1" {
+entry:
+  %"@_val" = alloca i64, align 8
+  %lookup_elem_val = alloca i64, align 8
+  %"@_key" = alloca i64, align 8
+  %1 = bitcast i8* %0 to i64*
+  %2 = getelementptr i64, i64* %1, i64 5
+  %retval = load volatile i64, i64* %2, align 8
+  %3 = add i64 %retval, 0
+  %4 = add i64 %3, 0
+  %5 = inttoptr i64 %4 to i32*
+  %6 = load volatile i32, i32* %5, align 4
+  %cast = zext i32 %6 to i64
+  %7 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i64 %cast, i64* %"@_key", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* %"@_key")
+  %8 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+lookup_success:                                   ; preds = %entry
+  %cast1 = bitcast i8* %lookup_elem to i64*
+  %9 = load i64, i64* %cast1, align 8
+  store i64 %9, i64* %lookup_elem_val, align 8
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %entry
+  store i64 0, i64* %lookup_elem_val, align 8
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %10 = load i64, i64* %lookup_elem_val, align 8
+  %11 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %13 = add i64 %10, 1
+  store i64 %13, i64* %"@_val", align 8
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@_key", i64* %"@_val", i64 0)
+  %14 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }


### PR DESCRIPTION
k(ret)func and iter are btf-based tracing, which can detect whether dereferencing is safe through btf, so dereferencing does not need to call the helper function bpf_probe_read. This patch mainly modifies the semantic and codegen modules

semantic:
- Handle the ctx of iter, mark is_btftype as true
- When dealing with ArrayAccess, Unop, FieldAccess, inherit is_btftype attribute

codegen:
- If it is a string type, use CREATE_MEMCPY directly to load the data
- For other types, load data through CreateDatastructElemLoad instead of CreateProbeRead

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
