### PR TITLE
Removing unsupported options of subprocess.run()

### DIFF
--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -307,7 +307,8 @@ class Runner(object):
 
         if test.cleanup:
             try:
-                cleanup = subprocess.run(test.cleanup, shell=True, capture_output=True, text=True)
+                cleanup = subprocess.run(test.cleanup, shell=True, stderr=subprocess.PIPE,
+                                         stdout=subprocess.PIPE, universal_newlines=True)
                 cleanup.check_returncode()
             except subprocess.CalledProcessError as e:
                 print(fail("[  FAILED  ] ") + "%s.%s" % (test.suite, test.name))


### PR DESCRIPTION
"capture_output" and "text" options are supported beyond python-3.7, whereas some instances of current CI pipeline are using python-3.6 and facing failures. The "stderr" option is supported across python versions.
