### PR TITLE
Add the GetScratchMap and DebugOutput utilities

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -266,6 +266,13 @@ Default: bpftrace
 Output format for ustack and kstack builtins. Available modes/formats: `bpftrace`, `perf`, and `raw`.
 This can be overwritten at the call site.
 
+=== BPFTRACE_DEBUG_OUTPUT
+
+Default: 0
+
+Outputs bpftrace's runtime debug messages to the trace_pipe.
+This feature can be turned on by setting the value of this environment variable to `1`.
+
 ////
 !
 !

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -405,7 +405,10 @@ CallInst *IRBuilderBPF::createGetScratchMap(int mapid,
   CreateCondBr(condition, lookup_merge_block, lookup_failure_block);
 
   SetInsertPoint(lookup_failure_block);
-  // TODO: should we return a loud error?
+  if (bpftrace_.debug_output_)
+    CreateDebugOutput("unable to find the scratch map value for " + name,
+                      std::vector<Value *>{},
+                      loc);
   CreateBr(failure_callback);
 
   SetInsertPoint(lookup_merge_block);

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -338,7 +338,17 @@ CallInst *IRBuilderBPF::CreateBpfPseudoCallValue(Map &map)
   return CreateBpfPseudoCallValue(mapid);
 }
 
-CallInst *IRBuilderBPF::createMapLookup(int mapid, Value *key)
+CallInst *IRBuilderBPF::createMapLookup(int mapid,
+                                        Value *key,
+                                        const std::string &name)
+{
+  return createMapLookup(mapid, key, getInt8PtrTy(), name);
+}
+
+CallInst *IRBuilderBPF::createMapLookup(int mapid,
+                                        Value *key,
+                                        PointerType *val_ptr_ty,
+                                        const std::string &name)
 {
   Value *map_ptr = CreateBpfPseudoCallId(mapid);
   // void *map_lookup_elem(struct bpf_map * map, void * key)
@@ -346,24 +356,59 @@ CallInst *IRBuilderBPF::createMapLookup(int mapid, Value *key)
 
   assert(key->getType()->isPointerTy());
   FunctionType *lookup_func_type = FunctionType::get(
-      getInt8PtrTy(), { map_ptr->getType(), key->getType() }, false);
+      val_ptr_ty, { map_ptr->getType(), key->getType() }, false);
   PointerType *lookup_func_ptr_type = PointerType::get(lookup_func_type, 0);
   Constant *lookup_func = ConstantExpr::getCast(
       Instruction::IntToPtr,
       getInt64(libbpf::BPF_FUNC_map_lookup_elem),
       lookup_func_ptr_type);
-  return createCall(
-      lookup_func_type, lookup_func, { map_ptr, key }, "lookup_elem");
+  return createCall(lookup_func_type, lookup_func, { map_ptr, key }, name);
 }
 
-CallInst *IRBuilderBPF::CreateGetJoinMap(Value *ctx, const location &loc)
+CallInst *IRBuilderBPF::CreateGetJoinMap(BasicBlock *failure_callback,
+                                         const location &loc)
 {
-  AllocaInst *key = CreateAllocaBPF(getInt32Ty(), "key");
-  CreateStore(getInt32(0), key);
+  return createGetScratchMap(bpftrace_.maps[MapManager::Type::Join].value()->id,
+                             "join",
+                             getInt8PtrTy(),
+                             loc,
+                             failure_callback);
+}
+
+// createGetScratchMap will jump to failure_callback if it cannot find the map
+// value
+CallInst *IRBuilderBPF::createGetScratchMap(int mapid,
+                                            const std::string &name,
+                                            PointerType *val_ptr_ty,
+                                            const location &loc,
+                                            BasicBlock *failure_callback,
+                                            int key)
+{
+  AllocaInst *keyAlloc = CreateAllocaBPF(getInt32Ty(),
+                                         nullptr,
+                                         "lookup_" + name + "_key");
+  CreateStore(getInt32(key), keyAlloc);
 
   CallInst *call = createMapLookup(
-      bpftrace_.maps[MapManager::Type::Join].value()->id, key);
-  CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_map_lookup_elem, loc, true);
+      mapid, keyAlloc, val_ptr_ty, "lookup_" + name + "_map");
+  CreateLifetimeEnd(keyAlloc);
+
+  Function *parent = GetInsertBlock()->getParent();
+  BasicBlock *lookup_failure_block = BasicBlock::Create(
+      module_.getContext(), "lookup_" + name + "_failure", parent);
+  BasicBlock *lookup_merge_block = BasicBlock::Create(
+      module_.getContext(), "lookup_" + name + "_merge", parent);
+  Value *condition = CreateICmpNE(
+      CreateIntCast(call, getInt8PtrTy(), true),
+      ConstantExpr::getCast(Instruction::IntToPtr, getInt64(0), getInt8PtrTy()),
+      "lookup_" + name + "_cond");
+  CreateCondBr(condition, lookup_merge_block, lookup_failure_block);
+
+  SetInsertPoint(lookup_failure_block);
+  // TODO: should we return a loud error?
+  CreateBr(failure_callback);
+
+  SetInsertPoint(lookup_merge_block);
   return call;
 }
 
