### PR TITLE
Support kprobe:module:function

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2557,8 +2557,6 @@ void SemanticAnalyser::visit(Predicate &pred)
 void SemanticAnalyser::visit(AttachPoint &ap)
 {
   if (ap.provider == "kprobe" || ap.provider == "kretprobe") {
-    if (ap.target != "")
-      LOG(ERROR, ap.loc, err_) << "kprobes should not have a target";
     if (ap.func == "")
       LOG(ERROR, ap.loc, err_) << "kprobes should be attached to a function";
     if (is_final_pass())

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -935,11 +935,15 @@ void AttachedProbe::attach_kprobe(bool safe_mode)
     return;
   }
 
+  std::string funcname = probe_.attach_point;
+  if (probe_.path.length() > 0)
+    funcname = probe_.path + ":" + funcname;
+
   resolve_offset_kprobe(safe_mode);
   int perf_event_fd = bpf_attach_kprobe(progfd_,
                                         attachtype(probe_.type),
                                         eventname().c_str(),
-                                        probe_.attach_point.c_str(),
+                                        funcname.c_str(),
                                         offset_,
                                         0);
 


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

As mentioned in the issue #1413 ，the kprobe type currently does not support selecting kernel modules.

This draft MR supports it by allowing the 'kprobe:module:function' syntax with little code changes. Note that wildcard is not supported yet in this MR. I hope anyone who is interested in this feature can make use of this draft patch, or even improve it and make it mergeable in the future.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
