### PR TITLE
Assorted clang warning fixes

### DIFF
--- a/src/ast/elf_parser.cpp
+++ b/src/ast/elf_parser.cpp
@@ -23,7 +23,7 @@ BpfBytecode parseBpfBytecodeFromElfObject(void *const elf)
   // were ever to diverge.
   assert(sizeof(Elf64_Shdr) == ehdr->e_shentsize);
 
-  Elf64_Shdr *shdrs = (Elf64_Shdr *)(fileptr + ehdr->e_shoff);
+  Elf64_Shdr *shdrs = reinterpret_cast<Elf64_Shdr *>(fileptr + ehdr->e_shoff);
   Elf64_Shdr *strtable_shdr = &shdrs[ehdr->e_shstrndx];
   assert(strtable_shdr->sh_type == SHT_STRTAB);
   char *strtable = fileptr + strtable_shdr->sh_offset;

--- a/src/bpfprogram.h
+++ b/src/bpfprogram.h
@@ -30,7 +30,7 @@ public:
   BpfProgram(const BpfProgram &) = delete;
   BpfProgram &operator=(const BpfProgram &) = delete;
   BpfProgram(BpfProgram &&) = default;
-  BpfProgram &operator=(BpfProgram &&) = default;
+  BpfProgram &operator=(BpfProgram &&) = delete;
 
 private:
   explicit BpfProgram(const BpfBytecode &bytecode,

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1,6 +1,7 @@
 #include <arpa/inet.h>
 #include <cassert>
 #include <cerrno>
+#include <cinttypes>
 #include <cstdio>
 #include <cstring>
 #include <ctime>
@@ -2035,7 +2036,7 @@ std::string BPFtrace::resolve_timestamp(uint32_t mode,
   const auto &raw_fmt = resources.strftime_args[strftime_id];
   uint64_t us = ((basetime->tv_nsec + nsecs) % 1000000000) / 1000;
   char usecs_buf[7];
-  snprintf(usecs_buf, sizeof(usecs_buf), "%06lu", us);
+  snprintf(usecs_buf, sizeof(usecs_buf), "%06" PRIu64, us);
   auto fmt = std::regex_replace(raw_fmt, usec_regex, usecs_buf);
 
   char timestr[strlen_];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1020,7 +1020,7 @@ int main(int argc, char* argv[])
       llvm.emit_elf(args.output_elf);
       return 0;
     }
-    bytecode = std::move(llvm.emit());
+    bytecode = llvm.emit();
   }
   catch (const std::system_error& ex)
   {


### PR DESCRIPTION
Fixes a few warnings reported by clang 14.0.7 (Android NDK r25c):

- Remove unnecessary `std::move()` that prevents copy elision
- `BpfProgram` class has a non-static member of a reference type, so the move assignment operator is implicitly deleted[1]; remove `= default`
- Use `reinterpret_cast` in elf_parser to silence the warning about increased alignment requirement (the pointer is 8-byte aligned anyway)
- Use the correct printf specifier for `uint64_t`

[1] https://en.cppreference.com/w/cpp/language/move_assignment

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
