### PR TITLE
btf: Fix field resolution on structs with anon unions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to
 #### Deprecated
 #### Removed
 #### Fixed
+- Fix field resolution on structs with anon union as first field
+  - [#2964](https://github.com/iovisor/bpftrace/pull/2964)
 #### Docs
 #### Tools
 

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -829,7 +829,7 @@ void BTF::resolve_fields(const BTFId &type_id,
     if (btf_is_composite(field_type) &&
         (field_name.empty() || field_name == "(anon)")) {
       resolve_fields(field_id, record, field_offset);
-      return;
+      continue;
     }
 
     record->AddField(field_name,

--- a/tests/data/data_source.c
+++ b/tests/data/data_source.c
@@ -36,6 +36,16 @@ struct Foo3 *func_3(int a, int *b, struct Foo1 *foo1)
   return 0;
 }
 
+struct FirstFieldsAreAnonUnion {
+  union {
+    int a;
+    int b;
+  };
+  int c;
+};
+
+struct FirstFieldsAreAnonUnion first_fields_anon_union;
+
 struct Arrays {
   int int_arr[4];
   char char_arr[8];

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -256,6 +256,32 @@ TEST_F(field_analyser_btf, btf_types_bitfields)
   EXPECT_EQ(task_struct->GetField("d").bitfield->mask, 0xFFFFFU);
 }
 
+TEST_F(field_analyser_btf, btf_anon_union_first_in_struct)
+{
+  BPFtrace bpftrace;
+  bpftrace.parse_btf({});
+  test(bpftrace, "BEGIN { @ = (struct FirstFieldsAreAnonUnion *)0; }");
+
+  ASSERT_TRUE(bpftrace.structs.Has("struct FirstFieldsAreAnonUnion"));
+  auto record =
+      bpftrace.structs.Lookup("struct FirstFieldsAreAnonUnion").lock();
+
+  ASSERT_TRUE(record->HasField("a"));
+  EXPECT_EQ(record->GetField("a").type.type, Type::integer);
+  EXPECT_EQ(record->GetField("a").type.GetSize(), 4U);
+  EXPECT_EQ(record->GetField("a").offset, 0);
+
+  ASSERT_TRUE(record->HasField("b"));
+  EXPECT_EQ(record->GetField("b").type.type, Type::integer);
+  EXPECT_EQ(record->GetField("b").type.GetSize(), 4U);
+  EXPECT_EQ(record->GetField("b").offset, 0);
+
+  ASSERT_TRUE(record->HasField("c"));
+  EXPECT_EQ(record->GetField("c").type.type, Type::integer);
+  EXPECT_EQ(record->GetField("c").type.GetSize(), 4U);
+  EXPECT_EQ(record->GetField("c").offset, 4);
+}
+
 #ifdef HAVE_LIBDW
 
 #include "dwarf_common.h"


### PR DESCRIPTION
Before, we failed to correctly resolve fields in structs whose first field(s) were anonymous unions. This is b/c we incorrectly early terminated the loop through the struct's members during resolution.

Fix by changing the incorrect return to a continue. Without the fix, the included test would fail trying to find `c`.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
