### PR TITLE
BTF: Handle array types

### DIFF
--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -412,6 +412,20 @@ SizedType BTF::get_stype(const BTFId &btf_id, bool resolve_structs)
     stype = CreatePointer(
         get_stype(BTFId{ .btf = btf_id.btf, .id = t->type }, false));
   }
+  else if (btf_is_array(t))
+  {
+    auto *array = btf_array(t);
+    const auto &elem_type = get_stype(
+        BTFId{ .btf = btf_id.btf, .id = array->type });
+    if (elem_type.type == Type::integer && elem_type.GetSize() == 1)
+    {
+      stype = CreateString(array->nelems);
+    }
+    else
+    {
+      stype = CreateArray(array->nelems, elem_type);
+    }
+  }
 
   return stype;
 }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -293,7 +293,10 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
     return res.str();
   }
   else
-    return std::to_string(read_data<int64_t>(value.data()) / div);
+  {
+    assert(type.IsNoneTy());
+    return "";
+  }
 }
 
 std::string Output::array_to_str(const std::vector<std::string> &elems) const

--- a/tests/data/data_source.c
+++ b/tests/data/data_source.c
@@ -41,6 +41,17 @@ struct Foo3 *func_3(int a, int *b, struct Foo1 *foo1)
   return 0;
 }
 
+struct Arrays
+{
+  int int_arr[4];
+  char char_arr[8];
+  void *ptr_arr[2];
+  int multi_dim[3][2];
+  int zero[0];
+  int flexible[];
+};
+struct Arrays arrays;
+
 struct task_struct
 {
   int pid;


### PR DESCRIPTION
This fixes a segmentation fault when attempting to print types containing arrays.

Unhandled BTF types are given Type::none and size 0. value_to_str previously attempted to read an int64_t into a 0-byte buffer allocated for this type, causing the SEGV.

This commit contains two fixes:
- Handle BTF arrays so they have Type::array and can be used & printed correctly in bpftrace
- Don't attempt to read an int64_t when printing a Type::none. Print nothing instead.

This script previously crashed bpftrace:
`BEGIN { $elem = (struct bpf_local_storage_data*)0; print(*$elem); }`

This type is defined as:
```
struct bpf_local_storage_data {
  struct bpf_local_storage_map *smap;
  u8 data[];
};
```

With this commit, we now successfully print the type:
`{ .smap = 0x0, .data = [] }`

Fixes #2861

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
