### PR TITLE
Introduce BpfBytecode class

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,6 +17,7 @@ add_library(runtime
   attached_probe.cpp
   bpffeature.cpp
   bpftrace.cpp
+  bpfbytecode.cpp
   bpfprogram.cpp
   btf.cpp
   child.cpp

--- a/src/ast/elf_parser.cpp
+++ b/src/ast/elf_parser.cpp
@@ -28,7 +28,7 @@ BpfBytecode parseBpfBytecodeFromElfObject(void *const elf)
   assert(strtable_shdr->sh_type == SHT_STRTAB);
   char *strtable = fileptr + strtable_shdr->sh_offset;
 
-  BpfBytecode result{};
+  BpfBytecode result;
 
   for (int i = 0; i < ehdr->e_shnum; ++i)
   {
@@ -45,7 +45,7 @@ BpfBytecode parseBpfBytecodeFromElfObject(void *const elf)
 
       std::memcpy(data.data(), fileptr + shdr->sh_offset, shdr->sh_size);
     }
-    result.emplace(name, std::move(data));
+    result.addSection(name, std::move(data));
   }
 
   return result;

--- a/src/ast/elf_parser.h
+++ b/src/ast/elf_parser.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "bpfbytecode.h"
 #include "bpftrace.h"
 
 namespace bpftrace {

--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -1,0 +1,28 @@
+#include "bpfbytecode.h"
+
+#include <stdexcept>
+
+namespace bpftrace {
+
+void BpfBytecode::addSection(const std::string &name,
+                             std::vector<uint8_t> &&data)
+{
+  sections_.emplace(name, data);
+}
+
+bool BpfBytecode::hasSection(const std::string &name) const
+{
+  return sections_.find(name) != sections_.end();
+}
+
+const std::vector<uint8_t> &BpfBytecode::getSection(
+    const std::string &name) const
+{
+  if (!hasSection(name))
+  {
+    throw std::runtime_error("Bytecode is missing section " + name);
+  }
+  return sections_.at(name);
+}
+
+} // namespace bpftrace

--- a/src/bpfbytecode.h
+++ b/src/bpfbytecode.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <cereal/access.hpp>
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace bpftrace {
+
+using SectionMap = std::unordered_map<std::string, std::vector<uint8_t>>;
+
+class BpfBytecode
+{
+public:
+  BpfBytecode()
+  {
+  }
+
+  BpfBytecode(const BpfBytecode &) = delete;
+  BpfBytecode &operator=(const BpfBytecode &) = delete;
+  BpfBytecode(BpfBytecode &&) = default;
+  BpfBytecode &operator=(BpfBytecode &&) = default;
+
+  void addSection(const std::string &name, std::vector<uint8_t> &&data);
+  bool hasSection(const std::string &name) const;
+  const std::vector<uint8_t> &getSection(const std::string &name) const;
+
+private:
+  SectionMap sections_;
+
+  friend class cereal::access;
+  template <typename Archive>
+  void serialize(Archive &archive)
+  {
+    archive(sections_);
+  }
+};
+
+} // namespace bpftrace

--- a/src/bpfprogram.h
+++ b/src/bpfprogram.h
@@ -1,17 +1,15 @@
 #pragma once
 
+#include "bpfbytecode.h"
 #include "mapmanager.h"
 
 #include <cstdint>
 #include <optional>
 #include <string>
 #include <tuple>
-#include <unordered_map>
 #include <vector>
 
 namespace bpftrace {
-
-using BpfBytecode = std::unordered_map<std::string, std::vector<uint8_t>>;
 
 class BPFtrace;
 

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -984,7 +984,7 @@ std::vector<std::unique_ptr<AttachedProbe>> BPFtrace::attach_usdt_probe(
 
 std::vector<std::unique_ptr<AttachedProbe>> BPFtrace::attach_probe(
     Probe &probe,
-    BpfBytecode &bytecode)
+    const BpfBytecode &bytecode)
 {
   std::vector<std::unique_ptr<AttachedProbe>> ret;
   // use the single-probe program if it exists (as is the case with wildcards
@@ -1124,7 +1124,7 @@ bool attach_reverse(const Probe &p)
 }
 
 int BPFtrace::run_special_probe(std::string name,
-                                BpfBytecode &bytecode,
+                                const BpfBytecode &bytecode,
                                 trigger_fn_t trigger)
 {
   for (auto probe = resources.special_probes.rbegin();

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -12,6 +12,7 @@
 
 #include "ast/ast.h"
 #include "attached_probe.h"
+#include "bpfbytecode.h"
 #include "bpffeature.h"
 #include "bpfprogram.h"
 #include "btf.h"
@@ -114,7 +115,7 @@ public:
   int run(BpfBytecode bytecode);
   std::vector<std::unique_ptr<AttachedProbe>> attach_probe(
       Probe &probe,
-      BpfBytecode &bytecode);
+      const BpfBytecode &bytecode);
   int run_iter();
   int print_maps();
   int clear_map(IMap &map);
@@ -223,7 +224,7 @@ public:
 
 private:
   int run_special_probe(std::string name,
-                        BpfBytecode &bytecode,
+                        const BpfBytecode &bytecode,
                         void (*trigger)(void));
   void* ksyms_{nullptr};
   // note: exe_sym_ is used when layout is same for all instances of program

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1032,7 +1032,7 @@ int main(int argc, char* argv[])
   act.sa_handler = [](int) { BPFtrace::sigusr1_recv = true; };
   sigaction(SIGUSR1, &act, NULL);
 
-  err = bpftrace.run(bytecode);
+  err = bpftrace.run(std::move(bytecode));
   if (err)
     return err;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ endif()
 
 add_executable(bpftrace_test
   ast.cpp
+  bpfbytecode.cpp
   bpftrace.cpp
   child.cpp
   clang_parser.cpp

--- a/tests/bpfbytecode.cpp
+++ b/tests/bpfbytecode.cpp
@@ -1,0 +1,37 @@
+#include "bpfbytecode.h"
+#include "driver.h"
+#include "mocks.h"
+#include "passes/codegen_llvm.h"
+#include "passes/semantic_analyser.h"
+
+#include "gtest/gtest.h"
+
+namespace bpftrace {
+namespace test {
+namespace bpfbytecode {
+
+BpfBytecode codegen(const std::string &input)
+{
+  auto bpftrace = get_mock_bpftrace();
+
+  Driver driver(*bpftrace);
+  EXPECT_EQ(driver.parse_str(input), 0);
+
+  ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
+  EXPECT_EQ(semantics.analyse(), 0);
+
+  ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
+  return codegen.compile();
+}
+
+TEST(bpfbytecode, populate_sections)
+{
+  auto bytecode = codegen("kprobe:foo { 1 } kprobe:bar { 1 }");
+
+  EXPECT_TRUE(bytecode.hasSection("s_kprobe:foo_1"));
+  EXPECT_TRUE(bytecode.hasSection("s_kprobe:bar_2"));
+}
+
+} // namespace bpfbytecode
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -47,23 +47,6 @@ public:
   }
 };
 
-TEST(codegen, populate_sections)
-{
-  auto bpftrace = get_mock_bpftrace();
-  Driver driver(*bpftrace);
-
-  ASSERT_EQ(driver.parse_str("kprobe:foo { 1 } kprobe:bar { 1 }"), 0);
-  // Override to mockbpffeature.
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-  ast::SemanticAnalyser semantics(driver.root.get(), *bpftrace);
-  ASSERT_EQ(semantics.analyse(), 0);
-  ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
-  auto bytecode = codegen.compile();
-
-  EXPECT_TRUE(bytecode.hasSection("s_kprobe:foo_1"));
-  EXPECT_TRUE(bytecode.hasSection("s_kprobe:bar_2"));
-}
-
 TEST(codegen, printf_offsets)
 {
   auto bpftrace = get_mock_bpftrace();

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -60,8 +60,8 @@ TEST(codegen, populate_sections)
   ast::CodegenLLVM codegen(driver.root.get(), *bpftrace);
   auto bytecode = codegen.compile();
 
-  EXPECT_NE(bytecode.find("s_kprobe:foo_1"), bytecode.end());
-  EXPECT_NE(bytecode.find("s_kprobe:bar_2"), bytecode.end());
+  EXPECT_TRUE(bytecode.hasSection("s_kprobe:foo_1"));
+  EXPECT_TRUE(bytecode.hasSection("s_kprobe:bar_2"));
 }
 
 TEST(codegen, printf_offsets)


### PR DESCRIPTION
So far, the generated BPF bytecode was represented as a map of section names to their contents. With the upcoming movement towards libbpf-based program loading and attachment, we will need to attach more information to the bytecode, so this introduces a new class `BpfBytecode` for that purpose.

For now, the class only contains the original section map and helper methods to access it.

No functional change.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
