### PR TITLE
Reduce visual noise in issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,14 +11,7 @@ recent version yet. Please make sure the bug reproduces on the latest release
 or master.
 -->
 
-### What reproduces the bug?
-<!--
-Enter details about your bug, preferably with a small code snippet.
+### What reproduces the bug? Provide code if possible.
 
-Also describe what you expect to happen.
--->
 
-### bpftrace --info
-<!--
-Place output here.
--->
+### `bpftrace --info` output

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -5,21 +5,10 @@ labels: enhancement
 
 ---
 
-<!--
-Please fill in as much of the template below as you're able.
--->
-
 ### Is your feature request related to a problem? Please describe.
-<!--
-Place description here
--->
+
 
 ### Describe the solution you'd like
-<!--
-Place description here
--->
+
 
 ### Describe alternative solutions or features you've considered
-<!--
-Place description here
--->


### PR DESCRIPTION
All the markdown comments create a lot of visual noise. It would be good to make it smoother for users to file new issues, as all feedback is useful.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
