### PR TITLE
Print stdout and stderr of befores and after on fail

### DIFF
--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -510,7 +510,7 @@ TIMEOUT 1
 
 NAME skboutput
 RUN {{BPFTRACE}} -e 'kfunc:__dev_queue_xmit { $ret = skboutput("skb.pcap", args.skb, args.skb->len, 14); if ($ret == 0) { printf("OK\n"); exit(); } }'
-AFTER ./testprogs/syscall 127.0.0.1 80
+AFTER ./testprogs/syscall connect 127.0.0.1 80
 EXPECT OK
 REQUIRES_FEATURE kfunc
 REQUIRES_FEATURE skboutput

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -209,7 +209,6 @@ class Runner(object):
                 with open(os.devnull, 'w') as dn:
                     child_names = [os.path.basename(x.strip().split()[-1]) for x in test.befores]
                     child_names = sorted((x[:15] for x in child_names))  # cut to comm length
-                    print(f"child_names: %{child_names}")
 
                     # Print the names of all of our children and look
                     # for the ones from BEFORE clauses
@@ -220,7 +219,6 @@ class Runner(object):
                         if children.returncode == 0 and children.stdout:
                             lines = [line.decode('utf-8') for line in children.stdout.splitlines()]
                             lines = sorted((line.strip() for line in lines if line != 'ps'))
-                            print(f"lines: %{lines}")
                             if lines == child_names:
                                 break
                         else:


### PR DESCRIPTION

If bpftrace is waiting for before to do something and it doesn't do it, it's good to know why.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
  * not user visible
- [ ] The new behaviour is covered by tests
  * Is part of testing
