### PR TITLE
Add libdw-dev to ubuntu install in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -296,6 +296,7 @@ sudo apt-get install -y \
   libgtest-dev \
   libgmock-dev \
   asciidoctor \
+  libdw-dev \
   pahole
 git clone https://github.com/iovisor/bpftrace --recurse-submodules
 mkdir bpftrace/build; cd bpftrace/build;


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

According to It #2635, it seems like we also need `libdw-dev` to build the bpftrace in ubuntu 22.04, or the same error (file READ must be called with at least two additional arguments) to the issue occurs.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
