### PR TITLE
threadsnoop: use `strftime` instead of `elapsed`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to
   - [#2876](https://github.com/iovisor/bpftrace/pull/2876)
 - Use `strftime` instead of `elapsed` in `execsnoop.bt`
   - [#2904](https://github.com/iovisor/bpftrace/pull/2904)
+- Use `strftime` instead of `elapsed` in `threadsnoop.bt`
+  - [#2917](https://github.com/iovisor/bpftrace/pull/2917)
 - Update runqlen.bt to remove `runnable_weight` field from cfs_rq struct.
   - [#2790](https://github.com/iovisor/bpftrace/pull/2790)
 - Update mdflush.bt to use blkdev.h instead of genhd.h for non-BTF builds.

--- a/tools/threadsnoop.bt
+++ b/tools/threadsnoop.bt
@@ -15,12 +15,12 @@
 
 BEGIN
 {
-	printf("%-10s %-6s %-16s %s\n", "TIME(ms)", "PID", "COMM", "FUNC");
+	printf("%-15s %-6s %-16s %s\n", "TIME", "PID", "COMM", "FUNC");
 }
 
 uprobe:libpthread:pthread_create,
 uprobe:libc:pthread_create
 {
-	printf("%-10u %-6d %-16s %s\n", elapsed / 1e6, pid, comm,
+	printf("%15s %-6d %-16s %s\n", strftime("%H:%M:%S.%f", nsecs), pid, comm,
 	    usym(arg2));
 }

--- a/tools/threadsnoop_example.txt
+++ b/tools/threadsnoop_example.txt
@@ -5,20 +5,20 @@ Tracing new threads via phtread_create():
 
 # ./threadsnoop.bt
 Attaching 2 probes...
-TIME(ms)   PID    COMM             FUNC
-1938       28549  dockerd          threadentry
-1939       28549  dockerd          threadentry
-1939       28549  dockerd          threadentry
-1940       28549  dockerd          threadentry
-1949       28549  dockerd          threadentry
-1958       28549  dockerd          threadentry
-1939       28549  dockerd          threadentry
-1950       28549  dockerd          threadentry
-2013       28579  docker-containe  0x562f30f2e710
-2036       28549  dockerd          threadentry
-2083       28579  docker-containe  0x562f30f2e710
-2116       629    systemd-journal  0x7fb7114955c0
-2116       629    systemd-journal  0x7fb7114955c0
+TIME            PID    COMM             FUNC
+10:20:31.938572 28549  dockerd          threadentry
+10:20:31.939213 28549  dockerd          threadentry
+10:20:31.939405 28549  dockerd          threadentry
+10:20:31.940642 28549  dockerd          threadentry
+10:20:31.949060 28549  dockerd          threadentry
+10:20:31.958319 28549  dockerd          threadentry
+10:20:31.939152 28549  dockerd          threadentry
+10:20:31.950978 28549  dockerd          threadentry
+10:20:32.013269 28579  docker-containe  0x562f30f2e710
+10:20:32.036764 28549  dockerd          threadentry
+10:20:32.083780 28579  docker-containe  0x562f30f2e710
+10:20:32.116738 629    systemd-journal  0x7fb7114955c0
+10:20:32.116844 629    systemd-journal  0x7fb7114955c0
 [...]
 
 The output shows a dockerd process creating several threads with the start


### PR DESCRIPTION
because `elapsed` gives relative time,
and `strftime` gives absolute time which
is is more readable and practical.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`

