### PR TITLE
tests: semantic: Fix semantic_analyser_btf.kfunc

### DIFF
--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -115,6 +115,7 @@ public:
     has_skb_output_ = std::make_optional<bool>(has_features);
     map_ringbuf_ = std::make_optional<bool>(has_features);
     has_ktime_get_tai_ns_ = std::make_optional<bool>(has_features);
+    has_get_func_ip_ = std::make_optional<bool>(has_features);
   };
   bool has_features_;
 };


### PR DESCRIPTION
Before, I was getting:

```
[ RUN      ] semantic_analyser_btf.kfunc
/home/dxu/dev/bpftrace/tests/semantic_analyser.cpp:82: Failure
Expected equality of these values:
  expected_result
    Which is: 0
  semantics.analyse()
    Which is: 1

Input:
kfunc:func_1 { @[func] = 1; }

Output:
stdin:1:16-22: ERROR: BPF_FUNC_get_func_ip not available for your kernel version
kfunc:func_1 { @[func] = 1; }
```

due to the helper test not being mocked out.

Fix by mocking the helper out as being available.

Fixes: bf7d0fe2 ("tests: semantic: Fix semantic_analyser_btf.kfunc")

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
