### PR TITLE
Fix unit tests with kprobe_multi/uprobe_multi

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -211,8 +211,7 @@ int BPFtrace::add_probe(ast::Probe &p)
               probe.type = probetype(attach_point->provider);
               probe.log_size = log_size_;
               probe.orig_name = p.name();
-              probe.name = attach_point->name(attach_point->target,
-                                              attach_point->func);
+              probe.name = attach_point->name(target, attach_point->func);
               probe.index = p.index();
               probe.funcs.push_back(func);
               target_map.insert({ { target, probe } });

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -222,34 +222,41 @@ TEST(bpftrace, add_probes_wildcard)
       "kprobe:sys_read,kprobe:my_*,kprobe:sys_write{}");
 
   auto bpftrace = get_strict_mock_bpftrace();
+  bpftrace->feature_ = std::make_unique<MockBPFfeature>(false);
+
   EXPECT_CALL(*bpftrace->mock_probe_matcher, get_symbols_from_traceable_funcs())
       .Times(1);
 
-  if (bpftrace->has_kprobe_multi())
-  {
-    ASSERT_EQ(0, bpftrace->add_probe(*probe));
-    ASSERT_EQ(3U, bpftrace->get_probes().size());
-    ASSERT_EQ(0U, bpftrace->get_special_probes().size());
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
+  ASSERT_EQ(4U, bpftrace->get_probes().size());
+  ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 
-    std::string probe_orig_name =
-        "kprobe:sys_read,kprobe:my_*,kprobe:sys_write";
-    check_kprobe(bpftrace->get_probes().at(0), "sys_read", probe_orig_name);
-    check_kprobe(bpftrace->get_probes().at(1), "my_*", probe_orig_name);
-    check_kprobe(bpftrace->get_probes().at(2), "sys_write", probe_orig_name);
-  }
-  else
-  {
-    ASSERT_EQ(0, bpftrace->add_probe(*probe));
-    ASSERT_EQ(4U, bpftrace->get_probes().size());
-    ASSERT_EQ(0U, bpftrace->get_special_probes().size());
+  std::string probe_orig_name = "kprobe:sys_read,kprobe:my_*,kprobe:sys_write";
+  check_kprobe(bpftrace->get_probes().at(0), "sys_read", probe_orig_name);
+  check_kprobe(bpftrace->get_probes().at(1), "my_one", probe_orig_name);
+  check_kprobe(bpftrace->get_probes().at(2), "my_two", probe_orig_name);
+  check_kprobe(bpftrace->get_probes().at(3), "sys_write", probe_orig_name);
+}
 
-    std::string probe_orig_name =
-        "kprobe:sys_read,kprobe:my_*,kprobe:sys_write";
-    check_kprobe(bpftrace->get_probes().at(0), "sys_read", probe_orig_name);
-    check_kprobe(bpftrace->get_probes().at(1), "my_one", probe_orig_name);
-    check_kprobe(bpftrace->get_probes().at(2), "my_two", probe_orig_name);
-    check_kprobe(bpftrace->get_probes().at(3), "sys_write", probe_orig_name);
-  }
+TEST(bpftrace, add_probes_wildcard_kprobe_multi)
+{
+  ast::Probe *probe = parse_probe(
+      "kprobe:sys_read,kprobe:my_*,kprobe:sys_write{}");
+
+  auto bpftrace = get_strict_mock_bpftrace();
+  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
+  EXPECT_CALL(*bpftrace->mock_probe_matcher, get_symbols_from_traceable_funcs())
+      .Times(1);
+
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
+  ASSERT_EQ(3U, bpftrace->get_probes().size());
+  ASSERT_EQ(0U, bpftrace->get_special_probes().size());
+
+  std::string probe_orig_name = "kprobe:sys_read,kprobe:my_*,kprobe:sys_write";
+  check_kprobe(bpftrace->get_probes().at(0), "sys_read", probe_orig_name);
+  check_kprobe(bpftrace->get_probes().at(1), "my_*", probe_orig_name);
+  check_kprobe(bpftrace->get_probes().at(2), "sys_write", probe_orig_name);
 }
 
 TEST(bpftrace, add_probes_wildcard_no_matches)
