### PR TITLE
CMake: Fix testlib dependencies

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -108,25 +108,7 @@ if(NOT STATIC_LINKING)
   target_link_libraries(bpftrace_test ${CMAKE_THREAD_LIBS_INIT})
 endif(NOT STATIC_LINKING)
 
-# Compile all testprograms, one per .c file for runtime testing
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testprogs/)
-file(GLOB testprogs testprogs/*.c)
-set(compiled_testprogs "")
-foreach(testprog ${testprogs})
-  get_filename_component(bin_name ${testprog} NAME_WE)
-  add_executable (${bin_name} ${testprog})
-  if(HAVE_SYSTEMTAP_SYS_SDT_H)
-    target_compile_definitions(${bin_name} PRIVATE HAVE_SYSTEMTAP_SYS_SDT_H)
-  endif(HAVE_SYSTEMTAP_SYS_SDT_H)
-  set_target_properties(${bin_name} PROPERTIES LINK_SEARCH_START_STATIC FALSE LINK_SEARCH_END_STATIC FALSE RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testprogs/ COMPILE_FLAGS "-g -O0" LINK_FLAGS "-no-pie")
-  list(APPEND compiled_testprogs ${CMAKE_CURRENT_BINARY_DIR}/testprogs/${bin_name})
-endforeach()
-add_custom_target(testprogs DEPENDS ${compiled_testprogs})
-
-target_include_directories(usdt_lib PUBLIC ${CMAKE_SOURCE_DIR}/tests/testlibs/)
-target_compile_options(usdt_lib PRIVATE -fPIC)
-target_link_libraries(usdt_lib usdt_tp)
-
+add_subdirectory(testprogs)
 add_subdirectory(testlibs)
 
 
@@ -138,7 +120,7 @@ add_custom_target(
   runtime_tests
   COMMAND ./runtime-tests.sh
   DEPENDS
-    ${compiled_testprogs}
+    testprogs
     testlibs
     ${CMAKE_BINARY_DIR}/src/bpftrace
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -127,24 +127,7 @@ target_include_directories(usdt_lib PUBLIC ${CMAKE_SOURCE_DIR}/tests/testlibs/)
 target_compile_options(usdt_lib PRIVATE -fPIC)
 target_link_libraries(usdt_lib usdt_tp)
 
-# Similarly compile all test libs
-file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testlibs/)
-file(GLOB testlibs testlibs/*.c)
-set(compiled_testlibs "")
-foreach(testlib_source ${testlibs})
-  get_filename_component(testlib_name ${testlib_source} NAME_WE)
-  add_library(${testlib_name} SHARED ${testlib_source})
-  set_target_properties(${testlib_name} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/testlibs/ COMPILE_FLAGS "-g -O0")
-  if(HAVE_SYSTEMTAP_SYS_SDT_H)
-    target_compile_definitions(${testlib_name} PRIVATE HAVE_SYSTEMTAP_SYS_SDT_H)
-  endif(HAVE_SYSTEMTAP_SYS_SDT_H)
-  # clear the executable bit
-  add_custom_command(TARGET ${testlib_name}
-    POST_BUILD
-    COMMAND chmod -x ${CMAKE_CURRENT_BINARY_DIR}/testlibs/lib${testlib_name}.so)
-  list(APPEND compiled_testlibs ${CMAKE_CURRENT_BINARY_DIR}/testlibs/lib${testlib_name}.so)
-endforeach()
-add_custom_target(testlibs DEPENDS ${compiled_testlibs})
+add_subdirectory(testlibs)
 
 
 #
@@ -156,7 +139,7 @@ add_custom_target(
   COMMAND ./runtime-tests.sh
   DEPENDS
     ${compiled_testprogs}
-    ${compiled_testlibs}
+    testlibs
     ${CMAKE_BINARY_DIR}/src/bpftrace
 )
 add_test(NAME runtime_tests COMMAND ./runtime-tests.sh)

--- a/tests/testlibs/CMakeLists.txt
+++ b/tests/testlibs/CMakeLists.txt
@@ -1,0 +1,20 @@
+file(GLOB testlib_sources CONFIGURE_DEPENDS *.c)
+set(testlibtargets "")
+foreach(testlib_source ${testlib_sources})
+  get_filename_component(testlib_name ${testlib_source} NAME_WE)
+  add_library(${testlib_name} SHARED ${testlib_source})
+  set_target_properties(${testlib_name}
+    PROPERTIES
+      LIBRARY_OUTPUT_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+      COMPILE_FLAGS "-g -O0")
+  if(HAVE_SYSTEMTAP_SYS_SDT_H)
+    target_compile_definitions(${testlib_name} PRIVATE HAVE_SYSTEMTAP_SYS_SDT_H)
+  endif(HAVE_SYSTEMTAP_SYS_SDT_H)
+  # clear the executable bit - ensure bpftrace can trace non-executable
+  # shared objects
+  add_custom_command(TARGET ${testlib_name}
+    POST_BUILD
+    COMMAND chmod -x $<TARGET_FILE_NAME:${testlib_name}>)
+  list(APPEND testlibtargets ${testlib_name})
+endforeach()
+add_custom_target(testlibs DEPENDS ${testlibtargets})

--- a/tests/testprogs/CMakeLists.txt
+++ b/tests/testprogs/CMakeLists.txt
@@ -1,0 +1,21 @@
+file(GLOB testprog_sources CONFIGURE_DEPENDS *.c)
+set(testprogtargets "")
+foreach(testprog_source ${testprog_sources})
+  get_filename_component(testprog_name ${testprog_source} NAME_WE)
+  add_executable(${testprog_name} ${testprog_source})
+  set_target_properties(${testprog_name}
+    PROPERTIES
+      LINK_SEARCH_START_STATIC FALSE
+      LINK_SEARCH_END_STATIC FALSE
+      COMPILE_FLAGS "-g -O0"
+      LINK_FLAGS "-no-pie")
+  if(HAVE_SYSTEMTAP_SYS_SDT_H)
+    target_compile_definitions(${testprog_name} PRIVATE HAVE_SYSTEMTAP_SYS_SDT_H)
+  endif(HAVE_SYSTEMTAP_SYS_SDT_H)
+  list(APPEND testprogtargets ${testprog_name})
+endforeach()
+add_custom_target(testprogs DEPENDS ${testprogtargets})
+
+target_include_directories(usdt_lib PUBLIC ${CMAKE_SOURCE_DIR}/tests/testlibs/)
+target_compile_options(usdt_lib PRIVATE -fPIC)
+target_link_libraries(usdt_lib usdt_tp)


### PR DESCRIPTION
The "testlibs" target previously depended on "compiled_testlibs", but there was no rule which told CMake how to generate these compiled testlibs from their output names.

Now we make "testlibs" depend directly on the individual testlib targets instead of their outputs.


Repro:
1. Start with a completely clean build directory: `sudo rm -rf * && cmake ../`
2. `make testlibs`

Previous output:
```
No rule to make target 'tests/testlibs/libsimple.so', needed by 'tests/CMakeFiles/testlibs'.  Stop.
```

Also made similar cleanups to testprogs, but they were not causing the same issues as testprog binary names match their CMake target names.