### PR TITLE
Fix JSON output for cgroup_path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
 #### Deprecated
 #### Removed
 #### Fixed
+- Fix JSON output for cgroup_path
+  - [#2793](https://github.com/iovisor/bpftrace/pull/2793)
 #### Docs
 #### Tools
 - Update runqlen.bt to remove `runnable_weight` field from cfs_rq struct.

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -11,7 +11,7 @@ bool is_quoted_type(const SizedType &ty)
 {
   return ty.IsKstackTy() || ty.IsUstackTy() || ty.IsKsymTy() || ty.IsUsymTy() ||
          ty.IsInetTy() || ty.IsUsernameTy() || ty.IsStringTy() ||
-         ty.IsBufferTy() || ty.IsProbeTy();
+         ty.IsBufferTy() || ty.IsProbeTy() || ty.IsCgroupPathTy();
 }
 } // namespace
 

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -163,3 +163,8 @@ NAME helper_error
 RUN {{BPFTRACE}} -kk -q -f json -e 'struct foo {int a;}; BEGIN { $tmp = ((struct foo*) 0)->a; exit(); }'
 EXPECT {"type": "helper_error", "helper": "probe_read", "retcode": -14, "line": 1, "col": 37}
 TIMEOUT 1
+
+NAME cgroup_path
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { print(cgroup_path(cgroup)); exit(); }' | python3 -c 'import sys,json; print(json.load(sys.stdin))'
+EXPECT ^{'type': 'value', 'data': '.*'}$
+TIMEOUT 5


### PR DESCRIPTION
As #2792 noted, for some reason, cgroup path is not surrounded by quotes in the output which poses problems for JSON parsers as it may contain JSON-reserved characters (`:`). This is strange, because the same doesn't happen with other builtins, e.g. `inet`, which also have `:` in the output.

Anyways, add surrounding quotes manually and write a test for this. The test passes the produced JSON to Python's JSON parser to see if it parses correctly. Prior to this change, the test fails.

Fixes #2792.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
