### PR TITLE
Fixing runtime tests for ppc

### DIFF
--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -231,6 +231,6 @@ TIMEOUT 5
 NAME print args in kfunc
 PROG kfunc:vfs_open { print(args); exit(); }
 EXPECT { .path = 0x[0-9a-f]+, .file = 0x[0-9a-f]+ }
-REQUIRES_FEATURE btf
+REQUIRES_FEATURE kfunc
 TIMEOUT 5
 AFTER ./testprogs/syscall open

--- a/tests/runtime/tuples
+++ b/tests/runtime/tuples
@@ -93,4 +93,12 @@ NAME bytearray in tuple
 PROG uprobe:./testprogs/uprobe_test:function1 { @ = ((int8)1, usym(reg("ip")), 10); exit(); }
 EXPECT ^@: \(1, 0x[0-9a-f]+, 10\)$
 TIMEOUT 5
+ARCH x86_64
+AFTER ./testprogs/uprobe_test
+
+NAME bytearray in tuple
+PROG uprobe:./testprogs/uprobe_test:function1 { @ = ((int8)1, usym(reg("nip")), 10); exit(); }
+EXPECT ^@: \(1, 0x[0-9a-f]+, 10\)$
+TIMEOUT 5
+ARCH ppc64|ppc64le
 AFTER ./testprogs/uprobe_test


### PR DESCRIPTION
In ppc, "nip" is used for instruction pointer.
Other fix is general dependency issue.