@@ -287,6 +294,8 @@ TEST(bpftrace, add_probes_kernel_module_wildcard)
 {
   ast::Probe *probe = parse_probe("kprobe:func_in_mo*{}");
   auto bpftrace = get_strict_mock_bpftrace();
+  bpftrace->feature_ = std::make_unique<MockBPFfeature>(false);
+
   EXPECT_CALL(*bpftrace->mock_probe_matcher, get_symbols_from_traceable_funcs())
       .Times(1);
 
@@ -295,14 +304,24 @@ TEST(bpftrace, add_probes_kernel_module_wildcard)
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 
   std::string probe_orig_name = "kprobe:func_in_mo*";
-  if (bpftrace->has_kprobe_multi())
-  {
-    check_kprobe(bpftrace->get_probes().at(0), "func_in_mo*", probe_orig_name);
-  }
-  else
-  {
-    check_kprobe(bpftrace->get_probes().at(0), "func_in_mod", probe_orig_name);
-  }
+  check_kprobe(bpftrace->get_probes().at(0), "func_in_mod", probe_orig_name);
+}
+
+TEST(bpftrace, add_probes_kernel_module_wildcard_kprobe_multi)
+{
+  ast::Probe *probe = parse_probe("kprobe:func_in_mo*{}");
+  auto bpftrace = get_strict_mock_bpftrace();
+  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
+  EXPECT_CALL(*bpftrace->mock_probe_matcher, get_symbols_from_traceable_funcs())
+      .Times(1);
+
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
+  ASSERT_EQ(1U, bpftrace->get_probes().size());
+  ASSERT_EQ(0U, bpftrace->get_special_probes().size());
+
+  std::string probe_orig_name = "kprobe:func_in_mo*";
+  check_kprobe(bpftrace->get_probes().at(0), "func_in_mo*", probe_orig_name);
 }
 
 TEST(bpftrace, add_probes_offset)

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -354,6 +354,8 @@ TEST(bpftrace, add_probes_uprobe_wildcard)
   ast::Probe *probe = parse_probe("uprobe:/bin/sh:*open {}");
 
   auto bpftrace = get_strict_mock_bpftrace();
+  bpftrace->feature_ = std::make_unique<MockBPFfeature>(false);
+
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
               get_func_symbols_from_file(0, "/bin/sh"))
       .Times(1);
@@ -365,6 +367,26 @@ TEST(bpftrace, add_probes_uprobe_wildcard)
   std::string probe_orig_name = "uprobe:/bin/sh:*open";
   check_uprobe(bpftrace->get_probes().at(0), "/bin/sh", "first_open", probe_orig_name);
   check_uprobe(bpftrace->get_probes().at(1), "/bin/sh", "second_open", probe_orig_name);
+}
+
+TEST(bpftrace, add_probes_uprobe_wildcard_uprobe_multi)
+{
+  ast::Probe *probe = parse_probe("uprobe:/bin/sh:*open {}");
+
+  auto bpftrace = get_strict_mock_bpftrace();
+  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
+  EXPECT_CALL(*bpftrace->mock_probe_matcher,
+              get_func_symbols_from_file(0, "/bin/sh"))
+      .Times(1);
+
+  std::string probe_orig_name = "uprobe:/bin/sh:*open";
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
+  ASSERT_EQ(1U, bpftrace->get_probes().size());
+  ASSERT_EQ(0U, bpftrace->get_special_probes().size());
+
+  check_uprobe(
+      bpftrace->get_probes().at(0), "/bin/sh", "*open", probe_orig_name);
 }
 
 TEST(bpftrace, add_probes_uprobe_wildcard_file)
@@ -391,6 +413,8 @@ TEST(bpftrace, add_probes_uprobe_wildcard_for_target)
   ast::Probe *probe = parse_probe("uprobe:*:*open {}");
 
   auto bpftrace = get_strict_mock_bpftrace();
