### PR TITLE
Update tutorial_one_liners.md - Lesson 3 args.filename

### DIFF
--- a/docs/tutorial_one_liners.md
+++ b/docs/tutorial_one_liners.md
@@ -33,7 +33,7 @@ This prints a welcome message. Run it, then hit Ctrl-C to end.
 # Lesson 3. File Opens
 
 ```
-# bpftrace -e 'tracepoint:syscalls:sys_enter_openat { printf("%s %s\n", comm, str(args.filename)); }'
+# bpftrace -e 'tracepoint:syscalls:sys_enter_openat { printf("%s %s\n", comm, str(args->filename)); }'
 Attaching 1 probe...
 snmp-pass /proc/cpuinfo
 snmp-pass /proc/stat


### PR DESCRIPTION
should be args->filename

 bpftrace -e 'tracepoint:syscalls:sys_enter_openat { printf("%s %s\n", comm, str(args.filename)); }'
stdin:1:64-73: ERROR: Can not access field 'filename' on type '(ctx) struct _tracepoint_syscalls_sys_enter_openat *'. Try dereferencing it first, or using '->'
