### PR TITLE
Fix memory leak when listing probes

### DIFF
--- a/src/ast/attachpoint_parser.cpp
+++ b/src/ast/attachpoint_parser.cpp
@@ -76,7 +76,8 @@ int AttachPointParser::parse()
   {
     for (size_t i = 0; i < probe->attach_points->size(); ++i)
     {
-      auto &ap = *(*probe->attach_points)[i];
+      auto ap_ptr = (*probe->attach_points)[i];
+      auto &ap = *ap_ptr;
       new_attach_points.clear();
 
       State s = parse_attachpoint(ap);
@@ -88,6 +89,7 @@ int AttachPointParser::parse()
       else if (s == SKIP || s == NEW_APS)
       {
         // Remove the current attach point
+        delete ap_ptr;
         probe->attach_points->erase(probe->attach_points->begin() + i);
         i--;
         if (s == NEW_APS)

--- a/tests/memleak-tests.sh
+++ b/tests/memleak-tests.sh
@@ -28,15 +28,16 @@ fi
 
 # Add new testcases here
 tests=(
-    '"BEGIN { exit(); }"'
-    $'"#include <linux/skbuff.h>\n BEGIN { \$x = ((struct sk_buff *)curtask)->data_len; exit(); }"'
+    'bpftrace -e "BEGIN { exit(); }"'
+    $'bpftrace -e "#include <linux/skbuff.h>\n BEGIN { \$x = ((struct sk_buff *)curtask)->data_len; exit(); }"'
+    'bpftrace -l "kprobe_seq_*"'
     )
 
 echo "${GREEN}[==========]${NC} Running ${#tests[@]} tests"
 
 result=0
 for tst in "${tests[@]}"; do
-    echo "${GREEN}[ RUN      ]${NC} bpftrace -e $tst"
+    echo "${GREEN}[ RUN      ]${NC} $tst"
 
     export ASAN_OPTIONS="alloc_dealloc_mismatch=0"
     if eval $BPFTRACE_ASAN -e "$tst" > /dev/null 2>&1 ; then
@@ -56,4 +57,3 @@ else
 fi
 
 exit $result
-


### PR DESCRIPTION
Repro command with ASAN build: `sudo bpftrace -l "kprobe_seq_*"`

Fix is to also free the memory after erasing the attach point from the vector of attach points.

Error output:
```
$ sudo bpftrace -l "kprobe_seq_*"
kfunc:vmlinux:kprobe_seq_next
kfunc:vmlinux:kprobe_seq_start
kfunc:vmlinux:kprobe_seq_stop
kprobe:kprobe_seq_next
kprobe:kprobe_seq_start
kprobe:kprobe_seq_stop

=================================================================
==3018628==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 456 byte(s) in 1 object(s) allocated from:
    #0 0x7f93b34b6367 in operator new(unsigned long) (/lib64/libasan.so.6+0xb6367)
    #1 0x7c0a0f in bpftrace::Parser::parse() (/usr/local/bin/bpftrace+0x7c0a0f)
    #2 0x4c8275 in bpftrace::Driver::parse() (/usr/local/bin/bpftrace+0x4c8275)
    #3 0x426389 in main (/usr/local/bin/bpftrace+0x426389)
    #4 0x7f93aa03feaf in __libc_start_call_main (/lib64/libc.so.6+0x3feaf)

SUMMARY: AddressSanitizer: 456 byte(s) leaked in 1 allocation(s).
```

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
