### PR TITLE
scripts: create-assets.sh: Copy instead of hard link

### DIFF
--- a/scripts/create-assets.sh
+++ b/scripts/create-assets.sh
@@ -45,7 +45,7 @@ asciidoctor man/adoc/bpftrace.adoc  -b manpage -o - | gzip - > "$TMP/share/man/m
 tar --xz -cf "$OUT/man.tar.xz" -C "$TMP/share" man
 
 info "Creating bundle"
-ln bpftrace "$TMP/bin/bpftrace"
+cp bpftrace "$TMP/bin/bpftrace"
 tar -cf "$OUT/binary_tools_man-bundle.tar" -C "$TMP" bin share
 zstd $ZSTDFLAGS -q -k "$OUT/binary_tools_man-bundle.tar"
 xz "$OUT/binary_tools_man-bundle.tar"


### PR DESCRIPTION
Before, I was getting:

```
$ ./scripts/create-assets.sh
Using '/tmp/tmp.q9BHGxFIRP' as assert dir
Creating tools archive
Creating man archive
Creating bundle
ln: failed to create hard link '/tmp/tmp.q9BHGxFIRP/tmp/bin/bpftrace' => 'bpftrace': Invalid cross-device link
```

Probably b/c my bpftrace repo is on my root fs and /tmp is on a tmpfs mount.

Fix by using copy.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
