### PR TITLE
Add jiffies builtin with bpf_jiffies64

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 ## Unreleased
 
 #### Added
+- Add a `jiffies` builtin for advanced usages
+  - [#2769](https://github.com/iovisor/bpftrace/pull/2769)
 #### Changed
 #### Deprecated
 #### Removed

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1943,6 +1943,7 @@ NetworkManager:1155 /var/lib/sss/mc/passwd (deleted)
 - `uid` - User ID
 - `gid` - Group ID
 - `nsecs` - Nanosecond timestamp. Alias of [`nsecs()`](#36-nsecs-timestamps-and-time-deltas)
+- `jiffies` - Jiffies of the kernel. In 32-bit system, using this builtin might be slower.
 - `elapsed` - Nanoseconds since bpftrace initialization
 - `numaid` - NUMA Node ID
 - `cpu` - Processor ID

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1045,6 +1045,12 @@ For string arguments use the `str()` call to retrieve the value.
 | ktime_get_ns / ktime_get_boot_ns
 | nanoseconds since kernel boot. On kernels that support `ktime_get_boot_ns` this includes the time spent suspended, on older kernels it does not.
 
+| jiffies
+| uint64
+| 5.9
+| get_jiffies_64
+| Jiffies of the kernel. In 32-bit system, using this builtin might be slower.
+
 | pid
 | uint64
 | 4.2

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -999,6 +999,15 @@ CallInst *IRBuilderBPF::CreateGetNs(TimestampMode ts, const location &loc)
   return CreateHelperCall(fn, gettime_func_type, {}, "get_ns", &loc);
 }
 
+CallInst *IRBuilderBPF::CreateJiffies64(const location &loc)
+{
+  // u64 bpf_jiffies64()
+  // Return: jiffies (BITS_PER_LONG == 64) or jiffies_64 (otherwise)
+  FunctionType *jiffies64_func_type = FunctionType::get(getInt64Ty(), false);
+  return CreateHelperCall(
+      libbpf::BPF_FUNC_jiffies64, jiffies64_func_type, {}, "jiffies64", &loc);
+}
+
 Value *IRBuilderBPF::CreateIntegerArrayCmpUnrolled(Value *ctx,
                                                    Value *val1,
                                                    Value *val2,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -160,6 +160,7 @@ public:
                                const location &loc,
                                MDNode *metadata);
   CallInst *CreateGetNs(TimestampMode ts, const location &loc);
+  CallInst *CreateJiffies64(const location &loc);
   CallInst *CreateGetPidTgid(const location &loc);
   CallInst *CreateGetCurrentCgroupId(const location &loc);
   CallInst *CreateGetUidGid(const location &loc);

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -365,6 +365,10 @@ void CodegenLLVM::visit(Builtin &builtin)
     }
     expr_ = b_.getInt64(cpid);
   }
+  else if (builtin.ident == "jiffies")
+  {
+    expr_ = b_.CreateJiffies64(builtin.loc);
+  }
   else
   {
     LOG(FATAL) << "unknown builtin \"" << builtin.ident << "\"";

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -305,7 +305,8 @@ void SemanticAnalyser::visit(Builtin &builtin)
            builtin.ident == "pid" || builtin.ident == "tid" ||
            builtin.ident == "cgroup" || builtin.ident == "uid" ||
            builtin.ident == "gid" || builtin.ident == "cpu" ||
-           builtin.ident == "rand" || builtin.ident == "numaid")
+           builtin.ident == "rand" || builtin.ident == "numaid" ||
+           builtin.ident == "jiffies")
   {
     builtin.type = CreateUInt64();
     if (builtin.ident == "cgroup" &&
@@ -314,6 +315,12 @@ void SemanticAnalyser::visit(Builtin &builtin)
       LOG(ERROR, builtin.loc, err_)
           << "BPF_FUNC_get_current_cgroup_id is not available for your kernel "
              "version";
+    }
+    else if (builtin.ident == "jiffies" &&
+             !bpftrace_.feature_->has_helper_jiffies64())
+    {
+      LOG(ERROR, builtin.loc, err_)
+          << "BPF_FUNC_jiffies64 is not available for your kernel version";
     }
   }
   else if (builtin.ident == "curtask")

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -502,6 +502,7 @@ std::string BPFfeature::report(void)
       << "  skboutput: " << to_str(has_skb_output())
       << "  get_tai_ns: " << to_str(has_helper_ktime_get_tai_ns())
       << "  get_func_ip: " << to_str(has_helper_get_func_ip())
