### PR TITLE
ci: Cancel previous workflow runs if a new one is started

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: CI
 
 on: [push, pull_request]
+
+# Cancel previous run if a new one is started
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   clang-format:
     # Only run clang-format on pull requests. We want to allow people to

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -8,6 +8,11 @@ on:
   schedule:
     - cron: "19 22 * * 1"
 
+# Cancel previous run if a new one is started
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -1,6 +1,12 @@
 name: Embedded Builds
 
 on: [push, pull_request]
+
+# Cancel previous run if a new one is started
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   llvm_clang:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Should help reduce the amount of redundant jobs in flight. This will make the latest runs complete faster b/c they will not be queued behind stale/irrelevant runs.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
