### PR TITLE
Align byte-arrays to 8 bytes

### DIFF
--- a/src/types.cpp
+++ b/src/types.cpp
@@ -528,7 +528,7 @@ ssize_t SizedType::GetAlignment() const
     return GetSize();
   else if (IsArrayTy())
     return element_type_->GetAlignment();
-  else if (IsByteArray() || GetSize() <= 4)
+  else if (GetSize() <= 4)
     return 4;
   else
     return 8;


### PR DESCRIPTION
Several types defined as byte-arrays (e.g. `usym`) are represented using 64-bit integers in codegen. Since 64-bit ints require 8-byte alignment, set that to be the default for byte arrays, too.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
