### PR TITLE
Fix Invalid Strict Weak Ordering Predicate

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -659,12 +659,11 @@ std::vector<std::pair<std::string, std::string>> get_cgroup_paths(
   // Sort paths lexically by name (with the exception of unified, which always
   // comes first)
   std::sort(result.begin(), result.end(), [](auto &pair1, auto &pair2) {
+    if (pair2.first == "unified")
+      return false;
     if (pair1.first == "unified")
       return true;
-    else if (pair2.first == "unified")
-      return false;
-    else
-      return pair1.first < pair2.first;
+    return pair1.first < pair2.first;
   });
 
   return result;


### PR DESCRIPTION
This bug was highlighted in a CppCon talk about sorting today: https://cppcon2023.sched.com/event/1Qtft
The presenter (@danlark1) explicitly called out this comparator in bpftrace as an example of an invalid strict weak ordering.


Previously, cmp({"unified", 1}, {"unified", 1}) would have returned true. This is a violation of strict weak ordering's irreflexivity invariant. i.e. cmp(x, x) must be false.

This can result in out of bounds memory reads in std::sort for larger array sizes.

Strict weak ordering: https://www.boost.org/sgi/stl/StrictWeakOrdering.html

Here's an example I put together demonstrating that our old comparator would perform out of bounds reads for longer inputs: https://godbolt.org/z/ePhxea6e9

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
