### PR TITLE
Support casting int <-> int array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
   - [#2477](https://github.com/iovisor/bpftrace/pull/2477)
 - Support func builtin for k(ret)func probes
   - [#2692](https://github.com/iovisor/bpftrace/pull/2692)
+- Support casting int <-> int array
+  - [#2686](https://github.com/iovisor/bpftrace/pull/2686)
 #### Changed
 - Make `args` a structure (instead of a pointer)
   - [#2578](https://github.com/iovisor/bpftrace/pull/2578)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -459,6 +459,18 @@ $py = (int16 *) $pz;
 Integer casts to a higher rank are sign extended.
 Conversion to a lower rank is done by zeroing leading bits.
 
+It is also possible to cast between integers and integer arrays using the same
+syntax:
+
+----
+$a = (uint8[8]) 12345;
+$x = (uint64) $a;
+----
+
+Both the cast and the destination type must have the same size. When casting to
+an array, it is possible to omit the size which will be determined automatically
+from the size of the cast value.
+
 === Operators and Expressions
 
 ==== Arithmetic Operators

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2106,6 +2106,14 @@ void CodegenLLVM::visit(Cast &cast)
                              cast.type.IsSigned(),
                              "cast");
   }
+  else if (cast.type.IsArrayTy() && cast.expr->type.IsIntTy())
+  {
+    // We need to store the cast integer on stack and reinterpret the pointer to
+    // it to an array pointer.
+    auto v = b_.CreateAllocaBPF(expr_->getType());
+    b_.CreateStore(expr_, v);
+    expr_ = b_.CreatePointerCast(v, b_.GetType(cast.type)->getPointerTo());
+  }
 }
 
 void CodegenLLVM::compareStructure(SizedType &our_type, llvm::Type *llvm_type)

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2370,6 +2370,25 @@ void SemanticAnalyser::visit(Cast &cast)
       return;
     }
 
