### PR TITLE
Attachpoint parser: improve stoull error messages

### DIFF
--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -345,7 +345,10 @@ AttachPointParser::State AttachPointParser::kprobe_parser(bool allow_offset)
 
     auto res = stoll(offset_parts[1]);
     if (!res)
+    {
+      errs_ << "Invalid offset" << std::endl;
       return INVALID;
+    }
     ap_->func_offset = *res;
   }
   // Default case (eg kprobe:func)
@@ -430,7 +433,10 @@ AttachPointParser::State AttachPointParser::uprobe_parser(bool allow_offset,
 
     auto res = stoll(offset_parts[1]);
     if (!res)
+    {
+      errs_ << "Invalid offset" << std::endl;
       return INVALID;
+    }
     ap_->func_offset = *res;
   }
   // Default case (eg uprobe:[addr][func])
@@ -550,7 +556,10 @@ AttachPointParser::State AttachPointParser::profile_parser()
 
   auto res = stoull(parts_[2]);
   if (!res)
+  {
+    errs_ << "Invalid rate of " << ap_->provider << " probe";
     return INVALID;
+  }
 
   ap_->freq = *res;
   return OK;
@@ -567,7 +576,10 @@ AttachPointParser::State AttachPointParser::interval_parser()
   ap_->target = parts_[1];
   auto res = stoull(parts_[2]);
   if (!res)
+  {
+    errs_ << "Invalid rate of " << ap_->provider << " probe";
     return INVALID;
+  }
 
   ap_->freq = *res;
   return OK;
@@ -591,7 +603,10 @@ AttachPointParser::State AttachPointParser::software_parser()
   {
     auto res = stoull(parts_[2]);
     if (!res)
+    {
+      errs_ << "Invalid count for " << ap_->provider << " probe";
       return INVALID;
+    }
     ap_->freq = *res;
   }
 
@@ -616,7 +631,10 @@ AttachPointParser::State AttachPointParser::hardware_parser()
   {
     auto res = stoull(parts_[2]);
     if (!res)
+    {
+      errs_ << "Invalid count for " << ap_->provider << " probe";
       return INVALID;
+    }
     ap_->freq = *res;
   }
 
@@ -636,7 +654,10 @@ AttachPointParser::State AttachPointParser::watchpoint_parser(bool async)
   {
     auto parsed = stoull(parts_[1]);
     if (!parsed)
+    {
+      errs_ << "Invalid function/address argument" << std::endl;
       return INVALID;
+    }
     ap_->address = *parsed;
   }
   else
@@ -660,13 +681,19 @@ AttachPointParser::State AttachPointParser::watchpoint_parser(bool async)
 
     auto parsed = stoull(func_arg_parts[1].substr(3));
     if (!parsed)
+    {
+      errs_ << "Invalid function argument" << std::endl;
       return INVALID;
+    }
     ap_->address = *parsed;
   }
 
   auto len_parsed = stoull(parts_[2]);
   if (!len_parsed)
+  {
+    errs_ << "Invalid length argument" << std::endl;
     return INVALID;
+  }
   ap_->len = *len_parsed;
 
   // Semantic analyser will ensure a cmd/pid was provided


### PR DESCRIPTION
There's a number of probe types that expect a number as one of their arguments. We use our own parser to convert a string to an integer, however, when it fails, the error message is not very nice:

    # bpftrace -e 'interval:5:s{ @[comm] = count();}'
    stdin:1:1-13: ERROR: stoull
    interval:5:s{ @[comm] = count();}

Provide better messages for all places where stoull/stoll may fail in AttachPointParser:

    # bpftrace -e 'interval:5:s{ @[comm] = count();}'
    stdin:1:1-13: ERROR: stoull
    invalid rate of interval probe
    interval:5:s{ @[comm] = count();}

Fixes #2680.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
