### PR TITLE
Runtime tests: Fix a crash in the test framework

### DIFF
--- a/tests/runtime/engine/runner.py
+++ b/tests/runtime/engine/runner.py
@@ -411,7 +411,6 @@ class Runner(object):
                 print('\tCLEANUP error: %s' % e.stderr)
                 return Runner.FAIL
 
-        @staticmethod
         def to_utf8(s):
             return s.encode("unicode_escape").decode("utf-8")
 


### PR DESCRIPTION
I'm not familiar with Python or @staticmethod, but this seems to fix the crash on my machine.

`to_utf8()` is called when a test fails, but Python was not happy with this being a @staticmethod

Before:
```
    [  FAILED  ] call.printf_argument
            Command: /home/ajor/src/bpftrace/build/src/bpftrace  -e 'i:ms:1 { printf("value: %dms100\n", 100); exit();}'
            Expected REGEX: value: 100ms101
    Traceback (most recent call last):
      File "runtime/engine/main.py", line 89, in <module>
        main(args.test_filter or TEST_FILTER, args.run_aot_tests)
      File "runtime/engine/main.py", line 49, in main
        status = Runner.run_test(test)
      File "/home/ajor/src/bpftrace/build/tests/runtime/engine/runner.py", line 446, in run_test
        print('\tFound:\n' + to_utf8(output))
    TypeError: 'staticmethod' object is not callable
```

After:
```
    [  FAILED  ] call.printf_argument
            Command: /home/ajor/src/bpftrace/build/src/bpftrace  -e 'i:ms:1 { printf("value: %dms100\n", 100); exit();}'
            Expected REGEX: value: 100ms101
            Found:
    Attaching 1 probe...\n__BPFTRACE_NOTIFY_PROBES_ATTACHED\nvalue: 100ms100\n\n\n
```


This can be triggered by messing with the expected results of a test so that it fails, e.g.:
```
    --- a/tests/runtime/call
    +++ b/tests/runtime/call
    @@ -10,7 +10,7 @@ TIMEOUT 5
     
     NAME printf_argument
     PROG i:ms:1 { printf("value: %dms100\n", 100); exit();}
    -EXPECT value: 100ms100
    +EXPECT value: 100ms101 
     TIMEOUT 5
```