### PR TITLE
Use unique names for stackid maps

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -70,10 +70,21 @@ bool Config::is_aslr_enabled()
   return true;
 }
 
+std::map<std::string, StackMode> get_stack_mode_map()
+{
+  std::map<std::string, StackMode> result;
+  for (auto &mode : STACK_MODE_NAME_MAP)
+  {
+    result.emplace(mode.second, mode.first);
+  }
+  return result;
+}
+
 bool ConfigSetter::set_stack_mode(const std::string &s)
 {
-  auto found = STACK_MODE_MAP.find(s);
-  if (found != STACK_MODE_MAP.end())
+  static auto stack_mode_map = get_stack_mode_map();
+  auto found = stack_mode_map.find(s);
+  if (found != stack_mode_map.end())
   {
     return config_.set(ConfigKeyStackMode::default_, found->second, source_);
   }

--- a/src/config.h
+++ b/src/config.h
@@ -68,12 +68,6 @@ struct ConfigValue
       value;
 };
 
-const std::map<std::string, StackMode> STACK_MODE_MAP = {
-  { "bpftrace", StackMode::bpftrace },
-  { "perf", StackMode::perf },
-  { "raw", StackMode::raw },
-};
-
 class Config
 {
 public:

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -119,8 +119,12 @@ Map::Map(const SizedType &type) : IMap(type)
   int max_entries = 128 << 10;
   int flags = 0;
 
-  mapfd_ = create_map(
-      map_type_, "stack", key_size, value_size, max_entries, flags);
+  mapfd_ = create_map(map_type_,
+                      type.stack_type.name(),
+                      key_size,
+                      value_size,
+                      max_entries,
+                      flags);
   if (mapfd_ < 0)
   {
     LOG(ERROR) << "failed to create stack id map: " << strerror(errno);

--- a/src/types.h
+++ b/src/types.h
@@ -78,6 +78,12 @@ enum class StackMode : uint8_t
   raw,
 };
 
+const std::map<StackMode, std::string> STACK_MODE_NAME_MAP = {
+  { StackMode::bpftrace, "bpftrace" },
+  { StackMode::perf, "perf" },
+  { StackMode::raw, "raw" },
+};
+
 struct StackType
 {
   uint16_t limit = DEFAULT_STACK_SIZE;
@@ -85,6 +91,12 @@ struct StackType
 
   bool operator ==(const StackType &obj) const {
     return limit == obj.limit && mode == obj.mode;
+  }
+
+  std::string name() const
+  {
+    return "stack_" + STACK_MODE_NAME_MAP.at(mode) + "_" +
+           std::to_string(limit);
   }
 
 private:


### PR DESCRIPTION
We create a single BPF map for each `StackType`, defined by stack mode and the limit, used within the program. Until now, all these maps had the same name `stack`. While this is technically possible, it will cause problems once we start emitting BTF entries for maps.

To prevent this problem, use a unique name for each map in the form `stack_<mode>_<limit>`.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
