### PR TITLE
nix: Update libbpf

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -37,11 +37,11 @@
         "systems": "systems"
       },
       "locked": {
-        "lastModified": 1692799911,
-        "narHash": "sha256-3eihraek4qL744EvQXsK1Ha6C3CR7nnT8X2qWap4RNk=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f9e7cf818399d17d347f847525c5a5a8032e4e44",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -22,22 +22,22 @@
       (system:
         let
           # Overlay to specify build should use the specific libbpf we want
-          libbpfVersion = "1.2.0";
           libbpfOverlay =
             (self: super: {
               libbpf_1 = super.libbpf_1.overrideAttrs (old: {
-                version = libbpfVersion;
+                # 1.3 is the next release as of (11/11/23)
+                version = "1.3.0";
                 src = super.fetchFromGitHub {
                   owner = "libbpf";
                   repo = "libbpf";
-                  rev = "v${libbpfVersion}";
+                  rev = "3189f70538b50fe3d2fd63f77351991a224e435b";
                   # If you don't know the hash the first time, set:
                   # hash = "";
                   # then nix will fail the build with such an error message:
                   # hash mismatch in fixed-output derivation '/nix/store/m1ga09c0z1a6n7rj8ky3s31dpgalsn0n-source':
                   # specified: sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
                   # got:    sha256-173gxk0ymiw94glyjzjizp8bv8g72gwkjhacigd1an09jshdrjb4
-                  sha256 = "sha256-NimK4pdYcai21hZHdP1mBX1MOlNY61iDJ+PDYwpRuVE=";
+                  sha256 = "sha256-nh1xs4jT/YCBq6uT4WbSJc6/BfMg1Ussd11aY1Nmlq4=";
                 };
               });
             });


### PR DESCRIPTION
causes skew in the CI -- embedded builds will use a different libbpf than the nix based builds.

Fix by updating flake.nix.

The situation will be improved when embedded builds (and the submodules) are removed in the near future. IOW, this will be less likely to happen.

Fixes: ba92ae25 ("Update libbpf submodule")

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
