### PR TITLE
Runtime tests runner: do not fail on JSON parsing

### DIFF
--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -445,8 +445,16 @@ class Runner(object):
                 print('\tExpected REGEX: ' + test.expect)
                 print('\tFound:\n' + to_utf8(output))
             elif test.expect_mode == "json":
-                print('\tExpected JSON:\n' + json.dumps(json.loads(open(test.expect).read()), indent=2))
-                print('\tFound:\n' + json.dumps(json.loads(output), indent=2))
+                try:
+                    expected = json.dumps(json.loads(open(test.expect).read()), indent=2)
+                except json.decoder.JSONDecodeError as err:
+                    expected = "Could not parse JSON: " + str(err)
+                try:
+                    found = json.dumps(json.loads(output), indent=2)
+                except json.decoder.JSONDecodeError as err:
+                    found = "Could not parse JSON: " + str(err)
+                print('\tExpected JSON:\n' + expected)
+                print('\tFound:\n' + found)
             else:
                 print('\tExpected FILE:\n\t\t' + to_utf8(open(test.expect).read()))
                 print('\tFound:\n\t\t' + to_utf8(output))


### PR DESCRIPTION
If bpftrace produces an invalid JSON, runtime tests runner would fail on an uncaught exception. Catch that exception and fail only the current test.

Note: I was getting this error with some runtime tests which failed due to #2902.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
