### PR TITLE
Decouple kheaders unpacking from BTF support

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -418,7 +418,7 @@ static std::optional<struct timespec> get_delta_taitime()
     struct utsname utsname;
     uname(&utsname);
     std::string ksrc, kobj;
-    auto kdirs = get_kernel_dirs(utsname, !bpftrace.feature_->has_btf());
+    auto kdirs = get_kernel_dirs(utsname);
     ksrc = std::get<0>(kdirs);
     kobj = std::get<1>(kdirs);
 

--- a/src/utils.h
+++ b/src/utils.h
@@ -176,7 +176,7 @@ std::vector<int> get_possible_cpus();
 bool is_dir(const std::string &path);
 std::tuple<std::string, std::string> get_kernel_dirs(
     const struct utsname &utsname,
-    bool unpack_kheaders);
+    bool unpack_kheaders = true);
 std::vector<std::string> get_kernel_cflags(const char *uname_machine,
                                            const std::string &ksrc,
                                            const std::string &kobj,


### PR DESCRIPTION
This is a partial revert of 17bbcd2b0 ("kheader: Do not unpack kheaders if system has BTF"). Checking if the kernel supports BTF is not sufficient, as `ClangParser` may decide to not use the BTF-generated header in case there are conflicts with user-defined types[1].

For example, the following script falls back on kernel headers, which on a system that relies on CONFIG_IKHEADERS (e.g. Android) produces this error:

```
  $ sudo bpftrace -
  struct task_struct {}   // redefinition
  struct foo { struct task_struct dummy; }
  BEGIN {}
  ^D
  /bpftrace/include/clang_workarounds.h:14:10: fatal error: 'linux/types.h' file not found
```

This also unbreaks scripts written for older kernels without BTF support that unconditionally include kernel headers.

[1] https://github.com/iovisor/bpftrace/blob/3c417c8e3792c58a5958e3b1c49958ac063667a8/src/clang_parser.cpp#L765

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
