### PR TITLE
Etc ptr

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -590,15 +590,9 @@ void CodegenLLVM::visit(Call &call)
                                   "linear");
 
     AllocaInst *key = getHistMapKey(map, linear);
+    b_.CreateMapElemAdd(ctx_, map, key, b_.getInt64(1), call.loc);
 
-    Value *oldval = b_.CreateMapLookupElem(ctx_, map, key, call.loc);
-    AllocaInst *newval = b_.CreateAllocaBPF(map.type, map.ident + "_val");
-    b_.CreateStore(b_.CreateAdd(oldval, b_.getInt64(1)), newval);
-    b_.CreateMapUpdateElem(ctx_, map, key, newval, call.loc);
-
-    // oldval can only be an integer so won't be in memory and doesn't need lifetime end
     b_.CreateLifetimeEnd(key);
-    b_.CreateLifetimeEnd(newval);
     expr_ = nullptr;
   }
   else if (call.func == "delete")

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -461,26 +461,59 @@ void CodegenLLVM::visit(Call &call)
   {
     Map &map = *call.map;
     auto [key, scoped_key_deleter] = getMapKey(map);
-    Value *oldval = b_.CreateMapLookupElem(ctx_, map, key, call.loc);
-    AllocaInst *newval = b_.CreateAllocaBPF(map.type, map.ident + "_val");
+    CallInst *lookup = b_.CreateMapLookup(map, key);
+    SizedType &type = map.type;
 
-    Function *parent = b_.GetInsertBlock()->getParent();
     auto scoped_del = accept(call.vargs->front());
     // promote int to 64-bit
     expr_ = b_.CreateIntCast(expr_,
                              b_.getInt64Ty(),
                              call.vargs->front()->type.IsSigned());
-    BasicBlock *lt = BasicBlock::Create(module_->getContext(), "min.lt", parent);
-    BasicBlock *ge = BasicBlock::Create(module_->getContext(), "min.ge", parent);
-    b_.CreateCondBr(b_.CreateICmpSGE(expr_, oldval), ge, lt);
+
+    Function *parent = b_.GetInsertBlock()->getParent();
+    BasicBlock *lookup_success_block = BasicBlock::Create(module_->getContext(),
+                                                          "lookup_success",
+                                                          parent);
+    BasicBlock *lookup_failure_block = BasicBlock::Create(module_->getContext(),
+                                                          "lookup_failure",
+                                                          parent);
+    BasicBlock *lookup_merge_block = BasicBlock::Create(module_->getContext(),
+                                                        "lookup_merge",
+                                                        parent);
+
+    AllocaInst *value = b_.CreateAllocaBPF(type, "lookup_elem_val");
+    Value *condition = b_.CreateICmpNE(
+        b_.CreateIntCast(lookup, b_.getInt8PtrTy(), true),
+        ConstantExpr::getCast(Instruction::IntToPtr,
+                              b_.getInt64(0),
+                              b_.getInt8PtrTy()),
+        "map_lookup_cond");
+    b_.CreateCondBr(condition, lookup_success_block, lookup_failure_block);
+
+    b_.SetInsertPoint(lookup_success_block);
+
+    auto *cast = b_.CreatePointerCast(lookup, value->getType(), "cast");
+    BasicBlock *ge = BasicBlock::Create(module_->getContext(),
+                                        "max.ge",
+                                        parent);
+    b_.CreateCondBr(b_.CreateICmpSGE(expr_,
+                                     b_.CreateLoad(b_.getInt64Ty(), cast)),
+                    ge,
+                    lookup_merge_block);
 
     b_.SetInsertPoint(ge);
-    b_.CreateStore(expr_, newval);
-    b_.CreateMapUpdateElem(ctx_, map, key, newval, call.loc);
-    b_.CreateBr(lt);
+    b_.CreateStore(expr_, cast);
 
-    b_.SetInsertPoint(lt);
-    b_.CreateLifetimeEnd(newval);
+    b_.CreateBr(lookup_merge_block);
+
+    b_.SetInsertPoint(lookup_failure_block);
+
+    b_.CreateMapElemInit(ctx_, map, key, expr_, call.loc);
+
+    b_.CreateBr(lookup_merge_block);
+    b_.SetInsertPoint(lookup_merge_block);
+    b_.CreateLifetimeEnd(value);
+
     expr_ = nullptr;
   }
   else if (call.func == "avg" || call.func == "stats")

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -550,15 +550,8 @@ void CodegenLLVM::visit(Call &call)
                              call.vargs->front()->type.IsSigned());
     Value *log2 = b_.CreateCall(log2_func_, expr_, "log2");
     AllocaInst *key = getHistMapKey(map, log2);
