### PR TITLE
[min] update value directly in memory if available

### DIFF
--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -69,6 +69,9 @@ public:
   CallInst *CreateBpfPseudoCallId(Map &map);
   CallInst *CreateBpfPseudoCallValue(int mapid);
   CallInst *CreateBpfPseudoCallValue(Map &map);
+  CallInst *CreateMapLookup(Map &map,
+                            Value *key,
+                            const std::string &name = "lookup_elem");
   Value *CreateMapLookupElem(Value *ctx,
                              Map &map,
                              Value *key,
@@ -82,7 +85,8 @@ public:
                            Map &map,
                            Value *key,
                            Value *val,
-                           const location &loc);
+                           const location &loc,
+                           int64_t flags = 0);
   void CreateMapDeleteElem(Value *ctx,
                            Map &map,
                            Value *key,
@@ -186,6 +190,11 @@ public:
                     size_t size,
                     const location *loc = nullptr);
   void CreateAtomicIncCounter(int mapfd, uint32_t idx);
+  void CreateMapElemInit(Value *ctx,
+                         Map &map,
+                         Value *key,
+                         Value *val,
+                         const location &loc);
   void CreateMapElemAdd(Value *ctx,
                         Map &map,
                         Value *key,

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1337,7 +1337,7 @@ std::optional<std::string> abs_path(const std::string &rel_path)
 
 int64_t min_value(const std::vector<uint8_t> &value, int nvalues)
 {
-  int64_t val, max = 0, retval;
+  int64_t val, max = 0;
   for (int i = 0; i < nvalues; i++)
   {
     val = read_data<int64_t>(value.data() + i * sizeof(int64_t));
@@ -1345,20 +1345,7 @@ int64_t min_value(const std::vector<uint8_t> &value, int nvalues)
       max = val;
   }
 
-  /*
-   * This is a hack really until the code generation for the min() function
-   * is sorted out. The way it is currently implemented doesn't allow >
-   * 32 bit quantities and also means we have to do gymnastics with the return
-   * value owing to the way it is stored (i.e., 0xffffffff - val).
-   */
-  if (max == 0) /* If we have applied the zero() function */
-    retval = max;
-  else if ((0xffffffff - max) <= 0) /* A negative 32 bit value */
-    retval = 0 - (max - 0xffffffff);
-  else
-    retval = 0xffffffff - max; /* A positive 32 bit value */
-
-  return retval;
+  return max;
 }
 
 uint64_t max_value(const std::vector<uint8_t> &value, int nvalues)

--- a/tests/codegen/llvm/argN_rawtracepoint.ll
+++ b/tests/codegen/llvm/argN_rawtracepoint.ll
@@ -36,7 +36,7 @@ lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
   store i64 1, i64* %initial_value, align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %initial_value, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %initial_value, i64 1)
   %8 = bitcast i64* %initial_value to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
   br label %lookup_merge

--- a/tests/codegen/llvm/args_multiple_tracepoints.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints.ll
@@ -37,7 +37,7 @@ lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 1, i64* %initial_value, align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %initial_value, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %initial_value, i64 1)
   %10 = bitcast i64* %initial_value to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   br label %lookup_merge
@@ -87,7 +87,7 @@ lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 1, i64* %initial_value, align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %initial_value, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %initial_value, i64 1)
   %10 = bitcast i64* %initial_value to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   br label %lookup_merge

--- a/tests/codegen/llvm/args_multiple_tracepoints_category_wild.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints_category_wild.ll
@@ -37,7 +37,7 @@ lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 1, i64* %initial_value, align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %initial_value, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %initial_value, i64 1)
   %10 = bitcast i64* %initial_value to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   br label %lookup_merge
@@ -87,7 +87,7 @@ lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 1, i64* %initial_value, align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %initial_value, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %initial_value, i64 1)
   %10 = bitcast i64* %initial_value to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   br label %lookup_merge
@@ -131,7 +131,7 @@ lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 1, i64* %initial_value, align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %initial_value, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %initial_value, i64 1)
   %10 = bitcast i64* %initial_value to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   br label %lookup_merge

