### PR TITLE
add a MapError async event type for join()

### DIFF
--- a/src/ast/async_event_types.cpp
+++ b/src/ast/async_event_types.cpp
@@ -104,5 +104,13 @@ std::vector<llvm::Type*> SkbOutput::asLLVMType(ast::IRBuilderBPF& b)
   };
 }
 
+std::vector<llvm::Type*> MapError::asLLVMType(ast::IRBuilderBPF& b)
+{
+  return {
+    b.getInt64Ty(), // asyncid
+    b.getInt32Ty(), // map id
+  };
+}
+
 } // namespace AsyncEvent
 } // namespace bpftrace

--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -127,5 +127,13 @@ struct SkbOutput
   std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b);
 } __attribute__((packed));
 
+struct MapError
+{
+  uint64_t action_id;
+  uint32_t map_id;
+
+  std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b);
+} __attribute__((packed));
+
 } // namespace AsyncEvent
 } // namespace bpftrace

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -170,7 +170,7 @@ public:
   CallInst *CreateGetRandom(const location &loc);
   CallInst   *CreateGetStackId(Value *ctx, bool ustack, StackType stack_type, const location& loc);
   CallInst *CreateGetFuncIp(const location &loc);
-  CallInst   *CreateGetJoinMap(Value *ctx, const location& loc);
+  CallInst *CreateGetJoinMap(Value *ctx, const location &loc);
   CallInst *CreateHelperCall(libbpf::bpf_func_id func_id,
                              FunctionType *helper_type,
                              ArrayRef<Value *> args,
@@ -247,7 +247,25 @@ private:
                                 Builtin &builtin,
                                 AddrSpace as,
                                 const location &loc);
-  CallInst *createMapLookup(int mapid, Value *key);
+  CallInst *createMapLookup(int mapid,
+                            Value *key,
+                            const std::string &name = "lookup_elem");
+  CallInst *createMapLookup(int mapid,
+                            Value *key,
+                            PointerType *val_ptr_ty,
+                            const std::string &name = "lookup_elem");
+  void createMapErrorCond(Value *ctx,
+                          int mapid,
+                          CallInst *call,
+                          const location &loc,
+                          bool must_exists = false);
+  void createMapError(Value *ctx, int mapid, const location &loc);
+  CallInst *createGetScratchMap(Value *ctx,
+                                int mapid,
+                                const std::string &name,
+                                PointerType *val_ptr_ty,
+                                const location &loc,
+                                int key = 0);
   libbpf::bpf_func_id selectProbeReadHelper(AddrSpace as, bool str);
 
   llvm::Type *getKernelPointerStorageTy();

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -487,6 +487,14 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
                                  info.loc);
     return;
   }
+  else if (printf_id == asyncactionint(AsyncAction::map_error))
+  {
+    auto map_error = static_cast<AsyncEvent::MapError *>(data);
+    bpftrace->request_finalize();
+    IMap *map = *bpftrace->maps[map_error->map_id];
+    bpftrace->out_->map_error(*map);
+    return;
+  }
   else if (printf_id == asyncactionint(AsyncAction::watchpoint_attach))
   {
     bool abort = false;

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -568,6 +568,11 @@ void TextOutput::helper_error(const std::string &helper,
   LOG(WARNING, loc, out_) << msg.str();
 }
 
+void TextOutput::map_error(IMap &map) const
+{
+  LOG(WARNING, out_) << "Failed to lookup map " << map.name_;
+}
+
 std::string TextOutput::field_to_str(const std::string &name,
                                      const std::string &value) const
 {
@@ -846,6 +851,12 @@ void JsonOutput::helper_error(const std::string &helper,
   out_ << "{\"type\": \"helper_error\", \"helper\": \"" << helper
        << "\", \"retcode\": " << retcode << ", \"line\": " << loc.begin.line
        << ", \"col\": " << loc.begin.column << "}" << std::endl;
+}
+
+void JsonOutput::map_error(IMap &map) const
+{
+  out_ << "{\"type\": \"map_error\", \"map_name\": \"" << map.name_ << "\"}"
+       << std::endl;
 }
 
 std::string JsonOutput::field_to_str(const std::string &name,

--- a/src/output.h
+++ b/src/output.h
@@ -26,6 +26,7 @@ enum class MessageType
   attached_probes,
   lost_events,
   helper_error,
+  map_error,
 };
 
 std::ostream& operator<<(std::ostream& out, MessageType type);
@@ -80,6 +81,7 @@ public:
   virtual void helper_error(const std::string &helper,
                             int retcode,
                             const location &loc) const = 0;
+  virtual void map_error(IMap &map) const = 0;
 
 protected:
   std::ostream &out_;
@@ -196,6 +198,7 @@ public:
   void helper_error(const std::string &helper,
                     int retcode,
                     const location &loc) const override;
+  void map_error(IMap &map) const override;
 
 protected:
   static std::string hist_index_label(int power);
@@ -250,6 +253,7 @@ public:
   void helper_error(const std::string &helper,
                     int retcode,
                     const location &loc) const override;
+  void map_error(IMap &map) const override;
 
 private:
   std::string json_escape(const std::string &str) const;

--- a/src/types.h
+++ b/src/types.h
@@ -582,6 +582,7 @@ enum class AsyncAction
   watchpoint_attach,
   watchpoint_detach,
   skboutput,
+  map_error,
   // clang-format on
 };
 


### PR DESCRIPTION
This PR borrowed some content from #1801 by @Birch-san.

I added a MapError event type, which will be raised and terminate execution when join() failed to find the join map.

This PR is one of the prerequisites for the mentioned refactor of the printf function in #2651. I'll be implementing the refactor. But I'm splitting it into smaller PRs for quicker review and merging, if you don't mind.

I haven't update test cases. If we all found it feasible, I will update the test cases accordingly. Thanks!

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