-
-    Value *oldval = b_.CreateMapLookupElem(ctx_, map, key, call.loc);
-    AllocaInst *newval = b_.CreateAllocaBPF(map.type, map.ident + "_val");
-    b_.CreateStore(b_.CreateAdd(oldval, b_.getInt64(1)), newval);
-    b_.CreateMapUpdateElem(ctx_, map, key, newval, call.loc);
-
-    // oldval can only be an integer so won't be in memory and doesn't need lifetime end
+    b_.CreateMapElemAdd(ctx_, map, key, b_.getInt64(1), call.loc);
     b_.CreateLifetimeEnd(key);
-    b_.CreateLifetimeEnd(newval);
     expr_ = nullptr;
   }
   else if (call.func == "lhist")

--- a/tests/codegen/llvm/call_avg.ll
+++ b/tests/codegen/llvm/call_avg.ll
@@ -8,10 +8,10 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %initial_value11 = alloca i64, align 8
   %lookup_elem_val8 = alloca i64, align 8
   %"@x_key2" = alloca i64, align 8
-  %"@x_num" = alloca i64, align 8
+  %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %1 = bitcast i64* %"@x_key" to i8*
@@ -27,30 +27,30 @@ entry:
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
   %3 = load i64, i64* %cast, align 8
-  store i64 %3, i64* %lookup_elem_val, align 8
+  %4 = add i64 %3, 1
+  store i64 %4, i64* %cast, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  store i64 0, i64* %lookup_elem_val, align 8
+  %5 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i64 1, i64* %initial_value, align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %initial_value, i64 1)
+  %6 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %4 = load i64, i64* %lookup_elem_val, align 8
-  %5 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@x_num" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %7 = add i64 %4, 1
-  store i64 %7, i64* %"@x_num", align 8
-  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_num", i64 0)
+  %7 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   %8 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@x_num" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key2" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %9 = bitcast i64* %"@x_key2" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 1, i64* %"@x_key2", align 8
+  %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
+  %10 = lshr i64 %get_pid_tgid, 32
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %lookup_elem4 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo3, i64* %"@x_key2")
   %11 = bitcast i64* %lookup_elem_val8 to i8*
@@ -61,29 +61,25 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 lookup_success5:                                  ; preds = %lookup_merge
   %cast10 = bitcast i8* %lookup_elem4 to i64*
   %12 = load i64, i64* %cast10, align 8
-  store i64 %12, i64* %lookup_elem_val8, align 8
+  %13 = add i64 %12, %10
+  store i64 %13, i64* %cast10, align 8
   br label %lookup_merge7
 
 lookup_failure6:                                  ; preds = %lookup_merge
-  store i64 0, i64* %lookup_elem_val8, align 8
+  %14 = bitcast i64* %initial_value11 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  store i64 %10, i64* %initial_value11, align 8
+  %pseudo12 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem13 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo12, i64* %"@x_key2", i64* %initial_value11, i64 1)
+  %15 = bitcast i64* %initial_value11 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
   br label %lookup_merge7
 
 lookup_merge7:                                    ; preds = %lookup_failure6, %lookup_success5
-  %13 = load i64, i64* %lookup_elem_val8, align 8
-  %14 = bitcast i64* %lookup_elem_val8 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
-  %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %16 = lshr i64 %get_pid_tgid, 32
-  %17 = add i64 %16, %13
-  store i64 %17, i64* %"@x_val", align 8
-  %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem12 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo11, i64* %"@x_key2", i64* %"@x_val", i64 0)
-  %18 = bitcast i64* %"@x_key2" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
-  %19 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  %16 = bitcast i64* %lookup_elem_val8 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = bitcast i64* %"@x_key2" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_hist.ll
+++ b/tests/codegen/llvm/call_hist.ll
@@ -8,7 +8,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
@@ -27,27 +27,25 @@ entry:
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
   %4 = load i64, i64* %cast, align 8
