### PR TITLE
execsnoop: use `strftime` instead of `elapsed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,8 @@ and this project adheres to
 #### Tools
 - Add PPID field to `execsnoop.bt`
   - [#2876](https://github.com/iovisor/bpftrace/pull/2876)
+- Use `strftime` instead of `elapsed` in `execsnoop.bt`
+  - [#2904](https://github.com/iovisor/bpftrace/pull/2904)
 - Update runqlen.bt to remove `runnable_weight` field from cfs_rq struct.
   - [#2790](https://github.com/iovisor/bpftrace/pull/2790)
 - Update mdflush.bt to use blkdev.h instead of genhd.h for non-BTF builds.

--- a/tools/execsnoop.bt
+++ b/tools/execsnoop.bt
@@ -21,12 +21,12 @@
 
 BEGIN
 {
-	printf("%-10s %-7s %-7s %s\n", "TIME(ms)", "PID", "PPID", "ARGS");
+	printf("%-15s %-7s %-7s %s\n", "TIME", "PID", "PPID", "ARGS");
 }
 
 tracepoint:syscalls:sys_enter_exec*
 {
 	$task = (struct task_struct *)curtask;
-	printf("%-10u %-7d %-7d ", elapsed / 1e6, pid, $task->real_parent->pid);
+	printf("%15s %-7d %-7d ", strftime("%H:%M:%S.%f", nsecs), pid, $task->real_parent->pid);
 	join(args.argv);
 }

--- a/tools/execsnoop_example.txt
+++ b/tools/execsnoop_example.txt
@@ -5,32 +5,24 @@ Tracing all new process execution (via exec()):
 
 # ./execsnoop.bt
 Attaching 3 probes...
-TIME(ms)   PID     PPID    ARGS
-2460       3466    3441    ls --color=auto -lh execsnoop.bt execsnoop.bt.0 execsnoop.bt.1
-3996       3467    3441    man ls
-4005       3473    3441    preconv -e UTF-8
-4005       3473    3441    preconv -e UTF-8
-4005       3473    3441    preconv -e UTF-8
-4005       3473    3441    preconv -e UTF-8
-4005       3473    3441    preconv -e UTF-8
-4005       3474    3441    tbl
-4005       3474    3441    tbl
-4005       3474    3441    tbl
-4005       3474    3441    tbl
-4005       3474    3441    tbl
-4005       3476    3441    nroff -mandoc -rLL=193n -rLT=193n -Tutf8
-4005       3476    3441    nroff -mandoc -rLL=193n -rLT=193n -Tutf8
-4005       3476    3441    nroff -mandoc -rLL=193n -rLT=193n -Tutf8
-4005       3476    3441    nroff -mandoc -rLL=193n -rLT=193n -Tutf8
-4005       3476    3441    nroff -mandoc -rLL=193n -rLT=193n -Tutf8
-4006       3479    3441    pager  -rLL=193n
-4006       3479    3441    pager  -rLL=193n
-4006       3479    3441    pager  -rLL=193n
-4006       3479    3441    pager  -rLL=193n
-4006       3479    3441    pager  -rLL=193n
-4007       3481    3441    locale charmap
-4008       3482    3441    groff -mtty-char -Tutf8 -mandoc -rLL=193n -rLT=193n
-4009       3483    3441    troff -mtty-char -mandoc -rLL=193n -rLT=193n -Tutf8
+TIME            PID     PPID    ARGS
+08:57:52.430193 3187374 1971701 ls --color --color=auto -lh execsnoop.bt execsnoop.bt.0 execsnoop.bt.1
+08:57:52.441868 3187378 3187375 man ls
+08:57:52.473565 3187384 3187378 preconv -e UTF-8
+08:57:52.473620 3187384 3187378 preconv -e UTF-8
+08:57:52.473658 3187384 3187378 preconv -e UTF-8
+08:57:52.473839 3187385 3187378 tbl
+08:57:52.473897 3187385 3187378 tbl
+08:57:52.473944 3187385 3187378 tbl
+08:57:52.474055 3187386 3187378 nroff -mandoc -Tutf8
+08:57:52.474107 3187386 3187378 nroff -mandoc -Tutf8
+08:57:52.474145 3187386 3187378 nroff -mandoc -Tutf8
+08:57:52.474684 3187388 3187378 less
+08:57:52.474739 3187388 3187378 less
+08:57:52.474780 3187388 3187378 less
+08:57:52.475502 3187389 3187386 groff -Tutf8 -mtty-char -mandoc
+08:57:52.476717 3187390 3187389 troff -mtty-char -mandoc -Tutf8
+08:57:52.476811 3187391 3187389 grotty
 
 The output begins by showing an "ls" command, and then the process execution
 to serve "man ls". The same exec arguments appear multiple times: in this case


### PR DESCRIPTION
because `elapsed` gives relative time, and `strftime` gives absolute time which is more readable and practical.
