### PR TITLE
CI: Run clang-format on all branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,6 @@ concurrency:
 
 jobs:
   clang-format:
-    # Only run clang-format on pull requests. We want to allow people to
-    # ignore clang-format if they think it's not helpful.
-    if: "github.event_name == 'pull_request'"
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This will let it run on branches of forks so people can catch formatting errors before they open a PR.

I don't think this will cause failures on master even with bad formatting, as `git clang-format origin/master` will always return with "no modified files to format" when on origin/master.