### PR TITLE
docs: remove unneeded headers in example

### DIFF
--- a/docs/tutorial_one_liners.md
+++ b/docs/tutorial_one_liners.md
@@ -296,6 +296,11 @@ The context of this probe is important: this fires when the I/O is issued to the
 
 ```
 # cat path.bt
+#ifndef BPFTRACE_HAVE_BTF
+#include <linux/path.h>
+#include <linux/dcache.h>
+#endif
+
 kprobe:vfs_open
 {
 	printf("open path: %s\n", str(((struct path *)arg0)->dentry->d_name.name));
@@ -314,7 +319,8 @@ This uses kernel dynamic tracing of the vfs_open() function, which has a (struct
 - kprobe: As mentioned earlier, this is the kernel dynamic tracing probe type, which traces the entry of kernel functions (use kretprobe to trace their returns).
 - `arg0` is a builtin variable containing the first probe argument, the meaning of which is defined by the probe type. For `kprobe`, it is the first argument to the function. Other arguments can be accessed as arg1, ..., argN.
 - `((struct path *)arg0)->dentry->d_name.name`: this casts `arg0` as `struct path *`, then dereferences dentry, etc.
+- #include: these are necessary to include struct definitions for path and dentry on systems where the kernel was built without BTF  (BPF Type Format) data.
 
-The kernel struct support is the same as bcc, making use of kernel headers. This means that many structs are available, but not everything, and sometimes it might be necessary to manually include a struct. For an example of this, see the [dcsnoop tool](../tools/dcsnoop.bt), which includes a portion of struct nameidata manually as it wasn't in the available headers. If the kernel has BTF (BPF Type Format) data, all kernel structs are always available.
+The kernel struct support is the same as bcc, making use of kernel headers. This means that many structs are available, but not everything, and sometimes it might be necessary to manually include a struct. For an example of this, see the [dcsnoop tool](../tools/dcsnoop.bt), which includes a portion of struct nameidata manually as it wasn't in the available headers. If the kernel has BTF data, all kernel structs are always available.
 
 At this point you understand much of bpftrace, and can begin to use and write powerful one-liners. See the [Reference Guide](reference_guide.md) for more capabilities.

--- a/docs/tutorial_one_liners.md
+++ b/docs/tutorial_one_liners.md
@@ -296,9 +296,6 @@ The context of this probe is important: this fires when the I/O is issued to the
 
 ```
 # cat path.bt
-#include <linux/path.h>
-#include <linux/dcache.h>
-
 kprobe:vfs_open
 {
 	printf("open path: %s\n", str(((struct path *)arg0)->dentry->d_name.name));
@@ -317,7 +314,6 @@ This uses kernel dynamic tracing of the vfs_open() function, which has a (struct
 - kprobe: As mentioned earlier, this is the kernel dynamic tracing probe type, which traces the entry of kernel functions (use kretprobe to trace their returns).
 - `arg0` is a builtin variable containing the first probe argument, the meaning of which is defined by the probe type. For `kprobe`, it is the first argument to the function. Other arguments can be accessed as arg1, ..., argN.
 - `((struct path *)arg0)->dentry->d_name.name`: this casts `arg0` as `struct path *`, then dereferences dentry, etc.
-- #include: these were necessary to include struct definitions for path and dentry.
 
 The kernel struct support is the same as bcc, making use of kernel headers. This means that many structs are available, but not everything, and sometimes it might be necessary to manually include a struct. For an example of this, see the [dcsnoop tool](../tools/dcsnoop.bt), which includes a portion of struct nameidata manually as it wasn't in the available headers. If the kernel has BTF (BPF Type Format) data, all kernel structs are always available.
 


### PR DESCRIPTION
The include statements cause the "Kernel Struct Tracing" example to fail.

##### Checklist

- [X ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [X] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [X] The new behaviour is covered by tests
