### PR TITLE
uprobes: make C++ symbol demangling explicit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ and this project adheres to
   - [#2578](https://github.com/iovisor/bpftrace/pull/2578)
 - Improve user symbol resolution
   - [#2386](https://github.com/iovisor/bpftrace/pull/2386)
+- uprobes: make C++ symbol demangling explicit
+  - [#2657](https://github.com/iovisor/bpftrace/pull/2657)
 #### Fixed
 - Fix resolving username for malformed /etc/passwd
   - [#2631](https://github.com/iovisor/bpftrace/pull/2631)

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1148,6 +1148,14 @@ Allocated 4 bytes
 ...
 ```
 
+When tracing C++ programs, it is possible to turn on automatic symbol demangling
+by using the `:cpp` prefix:
+```
+# bpftrace -e 'u:src/bpftrace:cpp:"bpftrace::BPFtrace::add_probe" { print("adding probe\n"); }'
+Attaching 1 probe...
+adding probe
+```
+
 Examples in situ:
 [(uprobe) search /tools](https://github.com/iovisor/bpftrace/search?q=uprobe%3A+path%3Atools&type=Code)
 [(uretprobe) /tools](https://github.com/iovisor/bpftrace/search?q=uretprobe%3A+path%3Atools&type=Code)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -2477,6 +2477,15 @@ Allocated 4 bytes
 
 If the traced binary has DWARF included, function arguments are available in the `args` struct which can be inspected with verbose listing, see the <<Listing Probes>> section for more details.
 
+When tracing C{plus}{plus} programs, it is possible to turn on automatic symbol demangling
+by using the `:cpp` prefix:
+
+----
+# bpftrace -e 'u:src/bpftrace:cpp:"bpftrace::BPFtrace::add_probe" { print("adding probe\n"); }'
+Attaching 1 probe...
+adding probe
+----
+
 It is important to note that for `uretprobe` s to work the kernel runs a special helper on user-space function entry which overrides the return address on the stack.
 This can cause issues with languages that have their own runtime like Golang:
 

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -520,6 +520,8 @@ std::string AttachPoint::name(const std::string &attach_target,
   std::string n = provider;
   if (attach_target != "")
     n += ":" + attach_target;
+  if (lang != "")
+    n += ":" + lang;
   if (ns != "")
     n += ":" + ns;
   if (attach_point != "")

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -559,6 +559,7 @@ public:
 
   std::string provider;
   std::string target;
+  std::string lang; // for userspace probes, enable language-specific features
   std::string ns;
   std::string func;
   std::string pin;

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2579,6 +2579,8 @@ void SemanticAnalyser::visit(AttachPoint &ap)
     if (ap.func == "" && ap.address == 0)
       LOG(ERROR, ap.loc, err_)
           << ap.provider << " should be attached to a function and/or address";
+    if (ap.lang != "" && !is_supported_lang(ap.lang))
+      LOG(ERROR, ap.loc, err_) << "unsupported language type: " << ap.lang;
 
     if (ap.provider == "uretprobe" && ap.func_offset != 0)
       LOG(ERROR, ap.loc, err_)

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -178,18 +178,19 @@ int BPFtrace::add_probe(ast::Probe &p)
 
       struct symbol sym = {};
       int err = resolve_uname(attach_point->func, &sym, attach_point->target);
-      if (err < 0 || sym.address == 0)
+
+      if (attach_point->lang == "cpp")
       {
         // As the C++ language supports function overload, a given function name
         // (without parameters) could have multiple matches even when no
         // wildcards are used.
         matches = probe_matcher_->get_matches_for_ap(*attach_point);
-        attach_funcs.insert(attach_funcs.end(), matches.begin(), matches.end());
       }
-      else
-      {
-        attach_funcs.push_back(attach_point->target + ":" + attach_point->func);
-      }
+
+      if (err >= 0 && sym.address != 0)
+        matches.insert(attach_point->target + ":" + attach_point->func);
+
+      attach_funcs.insert(attach_funcs.end(), matches.begin(), matches.end());
     }
     else
     {

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -2124,7 +2124,8 @@ int BPFtrace::resolve_uname(const std::string &name,
   sym->name = name;
   struct bcc_symbol_option option;
   memset(&option, 0, sizeof(option));
-  option.use_symbol_type = (1 << STT_OBJECT);
+  option.use_symbol_type = (1 << STT_OBJECT | 1 << STT_FUNC |
+                            1 << STT_GNU_IFUNC);
 
   return bcc_elf_foreach_sym(path.c_str(), sym_resolve_callback, &option, sym);
 }

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -101,7 +101,8 @@ std::set<std::string> ProbeMatcher::get_matches_in_stream(
 std::set<std::string> ProbeMatcher::get_matches_for_probetype(
     const ProbeType& probe_type,
     const std::string& target,
-    const std::string& search_input)
+    const std::string& search_input,
+    bool demangle_symbols)
 {
   std::unique_ptr<std::istream> symbol_stream;
   bool ignore_trailing_module = false;
@@ -189,9 +190,8 @@ std::set<std::string> ProbeMatcher::get_matches_for_probetype(
   }
 
   if (symbol_stream)
-    return get_matches_in_stream(search_input,
-                                 *symbol_stream,
-                                 ignore_trailing_module);
+    return get_matches_in_stream(
+        search_input, *symbol_stream, ignore_trailing_module, demangle_symbols);
   else
     return {};
 }
@@ -571,7 +571,8 @@ std::set<std::string> ProbeMatcher::get_matches_for_ap(
 
   return get_matches_for_probetype(probetype(attach_point.provider),
                                    attach_point.target,
-                                   search_input);
+                                   search_input,
+                                   attach_point.lang == "cpp");
 }
 
 std::set<std::string> ProbeMatcher::expand_probetype_kernel(

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -91,7 +91,8 @@ private:
   std::set<std::string> get_matches_for_probetype(
       const ProbeType &probe_type,
       const std::string &target,
-      const std::string &search_input);
+      const std::string &search_input,
+      bool demangle_symbols);
   std::set<std::string> get_matches_in_set(const std::string &search_input,
                                            const std::set<std::string> &set);
 

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -82,10 +82,12 @@ public:
   const BPFtrace *bpftrace_;
 
 private:
-  std::set<std::string> get_matches_in_stream(const std::string &search_input,
-                                              bool ignore_trailing_module,
-                                              std::istream &symbol_stream,
-                                              const char delim = '\n');
+  std::set<std::string> get_matches_in_stream(
+      const std::string &search_input,
+      std::istream &symbol_stream,
+      bool ignore_trailing_module = false,
+      bool demangle_symbols = true,
+      const char delim = '\n');
   std::set<std::string> get_matches_for_probetype(
       const ProbeType &probe_type,
       const std::string &target,

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -768,7 +768,14 @@ bool is_compile_time_func(const std::string &func_name)
                      [&](const auto &cand) { return func_name == cand; });
 }
 
-std::string exec_system(const char* cmd)
+bool is_supported_lang(const std::string &lang)
+{
+  return std::any_of(UPROBE_LANGS.begin(),
+                     UPROBE_LANGS.end(),
+                     [&](const auto &cand) { return lang == cand; });
+}
+
+std::string exec_system(const char *cmd)
 {
   std::array<char, 128> buffer;
   std::string result;

--- a/src/utils.h
+++ b/src/utils.h
@@ -155,6 +155,8 @@ static std::vector<std::string> UNSAFE_BUILTIN_FUNCS = {
 
 static std::vector<std::string> COMPILE_TIME_FUNCS = { "cgroupid" };
 
+static std::vector<std::string> UPROBE_LANGS = { "cpp" };
+
 bool get_uint64_env_var(const ::std::string &str, uint64_t &dest);
 bool get_bool_env_var(const ::std::string &str, bool &dest, bool neg = false);
 std::string get_pid_exe(pid_t pid);
@@ -191,6 +193,7 @@ FuncsModulesMap get_traceable_funcs();
 const std::string &is_deprecated(const std::string &str);
 bool is_unsafe_func(const std::string &func_name);
 bool is_compile_time_func(const std::string &func_name);
+bool is_supported_lang(const std::string &lang);
 std::string exec_system(const char *cmd);
 std::vector<std::string> resolve_binary_path(const std::string &cmd);
 std::vector<std::string> resolve_binary_path(const std::string &cmd, int pid);

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -476,7 +476,7 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol_wildcard)
       .Times(1);
 
   ASSERT_EQ(0, bpftrace->add_probe(*probe));
-  ASSERT_EQ(3U, bpftrace->get_probes().size());
+  ASSERT_EQ(4U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
   check_uprobe(bpftrace->get_probes().at(0),
                "/bin/sh:cpp",
@@ -487,6 +487,10 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol_wildcard)
                "_Z11cpp_mangledv",
                "uprobe:/bin/sh:cpp_man*");
   check_uprobe(bpftrace->get_probes().at(2),
+               "/bin/sh:cpp",
+               "_Z18cpp_mangled_suffixv",
+               "uprobe:/bin/sh:cpp_man*");
+  check_uprobe(bpftrace->get_probes().at(3),
                "/bin/sh:cpp",
                "cpp_mangled",
                "uprobe:/bin/sh:cpp_man*");

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -40,7 +40,8 @@ void setup_mock_probe_matcher(MockProbeMatcher &matcher)
                          "/bin/sh:something_else\n"
                          "/bin/sh:cpp_mangled\n"
                          "/bin/sh:_Z11cpp_mangledi\n"
-                         "/bin/sh:_Z11cpp_mangledv\n";
+                         "/bin/sh:_Z11cpp_mangledv\n"
+                         "/bin/sh:_Z18cpp_mangled_suffixv\n";
   std::string bash_usyms = "/bin/bash:first_open\n";
   ON_CALL(matcher, get_func_symbols_from_file("/bin/sh"))
       .WillByDefault([sh_usyms](const std::string &) {

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -38,6 +38,7 @@ void setup_mock_probe_matcher(MockProbeMatcher &matcher)
                          "/bin/sh:second_open\n"
                          "/bin/sh:open_as_well\n"
                          "/bin/sh:something_else\n"
+                         "/bin/sh:cpp_mangled\n"
                          "/bin/sh:_Z11cpp_mangledi\n"
                          "/bin/sh:_Z11cpp_mangledv\n";
   std::string bash_usyms = "/bin/bash:first_open\n";

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -51,7 +51,7 @@ public:
   {
     (void)path;
     sym->name = name;
-    if (name == "cpp_mangled" || name == "cpp_mangled(int)")
+    if (name == "cpp_mangled(int)")
     {
       return -1;
     }

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1030,6 +1030,12 @@ TEST(Parser, uprobe)
        " uprobe:/my/program:A::f\n"
        "  int: 1\n");
 
+  // Language prefix
+  test("uprobe:/my/program:cpp:func { 1; }",
+       "Program\n"
+       " uprobe:/my/program:cpp:func\n"
+       "  int: 1\n");
+
   test_parse_failure("uprobe:f { 1 }");
   test_parse_failure("uprobe { 1 }");
   test_parse_failure("uprobe:/my/program*:0x1234 { 1 }");

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1432,8 +1432,10 @@ TEST(semantic_analyser, uprobe)
   test("uprobe:/bin/sh:f+0x10 { 1 }", 0);
   test("u:/bin/sh:f+0x10 { 1 }", 0);
   test("uprobe:sh:f { 1 }", 0);
+  test("uprobe:/bin/sh:cpp:f { 1 }", 0);
   test("uprobe:/notexistfile:f { 1 }", 1);
   test("uprobe:notexistfile:f { 1 }", 1);
+  test("uprobe:/bin/sh:nolang:f { 1 }", 1);
 
   test("uretprobe:/bin/sh:f { 1 }", 0);
   test("ur:/bin/sh:f { 1 }", 0);
@@ -1441,8 +1443,10 @@ TEST(semantic_analyser, uprobe)
   test("ur:sh:f { 1 }", 0);
   test("uretprobe:/bin/sh:0x10 { 1 }", 0);
   test("ur:/bin/sh:0x10 { 1 }", 0);
+  test("uretprobe:/bin/sh:cpp:f { 1 }", 0);
   test("uretprobe:/notexistfile:f { 1 }", 1);
   test("uretprobe:notexistfile:f { 1 }", 1);
+  test("uretprobe:/bin/sh:nolang:f { 1 }", 1);
 }
 
 TEST(semantic_analyser, usdt)


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

Introduce a new part of uprobe specification which allows to explicitly enable language-specific features. For now, C++ prefixes (`:c++` and `:cpp`) are supported. Specifying one of these turns on symbol demangling which is now disabled by default.

Some examples of the current behaviour
```
# cat cpptest.cpp
extern "C" int fun() { return 1; }
void fun(int x) {}
void function() {}
class Foo { void fun() {} };
class Bar { void fun() {} };

# nm cpptest
0000000000401126 T fun
0000000000401148 T _Z3funi
0000000000401131 T _Z8functionv
0000000000401184 W _ZN3Bar3funEv
0000000000401178 W _ZN3Foo3funEv

# 
bpftrace -e 'u:./cpptest:fun { exit(); }'
Attaching 1 probe...    (C "fun" only)

bpftrace -e  'u:./cpptest:c++:fun { exit(); }
Attaching 3 probes...   ("fun", "fun(int)", "function")

bpftrace -e 'u:./cpptest:c++"fun(int)" { exit(); }' 
Attaching 1 probe...    ("fun(int)")

bpftrace -e 'u:./cpptest:c++:*fun { exit(); }'
Attaching 5 probes...   (all the functions)

bpftrace -e 'u:./cpptest:c++:"*::fun" { exit(); }'
Attaching 2 probes...   ("Foo::fun" and "Bar::fun")
```

While this is not perfect (e.g. the second example should not match `function`), it's better than what it was before (see #2186). I'd prefer using this as a starting point and then following with more PRs rather than doing everything at once.

Missing features include:
- more sophisticated matching of mangled symbols (i.e. fix the above 2nd example)
- better support for namespaces (e.g. support `::fun`)
- support for demangling in probe listing

Note that this is a breaking change b/c demangling is not done by default now. However, since it was never documented and it sometimes had incorrect and unexpected behaviour, I believe that this is the correct step forward.

Resolves #2186.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
