### PR TITLE
utils: Remove unused config.h include

### DIFF
--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -24,7 +24,6 @@
 #include <unordered_set>
 
 #include "bpftrace.h"
-#include "config.h"
 #include "debugfs.h"
 #include "filesystem.h"
 #include "log.h"

--- a/src/utils.h
+++ b/src/utils.h
@@ -15,7 +15,6 @@
 #include <unordered_set>
 #include <vector>
 
-#include "config.h"
 #include "filesystem.h"
 
 namespace bpftrace {


### PR DESCRIPTION
Doesn't seem to be necessary to include `config.h` in utils TU.

See https://github.com/iovisor/bpftrace/commit/d5a26e9ca32db27ad0f60efcc87e97e1fa849141#diff-9022459f0ccbb7cf6daac6ecb5af4f37d240219981a8c23076c14c5f002f9c8c

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
