### PR TITLE
codeql: Use nix for codeql analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,20 +28,14 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Install Packages (cpp)
-        if: ${{ matrix.language == 'cpp' }}
-        run: |
-          sudo apt-get update
-          sudo apt-get remove 'llvm-*' 'clang-*' 'libclang-*'
-          sudo apt-get install --yes bison cmake flex g++ git libelf-dev libgtest-dev libgmock-dev zlib1g-dev libfl-dev libcereal-dev libdw-dev libpcap-dev systemtap-sdt-dev binutils-dev llvm-11 llvm-11-dev llvm-11-runtime libllvm11 clang-11 libclang-11-dev libclang-common-11-dev libclang1-11 libbpfcc-dev systemtap-sdt-dev python3 python3-distutils xxd libssl-dev pkg-config make dwarves
+      - uses: DeterminateSystems/nix-installer-action@v4
+      - uses: DeterminateSystems/magic-nix-cache-action@v2
 
       - name: Configure (cpp)
         if: ${{ matrix.language == 'cpp' }}
         run: |
           mkdir $GITHUB_WORKSPACE/build && cd $GITHUB_WORKSPACE/build
-          export LLVM_ROOT=/usr/lib/llvm-11; export LLVM_REQUESTED_VERSION=11;
-          ../build-libs.sh
-          cmake ..
+          nix develop --command cmake -DUSE_SYSTEM_BPF_BCC=1 ..
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2
@@ -58,7 +52,7 @@ jobs:
         if: ${{ matrix.language == 'cpp' }}
         run: |
           cd $GITHUB_WORKSPACE/build
-          make -j$(nproc)
+          nix develop --command make -j$(nproc)
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
This gives us tightly pinned dependencies. If we change flake.nix: codeql, ci, end developer builds, and appimages are all updated in sync. This is a really nice property.

This closes #2743.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
