### PR TITLE
Fixing shebang in ssllatency.bt and sslsnoop.bt

### DIFF
--- a/tools/ssllatency.bt
+++ b/tools/ssllatency.bt
@@ -1,4 +1,4 @@
-#!/usr/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * ssllatency	Trace SSL/TLS handshake for OpenSSL.
  * 		For Linux, uses bpftrace and eBPF.

--- a/tools/sslsnoop.bt
+++ b/tools/sslsnoop.bt
@@ -1,4 +1,4 @@
-#!/usr/bin/bpftrace
+#!/usr/bin/env bpftrace
 /*
  * sslsnoop	Trace SSL/TLS handshake for OpenSSL.
  * 		For Linux, uses bpftrace and eBPF.


### PR DESCRIPTION
All other bpftrace programs in tools/ directory have shebang line as /usr/bin/env bpftrace whereas ssllatency.bt and sslsnoop.bt have the shebang line as /usr/bin/bpftrace. This was causing error upon running these scripts when bpftrace is installed at a custom location.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
