### PR TITLE
utils: use /data/local/tmp as temprary dir on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@ and this project adheres to
   - [#2793](https://github.com/iovisor/bpftrace/pull/2793)
 - Fix silent truncation of 64-bit values in hist()
   - [#2822](https://github.com/iovisor/bpftrace/pull/2822)
+- utils: use /data/local/tmp as temprary dir on Android
+  - [#2828](https://github.com/iovisor/bpftrace/pull/2828)
 #### Docs
 #### Tools
 - Update runqlen.bt to remove `runnable_weight` field from cfs_rq struct.

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -714,7 +714,11 @@ namespace {
   std::string unpack_kheaders_tar_xz(const struct utsname& utsname)
   {
     std::error_code ec;
+#if defined(__ANDROID__)
+    std_filesystem::path path_prefix{ "/data/local/tmp" };
+#else
     std_filesystem::path path_prefix{ "/tmp" };
+#endif
     std_filesystem::path path_kheaders{ "/sys/kernel/kheaders.tar.xz" };
     if (const char* tmpdir = ::getenv("TMPDIR")) {
       path_prefix = tmpdir;


### PR DESCRIPTION
`/tmp` does not exist on Android and cannot be created by regular applications. 
Use `/data/local/tmp` as an alternate tmpDir.

## Test Plan
### before
Test bfptrace on Android device. bpftrace raises runtime_error due to the `/tmp` is not available and creatable.
```bash
$ ./bpftrace  -e 't:timer:hrtimer_start { @[ksym(args->function)] = count(); }'
terminating with uncaught exception of type std::runtime_error: creating temporary path for kheaders.tar.xz failed
Aborted
```

### after
runtime_error got migrated.
```
$ bpftrace  -e 't:timer:hrtimer_start { @[ksym(args->function)] = count(); }'
Attaching 1 probe...
[..]
```


