### PR TITLE
Link binaries against zlib

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,6 +110,9 @@ set_property( GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS TRUE )
 
 include_directories(SYSTEM ${KERNEL_INCLUDE_DIRS})
 
+find_package(ZLIB REQUIRED)
+include_directories(SYSTEM ${ZLIB_INCLUDE_DIRS})
+
 find_package(LibBcc REQUIRED)
 include_directories(SYSTEM ${LIBBCC_INCLUDE_DIRS})
 

--- a/cmake/FindLibBfd.cmake
+++ b/cmake/FindLibBfd.cmake
@@ -52,7 +52,7 @@ SET(CMAKE_REQUIRED_LIBRARIES ${LIBBFD_LIBRARIES} ${LIBOPCODES_LIBRARIES})
 # do it. Furthermore, libbfd uses some libc symbols that we must manually
 # link against if we're not using static libc (which includes such symbols).
 if(STATIC_LINKING)
-  find_package(LibZ)
+  find_package(ZLIB)
   list(APPEND CMAKE_REQUIRED_LIBRARIES ${LIBIBERTY_LIBRARIES} ${LIBZ_LIBRARIES})
   if(NOT STATIC_LIBC)
     set(CMAKE_REQUIRED_FLAGS

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -125,7 +125,7 @@ if(STATIC_LINKING)
 endif(STATIC_LINKING)
 
 
-target_link_libraries(runtime ${LIBBPF_LIBRARIES})
+target_link_libraries(runtime ${LIBBPF_LIBRARIES} ${ZLIB_LIBRARIES})
 target_link_libraries(libbpftrace parser resources runtime aot ast arch cxxdemangler_llvm)
 
 if(LIBPCAP_FOUND)


### PR DESCRIPTION
Commit 1181c12f ("Parse kernel configuration") placed an indirect link dependency on zlib. This makes linking fail on system with tighter controls on linking such as nixos.

Fix by directly declaring the dependency and directly linking against zlib.

This closes #2598.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
