### PR TITLE
USDT: Enable targeting all pids/paths on a host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
   - [#2692](https://github.com/iovisor/bpftrace/pull/2692)
 - Support casting int <-> int array
   - [#2686](https://github.com/iovisor/bpftrace/pull/2686)
+- Support targeting all running processes for USDTs
+  - [#2734](https://github.com/iovisor/bpftrace/pull/2734)
 #### Changed
 - Make `args` a structure (instead of a pointer)
   - [#2578](https://github.com/iovisor/bpftrace/pull/2578)

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1398,6 +1398,8 @@ usdt:library_path:[probe_namespace]:probe_name
 
 Where `probe_namespace` is optional if `probe_name` is unique within the binary.
 
+You can target the entire host (or an entire process's address space by using the `-p` arg) by using a single wildcard `*` in place of the `binary_path`/`library_path` e.g. `bpftrace -e 'usdt:*:loop { printf("hi\n"); }'`. Please note that if you use wildcards for the `probe_name` or `probe_namespace` and end up targeting multiple USDTs for the same probe you might get errors if you also utilize the USDT argument builtins (e.g. `arg0`) as they could be of different types.
+
 Examples:
 
 ```

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -2571,6 +2571,8 @@ fatal error: unknown caller pc
 .shortnames
 * `U`
 
+You can target the entire host (or an entire process's address space by using the `-p` arg) by using a single wildcard in place of the binary_path/library_path e.g. bpftrace -e 'usdt:*:loop { printf("hi\n"); }. Please note that if you use wildcards for the probe_name or probe_namespace and end up targeting multiple USDTs for the same probe you might get errors if you also utilize the USDT argument builtins (e.g. arg0) as they could be of different types.
+
 [#probes-watchpoint]
 === watchpoint and asyncwatchpoint
 

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2750,6 +2750,10 @@ void SemanticAnalyser::visit(AttachPoint &ap)
     {
       USDTHelper::probes_for_pid(bpftrace_.pid());
     }
+    else if (ap.target == "*")
+    {
+      USDTHelper::probes_for_all_pids();
+    }
     else if (ap.target != "")
     {
       for (auto &path : resolve_binary_path(ap.target))
@@ -2758,7 +2762,8 @@ void SemanticAnalyser::visit(AttachPoint &ap)
     else
     {
       LOG(ERROR, ap.loc, err_)
-          << "usdt probe must specify at least path or pid to probe";
+          << "usdt probe must specify at least path or pid to probe. To target "
+             "all paths/pids set the path to '*'.";
     }
   }
   else if (ap.provider == "tracepoint") {

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -326,6 +326,8 @@ std::unique_ptr<std::istream> ProbeMatcher::get_symbols_from_usdt(
 
   if (pid > 0)
     usdt_probes = USDTHelper::probes_for_pid(pid);
+  else if (target == "*")
+    usdt_probes = USDTHelper::probes_for_all_pids();
   else if (!target.empty())
   {
     std::vector<std::string> real_paths;

--- a/src/usdt.h
+++ b/src/usdt.h
@@ -25,10 +25,11 @@ public:
                                               const std::string &target,
                                               const std::string &provider,
                                               const std::string &name);
-  static usdt_probe_list probes_for_pid(int pid);
+  static usdt_probe_list probes_for_pid(int pid, bool print_error = true);
+  static usdt_probe_list probes_for_all_pids();
   static usdt_probe_list probes_for_path(const std::string &path);
 
 private:
-  static void read_probes_for_pid(int pid);
+  static void read_probes_for_pid(int pid, bool print_error = true);
   static void read_probes_for_path(const std::string &path);
 };

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1373,4 +1373,17 @@ std::vector<int> get_pids_for_program(const std::string &program)
   return pids;
 }
 
+std::vector<int> get_all_running_pids()
+{
+  std::vector<int> pids;
+  for (const auto &process : std_filesystem::directory_iterator("/proc"))
+  {
+    std::string filename = process.path().filename().string();
+    if (!std::all_of(filename.begin(), filename.end(), ::isdigit))
+      continue;
+    pids.emplace_back(std::stoi(filename));
+  }
+  return pids;
+}
+
 } // namespace bpftrace

--- a/src/utils.h
+++ b/src/utils.h
@@ -229,6 +229,7 @@ struct elf_symbol
 std::map<uintptr_t, elf_symbol, std::greater<>> get_symbol_table_for_elf(
     const std::string &elf_file);
 std::vector<int> get_pids_for_program(const std::string &program);
+std::vector<int> get_all_running_pids();
 
 // Generate object file section name for a given probe
 inline std::string get_section_name_for_probe(

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -563,6 +563,44 @@ TEST(bpftrace, add_probes_usdt_wildcard)
              "usdt:/bin/sh:prov2:tp");
 }
 
+TEST(bpftrace, add_probes_usdt_wildcard_for_target)
+{
+  auto probe = make_usdt_probe("*", "prov*", "tp*", true, 1);
+
+  auto bpftrace = get_strict_mock_bpftrace();
+  EXPECT_CALL(*bpftrace->mock_probe_matcher, get_symbols_from_usdt(0, "*"))
+      .Times(1);
+
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
+  ASSERT_EQ(5U, bpftrace->get_probes().size());
+  ASSERT_EQ(0U, bpftrace->get_special_probes().size());
+  check_usdt(bpftrace->get_probes().at(0),
+             "/bin/bash",
+             "prov1",
+             "tp3",
+             "usdt:/bin/bash:prov1:tp3");
+  check_usdt(bpftrace->get_probes().at(1),
+             "/bin/sh",
+             "prov1",
+             "tp1",
+             "usdt:/bin/sh:prov1:tp1");
+  check_usdt(bpftrace->get_probes().at(2),
+             "/bin/sh",
+             "prov1",
+             "tp2",
+             "usdt:/bin/sh:prov1:tp2");
+  check_usdt(bpftrace->get_probes().at(3),
+             "/bin/sh",
+             "prov2",
+             "tp",
+             "usdt:/bin/sh:prov2:tp");
+  check_usdt(bpftrace->get_probes().at(4),
+             "/proc/1234/exe",
+             "prov2",
+             "tp4",
+             "usdt:/proc/1234/exe:prov2:tp4");
+}
+
 TEST(bpftrace, add_probes_usdt_empty_namespace)
 {
   auto probe = make_usdt_probe("/bin/sh", "", "tp1", true, 1);

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -59,7 +59,8 @@ void setup_mock_probe_matcher(MockProbeMatcher &matcher)
                          "/bin/sh:prov2:tp\n"
                          "/bin/sh:prov2:notatp\n"
                          "/bin/sh:nahprov:tp\n";
-  std::string bash_usdts = "/bin/bash:prov1:tp3";
+  std::string bash_usdts = "/bin/bash:prov1:tp3\n";
+  std::string proc_usdts = "/proc/1234/exe:prov2:tp4\n";
   ON_CALL(matcher, get_symbols_from_usdt(_, "/bin/sh"))
       .WillByDefault([sh_usdts](int, const std::string &) {
         return std::unique_ptr<std::istream>(new std::istringstream(sh_usdts));
@@ -69,6 +70,12 @@ void setup_mock_probe_matcher(MockProbeMatcher &matcher)
         return std::unique_ptr<std::istream>(
             new std::istringstream(sh_usdts + bash_usdts));
       });
+  ON_CALL(matcher, get_symbols_from_usdt(_, "*"))
+      .WillByDefault(
+          [sh_usdts, bash_usdts, proc_usdts](int, const std::string &) {
+            return std::unique_ptr<std::istream>(
+                new std::istringstream(sh_usdts + bash_usdts + proc_usdts));
+          });
 }
 
 void setup_mock_bpftrace(MockBPFtrace &bpftrace)

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -81,6 +81,13 @@ BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
 TIMEOUT 5
 
+NAME usdt probes - attach to fully specified probe all pids
+RUN {{BPFTRACE}} -e 'usdt:*:tracetest:testprobe { printf("here\n" ); exit(); }'
+EXPECT here
+BEFORE ./testprogs/usdt_test
+REQUIRES ./testprogs/usdt_test should_not_skip
+TIMEOUT 5
+
 NAME usdt probes - attach to fully specified library probe by pid
 RUN {{BPFTRACE}} -e 'usdt:./testlibs/libusdt_tp.so:tracetestlib:lib_probe_1 { printf("here\n" ); exit(); }' -p $(pidof usdt_lib)
 BEFORE ./testprogs/usdt_lib


### PR DESCRIPTION
This utilizes the single wildcard `*` for the binary_path/library_path value to target all running pids on the host.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
