### PR TITLE
Fix kprobe_offset_module test with correct offset for ppc64

### DIFF
--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -104,17 +104,28 @@ NAME kprobe_offset_module
 RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x5 { printf("hit\n"); exit(); }'
 AFTER /usr/sbin/nft add table bpftrace
 EXPECT hit
+ARCH x86_64|aarch64
 TIMEOUT 5
 REQUIRES lsmod | grep '^nf_tables'
 REQUIRES /usr/sbin/nft --help
-CLEANUP nft delete table bpftrace
+CLEANUP /usr/sbin/nft delete table bpftrace
+
+# Local entry point to nft_trans_alloc_gfp is located at offset of 8 bytes in ppc64.
+NAME kprobe_offset_module
+RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x8 { printf("hit\n"); exit(); }'
+AFTER /usr/sbin/nft add table bpftrace
+EXPECT hit
+ARCH ppc64|ppc64le
+TIMEOUT 5
+REQUIRES lsmod | grep '^nf_tables'
+REQUIRES /usr/sbin/nft --help
+CLEANUP /usr/sbin/nft delete table bpftrace
 
 NAME kprobe_offset_module_error
 RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x1 { printf("hit\n"); exit(); }'
 EXPECT Possible attachment attempt in the middle of an instruction, try a different offset.
 TIMEOUT 5
 REQUIRES lsmod | grep '^nf_tables'
-REQUIRES /usr/sbin/nft --help
 WILL_FAIL
 
 NAME kretprobe


### PR DESCRIPTION
The instruction size in ppc64 is 4 bytes, but the entry-point to the local functions is located at an offset of 8 bytes. Therefore, a kprobe can be attached at offsets that are multiples of 4 bytes beyond the initial 8-byte offset.
