### PR TITLE
Allow probe builtin with aliased software/hardware probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,9 @@ and this project adheres to
   - [#2696](https://github.com/iovisor/bpftrace/pull/2696)
 - Improve listing and 'probe' builtin for several probe types
   - [#2691](https://github.com/iovisor/bpftrace/pull/2691)
+- Allow probe builtin with aliased software/hardware probes
+  - [#2711](https://github.com/iovisor/bpftrace/pull/2711)
+
 
 ## [0.18.0] 2023-05-15
 

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -359,7 +359,11 @@ std::unique_ptr<std::istream> ProbeMatcher::get_symbols_from_list(
 {
   std::string symbols;
   for (auto& probe : probes_list)
+  {
     symbols += probe.path + ":\n";
+    if (!probe.alias.empty())
+      symbols += probe.alias + ":\n";
+  }
   return std::make_unique<std::istringstream>(symbols);
 }
 

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -382,6 +382,11 @@ PROG software:page-faults:1 { print(probe); exit();}
 EXPECT software:page-faults:1
 TIMEOUT 5
 
+NAME software_alias_probe_builtin
+PROG software:cpu:1 { print(probe); exit();}
+EXPECT software:cpu:1
+TIMEOUT 5
+
 NAME hardware
 REQUIRES ls /sys/devices/cpu/events/cache-misses
 PROG hardware:cache-misses:10 { @[pid] = count(); exit(); }


### PR DESCRIPTION
Using `probe` builtin in `software`/`hardware` probes specified by alias name is not possible b/c `ProbeMatcher` cannot find the match:

    # bpftrace -e 'software:cpu:1 { print(probe); exit() }'
    No probes to attach

Fix this by adding the aliased name (if exists) to the search list.

Fixes #2700.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
