### PR TITLE
Fix symbolication on 32-bit userspace / 64-bit kernel

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -2029,7 +2029,7 @@ std::string BPFtrace::get_stack(int64_t stackid,
   return stack.str();
 }
 
-std::string BPFtrace::resolve_uid(uintptr_t addr) const
+std::string BPFtrace::resolve_uid(uint64_t addr) const
 {
   std::string file_name = "/etc/passwd";
   std::string uid = std::to_string(addr);
@@ -2114,7 +2114,7 @@ std::string BPFtrace::resolve_buf(char *buf, size_t size)
   return hex_format_buffer(buf, size);
 }
 
-std::string BPFtrace::resolve_ksym(uintptr_t addr, bool show_offset)
+std::string BPFtrace::resolve_ksym(uint64_t addr, bool show_offset)
 {
   struct bcc_symbol ksym;
   std::ostringstream symbol;
@@ -2349,7 +2349,7 @@ bool BPFtrace::is_aslr_enabled(int pid)
   return false;
 }
 
-std::string BPFtrace::resolve_usym(uintptr_t addr,
+std::string BPFtrace::resolve_usym(uint64_t addr,
                                    int pid,
                                    int probe_id,
                                    bool show_offset,


### PR DESCRIPTION
Symbolication is broken on platforms running a 64-bit kernel and a 32-bit userspace. For example, this simple test case can reproduce the issue: $ bpftrace -e 'profile:hz:99 { @[kstack] = count(); }' .

This is happening because bpftrace requests uint64_t addresses to the kernel here but then performs an implicit conversion to uintptr_t here when resolving ksyms, usyms and uids. Fix the issue by changing the signature of these functions so they receive a uint64_t address instead.

Ideally we should uncomment add_compile_options("-Wconversion") in bpftrace/CMakeLists.txt to avoid running into simple issues like this in the future. This patch is one small step towards fixing the current conversion warnings we have.

[Issue 2854](https://github.com/iovisor/bpftrace/issues/2854)