### PR TITLE
explicitly use ast namespace when including files

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,7 +113,6 @@ add_definitions("-DBPFTRACE_VERSION=\"${BPFTRACE_VERSION}\"")
 
 target_include_directories(runtime PRIVATE ${CMAKE_BINARY_DIR})
 target_include_directories(runtime PRIVATE ${CMAKE_SOURCE_DIR}/src)
-target_include_directories(runtime PRIVATE ${CMAKE_SOURCE_DIR}/src/ast)
 target_compile_definitions(runtime PRIVATE ${BPFTRACE_FLAGS})
 target_include_directories(libbpftrace PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 target_compile_definitions(libbpftrace PRIVATE ${BPFTRACE_FLAGS})

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -21,7 +21,6 @@ add_library(ast
 )
 
 target_include_directories(ast_defs PUBLIC ${CMAKE_SOURCE_DIR}/src)
-target_include_directories(ast_defs PUBLIC ${CMAKE_SOURCE_DIR}/src/ast)
 target_include_directories(ast_defs PUBLIC ${CMAKE_BINARY_DIR})
 target_link_libraries(ast ast_defs arch parser)
 

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -31,11 +31,11 @@
 #include <llvm/Support/TargetSelect.h>
 
 #include "arch/arch.h"
-#include "ast.h"
+#include "ast/ast.h"
 #include "ast/async_event_types.h"
 #include "ast/codegen_helper.h"
+#include "ast/elf_parser.h"
 #include "ast/signal_bt.h"
-#include "elf_parser.h"
 #include "log.h"
 #include "tracepoint_format_parser.h"
 #include "types.h"

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -1,6 +1,6 @@
 #include <cstring>
 
-#include "async_event_types.h"
+#include "ast/async_event_types.h"
 #include "bpftrace.h"
 #include "log.h"
 #include "mapkey.h"

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -1,8 +1,9 @@
 #include "output.h"
+
+#include "ast/async_event_types.h"
 #include "bpftrace.h"
 #include "log.h"
 #include "utils.h"
-#include <async_event_types.h>
 
 #include <bpf/libbpf.h>
 


### PR DESCRIPTION
##### Checklist

- [x] The new behaviour is covered by tests

##### Why

a couple of files from ast directory were included using the root namespace. To make this work, CMakeLists.txt needed to explicitely:
```
target_include_directories(runtime PRIVATE ${CMAKE_SOURCE_DIR}/src/ast)
```

This change update the couple of .cpp files that included ast header files from the root namespace to use the ast prefix, and remove the `target_include_directories` entries.

While it does not change anything fundamentally to how bpftrace is build using cmake, it does make building with other build systems such as buck, bazel... easier.