+  bpftrace->feature_ = std::make_unique<MockBPFfeature>(false);
+
   EXPECT_CALL(*bpftrace->mock_probe_matcher, get_func_symbols_from_file(0, "*"))
       .Times(1);
 
@@ -409,6 +433,29 @@ TEST(bpftrace, add_probes_uprobe_wildcard_for_target)
                "/proc/1234/exe",
                "third_open",
                probe_orig_name);
+}
+
+TEST(bpftrace, add_probes_uprobe_wildcard_for_target_uprobe_multi)
+{
+  ast::Probe *probe = parse_probe("uprobe:*:*open {}");
+
+  auto bpftrace = get_strict_mock_bpftrace();
+  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
+
+  EXPECT_CALL(*bpftrace->mock_probe_matcher, get_func_symbols_from_file(0, "*"))
+      .Times(1);
+
+  ASSERT_EQ(0, bpftrace->add_probe(*probe));
+  ASSERT_EQ(3U, bpftrace->get_probes().size());
+  ASSERT_EQ(0U, bpftrace->get_special_probes().size());
+
+  std::string probe_orig_name = "uprobe:*:*open";
+  check_uprobe(
+      bpftrace->get_probes().at(0), "/proc/1234/exe", "*open", probe_orig_name);
+  check_uprobe(
+      bpftrace->get_probes().at(1), "/bin/sh", "*open", probe_orig_name);
+  check_uprobe(
+      bpftrace->get_probes().at(2), "/bin/bash", "*open", probe_orig_name);
 }
 
 TEST(bpftrace, add_probes_uprobe_wildcard_no_matches)
@@ -515,6 +562,8 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol_wildcard)
   auto probe = parse_probe("uprobe:/bin/sh:cpp:cpp_man*{}");
 
   auto bpftrace = get_strict_mock_bpftrace();
+  bpftrace->feature_ = std::make_unique<MockBPFfeature>(false);
+
   EXPECT_CALL(*bpftrace->mock_probe_matcher,
               get_func_symbols_from_file(0, "/bin/sh"))
       .Times(1);
@@ -522,6 +571,7 @@ TEST(bpftrace, add_probes_uprobe_cpp_symbol_wildcard)
   ASSERT_EQ(0, bpftrace->add_probe(*probe));
   ASSERT_EQ(4U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
+
   check_uprobe(bpftrace->get_probes().at(0),
                "/bin/sh:cpp",
                "_Z11cpp_mangledi",

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -88,11 +88,6 @@ public:
     mock_probe_matcher = dynamic_cast<MockProbeMatcher *>(probe_matcher_.get());
   }
 
-  bool has_kprobe_multi(void)
-  {
-    return feature_->has_kprobe_multi();
-  }
-
   MockProbeMatcher *mock_probe_matcher;
 };
 

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -109,6 +109,7 @@ public:
     has_d_path_ = std::make_optional<bool>(has_features);
     has_ktime_get_boot_ns_ = std::make_optional<bool>(has_features);
     has_kprobe_multi_ = std::make_optional<bool>(has_features);
+    has_uprobe_multi_ = std::make_optional<bool>(has_features);
     has_skb_output_ = std::make_optional<bool>(has_features);
     map_ringbuf_ = std::make_optional<bool>(has_features);
     has_ktime_get_tai_ns_ = std::make_optional<bool>(has_features);


### PR DESCRIPTION
This updates probe addition unit tests w.r.t. presence of `(k|u)probe_multi`. Until now, tests for `kprobe_multi` checked its availability on the running system and adjusted the expected results accordingly. Tests with uprobe wildcards didn't consider `uprobe_multi` at all and therefore failed on some systems.

This PR uses `MockBPFfeature` to control the values of `(k|u)probe_multi` in the unit tests and adds separate tests cases for when the feature is available and when not.

Also changes the probe name for uprobes with wildcarded target when `uprobe_multi` is present (see the first commit for details).

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
