### PR TITLE
Add pid and host targeting for uprobes/uretprobes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
   - [#2686](https://github.com/iovisor/bpftrace/pull/2686)
 - Support targeting all running processes for USDTs
   - [#2734](https://github.com/iovisor/bpftrace/pull/2734)
+- Support targeting all running processes for uprobes/uretprobes
+  - [#2757](https://github.com/iovisor/bpftrace/pull/2757)
 #### Changed
 - Make `args` a structure (instead of a pointer)
   - [#2578](https://github.com/iovisor/bpftrace/pull/2578)

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -159,7 +159,7 @@ OPTIONS:
     -I DIR         add the specified DIR to the search path for include files.
     --include FILE adds an implicit #include which is read before the source file is preprocessed.
     -l [search]    list probes
-    -p PID         enable USDT probes on PID
+    -p PID         enable USDT probes or search for uprobes/uretprobes in PID address space
     -c 'CMD'       run CMD and enable USDT probes on resulting process
     -q             keep messages quiet
     -v             verbose messages
@@ -1091,6 +1091,8 @@ uretprobe:library_name:function_name
 
 These use uprobes (a Linux kernel capability). `uprobe` instruments the beginning of a user-level
 function's execution, and `uretprobe` instruments the end (its return).
+
+You can search the entire host (or an entire process's address space by using the `-p` arg) by using a single wildcard `*` in place of the `library_path` e.g. `bpftrace -e 'uprobe:*:loop { printf("hi\n"); }'`. But looking through the **entire host** for matching symbols is expensive and can take a while so either supply a PID or use with caution.
 
 To list available uprobes, you can use any program to list the text segment symbols from a binary, such
 as `objdump` and `nm`. For example:

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -118,7 +118,7 @@ u:lib.so:"fn(char const*)" { printf("arg0:%s\n", str(arg0));}
 
 *-p* _PID_::
   Attach to the process with _PID_. If the process terminates, bpftrace will also terminate.
-  When using USDT probes they will be attached to only this process.
+  When using USDT probes they will be attached to only this process. For uprobes/uretprobes if you also set the target to '*' the process's address space will be searched for the symbols.
 
 *-c* _COMMAND_::
   Run _COMMAND_ as a child process.

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2690,7 +2690,18 @@ void SemanticAnalyser::visit(AttachPoint &ap)
       LOG(ERROR, ap.loc, err_)
           << "uretprobes can not be attached to a function offset";
 
-    auto paths = resolve_binary_path(ap.target, bpftrace_.pid());
+    std::vector<std::string> paths;
+    if (ap.target == "*")
+    {
+      if (bpftrace_.pid() > 0)
+        paths = get_mapped_paths_for_pid(bpftrace_.pid());
+      else
+        paths = get_mapped_paths_for_running_pids();
+    }
+    else
+    {
+      paths = resolve_binary_path(ap.target, bpftrace_.pid());
+    }
     switch (paths.size())
     {
     case 0:

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -105,6 +105,7 @@ private:
   virtual std::unique_ptr<std::istream> get_symbols_from_file_safe(
       const std::string &path) const;
   virtual std::unique_ptr<std::istream> get_func_symbols_from_file(
+      int pid,
       const std::string &path) const;
   virtual std::unique_ptr<std::istream> get_symbols_from_usdt(
       int pid,

--- a/src/utils.h
+++ b/src/utils.h
@@ -161,6 +161,8 @@ bool get_uint64_env_var(const ::std::string &str, uint64_t &dest);
 bool get_bool_env_var(const ::std::string &str, bool &dest, bool neg = false);
 std::string get_pid_exe(pid_t pid);
 std::string get_pid_exe(const std::string &pid);
+std::string get_proc_maps(const std::string &pid);
+std::string get_proc_maps(pid_t pid);
 bool has_wildcard(const std::string &str);
 std::vector<std::string> split_string(const std::string &str,
                                       char delimiter,
@@ -216,6 +218,8 @@ std::pair<std::string, std::string> split_symbol_module(
 std::tuple<std::string, std::string, std::string> split_addrrange_symbol_module(
     const std::string &symbol);
 
+std::vector<std::string> get_mapped_paths_for_pid(pid_t pid);
+std::vector<std::string> get_mapped_paths_for_running_pids();
 struct elf_symbol
 {
   std::string name;

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -336,7 +336,7 @@ TEST(bpftrace, add_probes_uprobe_wildcard)
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_func_symbols_from_file("/bin/sh"))
+              get_func_symbols_from_file(0, "/bin/sh"))
       .Times(1);
 
   ASSERT_EQ(0, bpftrace->add_probe(*probe));
@@ -353,7 +353,7 @@ TEST(bpftrace, add_probes_uprobe_wildcard_file)
   ast::Probe *probe = parse_probe("uprobe:/bin/*sh:first_open {}");
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_func_symbols_from_file("/bin/*sh"))
+              get_func_symbols_from_file(0, "/bin/*sh"))
       .Times(1);
 
   ASSERT_EQ(0, bpftrace->add_probe(*probe));
@@ -367,12 +367,37 @@ TEST(bpftrace, add_probes_uprobe_wildcard_file)
       bpftrace->get_probes().at(1), "/bin/sh", "first_open", probe_orig_name);
 }
 
+TEST(bpftrace, add_probes_uprobe_wildcard_for_target)
+{
+  ast::Probe *probe = parse_probe("uprobe:*:*open {}");
+
+  auto bpftrace = get_strict_mock_bpftrace();
+  EXPECT_CALL(*bpftrace->mock_probe_matcher, get_func_symbols_from_file(0, "*"))
+      .Times(1);
+
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
+  ASSERT_EQ(4U, bpftrace->get_probes().size());
+  ASSERT_EQ(0U, bpftrace->get_special_probes().size());
+
+  std::string probe_orig_name = "uprobe:*:*open";
+  check_uprobe(
+      bpftrace->get_probes().at(0), "/bin/bash", "first_open", probe_orig_name);
+  check_uprobe(
+      bpftrace->get_probes().at(1), "/bin/sh", "first_open", probe_orig_name);
+  check_uprobe(
+      bpftrace->get_probes().at(2), "/bin/sh", "second_open", probe_orig_name);
+  check_uprobe(bpftrace->get_probes().at(3),
+               "/proc/1234/exe",
+               "third_open",
+               probe_orig_name);
+}
+
 TEST(bpftrace, add_probes_uprobe_wildcard_no_matches)
 {
   ast::Probe *probe = parse_probe("uprobe:/bin/sh:foo* {}");
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_func_symbols_from_file("/bin/sh"))
+              get_func_symbols_from_file(0, "/bin/sh"))
       .Times(1);
 
   ASSERT_EQ(0, bpftrace->add_probe(*probe));
@@ -428,7 +453,7 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol)
 
     auto bpftrace = get_strict_mock_bpftrace();
     EXPECT_CALL(*bpftrace->mock_probe_matcher,
-                get_func_symbols_from_file("/bin/sh"))
+                get_func_symbols_from_file(0, "/bin/sh"))
         .Times(1);
 
     ASSERT_EQ(0, bpftrace->add_probe(*probe));
@@ -454,7 +479,7 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol_full)
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_func_symbols_from_file("/bin/sh"))
+              get_func_symbols_from_file(0, "/bin/sh"))
       .Times(1);
 
   ASSERT_EQ(0, bpftrace->add_probe(*probe));
