### PR TITLE
Fix uprobe multi probe with target wildcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to
   - [#2822](https://github.com/iovisor/bpftrace/pull/2822)
 - utils: use /data/local/tmp as temprary dir on Android
   - [#2828](https://github.com/iovisor/bpftrace/pull/2828)
+- Fix uprobe multi probe for targets with wildcards
+  - [#2851](https://github.com/iovisor/bpftrace/pull/2851)
 #### Docs
 #### Tools
 - Update runqlen.bt to remove `runnable_weight` field from cfs_rq struct.

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -207,6 +207,14 @@ REQUIRES /usr/sbin/bpftool
 REQUIRES_FEATURE uprobe_multi
 AFTER ./testprogs/uprobe_test
 
+NAME uprobe_multi_wildcard_target_wildcard
+RUN {{BPFTRACE}} --unsafe -e 'uretprobe:*:uprobeFunction* { printf("link: "); system("/usr/sbin/bpftool link | grep -E \"uprobe_multi|type 12\" | wc -l"); exit(); }' -p {{BEFORE_PID}}
+EXPECT link: 1
+TIMEOUT 5
+REQUIRES /usr/sbin/bpftool
+REQUIRES_FEATURE uprobe_multi
+BEFORE ./testprogs/uprobe_test
+
 NAME uprobe
 PROG uprobe:/bin/bash:echo_builtin { printf("arg0: %d\n", arg0); exit();}
 EXPECT arg0: [0-9]*

--- a/tests/runtime/uprobe
+++ b/tests/runtime/uprobe
@@ -60,7 +60,7 @@ BEFORE ./testprogs/uprobe_test
 
 NAME uprobes - attach to multiple probes by pid with only wildcard
 RUN {{BPFTRACE}} -e 'uprobe:*:uprobeFunc* { printf("here\n" ); exit(); }' -p {{BEFORE_PID}}
-EXPECT Attaching 2 probes...
+EXPECT here
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 


### PR DESCRIPTION
When using uprobe multi probes if the target has a wildcard then we need to create one probe for each expanded target path similar to how non-multi uprobe probes work.

Found this bug because the runtime test:
"attach to multiple probes by pid with only wildcard" was failing when using multi probe.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