+    if (cast.type.GetNumElements() == 0)
+    {
+      if (cast.type.GetElementTy()->GetSize() == 0)
+        LOG(ERROR, cast.loc, err_) << "Could not determine size of the array";
+      else
+      {
+        if (rhs.GetSize() % cast.type.GetElementTy()->GetSize() != 0)
+        {
+          LOG(ERROR, cast.loc, err_)
+              << "Cannot determine array size: the element size is "
+                 "incompatible with the cast integer size";
+        }
+
+        // cast to unsized array (e.g. int8[]), determine size from RHS
+        auto num_elems = rhs.GetSize() / cast.type.GetElementTy()->GetSize();
+        cast.type = CreateArray(num_elems, *cast.type.GetElementTy());
+      }
+    }
+
     if (rhs.IsIntTy())
       cast.type.is_internal = true;
   }

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2394,10 +2394,12 @@ void SemanticAnalyser::visit(Cast &cast)
   }
 
   if ((cast.type.IsIntTy() && !rhs.IsIntTy() && !rhs.IsPtrTy() &&
-       !rhs.IsCtxAccess()) ||
-      // casting to int arrays must respect the size
+       !rhs.IsCtxAccess() && !(rhs.IsArrayTy())) ||
+      // casting from/to int arrays must respect the size
       (cast.type.IsArrayTy() &&
-       (!rhs.IsIntTy() || cast.type.GetSize() != rhs.GetSize())))
+       (!rhs.IsIntTy() || cast.type.GetSize() != rhs.GetSize())) ||
+      (rhs.IsArrayTy() &&
+       (!cast.type.IsIntTy() || cast.type.GetSize() != rhs.GetSize())))
   {
     LOG(ERROR, cast.loc, err_)
         << "Cannot cast from \"" << rhs << "\" to \"" << cast.type << "\"";

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -40,7 +40,8 @@ path     :(\\.|[_\-\./a-zA-Z0-9#+\*])+
 builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ctx|curtask|elapsed|func|gid|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
 call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|stats|str|strerror|strftime|strncmp|strcontains|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf
 
-simple_type     bool|(u)?int(8|16|32|64)|(u)?(min|max|sum|count|avg|stats)_t|probe_t|username_t|lhist_t|hist_t|usym_t|ksym_t|timestamp_t|macaddr_t|cgroup_path_t|strerror_t
+int_type        bool|(u)?int(8|16|32|64)
+builtin_type    (u)?(min|max|sum|count|avg|stats)_t|probe_t|username_t|lhist_t|hist_t|usym_t|ksym_t|timestamp_t|macaddr_t|cgroup_path_t|strerror_t
 sized_type      str_t|inet_t|buf_t
 
 /* Don't add to this! Use builtin OR call not both */
@@ -149,7 +150,8 @@ bpftrace|perf|raw       { return Parser::make_STACK_MODE(yytext, loc); }
 "sizeof"                { return Parser::make_SIZEOF(loc); }
 "offsetof"              { return Parser::make_OFFSETOF(loc); }
 
-{simple_type}           { return Parser::make_SIMPLE_TYPE(yytext, loc); }
+{int_type}              { return Parser::make_INT_TYPE(yytext, loc); }
+{builtin_type}          { return Parser::make_BUILTIN_TYPE(yytext, loc); }
 {sized_type}            { return Parser::make_SIZED_TYPE(yytext, loc); }
 
 

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -214,6 +214,9 @@ type:
         |       int_type "[" INT "]" {
                   $$ = CreateArray($3, $1);
                 }
+        |       int_type "[" "]" {
+                  $$ = CreateArray(0, $1);
+                }
         |       pointer_type { $$ = $1; }
         |       struct_type { $$ = $1; }
                 ;

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -211,6 +211,9 @@ type:
                         $$ = CreateBuffer($3);
                     }
                 }
+        |       int_type "[" INT "]" {
+                  $$ = CreateArray($3, $1);
+                }
         |       pointer_type { $$ = $1; }
         |       struct_type { $$ = $1; }
                 ;

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -110,7 +110,8 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %token <std::string> BUILTIN "builtin"
 %token <std::string> CALL "call"
 %token <std::string> CALL_BUILTIN "call_builtin"
-%token <std::string> SIMPLE_TYPE "simple type"
+%token <std::string> INT_TYPE "integer type"
+%token <std::string> BUILTIN_TYPE "builtin type"
 %token <std::string> SIZED_TYPE "sized type"
 %token <std::string> IDENT "identifier"
 %token <std::string> PATH "path"
@@ -144,7 +145,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %type <ast::ProbeList *> probes
 %type <ast::Statement *> assign_stmt block_stmt expr_stmt if_stmt jump_stmt loop_stmt
 %type <ast::StatementList *> block block_or_if stmt_list
-%type <SizedType> type pointer_type struct_type
+%type <SizedType> type int_type pointer_type struct_type
 %type <ast::Variable *> var
 
 %left COMMA
@@ -179,17 +180,9 @@ c_definitions:
                 ;
 
 type:
-                SIMPLE_TYPE {
+                int_type { $$ = $1; }
+        |       BUILTIN_TYPE {
                     static std::unordered_map<std::string, SizedType> type_map = {
-                        {"bool", CreateBool()},
-                        {"uint8", CreateUInt(8)},
-                        {"uint16", CreateUInt(16)},
-                        {"uint32", CreateUInt(32)},
-                        {"uint64", CreateUInt(64)},
-                        {"int8", CreateInt(8)},
-                        {"int16", CreateInt(16)},
-                        {"int32", CreateInt(32)},
-                        {"int64", CreateInt(64)},
                         {"min_t", CreateMin(true)},
                         {"max_t", CreateMax(true)},
                         {"sum_t", CreateSum(true)},
@@ -220,6 +213,23 @@ type:
                 }
         |       pointer_type { $$ = $1; }
         |       struct_type { $$ = $1; }
+                ;
+
+int_type:
+                INT_TYPE {
+                    static std::unordered_map<std::string, SizedType> type_map = {
+                        {"bool", CreateBool()},
+                        {"uint8", CreateUInt(8)},
+                        {"uint16", CreateUInt(16)},
+                        {"uint32", CreateUInt(32)},
+                        {"uint64", CreateUInt(64)},
+                        {"int8", CreateInt(8)},
+                        {"int16", CreateInt(16)},
+                        {"int32", CreateInt(32)},
+                        {"int64", CreateInt(64)},
+                    };
+                    $$ = type_map[$1];
+                }
                 ;
 
 pointer_type:

--- a/tests/codegen/cast_arr_to_int.cpp
+++ b/tests/codegen/cast_arr_to_int.cpp
@@ -1,0 +1,14 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, cast_arr_to_int)
+{
+  test("kprobe:f { @=(uint32)pton(\"127.0.0.1\"); }", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/cast_int_to_arr.cpp.cpp
+++ b/tests/codegen/cast_int_to_arr.cpp.cpp
@@ -1,0 +1,14 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, cast_int_to_arr)
+{
+  test("kprobe:f { $a=(uint8[8])pid; @ = $a[0]; }", NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/cast_arr_to_int.ll
+++ b/tests/codegen/llvm/cast_arr_to_int.ll
@@ -1,0 +1,51 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
+entry:
+  %"@_val" = alloca i64, align 8
+  %"@_key" = alloca i64, align 8
+  %addr4 = alloca [4 x i8], align 1
+  %1 = bitcast [4 x i8]* %addr4 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  %2 = getelementptr [4 x i8], [4 x i8]* %addr4, i64 0, i64 0
+  store i8 127, i8* %2, align 1
+  %3 = getelementptr [4 x i8], [4 x i8]* %addr4, i64 0, i64 1
+  store i8 0, i8* %3, align 1
+  %4 = getelementptr [4 x i8], [4 x i8]* %addr4, i64 0, i64 2
+  store i8 0, i8* %4, align 1
+  %5 = getelementptr [4 x i8], [4 x i8]* %addr4, i64 0, i64 3
+  store i8 1, i8* %5, align 1
+  %6 = bitcast [4 x i8]* %addr4 to i32*
+  %7 = load volatile i32, i32* %6, align 4
+  %8 = bitcast [4 x i8]* %addr4 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  store i64 0, i64* %"@_key", align 8
+  %10 = zext i32 %7 to i64
+  %11 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i64 %10, i64* %"@_val", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
+  %12 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
+  %13 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/codegen/llvm/cast_int_to_arr.ll
+++ b/tests/codegen/llvm/cast_int_to_arr.ll
@@ -1,0 +1,53 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
+entry:
+  %"@_val" = alloca i64, align 8
+  %"@_key" = alloca i64, align 8
+  %"$a" = alloca i64, align 8
+  %1 = bitcast i64* %"$a" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 0, i64* %"$a", align 8
+  %2 = alloca i64, align 8
+  %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
+  %3 = lshr i64 %get_pid_tgid, 32
+  %4 = bitcast i64* %2 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  store i64 %3, i64* %2, align 8
+  %5 = bitcast i64* %2 to [8 x i8]*
+  %6 = ptrtoint [8 x i8]* %5 to i64
+  store i64 %6, i64* %"$a", align 8
+  %7 = load i64, i64* %"$a", align 8
+  %8 = inttoptr i64 %7 to [8 x i8]*
+  %9 = getelementptr [8 x i8], [8 x i8]* %8, i32 0, i64 0
+  %10 = load volatile i8, i8* %9, align 1
+  %11 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
+  store i64 0, i64* %"@_key", align 8
+  %12 = zext i8 %10 to i64
+  %13 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %13)
+  store i64 %12, i64* %"@_val", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@_key", i64* %"@_val", i64 0)
+  %14 = bitcast i64* %"@_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
+  %15 = bitcast i64* %"@_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/runtime/array
+++ b/tests/runtime/array
@@ -166,3 +166,8 @@ PROG struct D { int x; int y[0]; } uprobe:./testprogs/array_access:test_variable
 EXPECT @y: 1
 TIMEOUT 5
 AFTER ./testprogs/array_access
+
+NAME cast literal to int array
+PROG BEGIN { printf("first byte: %x\n", ((int8[8])12345)[0]); exit(); }
+EXPECT first byte: 39
+TIMEOUT 1

--- a/tests/runtime/array
+++ b/tests/runtime/array
@@ -171,3 +171,8 @@ NAME cast literal to int array
 PROG BEGIN { printf("first byte: %x\n", ((int8[8])12345)[0]); exit(); }
 EXPECT first byte: 39
 TIMEOUT 1
+
+NAME cast to int array with automatic size
+PROG BEGIN { printf("byte: %x\n", ((int8[])12345)[0]); exit(); }
+EXPECT byte: 39
+TIMEOUT 1

--- a/tests/runtime/array
+++ b/tests/runtime/array
@@ -176,3 +176,15 @@ NAME cast to int array with automatic size
 PROG BEGIN { printf("byte: %x\n", ((int8[])12345)[0]); exit(); }
 EXPECT byte: 39
 TIMEOUT 1
+
+NAME cast int array to int internal
+PROG BEGIN { printf("ip: %x\n", (uint32)pton("127.0.0.1")); exit(); }
+EXPECT ip: 100007f
+TIMEOUT 5
+AFTER ./testprogs/array_access
+
+NAME cast int array to int proberead
+RUN {{BPFTRACE}} --include "stdint.h" -e 'struct A { int x[4]; uint8_t y[4]; } uprobe:./testprogs/array_access:test_arrays { $y = (int32)((struct A *)arg0)->y; printf("y: %x\n", $y); exit()}'
+EXPECT y: ddccbbaa
+TIMEOUT 5
+AFTER ./testprogs/array_access

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2063,6 +2063,32 @@ TEST(semantic_analyser, intptr_cast_usage)
   test("kprobe:f { @=avg(*(int32*)123) }", 0);
 }
 
+TEST(semantic_analyser, intarray_cast_types)
+{
+  test("kprobe:f { @ = (int8[8])1 }", 0);
+  test("kprobe:f { @ = (int16[4])1 }", 0);
+  test("kprobe:f { @ = (int32[2])1 }", 0);
+  test("kprobe:f { @ = (int64[1])1 }", 0);
+  test("kprobe:f { @ = (int8[4])(int32)1 }", 0);
+  test("kprobe:f { @ = (int8[2])(int16)1 }", 0);
+  test("kprobe:f { @ = (int8[1])(int8)1 }", 0);
+  test("kprobe:f { @ = (uint8[8])1 }", 0);
+  test("kretprobe:f { @ = (int8[8])retval }", 0);
+
+  test("kprobe:f { @ = (int8[4])1 }", 1);
+  test("kprobe:f { @ = (bool[64])1 }", 1);
+  test("kprobe:f { @ = (int8[6])\"hello\" }", 1);
+  test("struct Foo { int x; } kprobe:f { @ = (struct Foo [2])1 }", 1);
+}
+
+TEST(semantic_analyser, intarray_cast_usage)
+{
+  test("kprobe:f { $a=(int8[8])1; }", 0);
+  test("kprobe:f { @=(int8[8])1; }", 0);
+  test("kprobe:f { @[(int8[8])1] = 0; }", 0);
+  test("kprobe:f { if (((int8[8])1)[0] == 1) {} }", 0);
+}
+
 TEST(semantic_analyser, signal)
 {
   // int literals

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2072,11 +2072,13 @@ TEST(semantic_analyser, intarray_cast_types)
   test("kprobe:f { @ = (int8[4])(int32)1 }", 0);
   test("kprobe:f { @ = (int8[2])(int16)1 }", 0);
   test("kprobe:f { @ = (int8[1])(int8)1 }", 0);
+  test("kprobe:f { @ = (int8[])1 }", 0);
   test("kprobe:f { @ = (uint8[8])1 }", 0);
   test("kretprobe:f { @ = (int8[8])retval }", 0);
 
   test("kprobe:f { @ = (int8[4])1 }", 1);
   test("kprobe:f { @ = (bool[64])1 }", 1);
+  test("kprobe:f { @ = (int32[])(int16)1 }", 1);
   test("kprobe:f { @ = (int8[6])\"hello\" }", 1);
   test("struct Foo { int x; } kprobe:f { @ = (struct Foo [2])1 }", 1);
 }

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2091,6 +2091,31 @@ TEST(semantic_analyser, intarray_cast_usage)
   test("kprobe:f { if (((int8[8])1)[0] == 1) {} }", 0);
 }
 
+TEST(semantic_analyser, intarray_to_int_cast)
+{
+  test("#include <stdint.h>\n"
+       "struct Foo { uint8_t x[8]; } "
+       "kprobe:f { @ = (int64)((struct Foo *)arg0)->x; }",
+       0);
+  test("#include <stdint.h>\n"
+       "struct Foo { uint32_t x[2]; } "
+       "kprobe:f { @ = (int64)((struct Foo *)arg0)->x; }",
+       0);
+  test("#include <stdint.h>\n"
+       "struct Foo { uint8_t x[4]; } "
+       "kprobe:f { @ = (int32)((struct Foo *)arg0)->x; }",
+       0);
+
+  test("#include <stdint.h>\n"
+       "struct Foo { uint8_t x[8]; } "
+       "kprobe:f { @ = (int32)((struct Foo *)arg0)->x; }",
+       1);
+  test("#include <stdint.h>\n"
+       "struct Foo { uint8_t x[8]; } "
+       "kprobe:f { @ = (int32 *)((struct Foo *)arg0)->x; }",
+       1);
+}
+
 TEST(semantic_analyser, signal)
 {
   // int literals

--- a/tests/testprogs/array_access.c
+++ b/tests/testprogs/array_access.c
@@ -1,6 +1,9 @@
+#include <stdint.h>
+
 struct A
 {
   int x[4];
+  uint8_t y[4];
 };
 
 struct B
@@ -49,6 +52,10 @@ int main(int argc __attribute__((unused)), char ** argv __attribute__((unused)))
   a.x[1] = 2;
   a.x[2] = 3;
   a.x[3] = 4;
+  a.y[0] = 0xaa;
+  a.y[1] = 0xbb;
+  a.y[2] = 0xcc;
+  a.y[3] = 0xdd;
 
   struct B b;
   b.y[0][0] = 5;


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

This PR adds support for conversions between integers and integer arrays. The main purpose is to allow conversion from/to byte arrays.

A good use-case for this are scripts working with IPv4 addresses which the kernel sometimes stores as 32-bit integers (e.g. in [struct sock_common](https://elixir.bootlin.com/linux/v6.4/source/include/net/sock.h#L167)) and sometimes as 4-byte arrays (e.g. in [TCP tracepoints](https://elixir.bootlin.com/linux/v6.4/source/include/trace/events/tcp.h#L64)). This feature, in combination with array comparison added in #2387, allows to compare such representations:
```
kfunc:tcp_connect
{
    @ = args->sk->__sk_common.skc_daddr;
}
tracepoint:tcp:tcp_rcv_space_adjust
{
    // map values are always 64-bit so first cast to uint32
    // and then to the target array
    if ((uint8[4])(uint32)@ == args->daddr)
    {
        ...
    }
}
```

Similarly, it is now possible to compare the int IPv4 addresses with absolute addresses obtained from the `pton` builtin:
```
kfunc:tcp_connect
{
    if (args->sk->__sk_common.skc_daddr == (uint32)pton("127.0.0.1"))
        ...
}
```

Both the cast and the destination type must have the same size. When casting to an array, it is possible to omit the size which will be determined automatically from the size of the cast value.

This also does some refactoring of type parsing. See individual commit messages for more implementation details.

Resolves #2634.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
