### PR TITLE
ci: Install kmod and nftables packages

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -112,6 +112,8 @@
                   findutils
                   gawk
                   gnugrep
+                  kmod
+                  nftables
                   procps
                   python3
                   strace


### PR DESCRIPTION
I noticed in CI a lot of module related runtime tests were being skipped:

```
[   SKIP   ] btf.kernel_module_args (unmet condition: 'lsmod | grep '^nf_tables' && /usr/sbin/nft --help')
[   SKIP   ] btf.kernel_module_attach (unmet condition: 'lsmod | grep '^nf_tables' && /usr/sbin/nft --help')
[   SKIP   ] btf.kernel_module_tracepoint (unmet condition: 'lsmod | grep "^xfs"')
[   SKIP   ] btf.kernel_module_type_fwd (unmet condition: 'lsmod | grep '^kvm'')
[   SKIP   ] btf.kernel_module_types (unmet condition: 'lsmod | grep '^nf_tables' && /usr/sbin/nft --help')
```

It was b/c we weren't installing `kmod` and `nftables` packages (for
`lsmod` and `nft`, respectively) inside nix env. Fix by installing
packages.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
