### PR TITLE
Optimize probe matcher's work with available_filter_functions

### DIFF
--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -32,15 +32,10 @@ static int add_symbol(const char* symname,
 
 /*
  * Finds all matches of search_input in the provided input stream.
- *
- * If `ignore_trailing_module` is true, will ignore trailing kernel module.
- * For example, `[ehci_hcd]` will be ignored in:
- *     ehci_disable_ASE [ehci_hcd]
  */
 std::set<std::string> ProbeMatcher::get_matches_in_stream(
     const std::string& search_input,
     std::istream& symbol_stream,
-    bool ignore_trailing_module,
     bool demangle_symbols,
     const char delim)
 {
@@ -51,11 +46,6 @@ std::set<std::string> ProbeMatcher::get_matches_in_stream(
   std::set<std::string> matches;
   while (std::getline(symbol_stream, line, delim))
   {
-    if (ignore_trailing_module && symbol_has_module(line))
-    {
-      line = strip_symbol_module(line);
-    }
-
     if (!wildcard_match(line, tokens, start_wildcard, end_wildcard))
     {
       if (demangle_symbols)
@@ -119,7 +109,6 @@ std::set<std::string> ProbeMatcher::get_matches_for_probetype(
     bool demangle_symbols)
 {
   std::unique_ptr<std::istream> symbol_stream;
-  bool ignore_trailing_module = false;
 
   switch (probe_type)
   {
@@ -127,7 +116,6 @@ std::set<std::string> ProbeMatcher::get_matches_for_probetype(
     case ProbeType::kretprobe:
     {
       symbol_stream = get_symbols_from_traceable_funcs();
-      ignore_trailing_module = true;
       break;
     }
     case ProbeType::uprobe:
@@ -212,8 +200,9 @@ std::set<std::string> ProbeMatcher::get_matches_for_probetype(
   }
 
   if (symbol_stream)
-    return get_matches_in_stream(
-        search_input, *symbol_stream, ignore_trailing_module, demangle_symbols);
+    return get_matches_in_stream(search_input,
+                                 *symbol_stream,
+                                 demangle_symbols);
   else
     return {};
 }
@@ -232,7 +221,7 @@ std::set<std::string> ProbeMatcher::get_matches_in_set(
     stream_in.append(str + "$");
 
   std::istringstream stream(stream_in);
-  return get_matches_in_stream(search_input, stream, false, false, '$');
+  return get_matches_in_stream(search_input, stream, false, '$');
 }
 
 std::unique_ptr<std::istream> ProbeMatcher::get_symbols_from_file(
@@ -254,14 +243,7 @@ std::unique_ptr<std::istream> ProbeMatcher::get_symbols_from_traceable_funcs(
   std::string funcs;
   for (auto& func_mod : bpftrace_->get_traceable_funcs())
   {
-    if (func_mod.second.empty() || *func_mod.second.begin() == "vmlinux")
-    {
-      funcs += func_mod.first + "\n";
-    }
-    else
-    {
-      funcs += func_mod.first + " [" + *func_mod.second.begin() + "]\n";
-    }
+    funcs += func_mod.first + "\n";
   }
   return std::make_unique<std::istringstream>(funcs);
 }

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -84,12 +84,10 @@ public:
   const BPFtrace *bpftrace_;
 
 private:
-  std::set<std::string> get_matches_in_stream(
-      const std::string &search_input,
-      std::istream &symbol_stream,
-      bool ignore_trailing_module = false,
-      bool demangle_symbols = true,
-      const char delim = '\n');
+  std::set<std::string> get_matches_in_stream(const std::string &search_input,
+                                              std::istream &symbol_stream,
+                                              bool demangle_symbols = true,
+                                              const char delim = '\n');
   std::set<std::string> get_matches_for_probetype(
       const ProbeType &probe_type,
       const std::string &target,

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -99,7 +99,7 @@ private:
   virtual std::unique_ptr<std::istream> get_symbols_from_file(
       const std::string &path) const;
   virtual std::unique_ptr<std::istream> get_symbols_from_traceable_funcs(
-      void) const;
+      bool with_modules = false) const;
   virtual std::unique_ptr<std::istream> get_symbols_from_file_safe(
       const std::string &path) const;
   virtual std::unique_ptr<std::istream> get_func_symbols_from_file(
@@ -110,9 +110,6 @@ private:
       const std::string &target) const;
   virtual std::unique_ptr<std::istream> get_symbols_from_list(
       const std::vector<ProbeListItem> &probes_list) const;
-
-  virtual std::unique_ptr<std::istream> adjust_kernel_modules(
-      std::istream &symbol_list) const;
 
   virtual std::unique_ptr<std::istream> adjust_rawtracepoint(
       std::istream &symbol_list) const;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -1393,12 +1393,6 @@ bool symbol_has_module(const std::string &symbol)
   return !symbol.empty() && symbol[symbol.size() - 1] == ']';
 }
 
-std::string strip_symbol_module(const std::string &symbol)
-{
-  size_t idx = symbol.rfind(" [");
-  return idx != std::string::npos ? symbol.substr(0, idx) : symbol;
-}
-
 std::pair<std::string, std::string> split_symbol_module(
     const std::string &symbol)
 {

--- a/src/utils.h
+++ b/src/utils.h
@@ -219,7 +219,6 @@ std::string hex_format_buffer(const char *buf,
                               bool escape_hex = true);
 std::optional<std::string> abs_path(const std::string &rel_path);
 bool symbol_has_module(const std::string &symbol);
-std::string strip_symbol_module(const std::string &symbol);
 std::pair<std::string, std::string> split_symbol_module(
     const std::string &symbol);
 std::tuple<std::string, std::string, std::string> split_addrrange_symbol_module(

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -224,7 +224,8 @@ TEST(bpftrace, add_probes_wildcard)
   auto bpftrace = get_strict_mock_bpftrace();
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(false);
 
-  EXPECT_CALL(*bpftrace->mock_probe_matcher, get_symbols_from_traceable_funcs())
+  EXPECT_CALL(*bpftrace->mock_probe_matcher,
+              get_symbols_from_traceable_funcs(false))
       .Times(1);
 
   ASSERT_EQ(0, bpftrace->add_probe(*probe));
@@ -246,7 +247,8 @@ TEST(bpftrace, add_probes_wildcard_kprobe_multi)
   auto bpftrace = get_strict_mock_bpftrace();
   bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
 
-  EXPECT_CALL(*bpftrace->mock_probe_matcher, get_symbols_from_traceable_funcs())
+  EXPECT_CALL(*bpftrace->mock_probe_matcher,
+              get_symbols_from_traceable_funcs(false))
       .Times(1);
 
   ASSERT_EQ(0, bpftrace->add_probe(*probe));
@@ -265,7 +267,8 @@ TEST(bpftrace, add_probes_wildcard_no_matches)
       "kprobe:sys_read,kprobe:not_here_*,kprobe:sys_write{}");
 
   auto bpftrace = get_strict_mock_bpftrace();
-  EXPECT_CALL(*bpftrace->mock_probe_matcher, get_symbols_from_traceable_funcs())
+  EXPECT_CALL(*bpftrace->mock_probe_matcher,
+              get_symbols_from_traceable_funcs(false))
       .Times(1);
 
   ASSERT_EQ(0, bpftrace->add_probe(*probe));

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -290,40 +290,6 @@ TEST(bpftrace, add_probes_kernel_module)
   check_kprobe(bpftrace->get_probes().at(0), "func_in_mod", probe_orig_name);
 }
 
-TEST(bpftrace, add_probes_kernel_module_wildcard)
-{
-  ast::Probe *probe = parse_probe("kprobe:func_in_mo*{}");
-  auto bpftrace = get_strict_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(false);
-
-  EXPECT_CALL(*bpftrace->mock_probe_matcher, get_symbols_from_traceable_funcs())
-      .Times(1);
-
-  ASSERT_EQ(0, bpftrace->add_probe(*probe));
-  ASSERT_EQ(1U, bpftrace->get_probes().size());
-  ASSERT_EQ(0U, bpftrace->get_special_probes().size());
-
-  std::string probe_orig_name = "kprobe:func_in_mo*";
-  check_kprobe(bpftrace->get_probes().at(0), "func_in_mod", probe_orig_name);
-}
-
-TEST(bpftrace, add_probes_kernel_module_wildcard_kprobe_multi)
-{
-  ast::Probe *probe = parse_probe("kprobe:func_in_mo*{}");
-  auto bpftrace = get_strict_mock_bpftrace();
-  bpftrace->feature_ = std::make_unique<MockBPFfeature>(true);
-
-  EXPECT_CALL(*bpftrace->mock_probe_matcher, get_symbols_from_traceable_funcs())
-      .Times(1);
-
-  ASSERT_EQ(0, bpftrace->add_probe(*probe));
-  ASSERT_EQ(1U, bpftrace->get_probes().size());
-  ASSERT_EQ(0U, bpftrace->get_special_probes().size());
-
-  std::string probe_orig_name = "kprobe:func_in_mo*";
-  check_kprobe(bpftrace->get_probes().at(0), "func_in_mo*", probe_orig_name);
-}
-
 TEST(bpftrace, add_probes_offset)
 {
   auto offset = 10;

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -16,8 +16,7 @@ void setup_mock_probe_matcher(MockProbeMatcher &matcher)
                         "sys_read\n"
                         "sys_write\n"
                         "my_one\n"
-                        "my_two\n"
-                        "func_in_mod [kernel_mod]\n";
+                        "my_two\n";
     auto myval = std::unique_ptr<std::istream>(new std::istringstream(ksyms));
     return myval;
   });

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -11,15 +11,17 @@ using ::testing::StrictMock;
 
 void setup_mock_probe_matcher(MockProbeMatcher &matcher)
 {
-  ON_CALL(matcher, get_symbols_from_traceable_funcs()).WillByDefault([](void) {
-    std::string ksyms = "SyS_read\n"
-                        "sys_read\n"
-                        "sys_write\n"
-                        "my_one\n"
-                        "my_two\n";
-    auto myval = std::unique_ptr<std::istream>(new std::istringstream(ksyms));
-    return myval;
-  });
+  ON_CALL(matcher, get_symbols_from_traceable_funcs(false))
+      .WillByDefault([](void) {
+        std::string ksyms = "SyS_read\n"
+                            "sys_read\n"
+                            "sys_write\n"
+                            "my_one\n"
+                            "my_two\n";
+        auto myval = std::unique_ptr<std::istream>(
+            new std::istringstream(ksyms));
+        return myval;
+      });
 
   ON_CALL(matcher, get_symbols_from_file(tracefs::available_events()))
       .WillByDefault([](const std::string &) {

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -23,8 +23,8 @@ public:
 #endif
   MOCK_CONST_METHOD1(get_symbols_from_file,
                      std::unique_ptr<std::istream>(const std::string &path));
-  MOCK_CONST_METHOD0(get_symbols_from_traceable_funcs,
-                     std::unique_ptr<std::istream>(void));
+  MOCK_CONST_METHOD1(get_symbols_from_traceable_funcs,
+                     std::unique_ptr<std::istream>(bool with_modules));
   MOCK_CONST_METHOD2(get_symbols_from_usdt,
                      std::unique_ptr<std::istream>(int pid,
                                                    const std::string &target));


### PR DESCRIPTION
Probe matcher uses data from `/sys/kernel/tracing/available_filter_functions` in 2 places:
1. when matching kprobes and
2. when matching kfuncs when BTF is not yet parsed (this is used to determine the list of modules for which we need to parse BTF).

For both use-cases, there's a number of unnecessary string transformations and parsing done. The current workflow is as follows:
1. Parse `available_filter_functions` into `BPFtrace::traceable_funcs_`, which is a function/module map.
2. For kprobe matching, read entries from `traceable_funcs_`, transform them into `available_filter_functions` format (`function [module]`), and then parse that again in probe matcher with always ignoring the module part.
3. For kfunc matching, read entries from the `available_filter_functions` file (`function [module]` format), transform them into bpftrace probes format (`module:function`), and finally run matching against that.

It's obvious that most of the points (2) and (3) is unnecessary as we already have parsed data in `traceable_funcs_` and can transform them directly into the expected format. So, this PR proposes to change the above workflow to:
1. Stays the same.
2. For kprobe, read entries from `traceable_funcs_`, transform them into `func` format (as kprobes do not support modules, yet), and use that for matching.
3. For kfunc, read entries from `traceable_funcs_`, transform them into `module:func` format, and use that for matching.

This removes a bit of code and also speeds up kfunc attachment since `available_filter_functions` is now always parsed just once.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
