### PR TITLE
Improve runtime test filtering

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -42,6 +42,7 @@ Runtime tests will call the bpftrace executable. These are located in `tests/run
 
 * Run: `sudo make runtime-tests` inside your build folder or `sudo <builddir>/tests/runtime-tests.sh`
 * By default, runtime-tests will look for the executable in the build folder. You can set a value to the environment variable `BPFTRACE_RUNTIME_TEST_EXECUTABLE` to customize it
+* Use the `TEST_FILTER` environment variable (or the `--filter` arg when running `runtime_tests.sh`) to only run a subset of the tests e.g. `TEST_FILTER="uprobe.*" sudo make runtime-tests`
 
 Runtime tests are grouped into "suites". A suite is usually a single file. The
 name of the file is the name of the suite.

--- a/tests/runtime/engine/main.py
+++ b/tests/runtime/engine/main.py
@@ -2,16 +2,18 @@
 
 import argparse
 from datetime import timedelta
-from fnmatch import fnmatch
+import os
+import re
 import time
 
 from parser import TestParser, UnknownFieldError, RequiredFieldError
 from runner import Runner, ok, fail, warn
 
+TEST_FILTER = os.getenv("TEST_FILTER")
 
 def main(test_filter, run_aot_tests):
     if not test_filter:
-        test_filter = "*"
+        test_filter = ".*"
 
     try:
         test_suite = sorted(TestParser.read_all(run_aot_tests))
@@ -23,7 +25,7 @@ def main(test_filter, run_aot_tests):
     # Apply filter
     filtered_suites = []
     for fname, tests in test_suite:
-        filtered_tests = [t for t in tests if fnmatch("{}.{}".format(fname, t.name), test_filter)]
+        filtered_tests = [t for t in tests if re.search(test_filter, "{}.{}".format(fname, t.name))]
         if len(filtered_tests) != 0:
             filtered_suites.append((fname, filtered_tests))
     test_suite = filtered_suites
@@ -79,4 +81,4 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    main(args.test_filter, args.run_aot_tests)
+    main(args.test_filter or TEST_FILTER, args.run_aot_tests)


### PR DESCRIPTION
- Also check the TEST_FILTER env variable so users can filter when running `sudo make runtime-tests`
- Use a partial regex instead of exact match
- Add documentation on how to use it

Tested locally with both commands below:
```
TEST_FILTER="attach to probe by wildcard and file with child" sudo make runtime-tests
sudo ./tests/runtime-tests.sh --filter "attach to probe by wildcard and file with child"
```

```
[==========] Running 2 tests from 2 test cases.

[----------] 1 tests from usdt
[ RUN      ] usdt.usdt probes - attach to probe by wildcard and file with child
[       OK ] usdt.usdt probes - attach to probe by wildcard and file with child
[----------] 1 tests from usdt

[----------] 1 tests from usdt~
[ RUN      ] usdt~.usdt probes - attach to probe by wildcard and file with child
[       OK ] usdt~.usdt probes - attach to probe by wildcard and file with child
[----------] 1 tests from usdt~

[==========] 2 tests from 2 test cases ran. (0.6850640773773193 total)
[  PASSED  ] 2 tests.
[100%] Built target runtime-tests
```

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
