### PR TITLE
Fix runtime test target name

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -47,8 +47,8 @@ Run `./tests/codegen-tests.sh -u`. This updates all the codegen tests.
 
 Runtime tests will call the bpftrace executable. These are located in `tests/runtime` and are managed by a custom framework.
 
-* Run: `sudo make runtime-tests` inside your build directory or `sudo <builddir>/tests/runtime-tests.sh`
-* Use the `TEST_FILTER` environment variable (or the `--filter` arg when running `runtime_tests.sh`) to only run a subset of the tests e.g. `TEST_FILTER="uprobe.*" sudo make runtime-tests`
+* Run: `sudo make runtime_tests` inside your build directory or `sudo <builddir>/tests/runtime-tests.sh`
+* Use the `TEST_FILTER` environment variable (or the `--filter` arg when running `runtime-tests.sh`) to only run a subset of the tests e.g. `TEST_FILTER="uprobe.*" sudo make runtime-tests`
 * There are environment variables to override paths for the bpftrace executables, if necessary. See runtime-tests.sh for details.
 
 Runtime tests are grouped into "suites". A suite is usually a single file. The


### PR DESCRIPTION
This was changed accidentally here: https://github.com/iovisor/bpftrace/pull/2929

Also drive-by fix in documentation for the script name

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
