### PR TITLE
test: codegen: Make kfunc targets determinstic

### DIFF
--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -156,7 +156,7 @@ public:
   std::optional<int64_t> get_int_literal(const ast::Expression *expr) const;
   std::optional<std::string> get_watchpoint_binary_path() const;
   virtual bool is_traceable_func(const std::string &func_name) const;
-  std::unordered_set<std::string> get_func_modules(
+  virtual std::unordered_set<std::string> get_func_modules(
       const std::string &func_name) const;
   int create_pcaps(void);
   void close_pcaps(void);

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -1026,10 +1026,10 @@ TEST_F(bpftrace_btf, add_probes_kfunc)
 
   check_probe(bpftrace.get_probes().at(0),
               ProbeType::kfunc,
-              "kfunc:vmlinux:func_1");
+              "kfunc:mock_vmlinux:func_1");
   check_probe(bpftrace.get_probes().at(1),
               ProbeType::kretfunc,
-              "kretfunc:vmlinux:func_1");
+              "kretfunc:mock_vmlinux:func_1");
 }
 
 TEST_F(bpftrace_btf, add_probes_iter_task)

--- a/tests/codegen/llvm/builtin_func_kfunc.ll
+++ b/tests/codegen/llvm/builtin_func_kfunc.ll
@@ -6,7 +6,7 @@ target triple = "bpf-pc-linux"
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @"kfunc:f"(i8* %0) section "s_kfunc:f_1" {
+define i64 @"kfunc:mock_vmlinux:f"(i8* %0) section "s_kfunc:mock_vmlinux:f_1" {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8

--- a/tests/codegen/llvm/kfunc_dereference.ll
+++ b/tests/codegen/llvm/kfunc_dereference.ll
@@ -6,7 +6,7 @@ target triple = "bpf-pc-linux"
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @"kfunc:vmlinux:tcp_sendmsg"(i8* %0) section "s_kfunc:vmlinux:tcp_sendmsg_1" {
+define i64 @"kfunc:mock_vmlinux:tcp_sendmsg"(i8* %0) section "s_kfunc:mock_vmlinux:tcp_sendmsg_1" {
 entry:
   %"@_val" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8

--- a/tests/codegen/llvm/kretfunc_dereference.ll
+++ b/tests/codegen/llvm/kretfunc_dereference.ll
@@ -6,7 +6,7 @@ target triple = "bpf-pc-linux"
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
-define i64 @"kretfunc:vmlinux:sk_alloc"(i8* %0) section "s_kretfunc:vmlinux:sk_alloc_1" {
+define i64 @"kretfunc:mock_vmlinux:sk_alloc"(i8* %0) section "s_kretfunc:mock_vmlinux:sk_alloc_1" {
 entry:
   %"@_val" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -75,6 +75,12 @@ public:
     return true;
   }
 
+  std::unordered_set<std::string> get_func_modules(
+      const std::string &__attribute__((unused))) const override
+  {
+    return { "mock_vmlinux" };
+  }
+
   void set_mock_probe_matcher(std::unique_ptr<MockProbeMatcher> probe_matcher)
   {
     probe_matcher_ = std::move(probe_matcher);


### PR DESCRIPTION
Before, codegen tests tried to look at the host's actual tracefs for available_filter_functions. This would silently fail in most developer envs as we don't usually run codegen tests as root. However, in CI, they actually ran as root so reads succeeded. This caused difficult-to-debug skew.

Fix by mocking out the filesystem access so tests are consistent no matter where they are run.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
