### PR TITLE
Introduce builtin nsecs_tai which is nanoseconds of CLOCK_TAI 

### DIFF
--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -105,6 +105,7 @@ discussion to other files in /docs, the /tools/\*\_examples.txt files, or blog p
     - [33. `pton()`: Convert text IP address to byte array](#33-pton-convert-text-ip-address-to-byte-array)
     - [34. `strerror`: Get error message for errno value](#34-strerror-get-error-message-for-errno-code)
     - [35. `offsetof`: Offset of element in structure](#35-offsetof-offset-of-element-in-structure)
+    - [36. `nsecs()`: Timestamps and Time Deltas](#36-nsecs-timestamps-and-time-deltas)
 - [Map Functions](#map-functions)
     - [1. Builtins](#1-builtins-2)
     - [2. `count()`: Count](#2-count-count)
@@ -2289,6 +2290,7 @@ Tracing block I/O sizes > 0 bytes
 - `macaddr(char[6] addr)` - Convert MAC address data
 - `bswap(uint[8|16|32|64] n)` - Reverse byte order
 - `offsetof(struct, element)` - Offset of element in structure
+- `nsecs([TimestampMode mode])` - Timestamps and Time Deltas
 
 Some of these are asynchronous: the kernel queues the event, but some time later (milliseconds) it is
 processed in user-space. The asynchronous actions are: `printf()`, `time()`, and `join()`. Both `ksym()`
@@ -3359,6 +3361,39 @@ BEGIN
 Attaching 1 probe...
 Offset of flags: 44
 Offset of comm: 3216
+```
+
+## 36. `nsecs()`: Timestamps and Time Deltas
+
+Syntax: `nsecs([TimestampMode mode])`
+
+Get the nanoseconds of the specified clock. Three time types are currently supported, namely
+- boot: nsecs() or nsecs(boot) is to get nanoseconds since the system boot
+- tai: nsecs(tai) is to get nanoseconds of CLOCK_TAI through bpf_ktime_get_tai_ns helper function
+- sw_tai: nsecs(sw_tai) is to get nanoseconds of CLOCK_TAI, but it is obtained through the "triple vdso sandwich" method
+
+Examples:
+
+```
+# cat -n example.bt
+#!/usr/bin/env bpftrace
+i:s:1 {
+        $sw_tai1 = nsecs(sw_tai);
+        $tai = nsecs(tai);
+        $sw_tai2 = nsecs(sw_tai);
+
+        printf("sw_tai precision: %lldns\n", ($sw_tai1 + $sw_tai2)/2 - $tai);
+}
+```
+
+Running example.bt:
+
+```
+Attaching 1 probe...
+sw_tai precision: -98ns
+sw_tai precision: -92ns
+sw_tai precision: -99ns
+sw_tai precision: -99ns
 ```
 
 # Map Functions

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -104,6 +104,7 @@ discussion to other files in /docs, the /tools/\*\_examples.txt files, or blog p
     - [32. `skb_output`: Write `skb` 's data section into a PCAP file](#32-skb_output-write-skb-s-data-section-into-a-pcap-file)
     - [33. `pton()`: Convert text IP address to byte array](#33-pton-convert-text-ip-address-to-byte-array)
     - [34. `strerror`: Get error message for errno value](#34-strerror-get-error-message-for-errno-code)
+    - [35. `offsetof`: Offset of element in structure](#35-offsetof-offset-of-element-in-structure)
 - [Map Functions](#map-functions)
     - [1. Builtins](#1-builtins-2)
     - [2. `count()`: Count](#2-count-count)
@@ -3333,7 +3334,7 @@ Attaching 1 probe...
 Operation not permitted
 ```
 
-# 35. `offsetof`: Offset of element in structure
+## 35. `offsetof`: Offset of element in structure
 
 Syntax:
 - `offsetof(struct, element)`

--- a/src/ast/async_event_types.cpp
+++ b/src/ast/async_event_types.cpp
@@ -47,8 +47,9 @@ std::vector<llvm::Type*> Time::asLLVMType(ast::IRBuilderBPF& b)
 std::vector<llvm::Type*> Strftime::asLLVMType(ast::IRBuilderBPF& b)
 {
   return {
-    b.getInt64Ty(), // strftime id
-    b.getInt64Ty(), // strftime arg, time elapsed since boot
+    b.getInt32Ty(), // strftime id
+    b.getInt32Ty(), // timestamp mode
+    b.getInt64Ty(), // strftime arg, nanoseconds
   };
 }
 

--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -65,8 +65,9 @@ struct Time
 
 struct Strftime
 {
-  uint64_t strftime_id;
-  uint64_t nsecs_since_boot;
+  uint32_t strftime_id;
+  uint32_t mode;
+  uint64_t nsecs;
 
   std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b);
 } __attribute__((packed));

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -981,6 +981,13 @@ CallInst *IRBuilderBPF::CreateGetNs(bool boot_time, const location &loc)
   return CreateHelperCall(fn, gettime_func_type, {}, "get_ns", &loc);
 }
 
+CallInst *IRBuilderBPF::CreateGetTaiNs(const location &loc)
+{
+  auto fn = libbpf::BPF_FUNC_ktime_get_tai_ns;
+  FunctionType *gettime_func_type = FunctionType::get(getInt64Ty(), false);
+  return CreateHelperCall(fn, gettime_func_type, {}, "get_tai_ns", &loc);
+}
+
 Value *IRBuilderBPF::CreateIntegerArrayCmpUnrolled(Value *ctx,
                                                    Value *val1,
                                                    Value *val2,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -160,6 +160,7 @@ public:
                                const location &loc,
                                MDNode *metadata);
   CallInst *CreateGetNs(bool boot_time, const location &loc);
+  CallInst *CreateGetTaiNs(const location &loc);
   CallInst *CreateGetPidTgid(const location &loc);
   CallInst *CreateGetCurrentCgroupId(const location &loc);
   CallInst *CreateGetUidGid(const location &loc);

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1146,11 +1146,17 @@ void CodegenLLVM::visit(Call &call)
         b_.GetIntSameSize(strftime_id_, elements.at(0)),
         b_.CreateGEP(strftime_struct, buf, { b_.getInt64(0), b_.getInt32(0) }));
     strftime_id_++;
+    b_.CreateStore(
+        b_.GetIntSameSize(
+            static_cast<std::underlying_type<TimestampMode>::type>(
+                call.type.ts_mode),
+            elements.at(1)),
+        b_.CreateGEP(strftime_struct, buf, { b_.getInt64(0), b_.getInt32(1) }));
     Expression *arg = call.vargs->at(1);
     auto scoped_del = accept(arg);
     b_.CreateStore(
         expr_,
-        b_.CreateGEP(strftime_struct, buf, { b_.getInt64(0), b_.getInt32(1) }));
+        b_.CreateGEP(strftime_struct, buf, { b_.getInt64(0), b_.getInt32(2) }));
     expr_ = buf;
   }
   else if (call.func == "kstack" || call.func == "ustack")

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1319,10 +1319,17 @@ void CodegenLLVM::visit(Call &call)
   }
   else if (call.func == "nsecs")
   {
-    if (call.type.ts_mode == TimestampMode::boot)
+    if (call.type.ts_mode == TimestampMode::boot ||
+        call.type.ts_mode == TimestampMode::sw_tai)
     {
       expr_ = b_.CreateGetNs(bpftrace_.feature_->has_helper_ktime_get_boot_ns(),
                              call.loc);
+      if (call.type.ts_mode == TimestampMode::sw_tai)
+      {
+        uint64_t delta = bpftrace_.delta_taitime_->tv_sec * 1e9 +
+                         bpftrace_.delta_taitime_->tv_nsec;
+        expr_ = b_.CreateAdd(expr_, b_.getInt64(delta));
+      }
     }
     else if (call.type.ts_mode == TimestampMode::tai)
     {

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1311,6 +1311,14 @@ void CodegenLLVM::visit(Call &call)
     expr_ = ret;
     skb_output_id_++;
   }
+  else if (call.func == "nsecs")
+  {
+    if (call.type.ts_mode == TimestampMode::boot)
+    {
+      expr_ = b_.CreateGetNs(bpftrace_.feature_->has_helper_ktime_get_boot_ns(),
+                             call.loc);
+    }
+  }
   else
   {
     LOG(FATAL) << "missing codegen for function \"" << call.func << "\"";

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1324,6 +1324,10 @@ void CodegenLLVM::visit(Call &call)
       expr_ = b_.CreateGetNs(bpftrace_.feature_->has_helper_ktime_get_boot_ns(),
                              call.loc);
     }
+    else if (call.type.ts_mode == TimestampMode::tai)
+    {
+      expr_ = b_.CreateGetTaiNs(call.loc);
+    }
   }
   else
   {

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -144,6 +144,10 @@ void SemanticAnalyser::visit(Identifier &identifier)
     {
       identifier.type.ts_mode = TimestampMode::tai;
     }
+    else if (identifier.ident == "sw_tai")
+    {
+      identifier.type.ts_mode = TimestampMode::sw_tai;
+    }
     else
     {
       goto err;

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1113,9 +1113,13 @@ void SemanticAnalyser::visit(Call &call)
   else if (call.func == "strftime")
   {
     call.type = CreateTimestamp();
-    check_varargs(call, 2, 2) && is_final_pass() &&
+    if (check_varargs(call, 2, 2) && is_final_pass() &&
         check_arg(call, Type::string, 0, true) &&
-        check_arg(call, Type::integer, 1, false);
+        check_arg(call, Type::integer, 1, false))
+    {
+      auto &arg = *call.vargs->at(1);
+      call.type.ts_mode = arg.type.ts_mode;
+    }
   }
   else if (call.func == "kstack") {
     check_stack_call(call, true);

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -140,6 +140,10 @@ void SemanticAnalyser::visit(Identifier &identifier)
     {
       identifier.type.ts_mode = TimestampMode::boot;
     }
+    else if (identifier.ident == "tai")
+    {
+      identifier.type.ts_mode = TimestampMode::tai;
+    }
     else
     {
       goto err;
@@ -1361,6 +1365,13 @@ void SemanticAnalyser::visit(Call &call)
           check_arg(call, Type::timestamp_mode, 0))
       {
         call.type.ts_mode = call.vargs->at(0)->type.ts_mode;
+      }
+
+      if (call.type.ts_mode == TimestampMode::tai &&
+          !bpftrace_.feature_->has_helper_ktime_get_tai_ns())
+      {
+        LOG(ERROR, call.loc, err_)
+            << "Kernel does not support tai timestamp, please try sw_tai";
       }
     }
   }

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -500,6 +500,7 @@ std::string BPFfeature::report(void)
       << "  get_boot_ns: " << to_str(has_helper_ktime_get_boot_ns())
       << "  dpath: " << to_str(has_d_path())
       << "  skboutput: " << to_str(has_skb_output())
+      << "  get_tai_ns: " << to_str(has_helper_ktime_get_tai_ns())
 
       << std::endl;
 

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -103,6 +103,7 @@ public:
   DEFINE_HELPER_TEST(probe_read_user_str, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_HELPER_TEST(probe_read_kernel_str, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_HELPER_TEST(ktime_get_boot_ns, libbpf::BPF_PROG_TYPE_KPROBE);
+  DEFINE_HELPER_TEST(ktime_get_tai_ns, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_PROG_TEST(kprobe, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_PROG_TEST(tracepoint, libbpf::BPF_PROG_TYPE_TRACEPOINT);
   DEFINE_PROG_TEST(perf_event, libbpf::BPF_PROG_TYPE_PERF_EVENT);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -2017,7 +2017,7 @@ std::string BPFtrace::resolve_timestamp(uint32_t mode,
     }
     else
     {
-      basetime = boottime_.operator->();
+      basetime = &boottime_.value();
     }
   }
 

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -775,9 +775,11 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(const std::vec
         arg_values.push_back(
             std::make_unique<PrintableString>(resolve_timestamp(
                 reinterpret_cast<AsyncEvent::Strftime *>(arg_data + arg.offset)
+                    ->mode,
+                reinterpret_cast<AsyncEvent::Strftime *>(arg_data + arg.offset)
                     ->strftime_id,
                 reinterpret_cast<AsyncEvent::Strftime *>(arg_data + arg.offset)
-                    ->nsecs_since_boot)));
+                    ->nsecs)));
         break;
       case Type::pointer:
         arg_values.push_back(std::make_unique<PrintableInt>(
@@ -1996,12 +1998,14 @@ std::string BPFtrace::resolve_uid(uintptr_t addr) const
   return username;
 }
 
-std::string BPFtrace::resolve_timestamp(uint32_t strftime_id,
-                                        uint64_t nsecs_since_boot)
+std::string BPFtrace::resolve_timestamp(uint32_t mode,
+                                        uint32_t strftime_id,
+                                        uint64_t nsecs)
 {
   static const auto usec_regex = std::regex("%f");
+  TimestampMode ts_mode = static_cast<TimestampMode>(mode);
 
-  if (!boottime_)
+  if (!boottime_ && ts_mode == TimestampMode::boot)
   {
     LOG(ERROR) << "Cannot resolve timestamp due to failed boot time calcuation";
     return "(?)";
@@ -2009,8 +2013,7 @@ std::string BPFtrace::resolve_timestamp(uint32_t strftime_id,
 
   // Calculate and localize timestamp
   struct tm tmp;
-  time_t time = boottime_->tv_sec +
-                ((boottime_->tv_nsec + nsecs_since_boot) / 1e9);
+  time_t time = boottime_->tv_sec + ((boottime_->tv_nsec + nsecs) / 1e9);
   if (!localtime_r(&time, &tmp))
   {
     LOG(ERROR) << "localtime_r: " << strerror(errno);
@@ -2019,7 +2022,7 @@ std::string BPFtrace::resolve_timestamp(uint32_t strftime_id,
 
   // Process strftime() format string extensions
   const auto &raw_fmt = resources.strftime_args[strftime_id];
-  uint64_t us = ((boottime_->tv_nsec + nsecs_since_boot) % 1000000000) / 1000;
+  uint64_t us = ((boottime_->tv_nsec + nsecs) % 1000000000) / 1000;
   char usecs_buf[7];
   snprintf(usecs_buf, sizeof(usecs_buf), "%06lu", us);
   auto fmt = std::regex_replace(raw_fmt, usec_regex, usecs_buf);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -216,6 +216,7 @@ public:
   uint64_t ast_max_nodes_ = 0; // Maximum AST nodes allowed for fuzzing
   std::optional<StackMode> stack_mode_;
   std::optional<struct timespec> boottime_;
+  std::optional<struct timespec> delta_taitime_;
   static constexpr uint32_t rb_loss_cnt_key_ = 0;
   static constexpr uint64_t rb_loss_cnt_val_ = 0;
 

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -133,7 +133,9 @@ public:
                            bool show_module = false);
   std::string resolve_inet(int af, const uint8_t* inet) const;
   std::string resolve_uid(uintptr_t addr) const;
-  std::string resolve_timestamp(uint32_t strftime_id, uint64_t nsecs);
+  std::string resolve_timestamp(uint32_t mode,
+                                uint32_t strftime_id,
+                                uint64_t nsecs);
   uint64_t resolve_kname(const std::string &name) const;
   virtual int resolve_uname(const std::string &name,
                             struct symbol *sym,

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -37,14 +37,14 @@ hspace   [ \t]
 vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#\*])+
-builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ctx|curtask|elapsed|func|gid|nsecs|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
+builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ctx|curtask|elapsed|func|gid|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
 call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|stats|str|strerror|strftime|strncmp|strcontains|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf
 
 simple_type     bool|(u)?int(8|16|32|64)|(u)?(min|max|sum|count|avg|stats)_t|probe_t|username_t|lhist_t|hist_t|usym_t|ksym_t|timestamp_t|macaddr_t|cgroup_path_t|strerror_t
 sized_type      str_t|inet_t|buf_t
 
 /* Don't add to this! Use builtin OR call not both */
-call_and_builtin kstack|ustack
+call_and_builtin kstack|ustack|nsecs
 
 /* escape sequences in strings */
 hex_esc  (x|X)[0-9a-fA-F]{1,2}

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -92,7 +92,7 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
     case Type::timestamp:
     {
       auto p = static_cast<const AsyncEvent::Strftime *>(data);
-      return bpftrace.resolve_timestamp(p->strftime_id, p->nsecs_since_boot);
+      return bpftrace.resolve_timestamp(p->mode, p->strftime_id, p->nsecs);
     }
     case Type::ksym:
       return bpftrace.resolve_ksym(read_data<uint64_t>(data));

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -275,9 +275,9 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
     return bpftrace.resolve_probe(read_data<uint64_t>(value.data()));
   else if (type.IsTimestampTy())
     return bpftrace.resolve_timestamp(
+        reinterpret_cast<AsyncEvent::Strftime *>(value.data())->mode,
         reinterpret_cast<AsyncEvent::Strftime *>(value.data())->strftime_id,
-        reinterpret_cast<AsyncEvent::Strftime *>(value.data())
-            ->nsecs_since_boot);
+        reinterpret_cast<AsyncEvent::Strftime *>(value.data())->nsecs);
   else if (type.IsMacAddressTy())
     return bpftrace.resolve_mac_address(value.data());
   else if (type.IsCgroupPathTy())

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -186,6 +186,7 @@ std::string typestr(Type t)
     case Type::mac_address: return "mac_address"; break;
     case Type::cgroup_path: return "cgroup_path"; break;
     case Type::strerror: return "strerror"; break;
+    case Type::timestamp_mode: return "timestamp mode"; break;
       // clang-format on
   }
 
@@ -481,6 +482,11 @@ SizedType CreateStrerror()
   return SizedType(Type::strerror, 8);
 }
 
+SizedType CreateTimestampMode()
+{
+  return SizedType(Type::timestamp_mode, 0);
+}
+
 bool SizedType::IsSigned(void) const
 {
   return is_signed_;
@@ -629,6 +635,7 @@ size_t hash<bpftrace::SizedType>::operator()(
     case bpftrace::Type::mac_address:
     case bpftrace::Type::cgroup_path:
     case bpftrace::Type::strerror:
+    case bpftrace::Type::timestamp_mode:
       break;
   }
 

--- a/src/types.h
+++ b/src/types.h
@@ -98,6 +98,7 @@ enum class TimestampMode : uint8_t
 {
   boot = 0,
   tai,
+  sw_tai,
 };
 
 struct Struct;

--- a/src/types.h
+++ b/src/types.h
@@ -48,7 +48,8 @@ enum class Type : uint8_t
   timestamp,
   mac_address,
   cgroup_path,
-  strerror
+  strerror,
+  timestamp_mode,
   // clang-format on
 };
 
@@ -93,6 +94,11 @@ private:
   }
 };
 
+enum class TimestampMode : uint8_t
+{
+  boot = 0,
+};
+
 struct Struct;
 struct Field;
 
@@ -117,6 +123,7 @@ public:
   bool is_tparg = false;
   bool is_funcarg = false;
   bool is_btftype = false;
+  TimestampMode ts_mode = TimestampMode::boot;
 
 private:
   size_t size_bits_ = 0;                    // size in bits
@@ -204,6 +211,7 @@ public:
   bool IsPrintableTy()
   {
     return type != Type::none && type != Type::stack_mode &&
+           type != Type::timestamp_mode &&
            (!IsCtxAccess() || is_funcarg); // args builtin is printable
   }
 
@@ -374,6 +382,10 @@ public:
   {
     return type == Type::strerror;
   };
+  bool IsTimestampModeTy(void) const
+  {
+    return type == Type::timestamp_mode;
+  }
 
   friend std::ostream &operator<<(std::ostream &, const SizedType &);
   friend std::ostream &operator<<(std::ostream &, Type);
@@ -434,6 +446,7 @@ SizedType CreateTimestamp();
 SizedType CreateMacAddress();
 SizedType CreateCgroupPath();
 SizedType CreateStrerror();
+SizedType CreateTimestampMode();
 
 std::ostream &operator<<(std::ostream &os, const SizedType &type);
 

--- a/src/types.h
+++ b/src/types.h
@@ -97,6 +97,7 @@ private:
 enum class TimestampMode : uint8_t
 {
   boot = 0,
+  tai,
 };
 
 struct Struct;

--- a/tests/codegen/call_nsecs_tai.cpp
+++ b/tests/codegen/call_nsecs_tai.cpp
@@ -1,0 +1,14 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, call_nsecs_tai)
+{
+  test("k:f { @x = nsecs(tai); }", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/call_nsecs_tai.ll
+++ b/tests/codegen/llvm/call_nsecs_tai.ll
@@ -1,0 +1,36 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
+entry:
+  %"@x_val" = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  %get_tai_ns = call i64 inttoptr (i64 208 to i64 ()*)()
+  %1 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 0, i64* %"@x_key", align 8
+  %2 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 %get_tai_ns, i64* %"@x_val", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
+  %3 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/codegen/llvm/call_strftime.ll
+++ b/tests/codegen/llvm/call_strftime.ll
@@ -3,7 +3,7 @@ source_filename = "bpftrace"
 target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf-pc-linux"
 
-%strftime_t = type <{ i64, i64 }>
+%strftime_t = type <{ i32, i32, i64 }>
 %printf_t = type { i64, [16 x i8] }
 
 ; Function Attrs: nounwind
@@ -23,22 +23,24 @@ entry:
   %4 = bitcast %strftime_t* %strftime_args to i8*
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
   %5 = getelementptr %strftime_t, %strftime_t* %strftime_args, i64 0, i32 0
-  store i64 0, i64* %5, align 8
-  %get_ns = call i64 inttoptr (i64 125 to i64 ()*)()
+  store i32 0, i32* %5, align 4
   %6 = getelementptr %strftime_t, %strftime_t* %strftime_args, i64 0, i32 1
-  store i64 %get_ns, i64* %6, align 8
-  %7 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
-  %8 = bitcast [16 x i8]* %7 to i8*
-  %9 = bitcast %strftime_t* %strftime_args to i8*
-  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %8, i8* align 1 %9, i64 16, i1 false)
+  store i32 0, i32* %6, align 4
+  %get_ns = call i64 inttoptr (i64 125 to i64 ()*)()
+  %7 = getelementptr %strftime_t, %strftime_t* %strftime_args, i64 0, i32 2
+  store i64 %get_ns, i64* %7, align 8
+  %8 = getelementptr %printf_t, %printf_t* %printf_args, i32 0, i32 1
+  %9 = bitcast [16 x i8]* %8 to i8*
+  %10 = bitcast %strftime_t* %strftime_args to i8*
+  call void @llvm.memcpy.p0i8.p0i8.i64(i8* align 1 %9, i8* align 1 %10, i64 16, i1 false)
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, %printf_t*, i64, i64)*)(i64 %pseudo, %printf_t* %printf_args, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 event_loss_counter:                               ; preds = %entry
-  %10 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %11 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   store i32 0, i32* %key, align 4
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo1, i32* %key)
@@ -46,21 +48,21 @@ event_loss_counter:                               ; preds = %entry
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 counter_merge:                                    ; preds = %lookup_merge, %entry
-  %11 = bitcast %printf_t* %printf_args to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+  %12 = bitcast %printf_t* %printf_args to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   ret i64 0
 
 lookup_success:                                   ; preds = %event_loss_counter
-  %12 = bitcast i8* %lookup_elem to i64*
-  %13 = atomicrmw add i64* %12, i64 1 seq_cst
+  %13 = bitcast i8* %lookup_elem to i64*
+  %14 = atomicrmw add i64* %13, i64 1 seq_cst
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %event_loss_counter
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %14 = bitcast i32* %key to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
   br label %counter_merge
 }
 

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -114,6 +114,7 @@ public:
     has_kprobe_multi_ = std::make_optional<bool>(has_features);
     has_skb_output_ = std::make_optional<bool>(has_features);
     map_ringbuf_ = std::make_optional<bool>(has_features);
+    has_ktime_get_tai_ns_ = std::make_optional<bool>(has_features);
   };
   bool has_features_;
 };

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -970,11 +970,6 @@ TEST(Parser, call_unknown_function)
 TEST(Parser, call_builtin)
 {
   // Builtins should not be usable as function
-  test_parse_failure("k:f { nsecs(); }");
-  test_parse_failure("k:f { nsecs  (); }");
-  test_parse_failure("k:f { nsecs(\"abc\"); }");
-  test_parse_failure("k:f { nsecs(123); }");
-
   test_parse_failure("k:f { probe(\"blah\"); }");
   test_parse_failure("k:f { probe(); }");
   test_parse_failure("k:f { probe(123); }");

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -511,3 +511,25 @@ NAME debugf_with_seq_printf
 RUN echo > /sys/kernel/debug/tracing/trace; {{BPFTRACE}} -e 'i:ms:1 { printf("printf %d", 0); debugf("debugf %d", 1); exit();}'; cat /sys/kernel/debug/tracing/trace
 EXPECT bpf_trace_printk: debugf 1
 TIMEOUT 3
+
+NAME nsecs
+PROG i:ms:1 { printf("SUCCESS %d\n", nsecs()); exit(); }
+EXPECT SUCCESS -?[0-9][0-9]*
+TIMEOUT 5
+
+NAME nsecs_boot
+PROG i:ms:1 { printf("SUCCESS %d\n", nsecs(boot)); exit(); }
+EXPECT SUCCESS -?[0-9][0-9]*
+TIMEOUT 5
+
+NAME nsecs_tai
+PROG i:ms:1 { printf("SUCCESS %d\n", nsecs(tai)); exit(); }
+EXPECT SUCCESS -?[0-9][0-9]*
+TIMEOUT 5
+REQUIRES_FEATURE get_tai_ns
+MIN_KERNEL 6.1
+
+NAME nsecs_sw_tai
+PROG i:ms:1 { printf("SUCCESS %d\n", nsecs(sw_tai)); exit(); }
+EXPECT SUCCESS -?[0-9][0-9]*
+TIMEOUT 5

--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -164,6 +164,7 @@ class TestParser(object):
                     "aot",
                     "kprobe_multi",
                     "skboutput",
+                    "get_tai_ns",
                 }
 
                 for f in line.split(" "):

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -137,6 +137,7 @@ class Runner(object):
         bpffeature["kprobe_multi"] = output.find("kprobe_multi: yes") != -1
         bpffeature["aot"] = cmake_vars.LIBBCC_BPF_CONTAINS_RUNTIME
         bpffeature["skboutput"] = output.find("skboutput: yes") != -1
