### PR TITLE
Fix runtime tests using the nft tool

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -60,8 +60,8 @@ Each runtime testcase consists of multiple directives. In no particular order:
 * `BEFORE`: Run the command in a shell before running bpftrace. The command
   will be terminated after testcase is over. Can be used multiple times,
   commands will run in parallel.
-* `AFTER`: Run the command in a shell after running bpftrace. The command will
-  be terminated after the testcase is over.
+* `AFTER`: Run the command in a shell after running bpftrace (after the probes
+  are attached). The command will be terminated after the testcase is over.
 * `CLEANUP`: Run the command in a shell after test is over. This holds any
   cleanup command to free resources after test completes.
 * `MIN_KERNEL`: Skip the test unless the host's kernel version is >= the

--- a/tests/runtime/btf
+++ b/tests/runtime/btf
@@ -36,31 +36,34 @@ REQUIRES_FEATURE btf
 WILL_FAIL
 
 NAME kernel_module_attach
-RUN {{BPFTRACE}} -e 'kfunc:nft_trans_alloc_gfp { printf("hit\n"); exit(); }' -c '/usr/sbin/nft add table bpftrace'
+RUN {{BPFTRACE}} -e 'kfunc:nft_trans_alloc_gfp { printf("hit\n"); exit(); }'
+AFTER /usr/sbin/nft add table bpftrace
 EXPECT hit
 TIMEOUT 5
 REQUIRES_FEATURE kfunc
 REQUIRES lsmod | grep '^nf_tables'
 REQUIRES /usr/sbin/nft --help
-AFTER nft delete table bpftrace
+CLEANUP nft delete table bpftrace
 
 NAME kernel_module_args
-RUN {{BPFTRACE}} -e 'kfunc:nft_trans_alloc_gfp { printf("size: %d\n", args->size); exit(); }' -c '/usr/sbin/nft add table bpftrace'
+RUN {{BPFTRACE}} -e 'kfunc:nft_trans_alloc_gfp { printf("size: %d\n", args->size); exit(); }'
+AFTER /usr/sbin/nft add table bpftrace
 EXPECT size: [0-9]+
 TIMEOUT 5
 REQUIRES_FEATURE kfunc
 REQUIRES lsmod | grep '^nf_tables'
 REQUIRES /usr/sbin/nft --help
-AFTER nft delete table bpftrace
+CLEANUP nft delete table bpftrace
 
 NAME kernel_module_types
-RUN {{BPFTRACE}} -e 'kfunc:nft_trans_alloc_gfp { printf("portid: %d\n", args->ctx->portid); exit(); }' -c '/usr/sbin/nft add table bpftrace'
+RUN {{BPFTRACE}} -e 'kfunc:nft_trans_alloc_gfp { printf("portid: %d\n", args->ctx->portid); exit(); }'
+AFTER /usr/sbin/nft add table bpftrace
 EXPECT portid: [0-9]+
 TIMEOUT 5
 REQUIRES_FEATURE kfunc
 REQUIRES lsmod | grep '^nf_tables'
 REQUIRES /usr/sbin/nft --help
-AFTER nft delete table bpftrace
+CLEANUP nft delete table bpftrace
 
 NAME kernel_module_tracepoint
 PROG tracepoint:xfs:xfs_setfilesize { print(args->offset) } i:ms:1 { exit(); }

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -101,20 +101,20 @@ TIMEOUT 5
 WILL_FAIL
 
 NAME kprobe_offset_module
-RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x5 { printf("hit\n"); exit(); }' -c '/usr/sbin/nft add table bpftrace'
+RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x5 { printf("hit\n"); exit(); }'
+AFTER /usr/sbin/nft add table bpftrace
 EXPECT hit
 TIMEOUT 5
 REQUIRES lsmod | grep '^nf_tables'
 REQUIRES /usr/sbin/nft --help
-AFTER nft delete table bpftrace
+CLEANUP nft delete table bpftrace
 
 NAME kprobe_offset_module_error
-RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x1 { printf("hit\n"); exit(); }' -c '/usr/sbin/nft add table bpftrace'
+RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x1 { printf("hit\n"); exit(); }'
 EXPECT Possible attachment attempt in the middle of an instruction, try a different offset.
 TIMEOUT 5
 REQUIRES lsmod | grep '^nf_tables'
 REQUIRES /usr/sbin/nft --help
-AFTER nft delete table bpftrace
 WILL_FAIL
 
 NAME kretprobe


### PR DESCRIPTION
Several tests use the `nft` tool to fire probes in a kernel module (`nf_tables`). All the tests have two issues which are fixed by this PR:
- The command that invokes the traced function is called using the `-c` parameter which does not wait for the probes to attach. The correct way to run the command is via the `AFTER` directive.
- The created nftables table is deleted in the `AFTER` directive which is not correct. It should be deleted using the `CLEANUP` directive.

The above issues caused a race condition in the tests (the command is executed before the probes are attached) which should be now fixed.

In addition, I noticed that the fact that the `AFTER` directive is executed after the probes are attached is missing from the documentation, so I added it.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
