### PR TITLE
Various fixes for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,54 +39,64 @@ jobs:
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm10
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process
-          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
+          TOOLS_TEST_OLDVERSION: tcpdrop.bt
+          TOOLS_TEST_DISABLE: biosnoop.bt
         - NAME: LLVM 10 Release
           CMAKE_BUILD_TYPE: Release
           NIX_TARGET: .#bpftrace-llvm10
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process
-          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
+          TOOLS_TEST_OLDVERSION: tcpdrop.bt
+          TOOLS_TEST_DISABLE: biosnoop.bt
         - NAME: LLVM 10 Clang Debug
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm10
           CC: clang
           CXX: clang++
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process
-          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
+          TOOLS_TEST_OLDVERSION: tcpdrop.bt
+          TOOLS_TEST_DISABLE: biosnoop.bt
         - NAME: LLVM 11 Debug
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm11
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process
-          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
+          TOOLS_TEST_OLDVERSION: tcpdrop.bt
+          TOOLS_TEST_DISABLE: biosnoop.bt
         - NAME: LLVM 11 Release
           CMAKE_BUILD_TYPE: Release
           NIX_TARGET: .#bpftrace-llvm11
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process
-          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
+          TOOLS_TEST_OLDVERSION: tcpdrop.bt
+          TOOLS_TEST_DISABLE: biosnoop.bt
         - NAME: LLVM 12 Release
           CMAKE_BUILD_TYPE: Release
           NIX_TARGET: .#bpftrace-llvm12
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process
-          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
+          TOOLS_TEST_OLDVERSION: tcpdrop.bt
+          TOOLS_TEST_DISABLE: biosnoop.bt
         - NAME: LLVM 13 Release
           CMAKE_BUILD_TYPE: Release
           NIX_TARGET: .#bpftrace-llvm13
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process
-          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
+          TOOLS_TEST_OLDVERSION: tcpdrop.bt
+          TOOLS_TEST_DISABLE: biosnoop.bt
         - NAME: LLVM 14 Release
           CMAKE_BUILD_TYPE: Release
           NIX_TARGET: .#bpftrace-llvm14
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process
-          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
+          TOOLS_TEST_OLDVERSION: tcpdrop.bt
+          TOOLS_TEST_DISABLE: biosnoop.bt
         - NAME: LLVM 15 Release
           CMAKE_BUILD_TYPE: Release
           NIX_TARGET: .#bpftrace-llvm15
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process
-          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
+          TOOLS_TEST_OLDVERSION: tcpdrop.bt
+          TOOLS_TEST_DISABLE: biosnoop.bt
         - NAME: LLVM 16 Release
           CMAKE_BUILD_TYPE: Release
           NIX_TARGET: .#bpftrace-llvm16
           RUNTIME_TEST_DISABLE: probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process
-          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
+          TOOLS_TEST_OLDVERSION: tcpdrop.bt
+          TOOLS_TEST_DISABLE: biosnoop.bt
         - NAME: Memleak test (LLVM 11 Debug)
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm11

--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -22,7 +22,8 @@ jobs:
           EMBED_USE_LLVM: ON
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process
-          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
+          TOOLS_TEST_OLDVERSION: tcpdrop.bt
+          TOOLS_TEST_DISABLE: biosnoop.bt
           BASE: bionic
           DISTRO: ubuntu-glibc
           VENDOR_GTEST: ON
@@ -36,7 +37,8 @@ jobs:
           EMBED_USE_LLVM: ON
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size,other.string compare map lookup,call.skboutput,usdt.usdt probes - file based semaphore activation multi process
-          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
+          TOOLS_TEST_OLDVERSION: tcpdrop.bt
+          TOOLS_TEST_DISABLE: biosnoop.bt
           BASE: focal
           DISTRO: ubuntu-glibc
           VENDOR_GTEST: ON
@@ -49,8 +51,8 @@ jobs:
           EMBED_BUILD_LLVM: OFF
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: json-output.join_delim,other.string compare map lookup,probe.kprobe_offset_fail_size,probe.uprobe_library,usdt.usdt probes - attach to fully specified probe of child,usdt.usdt probes - all probes by wildcard and file with child,usdt.usdt probes - attach to probe by wildcard and file with child,usdt.usdt probes - attach to probes by wildcard file with child,usdt.usdt probes - attach to probe on multiple files by wildcard,usdt.usdt probes - attach to probe with probe builtin and args by file with child,usdt.usdt probes - list probes by pid in separate mountns,usdt.usdt sized arguments,usdt.usdt - list probes by file with wildcarded probe type,uprobe.uprobes - list probes by pid; uprobes only,uprobe.uprobes - list probes by pid in separate mount namespace,other.positional pointer arithmetics,call.skboutput,usdt.usdt probes - file based semaphore activation multi process,probe.uprobe_zero_size,probe.uprobe_zero_size_unsafe
-          TOOLS_TEST_DISABLE: gethostlatency.bt,threadsnoop.bt,ssllatency.bt,sslsnoop.bt
-          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
+          TOOLS_TEST_DISABLE: biosnoop.bt,gethostlatency.bt,threadsnoop.bt,ssllatency.bt,sslsnoop.bt
+          TOOLS_TEST_OLDVERSION: tcpdrop.bt
           BASE: alpine
           DISTRO: alpine
           ALPINE_VERSION: 3.12
