### PR TITLE
Add 'lazy_symbolication' config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to
 ## Unreleased
 
 #### Added
+- Add 'lazy_symbolication' config
+  - [#2958](https://github.com/iovisor/bpftrace/pull/2958)
 #### Changed
 #### Deprecated
 #### Removed

--- a/docs/reference_guide.md
+++ b/docs/reference_guide.md
@@ -175,6 +175,7 @@ ENVIRONMENT:
     BPFTRACE_DEBUG_OUTPUT               [default: 0] outputs bpftrace's runtime debug messages to the trace_pipe
     BPFTRACE_KERNEL_BUILD               [default: /lib/modules/$(uname -r)] kernel build directory
     BPFTRACE_KERNEL_SOURCE              [default: /lib/modules/$(uname -r)] kernel headers directory
+    BPFTRACE_LAZY_SYMBOLICATION         [default: 0] symbolicate lazily/on-demand
     BPFTRACE_LOG_SIZE                   [default: 1000000] log size in bytes
     BPFTRACE_MAX_BPF_PROGS              [default: 512] max number of generated BPF programs
     BPFTRACE_MAX_CAT_BYTES              [default: 10k] maximum bytes read by cat builtin
@@ -523,13 +524,19 @@ Default: `/lib/modules/$(uname -r)`
 
 bpftrace requires kernel headers for certain features, which are searched for in this directory.
 
-### 9.7 `BPFTRACE_LOG_SIZE`
+### 9.7 `BPFTRACE_LAZY_SYMBOLICATION`
+
+Default: 0
+
+For user space symbols, symbolicate lazily/on-demand (1) or symbolicate everything ahead of time (0).
+
+### 9.8 `BPFTRACE_LOG_SIZE`
 
 Default: 1000000
 
 Log size in bytes.
 
-### 9.8 `BPFTRACE_MAX_BPF_PROGS`
+### 9.9 `BPFTRACE_MAX_BPF_PROGS`
 
 Default: 512
 
@@ -537,13 +544,13 @@ This is the maximum number of BPF programs (functions) that bpftrace can generat
 The main purpose of this limit is to prevent bpftrace from hanging since generating a lot of probes
 takes a lot of resources (and it should not happen often).
 
-### 9.9 `BPFTRACE_MAX_CAT_BYTES`
+### 9.10 `BPFTRACE_MAX_CAT_BYTES`
 
 Default: 10k
 
 Maximum bytes read by cat builtin.
 
-### 9.10 `BPFTRACE_MAX_MAP_KEYS`
+### 9.11 `BPFTRACE_MAX_MAP_KEYS`
 
 Default: 4096
 
@@ -551,7 +558,7 @@ This is the maximum number of keys that can be stored in a map. Increasing the v
 memory and increase startup times. There are some cases where you will want to: for example, sampling
 stack traces, recording timestamps for each page, etc.
 
-### 9.11 `BPFTRACE_MAX_PROBES`
+### 9.12 `BPFTRACE_MAX_PROBES`
 
 Default: 512
 
@@ -559,7 +566,7 @@ This is the maximum number of probes that bpftrace can attach to. Increasing the
 memory, increase startup times and can incur high performance overhead or even freeze or crash the
 system.
 
-### 9.12 `BPFTRACE_MAX_STRLEN`
+### 9.13 `BPFTRACE_MAX_STRLEN`
 
 Default: 64
 
@@ -572,13 +579,13 @@ it composes a perf event output buffer). So in practice you can only grow this t
 
 Support for even larger strings is [being discussed](https://github.com/iovisor/bpftrace/issues/305).
 
-### 9.13 `BPFTRACE_MAX_TYPE_RES_ITERATIONS`
+### 9.14 `BPFTRACE_MAX_TYPE_RES_ITERATIONS`
 
 Default: 0
 
 Maximum should be the number of levels of nested field accesses for tracepoint args. 0 is unlimited.
 
-### 9.14 `BPFTRACE_PERF_RB_PAGES`
+### 9.15 `BPFTRACE_PERF_RB_PAGES`
 
 Default: 64
 
@@ -588,20 +595,20 @@ If you're getting a lot of dropped events bpftrace may not be processing events 
 fast enough. It may be useful to bump the value higher so more events can be queued up. The tradeoff
 is that bpftrace will use more memory.
 
-### 9.15 `BPFTRACE_STACK_MODE`
+### 9.16 `BPFTRACE_STACK_MODE`
 
 Default: bpftrace
 
 Output format for ustack and kstack builtins. Available modes/formats: `bpftrace`, `perf`, and `raw`.
 This can be overwritten at the call site.
 
-### 9.16 `BPFTRACE_STR_TRUNC_TRAILER`
+### 9.17 `BPFTRACE_STR_TRUNC_TRAILER`
 
 Default: `..`
 
 Trailer to add to strings that were truncated. Set to empty string to disable truncation trailers.
 
-### 9.17 `BPFTRACE_VMLINUX`
+### 9.18 `BPFTRACE_VMLINUX`
 
 Default: None
 
@@ -2363,7 +2370,7 @@ Syntax: `str(char *s [, int length])`
 
 Returns the string pointed to by s. `length` can be used to limit the size of the read, and/or introduce
 a null-terminator. By default, the string will have size 64 bytes (tuneable using [env var
-`BPFTRACE_MAX_STRLEN`](#912-bpftrace_max_strlen)).
+`BPFTRACE_MAX_STRLEN`](#913-bpftrace_max_strlen)).
 
 Examples:
 
@@ -3008,7 +3015,7 @@ Syntax: `buf(void *d [, int length])`
 Returns a hex-formatted string of the data pointed to by `d` that is safe to print. Because the
 length of the buffer cannot always be inferred, the `length` parameter may be provided to
 limit the number of bytes that are read. By default, the maximum number of bytes is 64, but this can
-be tuned using the [`BPFTRACE_MAX_STRLEN`](#912-bpftrace_max_strlen) environment variable.
+be tuned using the [`BPFTRACE_MAX_STRLEN`](#913-bpftrace_max_strlen) environment variable.
 
 Bytes with values >=32 and <=126 are printed using their ASCII character, other
 bytes are printed in hex form (e.g. `\x00`).

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -222,6 +222,12 @@ Default: `/lib/modules/$(uname -r)`
 
 bpftrace requires kernel headers for certain features, which are searched for in this directory.
 
+=== BPFTRACE_LAZY_SYMBOLICATION
+
+Default: 0
+
+For user space symbols, symbolicate lazily/on-demand (1) or symbolicate everything ahead of time (0).
+
 === BPFTRACE_LOG_SIZE
 
 Default: 1000000

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -31,6 +31,8 @@
 #include "types.h"
 #include "utils.h"
 
+#include <bcc/bcc_syms.h>
+
 namespace bpftrace {
 
 const int timeout_ms = 100;
@@ -266,6 +268,7 @@ private:
   int print_map_stats(IMap &map, uint32_t top, uint32_t div);
   static uint64_t read_address_from_output(std::string output);
   std::vector<uint8_t> find_empty_key(IMap &map, size_t size) const;
+  struct bcc_symbol_option &get_symbol_opts();
   bool has_iter_ = false;
   int epollfd_ = -1;
   struct ring_buffer *ringbuf_ = nullptr;

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -12,6 +12,7 @@ Config::Config(bool has_cmd, bool bt_verbose) : bt_verbose_(bt_verbose)
 {
   config_map_ = {
     { ConfigKeyBool::cpp_demangle, { .value = true } },
+    { ConfigKeyBool::lazy_symbolication, { .value = false } },
     { ConfigKeyInt::log_size, { .value = (uint64_t)1000000 } },
     { ConfigKeyInt::max_bpf_progs, { .value = (uint64_t)512 } },
     { ConfigKeyInt::max_cat_bytes, { .value = (uint64_t)10240 } },

--- a/src/config.h
+++ b/src/config.h
@@ -26,6 +26,7 @@ enum class ConfigSource
 enum class ConfigKeyBool
 {
   cpp_demangle,
+  lazy_symbolication,
 };
 
 enum class ConfigKeyInt
@@ -67,6 +68,7 @@ typedef std::variant<ConfigKeyBool,
 const std::map<std::string, ConfigKey> CONFIG_KEY_MAP = {
   { "cache_user_symbols", ConfigKeyUserSymbolCacheType::default_ },
   { "cpp_demangle", ConfigKeyBool::cpp_demangle },
+  { "lazy_symbolication", ConfigKeyBool::lazy_symbolication },
   { "log_size", ConfigKeyInt::log_size },
   { "max_bpf_progs", ConfigKeyInt::max_bpf_progs },
   { "max_cat_bytes", ConfigKeyInt::max_cat_bytes },

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -125,6 +125,7 @@ void usage()
   std::cerr << "    BPFTRACE_DEBUG_OUTPUT             [default: 0] enable bpftrace's internal debugging outputs" << std::endl;
   std::cerr << "    BPFTRACE_KERNEL_BUILD             [default: /lib/modules/$(uname -r)] kernel build directory" << std::endl;
   std::cerr << "    BPFTRACE_KERNEL_SOURCE            [default: /lib/modules/$(uname -r)] kernel headers directory" << std::endl;
+  std::cerr << "    BPFTRACE_LAZY_SYMBOLICATION       [default: 0] symbolicate lazily/on-demand" << std::endl;
   std::cerr << "    BPFTRACE_LOG_SIZE                 [default: 1000000] log size in bytes" << std::endl;
   std::cerr << "    BPFTRACE_MAX_BPF_PROGS            [default: 512] max number of generated BPF programs" << std::endl;
   std::cerr << "    BPFTRACE_MAX_CAT_BYTES            [default: 10k] maximum bytes read by cat builtin" << std::endl;
@@ -307,6 +308,11 @@ static std::optional<struct timespec> get_delta_taitime()
 
   if (!get_bool_env_var("BPFTRACE_DEBUG_OUTPUT",
                         [&](bool x) { bpftrace.debug_output_ = x; }))
+    return false;
+
+  if (!get_bool_env_var("BPFTRACE_LAZY_SYMBOLICATION", [&](bool x) {
+        config_setter.set(ConfigKeyBool::lazy_symbolication, x);
+      }))
     return false;
 
   if (!get_uint64_env_var("BPFTRACE_MAX_MAP_KEYS", [&](uint64_t x) {

--- a/tests/config.cpp
+++ b/tests/config.cpp
@@ -16,11 +16,14 @@ TEST(Config, get_and_set)
   EXPECT_TRUE(config_setter.set(ConfigKeyBool::cpp_demangle, true));
   EXPECT_EQ(config.get(ConfigKeyBool::cpp_demangle), true);
 
-  EXPECT_TRUE(config_setter.set(ConfigKeyInt::max_cat_bytes, 10));
-  EXPECT_EQ(config.get(ConfigKeyInt::max_cat_bytes), 10);
+  EXPECT_TRUE(config_setter.set(ConfigKeyBool::lazy_symbolication, true));
+  EXPECT_EQ(config.get(ConfigKeyBool::lazy_symbolication), true);
 
   EXPECT_TRUE(config_setter.set(ConfigKeyInt::log_size, 10));
   EXPECT_EQ(config.get(ConfigKeyInt::log_size), 10);
+
+  EXPECT_TRUE(config_setter.set(ConfigKeyInt::max_cat_bytes, 10));
+  EXPECT_EQ(config.get(ConfigKeyInt::max_cat_bytes), 10);
 
   EXPECT_TRUE(config_setter.set(ConfigKeyInt::max_map_keys, 10));
   EXPECT_EQ(config.get(ConfigKeyInt::max_map_keys), 10);
@@ -31,14 +34,14 @@ TEST(Config, get_and_set)
   EXPECT_TRUE(config_setter.set(ConfigKeyInt::max_bpf_progs, 10));
   EXPECT_EQ(config.get(ConfigKeyInt::max_bpf_progs), 10);
 
+  EXPECT_TRUE(config_setter.set(ConfigKeyInt::max_strlen, 10));
+  EXPECT_EQ(config.get(ConfigKeyInt::max_strlen), 10);
+
   EXPECT_TRUE(config_setter.set(ConfigKeyInt::max_type_res_iterations, 10));
   EXPECT_EQ(config.get(ConfigKeyInt::max_type_res_iterations), 10);
 
   EXPECT_TRUE(config_setter.set(ConfigKeyInt::perf_rb_pages, 10));
   EXPECT_EQ(config.get(ConfigKeyInt::perf_rb_pages), 10);
-
-  EXPECT_TRUE(config_setter.set(ConfigKeyInt::max_strlen, 10));
-  EXPECT_EQ(config.get(ConfigKeyInt::max_strlen), 10);
 
   EXPECT_TRUE(config_setter.set(ConfigKeyString::str_trunc_trailer, "str"));
   EXPECT_EQ(config.get(ConfigKeyString::str_trunc_trailer), "str");


### PR DESCRIPTION
This can be used to lazily symbolize userspace symbols instead of loading the entire symbol table ahead of time.

This is useful for when tracing large binaries.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
