### PR TITLE
arm: Fix gcc build when using -mthumb

### DIFF
--- a/src/triggers.h
+++ b/src/triggers.h
@@ -9,6 +9,8 @@
 #define __target_attr
 #endif
 
+using trigger_fn_t = void (*)();
+
 extern "C"
 {
   void __attribute__((noinline)) __target_attr BEGIN_trigger()


### PR DESCRIPTION
When compiling with `-mthumb`, we need to force the compiler to generate ARM code for the two trigger functions for uprobes to work. This is achieved by using the target attribute[1].

While this works fine with clang, gcc complains about an invalid conversion when calling run_special_probe[2]; latest development version (14.0) suggests this is a gcc bug:

```
  <source>:8:9: internal compiler error: canonical types differ for identical types 'void()' and 'void()'
```

This patch adds an explicit cast as a workaround.

Reported-by: @daniloegea [3]

[1] https://gcc.gnu.org/onlinedocs/gcc/ARM-Function-Attributes.html#index-target-function-attribute-1
[2] https://gcc.godbolt.org/z/44b5MjdbT
[3] https://github.com/iovisor/bpftrace/pull/2360

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
