### PR TITLE
Add FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+open_collective: bpftrace


### PR DESCRIPTION
As discussed during office hours, it would be useful if we have a way for sponsors to donate money. We may need to pay down some infra costs in the near term.

I looked at a few options and it looked like OpenCollective was the most straightforward. They can do fiscal hosting which means they'll deal with all the tax stuff. But in exchange they take 10%. Not too bad (but also not 0%).

This is the collective: https://opencollective.com/bpftrace

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