@@ -1550,6 +1595,24 @@ void IRBuilderBPF::CreatePerfEventOutput(Value *ctx,
                    { ctx, map_ptr, flags_val, data, size_val },
                    "perf_event_output",
                    loc);
+}
+
+void IRBuilderBPF::CreateDebugOutput(std::string fmt_str,
+                                     const std::vector<Value *> &values,
+                                     const location &loc)
+{
+  fmt_str = "[BPFTRACE_DEBUG_OUTPUT] " + fmt_str;
+  Constant *const_str = ConstantDataArray::getString(module_.getContext(),
+                                                     fmt_str,
+                                                     true);
+  AllocaInst *fmt = CreateAllocaBPF(
+      ArrayType::get(getInt8Ty(), fmt_str.length() + 1), "fmt_str");
+  CREATE_MEMSET(fmt, getInt8(0), fmt_str.length() + 1, 1);
+  CreateStore(const_str, fmt);
+  CreateTracePrintk(CreatePointerCast(fmt, getInt8Ty()->getPointerTo()),
+                    getInt32(fmt_str.length() + 1),
+                    values,
+                    loc);
 }
 
 void IRBuilderBPF::CreateTracePrintk(Value *fmt_ptr,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -191,6 +191,9 @@ public:
                         Value *key,
                         Value *val,
                         const location &loc);
+  void CreateDebugOutput(std::string fmt_str,
+                         const std::vector<Value *> &values,
+                         const location &loc);
   void CreateTracePrintk(Value *fmt,
                          Value *fmt_size,
                          const std::vector<Value *> &values,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -170,7 +170,7 @@ public:
   CallInst *CreateGetRandom(const location &loc);
   CallInst   *CreateGetStackId(Value *ctx, bool ustack, StackType stack_type, const location& loc);
   CallInst *CreateGetFuncIp(const location &loc);
-  CallInst   *CreateGetJoinMap(Value *ctx, const location& loc);
+  CallInst *CreateGetJoinMap(BasicBlock *failure_callback, const location &loc);
   CallInst *CreateHelperCall(libbpf::bpf_func_id func_id,
                              FunctionType *helper_type,
                              ArrayRef<Value *> args,
@@ -252,7 +252,19 @@ private:
                                 Builtin &builtin,
                                 AddrSpace as,
                                 const location &loc);
-  CallInst *createMapLookup(int mapid, Value *key);
+  CallInst *createMapLookup(int mapid,
+                            Value *key,
+                            const std::string &name = "lookup_elem");
+  CallInst *createMapLookup(int mapid,
+                            Value *key,
+                            PointerType *val_ptr_ty,
+                            const std::string &name = "lookup_elem");
+  CallInst *createGetScratchMap(int mapid,
+                                const std::string &name,
+                                PointerType *val_ptr_ty,
+                                const location &loc,
+                                BasicBlock *failure_callback,
+                                int key = 0);
   libbpf::bpf_func_id selectProbeReadHelper(AddrSpace as, bool str);
 
   llvm::Type *getKernelPointerStorageTy();

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -730,26 +730,14 @@ void CodegenLLVM::visit(Call &call)
     auto arg0 = call.vargs->front();
     auto scoped_del = accept(arg0);
     auto addrspace = arg0->type.GetAS();
-    Value *perfdata = b_.CreateGetJoinMap(ctx_, call.loc);
+
     Function *parent = b_.GetInsertBlock()->getParent();
-
-    BasicBlock *zero = BasicBlock::Create(module_->getContext(),
-                                          "joinzero",
-                                          parent);
-    BasicBlock *notzero = BasicBlock::Create(module_->getContext(),
-                                             "joinnotzero",
-                                             parent);
-
-    b_.CreateCondBr(b_.CreateICmpNE(perfdata,
-                                    ConstantExpr::getCast(Instruction::IntToPtr,
-                                                          b_.getInt64(0),
-                                                          b_.getInt8PtrTy()),
-                                    "joinzerocond"),
-                    notzero,
-                    zero);
+    BasicBlock *failure_callback = BasicBlock::Create(module_->getContext(),
+                                                      "failure_callback",
+                                                      parent);
+    Value *perfdata = b_.CreateGetJoinMap(failure_callback, call.loc);
 
     // arg0
-    b_.SetInsertPoint(notzero);
     b_.CreateStore(b_.getInt64(asyncactionint(AsyncAction::join)),
                    b_.CreatePointerCast(perfdata,
                                         b_.getInt64Ty()->getPointerTo()));
@@ -797,10 +785,10 @@ void CodegenLLVM::visit(Call &call)
                     8 + 8 + bpftrace_.join_argnum_ * bpftrace_.join_argsize_,
                     &call.loc);
 