+      << "  jiffies64: " << to_str(has_helper_jiffies64())
 
       << std::endl;
 

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -105,6 +105,7 @@ public:
   DEFINE_HELPER_TEST(ktime_get_boot_ns, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_HELPER_TEST(ktime_get_tai_ns, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_HELPER_TEST(get_func_ip, libbpf::BPF_PROG_TYPE_TRACING);
+  DEFINE_HELPER_TEST(jiffies64, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_PROG_TEST(kprobe, libbpf::BPF_PROG_TYPE_KPROBE);
   DEFINE_PROG_TEST(tracepoint, libbpf::BPF_PROG_TYPE_TRACEPOINT);
   DEFINE_PROG_TEST(perf_event, libbpf::BPF_PROG_TYPE_PERF_EVENT);

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -37,7 +37,7 @@ hspace   [ \t]
 vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#+\*])+
-builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ctx|curtask|elapsed|func|gid|pid|probe|rand|retval|sarg[0-9]|tid|uid|username
+builtin  arg[0-9]|args|cgroup|comm|cpid|numaid|cpu|ctx|curtask|elapsed|func|gid|pid|probe|rand|retval|sarg[0-9]|tid|uid|username|jiffies
 call     avg|buf|cat|cgroupid|clear|count|delete|exit|hist|join|kaddr|kptr|ksym|lhist|macaddr|max|min|ntop|override|print|printf|cgroup_path|reg|signal|stats|str|strerror|strftime|strncmp|strcontains|sum|system|time|uaddr|uptr|usym|zero|path|unwatch|bswap|skboutput|pton|debugf
 
 int_type        bool|(u)?int(8|16|32|64)

--- a/tests/codegen/builtin_jiffies.cpp
+++ b/tests/codegen/builtin_jiffies.cpp
@@ -1,0 +1,16 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, builtin_jiffies)
+{
+  test("kprobe:f { @x = jiffies }",
+
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/builtin_jiffies.ll
+++ b/tests/codegen/llvm/builtin_jiffies.ll
@@ -1,0 +1,36 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
+entry:
+  %"@x_val" = alloca i64, align 8
+  %"@x_key" = alloca i64, align 8
+  %jiffies64 = call i64 inttoptr (i64 118 to i64 ()*)()
+  %1 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %1)
+  store i64 0, i64* %"@x_key", align 8
+  %2 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  store i64 %jiffies64, i64* %"@x_val", align 8
+  %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo, i64* %"@x_key", i64* %"@x_val", i64 0)
+  %3 = bitcast i64* %"@x_val" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %3)
+  %4 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %4)
+  ret i64 0
+}
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.start.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+; Function Attrs: argmemonly nofree nosync nounwind willreturn
+declare void @llvm.lifetime.end.p0i8(i64 immarg %0, i8* nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { argmemonly nofree nosync nounwind willreturn }

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -118,6 +118,7 @@ public:
     map_ringbuf_ = std::make_optional<bool>(has_features);
     has_ktime_get_tai_ns_ = std::make_optional<bool>(has_features);
     has_get_func_ip_ = std::make_optional<bool>(has_features);
+    has_jiffies64_ = std::make_optional<bool>(has_features);
   };
 
   void has_loop(bool has)

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -276,3 +276,10 @@ EXPECT @[{.n=0x[0-9a-f]+,.c=120}]: 1
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
+
+NAME jiffies
+PROG i:ms:1 { printf("SUCCESS %d\n", jiffies); exit(); }
+EXPECT SUCCESS -?[0-9][0-9]*
+REQUIRES_FEATURE jiffies64
+TIMEOUT 5
+MIN_KERNEL 5.9

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -19,23 +19,23 @@ EXPECT SUCCESS [0-9][0-9]*
 TIMEOUT 5
 
 NAME nsecs
