### PR TITLE
Fixed cmake download path which had arch hardcoded to x86_64

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -40,7 +40,7 @@ RUN apk add --update \
 WORKDIR /
 
 RUN ln -s $(which python3) /usr/bin/python && \
-    ln -s /lib /lib/x86_64-linux-gnu
+    ln -s /lib /lib/$(uname -m)-linux-gnu
 
 RUN wget https://github.com/USCiLab/cereal/archive/refs/tags/v${CEREAL_VERSION}.tar.gz && \
     tar xf v${CEREAL_VERSION}.tar.gz && \

--- a/docker/Dockerfile.focal
+++ b/docker/Dockerfile.focal
@@ -13,8 +13,10 @@ deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-${LLVM_VERSION} main\n" 
     curl -L https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4052245BD4284CDD
 
-RUN curl -L --output /tmp/cmake.tar.gz \
-  https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-linux-x86_64.tar.gz \
+ARG ARCH
+RUN ARCH=$(uname -m) \
+  && curl -L --output /tmp/cmake.tar.gz \
+  https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-linux-${ARCH}.tar.gz \
   && tar -xf /tmp/cmake.tar.gz -C /usr/local/ --strip-components=1
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/docker/Dockerfile.focal
+++ b/docker/Dockerfile.focal
@@ -13,10 +13,8 @@ deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-${LLVM_VERSION} main\n" 
     curl -L https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add - && \
     apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 4052245BD4284CDD
 
-ARG ARCH
-RUN ARCH=$(uname -m) \
-  && curl -L --output /tmp/cmake.tar.gz \
-  https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-linux-${ARCH}.tar.gz \
+RUN curl -L --output /tmp/cmake.tar.gz \
+  https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-linux-$(uname -m).tar.gz \
   && tar -xf /tmp/cmake.tar.gz -C /usr/local/ --strip-components=1
 
 ARG DEBIAN_FRONTEND=noninteractive

--- a/docker/Dockerfile.llvm
+++ b/docker/Dockerfile.llvm
@@ -32,12 +32,10 @@ RUN apt update \
     tar \
   && update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 60 \
                          --slave /usr/bin/g++ g++ /usr/bin/g++-8      \
-  && cp /usr/lib/gcc/x86_64-linux-gnu/8/plugin/include/plugin-api.h /usr/local/include
+  && cp /usr/lib/gcc/$(uname -m)-linux-gnu/8/plugin/include/plugin-api.h /usr/local/include
 
-ARG ARCH
-RUN ARCH=$(uname -m) \
-  && curl -L --output /tmp/cmake.tar.gz \
-  https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-linux-${ARCH}.tar.gz \
+RUN curl -L --output /tmp/cmake.tar.gz \
+  https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-linux-$(uname -m).tar.gz \
   && tar -xf /tmp/cmake.tar.gz -C /usr/local/ --strip-components=1
 
 RUN cd /build/llvm \

--- a/docker/Dockerfile.llvm
+++ b/docker/Dockerfile.llvm
@@ -37,7 +37,7 @@ RUN apt update \
 ARG ARCH
 RUN ARCH=$(uname -m) \
   && curl -L --output /tmp/cmake.tar.gz \
-  https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-linux-x86_64.tar.gz \
+  https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-linux-${ARCH}.tar.gz \
   && tar -xf /tmp/cmake.tar.gz -C /usr/local/ --strip-components=1
 
 RUN cd /build/llvm \

--- a/docker/Dockerfile.llvm
+++ b/docker/Dockerfile.llvm
@@ -34,7 +34,9 @@ RUN apt update \
                          --slave /usr/bin/g++ g++ /usr/bin/g++-8      \
   && cp /usr/lib/gcc/x86_64-linux-gnu/8/plugin/include/plugin-api.h /usr/local/include
 
-RUN curl -L --output /tmp/cmake.tar.gz \
+ARG ARCH
+RUN ARCH=$(uname -m) \
+  && curl -L --output /tmp/cmake.tar.gz \
   https://github.com/Kitware/CMake/releases/download/v3.20.0/cmake-3.20.0-linux-x86_64.tar.gz \
   && tar -xf /tmp/cmake.tar.gz -C /usr/local/ --strip-components=1
 


### PR DESCRIPTION
<!--
Was running build.sh in my arm64 environment and script execution failed complaining about cmake file format being incorrect. Turned out it was caused by cmake download path had hardcoded arch to x86_64. 
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
