### PR TITLE
Support embedded nix builds

### DIFF
--- a/docs/nix.md
+++ b/docs/nix.md
@@ -46,6 +46,17 @@ $ sudo ./result/bin/bpftrace --info 2>&1 | grep LLVM
   LLVM: 13.0.1
 ```
 
+### Build bpftrace as a statically linked binary
+
+```
+$ nix build .#appimage
+$ ldd ./result
+        not a dynamic executable
+$ sudo ./result -e 'BEGIN { print("static!"); exit() }'
+Attaching 1 probe...
+static!
+```
+
 ### Don't use Nix to build, but rather only manage dependencies
 
 ```

--- a/flake.lock
+++ b/flake.lock
@@ -5,11 +5,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1681202837,
-        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
+        "lastModified": 1692799911,
+        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
+        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
         "type": "github"
       },
       "original": {
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1683979235,
-        "narHash": "sha256-3YXT3u8ORCoxnO6le33rLMIr74y8rtKnthFj6sxxpmo=",
+        "lastModified": 1688392541,
+        "narHash": "sha256-lHrKvEkCPTUO+7tPfjIcb7Trk6k31rz18vkyqmkeJfY=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e28ffb8f487503362962f05718bec6b95f27a672",
+        "rev": "ea4c80b39be4c09702b0cb3b42eab59e2ba4f24b",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,37 @@
 {
   "nodes": {
+    "appimage-runtime": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1652289700,
+        "narHash": "sha256-uxQBDy/JA7uEboTOUmGaZ2FAKY/0dQ9c0A0N8+J+a7I=",
+        "owner": "AppImageCrafters",
+        "repo": "appimage-runtime",
+        "rev": "6500a1ef68e039caba2ebab1c7ed74c2ea9e67a5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "AppImageCrafters",
+        "repo": "appimage-runtime",
+        "type": "github"
+      }
+    },
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1650374568,
+        "narHash": "sha256-Z+s0J8/r907g149rllvwhb4pKi8Wam5ij0st8PwAh+E=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "b4a34015c698c7793d592d66adbab377907a2be8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -15,6 +47,33 @@
       "original": {
         "owner": "numtide",
         "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nix-appimage": {
+      "inputs": {
+        "appimage-runtime": "appimage-runtime",
+        "flake-compat": "flake-compat",
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "squashfuse": "squashfuse"
+      },
+      "locked": {
+        "lastModified": 1693585308,
+        "narHash": "sha256-ic7iw7zmJ3D34b/7MYz/iEQaWQVYN2IPA+su21QwRqY=",
+        "owner": "danobi",
+        "repo": "nix-appimage",
+        "rev": "5d5093111a1ec4f116c1c57b7a807d41404bfa5e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "danobi",
+        "repo": "nix-appimage",
+        "rev": "5d5093111a1ec4f116c1c57b7a807d41404bfa5e",
         "type": "github"
       }
     },
@@ -37,7 +96,24 @@
     "root": {
       "inputs": {
         "flake-utils": "flake-utils",
+        "nix-appimage": "nix-appimage",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "squashfuse": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1655253282,
+        "narHash": "sha256-RIhDXzpmrYUOwj5OYzjWKJw0cwE+L3t/9pIkg/hFXA0=",
+        "owner": "vasi",
+        "repo": "squashfuse",
+        "rev": "d1d7ddafb765098b34239eacaf2f9abee1fbc27c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "vasi",
+        "repo": "squashfuse",
+        "type": "github"
       }
     },
     "systems": {


### PR DESCRIPTION
This adds support for building bpftrace as an appimage. See the
documentation update in nix.md in the commit for usage.

This is intended to replace the current semi-static embedded build.
This approach has both pros and cons over the semi-static embedded build.
For one, the appimage is actually fully static (as it bundles the
necesssary libc). So it's more likely to work on more systems.

The downside is that the appimage is a ~10x larger binary than the
semi-static binary. The appimage also requires fuse to work (which most
systems should support). It's takes ~1s longer to start up which I don't
think is a huge deal.

Note that I had to apply some patches to nix-appimage (upstreamed
in https://github.com/ralismark/nix-appimage/pull/8). As mentioned in
that PR description, I'm not 100% sure yet why the changes work.

I'd like to spend some time deep diving on that before we merge this.
But in the meantime, please give this a try.

This closes https://github.com/iovisor/bpftrace/issues/2721.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