-PROG i:ms:1 { printf("SUCCESS %d\n", nsecs); exit(); }
-EXPECT SUCCESS -?[0-9][0-9]*
+PROG i:ms:1 { printf("SUCCESS %llu\n", nsecs); exit(); }
+EXPECT SUCCESS [0-9]+
 TIMEOUT 5
 
 NAME elapsed
-PROG i:ms:1 { printf("SUCCESS %d\n", elapsed); exit(); }
-EXPECT SUCCESS -?[0-9][0-9]*
+PROG i:ms:1 { printf("SUCCESS %llu\n", elapsed); exit(); }
+EXPECT SUCCESS [0-9]+
 TIMEOUT 5
 
 NAME numaid
-PROG i:ms:1 { printf("SUCCESS %d\n", numaid); exit(); }
-EXPECT SUCCESS -?[0-9][0-9]*
+PROG i:ms:1 { printf("SUCCESS %lu\n", numaid); exit(); }
+EXPECT SUCCESS [0-9]+
 TIMEOUT 5
 
 NAME cpu
-PROG i:ms:1 { printf("SUCCESS %d\n", cpu); exit(); }
-EXPECT SUCCESS -?[0-9][0-9]*
+PROG i:ms:1 { printf("SUCCESS %lu\n", cpu); exit(); }
+EXPECT SUCCESS [0-9]+
 TIMEOUT 5
 
 NAME comm
@@ -57,8 +57,8 @@ TIMEOUT 5
 AFTER ./testprogs/syscall read
 
 NAME arg
-PROG k:vfs_read { printf("SUCCESS %d\n", arg0); exit(); }
-EXPECT SUCCESS -?[0-9][0-9]*
+PROG k:vfs_read { printf("SUCCESS %p\n", arg0); exit(); }
+EXPECT SUCCESS 0x[0-9a-f]+
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
@@ -143,8 +143,8 @@ TIMEOUT 5
 AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME curtask
-PROG i:ms:1 { printf("SUCCESS %d\n", curtask); exit(); }
-EXPECT SUCCESS -?[0-9][0-9]*
+PROG i:ms:1 { printf("SUCCESS %p\n", curtask); exit(); }
+EXPECT SUCCESS 0x[0-9a-f]+
 TIMEOUT 5
 
 NAME curtask_field
@@ -153,19 +153,19 @@ EXPECT SUCCESS -?[0-9][0-9]*
 TIMEOUT 5
 
 NAME rand
-PROG i:ms:1 { printf("SUCCESS %d\n", rand); exit(); }
-EXPECT SUCCESS -?[0-9][0-9]*
+PROG i:ms:1 { printf("SUCCESS %lu\n", rand); exit(); }
+EXPECT SUCCESS [0-9]+
 TIMEOUT 5
 
 NAME cgroup
-PROG i:ms:1 { printf("SUCCESS %d\n", cgroup); exit(); }
-EXPECT SUCCESS -?[0-9][0-9]*
+PROG i:ms:1 { printf("SUCCESS %llu\n", cgroup); exit(); }
+EXPECT SUCCESS [0-9]+
 TIMEOUT 5
 MIN_KERNEL 4.18
 
 NAME ctx
-PROG struct x {unsigned long x}; i:ms:1 { printf("SUCCESS %d\n", ((struct x*)ctx)->x); exit(); }
-EXPECT SUCCESS -?[0-9][0-9]*
+PROG struct x {unsigned long x}; i:ms:1 { printf("SUCCESS %lu\n", ((struct x*)ctx)->x); exit(); }
+EXPECT SUCCESS [0-9]+
 TIMEOUT 5
 
 NAME cat
@@ -278,8 +278,8 @@ TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
 NAME jiffies
-PROG i:ms:1 { printf("SUCCESS %d\n", jiffies); exit(); }
-EXPECT SUCCESS -?[0-9][0-9]*
+PROG i:ms:1 { printf("SUCCESS %llu\n", jiffies); exit(); }
+EXPECT SUCCESS [0-9]+
 REQUIRES_FEATURE jiffies64
 TIMEOUT 5
 MIN_KERNEL 5.9

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -533,28 +533,28 @@ EXPECT bpf_trace_printk: debugf 1
 TIMEOUT 3
 
 NAME nsecs
