### PR TITLE
Fix bpftrace -l for non supported attach points

### DIFF
--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -20,26 +20,13 @@ public:
   explicit SemanticAnalyser(Node *root,
                             BPFtrace &bpftrace,
                             std::ostream &out = std::cerr,
-                            bool has_child = true,
-                            bool listing = false)
-      : root_(root),
-        bpftrace_(bpftrace),
-        out_(out),
-        listing_(listing),
-        has_child_(has_child)
+                            bool has_child = true)
+      : root_(root), bpftrace_(bpftrace), out_(out), has_child_(has_child)
   {
   }
 
   explicit SemanticAnalyser(Node *root, BPFtrace &bpftrace, bool has_child)
       : SemanticAnalyser(root, bpftrace, std::cerr, has_child)
-  {
-  }
-
-  explicit SemanticAnalyser(Node *root,
-                            BPFtrace &bpftrace,
-                            bool has_child,
-                            bool listing)
-      : SemanticAnalyser(root, bpftrace, std::cerr, has_child, listing)
   {
   }
 
@@ -74,6 +61,7 @@ public:
   void visit(Program &program) override;
 
   int analyse();
+  bool attach_point_supported(AttachPoint &ap, bool output_err = false);
 
 private:
   Node *root_ = nullptr;
@@ -82,7 +70,6 @@ private:
   std::ostringstream err_;
   int pass_;
   const int num_passes_ = 10;
-  bool listing_;
 
   bool is_final_pass() const;
 

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -75,7 +75,7 @@ public:
   /*
    * Match all probes in prog and print them to stdout.
    */
-  void list_probes(ast::Program *prog);
+  void list_probes(std::vector<ast::AttachPoint *> attach_points);
   /*
    * Print definitions of structures matching search.
    */


### PR DESCRIPTION
Instead of completely bailing if an attach point is not supported (e.g. kfunc), list the attach points that ARE supported.

[Issue: 2855](https://github.com/iovisor/bpftrace/issues/2855)

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
