### PR TITLE
Fixing absolute address test issue across platforms

### DIFF
--- a/tests/runtime/watchpoint
+++ b/tests/runtime/watchpoint
@@ -1,7 +1,9 @@
 NAME watchpoint - absolute address
-RUN {{BPFTRACE}} -e 'watchpoint:0x10000000:8:w { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint
+BEFORE ./testprogs/watchpoint
+RUN {{BPFTRACE}} -e "watchpoint:$(awk '{print $1}' /tmp/watchpoint_mem):8:w { printf(\"hit!\n\"); exit() }" -p {{BEFORE_PID}}
 EXPECT hit!
 ARCH aarch64|ppc64|ppc64le|x86_64
+CLEANUP rm -f /tmp/watchpoint_mem
 TIMEOUT 5
 
 NAME kwatchpoint - knl absolute address


### PR DESCRIPTION
mmap to the address 0x10000000 works fine on few arch, i.e x86_64. However, on ppc64, this mmap fails on the hinted address, leading to an untriggered watchpoint on 0x10000000. This patch dynamically replaces the allocated address from mmap, causing the watchpoint to be triggered on write at the correct mapped address.