### PR TITLE
Make parallel map access test less flakey

### DIFF
--- a/tests/runtime/scripts/parallel_map_access.bt
+++ b/tests/runtime/scripts/parallel_map_access.bt
@@ -6,13 +6,11 @@
 // https://github.com/iovisor/bpftrace/pull/2623
 
 i:us:1 {
-    @data[rand % 100] = count();
-    if (rand % 5 == 0) {
-        delete(@data[rand % 10]);
-    }
+    @data[rand % 10] = count();
+    delete(@data[rand % 10]);
 }
 
-i:ms:1 {
+i:us:1 {
     print(@data);
     clear(@data);
     zero(@data);


### PR DESCRIPTION
The new test introduced in #2623 was a little flakey at detecting the bad behaviour on my machine.

This change increases the frequency at which missing map keys will be encountered and makes the test consistently fail when the patch from #2623 is reverted. It still passes with the patch applied.