### PR TITLE
tests: runtime: fix kprobe_offset_module* on aarch64

### DIFF
--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -153,18 +153,18 @@ NAME kprobe_offset_module
 RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x5 { printf("hit\n"); exit(); }'
 AFTER /usr/sbin/nft add table bpftrace
 EXPECT hit
-ARCH x86_64|aarch64
+ARCH x86_64
 TIMEOUT 5
 REQUIRES lsmod | grep '^nf_tables'
 REQUIRES /usr/sbin/nft --help
 CLEANUP /usr/sbin/nft delete table bpftrace
 
-# Local entry point to nft_trans_alloc_gfp is located at offset of 8 bytes in ppc64.
+# Local entry point to nft_trans_alloc_gfp is located at offset of 8 bytes in ppc64 and aarch64.
 NAME kprobe_offset_module
 RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x8 { printf("hit\n"); exit(); }'
 AFTER /usr/sbin/nft add table bpftrace
 EXPECT hit
-ARCH ppc64|ppc64le
+ARCH ppc64|ppc64le|aarch64
 TIMEOUT 5
 REQUIRES lsmod | grep '^nf_tables'
 REQUIRES /usr/sbin/nft --help
@@ -173,6 +173,15 @@ CLEANUP /usr/sbin/nft delete table bpftrace
 NAME kprobe_offset_module_error
 RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x1 { printf("hit\n"); exit(); }'
 EXPECT Possible attachment attempt in the middle of an instruction, try a different offset.
+ARCH x86_64
+TIMEOUT 5
+REQUIRES lsmod | grep '^nf_tables'
+WILL_FAIL
+
+NAME kprobe_offset_module_error
+RUN {{BPFTRACE}} -e 'kprobe:nft_trans_alloc_gfp+0x1 { printf("hit\n"); exit(); }'
+EXPECT Invalid argument
+ARCH aarch64
 TIMEOUT 5
 REQUIRES lsmod | grep '^nf_tables'
 WILL_FAIL


### PR DESCRIPTION
For kprobe_offset_module:
On aarch64, +0x5 is not a correct offset. Since +0x4 is reserved by ftrace, the test should use +0x8, which is the same as ppc64.

For kprobe_offset_module_error:
nft_trans_alloc_gfp is not in vmlinux so usermode offset check is skipped. The kernel will return -EINVAL instead of -EILSEQ during arch_prepare_kprobe() on aarch64, so change the expected string.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

BTW, I'm not familiar with other arch like ppc64, so I only keep x86_64 and aarch64 remained in kprobe_offset_module_error. Can anyone give some helps?

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
