### PR TITLE
Fix unused-unused compiler attribute

### DIFF
--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -76,7 +76,7 @@ void FieldAnalyser::visit(Map &map)
     sized_type_ = it->second;
 }
 
-void FieldAnalyser::visit(Variable &var __attribute__((unused)))
+void FieldAnalyser::visit(Variable &var)
 {
   auto it = var_types_.find(var.ident);
   if (it != var_types_.end())


### PR DESCRIPTION
The function argument is being used.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
