### PR TITLE
Fix bpftrace -l when kfunc is not available

### DIFF
--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -379,24 +379,24 @@ std::unique_ptr<std::istream> ProbeMatcher::get_symbols_from_list(
 
 /*
  * Get list of kernel probe types for the purpose of listing.
- * Ignore return probes.
+ * Ignore return probes and aliases.
  */
 std::unique_ptr<std::istream> ProbeMatcher::kernel_probe_list()
 {
   std::string probes;
   for (auto& p : PROBE_LIST)
   {
+    if (!p.show_in_kernel_list)
+    {
+      continue;
+    }
     if (p.type == ProbeType::kfunc)
     {
       // kfunc must be available
       if (bpftrace_->feature_->has_kfunc())
         probes += p.name + "\n";
     }
-    else if (p.name.find("ret") == std::string::npos &&
-             !is_userspace_probe(p.type) && p.type != ProbeType::interval &&
-             p.type != ProbeType::profile && p.type != ProbeType::watchpoint &&
-             p.type != ProbeType::asyncwatchpoint &&
-             p.type != ProbeType::special)
+    else
     {
       probes += p.name + "\n";
     }
@@ -414,8 +414,10 @@ std::unique_ptr<std::istream> ProbeMatcher::userspace_probe_list()
   std::string probes;
   for (auto& p : PROBE_LIST)
   {
-    if (p.name.find("ret") == std::string::npos && is_userspace_probe(p.type))
+    if (p.show_in_userspace_list)
+    {
       probes += p.name + "\n";
+    }
   }
 
   return std::make_unique<std::istringstream>(probes);

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -197,11 +197,12 @@ ProbeType probetype(const std::string &probeName)
 {
   ProbeType retType = ProbeType::invalid;
 
-  auto v = std::find_if(PROBE_LIST.begin(), PROBE_LIST.end(),
-                          [&probeName] (const ProbeItem& p) {
-                            return (p.name == probeName ||
-                                   p.abbr == probeName);
-                         });
+  auto v = std::find_if(PROBE_LIST.begin(),
+                        PROBE_LIST.end(),
+                        [&probeName](const ProbeItem &p) {
+                          return (p.name == probeName ||
+                                  p.aliases.find(probeName) != p.aliases.end());
+                        });
 
   if (v != PROBE_LIST.end())
     retType =  v->type;
@@ -216,7 +217,8 @@ std::string expand_probe_name(const std::string &orig_name)
   auto v = std::find_if(PROBE_LIST.begin(),
                         PROBE_LIST.end(),
                         [&orig_name](const ProbeItem &p) {
-                          return (p.name == orig_name || p.abbr == orig_name);
+                          return (p.name == orig_name ||
+                                  p.aliases.find(orig_name) != p.aliases.end());
                         });
 
   if (v != PROBE_LIST.end())
@@ -252,12 +254,6 @@ std::string probetypeName(ProbeType t)
   // clang-format on
 
   return {}; // unreached
-}
-
-bool is_userspace_probe(const ProbeType &probe_type)
-{
-  return probe_type == ProbeType::uprobe ||
-         probe_type == ProbeType::uretprobe || probe_type == ProbeType::usdt;
 }
 
 uint64_t asyncactionint(AsyncAction a)

--- a/src/types.h
+++ b/src/types.h
@@ -8,6 +8,7 @@
 #include <string>
 #include <sys/types.h>
 #include <unistd.h>
+#include <unordered_set>
 #include <vector>
 
 #include <cereal/access.hpp>
@@ -480,37 +481,39 @@ std::ostream &operator<<(std::ostream &os, ProbeType type);
 struct ProbeItem
 {
   std::string name;
-  std::string abbr;
+  std::unordered_set<std::string> aliases;
   ProbeType type;
+  // these are used in bpftrace -l
+  // to show which probes are available to attach to
+  bool show_in_kernel_list = false;
+  bool show_in_userspace_list = false;
 };
 
 const std::vector<ProbeItem> PROBE_LIST = {
-  { "kprobe", "k", ProbeType::kprobe },
-  { "kretprobe", "kr", ProbeType::kretprobe },
-  { "uprobe", "u", ProbeType::uprobe },
-  { "uretprobe", "ur", ProbeType::uretprobe },
-  { "usdt", "U", ProbeType::usdt },
-  { "BEGIN", "BEGIN", ProbeType::special },
-  { "END", "END", ProbeType::special },
-  { "tracepoint", "t", ProbeType::tracepoint },
-  { "profile", "p", ProbeType::profile },
-  { "interval", "i", ProbeType::interval },
-  { "software", "s", ProbeType::software },
-  { "hardware", "h", ProbeType::hardware },
-  { "watchpoint", "w", ProbeType::watchpoint },
-  { "asyncwatchpoint", "aw", ProbeType::asyncwatchpoint },
-  { "kfunc", "f", ProbeType::kfunc },
-  { "kretfunc", "fr", ProbeType::kretfunc },
-  // aliases for kfunc and kretfunc because kfunc was "borrowed"
-  // by the kernel to mean kernel functions exposed to bpf programs
-  { "fentry", "f", ProbeType::kfunc },
-  { "fexit", "fr", ProbeType::kretfunc },
-  { "iter", "it", ProbeType::iter },
-  { "rawtracepoint", "rt", ProbeType::rawtracepoint },
+  { "kprobe", { "k" }, ProbeType::kprobe, .show_in_kernel_list = true },
+  { "kretprobe", { "kr" }, ProbeType::kretprobe },
+  { "uprobe", { "u" }, ProbeType::uprobe, .show_in_userspace_list = true },
+  { "uretprobe", { "ur" }, ProbeType::uretprobe },
+  { "usdt", { "U" }, ProbeType::usdt, .show_in_userspace_list = true },
+  { "BEGIN", { "BEGIN" }, ProbeType::special },
+  { "END", { "END" }, ProbeType::special },
+  { "tracepoint", { "t" }, ProbeType::tracepoint, .show_in_kernel_list = true },
+  { "profile", { "p" }, ProbeType::profile },
+  { "interval", { "i" }, ProbeType::interval },
+  { "software", { "s" }, ProbeType::software, .show_in_kernel_list = true },
+  { "hardware", { "h" }, ProbeType::hardware, .show_in_kernel_list = true },
+  { "watchpoint", { "w" }, ProbeType::watchpoint },
+  { "asyncwatchpoint", { "aw" }, ProbeType::asyncwatchpoint },
+  { "kfunc", { "f", "fentry" }, ProbeType::kfunc, .show_in_kernel_list = true },
+  { "kretfunc", { "fr", "fexit" }, ProbeType::kretfunc },
+  { "iter", { "it" }, ProbeType::iter, .show_in_kernel_list = true },
+  { "rawtracepoint",
+    { "rt" },
+    ProbeType::rawtracepoint,
+    .show_in_kernel_list = true },
 };
 
 ProbeType probetype(const std::string &type);
-bool is_userspace_probe(const ProbeType &probe_type);
 std::string addrspacestr(AddrSpace as);
 std::string typestr(Type t);
 std::string expand_probe_name(const std::string &orig_name);


### PR DESCRIPTION
A change to add fentry/fexit broke `bpftrace -l` because these new probe types weren't accounted for in `kernel_probe_list`.

This also removes the need for 'is_userspace_probe' with the addition of two new fields to ProbeItem.

Change: https://github.com/iovisor/bpftrace/commit/4151babaf9b616e8006762cfa853c01fde3408ae

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
