### PR TITLE
tools/runqlen.bt: remove 'runnable_weight' field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
 #### Fixed
 #### Docs
 #### Tools
+- Update runqlen.bt to remove `runnable_weight` field from cfs_rq struct.
+  - [#2790](https://github.com/iovisor/bpftrace/pull/2790)
 
 ## [0.19.0] 2023-09-19
 

--- a/tools/runqlen.bt
+++ b/tools/runqlen.bt
@@ -19,7 +19,6 @@
 // your kernel version. It is from kernel/sched/sched.h:
 struct cfs_rq {
 	struct load_weight load;
-	unsigned long runnable_weight;
 	unsigned int nr_running;
 	unsigned int h_nr_running;
 };


### PR DESCRIPTION
In this commit, the 'runnable_weight' field has been removed from the 'cfs_rq' struct in runqlen.bt to align with the current  version of Linux, which no longer includes this field.

Reference to the Linux kernel commit (introduced from 5.7-rc1):

https://github.com/torvalds/linux/commit/0dacee1bfa70e171be3a12a30414c228453048d2

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->
-------------------------

This script always return 0 as runqlen even when the it is actually non-zero. 

Force run 4 processes affinitize'd to a single CPU (say, CPU 20) thereby making the runqlen of CPU 20 - 3-4.

##### Workload:

```
# taskset -c 20 stress-ng --cpu 4
stress-ng: info:  [68396] defaulting to a 1 day, 0 secs run per stressor
stress-ng: info:  [68396] dispatching hogs: 4 cpu
..
Running
```

##### Run the script while the workload is running

##### Before Patch: (value is always 0)

```
# ./tools/runqlen.bt 
Attaching 2 probes...
Sampling run queue length at 99 Hertz... Hit Ctrl-C to end.
^C

@runqlen: 
[0, 1)             60129 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
```


##### After Patch:

```
 ./tools/runqlen.bt 
Attaching 2 probes...
Sampling run queue length at 99 Hertz... Hit Ctrl-C to end.
^C

@runqlen: 
[0, 1)             57536 |@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@|
[1, 2)                 2 |                                                    |
[2, 3)                 0 |                                                    |
[3, 4)               454 |                                                    |
```



##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
