### PR TITLE
Load `/sys/kernel/tracing/available_filter_functions` lazily (and speedup tests)

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -2525,13 +2525,22 @@ std::optional<int64_t> BPFtrace::get_int_literal(
   return std::nullopt;
 }
 
+const FuncsModulesMap &BPFtrace::get_traceable_funcs() const
+{
+  if (traceable_funcs_.empty())
+    traceable_funcs_ = parse_traceable_funcs();
+
+  return traceable_funcs_;
+}
+
 bool BPFtrace::is_traceable_func(const std::string &func_name) const
 {
 #ifdef FUZZ
   (void)func_name;
   return true;
 #else
-  return traceable_funcs_.find(func_name) != traceable_funcs_.end();
+  auto &funcs = get_traceable_funcs();
+  return funcs.find(func_name) != funcs.end();
 #endif
 }
 
@@ -2542,9 +2551,9 @@ std::unordered_set<std::string> BPFtrace::get_func_modules(
   (void)func_name;
   return {};
 #else
-  auto mod = traceable_funcs_.find(func_name);
-  return mod != traceable_funcs_.end() ? mod->second
-                                       : std::unordered_set<std::string>();
+  auto &funcs = get_traceable_funcs();
+  auto mod = funcs.find(func_name);
+  return mod != funcs.end() ? mod->second : std::unordered_set<std::string>();
 #endif
 }
 

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -95,8 +95,7 @@ class BPFtrace
 {
 public:
   BPFtrace(std::unique_ptr<Output> o = std::make_unique<TextOutput>(std::cout))
-      : traceable_funcs_(get_traceable_funcs()),
-        out_(std::move(o)),
+      : out_(std::move(o)),
         feature_(std::make_unique<BPFfeature>()),
         probe_matcher_(std::make_unique<ProbeMatcher>(this)),
         ncpus_(get_possible_cpus().size())
@@ -180,8 +179,7 @@ public:
   std::map<std::string, std::string> macros_;
   std::map<std::string, uint64_t> enums_;
   std::map<libbpf::bpf_func_id, location> helper_use_loc_;
-  // mapping traceable functions to modules (or "vmlinux") that they appear in
-  FuncsModulesMap traceable_funcs_;
+  const FuncsModulesMap &get_traceable_funcs() const;
   KConfig kconfig;
   std::vector<std::unique_ptr<AttachedProbe>> attached_probes_;
 
@@ -284,6 +282,11 @@ private:
   int epollfd_ = -1;
   struct ring_buffer *ringbuf_ = nullptr;
   uint64_t ringbuf_loss_count_ = 0;
+
+  // Mapping traceable functions to modules (or "vmlinux") they appear in.
+  // Needs to be mutable to allow lazy loading of the mapping from const lookup
+  // functions.
+  mutable FuncsModulesMap traceable_funcs_;
 
   std::unordered_map<std::string, std::unique_ptr<Dwarf>> dwarves_;
 };

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -431,7 +431,7 @@ Struct BTF::resolve_args(const std::string &func, bool ret)
 
   if (bpftrace_ && !bpftrace_->is_traceable_func(func))
   {
-    if (bpftrace_->traceable_funcs_.empty())
+    if (bpftrace_->get_traceable_funcs().empty())
       throw std::runtime_error("could not read traceable functions from " +
                                tracefs::available_filter_functions() +
                                " (is tracefs mounted?)");

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -252,7 +252,7 @@ std::unique_ptr<std::istream> ProbeMatcher::get_symbols_from_traceable_funcs(
     void) const
 {
   std::string funcs;
-  for (auto& func_mod : bpftrace_->traceable_funcs_)
+  for (auto& func_mod : bpftrace_->get_traceable_funcs())
   {
     if (func_mod.second.empty() || *func_mod.second.begin() == "vmlinux")
     {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1149,7 +1149,7 @@ std::string hex_format_buffer(const char *buf,
   return std::string(s);
 }
 
-FuncsModulesMap get_traceable_funcs()
+FuncsModulesMap parse_traceable_funcs()
 {
 #ifdef FUZZ
   return {};

--- a/src/utils.h
+++ b/src/utils.h
@@ -191,7 +191,7 @@ std::vector<std::pair<std::string, std::string>> get_cgroup_hierarchy_roots();
 std::vector<std::pair<std::string, std::string>> get_cgroup_paths(
     uint64_t cgroupid,
     std::string filter);
-FuncsModulesMap get_traceable_funcs();
+FuncsModulesMap parse_traceable_funcs();
 const std::string &is_deprecated(const std::string &str);
 bool is_unsafe_func(const std::string &func_name);
 bool is_compile_time_func(const std::string &func_name);

--- a/tests/runtime/engine/main.py
+++ b/tests/runtime/engine/main.py
@@ -2,6 +2,7 @@
 
 import argparse
 from datetime import timedelta
+import math
 import os
 import re
 import time
@@ -57,8 +58,7 @@ def main(test_filter, run_aot_tests):
     elapsed = time.time() - start_time
     total_tests -= len(skipped_tests)
 
-    # TODO(mmarchini) pretty print time
-    print(ok("[==========]") + " %d tests from %d test cases ran. (%s total)" % (total_tests, len(test_suite), elapsed))
+    print(ok("[==========]") + " %d tests from %d test cases ran. (%s ms total)" % (total_tests, len(test_suite), math.ceil(elapsed * 1000)))
     print(ok("[  PASSED  ]") + " %d tests." % (total_tests - len(failed_tests)))
 
     if skipped_tests:


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

I was wondering why unit tests are taking so long. After a bit of profiling, I discovered that most of the time is spent in reading `/sys/kernel/tracing/available_filter_functions`. The file is parsed in the `BPFtrace` constructor which is not strictly necessary, b/c we need to query the list for certain probe types only (and almost never in unit tests).

This changes the approach to read the list lazily by creating a wrapper for accessing `BPFtrace::traceable_functions_` which only loads the list when accessed for the first time.

The speedup is huge, especially in unit tests. See below for numbers on my local setup.

Before:
    
    Unit tests:
    [==========] 410 tests from 22 test suites ran. (852498 ms total)
    Runtime tests:
    [==========] 554 tests from 26 test cases ran. (528572 ms total)

After:

    Unit tests:
    [==========] 410 tests from 22 test suites ran. (41140 ms total)
    Runtime tests:
    [==========] 554 tests from 26 test cases ran. (301417 ms total)

The PR also contains a patch to pretty-print elapsed time of runtime tests.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