@@ -64,8 +66,8 @@ jobs:
           EMBED_BUILD_LLVM: OFF
           RUN_ALL_TESTS: 1
           RUNTIME_TEST_DISABLE: other.string compare map lookup,probe.kprobe_offset_fail_size,probe.uprobe_library,usdt.usdt probes - attach to fully specified probe of child,usdt.usdt probes - all probes by wildcard and file with child,usdt.usdt probes - attach to probe by wildcard and file with child,usdt.usdt probes - attach to probes by wildcard file with child,usdt.usdt probes - attach to probe on multiple files by wildcard,usdt.usdt probes - attach to probe with probe builtin and args by file with child,usdt.usdt probes - list probes by pid in separate mountns,usdt.usdt sized arguments,usdt.usdt - list probes by file with wildcarded probe type,uprobe.uprobes - list probes by pid; uprobes only,uprobe.uprobes - list probes by pid in separate mount namespace,other.positional pointer arithmetics,call.skboutput,usdt.usdt probes - file based semaphore activation multi process,probe.uprobe_zero_size,probe.uprobe_zero_size_unsafe
-          TOOLS_TEST_DISABLE: gethostlatency.bt,threadsnoop.bt,ssllatency.bt,sslsnoop.bt
-          TOOLS_TEST_OLDVERSION: biosnoop.bt tcpdrop.bt
+          TOOLS_TEST_DISABLE: biosnoop.bt,gethostlatency.bt,threadsnoop.bt,ssllatency.bt,sslsnoop.bt
+          TOOLS_TEST_OLDVERSION: tcpdrop.bt
           BASE: alpine
           DISTRO: alpine
           ALPINE_VERSION: 3.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ and this project adheres to
   - [#2718](https://github.com/iovisor/bpftrace/pull/2718)
 - iter: Skip structures with '__safe_trusted' suffix
   - [#2732](https://github.com/iovisor/bpftrace/pull/2732)
+- Improve detection of unknown typedefs in ClangParser
+  - [#2763](https://github.com/iovisor/bpftrace/pull/2763)
 
 
 ## [0.18.0] 2023-05-15

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -792,19 +792,25 @@ bool ClangParser::parse(ast::Program *program, BPFtrace &bpftrace, std::vector<s
 }
 
 /*
- * Parse the given Clang diagnostics message and if it has the form:
+ * Parse the given Clang diagnostics message and if it has one of the forms:
  *   unknown type name 'type_t'
+ *   use of undeclared identifier 'type_t'
  * return type_t.
  */
 std::optional<std::string> ClangParser::ClangParser::get_unknown_type(
     const std::string &diagnostic_msg)
 {
-  const std::string unknown_type_msg = "unknown type name \'";
-  if (diagnostic_msg.find(unknown_type_msg) == 0)
+  const std::vector<std::string> unknown_type_msgs = {
+    "unknown type name \'", "use of undeclared identifier \'"
+  };
+  for (auto &unknown_type_msg : unknown_type_msgs)
   {
-    return diagnostic_msg.substr(unknown_type_msg.length(),
-                                 diagnostic_msg.length() -
-                                     unknown_type_msg.length() - 1);
+    if (diagnostic_msg.find(unknown_type_msg) == 0)
+    {
+      return diagnostic_msg.substr(unknown_type_msg.length(),
+                                   diagnostic_msg.length() -
+                                       unknown_type_msg.length() - 1);
+    }
   }
   return {};
 }


### PR DESCRIPTION
- GitHub Actions runners seem to have updated kernel and the old version of `biosnoop.bt` is no longer necessary. 
Unfortunately, it looks like this is the case for some runners only, so we cannot universally use neither the old nor the new variant. Let's disable the test for now and revisit later when all runners are updated.

- We're also observing CI failure in `memleak-test.sh`. It's not related to the memleak test itself, the bug is in `ClangParser` which one of the memleak tests executes:

        # cat script.bt
        #include <linux/skbuff.h>
        BEGIN {}
    
        # bpftrace script.bt
        [...]
        /lib/modules/[...]/ibt.h:71:10: error: use of undeclared identifier 'true'
        [...]
        /lib/modules/[...]/le.h:36:2: error: use of undeclared identifier 'uintptr_t'
    
  This is fixed by improving our parsing of undefined typedefs from Clang diagnostic messages to be able to pull those typedefs from BTF.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
