### PR TITLE
ci: Automate uploading release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+# This job listens for new releases and will build the appropriate artifacts
+# and upload them to the release.
+
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build-upload:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: DeterminateSystems/nix-installer-action@v4
+    - uses: DeterminateSystems/magic-nix-cache-action@v2
+
+    - name: Build artifacts
+      run: nix develop --command bash -c "OUT=./assets ./scripts/create-assets.sh"
+
+    - name: Upload artifacts
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: gh release upload ${{ github.ref_name }} ./assets/*

--- a/docs/release_process.md
+++ b/docs/release_process.md
@@ -42,5 +42,8 @@ You must do these things to formally release a version:
    as "commits"), then "Draft a new release". The tag version and release title
    should be the same and in `vX.Y.Z` format. The tag description should
    be the same as what you added to `CHANGELOG.md`.
-1. Run `scripts/create-assets.sh` from bpftrace root dir and attach the
-   generated archives to the release.
+1. Check that automation picks up the new release and uploads release assets
+   to the release.
+1. If automation fails, please fix the automation for next time and also manually
+   build+upload artifacts by running `scripts/create-assets.sh` from bpftrace root
+   dir and attach the generated archives to the release.

--- a/scripts/create-assets.sh
+++ b/scripts/create-assets.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
+#
+# This script creates builds the official release artifacts.
+#
+# Usage examples:
+#         ./scripts/create-assets.sh
+#         OUT=../out-dir ./scripts/create-assets.sh
+#
 
 ZSTDFLAGS="-19"
 
@@ -15,7 +22,8 @@ function info() {
 command -v zstd >/dev/null 2>&1 || err "zstd command not found, required for release"
 command -v asciidoctor >/dev/null 2>&1 || err "asciidoctor not found, required for manpage"
 
-OUT=$(mktemp -d) || err "Failed to create temp dir"
+# Take value from environment if set, otherwise use a tempdir
+: ${OUT:=$(mktemp -d)} || err "Failed to create temp dir"
 TMP="${OUT}/tmp"
 
 echo "Using '$OUT' as assert dir"


### PR DESCRIPTION
This frees maintainers from having to manually build + upload artfacts.
It also pins the tools used to build man pages and whatnot to the
versions defined in `flake.nix`. This helps with reproducibility.

This closes https://github.com/iovisor/bpftrace/issues/2609.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
