### PR TITLE
Fix threadsnoop.bt for greater than glibc 2.34

### DIFF
--- a/tools/threadsnoop.bt
+++ b/tools/threadsnoop.bt
@@ -18,7 +18,8 @@ BEGIN
 	printf("%-10s %-6s %-16s %s\n", "TIME(ms)", "PID", "COMM", "FUNC");
 }
 
-uprobe:libpthread:pthread_create
+uprobe:libpthread:pthread_create,
+uprobe:libc:pthread_create
 {
 	printf("%-10u %-6d %-16s %s\n", elapsed / 1e6, pid, comm,
 	    usym(arg2));


### PR DESCRIPTION
Fix #2611 

Starting with glibc 2.34, pthread-based functions seem to have been merged into libc.
https://developers.redhat.com/articles/2021/12/17/why-glibc-234-removed-libpthread

The threadsnoop in bcc was already supported, so it will be fixed as well.
https://github.com/iovisor/bcc/pull/3624

I have confirmed that it works on ubuntu 22 and ubuntu 20.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
