### PR TITLE
iter: Skip structures with '__safe_trusted' suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to
   - [#2708](https://github.com/iovisor/bpftrace/pull/2708)
 - Add access to `CLOCK_MONOTONIC` with `nsecs(monotonic)`
   - [#2718](https://github.com/iovisor/bpftrace/pull/2718)
+- iter: Skip structures with '__safe_trusted' suffix
+  - [#2732](https://github.com/iovisor/bpftrace/pull/2732)
 
 
 ## [0.18.0] 2023-05-15

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -726,6 +726,9 @@ std::unordered_set<std::string> BTF::get_all_iters_from_btf(
 {
   std::unordered_set<std::string> iter_set;
   const std::string prefix = "bpf_iter__";
+  // kernel commit 6fcd486b3a0a("bpf: Refactor RCU enforcement in the
+  // verifier.") add 'struct bpf_iter__task__safe_trusted'
+  const std::string suffix___safe_trusted = "__safe_trusted";
   __s32 id, max = (__s32)type_cnt(btf);
   for (id = start_id(btf); id <= max; id++)
   {
@@ -735,6 +738,12 @@ std::unordered_set<std::string> BTF::get_all_iters_from_btf(
       continue;
 
     const std::string name = btf_str(btf, t->name_off);
+
+    // skip __safe_trusted suffix struct
+    if (suffix___safe_trusted.length() < name.length() &&
+        name.rfind(suffix___safe_trusted) ==
+            (name.length() - suffix___safe_trusted.length()))
+      continue;
     if (name.size() > prefix.size() &&
         name.compare(0, prefix.size(), prefix) == 0)
     {

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -192,9 +192,9 @@ std::set<std::string> ProbeMatcher::get_matches_for_probetype(
         if (bpftrace_->feature_->has_iter(iter))
           ret += iter + "\n";
         else
-          LOG(WARNING) << "The kernel contains bpf_iter__$ITER struct but "
-                          "does not support loading an iterator program "
-                          "against it. Please report this bug.";
+          LOG(WARNING) << "The kernel contains bpf_iter__" << iter
+                       << " struct but does not support loading an iterator"
+                          " program against it. Please report this bug.";
       }
       symbol_stream = std::make_unique<std::istringstream>(ret);
       break;


### PR DESCRIPTION
If kernel >= 6.2, there is a warning with 'bpftrace -l' command:

```
    $ sudo bpftrace -l | grep iter:
    WARNING: The kernel contains bpf_iter__task__safe_trusted struct but does
    not support loading an iterator program against it. Please report this bug.
    iter:bpf_link
    iter:bpf_map
    iter:bpf_map_elem
    iter:bpf_prog
    iter:bpf_sk_storage_map
    iter:cgroup
    iter:ipv6_route
    iter:ksym
    iter:netlink
    iter:sockmap
    iter:task
    iter:task_file
    iter:task_vma
    iter:tcp
    iter:udp
    iter:unix
```

kernel commit 6fcd486b3a0a("bpf: Refactor RCU enforcement in the verifier.") add 'struct bpf_iter__task__safe_trusted':

```
    $ bpftool btf dump file /sys/kernel/btf/vmlinux format c | grep bpf_iter__task
    struct bpf_iter__task {
    struct bpf_iter__task_file {
    struct bpf_iter__task_vma {
    struct bpf_iter__task__safe_trusted {
```

This commit skips structs with '__safe_trusted' suffix.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