@@ -472,7 +497,7 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol_wildcard)
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_func_symbols_from_file("/bin/sh"))
+              get_func_symbols_from_file(0, "/bin/sh"))
       .Times(1);
 
   ASSERT_EQ(0, bpftrace->add_probe(*probe));
@@ -503,7 +528,7 @@ TEST(bpftrace, add_probes_uprobe_no_demangling)
 
   auto bpftrace = get_strict_mock_bpftrace();
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
-              get_func_symbols_from_file("/bin/sh"))
+              get_func_symbols_from_file(0, "/bin/sh"))
       .Times(0);
 
   ASSERT_EQ(0, bpftrace->add_probe(*probe));

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -43,16 +43,23 @@ void setup_mock_probe_matcher(MockProbeMatcher &matcher)
                          "/bin/sh:_Z11cpp_mangledv\n"
                          "/bin/sh:_Z18cpp_mangled_suffixv\n";
   std::string bash_usyms = "/bin/bash:first_open\n";
-  ON_CALL(matcher, get_func_symbols_from_file("/bin/sh"))
-      .WillByDefault([sh_usyms](const std::string &) {
+  std::string proc_usyms = "/proc/1234/exe:third_open\n";
+  ON_CALL(matcher, get_func_symbols_from_file(_, "/bin/sh"))
+      .WillByDefault([sh_usyms](int, const std::string &) {
         return std::unique_ptr<std::istream>(new std::istringstream(sh_usyms));
       });
 
-  ON_CALL(matcher, get_func_symbols_from_file("/bin/*sh"))
-      .WillByDefault([sh_usyms, bash_usyms](const std::string &) {
+  ON_CALL(matcher, get_func_symbols_from_file(_, "/bin/*sh"))
+      .WillByDefault([sh_usyms, bash_usyms](int, const std::string &) {
         return std::unique_ptr<std::istream>(
             new std::istringstream(sh_usyms + bash_usyms));
       });
+  ON_CALL(matcher, get_func_symbols_from_file(_, "*"))
+      .WillByDefault(
+          [sh_usyms, bash_usyms, proc_usyms](int, const std::string &) {
+            return std::unique_ptr<std::istream>(
+                new std::istringstream(sh_usyms + bash_usyms + proc_usyms));
+          });
 
   std::string sh_usdts = "/bin/sh:prov1:tp1\n"
                          "/bin/sh:prov1:tp2\n"

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -28,8 +28,9 @@ public:
   MOCK_CONST_METHOD2(get_symbols_from_usdt,
                      std::unique_ptr<std::istream>(int pid,
                                                    const std::string &target));
-  MOCK_CONST_METHOD1(get_func_symbols_from_file,
-                     std::unique_ptr<std::istream>(const std::string &path));
+  MOCK_CONST_METHOD2(get_func_symbols_from_file,
+                     std::unique_ptr<std::istream>(int pid,
+                                                   const std::string &path));
 #pragma GCC diagnostic pop
 };
 

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -250,28 +250,28 @@ TIMEOUT 5
 AFTER ./testprogs/syscall open
 
 NAME args in uprobe print
-PROG uprobe:./testprogs/uprobe_test:function1 { print(args); exit(); }
+PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { print(args); exit(); }
 EXPECT { .n = 0x[0-9a-f]+, .c = 120 }
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME args in uprobe store in map
-PROG uprobe:./testprogs/uprobe_test:function1 { @ = args; exit(); }
+PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { @ = args; exit(); }
 EXPECT @: { .n = 0x[0-9a-f]+, .c = 120 }
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME args in uprobe store in map and access field
-PROG uprobe:./testprogs/uprobe_test:function1 { @ = args; print(@.c); exit(); }
+PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { @ = args; print(@.c); exit(); }
 EXPECT 120
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME args in uprobe as a map key
-PROG uprobe:./testprogs/uprobe_test:function1 { @[args] = 1; exit(); }
+PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { @[args] = 1; exit(); }
 EXPECT @[{.n=0x[0-9a-f]+,.c=120}]: 1
 REQUIRES_FEATURE dwarf
 TIMEOUT 5

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -19,7 +19,7 @@ EXPECT Elapsed time: 1s
 TIMEOUT 5
 
 NAME printf_argument_alignment
-RUN {{BPFTRACE}} -e 'struct Foo { int a; char b[10]; } uprobe:testprogs/uprobe_test:function2 { $foo = (struct Foo *)arg0; $foo2 = (struct Foo *)arg1; printf("%d %s %d %s\n", $foo->a, $foo->b, $foo2->a, $foo2->b) }' -c ./testprogs/uprobe_test
+RUN {{BPFTRACE}} -e 'struct Foo { int a; char b[10]; } uprobe:testprogs/uprobe_test:uprobeFunction2 { $foo = (struct Foo *)arg0; $foo2 = (struct Foo *)arg1; printf("%d %s %d %s\n", $foo->a, $foo->b, $foo2->a, $foo2->b) }' -c ./testprogs/uprobe_test
 EXPECT 123 hello 456 world
 TIMEOUT 5
 
@@ -278,7 +278,7 @@ EXPECT [0-9]*.[0-9]* [0-9]*.[0-9]*
 TIMEOUT 5
 
 NAME uaddr
-RUN {{BPFTRACE}} -e 'uprobe:testprogs/uprobe_test:function1 { printf("0x%lx -- 0x%lx\n", *uaddr("GLOBAL_A"), *uaddr("GLOBAL_C")); exit(); }' -c ./testprogs/uprobe_test
+RUN {{BPFTRACE}} -e 'uprobe:testprogs/uprobe_test:uprobeFunction1 { printf("0x%lx -- 0x%lx\n", *uaddr("GLOBAL_A"), *uaddr("GLOBAL_C")); exit(); }' -c ./testprogs/uprobe_test
 EXPECT 0x55555555 -- 0x33333333
 TIMEOUT 5
 

--- a/tests/runtime/dwarf
+++ b/tests/runtime/dwarf
@@ -5,33 +5,33 @@ REQUIRES_FEATURE dwarf
 TIMEOUT 5
 
 NAME list uprobe args - pointer type
-RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test:function1'
+RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test:uprobeFunction1'
 EXPECT int\* n
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 
 NAME list uprobe args - struct pointer type
-RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test:function2'
+RUN {{BPFTRACE}} -lv 'uprobe:./testprogs/uprobe_test:uprobeFunction2'
 EXPECT struct Foo\* foo1
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 
 NAME uprobe arg by name - char
-PROG uprobe:./testprogs/uprobe_test:function1 { printf("c = %c\n", args.c); exit(); }
+PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("c = %c\n", args.c); exit(); }
 EXPECT c = x
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME uprobe arg by name - pointer
-PROG uprobe:./testprogs/uprobe_test:function1 { printf("n = %d\n", *(args.n)); exit(); }
+PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("n = %d\n", *(args.n)); exit(); }
 EXPECT n = 13
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME uprobe arg by name - struct
-PROG uprobe:./testprogs/uprobe_test:function2 { printf("foo1->a = %d\n", args.foo1->a); exit(); }
+PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("foo1->a = %d\n", args.foo1->a); exit(); }
 EXPECT foo1->a = 123
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
@@ -39,35 +39,35 @@ BEFORE ./testprogs/uprobe_test
 
 # Checking backwards compatibility
 NAME uprobe args as pointer
