### PR TITLE
update embedded-llvm to LLVM15+

### DIFF
--- a/cmake/embed/embed_clang.cmake
+++ b/cmake/embed/embed_clang.cmake
@@ -11,11 +11,21 @@ else()
   set(EMBEDDED_BUILD_TYPE ${CMAKE_BUILD_TYPE})
 endif()
 
+set(CLANG_CMAKE_MODULES false)
 if(${LLVM_VERSION} VERSION_EQUAL "12.0.0")
-  set(CLANG_DOWNLOAD_URL "https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/clang-${LLVM_VERSION}.src.tar.xz")
   set(CLANG_URL_CHECKSUM "SHA256=e26e452e91d4542da3ebbf404f024d3e1cbf103f4cd110c26bf0a19621cca9ed")
+elseif(${LLVM_VERSION} VERSION_EQUAL "15.0.7")
+  set(CLANG_URL_CHECKSUM "SHA256=a6b673ef15377fb46062d164e8ddc4d05c348ff8968f015f7f4af03f51000067")
+
+  set(CLANG_CMAKE_MODULES true)
+  set(CLANG_CMAKE_MODULES_CHECKSUM "SHA256=8986f29b634fdaa9862eedda78513969fe9788301c9f2d938f4c10a3e7a3e7ea")
 else()
   message(FATAL_ERROR "No supported LLVM version has been specified with LLVM_VERSION (${EMBED_LLVM_VERSION}), aborting")
+endif()
+
+set(CLANG_DOWNLOAD_URL "https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_VERSION}/clang-${LLVM_VERSION}.src.tar.xz")
+if(CLANG_CMAKE_MODULES)
+  set(CLANG_CMAKE_MODULES_DOWNLOAD_URL "https://github.com/llvm/llvm-project/releases/download/llvmorg-${LLVM_FULL_VERSION}/cmake-${LLVM_FULL_VERSION}.src.tar.xz")
 endif()
 
 ProcessorCount(nproc)
@@ -47,7 +57,15 @@ set(CLANG_LIBRARY_TARGETS
     clangToolingInclusions
     )
 
+
 if(${EMBED_LLVM_VERSION} VERSION_EQUAL "12")
+  # clangTesting is no longer exported: https://discourse.llvm.org/t/stop-exporting-clangtesting-library/61672
+  set(CLANG_LIBRARY_TARGETS ${CLANG_LIBRARY_TARGETS}
+      clangTesting
+    )
+endif()
+
+if(${EMBED_LLVM_VERSION} VERSION_GREATER_EQUAL "12")
   set(CLANG_LIBRARY_TARGETS ${CLANG_LIBRARY_TARGETS}
       clangAPINotes # 12
       clangARCMigrate
@@ -65,12 +83,18 @@ if(${EMBED_LLVM_VERSION} VERSION_EQUAL "12")
       clangStaticAnalyzerCheckers
       clangStaticAnalyzerCore
       clangStaticAnalyzerFrontend
-      clangTesting
       clangTooling
       clangToolingASTDiff
       clangToolingRefactoring
       clangToolingSyntax
       clangTransformer
+    )
+endif()
+
+if(${EMBED_LLVM_VERSION} VERSION_EQUAL "15")
+  # clangTesting is no longer exported: https://discourse.llvm.org/t/stop-exporting-clangtesting-library/61672
+  set(CLANG_LIBRARY_TARGETS ${CLANG_LIBRARY_TARGETS}
+      clangSupport
     )
 endif()
 
@@ -101,6 +125,19 @@ if(EMBED_BUILD_LLVM)
   foreach(clang_target IN LISTS CLANG_LIBRARY_TARGETS)
     list(APPEND CLANG_TARGET_LIBS "<INSTALL_DIR>/lib/lib${clang_target}.a")
   endforeach(clang_target)
