### PR TITLE
Fix dangerous compile warning: Compare signed and unsigned int

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -50,7 +50,7 @@ std::ostream& operator<<(std::ostream& out, MessageType type) {
 std::string TextOutput::hist_index_label(int index, int k)
 {
   const uint32_t n = (1 << k), interval = index & (n - 1);
-  assert(index >= n); // Smaller indexes are converted directly.
+  assert(index >= (int)n); // Smaller indexes are converted directly.
   uint32_t power = (index >> k) - 1;
   // Choose the suffix for the largest power of 2^10
   const uint32_t decade = power / 10;


### PR DESCRIPTION
```bash
    $ gcc --version
    gcc (Debian 12.2.0-14) 12.2.0

    $ cmake -DCMAKE_INSTALL_PREFIX=/usr/ -DCMAKE_BUILD_TYPE=Debug \
	-DBUILD_TESTING=ON -DVENDOR_GTEST=OFF ..
    $ make
    ...
    [ 75%] Building CXX object src/CMakeFiles/runtime.dir/output.cpp.o
    In file included from /usr/include/c++/12/cassert:44,
                     from /home/rongtao/Git/bpftrace/src/log.h:3,
                     from /home/rongtao/Git/bpftrace/src/output.cpp:3:
    /home/rongtao/Git/bpftrace/src/output.cpp: In static member function
    'static std::string bpftrace::TextOutput::hist_index_label(int, int)':
    /home/rongtao/Git/bpftrace/src/output.cpp:53:16: warning: comparison of
    integer expressions of different signedness: 'int' and 'const uint32_t'
    {aka 'const unsigned int'} [-Wsign-compare]
       53 |   assert(index >= n); // Smaller indexes are converted directly.
          |          ~~~~~~^~~~
```

