### PR TITLE
Fix USDT run_time test targeting all pids

### DIFF
--- a/.github/workflows/embedded.yml
+++ b/.github/workflows/embedded.yml
@@ -21,7 +21,7 @@ jobs:
           EMBED_BUILD_LLVM: OFF
           EMBED_USE_LLVM: ON
           RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process
+          RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size,usdt.usdt probes - file based semaphore activation multi process,usdt.usdt probes - attach to fully specified probe all pids
           TOOLS_TEST_OLDVERSION: tcpdrop.bt
           TOOLS_TEST_DISABLE: biosnoop.bt
           BASE: bionic
@@ -36,7 +36,7 @@ jobs:
           EMBED_BUILD_LLVM: OFF
           EMBED_USE_LLVM: ON
           RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size,other.string compare map lookup,call.skboutput,usdt.usdt probes - file based semaphore activation multi process
+          RUNTIME_TEST_DISABLE: builtin.cgroup,probe.kprobe_offset_fail_size,other.string compare map lookup,call.skboutput,usdt.usdt probes - file based semaphore activation multi process,usdt.usdt probes - attach to fully specified probe all pids
           TOOLS_TEST_OLDVERSION: tcpdrop.bt
           TOOLS_TEST_DISABLE: biosnoop.bt
           BASE: focal
@@ -50,7 +50,7 @@ jobs:
           STATIC_LIBC: ON
           EMBED_BUILD_LLVM: OFF
           RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: json-output.join_delim,other.string compare map lookup,probe.kprobe_offset_fail_size,probe.uprobe_library,usdt.usdt probes - attach to fully specified probe of child,usdt.usdt probes - all probes by wildcard and file with child,usdt.usdt probes - attach to probe by wildcard and file with child,usdt.usdt probes - attach to probes by wildcard file with child,usdt.usdt probes - attach to probe on multiple files by wildcard,usdt.usdt probes - attach to probe with probe builtin and args by file with child,usdt.usdt probes - list probes by pid in separate mountns,usdt.usdt sized arguments,usdt.usdt - list probes by file with wildcarded probe type,uprobe.uprobes - list probes by pid; uprobes only,uprobe.uprobes - list probes by pid in separate mount namespace,other.positional pointer arithmetics,call.skboutput,usdt.usdt probes - file based semaphore activation multi process,probe.uprobe_zero_size,probe.uprobe_zero_size_unsafe
+          RUNTIME_TEST_DISABLE: json-output.join_delim,other.string compare map lookup,probe.kprobe_offset_fail_size,probe.uprobe_library,usdt.usdt probes - attach to fully specified probe of child,usdt.usdt probes - all probes by wildcard and file with child,usdt.usdt probes - attach to probe by wildcard and file with child,usdt.usdt probes - attach to probes by wildcard file with child,usdt.usdt probes - attach to probe on multiple files by wildcard,usdt.usdt probes - attach to probe with probe builtin and args by file with child,usdt.usdt probes - list probes by pid in separate mountns,usdt.usdt sized arguments,usdt.usdt - list probes by file with wildcarded probe type,usdt.usdt probes - attach to fully specified probe all pids,uprobe.uprobes - list probes by pid; uprobes only,uprobe.uprobes - list probes by pid in separate mount namespace,other.positional pointer arithmetics,call.skboutput,usdt.usdt probes - file based semaphore activation multi process,probe.uprobe_zero_size,probe.uprobe_zero_size_unsafe
           TOOLS_TEST_DISABLE: biosnoop.bt,gethostlatency.bt,threadsnoop.bt,ssllatency.bt,sslsnoop.bt
           TOOLS_TEST_OLDVERSION: tcpdrop.bt
           BASE: alpine
@@ -65,7 +65,7 @@ jobs:
           STATIC_LIBC: ON
           EMBED_BUILD_LLVM: OFF
           RUN_ALL_TESTS: 1
