### PR TITLE
Add missing header to fix Fedora build

### DIFF
--- a/src/config.cpp
+++ b/src/config.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cstring>
 #include <fstream>
 


### PR DESCRIPTION
`std::transform` introduced in the last PR comes from this header. Most builds are able to find this header from somewhere, but Fedora requires this explicit include.

The CI doesn't run the "Distros" job on PRs - only on pushes - so this wasn't caught until the PR was merged. There also won't be any useful signal from this PR, but I confirmed it worked on my own fork.

Without fix: https://github.com/ajor/bpftrace2/actions/runs/7582687403
With fix: https://github.com/ajor/bpftrace2/actions/runs/7582685235

@danobi Should the "Distros" job run on PRs? Maybe it's an uncommon enough event that it doesn't matter?