### PR TITLE
Adding new directive CLEANUP to test-suite

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -61,6 +61,8 @@ Each runtime testcase consists of multiple directives. In no particular order:
   will be terminated after testcase is over.
 * `AFTER`: Run the command in a shell after running bpftrace. The command will
   be terminated after the testcase is over.
+* `CLEANUP`: Run the command in a shell after test is over. This holds any
+  cleanup command to free resources after test completes.
 * `MIN_KERNEL`: Skip the test unless the host's kernel version is >= the
   provided kernel version. Try not to use this directive as kernel versions may
   be misleading (backported kernel features, for example)

--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -27,6 +27,7 @@ TestStruct = namedtuple(
         'timeout',
         'before',
         'after',
+        'cleanup',
         'suite',
         'kernel_min',
         'kernel_max',
@@ -103,6 +104,7 @@ class TestParser(object):
         timeout = ''
         before = ''
         after = ''
+        cleanup = ''
         kernel_min = ''
         kernel_max = ''
         requirement = []
@@ -131,6 +133,8 @@ class TestParser(object):
                 before = line
             elif item_name == 'AFTER':
                 after = line
+            elif item_name == 'CLEANUP':
+                cleanup = line
             elif item_name == 'MIN_KERNEL':
                 kernel_min = line
             elif item_name == 'MAX_KERNEL':
@@ -196,6 +200,7 @@ class TestParser(object):
             timeout,
             before,
             after,
+            cleanup,
             test_suite,
             kernel_min,
             kernel_max,


### PR DESCRIPTION
CLEANUP directive aims to hold the clean-up command to clear the resources allocated during test run.

The command specified in CLEANUP directive will run after the termination of commands from other directives i.e. BEFORE/RUN/AFTER.