### PR TITLE
Fixing args-type in subprocess.Popen against f4bc83e

### DIFF
--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -287,7 +287,7 @@ class Runner(object):
 
         if test.cleanup:
             try:
-                cleanup = subprocess.run(test.cleanup.split(), shell=True, capture_output=True, text=True)
+                cleanup = subprocess.run(test.cleanup, shell=True, capture_output=True, text=True)
                 cleanup.check_returncode()
             except subprocess.CalledProcessError as e:
                 print(fail("[  FAILED  ] ") + "%s.%s" % (test.suite, test.name))


### PR DESCRIPTION
As per subprocess.Popen docs: If shell=True, it is recommended to pass args as string rather than as
a sequence.