### PR TITLE
Fix: strerror string not quoted

### DIFF
--- a/src/output.cpp
+++ b/src/output.cpp
@@ -11,7 +11,8 @@ bool is_quoted_type(const SizedType &ty)
 {
   return ty.IsKstackTy() || ty.IsUstackTy() || ty.IsKsymTy() || ty.IsUsymTy() ||
          ty.IsInetTy() || ty.IsUsernameTy() || ty.IsStringTy() ||
-         ty.IsBufferTy() || ty.IsProbeTy() || ty.IsCgroupPathTy();
+         ty.IsBufferTy() || ty.IsProbeTy() || ty.IsCgroupPathTy() ||
+         ty.IsStrerrorTy();
 }
 } // namespace
 

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -100,6 +100,11 @@ RUN {{BPFTRACE}} -f json -e 'BEGIN { cat("/proc/uptime"); exit(); }'
 EXPECT ^{"type": "cat", "data": "[0-9]*.[0-9]* [0-9]*.[0-9]*\\n"}$
 TIMEOUT 5
 
+NAME strerror
+RUN {{BPFTRACE}} -f json -e 'BEGIN { print((strerror(7))); exit(); }'
+EXPECT ^{"type": "value", "data": "Argument list too long"}$
+TIMEOUT 5
+
 # Careful with '[' and ']', they are read by the test engine as a regex
 # character class, so make sure to escape them.
 NAME tuple


### PR DESCRIPTION
`sudo bpftrace -e 'kretfunc:__sys_bpf { if (retval < 0) { print((strerror(-retval))); } }' -f json`

Before:
{"type": "value", "data": No such file or directory}

After:
{"type": "value", "data": "No such file or directory"}

Fixes this issue: https://github.com/iovisor/bpftrace/issues/2920

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
