### PR TITLE
Add fentry/fexit aliases for kfunc/kretfunc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to
   - [#2810](https://github.com/iovisor/bpftrace/pull/2810)
 - Attach BTF to generated BPF programs
   - [#2804](https://github.com/iovisor/bpftrace/pull/2804)
+- Add fentry/fexit aliases for kfunc/kretfunc
+  - [#2844](https://github.com/iovisor/bpftrace/pull/2844)
 #### Changed
 #### Deprecated
 #### Removed

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -1788,11 +1788,14 @@ Syntax:
 
 ```
 kfunc[:module]:function
+fentry[:module]:function
 kretfunc[:module]:function
+fexit[:module]:function
 ```
 
 These are kernel function probes implemented via eBPF trampolines which allows
 kernel code to call into BPF programs with practically zero overhead.
+`kfunc` and `kretfunc` are aliased as `fentry` and `fexit` to match how these are referenced in the kernel.
 
 If no kernel module is given, all loaded modules are searched for the given function.
 
@@ -1825,7 +1828,9 @@ Syntax:
 
 ```
 kfunc[:module]:function      args.NAME  ...
+fentry[:module]:function      args.NAME  ...
 kretfunc[:module]:function   args.NAME ... retval
+fexit[:module]:function   args.NAME ... retval
 ```
 
 Arguments can be accessed as the fields of the builtin `args` structure.

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -2324,7 +2324,9 @@ NetworkManager:1155 /var/lib/sss/mc/passwd (deleted)
 
 .variants
 * `kfunc[:mod]:fn`
+* `fentry[:mod]:fn`
 * `kretfunc[:mod]:fn`
+* `fexit[:mod]:fn`
 
 .shortnames
 * `f` (`kfunc`)
@@ -2336,6 +2338,7 @@ NetworkManager:1155 /var/lib/sss/mc/passwd (deleted)
 
 ``kfunc``s attach to kernel function similar to <<probes-kprobe>>.
 They make use of eBPF trampolines which allows kernel code to call into BPF programs with near zero overhead.
+`kfunc` and `kretfunc` are aliased as `fentry` and `fexit` to match how these are referenced in the kernel.
 
 `kfunc` s make use of BTF type information to derive the type of function arguments at compile time.
 This removes the need for manual type casting and makes the code more resilient against small signature changes in the kernel.

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2961,6 +2961,18 @@ void SemanticAnalyser::visit(AttachPoint &ap)
     if (ap.func == "")
       LOG(ERROR, ap.loc, err_) << "kfunc should specify a function";
   }
+  else if (ap.provider == "fentry" || ap.provider == "fexit")
+  {
+    if (!bpftrace_.feature_->has_kfunc())
+    {
+      LOG(ERROR, ap.loc, err_)
+          << "fentry/fexit not available for your kernel version.";
+      return;
+    }
+
+    if (ap.func == "")
+      LOG(ERROR, ap.loc, err_) << "fentry/fexit should specify a function";
+  }
   else if (ap.provider == "iter")
   {
     if (!listing_ && bpftrace_.btf_->get_all_iters().count(ap.func) <= 0)

--- a/src/types.h
+++ b/src/types.h
@@ -501,6 +501,10 @@ const std::vector<ProbeItem> PROBE_LIST = {
   { "asyncwatchpoint", "aw", ProbeType::asyncwatchpoint },
   { "kfunc", "f", ProbeType::kfunc },
   { "kretfunc", "fr", ProbeType::kretfunc },
+  // aliases for kfunc and kretfunc because kfunc was "borrowed"
+  // by the kernel to mean kernel functions exposed to bpf programs
+  { "fentry", "f", ProbeType::kfunc },
+  { "fexit", "fr", ProbeType::kretfunc },
   { "iter", "it", ProbeType::iter },
   { "rawtracepoint", "rt", ProbeType::rawtracepoint },
 };

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -68,6 +68,21 @@ REQUIRES_FEATURE get_func_ip
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
+# Sanity check for fentry/fexit alias
+NAME fentry
+PROG fentry:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
+EXPECT SUCCESS [0-9][0-9]*
+REQUIRES_FEATURE kfunc
+TIMEOUT 5
+AFTER ./testprogs/syscall read
+
+NAME fexit
+PROG fexit:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
+EXPECT SUCCESS [0-9][0-9]*
+REQUIRES_FEATURE kfunc
+TIMEOUT 5
+AFTER ./testprogs/syscall read
+
 NAME kprobe
 PROG kprobe:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
 EXPECT SUCCESS [0-9][0-9]*

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2897,6 +2897,31 @@ TEST_F(semantic_analyser_btf, iter)
   test("iter:task,f:func_1 { 1 }", 1);
 }
 
+// Sanity check for fentry/fexit aliases
+TEST_F(semantic_analyser_btf, fentry)
+{
+  test("fentry:func_1 { 1 }", 0);
+  test("fexit:func_1 { 1 }", 0);
+  test("fentry:func_1 { $x = args.a; $y = args.foo1; $z = args.foo2->f.a; }",
+       0);
+  test("fexit:func_1 { $x = retval; }", 0);
+  test("fentry:vmlinux:func_1 { 1 }", 0);
+  test("fentry:*:func_1 { 1 }", 0);
+  test("fentry:func_1 { @[func] = 1; }", 0);
+
+  test("fexit:func_1 { $x = args.foo; }", 1);
+  test("fexit:func_1 { $x = args; }", 0);
+  test("fentry:func_1 { @ = args; }", 0);
+  test("fentry:func_1 { @[args] = 1; }", 0);
+  // reg() is not available in fentry
+#ifdef ARCH_X86_64
+  test("fentry:func_1 { reg(\"ip\") }", 1);
+  test("fexit:func_1 { reg(\"ip\") }", 1);
+#endif
+  // Backwards compatibility
+  test("fentry:func_1 { $x = args->a; }", 0);
+}
+
 } // namespace semantic_analyser
 } // namespace test
 } // namespace bpftrace


### PR DESCRIPTION
The 'kfunc' name was in bpftrace first and was "borrowed" by the kernel to now mean something completely different (yet related to bpf). New users going to look for fentry/fexit equivalents in bpftrace are going to be confused that they are called kfunc and kretfunc here. This change just adds fentry/fexit as aliases for kfunc/kretfunc.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
