### PR TITLE
tests: Only set up dwarf data file once

### DIFF
--- a/tests/codegen/map_args.cpp
+++ b/tests/codegen/map_args.cpp
@@ -13,7 +13,7 @@ class codegen_dwarf : public test_dwarf
 
 TEST_F(codegen_dwarf, map_args)
 {
-  std::string uprobe = "uprobe:" + bin_ + ":func_1";
+  std::string uprobe = "uprobe:" + std::string(bin_) + ":func_1";
   test(uprobe + "{ @ = args }", NAME);
 }
 

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -209,7 +209,7 @@ class field_analyser_dwarf : public test_dwarf
 
 TEST_F(field_analyser_dwarf, uprobe_args)
 {
-  std::string uprobe = "uprobe:" + bin_;
+  std::string uprobe = "uprobe:" + std::string(bin_);
   test(uprobe + ":func_1 { $x = args.a; }", 0);
   test(uprobe + ":func_2 { $x = args.b; }", 0);
   // Backwards compatibility
@@ -238,7 +238,7 @@ TEST_F(field_analyser_dwarf, uprobe_args)
 TEST_F(field_analyser_dwarf, parse_struct)
 {
   BPFtrace bpftrace;
-  std::string uprobe = "uprobe:" + bin_;
+  std::string uprobe = "uprobe:" + std::string(bin_);
   test(bpftrace, uprobe + ":func_1 { $x = args.foo1->a; }", 0);
 
   ASSERT_TRUE(bpftrace.structs.Has("struct Foo1"));


### PR DESCRIPTION
We only need to do it once globally since the contents don't change.

Also delete the datafile after the tests are over and chmod to give everyone executable permissions (semantic analysis needs this).

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
