### PR TITLE
Runtime tests: Adjust meaning of BPFTRACE_RUNTIME_TEST_EXECUTABLE env var

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -115,7 +115,7 @@ add_subdirectory(testlibs)
 #
 # Runtime Tests
 #
-configure_file(runtime-tests.sh runtime-tests.sh COPYONLY)
+configure_file(runtime-tests.sh runtime-tests.sh @ONLY)
 add_custom_target(
   runtime_tests
   COMMAND ./runtime-tests.sh

--- a/tests/README.md
+++ b/tests/README.md
@@ -47,9 +47,9 @@ Run `./tests/codegen-tests.sh -u`. This updates all the codegen tests.
 
 Runtime tests will call the bpftrace executable. These are located in `tests/runtime` and are managed by a custom framework.
 
-* Run: `sudo make runtime-tests` inside your build folder or `sudo <builddir>/tests/runtime-tests.sh`
-* By default, runtime-tests will look for the executable in the build folder. You can set a value to the environment variable `BPFTRACE_RUNTIME_TEST_EXECUTABLE` to customize it
+* Run: `sudo make runtime-tests` inside your build directory or `sudo <builddir>/tests/runtime-tests.sh`
 * Use the `TEST_FILTER` environment variable (or the `--filter` arg when running `runtime_tests.sh`) to only run a subset of the tests e.g. `TEST_FILTER="uprobe.*" sudo make runtime-tests`
+* There are environment variables to override paths for the bpftrace executables, if necessary. See runtime-tests.sh for details.
 
 Runtime tests are grouped into "suites". A suite is usually a single file. The
 name of the file is the name of the suite.

--- a/tests/runtime-tests.sh
+++ b/tests/runtime-tests.sh
@@ -9,12 +9,14 @@ set -e;
 
 pushd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1
 
-BPFTRACE_RUNTIME_TEST_EXECUTABLE=${BPFTRACE_RUNTIME_TEST_EXECUTABLE:-../src/};
+BPFTRACE_RUNTIME_TEST_EXECUTABLE=${BPFTRACE_RUNTIME_TEST_EXECUTABLE:-@CMAKE_BINARY_DIR@/src/bpftrace};
 export BPFTRACE_RUNTIME_TEST_EXECUTABLE;
+BPFTRACE_AOT_RUNTIME_TEST_EXECUTABLE=${BPFTRACE_AOT_RUNTIME_TEST_EXECUTABLE:-@CMAKE_BINARY_DIR@/src/aot/bpftrace-aotrt};
+export BPFTRACE_AOT_RUNTIME_TEST_EXECUTABLE;
 
 echo "===================="
 echo "bpftrace --info:"
 echo "===================="
-"${BPFTRACE_RUNTIME_TEST_EXECUTABLE}/bpftrace" --info
+"${BPFTRACE_RUNTIME_TEST_EXECUTABLE}" --info
 
 python3 -u runtime/engine/main.py "$@"


### PR DESCRIPTION
The previous usage was misleading - it appeared to accept a path to an executable, but actually expected a directory.

Passing in binary paths seems more flexible than directories (in case a different build system is used), so I changed the variable to expect this and kept the old name.