### PR TITLE
Add new 'config' syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@ and this project adheres to
   - [#2840](https://github.com/iovisor/bpftrace/pull/2840)
 - Add more helpful error messages for map operations
   - [#2905](https://github.com/iovisor/bpftrace/pull/2905)
+- New config block syntax
+  - [#2815](https://github.com/iovisor/bpftrace/pull/2815)
 #### Changed
 #### Deprecated
 #### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ and this project adheres to
 - New config block syntax
   - [#2815](https://github.com/iovisor/bpftrace/pull/2815)
 #### Changed
+- Standardize config and env var names
+  - [#2815](https://github.com/iovisor/bpftrace/pull/2815)
 #### Deprecated
 #### Removed
 - Remove snapcraft support

--- a/docs/fuzzing.md
+++ b/docs/fuzzing.md
@@ -19,9 +19,9 @@ directly targets the function, but we need to write some glue code to connect a 
 ## bpftrace options for fuzzing
 bpftrace has several options useful for fuzzing.
 
-### `BPFTRACE_NODE_MAX` environment variable
+### `BPFTRACE_MAX_AST_NODES` environment variable
 When doing fuzzing, it is important to limit the number of AST nodes because otherwise, a fuzzer might
-keep generating a very long program that causes a stack overflow.  `BPFTRACE_NODE_MAX` environment
+keep generating a very long program that causes a stack overflow.  `BPFTRACE_MAX_AST_NODES` environment
 variable controls the maximum number of AST nodes.
 
 ## Fuzzing with AFL
@@ -82,7 +82,7 @@ FUZZER=/path/to/AFLplusplus/afl-fuzz
 
 sudo AFL_NO_AFFINITY=1 \
      ASAN_OPTIONS=detect_leaks=0:abort_on_error=1:symbolize=0 \
-     BPFTRACE_NODE_MAX=200 \
+     BPFTRACE_MAX_AST_NODES=200 \
      taskset -c ${CPU} \
      $FUZZER -M 0 -m none -i ./input -o ./output -t 3000 -- \
      ./src/bpftrace_fuzz @@

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -964,7 +964,7 @@ Example:
 ```
 config = {
     stack_mode=perf;
-    max_probes=2
+    max_map_keys=2
 }
 
 BEGIN { ... }

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -40,6 +40,7 @@ discussion to other files in /docs, the /tools/\*\_examples.txt files, or blog p
     - [14. Looping constructs](#14-looping-constructs)
     - [15. `return`: Terminate Early](#15-return-terminate-early)
     - [16. `( , )`: Tuples](#16----tuples)
+    - [17. `config = {}`: Config Block](#17-config---config-block)
 - [Probes](#probes)
     - [1. `kprobe`/`kretprobe`: Dynamic Tracing, Kernel-Level](#1-kprobekretprobe-dynamic-tracing-kernel-level)
     - [2. `kprobe`/`kretprobe`: Dynamic Tracing, Kernel-Level Arguments](#2-kprobekretprobe-dynamic-tracing-kernel-level-arguments)
@@ -476,6 +477,9 @@ bpftrace v0.8-90-g585e-dirty
 - The `--no-warnings` option disables warnings.
 
 ## 9. Environment Variables
+
+Most of these can also be set via the [config block](#17-config---config-block) directly in a script 
+(before any probes).
 
 ### 9.1 `BPFTRACE_BTF`
 
@@ -950,6 +954,30 @@ Attaching 1 probe...
 2 string
 ^C
 ```
+
+## 17. `config = {}`: Config Block
+
+To improve script portability, you can set bpftrace configs via the config block, 
+which can only be placed at the top of the script before any probes (even `BEGIN`).
+
+Example:
+```
+config = {
+    stack_mode=perf;
+    max_probes=2
+}
+
+BEGIN { ... }
+
+uprobe:./testprogs/uprobe_test:uprobeFunction1 { ... }
+```
+
+The names of the config variables can be in the format of environment variables 
+or their lowercase equivalent without the `BPFTRACE_` prefix. For example, 
+`BPFTRACE_STACK_MODE`, `STACK_MODE`, and `stack_mode` are equivalent.
+
+**Note**: Environment variables for the same config take precedence over those set 
+inside a script config block.
 
 # Probes
 

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -195,11 +195,13 @@ Default: PER_PROGRAM if ASLR disabled or `-c` option given, PER_PID otherwise.
 me. If there are many processes running, it will consume a lot of a memory.
 -* NONE - caching disabled. This saves the most memory, but at the cost of speed.
 
-=== BPFTRACE_CAT_BYTES_MAX
+=== BPFTRACE_CPP_DEMANGLE
 
-Default: 10k
+Default: 1
 
-Maximum bytes read by cat builtin.
+C++ symbol demangling in userspace stack traces is enabled by default.
+
+This feature can be turned off by setting the value of this environment variable to `0`.
 
 === BPFTRACE_DEBUG_OUTPUT
 
@@ -234,7 +236,13 @@ This is the maximum number of BPF programs (functions) that bpftrace can generat
 The main purpose of this limit is to prevent bpftrace from hanging since generating a lot of probes
 takes a lot of resources (and it should not happen often).
 
-=== BPFTRACE_MAP_KEYS_MAX
+=== BPFTRACE_MAX_CAT_BYTES
+
+Default: 10k
+
+Maximum bytes read by cat builtin.
+
+=== BPFTRACE_MAX_MAP_KEYS
 
 Default: 4096
 
@@ -250,19 +258,24 @@ This is the maximum number of probes that bpftrace can attach to. Increasing the
 memory, increase startup times and can incur high performance overhead or even freeze or crash the
 system.
 
+=== BPFTRACE_MAX_STRLEN
+
+Default: 64
+
+Number of bytes allocated on the BPF stack for the string returned by str().
+
+Make this larger if you wish to read bigger strings with str().
+
+Beware that the BPF stack is small (512 bytes), and that you pay the toll again inside printf() (whilst
+it composes a perf event output buffer). So in practice you can only grow this to about 200 bytes.
+
+Support for even larger strings is [being discussed](https://github.com/iovisor/bpftrace/issues/305).
+
 === BPFTRACE_MAX_TYPE_RES_ITERATIONS
 
 Default: 0
 
 Maximum should be the number of levels of nested field accesses for tracepoint args. 0 is unlimited.
-
-=== BPFTRACE_NO_CPP_DEMANGLE
-
-Default: 0
-
-C++ symbol demangling in userspace stack traces is enabled by default.
-
-This feature can be turned off by setting the value of this environment variable to `1`.
 
 === BPFTRACE_PERF_RB_PAGES
 
@@ -280,19 +293,6 @@ Default: bpftrace
 
 Output format for ustack and kstack builtins. Available modes/formats: `bpftrace`, `perf`, and `raw`.
 This can be overwritten at the call site.
-
-=== BPFTRACE_STRLEN
-
-Default: 64
-
-Number of bytes allocated on the BPF stack for the string returned by str().
-
-Make this larger if you wish to read bigger strings with str().
-
-Beware that the BPF stack is small (512 bytes), and that you pay the toll again inside printf() (whilst
-it composes a perf event output buffer). So in practice you can only grow this to about 200 bytes.
-
-Support for even larger strings is [being discussed](https://github.com/iovisor/bpftrace/issues/305).
 
 === BPFTRACE_STR_TRUNC_TRAILER
 
@@ -1407,7 +1407,7 @@ The return type is an unsigned integer of the same width as `n`.
 * `buf_t buf(void * data, [int64 length])`
 
 `buf` reads `length` amount of bytes from address `data`.
-The maximum value of `length` is limited to the `BPFTRACE_STRLEN` variable.
+The maximum value of `length` is limited to the `BPFTRACE_MAX_STRLEN` variable.
 For arrays the `length` is optional, it is automatically inferred from the signature.
 
 `buf` is address space aware and will call the correct helper based on the address space associated with `data`.
@@ -1723,7 +1723,7 @@ Note that subfields are not yet supported.
 *Helper* `probe_read_str, probe_read_{kernel,user}_str`
 
 `str` reads a NULL terminated (`\0`) string from `data`.
-The maximum string length is limited by the `BPFTRACE_STRLEN` env variable, unless `length` is specified and shorter than the maximum.
+The maximum string length is limited by the `BPFTRACE_MAX_STRLEN` env variable, unless `length` is specified and shorter than the maximum.
 In case the string is longer than the specified length only `length - 1` bytes are copied and a NULL byte is appended at the end.
 
 When available (starting from kernel 5.5, see the `--info` flag) bpftrace will automatically use the `kernel` or `user` variant of `probe_read_{kernel,user}_str` based on the address space of `data`, see <<Address-spaces>> for more information.

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -418,7 +418,7 @@ which can only be placed at the top of the script before any probes (even `BEGIN
 ----
 config = {
     stack_mode=perf;
-    max_probes=2
+    max_map_keys=2
 }
 
 BEGIN { ... }

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -171,6 +171,7 @@ This prefix reset must be at the end of the section, else cross references break
 == Environment Variables
 
 Some behavior can only be controlled through environment variables.
+Most of these can also be set via the config block directly in a script (before any probes).
 This section lists all those variables.
 
 ////
@@ -408,6 +409,29 @@ i:s:1 { // can also be used to comment inline
   print(/* inline comment block */ 1);
 }
 ----
+
+=== Config Block
+
+To improve script portability, you can set bpftrace configs via the config block, 
+which can only be placed at the top of the script before any probes (even `BEGIN`).
+
+----
+config = {
+    stack_mode=perf;
+    max_probes=2
+}
+
+BEGIN { ... }
+
+uprobe:./testprogs/uprobe_test:uprobeFunction1 { ... }
+----
+
+The names of the config variables can be in the format of environment variables 
+or their lowercase equivalent without the `BPFTRACE_` prefix. For example, 
+`BPFTRACE_STACK_MODE`, `STACK_MODE`, and `stack_mode` are equivalent.
+
+**Note**: Environment variables for the same config take precedence over those set 
+inside a script config block.
 
 === Data Types
 

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(ast
   signal.cpp
   visitors.cpp
 
+  passes/config_analyser.cpp
   passes/field_analyser.cpp
   passes/portability_analyser.cpp
   passes/printer.cpp

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -445,6 +445,24 @@ private:
   AssignVarStatement(const AssignVarStatement &other);
 };
 
+class AssignConfigVarStatement : public Statement
+{
+public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(AssignConfigVarStatement)
+
+  AssignConfigVarStatement(const std::string &config_var,
+                           Expression *expr,
+                           location loc = location());
+  ~AssignConfigVarStatement();
+
+  std::string config_var;
+  Expression *expr = nullptr;
+
+private:
+  AssignConfigVarStatement(const AssignConfigVarStatement &other);
+};
+
 class If : public Statement {
 public:
   DEFINE_ACCEPT
@@ -541,6 +559,23 @@ private:
   While(const While &other);
 };
 
+class Config : public Statement
+{
+public:
+  DEFINE_ACCEPT
+  DEFINE_LEAFCOPY(Config)
+
+  Config(StatementList *stmts) : stmts(stmts)
+  {
+  }
+  ~Config();
+
+  StatementList *stmts = nullptr;
+
+private:
+  Config(const Config &other);
+};
+
 class AttachPoint : public Node {
 public:
   DEFINE_ACCEPT
@@ -621,11 +656,12 @@ public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(Program)
 
-  Program(const std::string &c_definitions, ProbeList *probes);
+  Program(const std::string &c_definitions, Config *config, ProbeList *probes);
 
   ~Program();
 
   std::string c_definitions;
+  Config *config = nullptr;
   ProbeList *probes = nullptr;
 
 private:

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1981,7 +1981,7 @@ void IRBuilderBPF::CreatePath(Value *ctx,
   CallInst *call = CreateHelperCall(
       libbpf::bpf_func_id::BPF_FUNC_d_path,
       d_path_func_type,
-      { path, buf, getInt32(bpftrace_.config_.get(ConfigKeyInt::strlen)) },
+      { path, buf, getInt32(bpftrace_.config_.get(ConfigKeyInt::max_strlen)) },
       "d_path",
       &loc);
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_d_path, loc);

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -413,7 +413,7 @@ CallInst *IRBuilderBPF::createGetScratchMap(int mapid,
   CreateCondBr(condition, lookup_merge_block, lookup_failure_block);
 
   SetInsertPoint(lookup_failure_block);
-  if (bpftrace_.config_.get(ConfigKeyBool::debug_output))
+  if (bpftrace_.debug_output_)
     CreateDebugOutput("unable to find the scratch map value for " + name,
                       std::vector<Value *>{},
                       loc);

--- a/src/ast/passes/callback_visitor.h
+++ b/src/ast/passes/callback_visitor.h
@@ -35,6 +35,7 @@ public:
   void visit(ExprStatement &expr) override;
   void visit(AssignMapStatement &assignment) override;
   void visit(AssignVarStatement &assignment) override;
+  void visit(AssignConfigVarStatement &assignment) override;
   void visit(If &if_block) override;
   void visit(Unroll &unroll) override;
   void visit(While &while_block) override;
@@ -42,6 +43,7 @@ public:
   void visit(Predicate &pred) override;
   void visit(AttachPoint &ap) override;
   void visit(Probe &probe) override;
+  void visit(Config &config) override;
   void visit(Program &program) override;
 
 private:

--- a/src/ast/passes/config_analyser.cpp
+++ b/src/ast/passes/config_analyser.cpp
@@ -1,0 +1,205 @@
+#include "config_analyser.h"
+
+#include <cstring>
+#include <string>
+
+#include "ast/ast.h"
+#include "config.h"
+#include "log.h"
+#include "types.h"
+
+namespace bpftrace {
+namespace ast {
+
+template <class... Ts>
+struct overloaded : Ts...
+{
+  using Ts::operator()...;
+};
+// explicit deduction guide (not needed as of C++20)
+template <class... Ts>
+overloaded(Ts...) -> overloaded<Ts...>;
+
+void ConfigAnalyser::log_type_error(SizedType &type,
+                                    Type expected_type,
+                                    AssignConfigVarStatement &assignment)
+{
+  LOG(ERROR, assignment.loc, err_)
+      << "Invalid type for " << assignment.config_var << ". Type: " << type.type
+      << ". Expected Type: " << expected_type;
+}
+
+void ConfigAnalyser::set_uint64_config(AssignConfigVarStatement &assignment,
+                                       ConfigKeyInt key)
+{
+  auto &assignTy = assignment.expr->type;
+  if (!assignTy.IsIntegerTy())
+  {
+    log_type_error(assignTy, Type::integer, assignment);
+    return;
+  }
+
+  config_setter_.set(key, dynamic_cast<Integer *>(assignment.expr)->n);
+}
+
+void ConfigAnalyser::set_bool_config(AssignConfigVarStatement &assignment,
+                                     ConfigKeyBool key)
+{
+  auto &assignTy = assignment.expr->type;
+  if (!assignTy.IsIntegerTy())
+  {
+    log_type_error(assignTy, Type::integer, assignment);
+    return;
+  }
+
+  auto val = dynamic_cast<Integer *>(assignment.expr)->n;
+  if (val == 0)
+  {
+    config_setter_.set(key, false);
+  }
+  else if (val == 1)
+  {
+    config_setter_.set(key, true);
+  }
+  else
+  {
+    LOG(ERROR) << "Invalid value for " << assignment.config_var
+               << ". Needs to be 0 or 1. Value: " << val;
+  }
+}
+
+void ConfigAnalyser::set_string_config(AssignConfigVarStatement &assignment,
+                                       ConfigKeyString key)
+{
+  auto &assignTy = assignment.expr->type;
+  if (!assignTy.IsStringTy())
+  {
+    log_type_error(assignTy, Type::string, assignment);
+    return;
+  }
+
+  config_setter_.set(key, dynamic_cast<String *>(assignment.expr)->str);
+}
+
+void ConfigAnalyser::set_stack_mode_config(AssignConfigVarStatement &assignment)
+{
+  auto &assignTy = assignment.expr->type;
+  if (!assignTy.IsStackModeTy())
+  {
+    log_type_error(assignTy, Type::stack_mode, assignment);
+    return;
+  }
+
+  config_setter_.set(assignTy.stack_type.mode);
+}
+
+void ConfigAnalyser::set_user_symbol_cache_type_config(
+    AssignConfigVarStatement &assignment)
+{
+  auto &assignTy = assignment.expr->type;
+  if (!assignTy.IsStringTy())
+  {
+    log_type_error(assignTy, Type::string, assignment);
+    return;
+  }
+
+  config_setter_.set_user_symbol_cache_type(
+      dynamic_cast<String *>(assignment.expr)->str);
+}
+
+void ConfigAnalyser::visit(Integer &integer)
+{
+  integer.type = CreateInt64();
+}
+
+void ConfigAnalyser::visit(String &string)
+{
+  string.type = CreateString(string.str.size() + 1);
+}
+
+void ConfigAnalyser::visit(StackMode &mode)
+{
+  auto stack_mode = bpftrace::Config::get_stack_mode(mode.mode);
+  if (stack_mode.has_value())
+  {
+    mode.type = CreateStackMode();
+    mode.type.stack_type.mode = stack_mode.value();
+  }
+  else
+  {
+    mode.type = CreateNone();
+    LOG(ERROR, mode.loc, err_) << "Unknown stack mode: '" + mode.mode + "'";
+  }
+}
+
+void ConfigAnalyser::visit(AssignConfigVarStatement &assignment)
+{
+  Visitor::visit(assignment);
+  std::string &raw_ident = assignment.config_var;
+
+  const auto maybeConfigKey = bpftrace_.config_.get_config_key(raw_ident);
+
+  if (!maybeConfigKey.has_value())
+  {
+    LOG(ERROR, assignment.loc, err_)
+        << "Unrecognized config variable: " << raw_ident;
+    return;
+  }
+
+  if (!assignment.expr->is_literal)
+  {
+    LOG(ERROR, assignment.loc, err_)
+        << "Assignemnt for " << assignment.config_var << " must be literal.";
+    return;
+  }
+
+  auto configKey = maybeConfigKey.value();
+
+  if (!config_setter_.valid_source(configKey))
+  {
+    LOG(ERROR, assignment.loc, err_)
+        << assignment.config_var
+        << " can only be set as an environment variable.";
+    return;
+  }
+
+  std::visit(
+      overloaded{
+          [&, this](ConfigKeyBool key) { set_bool_config(assignment, key); },
+          [&, this](ConfigKeyInt key) { set_uint64_config(assignment, key); },
+          [&, this](ConfigKeyString key) {
+            set_string_config(assignment, key);
+          },
+          [&, this](ConfigKeyStackMode) { set_stack_mode_config(assignment); },
+          [&, this](ConfigKeyUserSymbolCacheType) {
+            set_user_symbol_cache_type_config(assignment);
+          } },
+      configKey);
+}
+
+bool ConfigAnalyser::analyse()
+{
+  Visit(*root_);
+  std::string errors = err_.str();
+  if (!errors.empty())
+  {
+    out_ << errors;
+    return false;
+  }
+  return true;
+}
+
+Pass CreateConfigPass()
+{
+  auto fn = [](Node &n, PassContext &ctx) {
+    auto configs = ConfigAnalyser(&n, ctx.b);
+    if (!configs.analyse())
+      return PassResult::Error("Config");
+    return PassResult::Success();
+  };
+
+  return Pass("ConfigAnalyser", fn);
+};
+
+} // namespace ast
+} // namespace bpftrace

--- a/src/ast/passes/config_analyser.cpp
+++ b/src/ast/passes/config_analyser.cpp
@@ -137,12 +137,13 @@ void ConfigAnalyser::visit(AssignConfigVarStatement &assignment)
   Visitor::visit(assignment);
   std::string &raw_ident = assignment.config_var;
 
-  const auto maybeConfigKey = bpftrace_.config_.get_config_key(raw_ident);
+  std::string err_msg;
+  const auto maybeConfigKey = bpftrace_.config_.get_config_key(raw_ident,
+                                                               err_msg);
 
   if (!maybeConfigKey.has_value())
   {
-    LOG(ERROR, assignment.loc, err_)
-        << "Unrecognized config variable: " << raw_ident;
+    LOG(ERROR, assignment.loc, err_) << err_msg;
     return;
   }
 
@@ -154,14 +155,6 @@ void ConfigAnalyser::visit(AssignConfigVarStatement &assignment)
   }
 
   auto configKey = maybeConfigKey.value();
-
-  if (!config_setter_.valid_source(configKey))
-  {
-    LOG(ERROR, assignment.loc, err_)
-        << assignment.config_var
-        << " can only be set as an environment variable.";
-    return;
-  }
 
   std::visit(
       overloaded{

--- a/src/ast/passes/config_analyser.h
+++ b/src/ast/passes/config_analyser.h
@@ -1,0 +1,60 @@
+#pragma once
+
+#include <iostream>
+#include <sstream>
+#include <unordered_set>
+
+#include "ast/pass_manager.h"
+#include "ast/visitors.h"
+#include "bpffeature.h"
+#include "bpftrace.h"
+#include "config.h"
+#include "map.h"
+#include "types.h"
+
+namespace bpftrace {
+namespace ast {
+
+class ConfigAnalyser : public Visitor
+{
+public:
+  explicit ConfigAnalyser(Node *root,
+                          BPFtrace &bpftrace,
+                          std::ostream &out = std::cerr)
+      : root_(root),
+        bpftrace_(bpftrace),
+        config_setter_(ConfigSetter(bpftrace.config_, ConfigSource::script)),
+        out_(out)
+  {
+  }
+
+  void visit(Integer &integer) override;
+  void visit(String &string) override;
+  void visit(StackMode &mode) override;
+  void visit(AssignConfigVarStatement &assignment) override;
+
+  bool analyse();
+
+private:
+  Node *root_ = nullptr;
+  BPFtrace &bpftrace_;
+  ConfigSetter config_setter_;
+  std::ostream &out_;
+  std::ostringstream err_;
+
+  void set_uint64_config(AssignConfigVarStatement &assignment,
+                         ConfigKeyInt key);
+  void set_bool_config(AssignConfigVarStatement &assignment, ConfigKeyBool key);
+  void set_string_config(AssignConfigVarStatement &assignment,
+                         ConfigKeyString key);
+  void set_stack_mode_config(AssignConfigVarStatement &assignment);
+  void set_user_symbol_cache_type_config(AssignConfigVarStatement &assignment);
+
+  void log_type_error(SizedType &type,
+                      Type expected_type,
+                      AssignConfigVarStatement &assignment);
+};
+
+Pass CreateConfigPass();
+} // namespace ast
+} // namespace bpftrace

--- a/src/ast/passes/node_counter.h
+++ b/src/ast/passes/node_counter.h
@@ -33,7 +33,7 @@ inline Pass CreateCounterPass()
     NodeCounter c;
     c.Visit(n);
     auto node_count = c.get_count();
-    auto max = ctx.b.config_.get(ConfigKeyInt::max_ast_nodes);
+    auto max = ctx.b.max_ast_nodes_;
     if (bt_verbose)
     {
       LOG(INFO) << "node count: " << node_count;

--- a/src/ast/passes/node_counter.h
+++ b/src/ast/passes/node_counter.h
@@ -33,7 +33,7 @@ inline Pass CreateCounterPass()
     NodeCounter c;
     c.Visit(n);
     auto node_count = c.get_count();
-    auto max = ctx.b.config_.get(ConfigKeyInt::ast_max_nodes);
+    auto max = ctx.b.config_.get(ConfigKeyInt::max_ast_nodes);
     if (bt_verbose)
     {
       LOG(INFO) << "node count: " << node_count;

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -280,6 +280,18 @@ void Printer::visit(AssignVarStatement &assignment)
   --depth_;
 }
 
+void Printer::visit(AssignConfigVarStatement &assignment)
+{
+  std::string indent(depth_, ' ');
+  out_ << indent << "=" << std::endl;
+
+  ++depth_;
+  std::string indentVar(depth_, ' ');
+  out_ << indentVar << "config var: " << assignment.config_var << std::endl;
+  assignment.expr->accept(*this);
+  --depth_;
+}
+
 void Printer::visit(If &if_block)
 {
   std::string indent(depth_, ' ');
@@ -339,6 +351,20 @@ void Printer::visit(While &while_block)
   }
 }
 
+void Printer::visit(Config &config)
+{
+  std::string indent(depth_, ' ');
+
+  out_ << indent << "config" << std::endl;
+
+  ++depth_;
+  for (Statement *stmt : *config.stmts)
+  {
+    stmt->accept(*this);
+  }
+  --depth_;
+}
+
 void Printer::visit(Jump &jump)
 {
   std::string indent(depth_, ' ');
@@ -384,6 +410,13 @@ void Printer::visit(Program &program)
 
   std::string indent(depth_, ' ');
   out_ << indent << "Program" << std::endl;
+
+  if (program.config)
+  {
+    ++depth_;
+    program.config->accept(*this);
+    --depth_;
+  }
 
   ++depth_;
   for (Probe *probe : *program.probes)

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -38,9 +38,11 @@ public:
   void visit(ExprStatement &expr) override;
   void visit(AssignMapStatement &assignment) override;
   void visit(AssignVarStatement &assignment) override;
+  void visit(AssignConfigVarStatement &assignment) override;
   void visit(If &if_block) override;
   void visit(Unroll &unroll) override;
   void visit(While &while_block) override;
+  void visit(Config &config) override;
   void visit(Jump &jump) override;
   void visit(Predicate &pred) override;
   void visit(AttachPoint &ap) override;

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -90,7 +90,7 @@ void SemanticAnalyser::visit(String &string)
   if (func_ == "printf" && func_arg_idx_ == 0)
     return;
 
-  auto str_len = bpftrace_.config_.get(ConfigKeyInt::strlen);
+  auto str_len = bpftrace_.config_.get(ConfigKeyInt::max_strlen);
   if (!is_compile_time_func(func_) && string.str.size() > str_len - 1)
   {
     LOG(ERROR, string.loc, err_)
@@ -705,7 +705,7 @@ void SemanticAnalyser::visit(Call &call)
             << call.func << "() expects an integer or a pointer type as first "
             << "argument (" << t << " provided)";
       }
-      call.type = CreateString(bpftrace_.config_.get(ConfigKeyInt::strlen));
+      call.type = CreateString(bpftrace_.config_.get(ConfigKeyInt::max_strlen));
       if (has_pos_param_)
       {
         if (dynamic_cast<PositionalParameter *>(arg))
@@ -758,7 +758,7 @@ void SemanticAnalyser::visit(Call &call)
           << typestr(arg.type.type);
     }
 
-    size_t max_buffer_size = bpftrace_.config_.get(ConfigKeyInt::strlen);
+    size_t max_buffer_size = bpftrace_.config_.get(ConfigKeyInt::max_strlen);
     size_t buffer_size = max_buffer_size;
 
     if (call.vargs->size() == 1)
@@ -800,8 +800,8 @@ void SemanticAnalyser::visit(Call &call)
       if (is_final_pass())
         LOG(WARNING, call.loc, out_)
             << call.func << "() length is too long and will be shortened to "
-            << std::to_string(bpftrace_.config_.get(ConfigKeyInt::strlen))
-            << " bytes (see BPFTRACE_STRLEN)";
+            << std::to_string(bpftrace_.config_.get(ConfigKeyInt::max_strlen))
+            << " bytes (see BPFTRACE_MAX_STRLEN)";
 
       buffer_size = max_buffer_size;
     }
@@ -1263,7 +1263,7 @@ void SemanticAnalyser::visit(Call &call)
       }
 
       call.type = SizedType(Type::string,
-                            bpftrace_.config_.get(ConfigKeyInt::strlen));
+                            bpftrace_.config_.get(ConfigKeyInt::max_strlen));
     }
 
     for (auto &attach_point : *probe_->attach_points)
@@ -2134,7 +2134,8 @@ void SemanticAnalyser::visit(Ternary &ternary)
       LOG(ERROR, ternary.loc, err_) << "Invalid condition in ternary: " << cond;
   }
   if (lhs == Type::string)
-    ternary.type = CreateString(bpftrace_.config_.get(ConfigKeyInt::strlen));
+    ternary.type = CreateString(
+        bpftrace_.config_.get(ConfigKeyInt::max_strlen));
   else if (lhs == Type::integer)
     ternary.type = CreateInteger(64, ternary.left->type.IsSigned());
   else if (lhs == Type::none)

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -8,6 +8,7 @@
 #include "ast/visitors.h"
 #include "bpffeature.h"
 #include "bpftrace.h"
+#include "config.h"
 #include "map.h"
 #include "types.h"
 
@@ -66,11 +67,13 @@ public:
   void visit(ExprStatement &expr) override;
   void visit(AssignMapStatement &assignment) override;
   void visit(AssignVarStatement &assignment) override;
+  void visit(AssignConfigVarStatement &assignment) override;
   void visit(If &if_block) override;
   void visit(Unroll &unroll) override;
   void visit(Predicate &pred) override;
   void visit(AttachPoint &ap) override;
   void visit(Probe &probe) override;
+  void visit(Config &config) override;
   void visit(Program &program) override;
 
   int analyse();

--- a/src/ast/visitors.h
+++ b/src/ast/visitors.h
@@ -36,6 +36,7 @@ public:
   virtual void visit(ExprStatement &expr) = 0;
   virtual void visit(AssignMapStatement &assignment) = 0;
   virtual void visit(AssignVarStatement &assignment) = 0;
+  virtual void visit(AssignConfigVarStatement &assignment) = 0;
   virtual void visit(If &if_block) = 0;
   virtual void visit(Jump &jump) = 0;
   virtual void visit(Unroll &unroll) = 0;
@@ -43,6 +44,7 @@ public:
   virtual void visit(Predicate &pred) = 0;
   virtual void visit(AttachPoint &ap) = 0;
   virtual void visit(Probe &probe) = 0;
+  virtual void visit(Config &config) = 0;
   virtual void visit(Program &program) = 0;
 };
 
@@ -100,6 +102,7 @@ public:
   void visit(ExprStatement &expr) override;
   void visit(AssignMapStatement &assignment) override;
   void visit(AssignVarStatement &assignment) override;
+  void visit(AssignConfigVarStatement &assignment) override;
   void visit(If &if_block) override;
   void visit(Unroll &unroll) override;
   void visit(While &while_block) override;
@@ -107,6 +110,7 @@ public:
   void visit(Predicate &pred) override;
   void visit(AttachPoint &ap) override;
   void visit(Probe &probe) override;
+  void visit(Config &config) override;
   void visit(Program &program) override;
 };
 
@@ -163,6 +167,7 @@ public:
   virtual R visit(ExprStatement &node) DEFAULT_FN;
   virtual R visit(AssignMapStatement &node) DEFAULT_FN;
   virtual R visit(AssignVarStatement &node) DEFAULT_FN;
+  virtual R visit(AssignConfigVarStatement &node) DEFAULT_FN;
   virtual R visit(If &node) DEFAULT_FN;
   virtual R visit(Jump &node) DEFAULT_FN;
   virtual R visit(Unroll &node) DEFAULT_FN;
@@ -170,6 +175,7 @@ public:
   virtual R visit(Predicate &node) DEFAULT_FN;
   virtual R visit(AttachPoint &node) DEFAULT_FN;
   virtual R visit(Probe &node) DEFAULT_FN;
+  virtual R visit(Config &node) DEFAULT_FN;
   virtual R visit(Program &node) DEFAULT_FN;
 
   virtual R default_visitor(Node &node)
@@ -209,6 +215,7 @@ private:
     DEFINE_DISPATCH(ExprStatement);
     DEFINE_DISPATCH(AssignMapStatement);
     DEFINE_DISPATCH(AssignVarStatement);
+    DEFINE_DISPATCH(AssignConfigVarStatement);
     DEFINE_DISPATCH(If);
     DEFINE_DISPATCH(Unroll);
     DEFINE_DISPATCH(Jump);
@@ -217,6 +224,7 @@ private:
     DEFINE_DISPATCH(While);
     DEFINE_DISPATCH(AttachPoint);
     DEFINE_DISPATCH(Probe);
+    DEFINE_DISPATCH(Config);
     DEFINE_DISPATCH(Program);
 
     return table;
@@ -260,6 +268,7 @@ public:
   Node *visit(ExprStatement &) override;
   Node *visit(AssignMapStatement &) override;
   Node *visit(AssignVarStatement &) override;
+  Node *visit(AssignConfigVarStatement &) override;
   Node *visit(If &) override;
   Node *visit(Jump &) override;
   Node *visit(Unroll &) override;
@@ -267,6 +276,7 @@ public:
   Node *visit(Predicate &) override;
   Node *visit(AttachPoint &) override;
   Node *visit(Probe &) override;
+  Node *visit(Config &) override;
   Node *visit(Program &) override;
 
 protected:

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -198,6 +198,8 @@ public:
   bool has_usdt_ = false;
   bool usdt_file_activation_ = false;
   int helper_check_level_ = 0;
+  uint64_t max_ast_nodes_ = 0; // Maximum AST nodes allowed for fuzzing
+  bool debug_output_ = false;
   std::optional<struct timespec> boottime_;
   std::optional<struct timespec> delta_taitime_;
   static constexpr uint32_t rb_loss_cnt_key_ = 0;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -11,18 +11,18 @@ Config::Config(bool has_cmd, bool bt_verbose) : bt_verbose_(bt_verbose)
 {
   config_map_ = {
     // Maximum AST nodes allowed for fuzzing
-    { ConfigKeyInt::ast_max_nodes, { .value = (uint64_t)0 } },
-    { ConfigKeyInt::cat_bytes_max, { .value = (uint64_t)10240 } },
+    { ConfigKeyInt::max_ast_nodes, { .value = (uint64_t)0 } },
+    { ConfigKeyInt::max_cat_bytes, { .value = (uint64_t)10240 } },
     { ConfigKeyBool::debug_output, { .value = false } },
     { ConfigKeyInt::log_size, { .value = (uint64_t)1000000 } },
-    { ConfigKeyInt::map_keys_max, { .value = (uint64_t)4096 } },
+    { ConfigKeyInt::max_map_keys, { .value = (uint64_t)4096 } },
     { ConfigKeyInt::max_probes, { .value = (uint64_t)512 } },
     { ConfigKeyInt::max_bpf_progs, { .value = (uint64_t)512 } },
     { ConfigKeyInt::max_type_res_iterations, { .value = (uint64_t)0 } },
-    { ConfigKeyBool::no_cpp_demangle, { .value = false } },
+    { ConfigKeyBool::cpp_demangle, { .value = true } },
     { ConfigKeyInt::perf_rb_pages, { .value = (uint64_t)64 } },
     { ConfigKeyStackMode::default_, { .value = StackMode::bpftrace } },
-    { ConfigKeyInt::strlen, { .value = (uint64_t)64 } },
+    { ConfigKeyInt::max_strlen, { .value = (uint64_t)64 } },
     { ConfigKeyString::str_trunc_trailer, { .value = ".." } },
     // by default, cache user symbols per program if ASLR is disabled on system
     // or `-c` option is given

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -34,15 +34,12 @@ Config::Config(bool has_cmd, bool bt_verbose) : bt_verbose_(bt_verbose)
   };
 }
 
-bool Config::can_set(ConfigSource prevSource, ConfigSource)
+bool Config::can_set(ConfigSource prevSource, ConfigSource source)
 {
-  if (prevSource == ConfigSource::default_)
+  if (prevSource == ConfigSource::default_ ||
+      (prevSource == ConfigSource::script && source == ConfigSource::env_var))
   {
     return true;
-  }
-  else if (prevSource == ConfigSource::env_var)
-  {
-    return false;
   }
   return false;
 }
@@ -80,19 +77,46 @@ std::map<std::string, StackMode> get_stack_mode_map()
   return result;
 }
 
-bool ConfigSetter::set_stack_mode(const std::string &s)
+std::optional<StackMode> Config::get_stack_mode(const std::string &s)
 {
   static auto stack_mode_map = get_stack_mode_map();
   auto found = stack_mode_map.find(s);
   if (found != stack_mode_map.end())
   {
-    return config_.set(ConfigKeyStackMode::default_, found->second, source_);
+    return std::make_optional(found->second);
   }
-  else
+  return std::nullopt;
+}
+
+std::optional<ConfigKey> Config::get_config_key(const std::string &str)
+{
+  std::string maybe_key = str;
+  static const std::string prefix = "bpftrace_";
+  std::transform(maybe_key.begin(),
+                 maybe_key.end(),
+                 maybe_key.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
+
+  if (maybe_key.rfind(prefix, 0) == 0)
   {
-    LOG(ERROR) << s << " is not a valid StackMode";
-    return false;
+    maybe_key = maybe_key.substr(prefix.length());
   }
+  auto found = CONFIG_KEY_MAP.find(maybe_key);
+  return found != CONFIG_KEY_MAP.end()
+             ? std::make_optional<ConfigKey>(found->second)
+             : std::nullopt;
+}
+
+bool ConfigSetter::set_stack_mode(const std::string &s)
+{
+  auto stack_mode = Config::get_stack_mode(s);
+  if (stack_mode.has_value())
+    return config_.set(ConfigKeyStackMode::default_,
+                       stack_mode.value(),
+                       source_);
+
+  LOG(ERROR) << s << " is not a valid StackMode";
+  return false;
 }
 
 // Note: options 0 and 1 are for compatibility with older versions of bpftrace
@@ -118,12 +142,17 @@ bool ConfigSetter::set_user_symbol_cache_type(const std::string &s)
   }
   else
   {
-    LOG(ERROR)
-        << "Env var 'BPFTRACE_CACHE_USER_SYMBOLS' did not contain a valid "
-           "value: valid values are PER_PID, PER_PROGRAM, and NONE.";
+    LOG(ERROR) << "Invalid value for cache_user_symbols: valid values are "
+                  "PER_PID, PER_PROGRAM, and NONE.";
     return false;
   }
   return config_.set(ConfigKeyUserSymbolCacheType::default_, usct, source_);
+}
+
+bool ConfigSetter::valid_source(ConfigKey key)
+{
+  return source_ == ConfigSource::env_var ||
+         ENV_ONLY_CONFIGS.find(key) == ENV_ONLY_CONFIGS.end();
 }
 
 } // namespace bpftrace

--- a/src/config.h
+++ b/src/config.h
@@ -26,14 +26,11 @@ enum class ConfigSource
 enum class ConfigKeyBool
 {
   cpp_demangle,
-  debug_output,
-  verify_llvm_ir,
 };
 
 enum class ConfigKeyInt
 {
   log_size,
-  max_ast_nodes,
   max_bpf_progs,
   max_cat_bytes,
   max_map_keys,
@@ -65,13 +62,12 @@ typedef std::variant<ConfigKeyBool,
                      ConfigKeyUserSymbolCacheType>
     ConfigKey;
 
-// These strings match the env variables (minus the 'BPFTRACE_' prefix)
+// The strings in CONFIG_KEY_MAP AND ENV_ONLY match the env variables (minus the
+// 'BPFTRACE_' prefix)
 const std::map<std::string, ConfigKey> CONFIG_KEY_MAP = {
   { "cache_user_symbols", ConfigKeyUserSymbolCacheType::default_ },
   { "cpp_demangle", ConfigKeyBool::cpp_demangle },
-  { "debug_output", ConfigKeyBool::debug_output },
   { "log_size", ConfigKeyInt::log_size },
-  { "max_ast_nodes", ConfigKeyInt::max_ast_nodes },
   { "max_bpf_progs", ConfigKeyInt::max_bpf_progs },
   { "max_cat_bytes", ConfigKeyInt::max_cat_bytes },
   { "max_map_keys", ConfigKeyInt::max_map_keys },
@@ -81,13 +77,12 @@ const std::map<std::string, ConfigKey> CONFIG_KEY_MAP = {
   { "perf_rb_pages", ConfigKeyInt::perf_rb_pages },
   { "stack_mode", ConfigKeyStackMode::default_ },
   { "str_trunc_trailer", ConfigKeyString::str_trunc_trailer },
-  { "verify_llvm_ir", ConfigKeyBool::verify_llvm_ir },
 };
 
-const std::set<ConfigKey> ENV_ONLY_CONFIGS = {
-  ConfigKeyInt::max_ast_nodes,
-  ConfigKeyBool::debug_output,
-  ConfigKeyBool::verify_llvm_ir,
+// These are not tracked by the config class
+const std::set<std::string> ENV_ONLY = {
+  "btf",           "debug_output",   "kernel_build", "kernel_source",
+  "max_ast_nodes", "verify_llvm_ir", "vmlinux",
 };
 
 struct ConfigValue
@@ -128,7 +123,8 @@ public:
   }
 
   static std::optional<StackMode> get_stack_mode(const std::string &s);
-  std::optional<ConfigKey> get_config_key(const std::string &str);
+  std::optional<ConfigKey> get_config_key(const std::string &str,
+                                          std::string &err);
 
   friend class ConfigSetter;
 
@@ -211,7 +207,6 @@ public:
 
   bool set_stack_mode(const std::string &s);
   bool set_user_symbol_cache_type(const std::string &s);
-  bool valid_source(ConfigKey key);
 
   Config &config_;
 

--- a/src/config.h
+++ b/src/config.h
@@ -25,22 +25,22 @@ enum class ConfigSource
 
 enum class ConfigKeyBool
 {
+  cpp_demangle,
   debug_output,
-  no_cpp_demangle,
   verify_llvm_ir,
 };
 
 enum class ConfigKeyInt
 {
-  ast_max_nodes,
-  cat_bytes_max,
   log_size,
-  map_keys_max,
-  max_probes,
+  max_ast_nodes,
   max_bpf_progs,
+  max_cat_bytes,
+  max_map_keys,
+  max_probes,
+  max_strlen,
   max_type_res_iterations,
   perf_rb_pages,
-  strlen,
 };
 
 enum class ConfigKeyString
@@ -67,25 +67,25 @@ typedef std::variant<ConfigKeyBool,
 
 // These strings match the env variables (minus the 'BPFTRACE_' prefix)
 const std::map<std::string, ConfigKey> CONFIG_KEY_MAP = {
-  { "node_max", ConfigKeyInt::ast_max_nodes },
-  { "cat_bytes_max", ConfigKeyInt::cat_bytes_max },
+  { "cache_user_symbols", ConfigKeyUserSymbolCacheType::default_ },
+  { "cpp_demangle", ConfigKeyBool::cpp_demangle },
   { "debug_output", ConfigKeyBool::debug_output },
   { "log_size", ConfigKeyInt::log_size },
-  { "map_keys_max", ConfigKeyInt::map_keys_max },
-  { "max_probes", ConfigKeyInt::max_probes },
+  { "max_ast_nodes", ConfigKeyInt::max_ast_nodes },
   { "max_bpf_progs", ConfigKeyInt::max_bpf_progs },
+  { "max_cat_bytes", ConfigKeyInt::max_cat_bytes },
+  { "max_map_keys", ConfigKeyInt::max_map_keys },
+  { "max_probes", ConfigKeyInt::max_probes },
+  { "max_strlen", ConfigKeyInt::max_strlen },
   { "max_type_res_iterations", ConfigKeyInt::max_type_res_iterations },
-  { "no_cpp_demangle", ConfigKeyBool::no_cpp_demangle },
   { "perf_rb_pages", ConfigKeyInt::perf_rb_pages },
   { "stack_mode", ConfigKeyStackMode::default_ },
-  { "strlen", ConfigKeyInt::strlen },
   { "str_trunc_trailer", ConfigKeyString::str_trunc_trailer },
-  { "cache_user_symbols", ConfigKeyUserSymbolCacheType::default_ },
   { "verify_llvm_ir", ConfigKeyBool::verify_llvm_ir },
 };
 
 const std::set<ConfigKey> ENV_ONLY_CONFIGS = {
-  ConfigKeyInt::ast_max_nodes,
+  ConfigKeyInt::max_ast_nodes,
   ConfigKeyBool::debug_output,
   ConfigKeyBool::verify_llvm_ir,
 };

--- a/src/fuzz_main.cpp
+++ b/src/fuzz_main.cpp
@@ -107,15 +107,15 @@ int fuzz_main(const char* data, size_t sz)
     return err;
 
   // Limit node size
-  uint64_t node_max = DEFAULT_NODE_MAX;
-  if (!get_uint64_env_var("BPFTRACE_NODE_MAX",
-                          [&](uint64_t x) { node_max = x; }))
+  uint64_t max_ast_nodes = DEFAULT_NODE_MAX;
+  if (!get_uint64_env_var("BPFTRACE_MAX_AST_NODES",
+                          [&](uint64_t x) { max_ast_nodes = x; }))
     return 1;
   uint64_t node_count = 0;
   ast::CallbackVisitor counter(
       [&](ast::Node* node __attribute__((unused))) { node_count += 1; });
   driver.root->accept(counter);
-  if (node_count > node_max)
+  if (node_count > max_ast_nodes)
     return 1;
 
   // Field Analyzer

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -143,6 +143,7 @@ bpftrace|perf|raw       { return Parser::make_STACK_MODE(yytext, loc); }
 "?"                     { return Parser::make_QUES(loc); }
 "unroll"                { return Parser::make_UNROLL(loc); }
 "while"                 { return Parser::make_WHILE(loc); }
+"config"                { return Parser::make_CONFIG(loc); }
 "for"                   { return Parser::make_FOR(loc); }
 "return"                { return Parser::make_RETURN(loc); }
 "continue"              { return Parser::make_CONTINUE(loc); }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,6 +17,7 @@
 #include "ast/pass_manager.h"
 
 #include "ast/passes/codegen_llvm.h"
+#include "ast/passes/config_analyser.h"
 #include "ast/passes/field_analyser.h"
 #include "ast/passes/node_counter.h"
 #include "ast/passes/portability_analyser.h"
@@ -438,6 +439,7 @@ static std::optional<struct timespec> get_delta_taitime()
 ast::PassManager CreateDynamicPM()
 {
   ast::PassManager pm;
+  pm.AddPass(ast::CreateConfigPass());
   pm.AddPass(ast::CreateSemanticPass());
   pm.AddPass(ast::CreateCounterPass());
   pm.AddPass(ast::CreateResourcePass());

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -192,7 +192,7 @@ std::string Output::get_helper_error_msg(int func_id, int retcode) const
   std::string msg;
   if (func_id == libbpf::BPF_FUNC_map_update_elem && retcode == -E2BIG)
   {
-    msg = "Map full; can't update element. Try increasing MAP_KEYS_MAX.";
+    msg = "Map full; can't update element. Try increasing max_map_keys config";
   }
   else if (func_id == libbpf::BPF_FUNC_map_delete_elem && retcode == -ENOENT)
   {

--- a/src/required_resources.cpp
+++ b/src/required_resources.cpp
@@ -41,7 +41,7 @@ int RequiredResources::create_maps_impl(BPFtrace &bpftrace, bool fake)
       LOG(FATAL) << "map key \"" << map_name << "\" not found";
 
     auto &key = search_args->second;
-    auto map_keys_max = bpftrace.config_.get(ConfigKeyInt::map_keys_max);
+    auto max_map_keys = bpftrace.config_.get(ConfigKeyInt::max_map_keys);
 
     if (type.IsLhistTy())
     {
@@ -53,7 +53,7 @@ int RequiredResources::create_maps_impl(BPFtrace &bpftrace, bool fake)
       auto max = args->second.max;
       auto step = args->second.step;
       auto map = std::make_unique<T>(
-          map_name, type, key, min, max, step, map_keys_max);
+          map_name, type, key, min, max, step, max_map_keys);
       failed_maps += is_invalid_map(map->mapfd_);
       bpftrace.maps.Add(std::move(map));
     }
@@ -70,13 +70,13 @@ int RequiredResources::create_maps_impl(BPFtrace &bpftrace, bool fake)
                                      0,
                                      args->second,
                                      bpftrace.config_.get(
-                                         ConfigKeyInt::map_keys_max));
+                                         ConfigKeyInt::max_map_keys));
       failed_maps += is_invalid_map(map->mapfd_);
       bpftrace.maps.Add(std::move(map));
     }
     else
     {
-      auto map = std::make_unique<T>(map_name, type, key, map_keys_max);
+      auto map = std::make_unique<T>(map_name, type, key, max_map_keys);
       failed_maps += is_invalid_map(map->mapfd_);
       bpftrace.maps.Add(std::move(map));
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(bpftrace_test
   portability_analyser.cpp
   procmon.cpp
   probe.cpp
+  config_analyser.cpp
   resource_analyser.cpp
   required_resources.cpp
   semantic_analyser.cpp

--- a/tests/codegen/call_join.cpp
+++ b/tests/codegen/call_join.cpp
@@ -16,8 +16,7 @@ TEST(codegen, call_join_with_debug)
 {
   auto bpftrace = get_mock_bpftrace();
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  auto config_setter = ConfigSetter(bpftrace->config_, ConfigSource::env_var);
-  config_setter.set(ConfigKeyBool::debug_output, true);
+  bpftrace->debug_output_ = true;
   test(*bpftrace,
        "struct arg { char **argv } kprobe:f { $x = (struct arg *) 0; "
        "join($x->argv); }",

--- a/tests/config.cpp
+++ b/tests/config.cpp
@@ -16,23 +16,23 @@ TEST(Config, get_and_set)
   EXPECT_TRUE(config_setter.set(ConfigKeyBool::debug_output, true));
   EXPECT_EQ(config.get(ConfigKeyBool::debug_output), true);
 
-  EXPECT_TRUE(config_setter.set(ConfigKeyBool::no_cpp_demangle, true));
-  EXPECT_EQ(config.get(ConfigKeyBool::no_cpp_demangle), true);
+  EXPECT_TRUE(config_setter.set(ConfigKeyBool::cpp_demangle, true));
+  EXPECT_EQ(config.get(ConfigKeyBool::cpp_demangle), true);
 
   EXPECT_TRUE(config_setter.set(ConfigKeyBool::verify_llvm_ir, true));
   EXPECT_EQ(config.get(ConfigKeyBool::verify_llvm_ir), true);
 
-  EXPECT_TRUE(config_setter.set(ConfigKeyInt::ast_max_nodes, 10));
-  EXPECT_EQ(config.get(ConfigKeyInt::ast_max_nodes), 10);
+  EXPECT_TRUE(config_setter.set(ConfigKeyInt::max_ast_nodes, 10));
+  EXPECT_EQ(config.get(ConfigKeyInt::max_ast_nodes), 10);
 
-  EXPECT_TRUE(config_setter.set(ConfigKeyInt::cat_bytes_max, 10));
-  EXPECT_EQ(config.get(ConfigKeyInt::cat_bytes_max), 10);
+  EXPECT_TRUE(config_setter.set(ConfigKeyInt::max_cat_bytes, 10));
+  EXPECT_EQ(config.get(ConfigKeyInt::max_cat_bytes), 10);
 
   EXPECT_TRUE(config_setter.set(ConfigKeyInt::log_size, 10));
   EXPECT_EQ(config.get(ConfigKeyInt::log_size), 10);
 
-  EXPECT_TRUE(config_setter.set(ConfigKeyInt::map_keys_max, 10));
-  EXPECT_EQ(config.get(ConfigKeyInt::map_keys_max), 10);
+  EXPECT_TRUE(config_setter.set(ConfigKeyInt::max_map_keys, 10));
+  EXPECT_EQ(config.get(ConfigKeyInt::max_map_keys), 10);
 
   EXPECT_TRUE(config_setter.set(ConfigKeyInt::max_probes, 10));
   EXPECT_EQ(config.get(ConfigKeyInt::max_probes), 10);
@@ -46,8 +46,8 @@ TEST(Config, get_and_set)
   EXPECT_TRUE(config_setter.set(ConfigKeyInt::perf_rb_pages, 10));
   EXPECT_EQ(config.get(ConfigKeyInt::perf_rb_pages), 10);
 
-  EXPECT_TRUE(config_setter.set(ConfigKeyInt::strlen, 10));
-  EXPECT_EQ(config.get(ConfigKeyInt::strlen), 10);
+  EXPECT_TRUE(config_setter.set(ConfigKeyInt::max_strlen, 10));
+  EXPECT_EQ(config.get(ConfigKeyInt::max_strlen), 10);
 
   EXPECT_TRUE(config_setter.set(ConfigKeyString::str_trunc_trailer, "str"));
   EXPECT_EQ(config.get(ConfigKeyString::str_trunc_trailer), "str");
@@ -98,21 +98,21 @@ TEST(ConfigSetter, source_precedence)
   auto config_setter_script = ConfigSetter(config, ConfigSource::script);
 
   // env var takes precedence over script
-  EXPECT_TRUE(config_setter_env.set(ConfigKeyInt::ast_max_nodes, 10));
-  EXPECT_FALSE(config_setter_script.set(ConfigKeyInt::ast_max_nodes, 11));
-  EXPECT_EQ(config.get(ConfigKeyInt::ast_max_nodes), 10);
+  EXPECT_TRUE(config_setter_env.set(ConfigKeyInt::max_ast_nodes, 10));
+  EXPECT_FALSE(config_setter_script.set(ConfigKeyInt::max_ast_nodes, 11));
+  EXPECT_EQ(config.get(ConfigKeyInt::max_ast_nodes), 10);
 
-  EXPECT_TRUE(config_setter_script.set(ConfigKeyInt::cat_bytes_max, 19));
-  EXPECT_TRUE(config_setter_env.set(ConfigKeyInt::cat_bytes_max, 20));
-  EXPECT_EQ(config.get(ConfigKeyInt::cat_bytes_max), 20);
+  EXPECT_TRUE(config_setter_script.set(ConfigKeyInt::max_cat_bytes, 19));
+  EXPECT_TRUE(config_setter_env.set(ConfigKeyInt::max_cat_bytes, 20));
+  EXPECT_EQ(config.get(ConfigKeyInt::max_cat_bytes), 20);
 }
 
 TEST(ConfigSetter, same_source_cannot_set_twice)
 {
   auto config = Config();
   auto config_setter = ConfigSetter(config, ConfigSource::env_var);
-  EXPECT_TRUE(config_setter.set(ConfigKeyInt::ast_max_nodes, 10));
-  EXPECT_FALSE(config_setter.set(ConfigKeyInt::ast_max_nodes, 11));
+  EXPECT_TRUE(config_setter.set(ConfigKeyInt::max_ast_nodes, 10));
+  EXPECT_FALSE(config_setter.set(ConfigKeyInt::max_ast_nodes, 11));
 }
 
 TEST(ConfigSetter, valid_source)
@@ -121,11 +121,11 @@ TEST(ConfigSetter, valid_source)
   auto config_setter_env = ConfigSetter(config, ConfigSource::env_var);
   auto config_setter_script = ConfigSetter(config, ConfigSource::script);
 
-  EXPECT_TRUE(config_setter_env.valid_source(ConfigKeyInt::ast_max_nodes));
-  EXPECT_FALSE(config_setter_script.valid_source(ConfigKeyInt::ast_max_nodes));
+  EXPECT_TRUE(config_setter_env.valid_source(ConfigKeyInt::max_ast_nodes));
+  EXPECT_FALSE(config_setter_script.valid_source(ConfigKeyInt::max_ast_nodes));
 
-  EXPECT_TRUE(config_setter_env.valid_source(ConfigKeyInt::map_keys_max));
-  EXPECT_TRUE(config_setter_script.valid_source(ConfigKeyInt::map_keys_max));
+  EXPECT_TRUE(config_setter_env.valid_source(ConfigKeyInt::max_map_keys));
+  EXPECT_TRUE(config_setter_script.valid_source(ConfigKeyInt::max_map_keys));
 }
 
 } // namespace test

--- a/tests/config_analyser.cpp
+++ b/tests/config_analyser.cpp
@@ -68,12 +68,12 @@ void test(BPFtrace &bpftrace, const std::string &input)
 TEST(config_analyser, config)
 {
   test("config = { BAD_CONFIG=1 } BEGIN { }", false);
-  test("config = { BPFTRACE_MAX_PROBES=1 } BEGIN { }", true);
+  test("config = { BPFTRACE_MAX_MAP_KEYS=1 } BEGIN { }", true);
 
-  test("config = { BPFTRACE_MAX_PROBES=perf } BEGIN { }", false);
+  test("config = { BPFTRACE_MAX_MAP_KEYS=perf } BEGIN { }", false);
   test("config = { BPFTRACE_STACK_MODE=perf } BEGIN { }", true);
   test("config = { stack_mode=perf } BEGIN { }", true);
-  test("config = { BPFTRACE_MAX_PROBES=1; stack_mode=perf } BEGIN { $ns = "
+  test("config = { BPFTRACE_MAX_MAP_KEYS=1; stack_mode=perf } BEGIN { $ns = "
        "nsecs(); }",
        true);
   test("config = { BPFTRACE_CACHE_USER_SYMBOLS=\"PER_PROGRAM\" } BEGIN { $ns = "
@@ -98,7 +98,7 @@ config = { BPFTRACE_MAX_PROBES="hello" } BEGIN { }
       false);
   test(
       "config = { max_ast_nodes=1 } BEGIN { }",
-      R"(stdin:1:12-26: ERROR: max_ast_nodes can only be set as an environment variable.
+      R"(stdin:1:12-26: ERROR: max_ast_nodes can only be set as an environment variable
 config = { max_ast_nodes=1 } BEGIN { }
            ~~~~~~~~~~~~~~
 )",
@@ -109,9 +109,9 @@ TEST(config_analyser, config_setting)
 {
   auto bpftrace = get_mock_bpftrace();
 
-  EXPECT_NE(bpftrace->config_.get(ConfigKeyInt::max_probes), 9);
-  test(*bpftrace, "config = { BPFTRACE_MAX_PROBES=9 } BEGIN { }");
-  EXPECT_EQ(bpftrace->config_.get(ConfigKeyInt::max_probes), 9);
+  EXPECT_NE(bpftrace->config_.get(ConfigKeyInt::max_map_keys), 9);
+  test(*bpftrace, "config = { BPFTRACE_MAX_MAP_KEYS=9 } BEGIN { }");
+  EXPECT_EQ(bpftrace->config_.get(ConfigKeyInt::max_map_keys), 9);
 
   EXPECT_NE(bpftrace->config_.get(ConfigKeyStackMode::default_),
             StackMode::perf);

--- a/tests/config_analyser.cpp
+++ b/tests/config_analyser.cpp
@@ -97,10 +97,10 @@ config = { BPFTRACE_MAX_PROBES="hello" } BEGIN { }
 )",
       false);
   test(
-      "config = { node_max=1 } BEGIN { }",
-      R"(stdin:1:12-21: ERROR: node_max can only be set as an environment variable.
-config = { node_max=1 } BEGIN { }
-           ~~~~~~~~~
+      "config = { max_ast_nodes=1 } BEGIN { }",
+      R"(stdin:1:12-26: ERROR: max_ast_nodes can only be set as an environment variable.
+config = { max_ast_nodes=1 } BEGIN { }
+           ~~~~~~~~~~~~~~
 )",
       false);
 }

--- a/tests/config_analyser.cpp
+++ b/tests/config_analyser.cpp
@@ -1,0 +1,135 @@
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+#include "ast/passes/config_analyser.h"
+#include "ast/passes/semantic_analyser.h"
+#include "clang_parser.h"
+#include "driver.h"
+#include "mocks.h"
+
+namespace bpftrace {
+namespace test {
+namespace config_analyser {
+
+using ::testing::_;
+
+void test(BPFtrace &bpftrace,
+          const std::string &input,
+          std::string_view expected_error,
+          bool expected_result)
+{
+  Driver driver(bpftrace);
+  std::stringstream out;
+  std::stringstream msg;
+  msg << "\nInput:\n" << input << "\n\nOutput:\n";
+
+  ASSERT_EQ(driver.parse_str(input), 0);
+
+  ClangParser clang;
+  ASSERT_TRUE(clang.parse(driver.root.get(), bpftrace));
+
+  ASSERT_EQ(driver.parse_str(input), 0);
+  out.str("");
+  ast::SemanticAnalyser semantics(driver.root.get(), bpftrace, out, false);
+  ASSERT_EQ(semantics.analyse(), 0) << msg.str() << out.str();
+
+  ast::ConfigAnalyser config_analyser(driver.root.get(), bpftrace, out);
+  EXPECT_EQ(config_analyser.analyse(), expected_result)
+      << msg.str() << out.str();
+  if (expected_error.data())
+  {
+    if (!expected_error.empty() && expected_error[0] == '\n')
+      expected_error.remove_prefix(1); // Remove initial '\n'
+    EXPECT_EQ(out.str(), expected_error);
+  }
+}
+
+void test(const std::string &input, bool expected_result)
+{
+  auto bpftrace = get_mock_bpftrace();
+  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+  test(*bpftrace, input, {}, expected_result);
+}
+
+void test(const std::string &input,
+          std::string_view expected_error,
+          bool expected_result)
+{
+  auto bpftrace = get_mock_bpftrace();
+  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+  test(*bpftrace, input, expected_error, expected_result);
+}
+
+void test(BPFtrace &bpftrace, const std::string &input)
+{
+  test(bpftrace, input, {}, true);
+}
+
+TEST(config_analyser, config)
+{
+  test("config = { BAD_CONFIG=1 } BEGIN { }", false);
+  test("config = { BPFTRACE_MAX_PROBES=1 } BEGIN { }", true);
+
+  test("config = { BPFTRACE_MAX_PROBES=perf } BEGIN { }", false);
+  test("config = { BPFTRACE_STACK_MODE=perf } BEGIN { }", true);
+  test("config = { stack_mode=perf } BEGIN { }", true);
+  test("config = { BPFTRACE_MAX_PROBES=1; stack_mode=perf } BEGIN { $ns = "
+       "nsecs(); }",
+       true);
+  test("config = { BPFTRACE_CACHE_USER_SYMBOLS=\"PER_PROGRAM\" } BEGIN { $ns = "
+       "nsecs(); }",
+       true);
+}
+
+TEST(config_analyser, config_error)
+{
+  test("config = { BAD_CONFIG=1 } BEGIN { }",
+       R"(stdin:1:12-23: ERROR: Unrecognized config variable: BAD_CONFIG
+config = { BAD_CONFIG=1 } BEGIN { }
+           ~~~~~~~~~~~
+)",
+       false);
+  test(
+      "config = { BPFTRACE_MAX_PROBES=\"hello\" } BEGIN { }",
+      R"(stdin:1:12-32: ERROR: Invalid type for BPFTRACE_MAX_PROBES. Type: string. Expected Type: integer
+config = { BPFTRACE_MAX_PROBES="hello" } BEGIN { }
+           ~~~~~~~~~~~~~~~~~~~~
+)",
+      false);
+  test(
+      "config = { node_max=1 } BEGIN { }",
+      R"(stdin:1:12-21: ERROR: node_max can only be set as an environment variable.
+config = { node_max=1 } BEGIN { }
+           ~~~~~~~~~
+)",
+      false);
+}
+
+TEST(config_analyser, config_setting)
+{
+  auto bpftrace = get_mock_bpftrace();
+
+  EXPECT_NE(bpftrace->config_.get(ConfigKeyInt::max_probes), 9);
+  test(*bpftrace, "config = { BPFTRACE_MAX_PROBES=9 } BEGIN { }");
+  EXPECT_EQ(bpftrace->config_.get(ConfigKeyInt::max_probes), 9);
+
+  EXPECT_NE(bpftrace->config_.get(ConfigKeyStackMode::default_),
+            StackMode::perf);
+  test(*bpftrace, "config = { stack_mode=perf } BEGIN { }");
+  EXPECT_EQ(bpftrace->config_.get(ConfigKeyStackMode::default_),
+            StackMode::perf);
+
+  EXPECT_NE(bpftrace->config_.get(ConfigKeyUserSymbolCacheType::default_),
+            UserSymbolCacheType::per_program);
+  EXPECT_NE(bpftrace->config_.get(ConfigKeyInt::log_size), 150);
+  test(*bpftrace,
+       "config = { BPFTRACE_CACHE_USER_SYMBOLS=\"PER_PROGRAM\"; log_size=150 "
+       "} BEGIN { }");
+  EXPECT_EQ(bpftrace->config_.get(ConfigKeyUserSymbolCacheType::default_),
+            UserSymbolCacheType::per_program);
+  EXPECT_EQ(bpftrace->config_.get(ConfigKeyInt::log_size), 150);
+}
+
+} // namespace config_analyser
+} // namespace test
+} // namespace bpftrace

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -1999,6 +1999,21 @@ uprobe:asdf:Stream {} tracepoint:only_one_arg {}
 )");
 }
 
+TEST(Parser, config_error)
+{
+  test_parse_failure("i:s:1 { exit(); } config = { BPFTRACE_STACK_MODE=perf }");
+  test_parse_failure("config = { exit(); } i:s:1 { exit(); }");
+  test_parse_failure("config = { @start = nsecs; } i:s:1 { exit(); }");
+  test_parse_failure("BEGIN { @start = nsecs; } config = { "
+                     "BPFTRACE_STACK_MODE=perf } i:s:1 { exit(); }");
+  test_parse_failure("config = { BPFTRACE_STACK_MODE=perf "
+                     "BPFTRACE_MAX_PROBES=2 } i:s:1 { exit(); }");
+  test_parse_failure("config = { BPFTRACE_STACK_MODE=perf } i:s:1 { "
+                     "BPFTRACE_MAX_PROBES=2; exit(); }");
+  test_parse_failure("config { BPFTRACE_STACK_MODE=perf } i:s:1 { exit(); }");
+  test_parse_failure("BPFTRACE_STACK_MODE=perf; i:s:1 { exit(); }");
+}
+
 } // namespace parser
 } // namespace test
 } // namespace bpftrace

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -174,7 +174,7 @@ EXPECT ^([0-9]+\.[0-9]+ ?)+.*$
 TIMEOUT 5
 
 NAME cat limited output
-ENV BPFTRACE_CAT_BYTES_MAX=1
+ENV BPFTRACE_MAX_CAT_BYTES=1
 PROG i:ms:1 { cat("/proc/loadavg"); exit(); }
 EXPECT ^[0-9]$
 TIMEOUT 5

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -66,14 +66,14 @@ TIMEOUT 5
 
 NAME str_truncated
 PROG t:syscalls:sys_enter_execve { printf("P: %s\n", str(args.filename)); exit();}
-ENV BPFTRACE_STRLEN=5
+ENV BPFTRACE_MAX_STRLEN=5
 AFTER ./testprogs/syscall execve /bin/ls &>/dev/null
 EXPECT P: /...\.\.
 TIMEOUT 5
 
 NAME str_truncated_custom
 PROG t:syscalls:sys_enter_execve { printf("P: %s\n", str(args.filename)); exit();}
-ENV BPFTRACE_STRLEN=5 BPFTRACE_STR_TRUNC_TRAILER=_xxx
+ENV BPFTRACE_MAX_STRLEN=5 BPFTRACE_STR_TRUNC_TRAILER=_xxx
 AFTER ./testprogs/syscall execve /bin/ls &>/dev/null
 EXPECT P: /..._xxx
 TIMEOUT 5

--- a/tests/runtime/config
+++ b/tests/runtime/config
@@ -19,14 +19,14 @@ BEFORE ./testprogs/uprobe_test
 
 NAME bad config
 RUN {{BPFTRACE}} -e 'config = { bad_config=raw } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }' -p {{BEFORE_PID}}
-EXPECT ERROR: Unrecognized config variable
+EXPECT ERROR: Unrecognized config variable: bad_config
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 WILL_FAIL
 
 NAME env only config
 RUN {{BPFTRACE}} -e 'config = { debug_output=1 } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }' -p {{BEFORE_PID}}
-EXPECT ERROR: debug_output can only be set as an environment variable.
+EXPECT ERROR: debug_output can only be set as an environment variable
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 WILL_FAIL

--- a/tests/runtime/config
+++ b/tests/runtime/config
@@ -1,0 +1,32 @@
+NAME config as env var
+RUN {{BPFTRACE}} -e 'config = { BPFTRACE_STACK_MODE=raw } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }' -p {{BEFORE_PID}}
+EXPECT ^\s+[0-9a-f]+$
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+
+NAME config short name
+RUN {{BPFTRACE}} -e 'config = { stack_mode=raw } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }' -p {{BEFORE_PID}}
+EXPECT ^\s+[0-9a-f]+$
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+
+NAME env var takes precedence
+RUN {{BPFTRACE}} -e 'config = { BPFTRACE_STACK_MODE=perf } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }' -p {{BEFORE_PID}}
+ENV BPFTRACE_STACK_MODE=raw
+EXPECT ^\s+[0-9a-f]+$
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+
+NAME bad config
+RUN {{BPFTRACE}} -e 'config = { bad_config=raw } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }' -p {{BEFORE_PID}}
+EXPECT ERROR: Unrecognized config variable
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+WILL_FAIL
+
+NAME env only config
+RUN {{BPFTRACE}} -e 'config = { debug_output=1 } uprobe:./testprogs/uprobe_test:uprobeFunction1 { printf("%s", ustack(1)); exit(); }' -p {{BEFORE_PID}}
+EXPECT ERROR: debug_output can only be set as an environment variable.
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+WILL_FAIL

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2840,8 +2840,8 @@ BEGIN { nsecs(xxx); }
 
 TEST(semantic_analyser, config)
 {
-  test("config = { BPFTRACE_NODE_MAX=1 } BEGIN { $ns = nsecs(); }", 0);
-  test("config = { BPFTRACE_NODE_MAX=1; stack_mode=raw } BEGIN { $ns = "
+  test("config = { BPFTRACE_MAX_AST_NODES=1 } BEGIN { $ns = nsecs(); }", 0);
+  test("config = { BPFTRACE_MAX_AST_NODES=1; stack_mode=raw } BEGIN { $ns = "
        "nsecs(); }",
        0);
 }

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2838,6 +2838,14 @@ BEGIN { nsecs(xxx); }
 )");
 }
 
+TEST(semantic_analyser, config)
+{
+  test("config = { BPFTRACE_NODE_MAX=1 } BEGIN { $ns = nsecs(); }", 0);
+  test("config = { BPFTRACE_NODE_MAX=1; stack_mode=raw } BEGIN { $ns = "
+       "nsecs(); }",
+       0);
+}
+
 class semantic_analyser_btf : public test_btf
 {
 };


### PR DESCRIPTION
This new feature allows users to set environment variables and other configuration in bpftrace scripts. This makes scripts more portable e.g. it's easier to reproduce behaviors without having to remember how scripts were invoked.

Environment variables passed on the command line take precedence
over ones set in the script itself.

Example:
```
sudo bpftrace -v -e 'config = { BPFTRACE_STACK_MODE=raw; } kprobe:vfs_read {
print(kstack()); }'
```


##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
