### PR TITLE
tools/mdflush.bt: update include headers for non-BTF builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ and this project adheres to
 #### Tools
 - Update runqlen.bt to remove `runnable_weight` field from cfs_rq struct.
   - [#2790](https://github.com/iovisor/bpftrace/pull/2790)
+- Update mdflush.bt to use blkdev.h instead of genhd.h for non-BTF builds.
+  - [#2849](https://github.com/iovisor/bpftrace/pull/2849)
 
 ## [0.19.0] 2023-09-19
 

--- a/tools/mdflush.bt
+++ b/tools/mdflush.bt
@@ -16,7 +16,7 @@
  */
 
 #ifndef BPFTRACE_HAVE_BTF
-#include <linux/genhd.h>
+#include <linux/blkdev.h>
 #include <linux/bio.h>
 #endif
 


### PR DESCRIPTION
This commit updates the include headers in mdflush.bt to use <linux/blkdev.h> instead of <linux/genhd.h> for non-BTF builds. This change ensures proper compatibility to align with this Linux kernel commit 322cbb50de71 ("block: remove genhd.h")

Reference to the Linux kernel commit (introduced from v5.18-rc1):

https://github.com/torvalds/linux/commit/322cbb50de711814c42fb088f6d31901502c711a

---

**On a system with non-BTF linux build:**

**Before Patch:**

```
# ./tools/mdflush.bt 
definitions.h:2:10: fatal error: 'linux/genhd.h' file not found
```

**After Patch:**

```
# ./tools/mdflush.bt 
Attaching 2 probes...
Tracing md flush events... Hit Ctrl-C to end.
```


##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
