### PR TITLE
aot: Finish up write side

### DIFF
--- a/src/aot/aot.cpp
+++ b/src/aot/aot.cpp
@@ -63,7 +63,6 @@ uint32_t rs_hash(const std::string &str)
 void serialize_bytecode(const BpfBytecode &bytecode, std::ostream &out)
 {
   cereal::BinaryOutputArchive archive(out);
-  // cereal::JSONOutputArchive archive(out);
   archive(bytecode);
 }
 

--- a/src/filesystem.h
+++ b/src/filesystem.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace std_filesystem = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace std_filesystem = std::experimental::filesystem;
+#else
+#error "neither <filesystem> nor <experimental/filesystem> are present"
+#endif

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -26,6 +26,7 @@
 #include "bpftrace.h"
 #include "config.h"
 #include "debugfs.h"
+#include "filesystem.h"
 #include "log.h"
 #include "probe_matcher.h"
 #include "tracefs.h"
@@ -37,16 +38,6 @@
 #include <zlib.h>
 
 #include <linux/version.h>
-
-#if __has_include(<filesystem>)
-#include <filesystem>
-namespace std_filesystem = std::filesystem;
-#elif __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
-namespace std_filesystem = std::experimental::filesystem;
-#else
-#error "neither <filesystem> nor <experimental/filesystem> are present"
-#endif
 
 namespace {
 

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -266,6 +266,25 @@ bool get_bool_env_var(const ::std::string &str,
   return true;
 }
 
+std::optional<std_filesystem::path> find_in_path(const std::string &name)
+{
+  std::error_code ec;
+
+  const char *path_env = std::getenv("PATH");
+  if (!path_env)
+    return std::nullopt;
+
+  auto paths = split_string(path_env, ':', true);
+  for (const auto &path : paths)
+  {
+    auto fpath = std_filesystem::path(path) / name;
+    if (std_filesystem::exists(fpath, ec))
+      return fpath;
+  }
+
+  return std::nullopt;
+}
+
 std::string get_pid_exe(const std::string &pid)
 {
   std::error_code ec;

--- a/src/utils.h
+++ b/src/utils.h
@@ -16,6 +16,7 @@
 #include <vector>
 
 #include "config.h"
+#include "filesystem.h"
 
 namespace bpftrace {
 
@@ -164,6 +165,8 @@ bool get_uint64_env_var(const ::std::string &str,
                         const std::function<void(uint64_t)> &cb);
 bool get_bool_env_var(const ::std::string &str,
                       const std::function<void(bool)> &cb);
+// Tries to find a file in $PATH
+std::optional<std_filesystem::path> find_in_path(const std::string &name);
 std::string get_pid_exe(pid_t pid);
 std::string get_pid_exe(const std::string &pid);
 std::string get_proc_maps(const std::string &pid);

--- a/tests/child.cpp
+++ b/tests/child.cpp
@@ -13,17 +13,8 @@
 
 #include "child.h"
 #include "childhelper.h"
+#include "filesystem.h"
 #include "utils.h"
-
-#if __has_include(<filesystem>)
-#include <filesystem>
-namespace std_filesystem = std::filesystem;
-#elif __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
-namespace std_filesystem = std::experimental::filesystem;
-#else
-#error "neither <filesystem> nor <experimental/filesystem> are present"
-#endif
 
 namespace bpftrace {
 namespace test {

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -4,6 +4,7 @@
 #include <cstring>
 #include <fcntl.h>
 #include <fstream>
+#include <stdlib.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
@@ -271,6 +272,84 @@ TEST(utils, sanitiseBPFProgramName)
   ASSERT_EQ(long_sanitised,
             "uretprobe__this_is_a_very_long_path_to_a_binary_executable_this_"
             "is_a_very_long_function_name_which_exceeds_the_ba30ddc67a52bad2");
+}
+
+// Run a function with environment var set to specific value.
+// Does its best to clean up env var so it doesn't leak between tests.
+static void with_env(const std::string &key,
+                     const std::string &val,
+                     std::function<void()> fn)
+{
+  EXPECT_EQ(::setenv(key.c_str(), val.c_str(), 1), 0);
+  try
+  {
+    fn();
+  }
+  catch (const std::exception &ex)
+  {
+    EXPECT_EQ(::unsetenv(key.c_str()), 0);
+    throw ex;
+  }
+  EXPECT_EQ(::unsetenv(key.c_str()), 0);
+}
+
+TEST(utils, find_in_path)
+{
+  std::string tmpdir = "/tmp/bpftrace-test-utils-XXXXXX";
+  ASSERT_TRUE(::mkdtemp(&tmpdir[0]));
+
+  // Create some directories
+  const std_filesystem::path path(tmpdir);
+  const std_filesystem::path usr_bin = path / "usr" / "bin";
+  const std_filesystem::path usr_local_bin = path / "usr" / "local" / "bin";
+  ASSERT_TRUE(std_filesystem::create_directories(usr_bin));
+  ASSERT_TRUE(std_filesystem::create_directories(usr_local_bin));
+
+  // Create some dummy binaries
+  const std_filesystem::path usr_bin_echo = usr_bin / "echo";
+  const std_filesystem::path usr_local_bin_echo = usr_local_bin / "echo";
+  const std_filesystem::path usr_bin_cat = usr_bin / "cat";
+  {
+    std::ofstream(usr_bin_echo) << "zz";
+    std::ofstream(usr_local_bin_echo) << "zz";
+    std::ofstream(usr_bin_cat) << "zz";
+  }
+
+  // Test basic find
+  with_env("PATH", usr_bin, [&]() {
+    auto f = find_in_path("echo");
+    ASSERT_TRUE(f.has_value());
+    EXPECT_TRUE(f->native().find("/usr/bin/echo") != std::string::npos);
+  });
+
+  // Test no entries found
+  with_env("PATH", usr_bin, [&]() {
+    auto f = find_in_path("echoz");
+    ASSERT_FALSE(f.has_value());
+  });
+
+  // Test precedence in find with two entries in $PATH
+  auto two_path = usr_local_bin.native() + ":" + usr_bin.native();
+  with_env("PATH", two_path, [&]() {
+    auto f = find_in_path("echo");
+    ASSERT_TRUE(f.has_value());
+    EXPECT_TRUE(f->native().find("/usr/local/bin/echo") != std::string::npos);
+  });
+
+  // Test no entries found with two entries in $PATH
+  with_env("PATH", two_path, [&]() {
+    auto f = find_in_path("echoz");
+    ASSERT_FALSE(f.has_value());
+  });
+
+  // Test empty $PATH
+  with_env("PATH", "", [&]() {
+    auto f = find_in_path("echo");
+    ASSERT_FALSE(f.has_value());
+  });
+
+  // Cleanup
+  EXPECT_TRUE(std_filesystem::remove_all(path));
 }
 
 } // namespace utils

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -8,15 +8,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#if __has_include(<filesystem>)
-#include <filesystem>
-namespace std_filesystem = std::filesystem;
-#elif __has_include(<experimental/filesystem>)
-#include <experimental/filesystem>
-namespace std_filesystem = std::experimental::filesystem;
-#else
-#error "neither <filesystem> nor <experimental/filesystem> are present"
-#endif
+#include "filesystem.h"
 
 namespace bpftrace {
 namespace test {


### PR DESCRIPTION
This PR finishes up write side support as described in https://dxuuu.xyz/aot-bpftrace.html .

Basically start cloning the shim and injecting a `.btaot` section into the new binary.
The read side will look in that section later. Next PR.

There's lots and lots still broken about AOT. Lots of language features don't work.
Also it looks like `bpftrace-aotrt` (the shim) is dynamically linked against a crazy
number of libraries again. I'll have to pull that apart and try to enforce it somehow.

Runtime tests were augmented a long time ago to reuse existing test cases against
AOT. Will fix those later as well.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
