### PR TITLE
Add codegen-tests.sh to update or run the tests

### DIFF
--- a/scripts/update_codegen_tests.sh
+++ b/scripts/update_codegen_tests.sh
@@ -1,23 +1,3 @@
 #!/bin/bash
 
-# Updates codegen tests' expected LLVM IR
-#
-# Example usage:
-#
-#     ./scripts/update_codegen_tests.sh
-#
-
-set -eu
-
-BUILD_DIR=build-codegen-update
-
-function run() {
-  nix develop .#bpftrace-llvm12 --command "$@"
-}
-
-# Change dir to project root
-cd "$(git rev-parse --show-toplevel)"
-
-run cmake -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=Debug -DUSE_SYSTEM_BPF_BCC=1
-run make -C "$BUILD_DIR" -j $(nproc)
-BPFTRACE_UPDATE_TESTS=1 run ./"$BUILD_DIR"/tests/bpftrace_test --gtest_filter="codegen*"
+echo "This script has been deprecated. Use ./tests/codegen-tests.sh"

--- a/tests/README.md
+++ b/tests/README.md
@@ -27,14 +27,21 @@ compares it (string compare) with the expected result, a file named by the
 second argument. The `NAME` macro holds the test name,  which is `call_avg` in
 this case.
 
+These tests run as part of the normal suite of unit tests if you are running LLVM 12.
+If not, you need to install 'nix' and run these tests via this script:
+`./tests/codegen-tests.sh`.
+
 #### Updating
 
-Run `./scripts/update_codegen_tests.sh` after making codegen changes up update
-the expected LLVM IR.
+**LLVM 12**
 
-Alternatively (if you need more control over which tests are updated), if the
-test is run with `BPFTRACE_UPDATE_TESTS=1` the `test` helper will update the IR
-instead of running the tests.
+If you are running LLVM 12 or want to only update specific tests with `--gtest_filter`
+run `<builddir>/tests/bpftrace_test` with `BPFTRACE_UPDATE_TESTS=1` and the `test`
+helper will update the IR instead of running the tests.
+
+**Not LLVM 12**
+
+Run `./tests/codegen-tests.sh -u`. This updates all the codegen tests.
 
 ## Runtime tests
 

--- a/tests/codegen-tests.sh
+++ b/tests/codegen-tests.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Runs or updates codegen tests' expected LLVM IR
+# requires nix
+#
+# Example usage:
+#
+#     ./tests/codegen-tests.sh
+#
+
+set -eu
+
+BUILD_DIR=build-codegen-update
+UPDATE_TESTS=${BPFTRACE_UPDATE_TESTS:-0}
+SCRIPT_NAME=$0
+
+function run() {
+  nix develop .#bpftrace-llvm12 --command "$@"
+}
+
+usage() {
+  echo "Usage:"
+  echo "    ${SCRIPT_NAME} [OPTIONS]"
+  echo ""
+  echo " Run or update the codegen tests with nix."
+  echo ""
+  echo "OPTIONS"
+  echo "    -u      Update the tests."
+  echo "    -d <BUILD_DIR>   Change the default build directory. Default: ${BUILD_DIR}"
+}
+
+while getopts ":d:uh" opt; do
+case ${opt} in
+    u )
+        UPDATE_TESTS=1
+        ;;
+    d )
+        BUILD_DIR=${OPTARG}
+        ;;
+    h )
+        usage
+        exit 0
+        ;;
+esac
+done
+
+# Change dir to project root
+cd "$(git rev-parse --show-toplevel)"
+
+run cmake -B "$BUILD_DIR" -DCMAKE_BUILD_TYPE=Debug -DUSE_SYSTEM_BPF_BCC=1
+run make -C "$BUILD_DIR" -j $(nproc)
+BPFTRACE_UPDATE_TESTS=${UPDATE_TESTS} run ./"$BUILD_DIR"/tests/bpftrace_test --gtest_filter="codegen*"


### PR DESCRIPTION
Right now if you go the 'nix' route of updating the codegen tests (because you're not on llvm-12) you have to first figure out that the script builds everything in a different directory "build-codegen-update" then run all the codegen tests separately there. This just adjusts the script so you can either run the tests or regenerate them and puts the script in the same place as the other test runner scripts. Also update the test documentation so it's clearer how to run and update the codegen tests.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
