### PR TITLE
docker/debian: Install deps xxd, libgtest-dev and libgmock-dev

### DIFF
--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -13,11 +13,14 @@ RUN apt-get update && apt-get install -y \
     clang \
     cmake \
     flex \
+    xxd \
     libbpf-dev \
     libbpfcc-dev \
     libcereal-dev \
     libdw-dev \
     libelf-dev \
+    libgmock-dev \
+    libgtest-dev \
     libiberty-dev \
     libpcap-dev \
     llvm-dev \


### PR DESCRIPTION
On Debian 12, i just install all deps in Dockerfile.debian, however:

```bash
    $ cmake -DCMAKE_INSTALL_PREFIX=/usr/ -DCMAKE_BUILD_TYPE=Debug \
    	-DBUILD_TESTING=ON -DVENDOR_GTEST=OFF ..
    ...
    -- Found LibXml2: /usr/lib/aarch64-linux-gnu/libxml2.so (found version "2.9.14")
    -- Found LLVM 14.0.6: /usr/lib/llvm-14/lib/cmake/llvm
    -- Disabled codegen test for LLVM != 12
    CMake Error at tests/data/CMakeLists.txt:4 (find_program):
      Could not find XXD using the following names: xxd
```
