### PR TITLE
Removed unused ptr_to_u64() function

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -909,11 +909,6 @@ void AttachedProbe::load_prog(BPFfeature &feature)
   cache_progfd();
 }
 
-static inline uint64_t ptr_to_u64(const void *ptr)
-{
-  return (uint64_t)(unsigned long)ptr;
-}
-
 void AttachedProbe::attach_multi_kprobe(void)
 {
   DECLARE_LIBBPF_OPTS(bpf_link_create_opts, opts);


### PR DESCRIPTION
Hi, this is a minor patch that removes the unused `ptr_to_u64()` static function. As far as I can tell while it was added in commit 5ab53fad, it was not used since its introduction (probably because C++ cast was used instead).

This PR removes the unused `ptr_to_u64()` to silence the compiler warning.