### PR TITLE
Fixing runtime test filter option: --filter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
           TYPE: Debug
           LLVM_VERSION: 10
           RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt."usdt probes - file based semaphore activation multi process"
+          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process
           TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: focal
           VENDOR_GTEST: ON
@@ -41,7 +41,7 @@ jobs:
           TYPE: Release
           LLVM_VERSION: 10
           RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt."usdt probes - file based semaphore activation multi process"
+          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process
           TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: focal
           VENDOR_GTEST: ON
@@ -51,7 +51,7 @@ jobs:
           CC: clang-10
           CXX: clang++-10
           RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt."usdt probes - file based semaphore activation multi process"
+          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process
           TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: focal
           VENDOR_GTEST: ON
@@ -59,7 +59,7 @@ jobs:
           TYPE: Debug
           LLVM_VERSION: 11
           RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt."usdt probes - file based semaphore activation multi process"
+          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process
           TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: focal
           VENDOR_GTEST: ON
@@ -67,7 +67,7 @@ jobs:
           TYPE: Release
           LLVM_VERSION: 11
           RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt."usdt probes - file based semaphore activation multi process"
+          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process
           TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: focal
           VENDOR_GTEST: ON
@@ -75,7 +75,7 @@ jobs:
           TYPE: Release
           LLVM_VERSION: 12
           RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt."usdt probes - file based semaphore activation multi process"
+          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process
           TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: focal
           VENDOR_GTEST: ON
@@ -83,7 +83,7 @@ jobs:
           TYPE: Release
           LLVM_VERSION: 13
           RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt."usdt probes - file based semaphore activation multi process"
+          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process
           TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: focal
           VENDOR_GTEST: ON
@@ -91,7 +91,7 @@ jobs:
           TYPE: Release
           LLVM_VERSION: 14
           RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt."usdt probes - file based semaphore activation multi process"
+          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process
           TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: focal
           VENDOR_GTEST: ON
@@ -99,7 +99,7 @@ jobs:
           TYPE: Release
           LLVM_VERSION: 15
           RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt."usdt probes - file based semaphore activation multi process"
+          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process
           TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: focal
           VENDOR_GTEST: ON
@@ -107,7 +107,7 @@ jobs:
           TYPE: Release
           LLVM_VERSION: 16
           RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt."usdt probes - file based semaphore activation multi process"
+          RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process
           TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: focal
           VENDOR_GTEST: ON

--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -15,7 +15,7 @@ jobs:
           EMBED_BUILD_LLVM: OFF
           EMBED_USE_LLVM: ON
           RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size,usdt."usdt probes - file based semaphore activation multi process"
+          RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process
           TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: bionic
           DISTRO: ubuntu-glibc
@@ -29,7 +29,7 @@ jobs:
           EMBED_BUILD_LLVM: OFF
           EMBED_USE_LLVM: ON
           RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size,other."string compare map lookup",call.skboutput,usdt."usdt probes - file based semaphore activation multi process"
+          RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size,other.string compare map lookup,call.skboutput,usdt.usdt probes - file based semaphore activation multi process
           TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: focal
           DISTRO: ubuntu-glibc
@@ -42,7 +42,7 @@ jobs:
           STATIC_LIBC: ON
           EMBED_BUILD_LLVM: OFF
           RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: json-output.join_delim,other.string compare map lookup,probe.kprobe_offset_fail_size,probe.uprobe_library,usdt."usdt probes - attach to fully specified probe of child",usdt."usdt probes - all probes by wildcard and file with child",usdt."usdt probes - attach to probe by wildcard and file with child",usdt."usdt probes - attach to probes by wildcard file with child",usdt."usdt probes - attach to probe on multiple files by wildcard",usdt."usdt probes - attach to probe with probe builtin and args by file with child",usdt."usdt probes - list probes by pid in separate mountns",usdt."usdt sized arguments",usdt."usdt - list probes by file with wildcarded probe type",uprobe."uprobes - list probes by pid; uprobes only",uprobe."uprobes - list probes by pid in separate mount namespace",other."positional pointer arithmetics",call.skboutput,usdt."usdt probes - file based semaphore activation multi process",probe.uprobe_zero_size,probe.uprobe_zero_size_unsafe