-  store i64 %4, i64* %lookup_elem_val, align 8
+  %5 = add i64 %4, 1
+  store i64 %5, i64* %cast, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  store i64 0, i64* %lookup_elem_val, align 8
+  %6 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  store i64 1, i64* %initial_value, align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %initial_value, i64 1)
+  %7 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %5 = load i64, i64* %lookup_elem_val, align 8
-  %6 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
-  %7 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
-  %8 = add i64 %5, 1
-  store i64 %8, i64* %"@x_val", align 8
-  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_val", i64 0)
+  %8 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
   %9 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_lhist.ll
+++ b/tests/codegen/llvm/call_lhist.ll
@@ -8,7 +8,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
@@ -29,27 +29,25 @@ entry:
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
   %5 = load i64, i64* %cast, align 8
-  store i64 %5, i64* %lookup_elem_val, align 8
+  %6 = add i64 %5, 1
+  store i64 %6, i64* %cast, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  store i64 0, i64* %lookup_elem_val, align 8
+  %7 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %7)
+  store i64 1, i64* %initial_value, align 8
+  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@x_key", i64* %initial_value, i64 1)
+  %8 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %6 = load i64, i64* %lookup_elem_val, align 8
-  %7 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
-  %8 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %8)
-  %9 = add i64 %6, 1
-  store i64 %9, i64* %"@x_val", align 8
-  %pseudo2 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo2, i64* %"@x_key", i64* %"@x_val", i64 0)
+  %9 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
   %10 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
-  %11 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %11)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_max.ll
+++ b/tests/codegen/llvm/call_max.ll
@@ -8,7 +8,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %1 = bitcast i64* %"@x_key" to i8*
@@ -16,44 +16,39 @@ entry:
   store i64 0, i64* %"@x_key", align 8
   %pseudo = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %lookup_elem = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo, i64* %"@x_key")
-  %2 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %2)
+  %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
+  %2 = lshr i64 %get_pid_tgid, 32
+  %3 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %3)
   %map_lookup_cond = icmp ne i8* %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
-  %3 = load i64, i64* %cast, align 8
-  store i64 %3, i64* %lookup_elem_val, align 8
-  br label %lookup_merge
+  %4 = load i64, i64* %cast, align 8
+  %5 = icmp sge i64 %2, %4
+  br i1 %5, label %max.ge, label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  store i64 0, i64* %lookup_elem_val, align 8
+  %6 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
+  store i64 %2, i64* %initial_value, align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %initial_value, i64 1)
+  %7 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   br label %lookup_merge
 
-lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %4 = load i64, i64* %lookup_elem_val, align 8
-  %5 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %7 = lshr i64 %get_pid_tgid, 32
-  %8 = icmp sge i64 %7, %4
-  br i1 %8, label %min.ge, label %min.lt
-
-min.lt:                                           ; preds = %min.ge, %lookup_merge
-  %9 = bitcast i64* %"@x_val" to i8*
+lookup_merge:                                     ; preds = %lookup_failure, %max.ge, %lookup_success
+  %8 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
+  %9 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %10)
   ret i64 0
 
-min.ge:                                           ; preds = %lookup_merge
-  store i64 %7, i64* %"@x_val", align 8
-  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_val", i64 0)
-  br label %min.lt
+max.ge:                                           ; preds = %lookup_success
+  store i64 %2, i64* %cast, align 8
+  br label %lookup_merge
 }
 
 ; Function Attrs: argmemonly nofree nosync nounwind willreturn

