### PR TITLE
Improve listing and 'probe' builtin for several probe types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to
   - [#2673](https://github.com/iovisor/bpftrace/pull/2673)
 - Allow '+' in attach point path
   - [#2696](https://github.com/iovisor/bpftrace/pull/2696)
+- Improve listing and 'probe' builtin for several probe types
+  - [#2691](https://github.com/iovisor/bpftrace/pull/2691)
 
 ## [0.18.0] 2023-05-15
 

--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -556,6 +556,14 @@ AttachPointParser::State AttachPointParser::tracepoint_parser()
 
 AttachPointParser::State AttachPointParser::profile_parser()
 {
+  if (parts_.size() == 2 && has_wildcard(parts_[1]))
+  {
+    // Wildcards are allowed for listing
+    ap_->target = parts_[1];
+    ap_->freq = 0;
+    return OK;
+  }
+
   if (parts_.size() != 3)
   {
     errs_ << ap_->provider << " probe type requires 2 arguments" << std::endl;
@@ -577,6 +585,14 @@ AttachPointParser::State AttachPointParser::profile_parser()
 
 AttachPointParser::State AttachPointParser::interval_parser()
 {
+  if (parts_.size() == 2 && has_wildcard(parts_[1]))
+  {
+    // Wildcards are allowed for listing
+    ap_->target = parts_[1];
+    ap_->freq = 0;
+    return OK;
+  }
+
   if (parts_.size() != 3)
   {
     errs_ << ap_->provider << " probe type requires 2 arguments" << std::endl;

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2724,6 +2724,14 @@ void CodegenLLVM::visit(Probe &probe)
             erase_prefix(match);
             probefull_ = attach_point->name(match);
           }
+          else if (probetype(attach_point->provider) == ProbeType::software ||
+                   probetype(attach_point->provider) == ProbeType::hardware)
+          {
+            // Hardware and software probes do not support wildcards but they
+            // still may need expansion when the 'probe' builtin is used. Just
+            // use the name stored in the probe in such a case.
+            probefull_ = attach_point->name("");
+          }
           else
             probefull_ = attach_point->name(match);
 

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2725,11 +2725,14 @@ void CodegenLLVM::visit(Probe &probe)
             probefull_ = attach_point->name(match);
           }
           else if (probetype(attach_point->provider) == ProbeType::software ||
-                   probetype(attach_point->provider) == ProbeType::hardware)
+                   probetype(attach_point->provider) == ProbeType::hardware ||
+                   probetype(attach_point->provider) == ProbeType::interval ||
+                   probetype(attach_point->provider) == ProbeType::profile)
           {
-            // Hardware and software probes do not support wildcards but they
-            // still may need expansion when the 'probe' builtin is used. Just
-            // use the name stored in the probe in such a case.
+            // Hardware, software, interval, and profile probes do not support
+            // wildcards but they still may need expansion when the 'probe'
+            // builtin is used.
+            // Just use the name stored in the probe in such a case.
             probefull_ = attach_point->name("");
           }
           else

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2718,29 +2718,34 @@ void SemanticAnalyser::visit(AttachPoint &ap)
   else if (ap.provider == "profile") {
     if (ap.target == "")
       LOG(ERROR, ap.loc, err_) << "profile probe must have unit of time";
-    else if (ap.target != "hz" &&
-             ap.target != "us" &&
-             ap.target != "ms" &&
-             ap.target != "s")
-      LOG(ERROR, ap.loc, err_)
-          << ap.target << " is not an accepted unit of time";
-    if (ap.func != "")
-      LOG(ERROR, ap.loc, err_)
-          << "profile probe must have an integer frequency";
-    else if (ap.freq <= 0)
-      LOG(ERROR, ap.loc, err_)
-          << "profile frequency should be a positive integer";
+    else if (!listing_)
+    {
+      if (TIME_UNITS.find(ap.target) == TIME_UNITS.end())
+        LOG(ERROR, ap.loc, err_)
+            << ap.target << " is not an accepted unit of time";
+      if (ap.func != "")
+        LOG(ERROR, ap.loc, err_)
+            << "profile probe must have an integer frequency";
+      else if (ap.freq <= 0)
+        LOG(ERROR, ap.loc, err_)
+            << "profile frequency should be a positive integer";
+    }
   }
   else if (ap.provider == "interval") {
     if (ap.target == "")
       LOG(ERROR, ap.loc, err_) << "interval probe must have unit of time";
-    else if (ap.target != "ms" && ap.target != "s" && ap.target != "us" &&
-             ap.target != "hz")
-      LOG(ERROR, ap.loc, err_)
-          << ap.target << " is not an accepted unit of time";
-    if (ap.func != "")
-      LOG(ERROR, ap.loc, err_)
-          << "interval probe must have an integer frequency";
+    else if (!listing_)
+    {
+      if (TIME_UNITS.find(ap.target) == TIME_UNITS.end())
+        LOG(ERROR, ap.loc, err_)
+            << ap.target << " is not an accepted unit of time";
+      if (ap.func != "")
+        LOG(ERROR, ap.loc, err_)
+            << "interval probe must have an integer frequency";
+      else if (ap.freq <= 0)
+        LOG(ERROR, ap.loc, err_)
+            << "interval frequency should be a positive integer";
+    }
   }
   else if (ap.provider == "software") {
     if (ap.target == "")

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -552,7 +552,7 @@ std::set<std::string> ProbeMatcher::get_matches_for_ap(
     }
     case ProbeType::hardware:
     case ProbeType::software: {
-      search_input = attach_point.target;
+      search_input = attach_point.target + ":";
       break;
     }
     case ProbeType::usdt:

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -199,6 +199,14 @@ std::set<std::string> ProbeMatcher::get_matches_for_probetype(
       symbol_stream = std::make_unique<std::istringstream>(ret);
       break;
     }
+    case ProbeType::interval:
+    case ProbeType::profile: {
+      std::string ret;
+      for (auto& unit : TIME_UNITS)
+        ret += unit + ":\n";
+      symbol_stream = std::make_unique<std::istringstream>(ret);
+      break;
+    }
     default:
       return {};
   }
@@ -551,7 +559,9 @@ std::set<std::string> ProbeMatcher::get_matches_for_ap(
       break;
     }
     case ProbeType::hardware:
-    case ProbeType::software: {
+    case ProbeType::software:
+    case ProbeType::profile:
+    case ProbeType::interval: {
       search_input = attach_point.target + ":";
       break;
     }
@@ -579,11 +589,6 @@ std::set<std::string> ProbeMatcher::get_matches_for_ap(
       throw WildcardException(
           "Wildcard matches aren't available on probe type '" +
           attach_point.provider + "'");
-    case ProbeType::profile:
-    case ProbeType::interval:
-      // Wildcard matches are not supported on these probe types, however
-      // expansion can still happen when the probe builtin is used
-      return { "" };
   }
 
   return get_matches_for_probetype(probetype(attach_point.provider),

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -540,8 +540,6 @@ std::set<std::string> ProbeMatcher::get_matches_for_ap(
     case ProbeType::watchpoint:
     case ProbeType::asyncwatchpoint:
     case ProbeType::tracepoint:
-    case ProbeType::hardware:
-    case ProbeType::software:
     case ProbeType::kfunc:
     case ProbeType::kretfunc: {
       // Do not expand "target:" as that would match all functions in target.
@@ -550,6 +548,11 @@ std::set<std::string> ProbeMatcher::get_matches_for_ap(
         return { attach_point.target + ":" };
 
       search_input = attach_point.target + ":" + attach_point.func;
+      break;
+    }
+    case ProbeType::hardware:
+    case ProbeType::software: {
+      search_input = attach_point.target;
       break;
     }
     case ProbeType::usdt:

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -46,6 +46,8 @@ const std::vector<ProbeListItem> HW_PROBE_LIST = {
 };
 // clang-format on
 
+const std::unordered_set<std::string> TIME_UNITS = { "s", "ms", "us", "hz" };
+
 class BPFtrace;
 
 typedef std::map<std::string, std::vector<std::string>> FuncParamLists;

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -113,6 +113,16 @@ REQUIRES_FEATURE btf
 REQUIRES_FEATURE kfunc
 TIMEOUT 1
 
+NAME it lists interval probes with regex filter
+RUN {{BPFTRACE}} -l "interval:*"
+EXPECT interval:s
+TIMEOUT 1
+
+NAME it lists profile probes with regex filter
+RUN {{BPFTRACE}} -l "profile:*"
+EXPECT profile:*
+TIMEOUT 1
+
 NAME listing with wildcarded probe type
 RUN {{BPFTRACE}} -l "*ware:*"
 EXPECT hardware:

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -91,12 +91,12 @@ TIMEOUT 1
 
 NAME it lists software events with regex filter
 RUN {{BPFTRACE}} -l "software:*"
-EXPECT software
+EXPECT software:cpu
 TIMEOUT 1
 
 NAME it lists hardware events with regex filter
 RUN {{BPFTRACE}} -l "hardware:*"
-EXPECT hardware
+EXPECT hardware:cpu
 TIMEOUT 1
 
 NAME it lists kfuncs events with regex filter

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -368,10 +368,21 @@ RUN {{BPFTRACE}} runtime/scripts/software_order.bt
 EXPECT first second
 TIMEOUT 5
 
+NAME software_probe_builtin
+PROG software:page-faults:1 { print(probe); exit();}
+EXPECT software:page-faults:1
+TIMEOUT 5
+
 NAME hardware
 REQUIRES ls /sys/devices/cpu/events/cache-misses
 PROG hardware:cache-misses:10 { @[pid] = count(); exit(); }
 EXPECT @\[.*\]\:\s[0-9]*
+TIMEOUT 5
+
+NAME hardware_probe_builtin
+REQUIRES ls /sys/devices/cpu/events/cache-misses
+PROG hardware:cache-misses:10 { print(probe); exit();}
+EXPECT hardware:cache-misses:10
 TIMEOUT 5
 
 NAME BEGIN


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

This allows to list hardware, software, interval, and profile probes:
```
# bpftrace -l 'hardware:*'
hardware:backend-stalls:
hardware:branch-instructions:
hardware:branch-misses:
hardware:bus-cycles:
hardware:cache-misses:
hardware:cache-references:
hardware:cpu-cycles:
hardware:frontend-stalls:
hardware:instructions:
hardware:ref-cycles:

# bpftrace -l 'software:*'
software:alignment-faults:
software:bpf-output:
software:context-switches:
software:cpu-clock:
software:cpu-migrations:
software:dummy:
software:emulation-faults:
software:major-faults:
software:minor-faults:
software:page-faults:
software:task-clock:

# bpftrace -l 'interval:*'
interval:hz:
interval:ms:
interval:s:
interval:us:

# bpftrace -l 'profile:*'
profile:hz:
profile:ms:
profile:s:
profile:us:
```

Also fixes failures when using the `probe` builtin from hardware and software probes.

Fixes #2690.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
