### PR TITLE
child.cpp: validate_cmd: Support symbolic links in environment variables

### DIFF
--- a/src/child.cpp
+++ b/src/child.cpp
@@ -120,7 +120,7 @@ static void validate_cmd(std::vector<std::string>& cmd)
       if (uniq_abs_path.size() == 1)
       {
         cmd[0] = paths.front().c_str();
-        return;
+        break;
       }
       else
       {
@@ -128,7 +128,6 @@ static void validate_cmd(std::vector<std::string>& cmd)
             "path '" + cmd[0] + "' must refer to a unique binary but matched " +
             std::to_string(paths.size()) + " binaries");
       }
-      return;
   }
 
   if (cmd.size() >= (maxargs - 1))

--- a/tests/child.cpp
+++ b/tests/child.cpp
@@ -1,5 +1,7 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include <fstream>
+#include <iostream>
 #include <sstream>
 #include <string>
 
@@ -11,6 +13,16 @@
 #include "child.h"
 #include "childhelper.h"
 #include "utils.h"
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace std_filesystem = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace std_filesystem = std::experimental::filesystem;
+#else
+#error "neither <filesystem> nor <experimental/filesystem> are present"
+#endif
 
 namespace bpftrace {
 namespace test {
@@ -202,6 +214,70 @@ TEST(childproc, ptrace_child_term_before_execve)
   EXPECT_FALSE(child->is_alive());
   EXPECT_EQ(child->exit_code(), -1);
   EXPECT_EQ(child->term_signal(), 15);
+}
+
+TEST(childproc, multi_exec_match)
+{
+  std::string tmpdir = "/tmp/bpftrace-test-child-XXXXXX";
+
+  // Create directory for test
+  EXPECT_NE(::mkdtemp(&tmpdir[0]), nullptr);
+
+  const std_filesystem::path path(tmpdir);
+  const std_filesystem::path usr = path / "usr";
+  const std_filesystem::path usr_bin = usr / "bin";
+  const std_filesystem::path symlnk_bin = path / "bin";
+  const std_filesystem::path binary = usr_bin / "mysleep";
+
+  EXPECT_TRUE(std_filesystem::create_directory(usr));
+  EXPECT_TRUE(std_filesystem::create_directory(usr_bin));
+
+  // Create symbol link: bin -> usr/bin
+  char cwd[512];
+  EXPECT_NE(::getcwd(cwd, sizeof(cwd)), nullptr);
+  EXPECT_EQ(::chdir(path.c_str()), 0);
+  std_filesystem::create_directory_symlink("usr/bin", "bin");
+  EXPECT_EQ(::chdir(cwd), 0);
+
+  // Copy a 'mysleep' binary and add x permission
+  {
+    std::ifstream src;
+    std::ofstream dst;
+
+    src.open("/bin/sleep", std::ios::in | std::ios::binary);
+    dst.open(binary, std::ios::out | std::ios::binary);
+    dst << src.rdbuf();
+    src.close();
+    dst.close();
+    int err = chmod(binary.c_str(), 0755);
+    if (err)
+      throw std::runtime_error("Failed to chmod dwarf data file: " +
+                               std::to_string(err));
+  }
+
+  // Set ENV
+  char ENV_PATH[2048], OLD_PATH[2048];
+  char *env = ::getenv("PATH");
+  snprintf(OLD_PATH, sizeof(ENV_PATH), "%s", env);
+  snprintf(ENV_PATH,
+           sizeof(ENV_PATH),
+           "PATH=%s:%s:%s",
+           env,
+           usr_bin.c_str(),
+           symlnk_bin.c_str());
+
+  ::putenv(ENV_PATH);
+
+  // 'mysleep' will match /bin/mysleep and /usr/bin/mysleep, but they are
+  // actually the same file.
+  auto child = getChild("mysleep 5");
+
+  child->run();
+  child->terminate();
+  wait_for(child.get(), 100);
+  EXPECT_FALSE(child->is_alive());
+  EXPECT_EQ(child->term_signal(), SIGTERM);
+  ::setenv("PATH", OLD_PATH, 1);
 }
 
 } // namespace child


### PR DESCRIPTION
On some systems /bin is a symbolic link to /usr/bin (/bin -> /usr/bin), When using the '-c' parameter to specify the executable program in the environment variable, the problem of "multiple binary files matching" occurs, for example:
```bash
  $ sudo bpftrace -e 'kprobe:do_nanosleep { printf("%d sleeping\n", pid); }' -c 'sleep 5'
  ERROR: Failed to fork child: path 'sleep' must refer to a unique binary but matched 2 binaries
```
Debugging the bpftrace program through gdb can also be verified:
```bash
  (gdb) p valid_executable_paths
  $9 = std::vector of length 2, capacity 2 = {"/bin/ls", "/usr/bin/ls"}
```
This commit fixes the issue. The v1[0] will cause CICD busybox error.

[0] https://github.com/iovisor/bpftrace/pull/2689
