### PR TITLE
hist: PR followups

### DIFF
--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -135,12 +135,12 @@ void ResourceAnalyser::visit(Call &call)
   else if (call.func == "hist")
   {
     auto &r = resources_.hist_bits_arg;
-    int old, bits = static_cast<Integer *>(call.vargs->at(1))->n;
-    if (r.find(call.map->ident) != r.end() &&
-        (old = r[call.map->ident]) != bits)
+
+    int bits = static_cast<Integer *>(call.vargs->at(1))->n;
+    if (r.find(call.map->ident) != r.end() && (r[call.map->ident]) != bits)
     {
-      LOG(ERROR, call.loc, err_)
-          << "Different bits in a single hist, had " << old << " now " << bits;
+      LOG(ERROR, call.loc, err_) << "Different bits in a single hist, had "
+                                 << r[call.map->ident] << " now " << bits;
     }
     else
     {

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -47,10 +47,10 @@ std::ostream& operator<<(std::ostream& out, MessageType type) {
 // - the last 2 bits 11 indicate the third interval so the
 //   starting value is 128 + 32*3 = 224
 
-std::string TextOutput::hist_index_label(int index, int k)
+std::string TextOutput::hist_index_label(uint32_t index, uint32_t k)
 {
   const uint32_t n = (1 << k), interval = index & (n - 1);
-  assert(index >= n); // Smaller indexes are converted directly.
+  assert(index >= n);
   uint32_t power = (index >> k) - 1;
   // Choose the suffix for the largest power of 2^10
   const uint32_t decade = power / 10;
@@ -425,7 +425,7 @@ void TextOutput::map(
 
 std::string TextOutput::hist_to_str(const std::vector<uint64_t> &values,
                                     uint32_t div,
-                                    int k) const
+                                    uint32_t k) const
 {
   int min_index, max_index, max_value;
   hist_prepare(values, min_index, max_index, max_value);
@@ -694,7 +694,7 @@ void JsonOutput::map(
 
 std::string JsonOutput::hist_to_str(const std::vector<uint64_t> &values,
                                     uint32_t div,
-                                    int k) const
+                                    uint32_t k) const
 {
   int min_index, max_index, max_value;
   hist_prepare(values, min_index, max_index, max_value);

--- a/src/output.h
+++ b/src/output.h
@@ -89,7 +89,7 @@ protected:
   // Convert a log2 histogram into string
   virtual std::string hist_to_str(const std::vector<uint64_t> &values,
                                   uint32_t div,
-                                  int k) const = 0;
+                                  uint32_t k) const = 0;
   // Convert a linear histogram into string
   virtual std::string lhist_to_str(const std::vector<uint64_t> &values,
                                    int min,
@@ -199,11 +199,11 @@ public:
                     const location &loc) const override;
 
 protected:
-  static std::string hist_index_label(int index, int bits);
+  static std::string hist_index_label(uint32_t index, uint32_t bits);
   static std::string lhist_index_label(int number);
   virtual std::string hist_to_str(const std::vector<uint64_t> &values,
                                   uint32_t div,
-                                  int k) const override;
+                                  uint32_t k) const override;
   virtual std::string lhist_to_str(const std::vector<uint64_t> &values,
                                    int min,
                                    int max,
@@ -264,7 +264,7 @@ protected:
                            uint32_t div) const override;
   std::string hist_to_str(const std::vector<uint64_t> &values,
                           uint32_t div,
-                          int k) const override;
+                          uint32_t k) const override;
   std::string lhist_to_str(const std::vector<uint64_t> &values,
                            int min,
                            int max,


### PR DESCRIPTION
Fixes up some follow-on comments from [0].

Also fixes a compile time warning:

```
[25/85] Building CXX object src/CMakeFiles/runtime.dir/output.cpp.o In file included from /usr/include/c++/13.2.1/cassert:44,
                 from /home/dxu/dev/bpftrace/src/log.h:3,
                 from /home/dxu/dev/bpftrace/src/output.cpp:3:
/home/dxu/dev/bpftrace/src/output.cpp: In static member function ‘static std::string bpftrace::TextOutput::hist_index_label(int, int)’: /home/dxu/dev/bpftrace/src/output.cpp:53:16: warning: comparison of integer expressions of different signedness: ‘int’ and ‘const uint32_t’ {aka ‘const unsigned int’} [-Wsign-compare]
   53 |   assert(index >= n); // Smaller indexes are converted directly.
      |          ~~~~~~^~~~
```

[0]: https://github.com/iovisor/bpftrace/pull/2831#discussion_r1417767030

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
