### PR TITLE
utils: Fix error: ‘PATH_MAX’ was not declared in this scope

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <array>
+#include <climits>
 #include <cmath>
 #include <cstring>
 #include <errno.h>


### PR DESCRIPTION
PATH_MAX if defined in "climits".

g++ (GCC) 13.2.1 20231205 version get the follow error:

```
    $ make
    ....
    [  3%] Building CXX object src/CMakeFiles/runtime.dir/utils.cpp.o
    /home/rongtao/Git/bpftrace/src/utils.cpp: In function ‘std::vector<std::__cxx11::basic_string<char> > bpftrace::get_mapped_paths_for_pid(pid_t)’:
    /home/rongtao/Git/bpftrace/src/utils.cpp:353:14: error: ‘PATH_MAX’ was not declared in this scope
      353 |     char buf[PATH_MAX + 1];
          |              ^~~~~~~~
    /home/rongtao/Git/bpftrace/src/utils.cpp:354:5: error: ‘buf’ was not declared in this scope; did you mean ‘btf’?
      354 |     buf[0] = '\0';
          |     ^~~
          |     btf
    /home/rongtao/Git/bpftrace/src/utils.cpp: In function ‘uint32_t bpftrace::kernel_version(int)’:
    /home/rongtao/Git/bpftrace/src/utils.cpp:1320:41: warning: control reaches end of non-void function [-Wreturn-type]
     1320 |                << std::to_string(attempt);
          |                                         ^
    make[2]: *** [src/CMakeFiles/runtime.dir/build.make:426: src/CMakeFiles/runtime.dir/utils.cpp.o] Error 1
    make[1]: *** [CMakeFiles/Makefile2:1340: src/CMakeFiles/runtime.dir/all] Error 2
    make: *** [Makefile:146: all] Error 2
```