--- a/tests/codegen/llvm/args_multiple_tracepoints_wild.ll
+++ b/tests/codegen/llvm/args_multiple_tracepoints_wild.ll
@@ -37,7 +37,7 @@ lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 1, i64* %initial_value, align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %initial_value, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %initial_value, i64 1)
   %10 = bitcast i64* %initial_value to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   br label %lookup_merge
@@ -87,7 +87,7 @@ lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 1, i64* %initial_value, align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %initial_value, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %initial_value, i64 1)
   %10 = bitcast i64* %initial_value to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   br label %lookup_merge

--- a/tests/codegen/llvm/call_count.ll
+++ b/tests/codegen/llvm/call_count.ll
@@ -33,7 +33,7 @@ lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
   store i64 1, i64* %initial_value, align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %initial_value, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %initial_value, i64 1)
   %6 = bitcast i64* %initial_value to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   br label %lookup_merge

--- a/tests/codegen/llvm/call_min.ll
+++ b/tests/codegen/llvm/call_min.ll
@@ -8,7 +8,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %1 = bitcast i64* %"@x_key" to i8*
@@ -16,45 +16,39 @@ entry:
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* %"@x_key")
-  %2 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
+  %2 = lshr i64 %get_pid_tgid, 32
+  %3 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %3 = load i64, i64* %cast, align 8
-  store i64 %3, i64* %lookup_elem_val, align 8
-  br label %lookup_merge
+  %4 = load i64, i64* %cast, align 8
+  %5 = icmp sge i64 %4, %2
+  br i1 %5, label %min.ge, label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  store i64 0, i64* %lookup_elem_val, align 8
+  %6 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  store i64 %2, i64* %initial_value, align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %initial_value, i64 1)
+  %7 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   br label %lookup_merge
 
-lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %4 = load i64, i64* %lookup_elem_val, align 8
-  %5 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %7 = lshr i64 %get_pid_tgid, 32
-  %8 = sub i64 4294967295, %7
-  %9 = icmp sge i64 %8, %4
-  br i1 %9, label %min.ge, label %min.lt
-
-min.lt:                                           ; preds = %min.ge, %lookup_merge
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
+lookup_merge:                                     ; preds = %lookup_failure, %min.ge, %lookup_success
+  %8 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast i64* %"@x_key" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   ret i64 0
 
-min.ge:                                           ; preds = %lookup_merge
-  store i64 %8, i64* %"@x_val", align 8
-  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_val", i64 0)
-  br label %min.lt
+min.ge:                                           ; preds = %lookup_success
+  store i64 %2, i64* %cast, align 8
+  br label %lookup_merge
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/call_ntop_key.ll
+++ b/tests/codegen/llvm/call_ntop_key.ll
@@ -41,7 +41,7 @@ lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 1, i64* %initial_value, align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, %inet_t*, i64*, i64)*)(i64 %pseudo1, %inet_t* %inet, i64* %initial_value, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, %inet_t*, i64*, i64)*)(i64 %pseudo1, %inet_t* %inet, i64* %initial_value, i64 1)
   %10 = bitcast i64* %initial_value to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   br label %lookup_merge

--- a/tests/codegen/llvm/call_sum.ll
+++ b/tests/codegen/llvm/call_sum.ll
@@ -35,7 +35,7 @@ lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
   store i64 %2, i64* %initial_value, align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %initial_value, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %initial_value, i64 1)
   %7 = bitcast i64* %initial_value to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   br label %lookup_merge

--- a/tests/codegen/llvm/call_usym_key.ll
+++ b/tests/codegen/llvm/call_usym_key.ll
@@ -42,7 +42,7 @@ lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 1, i64* %initial_value, align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, %usym_t*, i64*, i64)*)(i64 %pseudo1, %usym_t* %usym, i64* %initial_value, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, %usym_t*, i64*, i64)*)(i64 %pseudo1, %usym_t* %usym, i64* %initial_value, i64 1)
   %10 = bitcast i64* %initial_value to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   br label %lookup_merge