-    b_.CreateBr(zero);
+    b_.CreateBr(failure_callback);
 
-    // done
-    b_.SetInsertPoint(zero);
+    // if we cannot find a valid map value, we will output nothing and continue
+    b_.SetInsertPoint(failure_callback);
     expr_ = nullptr;
   }
   else if (call.func == "ksym")

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -200,6 +200,7 @@ public:
   uint64_t max_type_res_iterations = 0;
   bool demangle_cpp_symbols_ = true;
   bool resolve_user_symbols_ = true;
+  bool debug_output_ = false;
   enum class UserSymbolCacheType
   {
     per_pid,

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -130,6 +130,7 @@ void usage()
   std::cerr << "    BPFTRACE_BTF                [default: none] BTF file" << std::endl;
   std::cerr << "    BPFTRACE_STR_TRUNC_TRAILER  [default: '..'] string truncation trailer" << std::endl;
   std::cerr << "    BPFTRACE_STACK_MODE         [default: bpftrace] Output format for ustack and kstack builtins" << std::endl;
+  std::cerr << "    BPFTRACE_DEBUG_OUTPUT       [default: 0] enable bpftrace's internal debugging outputs" << std::endl;
   std::cerr << std::endl;
   std::cerr << "EXAMPLES:" << std::endl;
   std::cerr << "bpftrace -l '*sleep*'" << std::endl;
@@ -286,6 +287,9 @@ static std::optional<struct timespec> get_delta_taitime()
   if (!get_bool_env_var("BPFTRACE_NO_CPP_DEMANGLE",
                         bpftrace.demangle_cpp_symbols_,
                         true))
+    return false;
+
+  if (!get_bool_env_var("BPFTRACE_DEBUG_OUTPUT", bpftrace.debug_output_, false))
     return false;
 
   if (!get_uint64_env_var("BPFTRACE_MAP_KEYS_MAX", bpftrace.mapmax_))

--- a/tests/codegen/call_join.cpp
+++ b/tests/codegen/call_join.cpp
@@ -1,0 +1,27 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, call_join)
+{
+  test("struct arg { char **argv } kprobe:f { $x = (struct arg *) 0; "
+       "join($x->argv); }",
+       NAME);
+}
+
+TEST(codegen, call_join_with_debug)
+{
+  auto bpftrace = get_mock_bpftrace();
+  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+  bpftrace->debug_output_ = 1;
+  test(*bpftrace,
+       "struct arg { char **argv } kprobe:f { $x = (struct arg *) 0; "
+       "join($x->argv); }",
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/call_join.ll
+++ b/tests/codegen/llvm/call_join.ll
@@ -1,0 +1,169 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
+entry:
+  %key = alloca i32, align 4
+  %join_r0 = alloca i64, align 8
+  %lookup_join_key = alloca i32, align 4
+  %"struct arg.argv" = alloca i64, align 8
+  %"$x" = alloca i64, align 8
+  %1 = bitcast i64* %"$x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 0, i64* %"$x", align 8
+  store i64 0, i64* %"$x", align 8
+  %2 = load i64, i64* %"$x", align 8
+  %3 = add i64 %2, 0
+  %4 = bitcast i64* %"struct arg.argv" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct arg.argv", i32 8, i64 %3)
+  %5 = load i64, i64* %"struct arg.argv", align 8
+  %6 = bitcast i64* %"struct arg.argv" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast i32* %lookup_join_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i32 0, i32* %lookup_join_key, align 4
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %lookup_join_map = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo, i32* %lookup_join_key)
+  %8 = bitcast i32* %lookup_join_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %lookup_join_cond = icmp ne i8* %lookup_join_map, null
+  br i1 %lookup_join_cond, label %lookup_join_merge, label %lookup_join_failure
+
+failure_callback:                                 ; preds = %counter_merge, %lookup_join_failure
+  ret i64 0
+
+lookup_join_failure:                              ; preds = %entry
+  br label %failure_callback
+
+lookup_join_merge:                                ; preds = %entry
+  %9 = bitcast i8* %lookup_join_map to i64*
+  store i64 30005, i64* %9, align 8
+  %10 = getelementptr i8, i8* %lookup_join_map, i64 8
+  %11 = bitcast i8* %10 to i64*
+  store i64 0, i64* %11, align 8
+  %12 = bitcast i64* %join_r0 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %5)
+  %13 = load i64, i64* %join_r0, align 8
+  %14 = getelementptr i8, i8* %lookup_join_map, i64 16
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %14, i32 1024, i64 %13)
+  %15 = add i64 %5, 8
+  %probe_read_kernel2 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %15)
+  %16 = load i64, i64* %join_r0, align 8
+  %17 = getelementptr i8, i8* %lookup_join_map, i64 1040
+  %probe_read_kernel_str3 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %17, i32 1024, i64 %16)
+  %18 = add i64 %15, 8
+  %probe_read_kernel4 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %18)
+  %19 = load i64, i64* %join_r0, align 8
+  %20 = getelementptr i8, i8* %lookup_join_map, i64 2064
+  %probe_read_kernel_str5 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %20, i32 1024, i64 %19)
+  %21 = add i64 %18, 8
+  %probe_read_kernel6 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %21)
+  %22 = load i64, i64* %join_r0, align 8
+  %23 = getelementptr i8, i8* %lookup_join_map, i64 3088
+  %probe_read_kernel_str7 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %23, i32 1024, i64 %22)
+  %24 = add i64 %21, 8
+  %probe_read_kernel8 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %24)
+  %25 = load i64, i64* %join_r0, align 8
+  %26 = getelementptr i8, i8* %lookup_join_map, i64 4112
+  %probe_read_kernel_str9 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %26, i32 1024, i64 %25)
+  %27 = add i64 %24, 8
+  %probe_read_kernel10 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %27)
+  %28 = load i64, i64* %join_r0, align 8
+  %29 = getelementptr i8, i8* %lookup_join_map, i64 5136
+  %probe_read_kernel_str11 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %29, i32 1024, i64 %28)
+  %30 = add i64 %27, 8
+  %probe_read_kernel12 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %30)
+  %31 = load i64, i64* %join_r0, align 8
+  %32 = getelementptr i8, i8* %lookup_join_map, i64 6160
+  %probe_read_kernel_str13 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %32, i32 1024, i64 %31)
+  %33 = add i64 %30, 8
+  %probe_read_kernel14 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %33)
+  %34 = load i64, i64* %join_r0, align 8
+  %35 = getelementptr i8, i8* %lookup_join_map, i64 7184
+  %probe_read_kernel_str15 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %35, i32 1024, i64 %34)
+  %36 = add i64 %33, 8
+  %probe_read_kernel16 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %36)
+  %37 = load i64, i64* %join_r0, align 8
+  %38 = getelementptr i8, i8* %lookup_join_map, i64 8208
+  %probe_read_kernel_str17 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %38, i32 1024, i64 %37)
+  %39 = add i64 %36, 8
+  %probe_read_kernel18 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %39)
+  %40 = load i64, i64* %join_r0, align 8
+  %41 = getelementptr i8, i8* %lookup_join_map, i64 9232
+  %probe_read_kernel_str19 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %41, i32 1024, i64 %40)
+  %42 = add i64 %39, 8
+  %probe_read_kernel20 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %42)
+  %43 = load i64, i64* %join_r0, align 8
+  %44 = getelementptr i8, i8* %lookup_join_map, i64 10256
+  %probe_read_kernel_str21 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %44, i32 1024, i64 %43)
+  %45 = add i64 %42, 8
+  %probe_read_kernel22 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %45)
+  %46 = load i64, i64* %join_r0, align 8
+  %47 = getelementptr i8, i8* %lookup_join_map, i64 11280
+  %probe_read_kernel_str23 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %47, i32 1024, i64 %46)
+  %48 = add i64 %45, 8
+  %probe_read_kernel24 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %48)
+  %49 = load i64, i64* %join_r0, align 8
+  %50 = getelementptr i8, i8* %lookup_join_map, i64 12304
+  %probe_read_kernel_str25 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %50, i32 1024, i64 %49)
+  %51 = add i64 %48, 8
+  %probe_read_kernel26 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %51)
+  %52 = load i64, i64* %join_r0, align 8
+  %53 = getelementptr i8, i8* %lookup_join_map, i64 13328
+  %probe_read_kernel_str27 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %53, i32 1024, i64 %52)
+  %54 = add i64 %51, 8
+  %probe_read_kernel28 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %54)
+  %55 = load i64, i64* %join_r0, align 8
+  %56 = getelementptr i8, i8* %lookup_join_map, i64 14352
+  %probe_read_kernel_str29 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %56, i32 1024, i64 %55)
+  %57 = add i64 %54, 8
+  %probe_read_kernel30 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %57)
+  %58 = load i64, i64* %join_r0, align 8
+  %59 = getelementptr i8, i8* %lookup_join_map, i64 15376
+  %probe_read_kernel_str31 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %59, i32 1024, i64 %58)
+  %pseudo32 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, i8*, i64, i64)*)(i64 %pseudo32, i8* %lookup_join_map, i64 16400, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %lookup_join_merge
+  %60 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %60)
+  store i32 0, i32* %key, align 4
+  %pseudo33 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo33, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %lookup_join_merge
+  br label %failure_callback
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %61 = bitcast i8* %lookup_elem to i64*
+  %62 = atomicrmw add i64* %61, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %63 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %63)
+  br label %counter_merge
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/codegen/llvm/call_join_with_debug.ll
+++ b/tests/codegen/llvm/call_join_with_debug.ll
@@ -1,0 +1,181 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
+entry:
+  %key = alloca i32, align 4
+  %join_r0 = alloca i64, align 8
+  %fmt_str = alloca [70 x i8], align 1
+  %lookup_join_key = alloca i32, align 4
+  %"struct arg.argv" = alloca i64, align 8
+  %"$x" = alloca i64, align 8
+  %1 = bitcast i64* %"$x" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 0, i64* %"$x", align 8
+  store i64 0, i64* %"$x", align 8
+  %2 = load i64, i64* %"$x", align 8
+  %3 = add i64 %2, 0
+  %4 = bitcast i64* %"struct arg.argv" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %4)
+  %probe_read_kernel = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %"struct arg.argv", i32 8, i64 %3)
+  %5 = load i64, i64* %"struct arg.argv", align 8
+  %6 = bitcast i64* %"struct arg.argv" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
+  %7 = bitcast i32* %lookup_join_key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i32 0, i32* %lookup_join_key, align 4
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %lookup_join_map = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo, i32* %lookup_join_key)
+  %8 = bitcast i32* %lookup_join_key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %lookup_join_cond = icmp ne i8* %lookup_join_map, null
+  br i1 %lookup_join_cond, label %lookup_join_merge, label %lookup_join_failure
+
+failure_callback:                                 ; preds = %counter_merge, %lookup_join_failure
+  ret i64 0
+
+lookup_join_failure:                              ; preds = %entry
+  %9 = bitcast [70 x i8]* %fmt_str to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
+  %10 = bitcast [70 x i8]* %fmt_str to i8*
+  call void @llvm.memset.p0i8.i64(i8* align 1 %10, i8 0, i64 70, i1 false)
+  store [70 x i8] c"[BPFTRACE_DEBUG_OUTPUT] unable to find the scratch map value for join\00", [70 x i8]* %fmt_str, align 1
+  %11 = bitcast [70 x i8]* %fmt_str to i8*
+  %trace_printk = call i64 (i8*, i32, ...) inttoptr (i64 6 to i64 (i8*, i32, ...)*)(i8* %11, i32 70)
+  br label %failure_callback
+
+lookup_join_merge:                                ; preds = %entry
+  %12 = bitcast i8* %lookup_join_map to i64*
+  store i64 30005, i64* %12, align 8
+  %13 = getelementptr i8, i8* %lookup_join_map, i64 8
+  %14 = bitcast i8* %13 to i64*
+  store i64 0, i64* %14, align 8
+  %15 = bitcast i64* %join_r0 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
+  %probe_read_kernel1 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %5)
+  %16 = load i64, i64* %join_r0, align 8
+  %17 = getelementptr i8, i8* %lookup_join_map, i64 16
+  %probe_read_kernel_str = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %17, i32 1024, i64 %16)
+  %18 = add i64 %5, 8
+  %probe_read_kernel2 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %18)
+  %19 = load i64, i64* %join_r0, align 8
+  %20 = getelementptr i8, i8* %lookup_join_map, i64 1040
+  %probe_read_kernel_str3 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %20, i32 1024, i64 %19)
+  %21 = add i64 %18, 8
+  %probe_read_kernel4 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %21)
+  %22 = load i64, i64* %join_r0, align 8
+  %23 = getelementptr i8, i8* %lookup_join_map, i64 2064
+  %probe_read_kernel_str5 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %23, i32 1024, i64 %22)
+  %24 = add i64 %21, 8
+  %probe_read_kernel6 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %24)
+  %25 = load i64, i64* %join_r0, align 8
+  %26 = getelementptr i8, i8* %lookup_join_map, i64 3088
+  %probe_read_kernel_str7 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %26, i32 1024, i64 %25)
+  %27 = add i64 %24, 8
+  %probe_read_kernel8 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %27)
+  %28 = load i64, i64* %join_r0, align 8
+  %29 = getelementptr i8, i8* %lookup_join_map, i64 4112
+  %probe_read_kernel_str9 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %29, i32 1024, i64 %28)
+  %30 = add i64 %27, 8
+  %probe_read_kernel10 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %30)
+  %31 = load i64, i64* %join_r0, align 8
+  %32 = getelementptr i8, i8* %lookup_join_map, i64 5136
+  %probe_read_kernel_str11 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %32, i32 1024, i64 %31)
+  %33 = add i64 %30, 8
+  %probe_read_kernel12 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %33)
+  %34 = load i64, i64* %join_r0, align 8
+  %35 = getelementptr i8, i8* %lookup_join_map, i64 6160
+  %probe_read_kernel_str13 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %35, i32 1024, i64 %34)
+  %36 = add i64 %33, 8
+  %probe_read_kernel14 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %36)
+  %37 = load i64, i64* %join_r0, align 8
+  %38 = getelementptr i8, i8* %lookup_join_map, i64 7184
+  %probe_read_kernel_str15 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %38, i32 1024, i64 %37)
+  %39 = add i64 %36, 8
+  %probe_read_kernel16 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %39)
+  %40 = load i64, i64* %join_r0, align 8
+  %41 = getelementptr i8, i8* %lookup_join_map, i64 8208
+  %probe_read_kernel_str17 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %41, i32 1024, i64 %40)
+  %42 = add i64 %39, 8
+  %probe_read_kernel18 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %42)
+  %43 = load i64, i64* %join_r0, align 8
+  %44 = getelementptr i8, i8* %lookup_join_map, i64 9232
+  %probe_read_kernel_str19 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %44, i32 1024, i64 %43)
+  %45 = add i64 %42, 8
+  %probe_read_kernel20 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %45)
+  %46 = load i64, i64* %join_r0, align 8
+  %47 = getelementptr i8, i8* %lookup_join_map, i64 10256
+  %probe_read_kernel_str21 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %47, i32 1024, i64 %46)
+  %48 = add i64 %45, 8
+  %probe_read_kernel22 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %48)
+  %49 = load i64, i64* %join_r0, align 8
+  %50 = getelementptr i8, i8* %lookup_join_map, i64 11280
+  %probe_read_kernel_str23 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %50, i32 1024, i64 %49)
+  %51 = add i64 %48, 8
+  %probe_read_kernel24 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %51)
+  %52 = load i64, i64* %join_r0, align 8
+  %53 = getelementptr i8, i8* %lookup_join_map, i64 12304
+  %probe_read_kernel_str25 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %53, i32 1024, i64 %52)
+  %54 = add i64 %51, 8
+  %probe_read_kernel26 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %54)
+  %55 = load i64, i64* %join_r0, align 8
+  %56 = getelementptr i8, i8* %lookup_join_map, i64 13328
+  %probe_read_kernel_str27 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %56, i32 1024, i64 %55)
+  %57 = add i64 %54, 8
+  %probe_read_kernel28 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %57)
+  %58 = load i64, i64* %join_r0, align 8
+  %59 = getelementptr i8, i8* %lookup_join_map, i64 14352
+  %probe_read_kernel_str29 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %59, i32 1024, i64 %58)
+  %60 = add i64 %57, 8
+  %probe_read_kernel30 = call i64 inttoptr (i64 113 to i64 (i64*, i32, i64)*)(i64* %join_r0, i32 8, i64 %60)
+  %61 = load i64, i64* %join_r0, align 8
+  %62 = getelementptr i8, i8* %lookup_join_map, i64 15376
+  %probe_read_kernel_str31 = call i64 inttoptr (i64 115 to i64 (i8*, i32, i64)*)(i8* %62, i32 1024, i64 %61)
+  %pseudo32 = call i64 @llvm.bpf.pseudo(i64 1, i64 1)
+  %ringbuf_output = call i64 inttoptr (i64 130 to i64 (i64, i8*, i64, i64)*)(i64 %pseudo32, i8* %lookup_join_map, i64 16400, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %lookup_join_merge
+  %63 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %63)
+  store i32 0, i32* %key, align 4
+  %pseudo33 = call i64 @llvm.bpf.pseudo(i64 1, i64 2)
+  %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i32*)*)(i64 %pseudo33, i32* %key)
+  %map_lookup_cond = icmp ne i8* %lookup_elem, null
+  br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
+
+counter_merge:                                    ; preds = %lookup_merge, %lookup_join_merge
+  br label %failure_callback
+
+lookup_success:                                   ; preds = %event_loss_counter
+  %64 = bitcast i8* %lookup_elem to i64*
+  %65 = atomicrmw add i64* %64, i64 1 seq_cst
+  br label %lookup_merge
+
+lookup_failure:                                   ; preds = %event_loss_counter
+  br label %lookup_merge
+
+lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
+  %66 = bitcast i32* %key to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %66)
+  br label %counter_merge
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn writeonly
+declare void @llvm.memset.p0i8.i64(i8* nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }
+attributes #2 = { argmemonly nofree nosync nounwind willreturn writeonly }


### PR DESCRIPTION
This PR reimplements https://github.com/iovisor/bpftrace/pull/2719. The GetScratchMap part remains identical with the old PR.

I added a DebugOutput utility in this PR, for outputting unexpected + bpftrace internal error messages. The missing map value in the GetScratchMap utility is a typical use of it.

How to use:
```bash
# export BPFTRACE_DEBUG_OUTPUT=1
# bpftrace -e 'tracepoint:syscalls:sys_enter_execve { printf("hello world\n"); join(args.argv); }'
Attaching 1 probe...
DEBUG:            <...>-144298  [001] d...1 961288.443108: bpf_trace_printk: [BPFTRACE_DEBUG_OUTPUT] unable to find the scratch map value for join
hello world
^C
```

Note: This DEBUG utility *consumes* messages from the trace_pipe, so if some other applications are using the pipe, they may receive bpftrace's message or lost their own message. Since this is a *debug* purpose utility, and disabled by default, I think this is okay, better than the case that bpftrace hits error but nothing printed.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
