### PR TITLE
test: dev_queue_xmit() made static inline

### DIFF
--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -509,7 +509,7 @@ EXPECT 1234
 TIMEOUT 1
 
 NAME skboutput
-RUN {{BPFTRACE}} -e 'kfunc:dev_queue_xmit { $ret = skboutput("skb.pcap", args.skb, args.skb->len, 14); if ($ret == 0) { printf("OK\n"); exit(); } }'
+RUN {{BPFTRACE}} -e 'kfunc:__dev_queue_xmit { $ret = skboutput("skb.pcap", args.skb, args.skb->len, 14); if ($ret == 0) { printf("OK\n"); exit(); } }'
 AFTER ./testprogs/syscall 127.0.0.1 80
 EXPECT OK
 REQUIRES_FEATURE skboutput


### PR DESCRIPTION
dev_queue_xmit() is a wrapper for __dev_queue_xmit(). modifying kfunc trace to __dev_queue_xmit().

Commit reference in Linux: c526fd8
