### PR TITLE
Fix resolving username for malformed /etc/passwd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to
   - [#2588](https://github.com/iovisor/bpftrace/pull/2588)
 #### Changed
 #### Fixed
+- Fix resolving username for malformed /etc/passwd
+  - [#2631](https://github.com/iovisor/bpftrace/pull/2631)
 
 
 ## [0.18.0] 2023-05-15

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1943,7 +1943,7 @@ std::string BPFtrace::resolve_uid(uintptr_t addr) const
   {
     auto fields = split_string(line, ':');
 
-    if (fields[2] == uid)
+    if (fields.size() >= 3 && fields[2] == uid)
     {
       found = true;
       username = fields[0];


### PR DESCRIPTION
When `/etc/passwd` has malformed or unexpected content (e.g. contains an empty line), resolving the `username` builtin causes segfault due to out-of-bounds access to a `std::vector`. This fixes the issue.

Fixes #2628.

I didn't add a regression test as the fix is so trivial that I don't think it deserves a separate test. Feel free to correct this assumption.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
