### PR TITLE
Allow '+' in attach point path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,8 @@ and this project adheres to
   - [#2625](https://github.com/iovisor/bpftrace/pull/2625)
 - cmake: fix linking libbfd
   - [#2673](https://github.com/iovisor/bpftrace/pull/2673)
-
+- Allow '+' in attach point path
+  - [#2696](https://github.com/iovisor/bpftrace/pull/2696)
 
 ## [0.18.0] 2023-05-15
 

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -36,7 +36,7 @@ var      ${ident}
 hspace   [ \t]
 vspace   [\n\r]
 space    {hspace}|{vspace}
-path     :(\\.|[_\-\./a-zA-Z0-9#\*])+
+path     :(\\.|[_\-\./a-zA-Z0-9#+\*])+
 builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ctx|curtask|elapsed|func|gid|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
 call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|stats|str|strerror|strftime|strncmp|strcontains|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf
 

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1031,6 +1031,11 @@ TEST(Parser, uprobe)
        " uprobe:/my/program:cpp:func\n"
        "  int: 1\n");
 
+  test("uprobe:/my/dir+/program:1234abc { 1; }",
+       "Program\n"
+       " uprobe:/my/dir+/program:1234abc\n"
+       "  int: 1\n");
+
   test_parse_failure("uprobe:f { 1 }");
   test_parse_failure("uprobe { 1 }");
   test_parse_failure("uprobe:/my/program*:0x1234 { 1 }");


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

This PR fixes #2695

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
