### PR TITLE
DwarfParser: handle null DW_AT_name

### DIFF
--- a/src/dwarf_parser.cpp
+++ b/src/dwarf_parser.cpp
@@ -181,7 +181,9 @@ SizedType Dwarf::get_stype(Dwarf_Die &type_die, bool resolve_structs) const
     }
     case DW_TAG_structure_type:
     case DW_TAG_union_type: {
-      std::string name = dwarf_diename(&type_die);
+      std::string name = dwarf_hasattr(&type_die, DW_AT_name)
+                             ? dwarf_diename(&type_die)
+                             : "<anonymous>";
       name = (tag == DW_TAG_structure_type ? "struct " : "union ") + name;
       auto result = CreateRecord(
           name, bpftrace_->structs.LookupOrAdd(name, bit_size / 8));

--- a/tests/data/data_source.c
+++ b/tests/data/data_source.c
@@ -41,6 +41,11 @@ struct Foo3 *func_3(int a, int *b, struct Foo1 *foo1)
   return 0;
 }
 
+void *func_4(const struct Foo2 *p)
+{
+  return 0;
+}
+
 struct task_struct
 {
   int pid;

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -224,6 +224,8 @@ TEST_F(field_analyser_dwarf, uprobe_args)
   // func_2 and func_3 have same args -> PASS
   test(uprobe + ":func_2, " + uprobe + ":func_3 { }", 0);
   test(uprobe + ":func_2, " + uprobe + ":func_3 { $x = args.a; }", 0);
+  // func_4 has a parameter with a const qualifier
+  test(uprobe + ":func_4 { $x = args.p; }", 0);
 
   // Probes with wildcards (need non-mock BPFtrace)
   BPFtrace bpftrace;


### PR DESCRIPTION
This attribute is optional. Gracefully handle the case where it is not present.

---

I'm not too sure what the proper error handling should be, so I left the string as `"<anonymous>"` similar to an earlier section.

Fixes the following error:

```
$ pacman -Q bpftrace
bpftrace 0.19.1-1

$ printenv DEBUGINFOD_URLS
https://debuginfod.archlinux.org

$ sudo bpftrace -e 'uprobe:libc:getaddrinfo {printf("%s %s\n", comm, str(args->name);}'
terminate called after throwing an instance of 'std::logic_error'
  what():  basic_string: construction from null is not valid
zsh: IOT instruction  sudo -H --preserve-env=DEBUGINFOD_URLS bpftrace -e
```

<details><summary>backtrace</summary>

```
#0  __pthread_kill_implementation (threadid=<optimized out>, signo=signo@entry=6, no_tid=no_tid@entry=0) at pthread_kill.c:44
#1  0x00007fffed4ac8a3 in __pthread_kill_internal (signo=6, threadid=<optimized out>) at pthread_kill.c:78
#2  0x00007fffed45c668 in __GI_raise (sig=sig@entry=6) at ../sysdeps/posix/raise.c:26
#3  0x00007fffed4444b8 in __GI_abort () at abort.c:79
#4  0x00007fffed69ca6f in __gnu_cxx::__verbose_terminate_handler () at /usr/src/debug/gcc/gcc/libstdc++-v3/libsupc++/vterminate.cc:95
#5  0x00007fffed6b011c in __cxxabiv1::__terminate (handler=<optimized out>) at /usr/src/debug/gcc/gcc/libstdc++-v3/libsupc++/eh_terminate.cc:48
#6  0x00007fffed6b0189 in std::terminate () at /usr/src/debug/gcc/gcc/libstdc++-v3/libsupc++/eh_terminate.cc:58
#7  0x00007fffed6b03ed in __cxxabiv1::__cxa_throw (obj=<optimized out>, tinfo=0x7ffff7e43978 <typeinfo for std::logic_error>, dest=0x7fffed6c8470 <std::logic_error::~logic_error()>)
    at /usr/src/debug/gcc/gcc/libstdc++-v3/libsupc++/eh_throw.cc:98
#8  0x00007fffed6a00a9 in std::__throw_logic_error (__s=0x55555595eb88 "basic_string: construction from null is not valid") at /usr/src/debug/gcc/gcc/libstdc++-v3/src/c++11/functexcept.cc:70
#9  0x00005555555e70f0 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::basic_string<std::allocator<char> > (this=0x7fffffffb8f0, __s=0x0, __a=...)
    at /usr/include/c++/13.2.1/bits/basic_string.h:636
#10 0x00005555556c6029 in bpftrace::Dwarf::get_stype (this=0x555555cecad0, type_die=..., resolve_structs=false) at /home/rpigott/work/foss/bpftrace/src/dwarf_parser.cpp:184
#11 0x00005555556c5f88 in bpftrace::Dwarf::get_stype (this=0x555555cecad0, type_die=..., resolve_structs=true) at /home/rpigott/work/foss/bpftrace/src/dwarf_parser.cpp:177
#12 0x00005555556c6f7a in bpftrace::Dwarf::resolve_args (this=0x555555cecad0, function="getaddrinfo") at /home/rpigott/work/foss/bpftrace/src/dwarf_parser.cpp:309
#13 0x000055555587e021 in bpftrace::ast::FieldAnalyser::resolve_args (this=0x7fffffffca90, probe=...) at /home/rpigott/work/foss/bpftrace/src/ast/passes/field_analyser.cpp:259
#14 0x000055555587cf3a in bpftrace::ast::FieldAnalyser::visit (this=0x7fffffffca90, builtin=...) at /home/rpigott/work/foss/bpftrace/src/ast/passes/field_analyser.cpp:47
#15 0x0000555555955070 in bpftrace::ast::Builtin::accept (this=0x555555cc3e00, v=...) at /home/rpigott/work/foss/bpftrace/src/ast/ast.cpp:20
#16 0x00005555555e57b0 in bpftrace::ast::Visitor::Visit (this=0x7fffffffca90, n=...) at /home/rpigott/work/foss/bpftrace/src/ast/visitors.h:73
#17 0x000055555587d95d in bpftrace::ast::FieldAnalyser::visit (this=0x7fffffffca90, unop=...) at /home/rpigott/work/foss/bpftrace/src/ast/passes/field_analyser.cpp:158
#18 0x0000555555955220 in bpftrace::ast::Unop::accept (this=0x555555becf20, v=...) at /home/rpigott/work/foss/bpftrace/src/ast/ast.cpp:29
#19 0x00005555555e57b0 in bpftrace::ast::Visitor::Visit (this=0x7fffffffca90, n=...) at /home/rpigott/work/foss/bpftrace/src/ast/visitors.h:73
#20 0x000055555587d3f1 in bpftrace::ast::FieldAnalyser::visit (this=0x7fffffffca90, acc=...) at /home/rpigott/work/foss/bpftrace/src/ast/passes/field_analyser.cpp:90
#21 0x0000555555955280 in bpftrace::ast::FieldAccess::accept (this=0x555555cc3ee0, v=...) at /home/rpigott/work/foss/bpftrace/src/ast/ast.cpp:31
#22 0x00005555555e57b0 in bpftrace::ast::Visitor::Visit (this=0x7fffffffca90, n=...) at /home/rpigott/work/foss/bpftrace/src/ast/visitors.h:73
#23 0x0000555555872f7b in bpftrace::ast::Visitor::visit (this=0x7fffffffca90, call=...) at /home/rpigott/work/foss/bpftrace/src/ast/visitors.cpp:38
#24 0x0000555555955100 in bpftrace::ast::Call::accept (this=0x555555cc3fe0, v=...) at /home/rpigott/work/foss/bpftrace/src/ast/ast.cpp:23
#25 0x00005555555e57b0 in bpftrace::ast::Visitor::Visit (this=0x7fffffffca90, n=...) at /home/rpigott/work/foss/bpftrace/src/ast/visitors.h:73
#26 0x0000555555872f7b in bpftrace::ast::Visitor::visit (this=0x7fffffffca90, call=...) at /home/rpigott/work/foss/bpftrace/src/ast/visitors.cpp:38
#27 0x0000555555955100 in bpftrace::ast::Call::accept (this=0x555555cc40c0, v=...) at /home/rpigott/work/foss/bpftrace/src/ast/ast.cpp:23
#28 0x00005555555e57b0 in bpftrace::ast::Visitor::Visit (this=0x7fffffffca90, n=...) at /home/rpigott/work/foss/bpftrace/src/ast/visitors.h:73
#29 0x0000555555873445 in bpftrace::ast::Visitor::visit (this=0x7fffffffca90, expr=...) at /home/rpigott/work/foss/bpftrace/src/ast/visitors.cpp:112
#30 0x0000555555955348 in bpftrace::ast::ExprStatement::accept (this=0x555555e1f870, v=...) at /home/rpigott/work/foss/bpftrace/src/ast/ast.cpp:35
#31 0x00005555555e57b0 in bpftrace::ast::Visitor::Visit (this=0x7fffffffca90, n=...) at /home/rpigott/work/foss/bpftrace/src/ast/visitors.h:73
#32 0x000055555587f06f in bpftrace::ast::FieldAnalyser::visit (this=0x7fffffffca90, probe=...) at /home/rpigott/work/foss/bpftrace/src/ast/passes/field_analyser.cpp:338
#33 0x000055555595550a in bpftrace::ast::Probe::accept (this=0x555555cc41c0, v=...) at /home/rpigott/work/foss/bpftrace/src/ast/ast.cpp:44
#34 0x00005555555e57b0 in bpftrace::ast::Visitor::Visit (this=0x7fffffffca90, n=...) at /home/rpigott/work/foss/bpftrace/src/ast/visitors.h:73
#35 0x0000555555873a92 in bpftrace::ast::Visitor::visit (this=0x7fffffffca90, program=...) at /home/rpigott/work/foss/bpftrace/src/ast/visitors.cpp:197
#36 0x000055555595553c in bpftrace::ast::Program::accept (this=0x555555cc2970, v=...) at /home/rpigott/work/foss/bpftrace/src/ast/ast.cpp:45
#37 0x00005555555e57b0 in bpftrace::ast::Visitor::Visit (this=0x7fffffffca90, n=...) at /home/rpigott/work/foss/bpftrace/src/ast/visitors.h:73
#38 0x000055555587f0ea in bpftrace::ast::FieldAnalyser::analyse (this=0x7fffffffca90) at /home/rpigott/work/foss/bpftrace/src/ast/passes/field_analyser.cpp:344
#39 0x00005555555da525 in parse (bpftrace=..., name="stdin", program="uprobe:libc:getaddrinfo {printf(\"%s %s\\n\", comm, str(args->name));}", include_dirs=std::vector of length 0, capacity 0,
    include_files=std::vector of length 0, capacity 0) at /home/rpigott/work/foss/bpftrace/src/main.cpp:416
#40 0x00005555555dcfc2 in main (argc=3, argv=0x7fffffffe368) at /home/rpigott/work/foss/bpftrace/src/main.cpp:954
```
</details>