-PROG uprobe:./testprogs/uprobe_test:function1 { printf("c = %c\n", args->c); exit(); }
+PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("c = %c\n", args->c); exit(); }
 EXPECT c = x
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME struct field string
-PROG uprobe:./testprogs/uprobe_test:function2 { printf("foo1->b = %s\n", args.foo1->b); exit(); }
+PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("foo1->b = %s\n", args.foo1->b); exit(); }
 EXPECT foo1->b = hello
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME struct field array
-PROG uprobe:./testprogs/uprobe_test:function2 { print(args.foo1->c); exit(); }
+PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { print(args.foo1->c); exit(); }
 EXPECT \[1,2,3\]
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME cast to struct
-PROG uprobe:./testprogs/uprobe_test:function2 { printf("foo1->a = %d\n", ((struct Foo *)arg0)->a); exit(); }
+PROG uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("foo1->a = %d\n", ((struct Foo *)arg0)->a); exit(); }
 EXPECT foo1->a = 123
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME struct override
-PROG struct Foo { int b; } uprobe:./testprogs/uprobe_test:function2 { printf("foo1->b = %d\n", ((struct Foo *)arg0)->b); exit(); }
+PROG struct Foo { int b; } uprobe:./testprogs/uprobe_test:uprobeFunction2 { printf("foo1->b = %d\n", ((struct Foo *)arg0)->b); exit(); }
 EXPECT foo1->b = 123
 REQUIRES_FEATURE dwarf
 TIMEOUT 5

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -24,7 +24,7 @@ EXPECT 0
 TIMEOUT 5
 
 NAME c_array_indexing
