### PR TITLE
remove btf related fd leaks in AttachedProbe::load_prog()

### DIFF
--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -89,7 +89,6 @@ private:
   int progfd_ = -1;
   uint64_t offset_ = 0;
   int tracing_fd_ = -1;
-  int btf_fd_ = -1;
   std::function<void()> usdt_destructor_;
 
   BTF &btf_;


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->
Currently, `AttachedProbe::load_prog()` creates a pair of descriptors related to btf information when loading each BPF program. These descriptors are not subsequently required and can safely be closed after the load call has completed.

Without the fix:

```
$ cat ~/BPFTrace/fentry.bt
fentry:b*
{
  @[func] = count();
}
$ BPFTRACE_MAX_BPF_PROGS=10000 BPFTRACE_MAX_PROBES=10000 sudo src/bpftrace ~/BPFTrace/fentry.bt
Attaching 3486 probes..
<chop>

$ sudo ls -l /proc/`pgrep bpftrace`/fd | wc -l
13966
```

After the fix:

```

$ sudo ls -l /proc/`pgrep bpftrace`/fd | wc -l
6960
```

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
