### PR TITLE
Runtime tests: mark timed-out tests in overview

### DIFF
--- a/tests/runtime/engine/main.py
+++ b/tests/runtime/engine/main.py
@@ -35,6 +35,7 @@ def main(test_filter, run_aot_tests):
         total_tests += len(suite_tests)
 
     failed_tests = []
+    timeouted_tests = []
 
 
     print(ok("[==========]") + " Running %d tests from %d test cases.\n" % (total_tests, len(test_suite)))
@@ -49,6 +50,8 @@ def main(test_filter, run_aot_tests):
                 skipped_tests.append((fname, test, status))
             if Runner.failed(status):
                 failed_tests.append("%s.%s" % (fname, test.name))
+            if Runner.timeouted(status):
+                timeouted_tests.append("%s.%s" % (fname, test.name))
         # TODO(mmarchini) elapsed time per test suite and per test (like gtest)
         print(ok("[----------]") + " %d tests from %s\n" % (len(tests), fname))
     elapsed = time.time() - start_time
@@ -63,10 +66,12 @@ def main(test_filter, run_aot_tests):
         for test_suite, test, status in skipped_tests:
             print(warn("[   SKIP   ]") + " %s.%s (%s)" % (test_suite, test.name, Runner.skip_reason(test, status)))
 
-    if failed_tests:
-        print(fail("[  FAILED  ]") + " %d tests, listed below:" % len(failed_tests))
+    if failed_tests or timeouted_tests:
+        print(fail("[  FAILED  ]") + " %d tests, listed below:" % (len(failed_tests) + len(timeouted_tests)))
         for failed_test in failed_tests:
             print(fail("[  FAILED  ]") + " %s" % failed_test)
+        for timeouted_test in timeouted_tests:
+            print(fail("[  TIMEOUT ]") + " %s" % timeouted_test)
 
     if failed_tests:
         exit(1)

--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -50,7 +50,11 @@ class Runner(object):
 
     @staticmethod
     def failed(status):
-        return status in [Runner.FAIL, Runner.TIMEOUT]
+        return status == Runner.FAIL
+
+    @staticmethod
+    def timeouted(status):
+        return status == Runner.TIMEOUT
 
     @staticmethod
     def skipped(status):


### PR DESCRIPTION
Runtime tests engine lists all the failed at the end of the test run. This is useful, however, both the tests which timed-out and the tests which legitimately failed have the same annotation `[  FAILED  ]`.

Change the behaviour and properly mark timed-out tests. This can be useful to quickly spot that all failed tests are time-outs (e.g. b/c the system was under heavy load) and restart will probably be sufficient.

Before:

    [  FAILED  ] 2 tests, listed below:
    [  FAILED  ] dwarf.struct field array
    [  FAILED  ] dwarf.struct field string

Now:

    [  FAILED  ] 2 tests, listed below:
    [  TIMEOUT ] dwarf.struct field array
    [  TIMEOUT ] dwarf.struct field string

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
