### PR TITLE
Fix -Wsign-compare warning in testprogs

### DIFF
--- a/tests/testprogs/mountns_pivot_wrapper.c
+++ b/tests/testprogs/mountns_pivot_wrapper.c
@@ -90,7 +90,7 @@ int main(int argc, char *argv[])
   glob("/lib*", GLOB_NOSORT, NULL, &globbuf);
   glob("/usr/lib*", GLOB_NOSORT | GLOB_APPEND, NULL, &globbuf);
   glob("/nix/store", GLOB_NOSORT | GLOB_APPEND, NULL, &globbuf);
-  for (int i = 0; i < globbuf.gl_pathc; i++)
+  for (size_t i = 0; i < globbuf.gl_pathc; i++)
   {
     const char *global_lib_dir = globbuf.gl_pathv[i];
     char shared_dir_mount[PATH_MAX];


### PR DESCRIPTION
Fixes the following warning:

[41/279] Building C object tests/testprogs/CMakeFiles/mountns_pivot_wrapper.dir/mountns_pivot_wrapper.c.o /home/dxu/dev/bpftrace/tests/testprogs/mountns_pivot_wrapper.c: In function ‘main’: /home/dxu/dev/bpftrace/tests/testprogs/mountns_pivot_wrapper.c:93:21: warning: comparison of integer expressions of different signedness: ‘int’ and ‘__size_t’ {aka ‘long unsigned int’} [-Wsign-compare]
   93 |   for (int i = 0; i < globbuf.gl_pathc; i++)

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