-RUN {{BPFTRACE}} -e 'struct Foo { int a; uint8_t b[10]; } uprobe:testprogs/uprobe_test:function2 { $foo = (struct Foo *)arg0; printf("%c %c %c %c %c\n", $foo->b[0], $foo->b[1], $foo->b[2], $foo->b[3], $foo->b[4]) }' -c ./testprogs/uprobe_test
+RUN {{BPFTRACE}} -e 'struct Foo { int a; uint8_t b[10]; } uprobe:testprogs/uprobe_test:uprobeFunction2 { $foo = (struct Foo *)arg0; printf("%c %c %c %c %c\n", $foo->b[0], $foo->b[1], $foo->b[2], $foo->b[3], $foo->b[4]) }' -c ./testprogs/uprobe_test
 EXPECT h e l l o
 TIMEOUT 5
 
@@ -79,6 +79,6 @@ TIMEOUT 1
 
 # https://github.com/iovisor/bpftrace/issues/2135
 NAME address_probe_invalid_expansion
-RUN {{BPFTRACE}} -e "uprobe:./testprogs/uprobe_test:0x$(nm ./testprogs/uprobe_test | awk '$3 == "function1" {print $1}') { @[probe] = count(); exit() }"
+RUN {{BPFTRACE}} -e "uprobe:./testprogs/uprobe_test:0x$(nm ./testprogs/uprobe_test | awk '$3 == "uprobeFunction1" {print $1}') { @[probe] = count(); exit() }"
 EXPECT Attaching 1 probe
 TIMEOUT 1

