### PR TITLE
Fix build failure on 32-bit ARM

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -1034,7 +1034,7 @@ static void resolve_offset_uprobe_multi(const std::string &path,
                                         const std::string &probe_name,
                                         const std::vector<std::string> &funcs,
                                         std::vector<std::string> &syms,
-                                        std::vector<uint64_t> &offsets)
+                                        std::vector<unsigned long> &offsets)
 {
   struct bcc_symbol_option option = {};
   int err;
@@ -1099,7 +1099,7 @@ static void resolve_offset_uprobe_multi(const std::string &path,
 void AttachedProbe::attach_multi_uprobe(int pid)
 {
   std::vector<std::string> syms;
-  std::vector<uint64_t> offsets;
+  std::vector<unsigned long> offsets;
   unsigned int i;
 
   // Resolve probe_.funcs into offsets and syms vector

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -128,14 +128,14 @@ public:
                         StackType stack_type,
                         int indent = 0);
   std::string resolve_buf(char *buf, size_t size);
-  std::string resolve_ksym(uintptr_t addr, bool show_offset=false);
-  std::string resolve_usym(uintptr_t addr,
+  std::string resolve_ksym(uint64_t addr, bool show_offset = false);
+  std::string resolve_usym(uint64_t addr,
                            int pid,
                            int probe_id,
                            bool show_offset = false,
                            bool show_module = false);
-  std::string resolve_inet(int af, const uint8_t* inet) const;
-  std::string resolve_uid(uintptr_t addr) const;
+  std::string resolve_inet(int af, const uint8_t *inet) const;
+  std::string resolve_uid(uint64_t addr) const;
   std::string resolve_timestamp(uint32_t mode,
                                 uint32_t strftime_id,
                                 uint64_t nsecs);


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

Fixes #2953. I'm not certain that the uprobe_multi offset cast is correct/safe, but the tests seem okay with it.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
