### PR TITLE
appimage: Trim appimage size

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -63,17 +63,17 @@
         "squashfuse": "squashfuse"
       },
       "locked": {
-        "lastModified": 1693585308,
-        "narHash": "sha256-ic7iw7zmJ3D34b/7MYz/iEQaWQVYN2IPA+su21QwRqY=",
+        "lastModified": 1693845781,
+        "narHash": "sha256-E7jJuRU5ntWARmIWhFJfvpXEvxyDwWBtqPWx++4fhtc=",
         "owner": "danobi",
         "repo": "nix-appimage",
-        "rev": "5d5093111a1ec4f116c1c57b7a807d41404bfa5e",
+        "rev": "83c61d93ee96d4d530f5382edca51ee30ce2769f",
         "type": "github"
       },
       "original": {
         "owner": "danobi",
         "repo": "nix-appimage",
-        "rev": "5d5093111a1ec4f116c1c57b7a807d41404bfa5e",
+        "rev": "83c61d93ee96d4d530f5382edca51ee30ce2769f",
         "type": "github"
       }
     },


### PR DESCRIPTION
This commit trims the appimage size down to ~140M (down from ~300M) by excluding unnecessary files.

This brings the regression from the semi-static build down to ~3x (143/46.6).

This closes #2748 

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