+        bpffeature["get_tai_ns"] = output.find("get_ktime_ns: yes") != -1
         return bpffeature
 
     @staticmethod

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -204,6 +204,7 @@ TEST(semantic_analyser, builtin_functions)
   test("uprobe:/bin/bash:main { uaddr(\"glob_asciirange\") }", 0);
   test("kprobe:f { cgroupid(\"/sys/fs/cgroup/unified/mycg\"); }", 0);
   test("kprobe:f { macaddr(0xffff) }", 0);
+  test("kprobe:f { nsecs() }", 0);
 }
 
 TEST(semantic_analyser, undefined_map)
@@ -2700,6 +2701,16 @@ TEST(semantic_analyser, string_size)
   ASSERT_TRUE(var_assign->var->type.GetField(0).type.IsStringTy());
   ASSERT_EQ(var_assign->var->type.GetSize(), 16UL); // tuples are not packed
   ASSERT_EQ(var_assign->var->type.GetField(0).type.GetSize(), 6UL);
+}
+
+TEST(semantic_analyser, call_nsecs)
+{
+  test("BEGIN { $ns = nsecs(); }", 0);
+  test("BEGIN { $ns = nsecs(boot); }", 0);
+  MockBPFfeature hasfeature(true);
+  test(hasfeature, "BEGIN { $ns = nsecs(tai); }", 0);
+  test("BEGIN { $ns = nsecs(sw_tai); }", 0);
+  test("BEGIN { $ns = nsecs(xxx); }", 1);
 }
 
 class semantic_analyser_btf : public test_btf


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

introduce new builtin nsecs_tai，on kernels that version >= 6.1, get the nanoseconds through `ktime_get_tai_ns`, otherwise use the "triple vdso sandwich" method to get the nanoseconds of CLOCK_TAI, and its accuracy is about tens of nanoseconds.A typical case is to use necs_tai to obtain the delay of network packets between machines.

issues: #2512 

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
