### PR TITLE
tools: Remove stale comments about ipv4 limitation

### DIFF
--- a/tools/old/tcpdrop.bt
+++ b/tools/old/tcpdrop.bt
@@ -6,10 +6,10 @@
  * USAGE: tcpdrop.bt
  *
  * This is a bpftrace version of the bcc tool of the same name.
- * It is limited to ipv4 addresses, and cannot show tcp flags.
  *
  * This provides information such as packet details, socket state, and kernel
  * stack trace for packets/segments that were dropped via tcp_drop().
+ * It cannot show tcp flags.
 
  * WARNING: this script attaches to the tcp_drop kprobe which is likely inlined
  *          on newer kernels and not replaced by anything else, therefore

--- a/tools/tcpconnect.bt
+++ b/tools/tcpconnect.bt
@@ -6,7 +6,6 @@
  * USAGE: tcpconnect.bt
  *
  * This is a bpftrace version of the bcc tool of the same name.
- * It is limited to ipv4 addresses.
  *
  * All connection attempts are traced, even if they ultimately fail.
  *

--- a/tools/tcpdrop.bt
+++ b/tools/tcpdrop.bt
@@ -6,10 +6,10 @@
  * USAGE: tcpdrop.bt
  *
  * This is a bpftrace version of the bcc tool of the same name.
- * It is limited to ipv4 addresses, and cannot show tcp flags.
  *
  * This provides information such as packet details, socket state, and kernel
  * stack trace for packets/segments that were dropped via kfree_skb.
+ * It cannot show tcp flags.
  *
  * For Linux 5.17+ (see tools/old for script for lower versions).
  *

--- a/tools/tcpretrans.bt
+++ b/tools/tcpretrans.bt
@@ -6,7 +6,7 @@
  * USAGE: tcpretrans.bt
  *
  * This is a bpftrace version of the bcc tool of the same name.
- * It is limited to ipv4 addresses, and doesn't support tracking TLPs.
+ * It doesn't support tracking TLPs.
  *
  * This uses dynamic tracing of kernel functions, and will need to be updated
  * to match kernel changes.


### PR DESCRIPTION
Commit c9dd10f93ba2 ("[ntop] add support for arrays and IPv6") added ipv6 support to the tools, remove the stale comments about only supporting ipv4.

    Commit c9dd10f93ba2 ("[ntop] add support for arrays and IPv6") added
    ipv6 support to the tools, remove the stale comments about only
    supporting ipv4.

##### Checklist

- [ x ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ x ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ x ] The new behaviour is covered by tests
