### PR TITLE
[kfunc/kretfunc] fix arg and retval resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,8 @@ and this project adheres to
   - [#2851](https://github.com/iovisor/bpftrace/pull/2851)
 - Fix symbolication on for 32-bit userspcae and 64-bit kernel
   - [#2869](https://github.com/iovisor/bpftrace/pull/2869)
+- Fix retval for kretfunc/fexit
+  - [#2864](https://github.com/iovisor/bpftrace/pull/2864)
 #### Docs
 #### Tools
 - Update runqlen.bt to remove `runnable_weight` field from cfs_rq struct.

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -68,6 +68,14 @@ REQUIRES_FEATURE get_func_ip
 TIMEOUT 5
 AFTER ./testprogs/syscall read
 
+NAME kretfunc large args
+PROG kretfunc:__sys_bpf { if (args.cmd == 1111 && args.size == 2222 && (int64)retval == -7) { printf("SUCCESS %d\n", pid); exit(); }}
+EXPECT SUCCESS [0-9][0-9]*
+REQUIRES_FEATURE kfunc
+REQUIRES_FEATURE btf
+TIMEOUT 5
+AFTER ./testprogs/kfunc_args 1111 2222
+
 # Sanity check for fentry/fexit alias
 NAME fentry
 PROG fentry:vfs_read { printf("SUCCESS %d\n", pid); exit(); }

--- a/tests/testprogs/kfunc_args.c
+++ b/tests/testprogs/kfunc_args.c
@@ -1,0 +1,20 @@
+#include <linux/bpf.h>
+#include <linux/unistd.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+int main(int argc, char *argv[])
+{
+  if (argc != 3)
+  {
+    return 1;
+  }
+  usleep(1000000);
+
+  union bpf_attr attr;
+  int cmd = atoi(argv[1]);
+  unsigned int size = atoi(argv[2]);
+  syscall(__NR_bpf, cmd, &attr, size);
+
+  return 0;
+}


### PR DESCRIPTION
In the case of functions that have arguments that are larger than the size of the registers (e.g. '__sys_bpf' whose second arg, 'bpfptr_t uattr', which has a size of 16 bytes) the 'retval' for kretfunc/fexit is not correct.

What's needed is to resolve the btf type size and use that (by dividing by the register size) to determine the index into the args array.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