+
+  if(CLANG_CMAKE_MODULES)
+    include(FetchContent)
+
+    FetchContent_Declare(embedded_clang_cmake_modules
+      URL "${CLANG_CMAKE_MODULES_DOWNLOAD_URL}"
+      URL_HASH "${CLANG_CMAKE_MODULES_CHECKSUM}"
+    )
+    FetchContent_Populate(embedded_clang_cmake_modules)
+
+    list(APPEND CLANG_CONFIGURE_FLAGS
+         -DCMAKE_MODULE_PATH=${embedded_clang_cmake_modules_SOURCE_DIR}/Modules)
+  endif()
 
   ExternalProject_Add(embedded_clang
     URL "${CLANG_DOWNLOAD_URL}"

--- a/docker/Dockerfile.llvm
+++ b/docker/Dockerfile.llvm
@@ -1,7 +1,6 @@
 ARG BASE=bionic
 FROM ubuntu:${BASE}
 
-ARG BASE
 ARG LLVM_VERSION
 ARG BUILD_TYPE="Release"
 


### PR DESCRIPTION
bpftrace 0.16 with embedded LLVM12 produces strange crashes when trying unfold complex data structures such as network headers:
```
#0  0x0000555556d9f65a in llvm::cast_retty<llvm::ConstantSDNode, llvm::SDValue>::ret_type llvm::dyn_cast<llvm::ConstantSDNode, llvm::SDValue>(llvm::SDValue&) ()
#1  0x0000555556dec2ec in llvm::SelectionDAG::getNode(unsigned int, llvm::SDLoc const&, llvm::EVT, llvm::SDValue, llvm::SDValue, llvm::SDNodeFlags) ()
#2  0x0000555556ded4eb in llvm::SelectionDAG::getNode(unsigned int, llvm::SDLoc const&, llvm::EVT, llvm::SDValue, llvm::SDValue) ()
#3  0x0000555556f0bf2f in llvm::DAGTypeLegalizer::PromoteIntRes_SimpleIntBinOp(llvm::SDNode*) ()
#4  0x0000555556f12609 in llvm::DAGTypeLegalizer::PromoteIntegerResult(llvm::SDNode*, unsigned int) ()
#5  0x0000555556eb6c97 in llvm::DAGTypeLegalizer::run() ()
#6  0x0000555556eb7014 in llvm::SelectionDAG::LegalizeTypes() ()
#7  0x0000555556dffaa0 in llvm::SelectionDAGISel::CodeGenAndEmitDAG() ()
#8  0x0000555556e02475 in llvm::SelectionDAGISel::SelectAllBasicBlocks(llvm::Function const&) ()
#9  0x0000555556e02c5f in llvm::SelectionDAGISel::runOnMachineFunction(llvm::MachineFunction&) ()
#10 0x00005555567dbbda in llvm::MachineFunctionPass::runOnFunction(llvm::Function&) [clone .part.45] ()
#11 0x0000555556a38625 in llvm::FPPassManager::runOnFunction(llvm::Function&) ()
#12 0x0000555556a38b27 in llvm::FPPassManager::runOnModule(llvm::Module&) ()
#13 0x0000555556a380eb in llvm::legacy::PassManagerImpl::run(llvm::Module&) ()
#14 0x0000555556c52069 in llvm::orc::SimpleCompiler::operator()(llvm::Module&) ()
#15 0x0000555556c68283 in llvm::orc::IRCompileLayer::emit(std::unique_ptr<llvm::orc::MaterializationResponsibility, std::default_delete<llvm::orc::MaterializationResponsibility> >, llvm::orc::ThreadSafeModule) ()
#16 0x0000555556c6ac2d in llvm::orc::BasicIRLayerMaterializationUnit::materialize(std::unique_ptr<llvm::orc::MaterializationResponsibility, std::default_delete<llvm::orc::MaterializationResponsibility> >) ()
#17 0x0000555556c5e91b in llvm::orc::ExecutionSession::materializeOnCurrentThread(std::unique_ptr<llvm::orc::MaterializationUnit, std::default_delete<llvm::orc::MaterializationUnit> >, std::unique_ptr<llvm::orc::MaterializationResponsibility, std::default_delete<llvm::orc::MaterializationResponsibility> >) ()
#18 0x0000555556c5e99d in std::_Function_handler<void (std::unique_ptr<llvm::orc::MaterializationUnit, std::default_delete<llvm::orc::MaterializationUnit> >, std::unique_ptr<llvm::orc::MaterializationResponsibility, std::default_delete<llvm::orc::MaterializationResponsibility> >), void (*)(std::unique_ptr<llvm::orc::MaterializationUnit, std::default_delete<llvm::orc::MaterializationUnit> >, std::unique_ptr<llvm::orc::MaterializationResponsibility, std::default_delete<llvm::orc::MaterializationResponsibility> >)>::_M_invoke(std::_Any_data const&, std::unique_ptr<llvm::orc::MaterializationUnit, std::default_delete<llvm::orc::MaterializationUnit> >&&, std::unique_ptr<llvm::orc::MaterializationResponsibility, std::default_delete<llvm::orc::MaterializationResponsibility> >&&) ()
#19 0x0000555556c5e89f in llvm::orc::ExecutionSession::dispatchMaterialization(std::unique_ptr<llvm::orc::MaterializationUnit, std::default_delete<llvm::orc::MaterializationUnit> >, std::unique_ptr<llvm::orc::MaterializationResponsibility, std::default_delete<llvm::orc::MaterializationResponsibility> >) ()
#20 0x0000555556c5ebf5 in llvm::orc::ExecutionSession::dispatchOutstandingMUs() ()
#21 0x0000555556c671ba in llvm::orc::ExecutionSession::OL_completeLookup(std::unique_ptr<llvm::orc::InProgressLookupState, std::default_delete<llvm::orc::InProgressLookupState> >, std::shared_ptr<llvm::orc::AsynchronousSymbolQuery>, std::function<void (llvm::DenseMap<llvm::orc::JITDylib*, llvm::DenseSet<llvm::orc::SymbolStringPtr, llvm::DenseMapInfo<llvm::orc::SymbolStringPtr> >, llvm::DenseMapInfo<llvm::orc::JITDylib*>, llvm::detail::DenseMapPair<llvm::orc::JITDylib*, llvm::DenseSet<llvm::orc::SymbolStringPtr, llvm::DenseMapInfo<llvm::orc::SymbolStringPtr> > > > const&)>) ()
#22 0x0000555556c672de in llvm::orc::InProgressFullLookupState::complete(std::unique_ptr<llvm::orc::InProgressLookupState, std::default_delete<llvm::orc::InProgressLookupState> >) ()
#23 0x0000555556c5bd8a in llvm::orc::ExecutionSession::OL_applyQueryPhase1(std::unique_ptr<llvm::orc::InProgressLookupState, std::default_delete<llvm::orc::InProgressLookupState> >, llvm::Error) ()
#24 0x0000555556c5edca in llvm::orc::ExecutionSession::lookup(llvm::orc::LookupKind, std::vector<std::pair<llvm::orc::JITDylib*, llvm::orc::JITDylibLookupFlags>, std::allocator<std::pair<llvm::orc::JITDylib*, llvm::orc::JITDylibLookupFlags> > > const&, llvm::orc::SymbolLookupSet, llvm::orc::SymbolState, llvm::unique_function<void (llvm::Expected<llvm::DenseMap<llvm::orc::SymbolStringPtr, llvm::JITEvaluatedSymbol, llvm::DenseMapInfo<llvm::orc::SymbolStringPtr>, llvm::detail::DenseMapPair<llvm::orc::SymbolStringPtr, llvm::JITEvaluatedSymbol> > >)>, std::function<void (llvm::DenseMap<llvm::orc::JITDylib*, llvm::DenseSet<llvm::orc::SymbolStringPtr, llvm::DenseMapInfo<llvm::orc::SymbolStringPtr> >, llvm::DenseMapInfo<llvm::orc::JITDylib*>, llvm::detail::DenseMapPair<llvm::orc::JITDylib*, llvm::DenseSet<llvm::orc::SymbolStringPtr, llvm::DenseMapInfo<llvm::orc::SymbolStringPtr> > > > const&)>) ()
#25 0x0000555556c5f418 in llvm::orc::ExecutionSession::lookup(std::vector<std::pair<llvm::orc::JITDylib*, llvm::orc::JITDylibLookupFlags>, std::allocator<std::pair<llvm::orc::JITDylib*, llvm::orc::JITDylibLookupFlags> > > const&, llvm::orc::SymbolLookupSet const&, llvm::orc::LookupKind, llvm::orc::SymbolState, std::function<void (llvm::DenseMap<llvm::orc::JITDylib*, llvm::Den--Type <RET> for more, q to quit, c to continue without paging--
seSet<llvm::orc::SymbolStringPtr, llvm::DenseMapInfo<llvm::orc::SymbolStringPtr> >, llvm::DenseMapInfo<llvm::orc::JITDylib*>, llvm::detail::DenseMapPair<llvm::orc::JITDylib*, llvm::DenseSet<llvm::orc::SymbolStringPtr, llvm::DenseMapInfo<llvm::orc::SymbolStringPtr> > > > const&)>) ()
#26 0x0000555556c5f73c in llvm::orc::ExecutionSession::lookup(std::vector<std::pair<llvm::orc::JITDylib*, llvm::orc::JITDylibLookupFlags>, std::allocator<std::pair<llvm::orc::JITDylib*, llvm::orc::JITDylibLookupFlags> > > const&, llvm::orc::SymbolStringPtr, llvm::orc::SymbolState) ()
#27 0x0000555556c5f958 in llvm::orc::ExecutionSession::lookup(llvm::ArrayRef<llvm::orc::JITDylib*>, llvm::orc::SymbolStringPtr, llvm::orc::SymbolState) ()


#28 0x0000555555d5a9c1 in bpftrace::BpfOrc::lookup (this=0x7ffff0935fc0, Name=...) at /bpftrace/src/ast/bpforc/bpforc.h:162
#29 0x0000555555d4c691 in bpftrace::ast::CodegenLLVM::<lambda(const string&)>::operator()(const std::__cxx11::string &) const (__closure=0x7fffffffcf50, s=...)
    at /bpftrace/src/ast/passes/codegen_llvm.cpp:3323
#30 0x0000555555d4c90f in bpftrace::ast::CodegenLLVM::emit (this=0x7fffffffd8e0) at /bpftrace/src/ast/passes/codegen_llvm.cpp:3333
#31 0x0000555555a4495a in main (argc=2, argv=0x7fffffffe378) at /bpftrace/src/main.cpp:935
```

THis commit adds support for embedded LLVM15 builds which seems to fix the issue. Note that CMake modules  are now packaged separately.
