### PR TITLE
child.cpp: validate_cmd: Support symbolic links in environment variables

### DIFF
--- a/src/child.cpp
+++ b/src/child.cpp
@@ -95,18 +95,26 @@ static int childfn(void* arg)
 static void validate_cmd(std::vector<std::string>& cmd)
 {
   auto paths = resolve_binary_path(cmd[0]);
-  switch (paths.size())
+
+  // /usr/bin/ls and /bin/ls may be the same file.
+  std::unordered_set<std::string> abs_path;
+  for (const auto& str : paths)
+  {
+    abs_path.insert(get_absolute_path(str.c_str()));
+  }
+
+  switch (abs_path.size())
   {
     case 0:
       throw std::runtime_error("path '" + cmd[0] +
                                "' does not exist or is not executable");
     case 1:
-      cmd[0] = paths.front().c_str();
+      cmd[0] = *(abs_path.begin());
       break;
     default:
       throw std::runtime_error("path '" + cmd[0] +
                                "' must refer to a unique binary but matched " +
-                               std::to_string(paths.size()) + " binaries");
+                               std::to_string(abs_path.size()) + " binaries");
       return;
   }
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -788,6 +788,18 @@ std::string exec_system(const char *cmd)
   return result;
 }
 
+std::string get_absolute_path(std::string const &path)
+{
+  std::error_code ec;
+  std_filesystem::path p(path);
+  std::string abs_path = std_filesystem::canonical(p, ec);
+  if (ec || errno == ENOENT)
+  {
+    return path;
+  }
+  return abs_path;
+}
+
 /*
 Original resolve_binary_path API defaulting to bpftrace's mount namespace
 */

--- a/src/utils.h
+++ b/src/utils.h
@@ -195,6 +195,7 @@ bool is_unsafe_func(const std::string &func_name);
 bool is_compile_time_func(const std::string &func_name);
 bool is_supported_lang(const std::string &lang);
 std::string exec_system(const char *cmd);
+std::string get_absolute_path(std::string const &path);
 std::vector<std::string> resolve_binary_path(const std::string &cmd);
 std::vector<std::string> resolve_binary_path(const std::string &cmd, int pid);
 std::string path_for_pid_mountns(int pid, const std::string &path);

--- a/tests/child.cpp
+++ b/tests/child.cpp
@@ -129,7 +129,8 @@ TEST(childproc, stop_cont)
   int status = 0;
 
   child->run();
-  msleep(25);
+  // Give children enough time to spawn.
+  msleep(250);
   EXPECT_TRUE(child->is_alive());
 
   if (kill(child->pid(), SIGSTOP))

--- a/tests/childhelper.h
+++ b/tests/childhelper.h
@@ -28,8 +28,8 @@ static std::unique_ptr<ChildProc> getChild(std::string cmd)
   {
     StderrSilencer es;
     StdoutSilencer os;
-    os.silence();
-    es.silence();
+    // os.silence();
+    // es.silence();
     child = std::make_unique<ChildProc>(cmd);
   }
   EXPECT_NE(child->pid(), -1);


### PR DESCRIPTION
On some systems `/bin` is a symbolic link to `/usr/bin` (`/bin -> /usr/bin`), When using the '-c' parameter to specify the executable program in the environment variable, the problem of "multiple binary files matching" occurs, for example:

```
  $ sudo bpftrace -e 'kprobe:do_nanosleep { printf("%d sleeping\n", pid); }' -c 'sleep 5'
  ERROR: Failed to fork child: path 'sleep' must refer to a unique binary but matched 2 binaries
```

Debugging the bpftrace program through gdb can also be verified:

```
  (gdb) p valid_executable_paths
  $9 = std::vector of length 2, capacity 2 = {"/bin/ls", "/usr/bin/ls"}
```

This commit fixes the issue. This is the V2 submition, V1(https://github.com/iovisor/bpftrace/pull/2682)