### PR TITLE
Add Config class

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(runtime
   bpfprogram.cpp
   btf.cpp
   child.cpp
+  config.cpp
   disasm.cpp
   dwarf_parser.cpp
   fake_map.cpp

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -413,7 +413,7 @@ CallInst *IRBuilderBPF::createGetScratchMap(int mapid,
   CreateCondBr(condition, lookup_merge_block, lookup_failure_block);
 
   SetInsertPoint(lookup_failure_block);
-  if (bpftrace_.debug_output_)
+  if (bpftrace_.config_.get(ConfigKeyBool::debug_output))
     CreateDebugOutput("unable to find the scratch map value for " + name,
                       std::vector<Value *>{},
                       loc);
@@ -1978,11 +1978,12 @@ void IRBuilderBPF::CreatePath(Value *ctx,
   // Return: 0 or error
   FunctionType *d_path_func_type = FunctionType::get(
       getInt64Ty(), { getInt8PtrTy(), buf->getType(), getInt32Ty() }, false);
-  CallInst *call = CreateHelperCall(libbpf::bpf_func_id::BPF_FUNC_d_path,
-                                    d_path_func_type,
-                                    { path, buf, getInt32(bpftrace_.strlen_) },
-                                    "d_path",
-                                    &loc);
+  CallInst *call = CreateHelperCall(
+      libbpf::bpf_func_id::BPF_FUNC_d_path,
+      d_path_func_type,
+      { path, buf, getInt32(bpftrace_.config_.get(ConfigKeyInt::strlen)) },
+      "d_path",
+      &loc);
   CreateHelperErrorCond(ctx, call, libbpf::BPF_FUNC_d_path, loc);
 }
 

--- a/src/ast/passes/node_counter.h
+++ b/src/ast/passes/node_counter.h
@@ -3,6 +3,7 @@
 #include "ast/pass_manager.h"
 #include "ast/visitors.h"
 #include "bpftrace.h"
+#include "config.h"
 #include "log.h"
 
 namespace bpftrace {
@@ -32,7 +33,7 @@ inline Pass CreateCounterPass()
     NodeCounter c;
     c.Visit(n);
     auto node_count = c.get_count();
-    auto max = ctx.b.ast_max_nodes_;
+    auto max = ctx.b.config_.get(ConfigKeyInt::ast_max_nodes);
     if (bt_verbose)
     {
       LOG(INFO) << "node count: " << node_count;

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -102,7 +102,7 @@ int BPFtrace::add_probe(ast::Probe &p)
       probe.path = "/proc/self/exe";
       probe.attach_point = attach_point->provider + "_trigger";
       probe.type = probetype(attach_point->provider);
-      probe.log_size = log_size_;
+      probe.log_size = config_.get(ConfigKeyInt::log_size);
       probe.orig_name = p.name();
       probe.name = p.name();
       probe.loc = 0;
@@ -157,7 +157,7 @@ int BPFtrace::add_probe(ast::Probe &p)
         Probe probe;
         probe.attach_point = attach_point->func;
         probe.type = probetype(attach_point->provider);
-        probe.log_size = log_size_;
+        probe.log_size = config_.get(ConfigKeyInt::log_size);
         probe.orig_name = p.name();
         probe.name = attach_point->name(attach_point->target,
                                         attach_point->func);
@@ -179,7 +179,7 @@ int BPFtrace::add_probe(ast::Probe &p)
           probe.attach_point = attach_point->func;
           probe.path = attach_point->target;
           probe.type = probetype(attach_point->provider);
-          probe.log_size = log_size_;
+          probe.log_size = config_.get(ConfigKeyInt::log_size);
           probe.orig_name = p.name();
           probe.name = attach_point->name(attach_point->target,
                                           attach_point->func);
@@ -209,7 +209,7 @@ int BPFtrace::add_probe(ast::Probe &p)
               probe.attach_point = attach_point->func;
               probe.path = target;
               probe.type = probetype(attach_point->provider);
-              probe.log_size = log_size_;
+              probe.log_size = config_.get(ConfigKeyInt::log_size);
               probe.orig_name = p.name();
               probe.name = attach_point->name(attach_point->target,
                                               attach_point->func);
@@ -331,7 +331,7 @@ int BPFtrace::add_probe(ast::Probe &p)
       probe.path = target;
       probe.attach_point = func_id;
       probe.type = probetype(attach_point->provider);
-      probe.log_size = log_size_;
+      probe.log_size = config_.get(ConfigKeyInt::log_size);
       probe.orig_name = p.name();
       probe.ns = attach_point->ns;
       probe.name = attach_point->name(target, func_id);
@@ -382,17 +382,19 @@ int BPFtrace::add_probe(ast::Probe &p)
             resources.probes_using_usym.end() &&
         bcc_elf_is_exe(attach_point->target.c_str()))
     {
+      auto user_symbol_cache_type = config_.get(
+          ConfigKeyUserSymbolCacheType::default_);
       // preload symbol table for executable to make it available even if the
       // binary is not present at symbol resolution time
       // note: this only makes sense with ASLR disabled, since with ASLR offsets
       // might be different
-      if (user_symbol_cache_type_ == UserSymbolCacheType::per_program &&
+      if (user_symbol_cache_type == UserSymbolCacheType::per_program &&
           symbol_table_cache_.find(attach_point->target) ==
               symbol_table_cache_.end())
         symbol_table_cache_[attach_point->target] = get_symbol_table_for_elf(
             attach_point->target);
 
-      if (user_symbol_cache_type_ == UserSymbolCacheType::per_pid)
+      if (user_symbol_cache_type == UserSymbolCacheType::per_pid)
         // preload symbol tables from running processes
         // this allows symbol resolution for processes that are running at probe
         // attach time, but not at symbol resolution time, even with ASLR
@@ -500,7 +502,7 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
   }
   else if (printf_id == asyncactionint(AsyncAction::time))
   {
-    char timestr[64]; // not respecting strlen_ here...
+    char timestr[64]; // not respecting config_.get(ConfigKeyInt::strlen)
     time_t t;
     struct tm tmp;
     t = time(NULL);
@@ -682,7 +684,9 @@ void perf_event_printer(void *cb_cookie, void *data, int size)
     auto arg_values = bpftrace->get_arg_values(args, arg_data);
 
     std::stringstream buf;
-    cat_file(fmt.format_str(arg_values).c_str(), bpftrace->cat_bytes_max_, buf);
+    cat_file(fmt.format_str(arg_values).c_str(),
+             bpftrace->config_.get(ConfigKeyInt::cat_bytes_max),
+             buf);
     bpftrace->out_->message(MessageType::cat, buf.str(), false);
 
     return;
@@ -773,8 +777,8 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(const std::vec
         auto p = reinterpret_cast<char *>(arg_data + arg.offset);
         arg_values.push_back(std::make_unique<PrintableString>(
             std::string(p, strnlen(p, arg.type.GetSize())),
-            strlen_,
-            str_trunc_trailer_));
+            config_.get(ConfigKeyInt::strlen),
+            config_.get(ConfigKeyString::str_trunc_trailer).c_str()));
         break;
       }
       case Type::buffer:
@@ -1216,17 +1220,18 @@ int BPFtrace::run_iter()
 int BPFtrace::prerun() const
 {
   uint64_t num_probes = this->num_probes();
+  uint64_t max_probes = config_.get(ConfigKeyInt::max_probes);
   if (num_probes == 0)
   {
     if (!bt_quiet)
       std::cout << "No probes to attach" << std::endl;
     return 1;
   }
-  else if (num_probes > max_probes_)
+  else if (num_probes > max_probes)
   {
     LOG(ERROR)
         << "Can't attach to " << num_probes << " probes because it "
-        << "exceeds the current limit of " << max_probes_ << " probes.\n"
+        << "exceeds the current limit of " << max_probes << " probes.\n"
         << "You can increase the limit through the BPFTRACE_MAX_PROBES "
         << "environment variable, but BE CAREFUL since a high number of probes "
         << "attached can cause your system to crash.";
@@ -1406,8 +1411,13 @@ int BPFtrace::setup_perf_events()
   online_cpus_ = cpus.size();
   for (int cpu : cpus)
   {
-    void *reader = bpf_open_perf_buffer(
-        &perf_event_printer, &perf_event_lost, this, -1, cpu, perf_rb_pages_);
+    void *reader = bpf_open_perf_buffer(&perf_event_printer,
+                                        &perf_event_lost,
+                                        this,
+                                        -1,
+                                        cpu,
+                                        config_.get(
+                                            ConfigKeyInt::perf_rb_pages));
     if (reader == nullptr)
     {
       LOG(ERROR) << "Failed to open perf buffer";
@@ -2100,7 +2110,7 @@ std::string BPFtrace::resolve_timestamp(uint32_t mode,
   snprintf(usecs_buf, sizeof(usecs_buf), "%06" PRIu64, us);
   auto fmt = std::regex_replace(raw_fmt, usec_regex, usecs_buf);
 
-  char timestr[strlen_];
+  char timestr[config_.get(ConfigKeyInt::strlen)];
   if (strftime(timestr, sizeof(timestr), fmt.c_str(), &tmp) == 0)
   {
     LOG(ERROR) << "strftime returned 0";
@@ -2305,50 +2315,6 @@ std::string BPFtrace::resolve_inet(int af, const uint8_t* inet) const
   return addrstr;
 }
 
-// /proc/sys/kernel/randomize_va_space >= 1 and        // system-wide
-// (/proc/<pid>/personality & ADDR_NO_RNDOMIZE) == 0   // this pid
-// if pid == -1, then only check system-wide setting
-bool BPFtrace::is_aslr_enabled(int pid)
-{
-  std::string randomize_va_space_file = "/proc/sys/kernel/randomize_va_space";
-  std::string personality_file = "/proc/" + std::to_string(pid) +
-                                 "/personality";
-
-  {
-    std::ifstream file(randomize_va_space_file);
-    if (file.fail())
-    {
-      if (bt_verbose)
-        LOG(ERROR) << strerror(errno) << ": " << randomize_va_space_file;
-      // conservatively return true
-      return true;
-    }
-
-    std::string line;
-    if (std::getline(file, line) && std::stoi(line) < 1)
-      return false;
-  }
-
-  if (pid == -1)
-    return true;
-
-  {
-    std::ifstream file(personality_file);
-    if (file.fail())
-    {
-      if (bt_verbose)
-        LOG(ERROR) << strerror(errno) << ": " << personality_file;
-      return true;
-    }
-    std::string line;
-    if (std::getline(file, line) &&
-        ((std::stoi(line) & ADDR_NO_RANDOMIZE) == 0))
-      return true;
-  }
-
-  return false;
-}
-
 std::string BPFtrace::resolve_usym(uint64_t addr,
                                    int pid,
                                    int probe_id,
@@ -2358,6 +2324,8 @@ std::string BPFtrace::resolve_usym(uint64_t addr,
   struct bcc_symbol usym;
   std::ostringstream symbol;
   void *psyms = nullptr;
+  auto user_symbol_cache_type = config_.get(
+      ConfigKeyUserSymbolCacheType::default_);
 
   if (resolve_user_symbols_)
   {
@@ -2380,7 +2348,7 @@ std::string BPFtrace::resolve_usym(uint64_t addr,
         pid_exe = probe_full.substr(start, end - start);
       }
     }
-    if (user_symbol_cache_type_ == UserSymbolCacheType::per_program)
+    if (user_symbol_cache_type == UserSymbolCacheType::per_program)
     {
       if (!pid_exe.empty())
       {
@@ -2418,7 +2386,7 @@ std::string BPFtrace::resolve_usym(uint64_t addr,
         psyms = exe_sym_[pid_exe].second;
       }
     }
-    else if (user_symbol_cache_type_ == UserSymbolCacheType::per_pid)
+    else if (user_symbol_cache_type == UserSymbolCacheType::per_pid)
     {
       // cache user symbols per pid
       if (pid_sym_.find(pid) == pid_sym_.end())
@@ -2441,10 +2409,10 @@ std::string BPFtrace::resolve_usym(uint64_t addr,
 
   if (psyms && bcc_symcache_resolve(psyms, addr, &usym) == 0)
   {
-    if (demangle_cpp_symbols_)
-      symbol << usym.demangle_name;
-    else
+    if (config_.get(ConfigKeyBool::no_cpp_demangle))
       symbol << usym.name;
+    else
+      symbol << usym.demangle_name;
     if (show_offset)
       symbol << "+" << usym.offset;
     if (show_module)
@@ -2458,7 +2426,7 @@ std::string BPFtrace::resolve_usym(uint64_t addr,
   }
 
   if (resolve_user_symbols_ &&
-      user_symbol_cache_type_ == UserSymbolCacheType::none)
+      user_symbol_cache_type == UserSymbolCacheType::none)
     bcc_free_symcache(psyms, pid);
 
   return symbol.str();

--- a/src/clang_parser.cpp
+++ b/src/clang_parser.cpp
@@ -626,8 +626,8 @@ void ClangParser::resolve_incomplete_types_from_btf(
     if (probe->tp_args_structs_level > (int)field_lvl)
       field_lvl = probe->tp_args_structs_level;
 
-  unsigned max_iterations = std::max(bpftrace.max_type_res_iterations,
-                                     field_lvl);
+  unsigned max_iterations = std::max(
+      bpftrace.config_.get(ConfigKeyInt::max_type_res_iterations), field_lvl);
 
   bool check_incomplete_types = true;
   for (unsigned i = 0; i < max_iterations && check_incomplete_types; i++)

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,0 +1,118 @@
+#include <cstring>
+#include <fstream>
+
+#include "config.h"
+#include "log.h"
+#include "types.h"
+
+namespace bpftrace {
+
+Config::Config(bool has_cmd, bool bt_verbose) : bt_verbose_(bt_verbose)
+{
+  config_map_ = {
+    // Maximum AST nodes allowed for fuzzing
+    { ConfigKeyInt::ast_max_nodes, { .value = (uint64_t)0 } },
+    { ConfigKeyInt::cat_bytes_max, { .value = (uint64_t)10240 } },
+    { ConfigKeyBool::debug_output, { .value = false } },
+    { ConfigKeyInt::log_size, { .value = (uint64_t)1000000 } },
+    { ConfigKeyInt::map_keys_max, { .value = (uint64_t)4096 } },
+    { ConfigKeyInt::max_probes, { .value = (uint64_t)512 } },
+    { ConfigKeyInt::max_bpf_progs, { .value = (uint64_t)512 } },
+    { ConfigKeyInt::max_type_res_iterations, { .value = (uint64_t)0 } },
+    { ConfigKeyBool::no_cpp_demangle, { .value = false } },
+    { ConfigKeyInt::perf_rb_pages, { .value = (uint64_t)64 } },
+    { ConfigKeyStackMode::default_, { .value = StackMode::bpftrace } },
+    { ConfigKeyInt::strlen, { .value = (uint64_t)64 } },
+    { ConfigKeyString::str_trunc_trailer, { .value = ".." } },
+    // by default, cache user symbols per program if ASLR is disabled on system
+    // or `-c` option is given
+    { ConfigKeyUserSymbolCacheType::default_,
+      { .value = (has_cmd || !is_aslr_enabled())
+                     ? UserSymbolCacheType::per_program
+                     : UserSymbolCacheType::per_pid } },
+    { ConfigKeyBool::verify_llvm_ir, { .value = false } }
+  };
+}
+
+bool Config::can_set(ConfigSource prevSource, ConfigSource)
+{
+  if (prevSource == ConfigSource::default_)
+  {
+    return true;
+  }
+  else if (prevSource == ConfigSource::env_var)
+  {
+    return false;
+  }
+  return false;
+}
+
+// /proc/sys/kernel/randomize_va_space >= 1
+bool Config::is_aslr_enabled()
+{
+  std::string randomize_va_space_file = "/proc/sys/kernel/randomize_va_space";
+
+  {
+    std::ifstream file(randomize_va_space_file);
+    if (file.fail())
+    {
+      if (bt_verbose_)
+        LOG(ERROR) << std::strerror(errno) << ": " << randomize_va_space_file;
+      // conservatively return true
+      return true;
+    }
+
+    std::string line;
+    if (std::getline(file, line) && std::stoi(line) < 1)
+      return false;
+  }
+
+  return true;
+}
+
+bool ConfigSetter::set_stack_mode(const std::string &s)
+{
+  auto found = STACK_MODE_MAP.find(s);
+  if (found != STACK_MODE_MAP.end())
+  {
+    return config_.set(ConfigKeyStackMode::default_, found->second, source_);
+  }
+  else
+  {
+    LOG(ERROR) << s << " is not a valid StackMode";
+    return false;
+  }
+}
+
+// Note: options 0 and 1 are for compatibility with older versions of bpftrace
+bool ConfigSetter::set_user_symbol_cache_type(const std::string &s)
+{
+  UserSymbolCacheType usct;
+  if (s == "PER_PID")
+  {
+    usct = UserSymbolCacheType::per_pid;
+  }
+  else if (s == "PER_PROGRAM")
+  {
+    usct = UserSymbolCacheType::per_program;
+  }
+  else if (s == "1")
+  {
+    // use the default
+    return true;
+  }
+  else if (s == "NONE" || s == "0")
+  {
+    usct = UserSymbolCacheType::none;
+  }
+  else
+  {
+    LOG(ERROR)
+        << "Env var 'BPFTRACE_CACHE_USER_SYMBOLS' did not contain a valid "
+           "value: valid values are PER_PID, PER_PROGRAM, and NONE.";
+    return false;
+  }
+  return config_.set(ConfigKeyUserSymbolCacheType::default_, usct, source_);
+}
+
+} // namespace bpftrace

--- a/src/config.h
+++ b/src/config.h
@@ -1,0 +1,194 @@
+#pragma once
+
+#include <cstdint>
+#include <iostream>
+#include <map>
+#include <variant>
+
+#include "types.h"
+
+namespace bpftrace {
+
+// This is used to determine which source
+// takes precedence when a config key is set
+enum class ConfigSource
+{
+  // the default config value
+  default_,
+  // config set via environment variable
+  env_var,
+};
+
+enum class ConfigKeyBool
+{
+  debug_output,
+  no_cpp_demangle,
+  verify_llvm_ir,
+};
+
+enum class ConfigKeyInt
+{
+  ast_max_nodes,
+  cat_bytes_max,
+  log_size,
+  map_keys_max,
+  max_probes,
+  max_bpf_progs,
+  max_type_res_iterations,
+  perf_rb_pages,
+  strlen,
+};
+
+enum class ConfigKeyString
+{
+  str_trunc_trailer,
+};
+
+enum class ConfigKeyStackMode
+{
+  default_,
+};
+
+enum class ConfigKeyUserSymbolCacheType
+{
+  default_,
+};
+
+typedef std::variant<ConfigKeyBool,
+                     ConfigKeyInt,
+                     ConfigKeyString,
+                     ConfigKeyStackMode,
+                     ConfigKeyUserSymbolCacheType>
+    ConfigKey;
+
+struct ConfigValue
+{
+  ConfigSource source = ConfigSource::default_;
+  std::variant<bool, uint64_t, std::string, StackMode, UserSymbolCacheType>
+      value;
+};
+
+const std::map<std::string, StackMode> STACK_MODE_MAP = {
+  { "bpftrace", StackMode::bpftrace },
+  { "perf", StackMode::perf },
+  { "raw", StackMode::raw },
+};
+
+class Config
+{
+public:
+  explicit Config(bool has_cmd = false, bool bt_verbose = false);
+
+  bool get(ConfigKeyBool key) const
+  {
+    return get<bool>(key);
+  }
+
+  uint64_t get(ConfigKeyInt key) const
+  {
+    return get<uint64_t>(key);
+  }
+
+  std::string get(ConfigKeyString key) const
+  {
+    return get<std::string>(key);
+  }
+
+  StackMode get(ConfigKeyStackMode key) const
+  {
+    return get<StackMode>(key);
+  }
+
+  UserSymbolCacheType get(ConfigKeyUserSymbolCacheType key) const
+  {
+    return get<UserSymbolCacheType>(key);
+  }
+
+  friend class ConfigSetter;
+
+private:
+  template <typename T>
+  bool set(ConfigKey key, T val, ConfigSource source)
+  {
+    auto it = config_map_.find(key);
+    if (it == config_map_.end())
+    {
+      throw std::runtime_error("No default set for config key");
+    }
+    if (!can_set(it->second.source, source))
+    {
+      return false;
+    }
+
+    it->second.value = val;
+    it->second.source = source;
+    return true;
+  }
+
+  template <typename T>
+  T get(ConfigKey key) const
+  {
+    auto it = config_map_.find(key);
+    if (it == config_map_.end())
+    {
+      throw std::runtime_error("Config key does not exist in map");
+    }
+    try
+    {
+      return std::get<T>(it->second.value);
+    }
+    catch (std::bad_variant_access const &ex)
+    {
+      // This shouldn't happen
+      throw std::runtime_error("Type mismatch for config key");
+    }
+  }
+
+  bool can_set(ConfigSource prevSource, ConfigSource);
+  bool is_aslr_enabled();
+  bool bt_verbose_ = false;
+
+  std::map<ConfigKey, ConfigValue> config_map_;
+};
+
+class ConfigSetter
+{
+public:
+  explicit ConfigSetter(Config &config, ConfigSource source)
+      : config_(config), source_(source){};
+
+  bool set(ConfigKeyBool key, bool val)
+  {
+    return config_.set(key, val, source_);
+  }
+
+  bool set(ConfigKeyInt key, uint64_t val)
+  {
+    return config_.set(key, val, source_);
+  }
+
+  bool set(ConfigKeyString key, const std::string &val)
+  {
+    return config_.set(key, val, source_);
+  }
+
+  bool set(StackMode val)
+  {
+    return config_.set(ConfigKeyStackMode::default_, val, source_);
+  }
+
+  bool set(UserSymbolCacheType val)
+  {
+    return config_.set(ConfigKeyUserSymbolCacheType::default_, val, source_);
+  }
+
+  bool set_stack_mode(const std::string &s);
+  bool set_user_symbol_cache_type(const std::string &s);
+
+  Config &config_;
+
+private:
+  const ConfigSource source_;
+};
+
+} // namespace bpftrace

--- a/src/fuzz_main.cpp
+++ b/src/fuzz_main.cpp
@@ -108,7 +108,8 @@ int fuzz_main(const char* data, size_t sz)
 
   // Limit node size
   uint64_t node_max = DEFAULT_NODE_MAX;
-  if (!get_uint64_env_var("BPFTRACE_NODE_MAX", node_max))
+  if (!get_uint64_env_var("BPFTRACE_NODE_MAX",
+                          [&](uint64_t x) { node_max = x; }))
     return 1;
   uint64_t node_count = 0;
   ast::CallbackVisitor counter(

--- a/src/types.h
+++ b/src/types.h
@@ -64,17 +64,18 @@ enum class AddrSpace : uint8_t
 std::ostream &operator<<(std::ostream &os, Type type);
 std::ostream &operator<<(std::ostream &os, AddrSpace as);
 
+enum class UserSymbolCacheType
+{
+  per_pid,
+  per_program,
+  none,
+};
+
 enum class StackMode : uint8_t
 {
   bpftrace,
   perf,
   raw,
-};
-
-const std::map<std::string, StackMode> STACK_MODE_MAP = {
-  { "bpftrace", StackMode::bpftrace },
-  { "perf", StackMode::perf },
-  { "raw", StackMode::raw },
 };
 
 struct StackType

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -24,6 +24,7 @@
 #include <unordered_set>
 
 #include "bpftrace.h"
+#include "config.h"
 #include "debugfs.h"
 #include "log.h"
 #include "probe_matcher.h"
@@ -233,9 +234,11 @@ KConfig::KConfig()
   }
 }
 
-bool get_uint64_env_var(const std::string &str, uint64_t &dest)
+bool get_uint64_env_var(const ::std::string &str,
+                        const std::function<void(uint64_t)> &cb)
 {
-  if (const char* env_p = std::getenv(str.c_str()))
+  uint64_t dest;
+  if (const char *env_p = std::getenv(str.c_str()))
   {
     std::istringstream stringstream(env_p);
     if (!(stringstream >> dest))
@@ -244,19 +247,22 @@ bool get_uint64_env_var(const std::string &str, uint64_t &dest)
                  << "' did not contain a valid uint64_t, or was zero-valued.";
       return false;
     }
+    cb(dest);
   }
   return true;
 }
 
-bool get_bool_env_var(const std::string &str, bool &dest, bool neg)
+bool get_bool_env_var(const ::std::string &str,
+                      const std::function<void(bool)> &cb)
 {
   if (const char *env_p = std::getenv(str.c_str()))
   {
+    bool dest;
     std::string s(env_p);
     if (s == "1")
-      dest = !neg;
+      dest = true;
     else if (s == "0")
-      dest = neg;
+      dest = false;
     else
     {
       LOG(ERROR) << "Env var '" << str
@@ -264,6 +270,7 @@ bool get_bool_env_var(const std::string &str, bool &dest, bool neg)
                     "valid value (0 or 1).";
       return false;
     }
+    cb(dest);
   }
   return true;
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <cstring>
 #include <exception>
+#include <functional>
 #include <iostream>
 #include <map>
 #include <optional>
@@ -13,6 +14,8 @@
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
+
+#include "config.h"
 
 namespace bpftrace {
 
@@ -157,8 +160,10 @@ static std::vector<std::string> COMPILE_TIME_FUNCS = { "cgroupid" };
 
 static std::vector<std::string> UPROBE_LANGS = { "cpp" };
 
-bool get_uint64_env_var(const ::std::string &str, uint64_t &dest);
-bool get_bool_env_var(const ::std::string &str, bool &dest, bool neg = false);
+bool get_uint64_env_var(const ::std::string &str,
+                        const std::function<void(uint64_t)> &cb);
+bool get_bool_env_var(const ::std::string &str,
+                      const std::function<void(bool)> &cb);
 std::string get_pid_exe(pid_t pid);
 std::string get_pid_exe(const std::string &pid);
 std::string get_proc_maps(const std::string &pid);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(bpftrace_test
   bpftrace.cpp
   child.cpp
   clang_parser.cpp
+  config.cpp
   field_analyser.cpp
   log.cpp
   main.cpp

--- a/tests/codegen/call_join.cpp
+++ b/tests/codegen/call_join.cpp
@@ -1,4 +1,5 @@
 #include "common.h"
+#include "config.h"
 
 namespace bpftrace {
 namespace test {
@@ -15,7 +16,8 @@ TEST(codegen, call_join_with_debug)
 {
   auto bpftrace = get_mock_bpftrace();
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  bpftrace->debug_output_ = 1;
+  auto config_setter = ConfigSetter(bpftrace->config_, ConfigSource::env_var);
+  config_setter.set(ConfigKeyBool::debug_output, true);
   test(*bpftrace,
        "struct arg { char **argv } kprobe:f { $x = (struct arg *) 0; "
        "join($x->argv); }",

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -77,7 +77,8 @@ static void test(BPFtrace &bpftrace,
   codegen.emit();
 
   uint64_t update_tests = 0;
-  if (get_uint64_env_var("BPFTRACE_UPDATE_TESTS", update_tests) &&
+  if (get_uint64_env_var("BPFTRACE_UPDATE_TESTS",
+                         [&](uint64_t x) { update_tests = x; }) &&
       update_tests >= 1)
   {
     std::cerr << "Running in update mode, test is skipped" << std::endl;

--- a/tests/config.cpp
+++ b/tests/config.cpp
@@ -1,0 +1,93 @@
+#include "config.h"
+#include "mocks.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include <iostream>
+
+namespace bpftrace {
+namespace test {
+
+TEST(Config, get_and_set)
+{
+  auto config = Config();
+  auto config_setter = ConfigSetter(config, ConfigSource::env_var);
+
+  // check all the keys
+  EXPECT_TRUE(config_setter.set(ConfigKeyBool::debug_output, true));
+  EXPECT_EQ(config.get(ConfigKeyBool::debug_output), true);
+
+  EXPECT_TRUE(config_setter.set(ConfigKeyBool::no_cpp_demangle, true));
+  EXPECT_EQ(config.get(ConfigKeyBool::no_cpp_demangle), true);
+
+  EXPECT_TRUE(config_setter.set(ConfigKeyBool::verify_llvm_ir, true));
+  EXPECT_EQ(config.get(ConfigKeyBool::verify_llvm_ir), true);
+
+  EXPECT_TRUE(config_setter.set(ConfigKeyInt::ast_max_nodes, 10));
+  EXPECT_EQ(config.get(ConfigKeyInt::ast_max_nodes), 10);
+
+  EXPECT_TRUE(config_setter.set(ConfigKeyInt::cat_bytes_max, 10));
+  EXPECT_EQ(config.get(ConfigKeyInt::cat_bytes_max), 10);
+
+  EXPECT_TRUE(config_setter.set(ConfigKeyInt::log_size, 10));
+  EXPECT_EQ(config.get(ConfigKeyInt::log_size), 10);
+
+  EXPECT_TRUE(config_setter.set(ConfigKeyInt::map_keys_max, 10));
+  EXPECT_EQ(config.get(ConfigKeyInt::map_keys_max), 10);
+
+  EXPECT_TRUE(config_setter.set(ConfigKeyInt::max_probes, 10));
+  EXPECT_EQ(config.get(ConfigKeyInt::max_probes), 10);
+
+  EXPECT_TRUE(config_setter.set(ConfigKeyInt::max_bpf_progs, 10));
+  EXPECT_EQ(config.get(ConfigKeyInt::max_bpf_progs), 10);
+
+  EXPECT_TRUE(config_setter.set(ConfigKeyInt::max_type_res_iterations, 10));
+  EXPECT_EQ(config.get(ConfigKeyInt::max_type_res_iterations), 10);
+
+  EXPECT_TRUE(config_setter.set(ConfigKeyInt::perf_rb_pages, 10));
+  EXPECT_EQ(config.get(ConfigKeyInt::perf_rb_pages), 10);
+
+  EXPECT_TRUE(config_setter.set(ConfigKeyInt::strlen, 10));
+  EXPECT_EQ(config.get(ConfigKeyInt::strlen), 10);
+
+  EXPECT_TRUE(config_setter.set(ConfigKeyString::str_trunc_trailer, "str"));
+  EXPECT_EQ(config.get(ConfigKeyString::str_trunc_trailer), "str");
+
+  EXPECT_TRUE(config_setter.set(StackMode::bpftrace));
+  EXPECT_EQ(config.get(ConfigKeyStackMode::default_), StackMode::bpftrace);
+
+  EXPECT_TRUE(config_setter.set(UserSymbolCacheType::per_program));
+  EXPECT_EQ(config.get(ConfigKeyUserSymbolCacheType::default_),
+            UserSymbolCacheType::per_program);
+}
+
+TEST(ConfigSetter, set_stack_mode)
+{
+  auto config = Config();
+  auto config_setter = ConfigSetter(config, ConfigSource::env_var);
+
+  EXPECT_FALSE(config_setter.set_stack_mode("invalid"));
+  EXPECT_TRUE(config_setter.set_stack_mode("raw"));
+  EXPECT_EQ(config.get(ConfigKeyStackMode::default_), StackMode::raw);
+}
+
+TEST(ConfigSetter, set_user_symbol_cache_type)
+{
+  auto config = Config();
+  auto config_setter = ConfigSetter(config, ConfigSource::env_var);
+
+  EXPECT_FALSE(config_setter.set_user_symbol_cache_type("invalid"));
+  EXPECT_TRUE(config_setter.set_user_symbol_cache_type("NONE"));
+  EXPECT_EQ(config.get(ConfigKeyUserSymbolCacheType::default_),
+            UserSymbolCacheType::none);
+}
+
+TEST(ConfigSetter, same_source_cannot_set_twice)
+{
+  auto config = Config();
+  auto config_setter = ConfigSetter(config, ConfigSource::env_var);
+  EXPECT_TRUE(config_setter.set(ConfigKeyInt::ast_max_nodes, 10));
+  EXPECT_FALSE(config_setter.set(ConfigKeyInt::ast_max_nodes, 11));
+}
+
+} // namespace test
+} // namespace bpftrace


### PR DESCRIPTION
This is in preparation for a new config syntax:
https://github.com/iovisor/bpftrace/pull/2815

This consolidates configuration into a single class/object and supports a hierarchy for setting config variables e.g. setting these variables via environment variables will take precedence over setting them from within a script.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
