### PR TITLE
Increase timeout for usdt runtime test

### DIFF
--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -86,7 +86,8 @@ RUN {{BPFTRACE}} -e 'usdt:*:tracetest:testprobe { printf("here\n" ); exit(); }'
 EXPECT here
 BEFORE ./testprogs/usdt_test
 REQUIRES ./testprogs/usdt_test should_not_skip
-TIMEOUT 5
+TIMEOUT 20
+# USDT discovery on the whole host might take longer
 
 NAME usdt probes - attach to fully specified library probe by pid
 RUN {{BPFTRACE}} -e 'usdt:./testlibs/libusdt_tp.so:tracetestlib:lib_probe_1 { printf("here\n" ); exit(); }' -p $(pidof usdt_lib)


### PR DESCRIPTION
This test could take longer due to iterating over all pids on the host.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
