### PR TITLE
RFC: Use correct format string length modifiers when printing integers

### DIFF
--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -63,21 +63,21 @@ TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME sarg
-PROG uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS %d %d\n", sarg0, sarg1); exit(); }
+PROG uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS %d %d\n", (int32)sarg0, (int32)sarg1); exit(); }
 EXPECT SUCCESS 32 64
 ARCH x86_64
 TIMEOUT 5
 AFTER ./testprogs/stack_args
 
 NAME sarg
-PROG uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS %d %d\n", sarg0, sarg1); exit(); }
+PROG uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS %d %d\n", (int32)sarg0, (int32)sarg1); exit(); }
 EXPECT SUCCESS 128 256
 ARCH aarch64|ppc64|ppc64le
 TIMEOUT 5
 AFTER ./testprogs/stack_args
 
 NAME sarg
-PROG uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS %d %d\n", sarg0, sarg1); exit(); }
+PROG uprobe:./testprogs/stack_args:too_many_args { printf("SUCCESS %d %d\n", (int32)sarg0, (int32)sarg1); exit(); }
 EXPECT SUCCESS 16 32
 ARCH s390x
 TIMEOUT 5

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -28,6 +28,11 @@ PROG BEGIN { printf("%dst: %sa; %dnd: %sb;; %drd: %sc;;; %dth: %sd;;;;\\n", 1, "
 EXPECT 1st: aa; 2nd: abb;; 3rd: abcc;;; 4th: abcdd;;;;
 TIMEOUT 5
 
+NAME printf_int64
+PROG BEGIN { printf("%.16x\n", 0x12345678abcdef); exit(); }
+EXPECT 0012345678abcdef
+TIMEOUT 5
+
 NAME time
 PROG i:ms:1 { time("%H:%M:%S\n"); exit();}
 EXPECT [0-9]*:[0-9]*:[0-9]*


### PR DESCRIPTION
Integer arguments to printf-style functions are represented as 64-bit ints, both in generated BPF code [1] and in bpftrace-side printing logic [2]. Therefore, a common pattern such as `printf("%d", pid)` is buggy -- it uses the conversion specifier for ints to print an int64_t value.

While in practice this works as expected on most platforms (the value is truncated to 4 bytes), it's by accident -- it depends on the architecture, toolchain, calling convention, etc. For example, the above breaks on arm with gcc where the compiler emits the following code for PrintableInt:

```
   0x000d6240 <+8>:     vldr    d7, [r12, #8]    # this->value_
   [...]
   0x000d6250 <+24>:    vstr    d7, [sp]
   0x000d6254 <+28>:    mov     r2, r3           # fmt
   0x000d6258 <+32>:    bl      0x1e000 <snprintf@plt>
```

(Note that the first 3 arguments to snprintf are passed via r0-r2, but `value_` is pushed onto the stack; `snprintf` expects the "%d" argument to be in r3, so it ends up printing the value of `fmt` instead)

With this patch, bpftrace internally replaces int format specifiers with their 64-bit variants (e.g. %x -> %llx on arm) in order to match int64_t values passed to snprintf.

[1] https://github.com/iovisor/bpftrace/blob/34cf5c2b53b82cddc9111055cd499d6e35763f3c/src/ast/passes/codegen_llvm.cpp#L3167
[2] https://github.com/iovisor/bpftrace/blob/34cf5c2b53b82cddc9111055cd499d6e35763f3c/src/printf.h#L82

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
