### PR TITLE
Correcting parameters to match expected string of runtime test

### DIFF
--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -185,14 +185,14 @@ EXPECT ^([0-9]+\.[0-9]+ ?)+.*$
 TIMEOUT 5
 
 NAME log size too small
-ENV BPFTRACE_LOG_SIZE=1
-RUN {{BPFTRACE}} -ve 'BEGIN { if (str($1) == str($2)) { printf("%s\n", str($1)); exit() } }' "hello" "hello"
+ENV BPFTRACE_LOG_SIZE=0
+RUN {{BPFTRACE}} -e 'BEGIN { if (str($1) == str($2)) { printf("%s\n", str($1)); exit() } }' "hello" "hello"
 EXPECT Error loading program: BEGIN
 TIMEOUT 5
 WILL_FAIL
 
 NAME increase log size
-RUN {{BPFTRACE}} -ve 'BEGIN { if (str($1) == str($2)) { printf("%s\n", str($1)); exit() } }' "hello" "hello"
+RUN {{BPFTRACE}} -e 'BEGIN { if (str($1) == str($2)) { printf("%s\n", str($1)); exit() } }' "hello" "hello"
 EXPECT ^Attaching 1 probe
 TIMEOUT 5
 


### PR DESCRIPTION
With -v option, the verbose error string is spitted out, which is not matching with the expected string. Without -v option, output is "hello". To match output with the expected string, only way is removing -v and reducing log size to 0. Then correct error message is thrown.

Difference in output is observed over different distros and compiler versions.

@danobi has removed -v from runtime tests(24e1ca2), removing same from log tests.