### PR TITLE
new tool hrtimersnoop

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ bpftrace contains various tools, which also serve as examples of programming in 
 - tools/[dcsnoop.bt](tools/dcsnoop.bt): Trace directory entry cache (dcache) lookups. [Examples](tools/dcsnoop_example.txt).
 - tools/[execsnoop.bt](tools/execsnoop.bt): Trace new processes via exec() syscalls. [Examples](tools/execsnoop_example.txt).
 - tools/[gethostlatency.bt](tools/gethostlatency.bt): Show latency for getaddrinfo/gethostbyname[2] calls. [Examples](tools/gethostlatency_example.txt).
+- tools/[hrtimersnoop.bt](tools/hrtimersnoop.bt): High-resolution timer latency tracing tool. [Examples](tools/hrtimersnoop_example.txt).
 - tools/[killsnoop.bt](tools/killsnoop.bt): Trace signals issued by the kill() syscall. [Examples](tools/killsnoop_example.txt).
 - tools/[loads.bt](tools/loads.bt): Print load averages. [Examples](tools/loads_example.txt).
 - tools/[mdflush.bt](tools/mdflush.bt): Trace md flush events. [Examples](tools/mdflush_example.txt).

--- a/tools/hrtimersnoop.bt
+++ b/tools/hrtimersnoop.bt
@@ -1,0 +1,52 @@
+#!/usr/bin/env bpftrace
+/*
+ * hrtimersnoop.bt   High-resolution timer latency tracing tool.
+ *
+ * USAGE: hrtimersnoop.bt [delay threshold in microseconds] [duration in microseconds]
+ *
+ * Copyright 2024 Red Hat, Inc.
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ *
+ * 3-Jan-2024 	Costa Shulyupin		Created this.
+ */
+
+BEGIN
+{
+	printf("Tracing high-resolution timer delay and duration in microseconds. Ctrl-C to end.\n");
+	printf("%-15s %-30s %8s %8s\n", "TIME", "HANDLER", "DELAY", "DURATION");
+}
+
+tracepoint:timer:hrtimer_expire_entry
+{
+	$expires = ((struct hrtimer*)args.hrtimer)->_softexpires;
+	if ($expires > 1 && args.now >= $expires) {
+		@delay[args.hrtimer] = ((uint64)args.now - (uint64)$expires) / 1000;
+	}
+	@start[args.hrtimer] = nsecs;
+	@function[args.hrtimer] = args.function;
+}
+
+tracepoint:timer:hrtimer_expire_exit
+/@function[args.hrtimer]/
+{
+	if (@start[args.hrtimer]) {
+		$duration = (nsecs - @start[args.hrtimer]) / 1000;
+	}
+	if (@delay[args.hrtimer] >= (uint64)$1 || $duration >= (uint64)$2) {
+		printf("%-15s %-30s %8ld %8ld\n",
+			strftime("%H:%M:%S.%f", nsecs),
+			ksym(@function[args.hrtimer]),
+			@delay[args.hrtimer],
+			$duration);
+	}
+	delete(@start[args.hrtimer]);
+	delete(@function[args.hrtimer]);
+	delete(@delay[args.hrtimer]);
+}
+
+END
+{
+	clear(@start);
+	clear(@function);
+	clear(@delay);
+}

--- a/tools/hrtimersnoop_example.txt
+++ b/tools/hrtimersnoop_example.txt
@@ -1,0 +1,18 @@
+Demonstration of hrtimersnoop.
+
+hrtimersnoop attaches to timer tracepoints hrtimer_expire_entry and
+hrtimer_expire_exit and measures delay of timer expiration
+and duration of timer handler execution.
+
+# ./hrtimersnoop.bt 100 10
+Attaching 4 probes...
+Tracing high-resolution timer delay and duration in microseconds. Ctrl-C to end.
+TIME            HANDLER                           DELAY DURATION
+11:37:32.804113 tick_sched_timer                      0       22
+11:37:32.804148 tick_sched_timer                     45       13
+11:37:32.804150 tick_sched_timer                     43       15
+11:37:32.804152 tick_sched_timer                     45       16
+11:37:32.804153 tick_sched_timer                     43       14
+11:37:32.805093 hrtimer_wakeup                       86       10
+11:37:32.805148 intel_uncore_fw_release_timer       966        1
+


### PR DESCRIPTION
attaches to timer tracepoints hrtimer_expire_entry, hrtimer_expire_exit and measures delay of timer expiration and duration of timer handler execution.
