### PR TITLE
Fix crashes caused by improper error handling on bpf_look/update/delete_elem

### DIFF
--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -196,6 +196,11 @@ PROG BEGIN { @x = 10; printf("%d", @x++); printf(" %d", ++@x); printf(" %d", @x-
 EXPECT 10 12 12 10
 TIMEOUT 1
 
+NAME parallel map access
+RUN {{BPFTRACE}} runtime/scripts/parallel_map_access.bt
+EXPECT SUCCESS
+TIMEOUT 2
+
 NAME increment/decrement variable
 PROG BEGIN { $x = 10; printf("%d", $x++); printf(" %d", ++$x); printf(" %d", $x--); printf(" %d\n", --$x); exit(); }
 EXPECT 10 12 12 10

--- a/tests/runtime/scripts/parallel_map_access.bt
+++ b/tests/runtime/scripts/parallel_map_access.bt
@@ -1,0 +1,24 @@
+// Regression testing the map's thread safety.
+// Bpftrace shouldn't crash during map's print/clear/zero operations
+// while delete is called at the same time.
+//
+// For more information, please refer to:
+// https://github.com/iovisor/bpftrace/pull/2623
+
+i:us:1 {
+    @data[rand % 100] = count();
+    if (rand % 5 == 0) {
+        delete(@data[rand % 10]);
+    }
+}
+
+i:ms:1 {
+    print(@data);
+    clear(@data);
+    zero(@data);
+}
+
+i:s:1 {
+    print("SUCCESS");
+    exit();
+}


### PR DESCRIPTION
bpf_*_elem returns -errno when error occured. These functions will return -ENOENT(-2) when they failed to find a entry. It's a harmless error that could be found when doing delete and print/zero/clear operations on the same map simultaneously. It's not reasonable to stop the whole program at this moment.

A simple script could reproduce this annoying situation:
```
i:us:1 {
    @data[rand % 100] = count();
    if (rand % 5 == 0) {
        delete(@data[rand % 10]);
    }
}

i:ms:1 {
    clear(@data);
    // or print(@data);
    // or zero(@data);
}
```

This script crashed almost immediately and reports errors likes:

```
Attaching 2 probes...
ERROR: failed to look up elem: -2
terminate called after throwing an instance of 'std::runtime_error'
  what():  Could not clear map with ident "@data", err=-1
fish: 'sudo bpftrace ../../../workspac…' terminated by signal SIGABRT (Abort)
```

But It's accepable for users that some entries are deleted asynchronously when tring to clear/print/zero a map.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
