### PR TITLE
printf: Fix mismatch between format specifier and argument

### DIFF
--- a/src/format_string.h
+++ b/src/format_string.h
@@ -82,6 +82,7 @@ public:
 private:
   std::string fmt_;
   std::vector<std::string> parts_;
+  std::vector<ArgumentType> expected_types_;
 
   friend class cereal::access;
 

--- a/src/printf.h
+++ b/src/printf.h
@@ -26,11 +26,28 @@ const std::regex format_specifier_re(generate_pattern_string());
 
 struct Field;
 
+enum class ArgumentType
+{
+  UNKNOWN = 0,
+  CHAR,
+  SHORT,
+  INT,
+  LONG,
+  LONG_LONG,
+  INTMAX_T,
+  SIZE_T,
+  PTRDIFF_T,
+  POINTER,
+};
+
 class IPrintable
 {
 public:
   virtual ~IPrintable() { };
-  virtual int print(char* buf, size_t size, const char* fmt) = 0;
+  virtual int print(char* buf,
+                    size_t size,
+                    const char* fmt,
+                    ArgumentType expected_type = ArgumentType::UNKNOWN) = 0;
 };
 
 class PrintableString : public virtual IPrintable
@@ -39,7 +56,7 @@ public:
   PrintableString(std::string value,
                   std::optional<size_t> buffer_size = std::nullopt,
                   const char* trunc_trailer = nullptr);
-  int print(char* buf, size_t size, const char* fmt) override;
+  int print(char* buf, size_t size, const char* fmt, ArgumentType) override;
 
 private:
   std::string value_;
@@ -52,7 +69,7 @@ public:
       : value_(std::vector<char>(buffer, buffer + size))
   {
   }
-  int print(char* buf, size_t size, const char* fmt) override;
+  int print(char* buf, size_t size, const char* fmt, ArgumentType) override;
   void keep_ascii(bool value);
   void escape_hex(bool value);
 
@@ -66,7 +83,7 @@ class PrintableCString : public virtual IPrintable
 {
 public:
   PrintableCString(char* value) : value_(value) { }
-  int print(char* buf, size_t size, const char* fmt) override;
+  int print(char* buf, size_t size, const char* fmt, ArgumentType) override;
 
 private:
   char* value_;
@@ -76,7 +93,10 @@ class PrintableInt : public virtual IPrintable
 {
 public:
   PrintableInt(uint64_t value) : value_(value) { }
-  int print(char* buf, size_t size, const char* fmt) override;
+  int print(char* buf,
+            size_t size,
+            const char* fmt,
+            ArgumentType expected_type) override;
 
 private:
   uint64_t value_;
@@ -88,7 +108,10 @@ public:
   PrintableSInt(int64_t value) : value_(value)
   {
   }
-  int print(char* buf, size_t size, const char* fmt) override;
+  int print(char* buf,
+            size_t size,
+            const char* fmt,
+            ArgumentType expected_type) override;
 
 private:
   int64_t value_;

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -28,6 +28,16 @@ PROG BEGIN { printf("%dst: %sa; %dnd: %sb;; %drd: %sc;;; %dth: %sd;;;;\\n", 1, "
 EXPECT 1st: aa; 2nd: abb;; 3rd: abcc;;; 4th: abcdd;;;;
 TIMEOUT 5
 
+NAME printf_length_modifiers
+PROG BEGIN { $x = 0x12345678abcdef; printf("%hhx %hx %x %jx\n", $x, $x, $x, $x); exit(); }
+EXPECT ef cdef 78abcdef 12345678abcdef
+TIMEOUT 5
+
+NAME printf_char
+PROG BEGIN { printf("%c%c%c%c\n", 0x41, 0x42, 0x43, 0x44); exit(); }
+EXPECT ABCD
+TIMEOUT 5
+
 NAME time
 PROG i:ms:1 { time("%H:%M:%S\n"); exit();}
 EXPECT [0-9]*:[0-9]*:[0-9]*


### PR DESCRIPTION
Integer arguments to printf-style functions are represented as 64-bit ints, both in generated BPF code [1] and in bpftrace-side printing logic [2]. Therefore, a common pattern such as `printf("%d", pid)` is buggy -- it uses the conversion specifier for ints to print an int64_t value.

While in practice this works as expected on most platforms (the value is truncated to 4 bytes), it's by accident -- it depends on the architecture, toolchain, calling convention, etc. For example, the above breaks on arm with gcc where the compiler emits the following code for PrintableInt:
```
   0x000d6240 <+8>:     vldr    d7, [r12, #8]    # this->value_
   [...]
   0x000d6250 <+24>:    vstr    d7, [sp]
   0x000d6254 <+28>:    mov     r2, r3           # fmt
   0x000d6258 <+32>:    bl      0x1e000 <snprintf@plt>
```
(Note that the first 3 arguments to snprintf are passed via r0-r2, but `value_` is pushed onto the stack; `snprintf` expects the "%d" argument to be in r3, so it ends up printing the value of `fmt` instead)

This patch adds an explicit cast to make sure that the argument provided to `snprintf` is consistent with the conversion specifier.

[1] https://github.com/iovisor/bpftrace/blob/34cf5c2b53b82cddc9111055cd499d6e35763f3c/src/ast/passes/codegen_llvm.cpp#L3167
[2] https://github.com/iovisor/bpftrace/blob/34cf5c2b53b82cddc9111055cd499d6e35763f3c/src/printf.h#L82

This is the alternative implementation discussed in #2674 that fixes the bug without changing the existing behavior of "%d" and other specifiers.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
