### PR TITLE
Docker: drop unneeded packages from Fedora build

### DIFF
--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -4,8 +4,7 @@
 
 FROM fedora:rawhide
 
-RUN dnf -y groupinstall "Development Tools" && \
-    dnf install -y \
+RUN dnf install -y \
         asciidoctor \
         bison \
         binutils-devel \
@@ -13,12 +12,16 @@ RUN dnf -y groupinstall "Development Tools" && \
         cereal-devel \
         clang-devel \
         cmake \
+        elfutils-devel \
         elfutils-libelf-devel \
         elfutils-libs \
         flex \
+        gcc \
+        gcc-c++ \
         libpcap-devel \
         libbpf-devel \
         llvm-devel \
+        make \
         systemtap-sdt-devel \
         zlib-devel
 


### PR DESCRIPTION
Do not install the "Development Tools" group which contains a lot of packages not necessary for bpftrace build (in fact, we should be instaling the "C Development Tools and Libraries" group, but that one still contains a lot of packages).

Instead, install only the minimal packages necessary.

This will also minimize the impact of Fedora Rawhide issues on our CI (e.g. [recent failures](https://github.com/iovisor/bpftrace/actions/runs/7607658584/job/20715368842) due to broken systemtap package which we don't need at all).

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