--- a/tests/runtime/tuples
+++ b/tests/runtime/tuples
@@ -90,14 +90,14 @@ EXPECT ^@: \(\d+, \d+:\d+\)$
 TIMEOUT 5
 
 NAME bytearray in tuple
-PROG uprobe:./testprogs/uprobe_test:function1 { @ = ((int8)1, usym(reg("ip")), 10); exit(); }
+PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { @ = ((int8)1, usym(reg("ip")), 10); exit(); }
 EXPECT ^@: \(1, 0x[0-9a-f]+, 10\)$
 TIMEOUT 5
 ARCH x86_64
 AFTER ./testprogs/uprobe_test
 
 NAME bytearray in tuple
-PROG uprobe:./testprogs/uprobe_test:function1 { @ = ((int8)1, usym(reg("nip")), 10); exit(); }
+PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { @ = ((int8)1, usym(reg("nip")), 10); exit(); }
 EXPECT ^@: \(1, 0x[0-9a-f]+, 10\)$
 TIMEOUT 5
 ARCH ppc64|ppc64le

--- a/tests/runtime/uprobe
+++ b/tests/runtime/uprobe
@@ -1,56 +1,68 @@
 NAME uprobes - list probes by file
 RUN {{BPFTRACE}} -l 'uprobe:./testprogs/uprobe_test:*'
-EXPECT uprobe:./testprogs/uprobe_test:function1
+EXPECT uprobe:./testprogs/uprobe_test:uprobeFunction1
 TIMEOUT 5
 
 NAME uprobes - list probes by file with wildcarded filter
-RUN {{BPFTRACE}} -l 'uprobe:./testprogs/uprobe_test:func*'
-EXPECT uprobe:./testprogs/uprobe_test:function1
+RUN {{BPFTRACE}} -l 'uprobe:./testprogs/uprobe_test:uprobeFunc*'
+EXPECT uprobe:./testprogs/uprobe_test:uprobeFunction1
 TIMEOUT 5
 
 NAME uprobes - list probes with wildcarded file matching multiple files
 RUN {{BPFTRACE}} -l 'uprobe:./testprogs/uprobe*:*'
-EXPECT uprobe:./testprogs/uprobe_test:function1
+EXPECT uprobe:./testprogs/uprobe_test:uprobeFunction1
 TIMEOUT 5
 
 NAME uprobes - list probes by file with wildcarded file and filter
-RUN {{BPFTRACE}} -l 'uprobe:./testprogs/uprobe_test*:func*'
-EXPECT uprobe:./testprogs/uprobe_test:function1
+RUN {{BPFTRACE}} -l 'uprobe:./testprogs/uprobe_test*:uprobeFunc*'
+EXPECT uprobe:./testprogs/uprobe_test:uprobeFunction1
 TIMEOUT 5
 
 NAME uprobes - list probes by file with specific filter
