### PR TITLE
elf_parser: Fix invalid-null-argument

### DIFF
--- a/src/ast/elf_parser.cpp
+++ b/src/ast/elf_parser.cpp
@@ -38,7 +38,7 @@ BpfBytecode parseBpfBytecodeFromElfObject(void *const elf)
     std::vector<uint8_t> data;
     data.resize(shdr->sh_size);
 
-    if (shdr->sh_type != SHT_NOBITS)
+    if (shdr->sh_size && shdr->sh_type != SHT_NOBITS)
     {
       // NOBITS sections occupy no size on disk but take up size in
       // memory. Copy the file data for all other sections.


### PR DESCRIPTION
When running
```
bpftrace -e 'kprobe:do_nanosleep { printf("PID %d sleeping...\n", pid);
```
with ASAN enabled, it was failing asan with `UndefinedBehaviorSanitizer: invalid-null-argument`:

```
src/ast/elf_parser.cpp:46:19: runtime error: null pointer passed as argument 1, which is declared to never be null
```

This change makes sure shdr->sh_size is non-zero before attempting memcpy

