### PR TITLE
[uprobe] support for pid targeting for shared libs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ and this project adheres to
   - [#2804](https://github.com/iovisor/bpftrace/pull/2804)
 - Add fentry/fexit aliases for kfunc/kretfunc
   - [#2844](https://github.com/iovisor/bpftrace/pull/2844)
+- Add support for uprobe pid targeting
+  - [#2830](https://github.com/iovisor/bpftrace/pull/2830)
 #### Changed
 #### Deprecated
 #### Removed

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -118,7 +118,8 @@ u:lib.so:"fn(char const*)" { printf("arg0:%s\n", str(arg0));}
 
 *-p* _PID_::
   Attach to the process with _PID_. If the process terminates, bpftrace will also terminate.
-  When using USDT probes they will be attached to only this process. For uprobes/uretprobes if you also set the target to '*' the process's address space will be searched for the symbols.
+  When using USDT probes, uprobes, and uretprobes they will be attached to only this process.
+  For listing uprobes/uretprobes if you set the target to '*' the process's address space will be searched for the symbols.
 
 *-c* _COMMAND_::
   Run _COMMAND_ as a child process.

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -30,7 +30,8 @@ public:
                 BpfProgram &&prog,
                 int pid,
                 BPFfeature &feature,
-                BTF &btf);
+                BTF &btf,
+                bool safe_mode = true);
   ~AttachedProbe();
   AttachedProbe(const AttachedProbe &) = delete;
   AttachedProbe &operator=(const AttachedProbe &) = delete;
@@ -46,9 +47,9 @@ private:
   bool resolve_offset_uprobe(bool safe_mode);
   void load_prog(BPFfeature &feature);
   void attach_multi_kprobe(void);
-  void attach_multi_uprobe(void);
+  void attach_multi_uprobe(int pid);
   void attach_kprobe(bool safe_mode);
-  void attach_uprobe(bool safe_mode);
+  void attach_uprobe(int pid, bool safe_mode);
 
   // Note: the following usdt attachment functions will only activate a
   // semaphore if one exists.

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1006,6 +1006,13 @@ std::vector<std::unique_ptr<AttachedProbe>> BPFtrace::attach_probe(
 
       return ret;
     }
+    else if (probe.type == ProbeType::uprobe ||
+             probe.type == ProbeType::uretprobe)
+    {
+      ret.emplace_back(std::make_unique<AttachedProbe>(
+          probe, std::move(*program), pid, *feature_, *btf_, safe_mode_));
+      return ret;
+    }
     else if (probe.type == ProbeType::watchpoint ||
              probe.type == ProbeType::asyncwatchpoint)
     {
@@ -1085,10 +1092,6 @@ int BPFtrace::run_special_probe(std::string name,
   {
     if ((*probe).attach_point == name)
     {
-      // This is only necessary for uprobe fallback case but it doesn't hurt
-      // to set for raw_tp
-      probe->pid = getpid();
-
       auto aps = attach_probe(*probe, bytecode);
       if (aps.size() != 1)
         return -1;

--- a/src/types.h
+++ b/src/types.h
@@ -532,7 +532,6 @@ struct Probe
   uint64_t log_size = 1000000;
   int index = 0;
   int freq = 0;
-  pid_t pid = -1;
   uint64_t len = 0;             // for watchpoint probes, size of region
   std::string mode;             // for watchpoint probes, watch mode (rwx)
   bool async = false; // for watchpoint probes, if it's an async watchpoint
@@ -557,7 +556,6 @@ private:
             log_size,
             index,
             freq,
-            pid,
             len,
             mode,
             async,

--- a/tests/runtime/scripts/uprobe_pid_check.bt
+++ b/tests/runtime/scripts/uprobe_pid_check.bt
@@ -1,0 +1,20 @@
+BEGIN {
+    @count = 0;
+}
+
+uprobe:./testprogs/uprobe_fork_loop:uprobeFunction1 {
+    if (pid == $1) {
+        // counting 10 instances of the expected pid
+        // is similar to a delay to ensure we never get
+        // an unexpected pid
+        if (@count == 10) {
+            print("hello");
+            exit();
+        } else {
+            @count++;
+        }
+    } else {
+        // pid should always be the first positional param
+        exit();
+    }
+}

--- a/tests/runtime/uprobe
+++ b/tests/runtime/uprobe
@@ -73,3 +73,9 @@ NAME uprobes - probe function in non-executable library
 PROG uprobe:./testlibs/libsimple.so:fun {}
 EXPECT Attaching 1 probe...
 TIMEOUT 5
+
+NAME uprobes - attach to single process with pid arg
+RUN {{BPFTRACE}} runtime/scripts/uprobe_pid_check.bt -p {{BEFORE_PID}} {{BEFORE_PID}}
+EXPECT hello
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_fork_loop

--- a/tests/testprogs/uprobe_fork_loop.c
+++ b/tests/testprogs/uprobe_fork_loop.c
@@ -1,0 +1,32 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int uprobeFunction1(int *n, char c __attribute__((unused)))
+{
+  return *n;
+}
+
+void spin()
+{
+  while (1)
+  {
+    int n = 13;
+    char c = 'x';
+    uprobeFunction1(&n, c);
+    usleep(500);
+  }
+}
+
+int main(int argc __attribute__((unused)), char **argv __attribute__((unused)))
+{
+  pid_t p = fork();
+  if (p < 0)
+  {
+    perror("fork fail");
+    exit(1);
+  }
+  spin();
+
+  return 0;
+}


### PR DESCRIPTION
This adds support for specifying the pid even when targeting a uprobe/uretprobe in a library shared by multiple pids.

Example:
```
sudo bpftrace -p 1899508 -e 'uprobe:libc:getaddrinfo {
  print((comm, pid));
}
```

[Issue 2817](https://github.com/iovisor/bpftrace/issues/2817)

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