-RUN {{BPFTRACE}} -l 'uprobe:./testprogs/uprobe_test:function1'
-EXPECT uprobe:./testprogs/uprobe_test:function1
+RUN {{BPFTRACE}} -l 'uprobe:./testprogs/uprobe_test:uprobeFunction1'
+EXPECT uprobe:./testprogs/uprobe_test:uprobeFunction1
 TIMEOUT 5
 
 NAME uprobes - list probes by file with wildcarded probe type
 RUN {{BPFTRACE}} -l '*:./testprogs/uprobe_test:*' | grep -e '^uprobe:'
-EXPECT uprobe:./testprogs/uprobe_test:function1
+EXPECT uprobe:./testprogs/uprobe_test:uprobeFunction1
 TIMEOUT 5
 
 NAME uprobes - list probes by pid
 RUN {{BPFTRACE}} -l -p {{BEFORE_PID}} | grep -e '^uprobe'
-EXPECT uprobe:.*/testprogs/uprobe_test:function1
+EXPECT uprobe:.*/testprogs/uprobe_test:uprobeFunction1
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME uprobes - list probes by pid; uprobes only
 RUN {{BPFTRACE}} -l 'uprobe:*' -p {{BEFORE_PID}}
-EXPECT uprobe:.*/testprogs/uprobe_test:function1
+EXPECT uprobe:.*/testprogs/uprobe_test:uprobeFunction1
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME uprobes - list probes by pid in separate mount namespace
 RUN {{BPFTRACE}} -l -p {{BEFORE_PID}} | grep -e '^uprobe'
-EXPECT uprobe:.*/bpftrace-unshare-mountns-test/uprobe_test:function1
+EXPECT uprobe:.*/bpftrace-unshare-mountns-test/uprobe_test:uprobeFunction1
 TIMEOUT 5
 BEFORE ./testprogs/mountns_wrapper uprobe_test
 
 NAME uprobes - attach to probe for executable in separate mount namespace
-RUN {{BPFTRACE}} -e 'uprobe:/tmp/bpftrace-unshare-mountns-test/uprobe_test:function1 { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -e 'uprobe:/tmp/bpftrace-unshare-mountns-test/uprobe_test:uprobeFunction1 { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
 EXPECT Attaching 1 probe...
 TIMEOUT 5
 BEFORE ./testprogs/mountns_wrapper uprobe_test
+
+NAME uprobes - attach to probe by pid with only wildcard
+RUN {{BPFTRACE}} -e 'uprobe:*:uprobeFunction1 { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
+EXPECT Attaching 1 probe...
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+
+NAME uprobes - attach to multiple probes by pid with only wildcard
+RUN {{BPFTRACE}} -e 'uprobe:*:uprobeFunc* { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
+EXPECT Attaching 2 probes...
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
 
 NAME uprobes - list probes in non-executable library
 RUN {{BPFTRACE}} -l 'uprobe:./testlibs/libsimple.so:fun'

--- a/tests/testprogs/uprobe_test.c
+++ b/tests/testprogs/uprobe_test.c
@@ -12,12 +12,13 @@ struct Foo
   int c[3];
 };
 
-int function1(int *n, char c __attribute__((unused)))
+int uprobeFunction1(int *n, char c __attribute__((unused)))
 {
   return *n;
 }
 
-struct Foo *function2(struct Foo *foo1, struct Foo *foo2 __attribute__((unused)))
+struct Foo *uprobeFunction2(struct Foo *foo1,
+                            struct Foo *foo2 __attribute__((unused)))
 {
   return foo1;
 }
@@ -28,11 +29,11 @@ int main(int argc __attribute__((unused)), char **argv __attribute__((unused)))
 
   int n = 13;
   char c = 'x';
-  function1(&n, c);
+  uprobeFunction1(&n, c);
 
   struct Foo foo1 = { .a = 123, .b = "hello", .c = { 1, 2, 3 } };
   struct Foo foo2 = { .a = 456, .b = "world", .c = { 4, 5, 6 } };
-  function2(&foo1, &foo2);
+  uprobeFunction2(&foo1, &foo2);
 
   return 0;
 }


### PR DESCRIPTION
This allows users to specify a single wildcard in place of the library_path to either target the whole host or a process's address space if a PID is also provided.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
