### PR TITLE
Support func builtin for k(ret)func probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to
   - [#2630](https://github.com/iovisor/bpftrace/pull/2630)
 - Improve working with all probe params (kfunc, uprobe)
   - [#2477](https://github.com/iovisor/bpftrace/pull/2477)
+- Support func builtin for k(ret)func probes
+  - [#2692](https://github.com/iovisor/bpftrace/pull/2692)
 #### Changed
 - Make `args` a structure (instead of a pointer)
   - [#2578](https://github.com/iovisor/bpftrace/pull/2578)

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1329,6 +1329,18 @@ CallInst *IRBuilderBPF::CreateGetStackId(Value *ctx,
   return call;
 }
 
+CallInst *IRBuilderBPF::CreateGetFuncIp(const location &loc)
+{
+  // u64 bpf_get_func_ip(void *ctx)
+  // Return: Address of the traced function.
+  FunctionType *getfuncip_func_type = FunctionType::get(getInt64Ty(), false);
+  return CreateHelperCall(libbpf::BPF_FUNC_get_func_ip,
+                          getfuncip_func_type,
+                          {},
+                          "get_func_ip",
+                          &loc);
+}
+
 void IRBuilderBPF::CreateGetCurrentComm(Value *ctx,
                                         AllocaInst *buf,
                                         size_t size,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -169,6 +169,7 @@ public:
   CallInst *CreateGetCurrentTask(const location &loc);
   CallInst *CreateGetRandom(const location &loc);
   CallInst   *CreateGetStackId(Value *ctx, bool ustack, StackType stack_type, const location& loc);
+  CallInst *CreateGetFuncIp(const location &loc);
   CallInst   *CreateGetJoinMap(Value *ctx, const location& loc);
   CallInst *CreateHelperCall(libbpf::bpf_func_id func_id,
                              FunctionType *helper_type,

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -373,6 +373,15 @@ void SemanticAnalyser::visit(Builtin &builtin)
         builtin.type = CreateKSym();
       else if (type == ProbeType::uprobe || type == ProbeType::uretprobe)
         builtin.type = CreateUSym();
+      else if (type == ProbeType::kfunc || type == ProbeType::kretfunc)
+      {
+        if (!bpftrace_.feature_->has_helper_get_func_ip())
+        {
+          LOG(ERROR, builtin.loc, err_)
+              << "BPF_FUNC_get_func_ip not available for your kernel version";
+        }
+        builtin.type = CreateKSym();
+      }
       else
         LOG(ERROR, builtin.loc, err_)
             << "The func builtin can not be used with '"

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -501,6 +501,7 @@ std::string BPFfeature::report(void)
       << "  dpath: " << to_str(has_d_path())
       << "  skboutput: " << to_str(has_skb_output())
       << "  get_tai_ns: " << to_str(has_helper_ktime_get_tai_ns())
+      << "  get_func_ip: " << to_str(has_helper_get_func_ip())
 
       << std::endl;
 

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -104,6 +104,7 @@ public:
   DEFINE_HELPER_TEST(probe_read_kernel_str, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_HELPER_TEST(ktime_get_boot_ns, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_HELPER_TEST(ktime_get_tai_ns, libbpf::BPF_PROG_TYPE_KPROBE);
+  DEFINE_HELPER_TEST(get_func_ip, libbpf::BPF_PROG_TYPE_TRACING);
   DEFINE_PROG_TEST(kprobe, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_PROG_TEST(tracepoint, libbpf::BPF_PROG_TYPE_TRACEPOINT);
   DEFINE_PROG_TEST(perf_event, libbpf::BPF_PROG_TYPE_PERF_EVENT);

--- a/tests/codegen/builtin_func.cpp
+++ b/tests/codegen/builtin_func.cpp
@@ -15,6 +15,11 @@ TEST(codegen, builtin_func_uprobe)
   test(*bpftrace, "uprobe:/bin/sh:f { @x = func }", NAME);
 }
 
+TEST(codegen, builtin_func_kfunc)
+{
+  test("kfunc:f { @x = func }", NAME);
+}
+
 } // namespace codegen
 } // namespace test
 } // namespace bpftrace

--- a/tests/codegen/llvm/builtin_func_kfunc.ll
+++ b/tests/codegen/llvm/builtin_func_kfunc.ll
@@ -1,0 +1,36 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @"kfunc:f"(i8* %0) section "s_kfunc:f_1" {
+entry:
+  %"@x_val" = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  %get_func_ip = call i64 inttoptr (i64 173 to i64 ()*)()
+  %1 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 0, i64* %"@x_key", align 8
+  %2 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 %get_func_ip, i64* %"@x_val", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
+  %3 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -165,6 +165,7 @@ class TestParser(object):
                     "kprobe_multi",
                     "skboutput",
                     "get_tai_ns",
+                    "get_func_ip",
                 }
 
                 for f in line.split(" "):

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -138,6 +138,7 @@ class Runner(object):
         bpffeature["aot"] = cmake_vars.LIBBCC_BPF_CONTAINS_RUNTIME
         bpffeature["skboutput"] = output.find("skboutput: yes") != -1
         bpffeature["get_tai_ns"] = output.find("get_ktime_ns: yes") != -1
+        bpffeature["get_func_ip"] = output.find("get_func_ip: yes") != -1
         return bpffeature
 
     @staticmethod

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -59,6 +59,15 @@ REQUIRES_FEATURE btf
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
+NAME kfunc func builtin
+PROG kfunc:vfs_read { printf("func: %s\n", func); exit(); }
+EXPECT func: vfs_read
+REQUIRES_FEATURE kfunc
+REQUIRES_FEATURE btf
+REQUIRES_FEATURE get_func_ip
+TIMEOUT 5
+AFTER ./testprogs/syscall read
+
 NAME kprobe
 PROG kprobe:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT SUCCESS [0-9][0-9]*

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2725,6 +2725,7 @@ TEST_F(semantic_analyser_btf, kfunc)
   test("kretfunc:func_1 { $x = retval; }", 0);
   test("kfunc:vmlinux:func_1 { 1 }", 0);
   test("kfunc:*:func_1 { 1 }", 0);
+  test("kfunc:func_1 { @[func] = 1; }", 0);
 
   test("kretfunc:func_1 { $x = args.foo; }", 1);
   test("kretfunc:func_1 { $x = args; }", 0);


### PR DESCRIPTION
Since https://github.com/torvalds/linux/commit/9b99edcae5c80c8fb9f8e7149bae528c9e610a72, kernel has the `bpf_get_func_ip` helper to get the value of instruction pointer from `BPF_PROG_TYPE_TRACING` programs. This allows to enable the `func` builtin in k(ret)func probes.

Resolves #2000.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