--- a/tests/codegen/llvm/intcast_call.ll
+++ b/tests/codegen/llvm/intcast_call.ll
@@ -38,7 +38,7 @@ lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
   store i64 %4, i64* %initial_value, align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@_key", i64* %initial_value, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@_key", i64* %initial_value, i64 1)
   %9 = bitcast i64* %initial_value to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   br label %lookup_merge

--- a/tests/codegen/llvm/intptrcast_call.ll
+++ b/tests/codegen/llvm/intptrcast_call.ll
@@ -43,7 +43,7 @@ lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
   store i64 %6, i64* %initial_value, align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %initial_value, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %initial_value, i64 1)
   %11 = bitcast i64* %initial_value to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   br label %lookup_merge

--- a/tests/codegen/llvm/iter_dereference.ll
+++ b/tests/codegen/llvm/iter_dereference.ll
@@ -47,7 +47,7 @@ lookup_failure:                                   ; preds = %pred_true
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
   store i64 1, i64* %initial_value, align 8
   %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %initial_value, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@_key", i64* %initial_value, i64 1)
   %13 = bitcast i64* %initial_value to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   br label %lookup_merge

--- a/tests/codegen/llvm/kfunc_dereference.ll
+++ b/tests/codegen/llvm/kfunc_dereference.ll
@@ -42,7 +42,7 @@ lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %12)
   store i64 1, i64* %initial_value, align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@_key", i64* %initial_value, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@_key", i64* %initial_value, i64 1)
   %13 = bitcast i64* %initial_value to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %13)
   br label %lookup_merge

--- a/tests/codegen/llvm/kretfunc_dereference.ll
+++ b/tests/codegen/llvm/kretfunc_dereference.ll
@@ -41,7 +41,7 @@ lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %11)
   store i64 1, i64* %initial_value, align 8
   %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@_key", i64* %initial_value, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@_key", i64* %initial_value, i64 1)
   %12 = bitcast i64* %initial_value to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %12)
   br label %lookup_merge

--- a/tests/codegen/llvm/literal_strncmp.ll
+++ b/tests/codegen/llvm/literal_strncmp.ll
@@ -85,7 +85,7 @@ lookup_failure:                                   ; preds = %pred_true
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %17)
   store i64 1, i64* %initial_value, align 8
   %pseudo7 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo7, [16 x i8]* %comm5, i64* %initial_value, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo7, [16 x i8]* %comm5, i64* %initial_value, i64 1)
   %18 = bitcast i64* %initial_value to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
   br label %lookup_merge

--- a/tests/codegen/llvm/string_equal_comparison.ll
+++ b/tests/codegen/llvm/string_equal_comparison.ll
@@ -115,7 +115,7 @@ lookup_failure:                                   ; preds = %pred_true
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
   store i64 1, i64* %initial_value, align 8
   %pseudo19 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo19, [16 x i8]* %comm17, i64* %initial_value, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo19, [16 x i8]* %comm17, i64* %initial_value, i64 1)
   %24 = bitcast i64* %initial_value to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
   br label %lookup_merge

--- a/tests/codegen/llvm/string_not_equal_comparison.ll
+++ b/tests/codegen/llvm/string_not_equal_comparison.ll
@@ -115,7 +115,7 @@ lookup_failure:                                   ; preds = %pred_true
   call void @llvm.lifetime.start.p0i8(i64 -1, i8* %23)
   store i64 1, i64* %initial_value, align 8
   %pseudo19 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo19, [16 x i8]* %comm17, i64* %initial_value, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, [16 x i8]*, i64*, i64)*)(i64 %pseudo19, [16 x i8]* %comm17, i64* %initial_value, i64 1)
   %24 = bitcast i64* %initial_value to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %24)
   br label %lookup_merge


### PR DESCRIPTION
Similar to changes in 'count' and 'sum', if the element already exists in the map, just update the value in memory directly instead of calling `CreateMapUpdateElem`.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