-PROG i:ms:1 { printf("SUCCESS %d\n", nsecs()); exit(); }
-EXPECT SUCCESS -?[0-9][0-9]*
+PROG i:ms:1 { printf("SUCCESS %llu\n", nsecs()); exit(); }
+EXPECT SUCCESS [0-9]+
 TIMEOUT 5
 
 NAME nsecs_monotonic
-PROG i:ms:1 { printf("SUCCESS %d\n", nsecs(monotonic)); exit(); }
-EXPECT SUCCESS -?[0-9][0-9]*
+PROG i:ms:1 { printf("SUCCESS %llu\n", nsecs(monotonic)); exit(); }
+EXPECT SUCCESS [0-9]+
 TIMEOUT 5
 
 NAME nsecs_boot
-PROG i:ms:1 { printf("SUCCESS %d\n", nsecs(boot)); exit(); }
-EXPECT SUCCESS -?[0-9][0-9]*
+PROG i:ms:1 { printf("SUCCESS %llu\n", nsecs(boot)); exit(); }
+EXPECT SUCCESS [0-9]+
 TIMEOUT 5
 
 NAME nsecs_tai
-PROG i:ms:1 { printf("SUCCESS %d\n", nsecs(tai)); exit(); }
-EXPECT SUCCESS -?[0-9][0-9]*
+PROG i:ms:1 { printf("SUCCESS %llu\n", nsecs(tai)); exit(); }
+EXPECT SUCCESS [0-9]+
 TIMEOUT 5
 REQUIRES_FEATURE get_tai_ns
 MIN_KERNEL 6.1
 
 NAME nsecs_sw_tai
-PROG i:ms:1 { printf("SUCCESS %d\n", nsecs(sw_tai)); exit(); }
-EXPECT SUCCESS -?[0-9][0-9]*
+PROG i:ms:1 { printf("SUCCESS %llu\n", nsecs(sw_tai)); exit(); }
+EXPECT SUCCESS [0-9]+
 TIMEOUT 5

--- a/tests/runtime/engine/parser.py
+++ b/tests/runtime/engine/parser.py
@@ -166,6 +166,7 @@ class TestParser(object):
                     "skboutput",
                     "get_tai_ns",
                     "get_func_ip",
+                    "jiffies64",
                 }
 
                 for f in line.split(" "):

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -134,6 +134,7 @@ class Runner(object):
         bpffeature["skboutput"] = output.find("skboutput: yes") != -1
         bpffeature["get_tai_ns"] = output.find("get_ktime_ns: yes") != -1
         bpffeature["get_func_ip"] = output.find("get_func_ip: yes") != -1
+        bpffeature["jiffies64"] = output.find("jiffies64: yes") != -1
         return bpffeature
 
     @staticmethod

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -257,8 +257,8 @@ EXPECT @: 1
 TIMEOUT 1
 
 NAME map_assign_map_ptr
-PROG i:ms:100 { @ = curtask; @a = @; printf("%d\n", @a); exit(); }
-EXPECT -?[0-9]+
+PROG i:ms:100 { @ = curtask; @a = @; printf("%p\n", @a); exit(); }
+EXPECT 0x[0-9a-f]+
 TIMEOUT 1
 
 NAME runtime_error_check_delete

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -189,9 +189,11 @@ TEST(semantic_analyser, builtin_variables)
   test("kprobe:f { probe }", 0);
   test("tracepoint:a:b { args }", 0);
   test("kprobe:f { fake }", 1);
+  test("kprobe:f { jiffies }", 0);
 
   MockBPFfeature feature(false);
   test(feature, "k:f { cgroup }", 1);
+  test(feature, "k:f { jiffies }", 1);
 }
 
 TEST(semantic_analyser, builtin_cpid)


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

Add jiffies builtin, one of the use case is to calculate the `sched_clock` indirectly within some old kernels.

Result:

```bash
bpftrace --unsafe -e 'BEGIN { system("grep jiffies: /proc/timer_list | head -1"); print(jiffies); exit() }'
Attaching 1 probe...
jiffies: 4325204698
4325204697
```

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
