### PR TITLE
ci: Set continue-on-error for matrix jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
 
   build_test:
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       matrix:
         env:

--- a/.github/workflows/distros.yml
+++ b/.github/workflows/distros.yml
@@ -10,6 +10,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    continue-on-error: true
     strategy:
       matrix:
         dockerfile:


### PR DESCRIPTION
Reasoning is we want to extract as much signal as possible in one-shot. Sometimes PRs can enter a whack-a-mole state where you iteratively fix one job at a time. This is time consuming and frustrating.

Better to run all the jobs to completion (trade off compute resources for human time).

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