--- a/tests/codegen/llvm/call_stats.ll
+++ b/tests/codegen/llvm/call_stats.ll
@@ -8,10 +8,10 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 define i64 @"kprobe:f"(i8* %0) section "s_kprobe:f_1" {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %initial_value11 = alloca i64, align 8
   %lookup_elem_val8 = alloca i64, align 8
   %"@x_key2" = alloca i64, align 8
-  %"@x_num" = alloca i64, align 8
+  %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   %1 = bitcast i64* %"@x_key" to i8*
@@ -27,30 +27,30 @@ entry:
 lookup_success:                                   ; preds = %entry
   %cast = bitcast i8* %lookup_elem to i64*
   %3 = load i64, i64* %cast, align 8
-  store i64 %3, i64* %lookup_elem_val, align 8
+  %4 = add i64 %3, 1
+  store i64 %4, i64* %cast, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  store i64 0, i64* %lookup_elem_val, align 8
+  %5 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %5)
+  store i64 1, i64* %initial_value, align 8
+  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %initial_value, i64 1)
+  %6 = bitcast i64* %initial_value to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %6)
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %4 = load i64, i64* %lookup_elem_val, align 8
-  %5 = bitcast i64* %lookup_elem_val to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %5)
-  %6 = bitcast i64* %"@x_num" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %6)
-  %7 = add i64 %4, 1
-  store i64 %7, i64* %"@x_num", align 8
-  %pseudo1 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo1, i64* %"@x_key", i64* %"@x_num", i64 0)
+  %7 = bitcast i64* %lookup_elem_val to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %7)
   %8 = bitcast i64* %"@x_key" to i8*
   call void @llvm.lifetime.end.p0i8(i64 -1, i8* %8)
-  %9 = bitcast i64* %"@x_num" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %9)
-  %10 = bitcast i64* %"@x_key2" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %10)
+  %9 = bitcast i64* %"@x_key2" to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %9)
   store i64 1, i64* %"@x_key2", align 8
+  %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
+  %10 = lshr i64 %get_pid_tgid, 32
   %pseudo3 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
   %lookup_elem4 = call i8* inttoptr (i64 1 to i8* (i64, i64*)*)(i64 %pseudo3, i64* %"@x_key2")
   %11 = bitcast i64* %lookup_elem_val8 to i8*
@@ -61,29 +61,25 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 lookup_success5:                                  ; preds = %lookup_merge
   %cast10 = bitcast i8* %lookup_elem4 to i64*
   %12 = load i64, i64* %cast10, align 8
-  store i64 %12, i64* %lookup_elem_val8, align 8
+  %13 = add i64 %12, %10
+  store i64 %13, i64* %cast10, align 8
   br label %lookup_merge7
 
 lookup_failure6:                                  ; preds = %lookup_merge
-  store i64 0, i64* %lookup_elem_val8, align 8
+  %14 = bitcast i64* %initial_value11 to i8*
+  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %14)
+  store i64 %10, i64* %initial_value11, align 8
+  %pseudo12 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
+  %update_elem13 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo12, i64* %"@x_key2", i64* %initial_value11, i64 1)
+  %15 = bitcast i64* %initial_value11 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %15)
   br label %lookup_merge7
 
 lookup_merge7:                                    ; preds = %lookup_failure6, %lookup_success5
-  %13 = load i64, i64* %lookup_elem_val8, align 8
-  %14 = bitcast i64* %lookup_elem_val8 to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %14)
-  %15 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.start.p0i8(i64 -1, i8* %15)
-  %get_pid_tgid = call i64 inttoptr (i64 14 to i64 ()*)()
-  %16 = lshr i64 %get_pid_tgid, 32
-  %17 = add i64 %16, %13
-  store i64 %17, i64* %"@x_val", align 8
-  %pseudo11 = call i64 @llvm.bpf.pseudo(i64 1, i64 0)
-  %update_elem12 = call i64 inttoptr (i64 2 to i64 (i64, i64*, i64*, i64)*)(i64 %pseudo11, i64* %"@x_key2", i64* %"@x_val", i64 0)
-  %18 = bitcast i64* %"@x_key2" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %18)
-  %19 = bitcast i64* %"@x_val" to i8*
-  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %19)
+  %16 = bitcast i64* %lookup_elem_val8 to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %16)
+  %17 = bitcast i64* %"@x_key2" to i8*
+  call void @llvm.lifetime.end.p0i8(i64 -1, i8* %17)
   ret i64 0
 }
 


### PR DESCRIPTION
Similar to previous PRs, if the element already exists in the map, just update the value in memory directly instead of calling CreateMapUpdateElem.

These 4 commits change "max", "avg", "stats", "hist", and "lhist".

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