+          RUNTIME_TEST_DISABLE: json-output.join_delim,other.string compare map lookup,probe.kprobe_offset_fail_size,probe.uprobe_library,usdt.usdt probes - attach to fully specified probe of child,usdt.usdt probes - all probes by wildcard and file with child,usdt.usdt probes - attach to probe by wildcard and file with child,usdt.usdt probes - attach to probes by wildcard file with child,usdt.usdt probes - attach to probe on multiple files by wildcard,usdt.usdt probes - attach to probe with probe builtin and args by file with child,usdt.usdt probes - list probes by pid in separate mountns,usdt.usdt sized arguments,usdt.usdt - list probes by file with wildcarded probe type,uprobe.uprobes - list probes by pid; uprobes only,uprobe.uprobes - list probes by pid in separate mount namespace,other.positional pointer arithmetics,call.skboutput,usdt.usdt probes - file based semaphore activation multi process,probe.uprobe_zero_size,probe.uprobe_zero_size_unsafe
           TOOLS_TEST_DISABLE: gethostlatency.bt,threadsnoop.bt,ssllatency.bt,sslsnoop.bt
           TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: alpine
@@ -57,7 +57,7 @@ jobs:
           STATIC_LIBC: ON
           EMBED_BUILD_LLVM: OFF
           RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: other.string compare map lookup,probe.kprobe_offset_fail_size,probe.uprobe_library,usdt."usdt probes - attach to fully specified probe of child",usdt."usdt probes - all probes by wildcard and file with child",usdt."usdt probes - attach to probe by wildcard and file with child",usdt."usdt probes - attach to probes by wildcard file with child",usdt."usdt probes - attach to probe on multiple files by wildcard",usdt."usdt probes - attach to probe with probe builtin and args by file with child",usdt."usdt probes - list probes by pid in separate mountns",usdt."usdt sized arguments",usdt."usdt - list probes by file with wildcarded probe type",uprobe."uprobes - list probes by pid; uprobes only",uprobe."uprobes - list probes by pid in separate mount namespace",other."positional pointer arithmetics",call.skboutput,usdt."usdt probes - file based semaphore activation multi process",probe.uprobe_zero_size,probe.uprobe_zero_size_unsafe
+          RUNTIME_TEST_DISABLE: other.string compare map lookup,probe.kprobe_offset_fail_size,probe.uprobe_library,usdt.usdt probes - attach to fully specified probe of child,usdt.usdt probes - all probes by wildcard and file with child,usdt.usdt probes - attach to probe by wildcard and file with child,usdt.usdt probes - attach to probes by wildcard file with child,usdt.usdt probes - attach to probe on multiple files by wildcard,usdt.usdt probes - attach to probe with probe builtin and args by file with child,usdt.usdt probes - list probes by pid in separate mountns,usdt.usdt sized arguments,usdt.usdt - list probes by file with wildcarded probe type,uprobe.uprobes - list probes by pid; uprobes only,uprobe.uprobes - list probes by pid in separate mount namespace,other.positional pointer arithmetics,call.skboutput,usdt.usdt probes - file based semaphore activation multi process,probe.uprobe_zero_size,probe.uprobe_zero_size_unsafe
           TOOLS_TEST_DISABLE: gethostlatency.bt,threadsnoop.bt,ssllatency.bt,sslsnoop.bt
           TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
           BASE: alpine

--- a/docs/developers.md
+++ b/docs/developers.md
@@ -59,8 +59,8 @@ override it (`--entrypoint=`) and build bpftrace manually in the container.
 
 Some tests are known to be flaky and sometimes fail in the CI environment. The
 list of known such tests:
-- runtime test `usdt."usdt probes - file based semaphore activation multi
-  process"` ([#2410](https://github.com/iovisor/bpftrace/issues/2402))
+- runtime test `usdt.usdt probes - file based semaphore activation multi
+  process` ([#2410](https://github.com/iovisor/bpftrace/issues/2402))
 
 What usually helps, is restarting the CI. This is simple on your own fork but
 requires one of the maintainers for pull requests.

--- a/tests/runtime-tests.sh
+++ b/tests/runtime-tests.sh
@@ -17,4 +17,4 @@ echo "bpftrace --info:"
 echo "===================="
 "${BPFTRACE_RUNTIME_TEST_EXECUTABLE}/bpftrace" --info
 
-python3 runtime/engine/main.py $@
+python3 runtime/engine/main.py "$@"

--- a/tests/runtime/engine/main.py
+++ b/tests/runtime/engine/main.py
@@ -72,11 +72,11 @@ def main(test_filter, run_aot_tests):
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Runtime tests for bpftrace.')
-    parser.add_argument('--filter', dest='tests_filter',
-                        help='filter runtime tests')
+    parser.add_argument('--filter', type=str, dest='test_filter',
+                        help='Run only specified runtime test. Format should be "<test feature/test group>.<testcase name>"')
     parser.add_argument('--run-aot-tests', action='store_true',
                         help='Run ahead-of-time compilation tests. Note this would roughly double test time.')
 
     args = parser.parse_args()
 
-    main(args.tests_filter, args.run_aot_tests)
+    main(args.test_filter, args.run_aot_tests)

--- a/tests/runtime/uprobe
+++ b/tests/runtime/uprobe
@@ -1,63 +1,63 @@
-NAME "uprobes - list probes by file"
+NAME uprobes - list probes by file
 RUN {{BPFTRACE}} -l 'uprobe:./testprogs/uprobe_test:*'
 EXPECT uprobe:./testprogs/uprobe_test:function1
 TIMEOUT 5
 
-NAME "uprobes - list probes by file with wildcarded filter"
+NAME uprobes - list probes by file with wildcarded filter
 RUN {{BPFTRACE}} -l 'uprobe:./testprogs/uprobe_test:func*'
 EXPECT uprobe:./testprogs/uprobe_test:function1
 TIMEOUT 5
 
-NAME "uprobes - list probes with wildcarded file matching multiple files"
+NAME uprobes - list probes with wildcarded file matching multiple files
 RUN {{BPFTRACE}} -l 'uprobe:./testprogs/uprobe*:*'
 EXPECT uprobe:./testprogs/uprobe_test:function1
 TIMEOUT 5
 
-NAME "uprobes - list probes by file with wildcarded file and filter"
+NAME uprobes - list probes by file with wildcarded file and filter
 RUN {{BPFTRACE}} -l 'uprobe:./testprogs/uprobe_test*:func*'
 EXPECT uprobe:./testprogs/uprobe_test:function1
 TIMEOUT 5
 
-NAME "uprobes - list probes by file with specific filter"
+NAME uprobes - list probes by file with specific filter
 RUN {{BPFTRACE}} -l 'uprobe:./testprogs/uprobe_test:function1'
 EXPECT uprobe:./testprogs/uprobe_test:function1
 TIMEOUT 5
 
-NAME "uprobes - list probes by file with wildcarded probe type"
+NAME uprobes - list probes by file with wildcarded probe type
 RUN {{BPFTRACE}} -l '*:./testprogs/uprobe_test:*' | grep -e '^uprobe:'
 EXPECT uprobe:./testprogs/uprobe_test:function1
 TIMEOUT 5
 
-NAME "uprobes - list probes by pid"
+NAME uprobes - list probes by pid
 RUN {{BPFTRACE}} -l -p {{BEFORE_PID}} | grep -e '^uprobe'
 EXPECT uprobe:.*/testprogs/uprobe_test:function1
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
-NAME "uprobes - list probes by pid; uprobes only"
+NAME uprobes - list probes by pid; uprobes only
 RUN {{BPFTRACE}} -l 'uprobe:*' -p {{BEFORE_PID}}
 EXPECT uprobe:.*/testprogs/uprobe_test:function1
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
-NAME "uprobes - list probes by pid in separate mount namespace"
+NAME uprobes - list probes by pid in separate mount namespace
 RUN {{BPFTRACE}} -l -p {{BEFORE_PID}} | grep -e '^uprobe'
 EXPECT uprobe:.*/bpftrace-unshare-mountns-test/uprobe_test:function1
 TIMEOUT 5
 BEFORE ./testprogs/mountns_wrapper uprobe_test
 
-NAME "uprobes - attach to probe for executable in separate mount namespace"
+NAME uprobes - attach to probe for executable in separate mount namespace
 RUN {{BPFTRACE}} -e 'uprobe:/tmp/bpftrace-unshare-mountns-test/uprobe_test:function1 { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT Attaching 1 probe...
 TIMEOUT 5
 BEFORE ./testprogs/mountns_wrapper uprobe_test
 
-NAME "uprobes - list probes in non-executable library"
+NAME uprobes - list probes in non-executable library
 RUN {{BPFTRACE}} -l 'uprobe:./testlibs/libsimple.so:fun'
 EXPECT uprobe:./testlibs/libsimple.so:fun
 TIMEOUT 5
 
-NAME "uprobes - probe function in non-executable library"
+NAME uprobes - probe function in non-executable library
 PROG uprobe:./testlibs/libsimple.so:fun {}
 EXPECT Attaching 1 probe...
 TIMEOUT 5

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -1,101 +1,101 @@
-NAME "usdt probes - list probes by file"
+NAME usdt probes - list probes by file
 RUN {{BPFTRACE}} -l 'usdt:./testprogs/usdt_test:*'
 EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe
 TIMEOUT 5
 REQUIRES ./testprogs/usdt_test should_not_skip
 
-NAME "usdt - list probes by file with wildcarded probe type"
+NAME usdt - list probes by file with wildcarded probe type
 RUN {{BPFTRACE}} -l '*:./testprogs/usdt_test:*' | grep -e '^usdt:'
 EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe
 TIMEOUT 5
 
-NAME "usdt probes - list probes by pid"
+NAME usdt probes - list probes by pid
 RUN {{BPFTRACE}} -l -p {{BEFORE_PID}} | grep -e '^usdt:'
 EXPECT usdt:.*/testprogs/usdt_test:tracetest:testprobe
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 
-NAME "usdt probes - list probes by pid; usdt only"
+NAME usdt probes - list probes by pid; usdt only
 RUN {{BPFTRACE}} -l 'usdt:*' -p {{BEFORE_PID}}
 EXPECT usdt_test:tracetest:testprobe
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 
-NAME "usdt probes - lists linked library probes by pid"
+NAME usdt probes - lists linked library probes by pid
 RUN {{BPFTRACE}} -l 'usdt:*' -p $(pidof usdt_lib)
 EXPECT libusdt_tp.so:tracetestlib:lib_probe_1
 TIMEOUT 5
 BEFORE ./testprogs/usdt_lib
 REQUIRES ./testprogs/usdt_lib should_not_skip
 
-NAME "usdt probes - filter probes by file on provider"
+NAME usdt probes - filter probes by file on provider
 RUN {{BPFTRACE}} -l 'usdt:./testprogs/usdt_test:tracetest2:*'
 EXPECT usdt:./testprogs/usdt_test:tracetest2:testprobe2
 TIMEOUT 5
 REQUIRES ./testprogs/usdt_test should_not_skip
 
-NAME "usdt probes - filter probes by pid on provider"
+NAME usdt probes - filter probes by pid on provider
 RUN {{BPFTRACE}} -l 'usdt:*:tracetest2:*' -p {{BEFORE_PID}}
 EXPECT usdt_test:tracetest2:testprobe2
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 
-NAME "usdt probes - filter probes by wildcard file and wildcard probe name"
+NAME usdt probes - filter probes by wildcard file and wildcard probe name
 RUN {{BPFTRACE}} -l 'usdt:./testprogs/usdt_test*:tracetest:test*'
 EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe2
 TIMEOUT 5
 REQUIRES ./testprogs/usdt_test should_not_skip
 
-NAME "usdt probes - filter probes by file and wildcard probe name"
+NAME usdt probes - filter probes by file and wildcard probe name
 RUN {{BPFTRACE}} -l 'usdt:./testprogs/usdt_test:tracetest:test*'
 EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe2
 TIMEOUT 5
 REQUIRES ./testprogs/usdt_test should_not_skip
 
-NAME "usdt probes - filter probes by pid and wildcard probe name"
+NAME usdt probes - filter probes by pid and wildcard probe name
 RUN {{BPFTRACE}} -l 'usdt:*:tracetest:test*' -p {{BEFORE_PID}}
 EXPECT usdt_test:tracetest:testprobe2
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 
-NAME "usdt probes - attach to fully specified probe by file"
+NAME usdt probes - attach to fully specified probe by file
 PROG usdt:./testprogs/usdt_test:tracetest:testprobe { printf("here\n" ); exit(); }
 EXPECT here
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 TIMEOUT 5
 
-NAME "usdt probes - attach to fully specified probe of child"
+NAME usdt probes - attach to fully specified probe of child
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:tracetest:testprobe { printf("here\n" ); exit(); }' -c ./testprogs/usdt_test
 EXPECT here
 TIMEOUT 5
 
-NAME "usdt probes - attach to fully specified probe by pid"
+NAME usdt probes - attach to fully specified probe by pid
 RUN {{BPFTRACE}} -e 'usdt::tracetest:testprobe { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT here
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 TIMEOUT 5
 
-NAME "usdt probes - attach to fully specified library probe by pid"
+NAME usdt probes - attach to fully specified library probe by pid
 RUN {{BPFTRACE}} -e 'usdt:./testlibs/libusdt_tp.so:tracetestlib:lib_probe_1 { printf("here\n" ); exit(); }' -p $(pidof usdt_lib)
 BEFORE ./testprogs/usdt_lib
 EXPECT here
 TIMEOUT 5
 REQUIRES ./testprogs/usdt_lib should_not_skip
 
-NAME "usdt probes - all probes by wildcard and file"
+NAME usdt probes - all probes by wildcard and file
 PROG usdt:./testprogs/usdt_test:* { printf("here\n" ); exit(); }
 EXPECT Attaching 3 probes...
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 
-NAME "usdt probes - all probes by wildcard and file with child"
+NAME usdt probes - all probes by wildcard and file with child
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:* { printf("here\n" ); exit(); }' -c ./testprogs/usdt_test
 EXPECT Attaching 3 probes...
 TIMEOUT 5
@@ -108,7 +108,7 @@ TIMEOUT 5
 #  - Skip if bcc doesn't support multiple probes with the same name
 #  - Fix https://github.com/iovisor/bpftrace/issues/565#issuecomment-496731112
 #    and https://github.com/iovisor/bpftrace/issues/688
-NAME "usdt probes - all probes by wildcard and pid"
+NAME usdt probes - all probes by wildcard and pid
 RUN {{BPFTRACE}} -e 'usdt:* { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT Attaching 3 probes...
 TIMEOUT 5
@@ -116,43 +116,43 @@ BEFORE ./testprogs/usdt_test
 REQUIRES bash -c "exit 1"
 # REQUIRES ./testprogs/usdt_test should_not_skip
 
-NAME "usdt probes - attach to probe by wildcard and file"
+NAME usdt probes - attach to probe by wildcard and file
 PROG usdt:./testprogs/usdt_test::*probe2 { printf("here\n" ); exit(); }
 EXPECT Attaching 2 probes...
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 
-NAME "usdt probes - attach to probe by wildcard and file with child"
+NAME usdt probes - attach to probe by wildcard and file with child
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test::*probe2 { printf("here\n" ); exit(); }' -c ./testprogs/usdt_test
 EXPECT Attaching 2 probes...
 TIMEOUT 5
 
-NAME "usdt probes - attach to probes by wildcard file"
+NAME usdt probes - attach to probes by wildcard file
 PROG usdt:./testprogs/usdt_test*::* { printf("here\n" ); exit(); }
 EXPECT Attaching 3 probes...
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 TIMEOUT 5
 
-NAME "usdt probes - attach to probes by wildcard file with child"
+NAME usdt probes - attach to probes by wildcard file with child
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test*::* { printf("here\n" ); exit(); }' -c ./testprogs/usdt_test
 EXPECT Attaching 3 probes...
 TIMEOUT 5
 
-NAME "usdt probes - attach to probe on multiple files by wildcard"
+NAME usdt probes - attach to probe on multiple files by wildcard
 PROG usdt:./testprogs/usdt*::* { printf("here\n" ); exit(); }
 EXPECT Attaching 48 probes...
 TIMEOUT 5
 
-NAME "usdt probes - attach to probe on multiple providers by wildcard and pid"
+NAME usdt probes - attach to probe on multiple providers by wildcard and pid
 RUN {{BPFTRACE}} -e 'usdt:::*probe2 { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT Attaching 2 probes...
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 
-NAME "usdt probes - attach to multiple probes with different number of locations by wildcard"
+NAME usdt probes - attach to multiple probes with different number of locations by wildcard
 PROG usdt:./testprogs/usdt_multiple_locations:tracetest:testprobe* { printf("here\n" ); exit(); }
 BEFORE ./testprogs/usdt_multiple_locations
 EXPECT Attaching 6 probes...
@@ -163,7 +163,7 @@ REQUIRES ./testprogs/usdt_multiple_locations should_not_skip
 # This test relies on the latest version of bcc. Before re-enabling this test,
 # we should:
 #  - Skip if bcc doesn't support multiple probes with the same name
-NAME "usdt probes - attach to probe with args by file"
+NAME usdt probes - attach to probe with args by file
 PROG usdt:./testprogs/usdt_test:* { printf("%s\n", str(arg1) ); exit(); }
 EXPECT Hello world
 TIMEOUT 5
@@ -175,7 +175,7 @@ REQUIRES bash -c "exit 1"
 # This test relies on the latest version of bcc. Before re-enabling this test,
 # we should:
 #  - Skip if bcc doesn't support multiple probes with the same name
-NAME "usdt probes - attach to probe with args by pid"
+NAME usdt probes - attach to probe with args by pid
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:* { printf("%s\n", str(arg1) ); exit(); }' -p {{BEFORE_PID}}
 EXPECT Hello world
 TIMEOUT 5
@@ -183,40 +183,40 @@ BEFORE ./testprogs/usdt_test
 REQUIRES bash -c "exit 1"
 # REQUIRES ./testprogs/usdt_test should_not_skip
 
-NAME "usdt probes - attach to probe with probe builtin and args by file"
+NAME usdt probes - attach to probe with probe builtin and args by file
 PROG usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }
 EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 
-NAME "usdt probes - attach to probe with probe builtin and args by file with child"
+NAME usdt probes - attach to probe with probe builtin and args by file with child
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }' -c ./testprogs/usdt_test
 EXPECT usdt:./testprogs/usdt_test:tracetest:testprobe
 TIMEOUT 5
 
-NAME "usdt probes - attach to probe with probe builtin and args by pid"
+NAME usdt probes - attach to probe with probe builtin and args by pid
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_test:* { printf("%lld %s\n", arg0, probe ); exit(); }' -p {{BEFORE_PID}}
 EXPECT usdt_test:tracetest:testprobe
 TIMEOUT 5
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 
-NAME "usdt probes - attach to probe with semaphore"
+NAME usdt probes - attach to probe with semaphore
 RUN {{BPFTRACE}} -e 'usdt::tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }' -p {{BEFORE_PID}}
 EXPECT tracetest_testprobe_semaphore: [1-9]
 TIMEOUT 5
 BEFORE ./testprogs/usdt_semaphore_test
 REQUIRES ./testprogs/usdt_semaphore_test should_not_skip
 
-NAME "usdt probes - file based semaphore activation"
+NAME usdt probes - file based semaphore activation
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }' --usdt-file-activation
 EXPECT tracetest_testprobe_semaphore: [1-9]
 TIMEOUT 5
 BEFORE ./testprogs/usdt_semaphore_test
 REQUIRES ./testprogs/usdt_semaphore_test should_not_skip
 
-NAME "usdt probes - file based semaphore activation no process"
+NAME usdt probes - file based semaphore activation no process
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { exit(); }' --usdt-file-activation
 EXPECT Failed to find processes running
 TIMEOUT 5
@@ -226,7 +226,7 @@ WILL_FAIL
 
 # We should be able to attach a probe even without any running processes
 # if the kernel handles the semaphore
-NAME "usdt probes - file based semaphore activation no process, kernel usdt semaphore"
+NAME usdt probes - file based semaphore activation no process, kernel usdt semaphore
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { exit(); }' --usdt-file-activation
 EXPECT Attaching 1 probe
 TIMEOUT 5
@@ -235,7 +235,7 @@ REQUIRES_FEATURE uprobe_refcount
 
 # We should be able to activate a semaphore without specifying a PID or
 # --usdt-file-activation if the kernel handles the semaphore
-NAME "usdt probes - file based semaphore activation"
+NAME usdt probes - file based semaphore activation
 PROG usdt:./testprogs/usdt_semaphore_test:tracetest:testprobe { printf("%s\n", str(arg1) ); exit(); }
 EXPECT tracetest_testprobe_semaphore: [1-9]
 TIMEOUT 5
@@ -243,7 +243,7 @@ BEFORE ./testprogs/usdt_semaphore_test
 REQUIRES ./testprogs/usdt_semaphore_test should_not_skip
 REQUIRES_FEATURE uprobe_refcount
 
-NAME "usdt probes - file based semaphore activation multi process"
+NAME usdt probes - file based semaphore activation multi process
 RUN {{BPFTRACE}} runtime/scripts/usdt_file_activation_multiprocess.bt --usdt-file-activation
 EXPECT found 2 processes
 TIMEOUT 5
@@ -251,7 +251,7 @@ BEFORE ./testprogs/usdt_semaphore_test
 BEFORE ./testprogs/usdt_semaphore_test
 REQUIRES ./testprogs/usdt_semaphore_test should_not_skip
 
-NAME "usdt probes - list probes by pid in separate mountns"
+NAME usdt probes - list probes by pid in separate mountns
 RUN {{BPFTRACE}} -l 'usdt:*' -p {{BEFORE_PID}}
 EXPECT usdt:.*/tmp/bpftrace-unshare-mountns-test/usdt_test:tracetest:testprobe
 TIMEOUT 5
@@ -260,27 +260,27 @@ BEFORE ./testprogs/mountns_wrapper usdt_test
 # TODO(dalehamel): re-enable this test
 # This test relies on the latest version of bcc (expected to be released as 0.13.0)
 # Once we build against this version with USDT fixes, we should re-enable this test.
-NAME "usdt probes - attach to fully specified probe by pid in separate mountns"
+NAME usdt probes - attach to fully specified probe by pid in separate mountns
 RUN {{BPFTRACE}} -e 'usdt:/tmp/bpftrace-unshare-mountns-test/usdt_test:tracetest:testprobe { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT here
 TIMEOUT 5
 BEFORE ./testprogs/mountns_wrapper usdt_test
 REQUIRES bash -c "exit 1"
 
-NAME "usdt quoted probe name"
+NAME usdt quoted probe name
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_quoted_probe:test:"\"probe1\"" { printf("%d\n", arg0); exit(); }' -p {{BEFORE_PID}}
 EXPECT 1
 TIMEOUT 5
 BEFORE ./testprogs/usdt_quoted_probe
 REQUIRES ./testprogs/usdt_quoted_probe should_not_skip
 
-NAME "usdt sized arguments"
+NAME usdt sized arguments
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_sized_args:test:probe2 { printf("%ld\n", arg0); exit(); }' -p {{BEFORE_PID}}
 EXPECT ^1$
 TIMEOUT 5
 BEFORE ./testprogs/usdt_sized_args
 
-NAME "usdt constant arguments"
+NAME usdt constant arguments
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_args:usdt_args:const_* { printf("%lld ", arg0); }' -c ./testprogs/usdt_args
 EXPECT 4092785136 -202182160 61936 -3600 240 -16
 #EXPECT -579005069656919568 -579005069656919568 4092785136 -202182160 61936 -3600 240 -16
@@ -288,19 +288,19 @@ EXPECT 4092785136 -202182160 61936 -3600 240 -16
 TIMEOUT 5
 REQUIRES ./testprogs/usdt_args should_not_skip
 
-NAME "usdt reg arguments"
+NAME usdt reg arguments
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_args:usdt_args:reg_* { printf("%lld ", arg0); }' -c ./testprogs/usdt_args
 EXPECT -579005069656919568 -579005069656919568 4092785136 -202182160 61936 -3600 240 -16
 TIMEOUT 5
 REQUIRES ./testprogs/usdt_args should_not_skip
 
-NAME "usdt addr arguments"
+NAME usdt addr arguments
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_args:usdt_args:addr_* { printf("%lld ", arg0); }' -c ./testprogs/usdt_args
 EXPECT -579005069656919568 -579005069656919568 4092785136 -202182160 61936 -3600 240 -16
 TIMEOUT 5
 REQUIRES ./testprogs/usdt_args should_not_skip
 
-NAME "usdt addr+index arguments"
+NAME usdt addr+index arguments
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_args:usdt_args:index_* { printf("%lld ", arg0); }' -c ./testprogs/usdt_args
 EXPECT -579005069656919568 -579005069656919568 4092785136 -202182160 61936 -3600 240 -16
 TIMEOUT 5
@@ -308,13 +308,13 @@ REQUIRES ./testprogs/usdt_args should_not_skip
 
 # USDT probes can be inlined which creates duplicate identical probes. We must
 # attach to all of them
-NAME "usdt duplicated markers"
+NAME usdt duplicated markers
 RUN {{BPFTRACE}} -e 'usdt:./testprogs/usdt_inlined:tracetest:testprobe { printf("%d\n", arg1); @a += 1; if (@a >= 2) {exit();} }' -c ./testprogs/usdt_inlined
 EXPECT Attaching 2 probes.*\n.*\s999\s*100
 TIMEOUT 1
 REQUIRES ./testprogs/usdt_inlined should_not_skip
 
-NAME "usdt probes in multiple modules"
+NAME usdt probes in multiple modules
 RUN {{BPFTRACE}} runtime/scripts/usdt_multi_modules.bt
 EXPECT Attaching 2 probes
 TIMEOUT 1


### PR DESCRIPTION
This patch handles following observed issues:

1. Inconsistency with test names, some have double qoutes('"'), whereas others don't. Extra pre-processing is required in runtime bash script for such inconsistent names, before they are supplied as args to python script.

2. Test name nomenclature for --test-filter option is missing. Need to manually figure out from code.