-          RUNTIME_TEST_DISABLE: other.string compare map lookup,probe.kprobe_offset_fail_size,probe.uprobe_library,usdt.usdt probes - attach to fully specified probe of child,usdt.usdt probes - all probes by wildcard and file with child,usdt.usdt probes - attach to probe by wildcard and file with child,usdt.usdt probes - attach to probes by wildcard file with child,usdt.usdt probes - attach to probe on multiple files by wildcard,usdt.usdt probes - attach to probe with probe builtin and args by file with child,usdt.usdt probes - list probes by pid in separate mountns,usdt.usdt sized arguments,usdt.usdt - list probes by file with wildcarded probe type,uprobe.uprobes - list probes by pid; uprobes only,uprobe.uprobes - list probes by pid in separate mount namespace,other.positional pointer arithmetics,call.skboutput,usdt.usdt probes - file based semaphore activation multi process,probe.uprobe_zero_size,probe.uprobe_zero_size_unsafe
+          RUNTIME_TEST_DISABLE: other.string compare map lookup,probe.kprobe_offset_fail_size,probe.uprobe_library,usdt.usdt probes - attach to fully specified probe of child,usdt.usdt probes - all probes by wildcard and file with child,usdt.usdt probes - attach to probe by wildcard and file with child,usdt.usdt probes - attach to probes by wildcard file with child,usdt.usdt probes - attach to probe on multiple files by wildcard,usdt.usdt probes - attach to probe with probe builtin and args by file with child,usdt.usdt probes - list probes by pid in separate mountns,usdt.usdt sized arguments,usdt.usdt - list probes by file with wildcarded probe type,usdt.usdt probes - attach to fully specified probe all pids,uprobe.uprobes - list probes by pid; uprobes only,uprobe.uprobes - list probes by pid in separate mount namespace,other.positional pointer arithmetics,call.skboutput,usdt.usdt probes - file based semaphore activation multi process,probe.uprobe_zero_size,probe.uprobe_zero_size_unsafe
           TOOLS_TEST_DISABLE: biosnoop.bt,gethostlatency.bt,threadsnoop.bt,ssllatency.bt,sslsnoop.bt
           TOOLS_TEST_OLDVERSION: tcpdrop.bt
           BASE: alpine

--- a/flake.nix
+++ b/flake.nix
@@ -116,6 +116,7 @@
                   procps
                   python3
                   strace
+                  util-linux
                 ];
               };
         in

--- a/tests/README.md
+++ b/tests/README.md
@@ -80,6 +80,9 @@ Each runtime testcase consists of multiple directives. In no particular order:
   built in. See `bpftrace --info` and `runtime/engine/runner.py` for more
   details. Also supports negative features (by prefixing `!` before feature).
 * `WILL_FAIL`: Mark that this test case will exit uncleanly (ie exit code != 0)
+* `NEW_PIDNS`: This will excute the `BEFORE`, the bpftrace (`RUN` or `PROG`),
+  and the `AFTER` commands in a new pid namespace that mounts proc. At least one
+  `BEFORE` is required.
 
 If you need to run a test program to probe (eg, uprobe/USDT), you can use the
 `BEFORE` clause. The test scripts will wait for the test program to have a pid.

--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -36,7 +36,8 @@ TestStruct = namedtuple(
         'arch',
         'feature_requirement',
         'neg_feature_requirement',
-        'will_fail'
+        'will_fail',
+        'new_pidns'
     ],
 )
 
@@ -113,6 +114,7 @@ class TestParser(object):
         feature_requirement = set()
         neg_feature_requirement = set()
         will_fail = False
+        new_pidns = False
 
         for item in test:
             item_split = item.split()
@@ -181,6 +183,8 @@ class TestParser(object):
                     raise UnknownFieldError('%s is invalid for REQUIRES_FEATURE. Suite: %s' % (','.join(unknown), test_suite))
             elif item_name == "WILL_FAIL":
                 will_fail = True
+            elif item_name == "NEW_PIDNS":
+                new_pidns = True
             else:
                 raise UnknownFieldError('Field %s is unknown. Suite: %s' % (item_name, test_suite))
 
@@ -212,4 +216,5 @@ class TestParser(object):
             arch,
             feature_requirement,
             neg_feature_requirement,
-            will_fail)
+            will_fail,
+            new_pidns)

--- a/tests/runtime/usdt
+++ b/tests/runtime/usdt
@@ -85,9 +85,8 @@ NAME usdt probes - attach to fully specified probe all pids
 RUN {{BPFTRACE}} -e 'usdt:*:tracetest:testprobe { printf("here\n" ); exit(); }'
 EXPECT here
 BEFORE ./testprogs/usdt_test
-REQUIRES ./testprogs/usdt_test should_not_skip
-TIMEOUT 20
-# USDT discovery on the whole host might take longer
+TIMEOUT 5
+NEW_PIDNS
 
 NAME usdt probes - attach to fully specified library probe by pid
 RUN {{BPFTRACE}} -e 'usdt:./testlibs/libusdt_tp.so:tracetestlib:lib_probe_1 { printf("here\n" ); exit(); }' -p $(pidof usdt_lib)


### PR DESCRIPTION
This creates a new pid namespace (and mounts proc) to run bpftrace inside of this namespace.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
