### PR TITLE
clang-format: Place opening braces on starting context

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -20,25 +20,10 @@ AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: true
 BinPackArguments: false
 BinPackParameters: false
-BraceWrapping:
-  # AfterCaseLabel was added in clang9
-  #AfterCaseLabel:        true
-  AfterClass:            true
-  AfterControlStatement: true
-  AfterEnum:             true
-  AfterFunction:         true
-  AfterNamespace:        false
-  AfterStruct:           true
-  AfterUnion:            true
-  AfterExternBlock:      true
-  BeforeCatch:           true
-  BeforeElse:            true
-  IndentBraces:          false
-  SplitEmptyFunction:    true
-  SplitEmptyRecord:      true
-  SplitEmptyNamespace:   true
 BreakBeforeBinaryOperators: None
 BreakBeforeBraces: Custom
+BraceWrapping:
+  AfterFunction: true
 BreakBeforeInheritanceComma: false
 BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: BeforeColon

--- a/.clang-format
+++ b/.clang-format
@@ -53,10 +53,6 @@ Cpp11BracedListStyle: false
 DerivePointerAlignment: true
 DisableFormat: false
 FixNamespaceComments: true
-ForEachMacros:
-  - foreach
-  - Q_FOREACH
-  - BOOST_FOREACH
 IncludeBlocks:   Preserve
 IncludeCategories:
   - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,19 +13,11 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: recursive
-    - name: Install clang-format
-      run: sudo apt-get install clang-format
-    - name: Download git-clang-format
-      run: wget https://raw.githubusercontent.com/llvm-mirror/clang/master/tools/clang-format/git-clang-format
-    - name: Install git-clang-format
-      run: sudo install -t /bin git-clang-format
-    - name: Fetch origin master
-      run: git fetch --no-tags --prune --depth=1 origin master
+        fetch-depth: 0
+    - uses: DeterminateSystems/nix-installer-action@v4
+    - uses: DeterminateSystems/magic-nix-cache-action@v2
     - name: clang-format
-      run: git clang-format origin/master
-    - name: diff
-      run: git diff --exit-code
+      run: nix develop --command git clang-format --diff origin/master
 
   build_test:
     runs-on: ubuntu-latest

--- a/flake.nix
+++ b/flake.nix
@@ -115,8 +115,11 @@
                   coreutils
                   findutils
                   gawk
+                  git
                   gnugrep
                   kmod
+                  # For git-clang-format
+                  libclang.python
                   nftables
                   procps
                   python3

--- a/scripts/seccomp.c
+++ b/scripts/seccomp.c
@@ -11,7 +11,8 @@
 #include <linux/bpf.h>
 #include <seccomp.h>
 
-void help() {
+void help()
+{
   printf("Simulate bpf(2) syscall failures based on the bpf(2) command ");
   printf("executed\n");
   printf("\n");
@@ -36,40 +37,41 @@ struct entry {
   const char* name;
 };
 
-#define ENTRY(symbol, name) \
-  { symbol, #symbol, name }
+#define ENTRY(symbol, name)                                                    \
+  {                                                                            \
+    symbol, #symbol, name                                                      \
+  }
 
 static const struct entry bpf_commands[] = {
-    ENTRY(BPF_MAP_CREATE, "map_create"),
-    ENTRY(BPF_MAP_LOOKUP_ELEM, "map_lookup_elem"),
-    ENTRY(BPF_MAP_UPDATE_ELEM, "map_update_elem"),
-    ENTRY(BPF_MAP_DELETE_ELEM, "map_delete_elem"),
-    ENTRY(BPF_MAP_GET_NEXT_KEY, "map_get_next_key"),
-    ENTRY(BPF_PROG_LOAD, "prog_load"),
-    ENTRY(BPF_OBJ_PIN, "obj_pin"),
-    ENTRY(BPF_OBJ_GET, "obj_get"),
-    ENTRY(BPF_PROG_ATTACH, "prog_attach"),
-    ENTRY(BPF_PROG_DETACH, "prog_detach"),
-    ENTRY(BPF_PROG_TEST_RUN, "prog_test_run"),
-    ENTRY(BPF_PROG_GET_NEXT_ID, "prog_get_next_id"),
-    ENTRY(BPF_MAP_GET_NEXT_ID, "map_get_next_id"),
-    ENTRY(BPF_PROG_GET_FD_BY_ID, "prog_get_fd_by_id"),
-    ENTRY(BPF_MAP_GET_FD_BY_ID, "map_get_fd_by_id"),
-    ENTRY(
-        BPF_OBJ_GET_INFO_BY_FD,
-        "obj_get_info_by_fd"),
-    ENTRY(BPF_PROG_QUERY, "prog_query"),
-    ENTRY(BPF_RAW_TRACEPOINT_OPEN,
-          "raw_tracepoint_open"),
-    ENTRY(BPF_BTF_LOAD, "btf_load"),
-    ENTRY(BPF_BTF_GET_FD_BY_ID, "btf_get_fd_by_id"),
-    ENTRY(BPF_TASK_FD_QUERY, "task_fd_query"),
+  ENTRY(BPF_MAP_CREATE, "map_create"),
+  ENTRY(BPF_MAP_LOOKUP_ELEM, "map_lookup_elem"),
+  ENTRY(BPF_MAP_UPDATE_ELEM, "map_update_elem"),
+  ENTRY(BPF_MAP_DELETE_ELEM, "map_delete_elem"),
+  ENTRY(BPF_MAP_GET_NEXT_KEY, "map_get_next_key"),
+  ENTRY(BPF_PROG_LOAD, "prog_load"),
+  ENTRY(BPF_OBJ_PIN, "obj_pin"),
+  ENTRY(BPF_OBJ_GET, "obj_get"),
+  ENTRY(BPF_PROG_ATTACH, "prog_attach"),
+  ENTRY(BPF_PROG_DETACH, "prog_detach"),
+  ENTRY(BPF_PROG_TEST_RUN, "prog_test_run"),
+  ENTRY(BPF_PROG_GET_NEXT_ID, "prog_get_next_id"),
+  ENTRY(BPF_MAP_GET_NEXT_ID, "map_get_next_id"),
+  ENTRY(BPF_PROG_GET_FD_BY_ID, "prog_get_fd_by_id"),
+  ENTRY(BPF_MAP_GET_FD_BY_ID, "map_get_fd_by_id"),
+  ENTRY(BPF_OBJ_GET_INFO_BY_FD, "obj_get_info_by_fd"),
+  ENTRY(BPF_PROG_QUERY, "prog_query"),
+  ENTRY(BPF_RAW_TRACEPOINT_OPEN, "raw_tracepoint_open"),
+  ENTRY(BPF_BTF_LOAD, "btf_load"),
+  ENTRY(BPF_BTF_GET_FD_BY_ID, "btf_get_fd_by_id"),
+  ENTRY(BPF_TASK_FD_QUERY, "task_fd_query"),
 };
 
-void list(void) {
+void list(void)
+{
   for (int x = 0; x < sizeof(bpf_commands) / sizeof(struct entry); x++) {
-    printf(
-        "name: %s\tflag: %s\n", bpf_commands[x].name, bpf_commands[x].symbol);
+    printf("name: %s\tflag: %s\n",
+           bpf_commands[x].name,
+           bpf_commands[x].symbol);
   }
   exit(0);
 }
@@ -78,7 +80,8 @@ void list(void) {
 // the argument name
 //
 // Return the bpf command value or -1 if the lookup failed
-int lookup_cmd(char* name) {
+int lookup_cmd(char* name)
+{
   for (int x = 0; x < sizeof(bpf_commands) / sizeof(struct entry); x++) {
     if (strcmp(name, bpf_commands[x].name) == 0 ||
         strcmp(name, bpf_commands[x].symbol) == 0) {
@@ -89,7 +92,8 @@ int lookup_cmd(char* name) {
 }
 
 // Parse the errno string and add the required filter to seccomp
-int add_errno(scmp_filter_ctx* ctx, char* str) {
+int add_errno(scmp_filter_ctx* ctx, char* str)
+{
   assert(ctx != NULL);
   assert(str != NULL);
   char* substr = strchr(str, ':');
@@ -137,7 +141,8 @@ exit:
 }
 
 // Parse CLI args, setup seccomp and execve into the command
-int main(int argc, char** argv) {
+int main(int argc, char** argv)
+{
   int index;
   int c;
 
@@ -151,35 +156,35 @@ int main(int argc, char** argv) {
 
   while ((c = getopt(argc, argv, "k:e:hl")) != -1) {
     switch (c) {
-    case 'h':
-      help();
-      break;
-    case 'l':
-      list();
-      break;
-    case 'k': {
-      int v = lookup_cmd(optarg);
-      if (v >= 0) {
-        int rc = seccomp_rule_add(
-            ctx, SCMP_ACT_KILL, SCMP_SYS(bpf), 1, SCMP_A0(SCMP_CMP_EQ, v));
-        if (rc < 0) {
-          printf("Failed to add KILL filter for command: %s: %s\n",
-                 optarg,
-                 strerror(-1 * rc));
+      case 'h':
+        help();
+        break;
+      case 'l':
+        list();
+        break;
+      case 'k': {
+        int v = lookup_cmd(optarg);
+        if (v >= 0) {
+          int rc = seccomp_rule_add(
+              ctx, SCMP_ACT_KILL, SCMP_SYS(bpf), 1, SCMP_A0(SCMP_CMP_EQ, v));
+          if (rc < 0) {
+            printf("Failed to add KILL filter for command: %s: %s\n",
+                   optarg,
+                   strerror(-1 * rc));
+          } else {
+            printf("Added KILL for command: %s\n", optarg);
+          }
         } else {
-          printf("Added KILL for command: %s\n", optarg);
+          printf("Unknown bpf command: %s\n", optarg);
         }
-      } else {
-        printf("Unknown bpf command: %s\n", optarg);
+        break;
       }
-      break;
-    }
-    case 'e':
-      add_errno(&ctx, optarg);
-      break;
-    default:
-      printf("Unknown option: %s\n", optarg);
-      break;
+      case 'e':
+        add_errno(&ctx, optarg);
+        break;
+      default:
+        printf("Unknown option: %s\n", optarg);
+        break;
     }
   }
 

--- a/src/act_helpers.h
+++ b/src/act_helpers.h
@@ -12,33 +12,36 @@
 #include <cstddef>
 #include <type_traits>
 
-namespace act_helpers
-{
+namespace act_helpers {
 
-template <typename T, typename M> M get_member_type(M T:: *);
+template <typename T, typename M>
+M get_member_type(M T::*);
 
 }
 
-#define ACTH_SAME_SIZE(cxxtype, ctype, extra_type) \
+#define ACTH_SAME_SIZE(cxxtype, ctype, extra_type)                             \
   (sizeof(cxxtype) == sizeof(ctype) + sizeof(extra_type))
-#define ACTH_GET_TYPE_OF(mem) \
-  decltype(act_helpers::get_member_type(&mem))
-#define ACTH_SAME_OFFSET(cxxtype, cxxmem, ctype, cmem) \
-  (std::is_standard_layout<cxxtype>::value && \
-   std::is_standard_layout<ctype>::value && \
+#define ACTH_GET_TYPE_OF(mem) decltype(act_helpers::get_member_type(&mem))
+#define ACTH_SAME_OFFSET(cxxtype, cxxmem, ctype, cmem)                         \
+  (std::is_standard_layout<cxxtype>::value &&                                  \
+   std::is_standard_layout<ctype>::value &&                                    \
    (offsetof(cxxtype, cxxmem) == offsetof(ctype, cmem)))
-#define ACTH_SAME_TYPE(cxxtype, cxxmem, ctype, cmem) \
-  std::is_same<ACTH_GET_TYPE_OF(cxxtype :: cxxmem), ACTH_GET_TYPE_OF(ctype :: cmem)>::value
+#define ACTH_SAME_TYPE(cxxtype, cxxmem, ctype, cmem)                           \
+  std::is_same<ACTH_GET_TYPE_OF(cxxtype ::cxxmem),                             \
+               ACTH_GET_TYPE_OF(ctype ::cmem)>::value
 
-#define ACTH_ASSERT_SAME_SIZE(cxxtype, ctype, extra_type) \
-  static_assert(ACTH_SAME_SIZE(cxxtype, ctype, extra_type), \
-                "assumption that is broken: " #cxxtype " == " #ctype " + " # extra_type)
-#define ACTH_ASSERT_SAME_OFFSET(cxxtype, cxxmem, ctype, cmem) \
-  static_assert(ACTH_SAME_OFFSET(cxxtype, cxxmem, ctype, cmem), \
-                "assumption that is broken: " #cxxtype "::" #cxxmem " is at the same offset as " #ctype "::" #cmem)
-#define ACTH_ASSERT_SAME_TYPE(cxxtype, cxxmem, ctype, cmem) \
-  static_assert(ACTH_SAME_TYPE(cxxtype, cxxmem, ctype, cmem), \
-                "assumption that is broken: " #cxxtype "::" #cxxmem " has the same type as " #ctype "::" #cmem)
-#define ACTH_ASSERT_SAME_MEMBER(cxxtype, cxxmem, ctype, cmem) \
-  ACTH_ASSERT_SAME_TYPE(cxxtype, cxxmem, ctype, cmem); \
+#define ACTH_ASSERT_SAME_SIZE(cxxtype, ctype, extra_type)                      \
+  static_assert(ACTH_SAME_SIZE(cxxtype, ctype, extra_type),                    \
+                "assumption that is broken: " #cxxtype " == " #ctype           \
+                " + " #extra_type)
+#define ACTH_ASSERT_SAME_OFFSET(cxxtype, cxxmem, ctype, cmem)                  \
+  static_assert(ACTH_SAME_OFFSET(cxxtype, cxxmem, ctype, cmem),                \
+                "assumption that is broken: " #cxxtype "::" #cxxmem            \
+                " is at the same offset as " #ctype "::" #cmem)
+#define ACTH_ASSERT_SAME_TYPE(cxxtype, cxxmem, ctype, cmem)                    \
+  static_assert(ACTH_SAME_TYPE(cxxtype, cxxmem, ctype, cmem),                  \
+                "assumption that is broken: " #cxxtype "::" #cxxmem            \
+                " has the same type as " #ctype "::" #cmem)
+#define ACTH_ASSERT_SAME_MEMBER(cxxtype, cxxmem, ctype, cmem)                  \
+  ACTH_ASSERT_SAME_TYPE(cxxtype, cxxmem, ctype, cmem);                         \
   ACTH_ASSERT_SAME_OFFSET(cxxtype, cxxmem, ctype, cmem)

--- a/src/aot/aot_main.cpp
+++ b/src/aot/aot_main.cpp
@@ -32,11 +32,9 @@ std::unique_ptr<Output> prepare_output(const std::string& output_file,
 {
   std::ostream* os = &std::cout;
   std::ofstream outputstream;
-  if (!output_file.empty())
-  {
+  if (!output_file.empty()) {
     outputstream.open(output_file);
-    if (outputstream.fail())
-    {
+    if (outputstream.fail()) {
       LOG(ERROR) << "Failed to open output file: \"" << output_file
                  << "\": " << strerror(errno);
       return nullptr;
@@ -45,16 +43,11 @@ std::unique_ptr<Output> prepare_output(const std::string& output_file,
   }
 
   std::unique_ptr<Output> output;
-  if (output_format.empty() || output_format == "text")
-  {
+  if (output_format.empty() || output_format == "text") {
     output = std::make_unique<TextOutput>(*os);
-  }
-  else if (output_format == "json")
-  {
+  } else if (output_format == "json") {
     output = std::make_unique<JsonOutput>(*os);
-  }
-  else
-  {
+  } else {
     LOG(ERROR) << "Invalid output format \"" << output_format << "\"\n"
                << "Valid formats: 'text', 'json'";
     return nullptr;
@@ -76,10 +69,8 @@ int main(int argc, char* argv[])
     option{ nullptr, 0, nullptr, 0 }, // Must be last
   };
 
-  while ((c = getopt_long(argc, argv, short_opts, long_opts, nullptr)) != -1)
-  {
-    switch (c)
-    {
+  while ((c = getopt_long(argc, argv, short_opts, long_opts, nullptr)) != -1) {
+    switch (c) {
       case 'o':
         output_file = optarg;
         break;
@@ -104,8 +95,7 @@ int main(int argc, char* argv[])
     }
   }
 
-  if (!argv[optind])
-  {
+  if (!argv[optind]) {
     usage();
     return 1;
   }
@@ -116,8 +106,7 @@ int main(int argc, char* argv[])
 
   BPFtrace bpftrace(std::move(output));
   int err = aot::load(bpftrace, argv[optind]);
-  if (err)
-  {
+  if (err) {
     LOG(ERROR) << "Failed to load AOT script";
     return err;
   }

--- a/src/arch/arm.cpp
+++ b/src/arch/arm.cpp
@@ -217,8 +217,7 @@ int get_kernel_ptr_width()
   // processes (e.g. "armv8l" instead of "aarch64"; see COMPAT_UTS_MACHINE), so
   // make sure this is taken into account.
   struct utsname utsname;
-  if (uname(&utsname) >= 0)
-  {
+  if (uname(&utsname) >= 0) {
     if (!strncmp(utsname.machine, "armv", 4) && utsname.machine[4] < '8')
       return 32;
   }

--- a/src/arch/loongarch64.cpp
+++ b/src/arch/loongarch64.cpp
@@ -100,13 +100,11 @@ static std::array<std::string, 8> arg_registers = {
 int offset(std::string reg_name)
 {
   auto it = find(registers.begin(), registers.end(), reg_name);
-  if (it == registers.end())
-  {
+  if (it == registers.end()) {
     // Also allow register names that match the fields in struct pt_regs.
     // These appear in USDT probe arguments.
     it = find(ptrace_registers.begin(), ptrace_registers.end(), reg_name);
-    if (it == ptrace_registers.end())
-    {
+    if (it == ptrace_registers.end()) {
       return -1;
     }
     return distance(ptrace_registers.begin(), it);

--- a/src/arch/mips64.cpp
+++ b/src/arch/mips64.cpp
@@ -96,13 +96,11 @@ static std::array<std::string, 8> arg_registers = {
 int offset(std::string reg_name)
 {
   auto it = find(registers.begin(), registers.end(), reg_name);
-  if (it == registers.end())
-  {
+  if (it == registers.end()) {
     // Also allow register names that match the fields in struct pt_regs.
     // These appear in USDT probe arguments.
     it = find(ptrace_registers.begin(), ptrace_registers.end(), reg_name);
-    if (it == ptrace_registers.end())
-    {
+    if (it == ptrace_registers.end()) {
       return -1;
     }
     return distance(ptrace_registers.begin(), it);

--- a/src/arch/ppc64.cpp
+++ b/src/arch/ppc64.cpp
@@ -76,8 +76,7 @@ static std::array<std::string, ARG_REGISTERS> arg_registers = {
 
 int offset(std::string reg_name)
 {
-  for (unsigned int i = 0; i < registers.size(); i++)
-  {
+  for (unsigned int i = 0; i < registers.size(); i++) {
     if (registers[i].count(reg_name))
       return i;
   }

--- a/src/arch/riscv64.cpp
+++ b/src/arch/riscv64.cpp
@@ -60,8 +60,7 @@ static std::array<std::string, 8> arg_registers = {
 int offset(std::string reg_name)
 {
   auto it = find(registers.begin(), registers.end(), reg_name);
-  if (it == registers.end())
-  {
+  if (it == registers.end()) {
     return -1;
   }
   return distance(registers.begin(), it);

--- a/src/arch/s390.cpp
+++ b/src/arch/s390.cpp
@@ -49,8 +49,7 @@ static std::array<std::string, ARG_REGISTERS> arg_registers = {
 
 int offset(std::string reg_name)
 {
-  for (unsigned int i = 0; i < registers.size(); i++)
-  {
+  for (unsigned int i = 0; i < registers.size(); i++) {
     if (registers[i].count(reg_name))
       return i;
   }

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -248,25 +248,21 @@ String::String(const std::string &str, location loc) : Expression(loc), str(str)
   is_literal = true;
 }
 
-
 StackMode::StackMode(const std::string &mode, location loc)
     : Expression(loc), mode(mode)
 {
   is_literal = true;
 }
 
-
 Builtin::Builtin(const std::string &ident, location loc)
     : Expression(loc), ident(is_deprecated(ident))
 {
 }
 
-
 Identifier::Identifier(const std::string &ident, location loc)
     : Expression(loc), ident(ident)
 {
 }
-
 
 PositionalParameter::PositionalParameter(PositionalParameterType ptype,
                                          long n,
@@ -275,7 +271,6 @@ PositionalParameter::PositionalParameter(PositionalParameterType ptype,
 {
   is_literal = true;
 }
-
 
 Call::Call(const std::string &func, location loc)
     : Expression(loc), func(is_deprecated(func)), vargs(nullptr)
@@ -316,8 +311,7 @@ Map::Map(const std::string &ident, ExpressionList *vargs, location loc)
     : Expression(loc), ident(ident), vargs(vargs)
 {
   is_map = true;
-  for (auto expr : *vargs)
-  {
+  for (auto expr : *vargs) {
     expr->key_for_map = this;
   }
 }
@@ -343,7 +337,6 @@ Unop::Unop(Operator op, Expression *expr, bool is_post_op, location loc)
 {
 }
 
-
 Ternary::Ternary(Expression *cond,
                  Expression *left,
                  Expression *right,
@@ -351,7 +344,6 @@ Ternary::Ternary(Expression *cond,
     : Expression(loc), cond(cond), left(left), right(right)
 {
 }
-
 
 FieldAccess::FieldAccess(Expression *expr,
                          const std::string &field,
@@ -365,7 +357,6 @@ FieldAccess::FieldAccess(Expression *expr, ssize_t index, location loc)
 {
 }
 
-
 ArrayAccess::ArrayAccess(Expression *expr, Expression *indexpr, location loc)
     : Expression(loc), expr(expr), indexpr(indexpr)
 {
@@ -377,12 +368,10 @@ Cast::Cast(SizedType cast_type, Expression *expr, location loc)
   type = cast_type;
 }
 
-
 Tuple::Tuple(ExpressionList *elems, location loc)
     : Expression(loc), elems(elems)
 {
 }
-
 
 ExprStatement::ExprStatement(Expression *expr, location loc)
     : Statement(loc), expr(expr)
@@ -419,12 +408,10 @@ Predicate::Predicate(Expression *expr, location loc) : Node(loc), expr(expr)
 {
 }
 
-
 AttachPoint::AttachPoint(const std::string &raw_input, location loc)
     : Node(loc), raw_input(raw_input)
 {
 }
-
 
 If::If(Expression *cond, StatementList *stmts) : cond(cond), stmts(stmts)
 {
@@ -434,7 +421,6 @@ If::If(Expression *cond, StatementList *stmts, StatementList *else_stmts)
     : cond(cond), stmts(stmts), else_stmts(else_stmts)
 {
 }
-
 
 Unroll::Unroll(Expression *expr, StatementList *stmts, location loc)
     : Statement(loc), expr(expr), stmts(stmts)
@@ -457,8 +443,7 @@ Program::Program(const std::string &c_definitions,
 
 std::string opstr(Jump &jump)
 {
-  switch (jump.ident)
-  {
+  switch (jump.ident) {
     case JumpType::RETURN:
       return "return";
     case JumpType::BREAK:
@@ -550,8 +535,7 @@ std::string AttachPoint::name(const std::string &attach_target,
     n += ":" + lang;
   if (ns != "")
     n += ":" + ns;
-  if (attach_point != "")
-  {
+  if (attach_point != "") {
     n += ":" + attach_point;
     if (func_offset != 0)
       n += "+" + std::to_string(func_offset);
@@ -585,8 +569,7 @@ void AttachPoint::set_index(int index)
 std::string Probe::name() const
 {
   std::string n;
-  for (auto &attach_point : *attach_points)
-  {
+  for (auto &attach_point : *attach_points) {
     if (!n.empty())
       n += ',';
     n += attach_point->provider;
@@ -594,8 +577,7 @@ std::string Probe::name() const
       n += ":" + attach_point->target;
     if (attach_point->ns != "")
       n += ":" + attach_point->ns;
-    if (attach_point->func != "")
-    {
+    if (attach_point->func != "") {
       n += ":" + attach_point->func;
       if (attach_point->func_offset != 0)
         n += "+" + std::to_string(attach_point->func_offset);
@@ -618,7 +600,8 @@ int Probe::index() const
   return index_;
 }
 
-void Probe::set_index(int index) {
+void Probe::set_index(int index)
+{
   index_ = index;
 }
 
@@ -697,8 +680,7 @@ bool Probe::has_ap_of_probetype(ProbeType probe_type)
 {
   if (!attach_points)
     return false;
-  for (auto ap : *attach_points)
-  {
+  for (auto ap : *attach_points) {
     if (probetype(ap->provider) == probe_type)
       return true;
   }

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -28,16 +28,14 @@ class VisitorBase;
     return new T(*this);                                                       \
   };
 
-enum class JumpType
-{
+enum class JumpType {
   INVALID = 0,
   RETURN,
   CONTINUE,
   BREAK,
 };
 
-enum class Operator
-{
+enum class Operator {
   INVALID = 0,
   ASSIGN,
   EQ,
@@ -64,8 +62,7 @@ enum class Operator
   BNOT,
 };
 
-class Node
-{
+class Node {
 public:
   Node() = default;
   Node(location loc) : loc(loc){};
@@ -99,7 +96,7 @@ public:
 
   SizedType type;
   Map *key_for_map = nullptr;
-  Map *map = nullptr; // Only set when this expression is assigned to a map
+  Map *map = nullptr;      // Only set when this expression is assigned to a map
   Variable *var = nullptr; // Set when this expression is assigned to a variable
   bool is_literal = false;
   bool is_variable = false;
@@ -211,8 +208,7 @@ private:
   Call(const Call &other);
 };
 
-class Sizeof : public Expression
-{
+class Sizeof : public Expression {
 public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(Sizeof)
@@ -228,8 +224,7 @@ private:
   Sizeof(const Sizeof &other);
 };
 
-class Offsetof : public Expression
-{
+class Offsetof : public Expression {
 public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(Offsetof)
@@ -364,8 +359,7 @@ private:
   Cast(const Cast &other);
 };
 
-class Tuple : public Expression
-{
+class Tuple : public Expression {
 public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(Tuple)
@@ -445,8 +439,7 @@ private:
   AssignVarStatement(const AssignVarStatement &other);
 };
 
-class AssignConfigVarStatement : public Statement
-{
+class AssignConfigVarStatement : public Statement {
 public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(AssignConfigVarStatement)
@@ -496,8 +489,7 @@ private:
   Unroll(const Unroll &other);
 };
 
-class Jump : public Statement
-{
+class Jump : public Statement {
 public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(Jump)
@@ -540,8 +532,7 @@ public:
   Expression *right = nullptr;
 };
 
-class While : public Statement
-{
+class While : public Statement {
 public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(While)
@@ -559,8 +550,7 @@ private:
   While(const While &other);
 };
 
-class Config : public Statement
-{
+class Config : public Statement {
 public:
   DEFINE_ACCEPT
   DEFINE_LEAFCOPY(Config)
@@ -598,7 +588,8 @@ public:
   std::string ns;
   std::string func;
   std::string pin;
-  usdt_probe_entry usdt; // resolved USDT entry, used to support arguments with wildcard matches
+  usdt_probe_entry usdt; // resolved USDT entry, used to support arguments with
+                         // wildcard matches
   int64_t freq = 0;
   uint64_t len = 0;   // for watchpoint probes, the width of watched addr
   std::string mode;   // for watchpoint probes, the watch mode
@@ -636,9 +627,9 @@ public:
 
   std::string name() const;
   std::string args_typename() const;
-  bool need_expansion = false;        // must build a BPF program per wildcard match
-  int tp_args_structs_level = -1;     // number of levels of structs that must
-                                      // be imported/resolved for tracepoints
+  bool need_expansion = false;    // must build a BPF program per wildcard match
+  int tp_args_structs_level = -1; // number of levels of structs that must
+                                  // be imported/resolved for tracepoints
 
   int index() const;
   void set_index(int index);

--- a/src/ast/async_event_types.h
+++ b/src/ast/async_event_types.h
@@ -27,8 +27,7 @@ class IRBuilderBPF;
 namespace bpftrace {
 namespace AsyncEvent {
 
-struct Print
-{
+struct Print {
   uint64_t action_id;
   uint32_t mapid;
   uint32_t top;
@@ -37,8 +36,7 @@ struct Print
   std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b);
 } __attribute__((packed));
 
-struct PrintNonMap
-{
+struct PrintNonMap {
   uint64_t action_id;
   uint64_t print_id;
   // See below why we don't use a flexible length array
@@ -47,24 +45,21 @@ struct PrintNonMap
   std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b, size_t size);
 } __attribute__((packed));
 
-struct MapEvent
-{
+struct MapEvent {
   uint64_t action_id;
   uint32_t mapid;
 
   std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b);
 } __attribute__((packed));
 
-struct Time
-{
+struct Time {
   uint64_t action_id;
   uint32_t time_id;
 
   std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b);
 } __attribute__((packed));
 
-struct Strftime
-{
+struct Strftime {
   uint32_t strftime_id;
   uint32_t mode;
   uint64_t nsecs;
@@ -72,8 +67,7 @@ struct Strftime
   std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b);
 } __attribute__((packed));
 
-struct Buf
-{
+struct Buf {
   uint8_t length;
   // Seems like GCC 7.4.x can't handle `char content[]`. Work around by using
   // 0 sized array (a GCC extension that clang also accepts:
@@ -84,8 +78,7 @@ struct Buf
   std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b, size_t length);
 } __attribute__((packed));
 
-struct HelperError
-{
+struct HelperError {
   uint64_t action_id;
   uint64_t error_id;
   int32_t return_value;
@@ -93,8 +86,7 @@ struct HelperError
   std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b);
 } __attribute__((packed));
 
-struct Watchpoint
-{
+struct Watchpoint {
   uint64_t action_id;
   uint64_t watchpoint_idx;
   uint64_t addr;
@@ -102,24 +94,21 @@ struct Watchpoint
   std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b);
 } __attribute__((packed));
 
-struct WatchpointUnwatch
-{
+struct WatchpointUnwatch {
   uint64_t action_id;
   uint64_t addr;
 
   std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b);
 } __attribute__((packed));
 
-struct CgroupPath
-{
+struct CgroupPath {
   uint64_t cgroup_path_id;
   uint64_t cgroup_id;
 
   std::vector<llvm::Type*> asLLVMType(ast::IRBuilderBPF& b);
 } __attribute__((packed));
 
-struct SkbOutput
-{
+struct SkbOutput {
   uint64_t action_id;
   uint64_t skb_output_id;
   uint64_t nsecs_since_boot;

--- a/src/ast/attachpoint_parser.h
+++ b/src/ast/attachpoint_parser.h
@@ -11,8 +11,7 @@
 namespace bpftrace {
 namespace ast {
 
-class AttachPointParser
-{
+class AttachPointParser {
 public:
   AttachPointParser(Program *root,
                     BPFtrace &bpftrace,
@@ -22,13 +21,7 @@ public:
   int parse();
 
 private:
-  enum State
-  {
-    OK = 0,
-    INVALID,
-    NEW_APS,
-    SKIP
-  };
+  enum State { OK = 0, INVALID, NEW_APS, SKIP };
 
   State parse_attachpoint(AttachPoint &ap);
   /*

--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -37,8 +37,7 @@ void DIBuilderBPF::createFunctionDebugInfo(Function &func)
                                          flags);
 
   std::string prefix("var");
-  for (size_t i = 0; i < types.size(); ++i)
-  {
+  for (size_t i = 0; i < types.size(); ++i) {
     createParameterVariable(subprog,
                             prefix + std::to_string(i),
                             i,

--- a/src/ast/dibuilderbpf.h
+++ b/src/ast/dibuilderbpf.h
@@ -7,8 +7,7 @@ namespace ast {
 
 using namespace llvm;
 
-class DIBuilderBPF : public DIBuilder
-{
+class DIBuilderBPF : public DIBuilder {
 public:
   DIBuilderBPF(Module &module);
 
@@ -20,8 +19,7 @@ public:
   DIFile *file = nullptr;
 
 private:
-  struct
-  {
+  struct {
     DIType *int64 = nullptr;
     DIType *int8_ptr = nullptr;
   } types_;

--- a/src/ast/elf_parser.cpp
+++ b/src/ast/elf_parser.cpp
@@ -30,16 +30,14 @@ BpfBytecode parseBpfBytecodeFromElfObject(void *const elf)
 
   BpfBytecode result;
 
-  for (int i = 0; i < ehdr->e_shnum; ++i)
-  {
+  for (int i = 0; i < ehdr->e_shnum; ++i) {
     Elf64_Shdr *shdr = &shdrs[i];
 
     char *name = strtable + shdr->sh_name;
     std::vector<uint8_t> data;
     data.resize(shdr->sh_size);
 
-    if (shdr->sh_size && shdr->sh_type != SHT_NOBITS)
-    {
+    if (shdr->sh_size && shdr->sh_type != SHT_NOBITS) {
       // NOBITS sections occupy no size on disk but take up size in
       // memory. Copy the file data for all other sections.
 

--- a/src/ast/int_parser.cpp
+++ b/src/ast/int_parser.cpp
@@ -36,13 +36,11 @@ std::variant<T, std::string> _parse_int(const std::string &num, int base)
 {
   // https://en.cppreference.com/w/cpp/language/integer_literal#The_type_of_the_literal
   static auto int_size_re = std::regex("^(u|u?l?l)$", std::regex::icase);
-  try
-  {
+  try {
     std::size_t idx;
     T ret = _parse_int<T>(num, &idx, base);
 
-    if (idx != num.size())
-    {
+    if (idx != num.size()) {
       auto trail = num.substr(idx, std::string::npos);
       auto match = std::regex_match(trail, int_size_re);
 
@@ -51,9 +49,7 @@ std::variant<T, std::string> _parse_int(const std::string &num, int base)
     }
 
     return ret;
-  }
-  catch (const std::exception &ex)
-  {
+  } catch (const std::exception &ex) {
     return ex.what();
   }
 }
@@ -74,16 +70,14 @@ std::variant<T, std::string> _parse_exp(const std::string &coeff,
 {
   std::stringstream errmsg;
   auto maybe_coeff = _parse_int<T>(coeff, 10);
-  if (std::string *err = std::get_if<std::string>(&maybe_coeff))
-  {
+  if (std::string *err = std::get_if<std::string>(&maybe_coeff)) {
     errmsg << "Coefficient part of scientific literal is not a valid number: "
            << coeff << ": " << *err;
     return errmsg.str();
   }
 
   auto maybe_exp = _parse_int<T>(exp, 10);
-  if (std::string *err = std::get_if<std::string>(&maybe_exp))
-  {
+  if (std::string *err = std::get_if<std::string>(&maybe_exp)) {
     errmsg << "Exponent part of scientific literal is not a valid number: "
            << exp << ": " << *err;
     return errmsg.str();
@@ -92,16 +86,14 @@ std::variant<T, std::string> _parse_exp(const std::string &coeff,
   auto c = std::get<T>(maybe_coeff);
   auto e = std::get<T>(maybe_exp);
 
-  if (c > 9)
-  {
+  if (c > 9) {
     errmsg << "Coefficient part of scientific literal must be in range (0,9), "
               "got: "
            << coeff;
     return errmsg.str();
   }
 
-  if (e > 16)
-  {
+  if (e > 16) {
     errmsg << "Exponent will overflow integer range: " << exp;
     return errmsg.str();
   }
@@ -124,20 +116,14 @@ T to_int(const std::string &num, int base)
   std::variant<T, std::string> res;
 
   // If hex
-  if ((n.rfind("0x", 0) == 0) || (n.rfind("0X", 0) == 0))
-  {
+  if ((n.rfind("0x", 0) == 0) || (n.rfind("0X", 0) == 0)) {
     res = _parse_int<T>(n, base);
-  }
-  else
-  {
+  } else {
     auto pos = n.find_first_of("eE");
-    if (pos != std::string::npos)
-    {
+    if (pos != std::string::npos) {
       res = _parse_exp<T>(n.substr(0, pos),
                           n.substr(pos + 1, std::string::npos));
-    }
-    else
-    {
+    } else {
       res = _parse_int<T>(n, base);
     }
   }

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -51,17 +51,22 @@ namespace ast {
 
 using namespace llvm;
 
-class IRBuilderBPF : public IRBuilder<>
-{
+class IRBuilderBPF : public IRBuilder<> {
 public:
   IRBuilderBPF(LLVMContext &context, Module &module, BPFtrace &bpftrace);
 
-  AllocaInst *CreateAllocaBPF(llvm::Type *ty, const std::string &name="");
-  AllocaInst *CreateAllocaBPF(const SizedType &stype, const std::string &name="");
-  AllocaInst *CreateAllocaBPFInit(const SizedType &stype, const std::string &name);
-  AllocaInst *CreateAllocaBPF(llvm::Type *ty, llvm::Value *arraysize, const std::string &name="");
-  AllocaInst *CreateAllocaBPF(const SizedType &stype, llvm::Value *arraysize, const std::string &name="");
-  AllocaInst *CreateAllocaBPF(int bytes, const std::string &name="");
+  AllocaInst *CreateAllocaBPF(llvm::Type *ty, const std::string &name = "");
+  AllocaInst *CreateAllocaBPF(const SizedType &stype,
+                              const std::string &name = "");
+  AllocaInst *CreateAllocaBPFInit(const SizedType &stype,
+                                  const std::string &name);
+  AllocaInst *CreateAllocaBPF(llvm::Type *ty,
+                              llvm::Value *arraysize,
+                              const std::string &name = "");
+  AllocaInst *CreateAllocaBPF(const SizedType &stype,
+                              llvm::Value *arraysize,
+                              const std::string &name = "");
+  AllocaInst *CreateAllocaBPF(int bytes, const std::string &name = "");
   llvm::Type *GetType(const SizedType &stype);
   llvm::ConstantInt *GetIntSameSize(uint64_t C, llvm::Value *expr);
   llvm::ConstantInt *GetIntSameSize(uint64_t C, llvm::Type *ty);
@@ -177,7 +182,10 @@ public:
   CallInst *CreateGetCpuId(const location &loc);
   CallInst *CreateGetCurrentTask(const location &loc);
   CallInst *CreateGetRandom(const location &loc);
-  CallInst   *CreateGetStackId(Value *ctx, bool ustack, StackType stack_type, const location& loc);
+  CallInst *CreateGetStackId(Value *ctx,
+                             bool ustack,
+                             StackType stack_type,
+                             const location &loc);
   CallInst *CreateGetFuncIp(const location &loc);
   CallInst *CreateGetJoinMap(BasicBlock *failure_callback, const location &loc);
   CallInst *CreateHelperCall(libbpf::bpf_func_id func_id,
@@ -189,7 +197,10 @@ public:
                        Value *callee,
                        ArrayRef<Value *> args,
                        const Twine &Name);
-  void        CreateGetCurrentComm(Value *ctx, AllocaInst *buf, size_t size, const location& loc);
+  void CreateGetCurrentComm(Value *ctx,
+                            AllocaInst *buf,
+                            size_t size,
+                            const location &loc);
   void CreateOutput(Value *ctx,
                     Value *data,
                     size_t size,
@@ -212,15 +223,24 @@ public:
                          Value *fmt_size,
                          const std::vector<Value *> &values,
                          const location &loc);
-  void        CreateSignal(Value *ctx, Value *sig, const location &loc);
-  void        CreateOverrideReturn(Value *ctx, Value *rc);
-  void        CreateHelperError(Value *ctx, Value *return_value, libbpf::bpf_func_id func_id, const location& loc);
-  void        CreateHelperErrorCond(Value *ctx, Value *return_value, libbpf::bpf_func_id func_id, const location& loc, bool compare_zero=false);
-  StructType *GetStructType(std::string name, const std::vector<llvm::Type *> & elements, bool packed = false);
+  void CreateSignal(Value *ctx, Value *sig, const location &loc);
+  void CreateOverrideReturn(Value *ctx, Value *rc);
+  void CreateHelperError(Value *ctx,
+                         Value *return_value,
+                         libbpf::bpf_func_id func_id,
+                         const location &loc);
+  void CreateHelperErrorCond(Value *ctx,
+                             Value *return_value,
+                             libbpf::bpf_func_id func_id,
+                             const location &loc,
+                             bool compare_zero = false);
+  StructType *GetStructType(std::string name,
+                            const std::vector<llvm::Type *> &elements,
+                            bool packed = false);
   AllocaInst *CreateUSym(llvm::Value *val, int probe_id, const location &loc);
   Value *CreateRegisterRead(Value *ctx, const std::string &builtin);
   Value *CreateRegisterRead(Value *ctx, int offset, const std::string &name);
-  Value      *CreatKFuncArg(Value *ctx, SizedType& type, std::string& name);
+  Value *CreatKFuncArg(Value *ctx, SizedType &type, std::string &name);
   Value *CreateRawTracepointArg(Value *ctx, const std::string &builtin);
   Value *CreateUprobeArgsRecord(Value *ctx, const SizedType &args_type);
   llvm::Type *UprobeArgsType(const SizedType &args_type);

--- a/src/ast/pass_manager.cpp
+++ b/src/ast/pass_manager.cpp
@@ -29,14 +29,12 @@ PassResult PassManager::Run(std::unique_ptr<Node> node, PassContext &ctx)
   Node *root = node.release();
   if (bt_debug != DebugLevel::kNone)
     print(root, "parser", std::cout);
-  for (auto &pass : passes_)
-  {
+  for (auto &pass : passes_) {
     auto result = pass.Run(*root, ctx);
     if (!result.Ok())
       return result;
 
-    if (result.Root())
-    {
+    if (result.Root()) {
       delete root;
       root = result.Root();
     }

--- a/src/ast/pass_manager.h
+++ b/src/ast/pass_manager.h
@@ -20,8 +20,7 @@ class Pass;
 /**
    Result of a pass run
  */
-class PassResult
-{
+class PassResult {
 public:
   static PassResult Error(const std::string &pass);
   static PassResult Error(const std::string &pass, int code);
@@ -94,8 +93,7 @@ private:
    Note: Most state should end up in the BPFtrace class instead of here
 */
 
-struct PassContext
-{
+struct PassContext {
 public:
   PassContext(BPFtrace &b) : b(b){};
   BPFtrace &b;
@@ -106,8 +104,7 @@ using PassFPtr = std::function<PassResult(Node &, PassContext &)>;
 /*
   Base pass
 */
-class Pass
-{
+class Pass {
 public:
   Pass() = delete;
   Pass(std::string name, PassFPtr fn) : fn_(fn), name(name){};
@@ -126,8 +123,7 @@ public:
   std::string name;
 };
 
-class PassManager
-{
+class PassManager {
 public:
   PassManager() = default;
 

--- a/src/ast/passes/callback_visitor.h
+++ b/src/ast/passes/callback_visitor.h
@@ -9,8 +9,7 @@ namespace ast {
 
 using callback = std::function<void(Node *)>;
 
-class CallbackVisitor : public Visitor
-{
+class CallbackVisitor : public Visitor {
 public:
   explicit CallbackVisitor(callback func) : func_(func)
   {

--- a/src/ast/passes/codegen_llvm.h
+++ b/src/ast/passes/codegen_llvm.h
@@ -26,8 +26,7 @@ using namespace llvm;
 
 using CallArgs = std::vector<std::tuple<FormatString, std::vector<Field>>>;
 
-class CodegenLLVM : public Visitor
-{
+class CodegenLLVM : public Visitor {
 public:
   explicit CodegenLLVM(Node *root, BPFtrace &bpftrace);
 
@@ -36,7 +35,7 @@ public:
   void visit(String &string) override;
   void visit(Identifier &identifier) override;
   void visit(Builtin &builtin) override;
-  void visit(StackMode &) override { };
+  void visit(StackMode &) override{};
   void visit(Call &call) override;
   void visit(Sizeof &szof) override;
   void visit(Offsetof &ofof) override;
@@ -62,15 +61,18 @@ public:
   void visit(Program &program) override;
   AllocaInst *getHistMapKey(Map &map, Value *log2);
   int getNextIndexForProbe();
-  Value      *createLogicalAnd(Binop &binop);
-  Value      *createLogicalOr(Binop &binop);
+  Value *createLogicalAnd(Binop &binop);
+  Value *createLogicalOr(Binop &binop);
 
   // Exists to make calling from a debugger easier
   void DumpIR(void);
   void DumpIR(std::ostream &out);
   void DumpIR(const std::string filename);
-  void createFormatStringCall(Call &call, int &id, CallArgs &call_args,
-                              const std::string &call_name, AsyncAction async_action);
+  void createFormatStringCall(Call &call,
+                              int &id,
+                              CallArgs &call_args,
+                              const std::string &call_name,
+                              AsyncAction async_action);
 
   void createPrintMapCall(Call &call);
   void createPrintNonMapCall(Call &call, int &id);
@@ -86,8 +88,7 @@ public:
 
 private:
   static constexpr char LLVMTargetTriple[] = "bpf-pc-linux";
-  class ScopedExprDeleter
-  {
+  class ScopedExprDeleter {
   public:
     explicit ScopedExprDeleter(std::function<void()> deleter)
     {
@@ -266,8 +267,7 @@ private:
   std::vector<std::tuple<BasicBlock *, BasicBlock *>> loops_;
   std::unordered_map<std::string, bool> probe_names_;
 
-  enum class State
-  {
+  enum class State {
     INIT,
     IR,
     OPT,

--- a/src/ast/passes/config_analyser.cpp
+++ b/src/ast/passes/config_analyser.cpp
@@ -12,8 +12,7 @@ namespace bpftrace {
 namespace ast {
 
 template <class... Ts>
-struct overloaded : Ts...
-{
+struct overloaded : Ts... {
   using Ts::operator()...;
 };
 // explicit deduction guide (not needed as of C++20)
@@ -33,8 +32,7 @@ void ConfigAnalyser::set_uint64_config(AssignConfigVarStatement &assignment,
                                        ConfigKeyInt key)
 {
   auto &assignTy = assignment.expr->type;
-  if (!assignTy.IsIntegerTy())
-  {
+  if (!assignTy.IsIntegerTy()) {
     log_type_error(assignTy, Type::integer, assignment);
     return;
   }
@@ -46,23 +44,17 @@ void ConfigAnalyser::set_bool_config(AssignConfigVarStatement &assignment,
                                      ConfigKeyBool key)
 {
   auto &assignTy = assignment.expr->type;
-  if (!assignTy.IsIntegerTy())
-  {
+  if (!assignTy.IsIntegerTy()) {
     log_type_error(assignTy, Type::integer, assignment);
     return;
   }
 
   auto val = dynamic_cast<Integer *>(assignment.expr)->n;
-  if (val == 0)
-  {
+  if (val == 0) {
     config_setter_.set(key, false);
-  }
-  else if (val == 1)
-  {
+  } else if (val == 1) {
     config_setter_.set(key, true);
-  }
-  else
-  {
+  } else {
     LOG(ERROR) << "Invalid value for " << assignment.config_var
                << ". Needs to be 0 or 1. Value: " << val;
   }
@@ -72,8 +64,7 @@ void ConfigAnalyser::set_string_config(AssignConfigVarStatement &assignment,
                                        ConfigKeyString key)
 {
   auto &assignTy = assignment.expr->type;
-  if (!assignTy.IsStringTy())
-  {
+  if (!assignTy.IsStringTy()) {
     log_type_error(assignTy, Type::string, assignment);
     return;
   }
@@ -84,8 +75,7 @@ void ConfigAnalyser::set_string_config(AssignConfigVarStatement &assignment,
 void ConfigAnalyser::set_stack_mode_config(AssignConfigVarStatement &assignment)
 {
   auto &assignTy = assignment.expr->type;
-  if (!assignTy.IsStackModeTy())
-  {
+  if (!assignTy.IsStackModeTy()) {
     log_type_error(assignTy, Type::stack_mode, assignment);
     return;
   }
@@ -97,8 +87,7 @@ void ConfigAnalyser::set_user_symbol_cache_type_config(
     AssignConfigVarStatement &assignment)
 {
   auto &assignTy = assignment.expr->type;
-  if (!assignTy.IsStringTy())
-  {
+  if (!assignTy.IsStringTy()) {
     log_type_error(assignTy, Type::string, assignment);
     return;
   }
@@ -120,13 +109,10 @@ void ConfigAnalyser::visit(String &string)
 void ConfigAnalyser::visit(StackMode &mode)
 {
   auto stack_mode = bpftrace::Config::get_stack_mode(mode.mode);
-  if (stack_mode.has_value())
-  {
+  if (stack_mode.has_value()) {
     mode.type = CreateStackMode();
     mode.type.stack_type.mode = stack_mode.value();
-  }
-  else
-  {
+  } else {
     mode.type = CreateNone();
     LOG(ERROR, mode.loc, err_) << "Unknown stack mode: '" + mode.mode + "'";
   }
@@ -141,14 +127,12 @@ void ConfigAnalyser::visit(AssignConfigVarStatement &assignment)
   const auto maybeConfigKey = bpftrace_.config_.get_config_key(raw_ident,
                                                                err_msg);
 
-  if (!maybeConfigKey.has_value())
-  {
+  if (!maybeConfigKey.has_value()) {
     LOG(ERROR, assignment.loc, err_) << err_msg;
     return;
   }
 
-  if (!assignment.expr->is_literal)
-  {
+  if (!assignment.expr->is_literal) {
     LOG(ERROR, assignment.loc, err_)
         << "Assignemnt for " << assignment.config_var << " must be literal.";
     return;
@@ -174,8 +158,7 @@ bool ConfigAnalyser::analyse()
 {
   Visit(*root_);
   std::string errors = err_.str();
-  if (!errors.empty())
-  {
+  if (!errors.empty()) {
     out_ << errors;
     return false;
   }

--- a/src/ast/passes/config_analyser.h
+++ b/src/ast/passes/config_analyser.h
@@ -15,8 +15,7 @@
 namespace bpftrace {
 namespace ast {
 
-class ConfigAnalyser : public Visitor
-{
+class ConfigAnalyser : public Visitor {
 public:
   explicit ConfigAnalyser(Node *root,
                           BPFtrace &bpftrace,

--- a/src/ast/passes/field_analyser.h
+++ b/src/ast/passes/field_analyser.h
@@ -14,8 +14,7 @@ namespace libbpf {
 namespace bpftrace {
 namespace ast {
 
-class FieldAnalyser : public Visitor
-{
+class FieldAnalyser : public Visitor {
 public:
   explicit FieldAnalyser(Node *root,
                          BPFtrace &bpftrace,
@@ -24,7 +23,8 @@ public:
         bpftrace_(bpftrace),
         prog_type_(libbpf::BPF_PROG_TYPE_UNSPEC),
         out_(out)
-  { }
+  {
+  }
 
   void visit(Identifier &identifier) override;
   void visit(Builtin &builtin) override;
@@ -50,13 +50,13 @@ private:
   ProbeType probe_type_;
   std::string attach_func_;
   SizedType sized_type_;
-  BPFtrace      &bpftrace_;
+  BPFtrace &bpftrace_;
   libbpf::bpf_prog_type prog_type_;
-  bool           has_builtin_args_;
-  Probe         *probe_;
+  bool has_builtin_args_;
+  Probe *probe_;
 
-  std::ostream       &out_;
-  std::ostringstream  err_;
+  std::ostream &out_;
+  std::ostringstream err_;
 
   std::map<std::string, SizedType> var_types_;
 };

--- a/src/ast/passes/node_counter.h
+++ b/src/ast/passes/node_counter.h
@@ -9,8 +9,7 @@
 namespace bpftrace {
 namespace ast {
 
-class NodeCounter : public Visitor
-{
+class NodeCounter : public Visitor {
 public:
   void Visit(Node &node) override
   {
@@ -34,12 +33,10 @@ inline Pass CreateCounterPass()
     c.Visit(n);
     auto node_count = c.get_count();
     auto max = ctx.b.max_ast_nodes_;
-    if (bt_verbose)
-    {
+    if (bt_verbose) {
       LOG(INFO) << "node count: " << node_count;
     }
-    if (node_count >= max)
-    {
+    if (node_count >= max) {
       LOG(ERROR) << "node count (" << node_count << ") exceeds the limit ("
                  << max << ")";
       return PassResult::Error("NodeCounter", "node count exceeded");

--- a/src/ast/passes/portability_analyser.cpp
+++ b/src/ast/passes/portability_analyser.cpp
@@ -18,8 +18,7 @@ int PortabilityAnalyser::analyse()
   Visit(*root_);
 
   std::string errors = err_.str();
-  if (!errors.empty())
-  {
+  if (!errors.empty()) {
     out_ << errors;
     return 1;
   }
@@ -47,8 +46,7 @@ void PortabilityAnalyser::visit(Builtin &builtin)
   // `struct task_struct` is unstable across kernel versions and configurations.
   // This makes it inherently unportable. We must block it until we support
   // field access relocations.
-  if (builtin.ident == "curtask")
-  {
+  if (builtin.ident == "curtask") {
     LOG(ERROR, builtin.loc, err_)
         << "AOT does not yet support accessing `curtask`";
   }
@@ -56,8 +54,7 @@ void PortabilityAnalyser::visit(Builtin &builtin)
 
 void PortabilityAnalyser::visit(Call &call)
 {
-  if (call.vargs)
-  {
+  if (call.vargs) {
     for (Expression *expr : *call.vargs)
       Visit(*expr);
   }
@@ -71,8 +68,7 @@ void PortabilityAnalyser::visit(Call &call)
   // resolved during codegen and the value embedded into the bytecode.  For AOT
   // to support cgroupid(), the cgroupid must be resolved at runtime and fixed
   // up during load time.
-  if (call.func == "kaddr" || call.func == "uaddr" || call.func == "cgroupid")
-  {
+  if (call.func == "kaddr" || call.func == "uaddr" || call.func == "cgroupid") {
     LOG(ERROR, call.loc, err_)
         << "AOT does not yet support " << call.func << "()";
   }
@@ -99,8 +95,7 @@ void PortabilityAnalyser::visit(AttachPoint &ap)
   // and offsets and type information is embedded into the bytecode. For AOT
   // support, this analyzing must be done during runtime and fixed up during
   // load time.
-  if (type == ProbeType::usdt)
-  {
+  if (type == ProbeType::usdt) {
     LOG(ERROR, ap.loc, err_) << "AOT does not yet support USDT probes";
   }
   // While userspace watchpoint probes are technically portable from codegen
@@ -109,8 +104,8 @@ void PortabilityAnalyser::visit(AttachPoint &ap)
   // (see https://github.com/iovisor/bpftrace/issues/1683).
   //
   // So disable for now and re-evalulate at another point.
-  else if (type == ProbeType::watchpoint || type == ProbeType::asyncwatchpoint)
-  {
+  else if (type == ProbeType::watchpoint ||
+           type == ProbeType::asyncwatchpoint) {
     LOG(ERROR, ap.loc, err_) << "AOT does not yet support watchpoint probes";
   }
 }
@@ -119,8 +114,7 @@ Pass CreatePortabilityPass()
 {
   auto fn = [](Node &n, PassContext &__attribute__((unused))) {
     PortabilityAnalyser analyser{ &n };
-    if (analyser.analyse())
-    {
+    if (analyser.analyse()) {
       // Used by runtime test framework to know when to skip an AOT test
       if (std::getenv("__BPFTRACE_NOTIFY_AOT_PORTABILITY_DISABLED"))
         std::cout << "__BPFTRACE_NOTIFY_AOT_PORTABILITY_DISABLED" << std::endl;

--- a/src/ast/passes/portability_analyser.h
+++ b/src/ast/passes/portability_analyser.h
@@ -14,8 +14,7 @@ namespace ast {
 //
 // Over time, we expect to relax these restrictions as AOT supports more
 // features.
-class PortabilityAnalyser : public Visitor
-{
+class PortabilityAnalyser : public Visitor {
 public:
   PortabilityAnalyser(Node *root, std::ostream &out = std::cerr);
   int analyse();

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -19,8 +19,7 @@ void Printer::print(Node *root)
 std::string Printer::type(const SizedType &ty)
 {
   std::stringstream buf;
-  if (print_types)
-  {
+  if (print_types) {
     buf << " :: type[" << ty << ", ctx: " << ty.IsCtxAccess();
     if (ty.GetAS() != AddrSpace::none)
       buf << ", AS(" << ty.GetAS() << ")";
@@ -56,21 +55,17 @@ void Printer::visit(String &string)
   std::string indent(depth_, ' ');
   std::stringstream ss;
 
-  for (char c: string.str)
-  {
+  for (char c : string.str) {
     // the argument of isprint() must be an unsigned char or EOF
     int code = static_cast<unsigned char>(c);
-    if (std::isprint(code))
-    {
+    if (std::isprint(code)) {
       if (c == '\\')
         ss << "\\\\";
       else if (c == '"')
         ss << "\\\"";
       else
         ss << c;
-    }
-    else
-    {
+    } else {
       if (c == '\n')
         ss << "\\n";
       else if (c == '\t')
@@ -78,8 +73,7 @@ void Printer::visit(String &string)
       else if (c == '\r')
         ss << "\\r";
       else
-        ss << "\\x" << std::setfill('0') << std::setw(2)
-           << std::hex << code;
+        ss << "\\x" << std::setfill('0') << std::setw(2) << std::hex << code;
     }
   }
 
@@ -175,15 +169,12 @@ void Printer::visit(Binop &binop)
 
 void Printer::visit(Unop &unop)
 {
-  if (unop.is_post_op)
-  {
+  if (unop.is_post_op) {
     std::string indent(depth_ + 1, ' ');
 
     unop.expr->accept(*this);
     out_ << indent << opstr(unop) << std::endl;
-  }
-  else
-  {
+  } else {
     std::string indent(depth_, ' ');
     out_ << indent << opstr(unop) << std::endl;
 
@@ -191,7 +182,6 @@ void Printer::visit(Unop &unop)
     unop.expr->accept(*this);
     --depth_;
   }
-
 }
 
 void Printer::visit(Ternary &ternary)
@@ -345,8 +335,7 @@ void Printer::visit(While &while_block)
   ++depth_;
   out_ << indent << " )" << std::endl;
 
-  for (Statement *stmt : *while_block.stmts)
-  {
+  for (Statement *stmt : *while_block.stmts) {
     stmt->accept(*this);
   }
 }
@@ -358,8 +347,7 @@ void Printer::visit(Config &config)
   out_ << indent << "config" << std::endl;
 
   ++depth_;
-  for (Statement *stmt : *config.stmts)
-  {
+  for (Statement *stmt : *config.stmts) {
     stmt->accept(*this);
   }
   --depth_;
@@ -411,8 +399,7 @@ void Printer::visit(Program &program)
   std::string indent(depth_, ' ');
   out_ << indent << "Program" << std::endl;
 
-  if (program.config)
-  {
+  if (program.config) {
     ++depth_;
     program.config->accept(*this);
     --depth_;

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -7,8 +7,7 @@
 namespace bpftrace {
 namespace ast {
 
-class Printer : public Visitor
-{
+class Printer : public Visitor {
 public:
   explicit Printer(std::ostream &out, bool print_types = false)
       : out_(out), print_types(print_types)

--- a/src/ast/passes/resource_analyser.h
+++ b/src/ast/passes/resource_analyser.h
@@ -19,8 +19,7 @@ namespace ast {
 // TODO(danobi): Note that while complete resource collection in this pass is
 // the goal, there are still places where the goal is not yet realized. For
 // example the helper error metadata is still being collected during codegen.
-class ResourceAnalyser : public Visitor
-{
+class ResourceAnalyser : public Visitor {
 public:
   ResourceAnalyser(Node *root, std::ostream &out = std::cerr);
 

--- a/src/ast/passes/semantic_analyser.h
+++ b/src/ast/passes/semantic_analyser.h
@@ -15,8 +15,7 @@
 namespace bpftrace {
 namespace ast {
 
-class SemanticAnalyser : public Visitor
-{
+class SemanticAnalyser : public Visitor {
 public:
   explicit SemanticAnalyser(Node *root,
                             BPFtrace &bpftrace,
@@ -89,7 +88,10 @@ private:
 
   bool is_final_pass() const;
 
-  bool check_assignment(const Call &call, bool want_map, bool want_var, bool want_map_key);
+  bool check_assignment(const Call &call,
+                        bool want_map,
+                        bool want_var,
+                        bool want_map_key);
   bool check_nargs(const Call &call, size_t expected_nargs);
   bool check_varargs(const Call &call, size_t min_nargs, size_t max_nargs);
   bool check_arg(const Call &call,

--- a/src/ast/signal.cpp
+++ b/src/ast/signal.cpp
@@ -20,8 +20,7 @@ static std::map<std::string, int> signals = {
 
 int signal_name_to_num(const std::string &signal)
 {
-  if (signal.empty())
-  {
+  if (signal.empty()) {
     return -1;
   }
 
@@ -29,8 +28,7 @@ int signal_name_to_num(const std::string &signal)
 
   std::for_each(sig.begin(), sig.end(), [](char &c) { c = ::toupper(c); });
 
-  if (sig[0] != 'S')
-  {
+  if (sig[0] != 'S') {
     sig.insert(0, "SIG");
   }
 

--- a/src/ast/visitors.cpp
+++ b/src/ast/visitors.cpp
@@ -31,10 +31,8 @@ void Visitor::visit(Identifier &identifier __attribute__((__unused__)))
 
 void Visitor::visit(Call &call)
 {
-  if (call.vargs)
-  {
-    for (Expression *expr : *call.vargs)
-    {
+  if (call.vargs) {
+    for (Expression *expr : *call.vargs) {
       Visit(*expr);
     }
   }
@@ -54,10 +52,8 @@ void Visitor::visit(Offsetof &ofof)
 
 void Visitor::visit(Map &map)
 {
-  if (map.vargs)
-  {
-    for (Expression *expr : *map.vargs)
-    {
+  if (map.vargs) {
+    for (Expression *expr : *map.vargs) {
       Visit(*expr);
     }
   }
@@ -133,15 +129,12 @@ void Visitor::visit(If &if_block)
 {
   Visit(*if_block.cond);
 
-  for (Statement *stmt : *if_block.stmts)
-  {
+  for (Statement *stmt : *if_block.stmts) {
     Visit(*stmt);
   }
 
-  if (if_block.else_stmts)
-  {
-    for (Statement *stmt : *if_block.else_stmts)
-    {
+  if (if_block.else_stmts) {
+    for (Statement *stmt : *if_block.else_stmts) {
       Visit(*stmt);
     }
   }
@@ -150,8 +143,7 @@ void Visitor::visit(If &if_block)
 void Visitor::visit(Unroll &unroll)
 {
   Visit(*unroll.expr);
-  for (Statement *stmt : *unroll.stmts)
-  {
+  for (Statement *stmt : *unroll.stmts) {
     Visit(*stmt);
   }
 }
@@ -160,8 +152,7 @@ void Visitor::visit(While &while_block)
 {
   Visit(*while_block.cond);
 
-  for (Statement *stmt : *while_block.stmts)
-  {
+  for (Statement *stmt : *while_block.stmts) {
     Visit(*stmt);
   }
 }
@@ -181,25 +172,21 @@ void Visitor::visit(AttachPoint &ap __attribute__((__unused__)))
 
 void Visitor::visit(Probe &probe)
 {
-  for (AttachPoint *ap : *probe.attach_points)
-  {
+  for (AttachPoint *ap : *probe.attach_points) {
     Visit(*ap);
   }
 
-  if (probe.pred)
-  {
+  if (probe.pred) {
     Visit(*probe.pred);
   }
-  for (Statement *stmt : *probe.stmts)
-  {
+  for (Statement *stmt : *probe.stmts) {
     Visit(*stmt);
   }
 }
 
 void Visitor::visit(Config &config)
 {
-  for (Statement *stmt : *config.stmts)
-  {
+  for (Statement *stmt : *config.stmts) {
     Visit(*stmt);
   }
 }
@@ -279,8 +266,7 @@ Node *Mutator::visit(Offsetof &ofof)
 Node *Mutator::visit(Map &map)
 {
   auto m = map.leafcopy();
-  if (map.vargs)
-  {
+  if (map.vargs) {
     m->vargs = mutateExprList(map.vargs);
 
     for (auto expr : *m->vargs)

--- a/src/ast/visitors.h
+++ b/src/ast/visitors.h
@@ -11,8 +11,7 @@ namespace ast {
 /**
    Base visitor for double dispatch based visitation
 */
-class VisitorBase
-{
+class VisitorBase {
 public:
   virtual ~VisitorBase() = default;
   virtual void visit(Integer &integer) = 0;
@@ -56,8 +55,7 @@ public:
 
    The individual visit() methods run on specific node types.
 */
-class Visitor : public VisitorBase
-{
+class Visitor : public VisitorBase {
 public:
   explicit Visitor() = default;
   ~Visitor() = default;
@@ -120,8 +118,7 @@ public:
    \tparam R return type for visitors
 */
 template <typename R>
-class Dispatcher
-{
+class Dispatcher {
 private:
   using tabletype = VTable<R, Node, Dispatcher>;
   using mytype = Dispatcher;
@@ -242,8 +239,7 @@ private:
 
 */
 
-class Mutator : public Dispatcher<Node *>
-{
+class Mutator : public Dispatcher<Node *> {
 public:
   Mutator(){};
 

--- a/src/ast/vtable.h
+++ b/src/ast/vtable.h
@@ -47,8 +47,7 @@ class Node;
   \tparam V visitor type
 */
 template <typename R, typename D, typename V>
-class VTable
-{
+class VTable {
 private:
   typedef R (*FuncPtr)(D &, V *);
   std::unordered_map<std::type_index, FuncPtr> vtable_;

--- a/src/attached_probe.h
+++ b/src/attached_probe.h
@@ -18,8 +18,7 @@ bpf_probe_attach_type attachtype(ProbeType t);
 libbpf::bpf_prog_type progtype(ProbeType t);
 std::string progtypeName(libbpf::bpf_prog_type t);
 
-class AttachedProbe
-{
+class AttachedProbe {
 public:
   AttachedProbe(Probe &probe,
                 BpfProgram &&prog,
@@ -94,8 +93,7 @@ private:
   BTF &btf_;
 };
 
-class HelperVerifierError : public std::runtime_error
-{
+class HelperVerifierError : public std::runtime_error {
 public:
   const libbpf::bpf_func_id func_id_;
   const std::string helper_name_;

--- a/src/bfd-disasm.cpp
+++ b/src/bfd-disasm.cpp
@@ -33,7 +33,9 @@ BfdDisasm::~BfdDisasm()
     close(fd_);
 }
 
-static int fprintf_nop(void *out __attribute__((unused)), const char *fmt __attribute__((unused)), ...)
+static int fprintf_nop(void *out __attribute__((unused)),
+                       const char *fmt __attribute__((unused)),
+                       ...)
 {
   return 0;
 }
@@ -59,8 +61,7 @@ static AlignState is_aligned_buf(void *buf, uint64_t size, uint64_t offset)
   if (bfdf == nullptr)
     return AlignState::Fail;
 
-  if (!bfd_check_format(bfdf, bfd_object))
-  {
+  if (!bfd_check_format(bfdf, bfd_object)) {
     bfd_close(bfdf);
     return AlignState::Fail;
   }
@@ -73,16 +74,13 @@ static AlignState is_aligned_buf(void *buf, uint64_t size, uint64_t offset)
 
   info.arch = bfd_get_arch(bfdf);
   info.mach = bfd_get_mach(bfdf);
-  info.buffer = static_cast<bfd_byte*>(buf);
+  info.buffer = static_cast<bfd_byte *>(buf);
   info.buffer_length = size;
 
   disassemble_init_for_target(&info);
 
 #ifdef LIBBFD_DISASM_FOUR_ARGS_SIGNATURE
-  disassemble = disassembler(info.arch,
-           bfd_big_endian(bfdf),
-           info.mach,
-           bfdf);
+  disassemble = disassembler(info.arch, bfd_big_endian(bfdf), info.mach, bfdf);
 #else
   disassemble = disassembler(bfdf);
 #endif
@@ -94,8 +92,7 @@ static AlignState is_aligned_buf(void *buf, uint64_t size, uint64_t offset)
     count = disassemble(pc, &info);
     pc += static_cast<uint64_t>(count);
 
-    if (pc == offset)
-    {
+    if (pc == offset) {
       bfd_close(bfdf);
       return AlignState::Ok;
     }

--- a/src/bfd-disasm.h
+++ b/src/bfd-disasm.h
@@ -4,8 +4,7 @@
 
 namespace bpftrace {
 
-class BfdDisasm : public IDisasm
-{
+class BfdDisasm : public IDisasm {
 public:
   BfdDisasm(std::string &path);
   ~BfdDisasm();

--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -19,8 +19,7 @@ bool BpfBytecode::hasSection(const std::string &name) const
 const std::vector<uint8_t> &BpfBytecode::getSection(
     const std::string &name) const
 {
-  if (!hasSection(name))
-  {
+  if (!hasSection(name)) {
     throw std::runtime_error("Bytecode is missing section " + name);
   }
   return sections_.at(name);
@@ -34,8 +33,7 @@ static int btf_type_size(const struct btf_type *t)
   const int base_size = sizeof(struct btf_type);
   __u16 vlen = btf_vlen(t);
 
-  switch (btf_kind(t))
-  {
+  switch (btf_kind(t)) {
     case BTF_KIND_FWD:
     case BTF_KIND_CONST:
     case BTF_KIND_VOLATILE:
@@ -96,15 +94,13 @@ void BpfBytecode::fixupBTF(BPFfeature &feature)
   // Unfortunately, libbpf's btf__type_by_id returns a const pointer which
   // doesn't allow modification. So, we must iterate the types manually.
   auto *ptr = types_start;
-  while (ptr + sizeof(struct btf_type) <= types_end)
-  {
+  while (ptr + sizeof(struct btf_type) <= types_end) {
     auto *btf_type = reinterpret_cast<struct btf_type *>(ptr);
     ptr += btf_type_size(btf_type);
 
     // Change linkage type to 0 if the kernel doesn't support BTF_FUNC_GLOBAL.
     if (!feature.has_btf_func_global() &&
-        BTF_INFO_KIND(btf_type->info) == BTF_KIND_FUNC)
-    {
+        BTF_INFO_KIND(btf_type->info) == BTF_KIND_FUNC) {
       btf_type->info = BTF_INFO_ENC(BTF_KIND_FUNC, 0, 0);
     }
   }

--- a/src/bpfbytecode.h
+++ b/src/bpfbytecode.h
@@ -11,8 +11,7 @@ namespace bpftrace {
 
 using SectionMap = std::unordered_map<std::string, std::vector<uint8_t>>;
 
-class BpfBytecode
-{
+class BpfBytecode {
 public:
   BpfBytecode()
   {

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -24,18 +24,12 @@ namespace bpftrace {
 
 int BPFnofeature::parse(const char* str)
 {
-  for (auto feat : split_string(str, ','))
-  {
-    if (feat == "kprobe_multi")
-    {
+  for (auto feat : split_string(str, ',')) {
+    if (feat == "kprobe_multi") {
       kprobe_multi_ = true;
-    }
-    else if (feat == "uprobe_multi")
-    {
+    } else if (feat == "uprobe_multi") {
       uprobe_multi_ = true;
-    }
-    else
-    {
+    } else {
       return -1;
     }
   }
@@ -53,11 +47,9 @@ static bool try_load_(const char* name,
                       size_t logbuf_size,
                       int* outfd = nullptr)
 {
-  for (int attempt = 0; attempt < 3; attempt++)
-  {
+  for (int attempt = 0; attempt < 3; attempt++) {
     auto version = kernel_version(attempt);
-    if (version == 0 && attempt > 0)
-    {
+    if (version == 0 && attempt > 0) {
       // Recent kernels don't check the version so we should try to call
       // bpf_prog_load during first iteration even if we failed to determine
       // the version. We should not do that in subsequent iterations to avoid
@@ -70,8 +62,7 @@ static bool try_load_(const char* name,
     opts.log_size = logbuf_size;
     opts.log_level = loglevel;
     opts.kern_version = version;
-    if (attach_type.has_value())
-    {
+    if (attach_type.has_value()) {
       opts.expected_attach_type = static_cast<::bpf_attach_type>(
           attach_type.value());
     }
@@ -84,8 +75,7 @@ static bool try_load_(const char* name,
                             insns,
                             insns_cnt,
                             &opts);
-    if (ret >= 0)
-    {
+    if (ret >= 0) {
       if (outfd)
         *outfd = ret;
       else
@@ -109,16 +99,14 @@ bool BPFfeature::try_load(enum libbpf::bpf_prog_type prog_type,
   char logbuf[log_size] = {};
 
   std::optional<unsigned> btf_id;
-  if (prog_type == libbpf::BPF_PROG_TYPE_TRACING && has_btf())
-  {
+  if (prog_type == libbpf::BPF_PROG_TYPE_TRACING && has_btf()) {
     auto id_fd = btf_.get_btf_id_fd(name, "vmlinux");
     btf_id = id_fd.first;
     if (id_fd.second >= 0)
       close(id_fd.second);
   }
 
-  if (prog_type == libbpf::BPF_PROG_TYPE_TRACING)
-  {
+  if (prog_type == libbpf::BPF_PROG_TYPE_TRACING) {
     // List of available functions must be readable
     std::ifstream traceable_funcs(tracefs::available_filter_functions());
     if (!traceable_funcs.good())
@@ -148,8 +136,7 @@ bool BPFfeature::try_load_btf(const void* btf_data, size_t btf_size)
               .log_size = log_size, );
 
   int fd = bpf_btf_load(btf_data, btf_size, &btf_opts);
-  if (fd >= 0)
-  {
+  if (fd >= 0) {
     close(fd);
     return true;
   }
@@ -214,8 +201,7 @@ bool BPFfeature::detect_map(enum libbpf::bpf_map_type map_type)
   int flags = 0;
   int map_fd = 0;
 
-  switch (map_type)
-  {
+  switch (map_type) {
     case libbpf::BPF_MAP_TYPE_STACK_TRACE:
       value_size = 8;
       break;
@@ -319,16 +305,14 @@ int BPFfeature::instruction_limit(void)
   // processed 2 insns (limit 131072), stack depth 0
   std::string log(logbuf, logsize);
   std::size_t line_start = log.find("processed 2 insns");
-  if (line_start == std::string::npos)
-  {
+  if (line_start == std::string::npos) {
     insns_limit_ = std::make_optional<int>(-1);
     return *insns_limit_;
   }
 
   // Old kernels don't have the instruction limit in the verifier output
   auto begin = log.find("limit", line_start);
-  if (begin == std::string::npos)
-  {
+  if (begin == std::string::npos) {
     insns_limit_ = std::make_optional<int>(-1);
     return *insns_limit_;
   }
@@ -419,8 +403,7 @@ bool BPFfeature::has_kprobe_multi()
   if (has_kprobe_multi_.has_value())
     return *has_kprobe_multi_;
 
-  if (no_feature_.kprobe_multi_)
-  {
+  if (no_feature_.kprobe_multi_) {
     has_kprobe_multi_ = false;
     return *has_kprobe_multi_;
   }
@@ -449,8 +432,7 @@ bool BPFfeature::has_kprobe_multi()
                          ARRAY_SIZE(insns),
                          &load_opts);
 
-  if (progfd >= 0)
-  {
+  if (progfd >= 0) {
     linkfd = bpf_link_create(progfd,
                              0,
                              static_cast<enum ::bpf_attach_type>(
@@ -460,12 +442,10 @@ bool BPFfeature::has_kprobe_multi()
 
   has_kprobe_multi_ = linkfd >= 0;
 
-  if (linkfd >= 0)
-  {
+  if (linkfd >= 0) {
     close(linkfd);
   }
-  if (progfd >= 0)
-  {
+  if (progfd >= 0) {
     close(progfd);
   }
   return *has_kprobe_multi_;
@@ -477,8 +457,7 @@ bool BPFfeature::has_uprobe_multi()
     return *has_uprobe_multi_;
 
 #if defined(HAVE_LIBBPF_UPROBE_MULTI)
-  if (no_feature_.uprobe_multi_)
-  {
+  if (no_feature_.uprobe_multi_) {
     has_uprobe_multi_ = false;
     return *has_uprobe_multi_;
   }
@@ -503,8 +482,7 @@ bool BPFfeature::has_uprobe_multi()
                          ARRAY_SIZE(insns),
                          &load_opts);
 
-  if (progfd >= 0)
-  {
+  if (progfd >= 0) {
     LIBBPF_OPTS(bpf_link_create_opts, link_opts);
     const unsigned long offset = 0;
 
@@ -522,12 +500,10 @@ bool BPFfeature::has_uprobe_multi()
 
   has_uprobe_multi_ = linkfd < 0 && err == -EBADF;
 
-  if (linkfd >= 0)
-  {
+  if (linkfd >= 0) {
     close(linkfd);
   }
-  if (progfd >= 0)
-  {
+  if (progfd >= 0) {
     close(progfd);
   }
 #else
@@ -599,14 +575,12 @@ bool BPFfeature::has_raw_tp_special()
                ARRAY_SIZE(insns),
                nullptr,
                std::nullopt,
-               &fd))
-  {
+               &fd)) {
     struct bpf_test_run_opts opts = {};
     opts.sz = sizeof(opts);
     has_raw_tp_special_ = !::bpf_prog_test_run_opts(fd, &opts);
     close(fd);
-  }
-  else
+  } else
     has_raw_tp_special_ = false;
 
   return *has_raw_tp_special_;
@@ -615,10 +589,7 @@ bool BPFfeature::has_raw_tp_special()
 std::string BPFfeature::report(void)
 {
   std::stringstream buf;
-  auto to_str = [](bool f) -> auto
-  {
-    return f ? "yes\n" : "no\n";
-  };
+  auto to_str = [](bool f) -> auto { return f ? "yes\n" : "no\n"; };
 
   buf << "Kernel helpers" << std::endl
       << "  probe_read: " << to_str(has_helper_probe_read())
@@ -674,8 +645,7 @@ std::string BPFfeature::report(void)
 
 bool BPFfeature::has_prog_kfunc()
 {
-  if (!has_prog_kfunc_.has_value())
-  {
+  if (!has_prog_kfunc_.has_value()) {
     int progfd;
     if (!detect_prog_type(libbpf::BPF_PROG_TYPE_TRACING,
                           "sched_fork",

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -56,8 +56,7 @@ public:                                                                        \
 
 class BPFfeature;
 
-class BPFnofeature
-{
+class BPFnofeature {
 public:
   BPFnofeature() : kprobe_multi_(false), uprobe_multi_(false)
   {
@@ -70,8 +69,7 @@ protected:
   friend class BPFfeature;
 };
 
-class BPFfeature
-{
+class BPFfeature {
 public:
   BPFfeature(BPFnofeature& no_feature) : no_feature_(no_feature)
   {

--- a/src/bpfprogram.h
+++ b/src/bpfprogram.h
@@ -13,8 +13,7 @@ namespace bpftrace {
 
 class BPFtrace;
 
-class BpfProgram
-{
+class BpfProgram {
 public:
   static std::optional<BpfProgram> CreateFromBytecode(
       const BpfBytecode &bytecode,

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -37,8 +37,7 @@ namespace bpftrace {
 
 const int timeout_ms = 100;
 
-struct symbol
-{
+struct symbol {
   std::string name;
   uint64_t start;
   uint64_t size;
@@ -53,17 +52,11 @@ extern bool bt_quiet;
 extern bool bt_verbose;
 extern bool bt_verbose2;
 
-enum class DebugLevel
-{
-  kNone,
-  kDebug,
-  kFullDebug
-};
+enum class DebugLevel { kNone, kDebug, kFullDebug };
 
 inline DebugLevel operator++(DebugLevel &level, int)
 {
-  switch (level)
-  {
+  switch (level) {
     case DebugLevel::kNone:
       level = DebugLevel::kDebug;
       break;
@@ -80,10 +73,11 @@ inline DebugLevel operator++(DebugLevel &level, int)
   return level;
 }
 
-class WildcardException : public std::exception
-{
+class WildcardException : public std::exception {
 public:
-  WildcardException(const std::string &msg) : msg_(msg) {}
+  WildcardException(const std::string &msg) : msg_(msg)
+  {
+  }
 
   const char *what() const noexcept override
   {
@@ -94,8 +88,7 @@ private:
   std::string msg_;
 };
 
-class BPFtrace
-{
+class BPFtrace {
 public:
   BPFtrace(std::unique_ptr<Output> o = std::make_unique<TextOutput>(std::cout),
            BPFnofeature no_feature = BPFnofeature(),
@@ -148,10 +141,13 @@ public:
   std::string resolve_mac_address(const uint8_t *mac_addr) const;
   std::string resolve_cgroup_path(uint64_t cgroup_path_id,
                                   uint64_t cgroup_id) const;
-  virtual std::string extract_func_symbols_from_path(const std::string &path) const;
+  virtual std::string extract_func_symbols_from_path(
+      const std::string &path) const;
   std::string resolve_probe(uint64_t probe_id) const;
   uint64_t resolve_cgroupid(const std::string &path) const;
-  std::vector<std::unique_ptr<IPrintable>> get_arg_values(const std::vector<Field> &args, uint8_t* arg_data);
+  std::vector<std::unique_ptr<IPrintable>> get_arg_values(
+      const std::vector<Field> &args,
+      uint8_t *arg_data);
   void add_param(const std::string &param);
   std::string get_param(size_t index, bool is_str) const;
   size_t num_params() const;
@@ -230,7 +226,7 @@ private:
   int run_special_probe(std::string name,
                         const BpfBytecode &bytecode,
                         void (*trigger)(void));
-  void* ksyms_{nullptr};
+  void *ksyms_{ nullptr };
   // note: exe_sym_ is used when layout is same for all instances of program
   std::map<std::string, std::pair<int, void *>> exe_sym_; // exe -> (pid, cache)
   std::map<int, void *> pid_sym_;                         // pid -> cache

--- a/src/btf.h
+++ b/src/btf.h
@@ -29,18 +29,15 @@ namespace bpftrace {
 
 class BPFtrace;
 
-class BTF
-{
-  enum state
-  {
+class BTF {
+  enum state {
     NODATA,
     OK,
   };
 
   // BTF object for vmlinux or a kernel module.
   // We're currently storing its name and BTF id.
-  struct BTFObj
-  {
+  struct BTFObj {
     struct btf* btf;
     __u32 id;
     std::string name;
@@ -48,8 +45,7 @@ class BTF
 
   // It is often necessary to store a BTF id along with the BTF data containing
   // its definition.
-  struct BTFId
-  {
+  struct BTFId {
     struct btf* btf;
     __u32 id;
   };

--- a/src/build_info.h
+++ b/src/build_info.h
@@ -4,8 +4,7 @@
 
 namespace bpftrace {
 
-class BuildInfo
-{
+class BuildInfo {
 public:
   static std::string report();
 };

--- a/src/child.h
+++ b/src/child.h
@@ -7,14 +7,12 @@
 
 namespace bpftrace {
 
-struct child_args
-{
+struct child_args {
   std::vector<std::string> cmd;
   int event_fd;
 };
 
-class ChildProcBase
-{
+class ChildProcBase {
 public:
   /**
      Parse command and fork a child process.
@@ -89,8 +87,7 @@ protected:
   int term_signal_ = -1;
 };
 
-class ChildProc : public ChildProcBase
-{
+class ChildProc : public ChildProcBase {
 public:
   /**
     Parse command and fork a child process. The child is run with the same
@@ -118,8 +115,7 @@ public:
   void resume(void) override;
 
 private:
-  enum class State
-  {
+  enum class State {
     INIT,
     FORKED,
     RUNNING,

--- a/src/clang_parser.h
+++ b/src/clang_parser.h
@@ -13,8 +13,7 @@ namespace ast {
 class Program;
 }
 
-class ClangParser
-{
+class ClangParser {
 public:
   bool parse(ast::Program *program,
              BPFtrace &bpftrace,
@@ -66,8 +65,7 @@ private:
   std::vector<CXUnsavedFile> input_files;
   std::string btf_cdef;
 
-  class ClangParserHandler
-  {
+  class ClangParserHandler {
   public:
     ClangParserHandler();
 

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -35,8 +35,7 @@ Config::Config(bool has_cmd, bool bt_verbose) : bt_verbose_(bt_verbose)
 bool Config::can_set(ConfigSource prevSource, ConfigSource source)
 {
   if (prevSource == ConfigSource::default_ ||
-      (prevSource == ConfigSource::script && source == ConfigSource::env_var))
-  {
+      (prevSource == ConfigSource::script && source == ConfigSource::env_var)) {
     return true;
   }
   return false;
@@ -49,8 +48,7 @@ bool Config::is_aslr_enabled()
 
   {
     std::ifstream file(randomize_va_space_file);
-    if (file.fail())
-    {
+    if (file.fail()) {
       if (bt_verbose_)
         LOG(ERROR) << std::strerror(errno) << ": " << randomize_va_space_file;
       // conservatively return true
@@ -68,8 +66,7 @@ bool Config::is_aslr_enabled()
 std::map<std::string, StackMode> get_stack_mode_map()
 {
   std::map<std::string, StackMode> result;
-  for (auto &mode : STACK_MODE_NAME_MAP)
-  {
+  for (auto &mode : STACK_MODE_NAME_MAP) {
     result.emplace(mode.second, mode.first);
   }
   return result;
@@ -79,8 +76,7 @@ std::optional<StackMode> Config::get_stack_mode(const std::string &s)
 {
   static auto stack_mode_map = get_stack_mode_map();
   auto found = stack_mode_map.find(s);
-  if (found != stack_mode_map.end())
-  {
+  if (found != stack_mode_map.end()) {
     return std::make_optional(found->second);
   }
   return std::nullopt;
@@ -96,20 +92,17 @@ std::optional<ConfigKey> Config::get_config_key(const std::string &str,
                  maybe_key.begin(),
                  [](unsigned char c) { return std::tolower(c); });
 
-  if (maybe_key.rfind(prefix, 0) == 0)
-  {
+  if (maybe_key.rfind(prefix, 0) == 0) {
     maybe_key = maybe_key.substr(prefix.length());
   }
-  if (ENV_ONLY.find(maybe_key) != ENV_ONLY.end())
-  {
+  if (ENV_ONLY.find(maybe_key) != ENV_ONLY.end()) {
     err = maybe_key + " can only be set as an environment variable";
     return std::nullopt;
   }
 
   auto found = CONFIG_KEY_MAP.find(maybe_key);
 
-  if (found == CONFIG_KEY_MAP.end())
-  {
+  if (found == CONFIG_KEY_MAP.end()) {
     err = "Unrecognized config variable: " + str;
     return std::nullopt;
   }
@@ -133,25 +126,16 @@ bool ConfigSetter::set_stack_mode(const std::string &s)
 bool ConfigSetter::set_user_symbol_cache_type(const std::string &s)
 {
   UserSymbolCacheType usct;
-  if (s == "PER_PID")
-  {
+  if (s == "PER_PID") {
     usct = UserSymbolCacheType::per_pid;
-  }
-  else if (s == "PER_PROGRAM")
-  {
+  } else if (s == "PER_PROGRAM") {
     usct = UserSymbolCacheType::per_program;
-  }
-  else if (s == "1")
-  {
+  } else if (s == "1") {
     // use the default
     return true;
-  }
-  else if (s == "NONE" || s == "0")
-  {
+  } else if (s == "NONE" || s == "0") {
     usct = UserSymbolCacheType::none;
-  }
-  else
-  {
+  } else {
     LOG(ERROR) << "Invalid value for cache_user_symbols: valid values are "
                   "PER_PID, PER_PROGRAM, and NONE.";
     return false;

--- a/src/config.h
+++ b/src/config.h
@@ -13,8 +13,7 @@ namespace bpftrace {
 
 // This is used to determine which source
 // takes precedence when a config key is set
-enum class ConfigSource
-{
+enum class ConfigSource {
   // the default config value
   default_,
   // config set via environment variable
@@ -23,14 +22,12 @@ enum class ConfigSource
   script,
 };
 
-enum class ConfigKeyBool
-{
+enum class ConfigKeyBool {
   cpp_demangle,
   lazy_symbolication,
 };
 
-enum class ConfigKeyInt
-{
+enum class ConfigKeyInt {
   log_size,
   max_bpf_progs,
   max_cat_bytes,
@@ -41,18 +38,15 @@ enum class ConfigKeyInt
   perf_rb_pages,
 };
 
-enum class ConfigKeyString
-{
+enum class ConfigKeyString {
   str_trunc_trailer,
 };
 
-enum class ConfigKeyStackMode
-{
+enum class ConfigKeyStackMode {
   default_,
 };
 
-enum class ConfigKeyUserSymbolCacheType
-{
+enum class ConfigKeyUserSymbolCacheType {
   default_,
 };
 
@@ -87,15 +81,13 @@ const std::set<std::string> ENV_ONLY = {
   "max_ast_nodes", "verify_llvm_ir", "vmlinux",
 };
 
-struct ConfigValue
-{
+struct ConfigValue {
   ConfigSource source = ConfigSource::default_;
   std::variant<bool, uint64_t, std::string, StackMode, UserSymbolCacheType>
       value;
 };
 
-class Config
-{
+class Config {
 public:
   explicit Config(bool has_cmd = false, bool bt_verbose = false);
 
@@ -135,12 +127,10 @@ private:
   bool set(ConfigKey key, T val, ConfigSource source)
   {
     auto it = config_map_.find(key);
-    if (it == config_map_.end())
-    {
+    if (it == config_map_.end()) {
       throw std::runtime_error("No default set for config key");
     }
-    if (!can_set(it->second.source, source))
-    {
+    if (!can_set(it->second.source, source)) {
       return false;
     }
 
@@ -153,16 +143,12 @@ private:
   T get(ConfigKey key) const
   {
     auto it = config_map_.find(key);
-    if (it == config_map_.end())
-    {
+    if (it == config_map_.end()) {
       throw std::runtime_error("Config key does not exist in map");
     }
-    try
-    {
+    try {
       return std::get<T>(it->second.value);
-    }
-    catch (std::bad_variant_access const &ex)
-    {
+    } catch (std::bad_variant_access const &ex) {
       // This shouldn't happen
       throw std::runtime_error("Type mismatch for config key");
     }
@@ -176,8 +162,7 @@ private:
   std::map<ConfigKey, ConfigValue> config_map_;
 };
 
-class ConfigSetter
-{
+class ConfigSetter {
 public:
   explicit ConfigSetter(Config &config, ConfigSource source)
       : config_(config), source_(source){};

--- a/src/disasm.cpp
+++ b/src/disasm.cpp
@@ -3,8 +3,7 @@
 
 namespace bpftrace {
 
-class DummyDisasm : public IDisasm
-{
+class DummyDisasm : public IDisasm {
   AlignState is_aligned(uint64_t offset __attribute__((unused)),
                         uint64_t pc __attribute__((unused))) override
   {

--- a/src/disasm.h
+++ b/src/disasm.h
@@ -5,23 +5,15 @@
 
 namespace bpftrace {
 
-enum class AlignState
-{
-  Ok,
-  Fail,
-  NotAlign,
-  NotSupp
-};
+enum class AlignState { Ok, Fail, NotAlign, NotSupp };
 
-class IDisasm
-{
+class IDisasm {
 public:
   virtual AlignState is_aligned(uint64_t offset, uint64_t pc) = 0;
   virtual ~IDisasm() = default;
 };
 
-class Disasm
-{
+class Disasm {
 public:
   Disasm(std::string &path);
 

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -7,7 +7,7 @@
 
 extern void *yy_scan_string(const char *yy_str, yyscan_t yyscanner);
 extern int yylex_init(yyscan_t *scanner);
-extern int yylex_destroy (yyscan_t yyscanner);
+extern int yylex_destroy(yyscan_t yyscanner);
 extern bpftrace::location loc;
 
 namespace bpftrace {
@@ -40,23 +40,20 @@ int Driver::parse()
   yyscan_t scanner;
   yylex_init(&scanner);
   Parser parser(*this, scanner);
-  if (debug_)
-  {
+  if (debug_) {
     parser.set_debug_level(1);
   }
   yy_scan_string(Log::get().get_source().c_str(), scanner);
   parser.parse();
   yylex_destroy(scanner);
 
-  if (!failed_)
-  {
+  if (!failed_) {
     ast::AttachPointParser ap_parser(root.get(), bpftrace_, out_, listing_);
     if (ap_parser.parse())
       failed_ = true;
   }
 
-  if (failed_)
-  {
+  if (failed_) {
     root.reset();
   }
 
@@ -84,31 +81,24 @@ void Driver::error(const std::string &m)
 std::set<std::string> Driver::list_modules() const
 {
   std::set<std::string> modules;
-  for (auto &probe : *root->probes)
-  {
-    for (auto &ap : *probe->attach_points)
-    {
+  for (auto &probe : *root->probes) {
+    for (auto &ap : *probe->attach_points) {
       auto probe_type = probetype(ap->provider);
       if (probe_type == ProbeType::kfunc || probe_type == ProbeType::kretfunc ||
           ((probe_type == ProbeType::kprobe ||
             probe_type == ProbeType::kretprobe) &&
-           !ap->target.empty()))
-      {
-        if (ap->need_expansion)
-        {
-          for (auto &match : bpftrace_.probe_matcher_->get_matches_for_ap(*ap))
-          {
+           !ap->target.empty())) {
+        if (ap->need_expansion) {
+          for (auto &match :
+               bpftrace_.probe_matcher_->get_matches_for_ap(*ap)) {
             std::string func = match;
             erase_prefix(func);
             auto match_modules = bpftrace_.get_func_modules(func);
             modules.insert(match_modules.begin(), match_modules.end());
           }
-        }
-        else
+        } else
           modules.insert(ap->target);
-      }
-      else if (probe_type == ProbeType::tracepoint)
-      {
+      } else if (probe_type == ProbeType::tracepoint) {
         // For now, we support this for a single target only since tracepoints
         // need dumping of C definitions BTF and that is not available for
         // multiple modules at once.

--- a/src/driver.h
+++ b/src/driver.h
@@ -6,12 +6,11 @@
 #include "ast/ast.h"
 #include "bpftrace.h"
 
-typedef void* yyscan_t;
+typedef void *yyscan_t;
 
 namespace bpftrace {
 
-class Driver
-{
+class Driver {
 public:
   explicit Driver(BPFtrace &bpftrace, std::ostream &o = std::cerr);
 

--- a/src/dwarf_parser.h
+++ b/src/dwarf_parser.h
@@ -17,8 +17,7 @@ namespace bpftrace {
 
 class BPFtrace;
 
-class Dwarf
-{
+class Dwarf {
 public:
   virtual ~Dwarf();
 
@@ -72,8 +71,7 @@ namespace bpftrace {
 
 class BPFtrace;
 
-class Dwarf
-{
+class Dwarf {
 public:
   static std::unique_ptr<Dwarf> GetFromBinary(BPFtrace *bpftrace
                                               __attribute__((unused)),

--- a/src/fake_map.h
+++ b/src/fake_map.h
@@ -4,8 +4,7 @@
 
 namespace bpftrace {
 
-class FakeMap : public IMap
-{
+class FakeMap : public IMap {
 public:
   FakeMap(const std::string &name,
           const SizedType &type,

--- a/src/format_string.cpp
+++ b/src/format_string.cpp
@@ -24,8 +24,7 @@ ArgumentType get_expected_argument_type(const std::string &fmt)
 {
   std::smatch match;
 
-  if (std::regex_search(fmt, match, length_modifier_re))
-  {
+  if (std::regex_search(fmt, match, length_modifier_re)) {
     if (match[2] == "p")
       return ArgumentType::POINTER;
     else if (match[2] == "c")
@@ -54,30 +53,26 @@ std::string validate_format_string(const std::string &fmt,
 
   auto num_tokens = std::distance(tokens_begin, tokens_end);
   int num_args = args.size();
-  if (num_args < num_tokens)
-  {
+  if (num_args < num_tokens) {
     message << call_func << ": Not enough arguments for format string ("
             << num_args << " supplied, " << num_tokens << " expected)"
             << std::endl;
     return message.str();
   }
-  if (num_args > num_tokens)
-  {
+  if (num_args > num_tokens) {
     message << call_func << ": Too many arguments for format string ("
             << num_args << " supplied, " << num_tokens << " expected)"
             << std::endl;
     return message.str();
   }
-  if (call_func == "debugf" && num_args > PRINTK_MAX_ARGS)
-  {
+  if (call_func == "debugf" && num_args > PRINTK_MAX_ARGS) {
     message << call_func << ": Cannot use more than " << PRINTK_MAX_ARGS
             << " conversion specifiers" << std::endl;
     return message.str();
   }
 
   auto token_iter = tokens_begin;
-  for (int i = 0; i < num_args; i++, token_iter++)
-  {
+  for (int i = 0; i < num_args; i++, token_iter++) {
     Type arg_type = args.at(i).type.type;
     if (arg_type == Type::ksym || arg_type == Type::usym ||
         arg_type == Type::probe || arg_type == Type::username ||
@@ -103,16 +98,14 @@ std::string validate_format_string(const std::string &fmt,
                                   ? bpf_trace_printk_format_types
                                   : printf_format_types;
     const auto token_type_iter = format_types.find(token);
-    if (token_type_iter == format_types.end())
-    {
+    if (token_type_iter == format_types.end()) {
       message << call_func << ": Unknown format string token: %" << token
               << std::endl;
       return message.str();
     }
     const Type &token_type = token_type_iter->second;
 
-    if (arg_type != token_type)
-    {
+    if (arg_type != token_type) {
       message << call_func << ": %" << token
               << " specifier expects a value of type " << token_type << " ("
               << arg_type << " supplied)" << std::endl;
@@ -130,15 +123,13 @@ void FormatString::split()
   auto tokens_end = std::sregex_iterator();
 
   size_t last_pos = 0;
-  for (std::regex_iterator i = tokens_begin; i != tokens_end; i++)
-  {
+  for (std::regex_iterator i = tokens_begin; i != tokens_end; i++) {
     int end = i->position() + i->length();
     parts_.push_back(fmt_.substr(last_pos, end - last_pos));
     last_pos = end;
   }
 
-  if (last_pos != fmt_.length())
-  {
+  if (last_pos != fmt_.length()) {
     parts_.push_back(fmt_.substr(last_pos));
   }
 }
@@ -146,8 +137,7 @@ void FormatString::split()
 void FormatString::format(std::ostream &out,
                           std::vector<std::unique_ptr<IPrintable>> &args)
 {
-  if (parts_.size() < 1)
-  {
+  if (parts_.size() < 1) {
     split();
 
     // figure out the argument type for each format specifier
@@ -157,27 +147,22 @@ void FormatString::format(std::ostream &out,
   }
   auto buffer = std::vector<char>(FMT_BUF_SZ);
   auto check_snprintf_ret = [](int r) {
-    if (r < 0)
-    {
+    if (r < 0) {
       LOG(FATAL) << "format() error occurred: " << std::strerror(errno);
     }
   };
 
   size_t i = 0;
-  for (; i < args.size(); i++)
-  {
-    for (int try_ = 0; try_ < 2; try_++)
-    {
+  for (; i < args.size(); i++) {
+    for (int try_ = 0; try_ < 2; try_++) {
       // find format specified in the string
       auto last_percent_sign = parts_[i].find_last_of('%');
       std::string fmt_string = last_percent_sign != std::string::npos
                                    ? parts_[i].substr(last_percent_sign)
                                    : "";
       std::string printf_fmt;
-      if (fmt_string == "%r" || fmt_string == "%rx" || fmt_string == "%rh")
-      {
-        if (fmt_string == "%rx" || fmt_string == "%rh")
-        {
+      if (fmt_string == "%r" || fmt_string == "%rx" || fmt_string == "%rh") {
+        if (fmt_string == "%rx" || fmt_string == "%rh") {
           auto printable_buffer = dynamic_cast<PrintableBuffer *>(&*args.at(i));
           // this is checked by semantic analyzer
           assert(printable_buffer);
@@ -189,9 +174,7 @@ void FormatString::format(std::ostream &out,
         printf_fmt = std::regex_replace(parts_[i],
                                         std::regex("%r[x|h]?"),
                                         "%s");
-      }
-      else
-      {
+      } else {
         printf_fmt = parts_[i];
       }
       int r = args.at(i)->print(buffer.data(),
@@ -210,8 +193,7 @@ void FormatString::format(std::ostream &out,
 
     out << buffer.data();
   }
-  if (i < parts_.size())
-  {
+  if (i < parts_.size()) {
     out << parts_[i];
   }
 }

--- a/src/format_string.h
+++ b/src/format_string.h
@@ -19,8 +19,7 @@ struct Field;
 /*
 **
 */
-class FormatString
-{
+class FormatString {
 private:
   /**
    * Split the format string on format specifiers, e.g.

--- a/src/fuzz_main.cpp
+++ b/src/fuzz_main.cpp
@@ -48,14 +48,11 @@ int main(int argc, char* argv[])
   // Read inputs
   std::stringstream buf;
   std::string line;
-  if (argc <= 1)
-  {
+  if (argc <= 1) {
     // Input from stdin (AFL's default)
     while (std::getline(std::cin, line))
       buf << line << std::endl;
-  }
-  else
-  {
+  } else {
     // Read from file
     std::string filename(argv[1]);
     std::ifstream file(filename);
@@ -168,18 +165,13 @@ int fuzz_main(const char* data, size_t sz)
   // Codegen
   ast::CodegenLLVM llvm(driver.root.get(), bpftrace);
   BpfBytecode bytecode;
-  try
-  {
+  try {
     llvm.generate_ir();
     llvm.optimize();
     bytecode = llvm.emit();
-  }
-  catch (const std::system_error& ex)
-  {
+  } catch (const std::system_error& ex) {
     return 1;
-  }
-  catch (const std::exception& ex)
-  {
+  } catch (const std::exception& ex) {
     // failed to compile
     return 1;
   }

--- a/src/imap.cpp
+++ b/src/imap.cpp
@@ -13,19 +13,14 @@ IMap::IMap(const std::string &name,
            int max_entries __attribute__((unused)))
     : name_(name), type_(type), key_(key), lqmin(min), lqmax(max), lqstep(step)
 {
-  if (type.IsCountTy() && !key.args_.size())
-  {
+  if (type.IsCountTy() && !key.args_.size()) {
     map_type_ = libbpf::BPF_MAP_TYPE_PERCPU_ARRAY;
-  }
-  else if ((type.IsHistTy() || type.IsLhistTy() || type.IsCountTy() ||
-            type.IsSumTy() || type.IsMinTy() || type.IsMaxTy() ||
-            type.IsAvgTy() || type.IsStatsTy()) &&
-           (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0)))
-  {
+  } else if ((type.IsHistTy() || type.IsLhistTy() || type.IsCountTy() ||
+              type.IsSumTy() || type.IsMinTy() || type.IsMaxTy() ||
+              type.IsAvgTy() || type.IsStatsTy()) &&
+             (LINUX_VERSION_CODE >= KERNEL_VERSION(4, 6, 0))) {
     map_type_ = libbpf::BPF_MAP_TYPE_PERCPU_HASH;
-  }
-  else
-  {
+  } else {
     map_type_ = libbpf::BPF_MAP_TYPE_HASH;
   }
 }

--- a/src/imap.h
+++ b/src/imap.h
@@ -13,8 +13,7 @@ namespace libbpf {
 
 namespace bpftrace {
 
-class IMap
-{
+class IMap {
 public:
   IMap(const std::string &name,
        const SizedType &type,

--- a/src/lockdown.cpp
+++ b/src/lockdown.cpp
@@ -34,8 +34,7 @@ static LockdownState read_security_lockdown(void)
 
   // Format: none [integrity] confidentiality
   // read one field at a time, if it starts with [ it's the one we want
-  while (!file.fail())
-  {
+  while (!file.fail()) {
     std::string field;
     file >> field;
     if (field[0] == '[')

--- a/src/lockdown.h
+++ b/src/lockdown.h
@@ -7,8 +7,7 @@
 namespace bpftrace {
 namespace lockdown {
 
-enum class LockdownState
-{
+enum class LockdownState {
   None,
   Integrity,
   Confidentiality,

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -4,8 +4,7 @@ namespace bpftrace {
 
 std::string logtype_str(LogType t)
 {
-  switch (t)
-  {
+  switch (t) {
     // clang-format off
     case LogType::DEBUG   : return "DEBUG";
     case LogType::INFO    : return "INFO";
@@ -44,32 +43,22 @@ void Log::take_input(LogType type,
     out << logtype_str(type) << ": " << input << std::endl;
   };
 
-  if (loc)
-  {
-    if (src_.empty())
-    {
+  if (loc) {
+    if (src_.empty()) {
       std::cerr << "Log: cannot resolve location before calling set_source()."
                 << std::endl;
       print_out();
-    }
-    else if (loc->begin.line == 0)
-    {
+    } else if (loc->begin.line == 0) {
       std::cerr << "Log: invalid location." << std::endl;
       print_out();
-    }
-    else if (loc->begin.line > loc->end.line)
-    {
+    } else if (loc->begin.line > loc->end.line) {
       std::cerr << "Log: loc.begin > loc.end: " << loc->begin << ":" << loc->end
                 << std::endl;
       print_out();
-    }
-    else
-    {
+    } else {
       log_with_location(type, loc.value(), out, input);
     }
-  }
-  else
-  {
+  } else {
     print_out();
   }
 }
@@ -80,8 +69,7 @@ const std::string Log::get_source_line(unsigned int n)
   // doesn't exist
   std::string line;
   std::stringstream ss(src_);
-  for (unsigned int idx = 0; idx <= n; idx++)
-  {
+  for (unsigned int idx = 0; idx <= n; idx++) {
     std::getline(ss, line);
     if (ss.eof() && idx == n)
       return line;
@@ -96,24 +84,21 @@ void Log::log_with_location(LogType type,
                             std::ostream& out,
                             const std::string& m)
 {
-  if (filename_.size())
-  {
+  if (filename_.size()) {
     out << filename_ << ":";
   }
 
   std::string msg(m);
   const std::string& typestr = logtype_str(type);
 
-  if (!msg.empty() && msg.back() == '\n')
-  {
+  if (!msg.empty() && msg.back() == '\n') {
     msg.pop_back();
   }
 
   /* For a multi line error only the line range is printed:
      <filename>:<start_line>-<end_line>: ERROR: <message>
   */
-  if (l.begin.line < l.end.line)
-  {
+  if (l.begin.line < l.end.line) {
     out << l.begin.line << "-" << l.end.line << ": " << typestr << ": " << msg
         << std::endl;
     return;
@@ -142,8 +127,7 @@ void Log::log_with_location(LogType type,
     return;
 
   // To get consistent printing all tabs will be replaced with 4 spaces
-  for (auto c : srcline)
-  {
+  for (auto c : srcline) {
     if (c == '\t')
       out << "    ";
     else
@@ -153,16 +137,12 @@ void Log::log_with_location(LogType type,
 
   for (unsigned int x = 0;
        x < srcline.size() && x < (static_cast<unsigned int>(l.end.column) - 1);
-       x++)
-  {
+       x++) {
     char marker = (x < (static_cast<unsigned int>(l.begin.column) - 1)) ? ' '
                                                                         : '~';
-    if (srcline[x] == '\t')
-    {
+    if (srcline[x] == '\t') {
       out << std::string(4, marker);
-    }
-    else
-    {
+    } else {
       out << marker;
     }
   }

--- a/src/log.h
+++ b/src/log.h
@@ -22,8 +22,7 @@ enum class LogType
 };
 // clang-format on
 
-class Log
-{
+class Log {
 public:
   static Log& get();
   void take_input(LogType type,
@@ -71,8 +70,7 @@ private:
   std::unordered_map<LogType, bool> enabled_map_;
 };
 
-class LogStream
-{
+class LogStream {
 public:
   LogStream(const std::string& file,
             int line,
@@ -102,8 +100,7 @@ protected:
   std::ostringstream buf_;
 };
 
-class LogStreamFatal : public LogStream
-{
+class LogStreamFatal : public LogStream {
 public:
   LogStreamFatal(const std::string& file,
                  int line,
@@ -119,8 +116,7 @@ public:
   [[noreturn]] ~LogStreamFatal();
 };
 
-class LogStreamBug : public LogStream
-{
+class LogStreamBug : public LogStream {
 public:
   LogStreamBug(const std::string& file,
                int line,

--- a/src/map.cpp
+++ b/src/map.cpp
@@ -24,8 +24,7 @@ int create_map(libbpf::bpf_map_type map_type,
 {
   std::string fixed_name;
   const std::string *name_ptr = &name;
-  if (!name.empty() && name[0] == '@')
-  {
+  if (!name.empty() && name[0] == '@') {
     fixed_name = "AT_" + name.substr(1);
     name_ptr = &fixed_name;
   }
@@ -56,8 +55,7 @@ Map::Map(const std::string &name,
     key_size += 8;
   if (key_size == 0)
     key_size = 8;
-  if (type.IsCountTy() && !key.args_.size())
-  {
+  if (type.IsCountTy() && !key.args_.size()) {
     max_entries = 1;
     key_size = 4;
   }
@@ -66,8 +64,7 @@ Map::Map(const std::string &name,
   int flags = 0;
   mapfd_ = create_map(
       map_type_, name, key_size, value_size, max_entries, flags);
-  if (mapfd_ < 0)
-  {
+  if (mapfd_ < 0) {
     LOG(ERROR) << "failed to create map: '" << name_
                << "': " << strerror(errno);
   }
@@ -83,8 +80,7 @@ Map::Map(const std::string &name,
 {
   mapfd_ = create_map(
       map_type_, name_, key_size, value_size, max_entries, flags);
-  if (mapfd_ < 0)
-  {
+  if (mapfd_ < 0) {
     LOG(ERROR) << "failed to create map: '" << name_
                << "': " << strerror(errno);
   }
@@ -125,8 +121,7 @@ Map::Map(const SizedType &type) : IMap(type)
                       value_size,
                       max_entries,
                       flags);
-  if (mapfd_ < 0)
-  {
+  if (mapfd_ < 0) {
     LOG(ERROR) << "failed to create stack id map: " << strerror(errno);
     if (errno == ENOMEM)
       LOG(ERROR) << "Tried to allocate " << max_entries << " entries of size "
@@ -154,8 +149,7 @@ Map::Map(libbpf::bpf_map_type map_type) : IMap(map_type)
 
   mapfd_ = create_map(
       map_type, "perf_event", key_size, value_size, max_entries, flags);
-  if (mapfd_ < 0)
-  {
+  if (mapfd_ < 0) {
     LOG(ERROR) << "failed to create " << name_ << " map: " << strerror(errno);
   }
 }
@@ -170,8 +164,7 @@ Map::Map(libbpf::bpf_map_type map_type, uint64_t perf_rb_pages) : IMap(map_type)
 
   mapfd_ = create_map(
       map_type, "ringbuf", key_size, value_size, max_entries, flags);
-  if (mapfd_ < 0)
-  {
+  if (mapfd_ < 0) {
     LOG(ERROR) << "failed to create " << name_ << " map: " << strerror(errno);
   }
 }
@@ -206,8 +199,7 @@ bool MapManager::Has(const std::string &name)
 std::optional<IMap *> MapManager::Lookup(const std::string &name)
 {
   auto search = maps_by_name_.find(name);
-  if (search == maps_by_name_.end())
-  {
+  if (search == maps_by_name_.end()) {
     return {};
   }
 
@@ -233,8 +225,7 @@ void MapManager::Set(MapManager::Type t, std::unique_ptr<IMap> map)
 std::optional<IMap *> MapManager::Lookup(Type t)
 {
   auto search = maps_by_type_.find(t);
-  if (search == maps_by_type_.end())
-  {
+  if (search == maps_by_type_.end()) {
     return {};
   }
 
@@ -258,8 +249,7 @@ void MapManager::Set(StackType t, std::unique_ptr<IMap> map)
 std::optional<IMap *> MapManager::Lookup(StackType t)
 {
   auto search = stackid_maps_.find(t);
-  if (search == stackid_maps_.end())
-  {
+  if (search == stackid_maps_.end()) {
     return {};
   }
 
@@ -273,8 +263,7 @@ bool MapManager::Has(StackType t)
 
 std::string to_string(MapManager::Type t)
 {
-  switch (t)
-  {
+  switch (t) {
     case MapManager::Type::PerfEvent:
       return "perf_event";
     case MapManager::Type::Join:

--- a/src/map.h
+++ b/src/map.h
@@ -4,8 +4,7 @@
 
 namespace bpftrace {
 
-class Map : public IMap
-{
+class Map : public IMap {
 public:
   Map(const std::string &name,
       const SizedType &type,

--- a/src/mapkey.cpp
+++ b/src/mapkey.cpp
@@ -25,8 +25,7 @@ std::string MapKey::argument_type_list() const
 {
   std::ostringstream list;
   list << "[";
-  for (size_t i = 0; i < args_.size(); i++)
-  {
+  for (size_t i = 0; i < args_.size(); i++) {
     if (i)
       list << ", ";
     list << args_[i];
@@ -35,20 +34,21 @@ std::string MapKey::argument_type_list() const
   return list.str();
 }
 
-std::vector<std::string> MapKey::argument_value_list(BPFtrace &bpftrace,
+std::vector<std::string> MapKey::argument_value_list(
+    BPFtrace &bpftrace,
     const std::vector<uint8_t> &data) const
 {
   std::vector<std::string> list;
   int offset = 0;
-  for (const SizedType &arg : args_)
-  {
+  for (const SizedType &arg : args_) {
     list.push_back(argument_value(bpftrace, arg, &data[offset]));
     offset += arg.GetSize();
   }
   return list;
 }
 
-std::string MapKey::argument_value_list_str(BPFtrace &bpftrace,
+std::string MapKey::argument_value_list_str(
+    BPFtrace &bpftrace,
     const std::vector<uint8_t> &data) const
 {
   if (args_.empty())
@@ -57,16 +57,14 @@ std::string MapKey::argument_value_list_str(BPFtrace &bpftrace,
 }
 
 std::string MapKey::argument_value(BPFtrace &bpftrace,
-    const SizedType &arg,
-    const void *data)
+                                   const SizedType &arg,
+                                   const void *data)
 {
-  auto arg_data = static_cast<const uint8_t*>(data);
+  auto arg_data = static_cast<const uint8_t *>(data);
   std::ostringstream ptr;
-  switch (arg.type)
-  {
+  switch (arg.type) {
     case Type::integer:
-      switch (arg.GetSize())
-      {
+      switch (arg.GetSize()) {
         case 1:
           return std::to_string(read_data<int8_t>(data));
         case 2:
@@ -89,8 +87,7 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
                                 true,
                                 arg.stack_type,
                                 4);
-    case Type::timestamp:
-    {
+    case Type::timestamp: {
       auto p = static_cast<const AsyncEvent::Strftime *>(data);
       return bpftrace.resolve_timestamp(p->mode, p->strftime_id, p->nsecs);
     }
@@ -107,24 +104,20 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
       return bpftrace.resolve_uid(read_data<uint64_t>(data));
     case Type::probe:
       return bpftrace.resources.probe_ids[read_data<uint64_t>(data)];
-    case Type::string:
-    {
+    case Type::string: {
       auto p = static_cast<const char *>(data);
       return std::string(p, strnlen(p, arg.GetSize()));
     }
-    case Type::buffer:
-    {
+    case Type::buffer: {
       auto p = static_cast<const char *>(data) + 1;
       return hex_format_buffer(p, arg.GetSize() - 1);
     }
-    case Type::pointer:
-    {
+    case Type::pointer: {
       // use case: show me these pointer values
       ptr << "0x" << std::hex << read_data<int64_t>(data);
       return ptr.str();
     }
-    case Type::array:
-    {
+    case Type::array: {
       std::vector<std::string> elems;
       for (size_t i = 0; i < arg.GetNumElements(); i++)
         elems.push_back(argument_value(bpftrace,
@@ -133,11 +126,9 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
                                            i * arg.GetElementTy()->GetSize()));
       return "[" + str_join(elems, ",") + "]";
     }
-    case Type::record:
-    {
+    case Type::record: {
       std::vector<std::string> elems;
-      for (auto &field : arg.GetFields())
-      {
+      for (auto &field : arg.GetFields()) {
         elems.push_back("." + field.name + "=" +
                         argument_value(bpftrace,
                                        field.type,
@@ -145,8 +136,7 @@ std::string MapKey::argument_value(BPFtrace &bpftrace,
       }
       return "{" + str_join(elems, ",") + "}";
     }
-    case Type::mac_address:
-    {
+    case Type::mac_address: {
       auto p = static_cast<const uint8_t *>(data);
       return bpftrace.resolve_mac_address(p);
     }

--- a/src/mapkey.h
+++ b/src/mapkey.h
@@ -11,8 +11,7 @@ namespace bpftrace {
 
 class BPFtrace;
 
-class MapKey
-{
+class MapKey {
 public:
   std::vector<SizedType> args_;
 

--- a/src/mapmanager.h
+++ b/src/mapmanager.h
@@ -12,8 +12,7 @@ namespace bpftrace {
    A container for all maps created during program execution.
 
 */
-class MapManager
-{
+class MapManager {
 public:
   MapManager() = default;
   MapManager &operator=(MapManager &&) = default;
@@ -54,8 +53,7 @@ public:
   /**
      Internal maps
   */
-  enum class Type
-  {
+  enum class Type {
     // Also update to_string
     PerfEvent,
     Join,

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -18,8 +18,7 @@ namespace bpftrace {
 namespace {
 bool is_quoted_type(const SizedType &ty)
 {
-  switch (ty.type)
-  {
+  switch (ty.type) {
     case Type::buffer:
     case Type::cgroup_path:
     case Type::inet:
@@ -56,22 +55,44 @@ bool is_quoted_type(const SizedType &ty)
 }
 } // namespace
 
-std::ostream& operator<<(std::ostream& out, MessageType type) {
+std::ostream &operator<<(std::ostream &out, MessageType type)
+{
   switch (type) {
-    case MessageType::map: out << "map"; break;
+    case MessageType::map:
+      out << "map";
+      break;
     case MessageType::value:
       out << "value";
       break;
-    case MessageType::hist: out << "hist"; break;
-    case MessageType::stats: out << "stats"; break;
-    case MessageType::printf: out << "printf"; break;
-    case MessageType::time: out << "time"; break;
-    case MessageType::cat: out << "cat"; break;
-    case MessageType::join: out << "join"; break;
-    case MessageType::syscall: out << "syscall"; break;
-    case MessageType::attached_probes: out << "attached_probes"; break;
-    case MessageType::lost_events: out << "lost_events"; break;
-    default: out << "?";
+    case MessageType::hist:
+      out << "hist";
+      break;
+    case MessageType::stats:
+      out << "stats";
+      break;
+    case MessageType::printf:
+      out << "printf";
+      break;
+    case MessageType::time:
+      out << "time";
+      break;
+    case MessageType::cat:
+      out << "cat";
+      break;
+    case MessageType::join:
+      out << "join";
+      break;
+    case MessageType::syscall:
+      out << "syscall";
+      break;
+    case MessageType::attached_probes:
+      out << "attached_probes";
+      break;
+    case MessageType::lost_events:
+      out << "lost_events";
+      break;
+    default:
+      out << "?";
   }
   return out;
 }
@@ -112,34 +133,29 @@ std::string TextOutput::lhist_index_label(int number)
 
   std::ostringstream label;
 
-  if (number == 0)
-  {
+  if (number == 0) {
     label << number;
-  }
-  else if (number % mega == 0)
-  {
+  } else if (number % mega == 0) {
     label << number / mega << 'M';
-  }
-  else if (number % kilo == 0)
-  {
+  } else if (number % kilo == 0) {
     label << number / kilo << 'K';
-  }
-  else
-  {
+  } else {
     label << number;
   }
 
   return label.str();
 }
 
-void Output::hist_prepare(const std::vector<uint64_t> &values, int &min_index, int &max_index, int &max_value) const
+void Output::hist_prepare(const std::vector<uint64_t> &values,
+                          int &min_index,
+                          int &max_index,
+                          int &max_value) const
 {
   min_index = -1;
   max_index = -1;
   max_value = 0;
 
-  for (size_t i = 0; i < values.size(); i++)
-  {
+  for (size_t i = 0; i < values.size(); i++) {
     int v = values.at(i);
     if (v > 0) {
       if (min_index == -1)
@@ -151,14 +167,21 @@ void Output::hist_prepare(const std::vector<uint64_t> &values, int &min_index, i
   }
 }
 
-void Output::lhist_prepare(const std::vector<uint64_t> &values, int min, int max, int step, int &max_index, int &max_value, int &buckets, int &start_value, int &end_value) const
+void Output::lhist_prepare(const std::vector<uint64_t> &values,
+                           int min,
+                           int max,
+                           int step,
+                           int &max_index,
+                           int &max_value,
+                           int &buckets,
+                           int &start_value,
+                           int &end_value) const
 {
   max_index = -1;
   max_value = 0;
   buckets = (max - min) / step; // excluding lt and gt buckets
 
-  for (size_t i = 0; i < values.size(); i++)
-  {
+  for (size_t i = 0; i < values.size(); i++) {
     int v = values.at(i);
     if (v != 0)
       max_index = i;
@@ -173,8 +196,7 @@ void Output::lhist_prepare(const std::vector<uint64_t> &values, int min, int max
   start_value = -1;
   end_value = 0;
 
-  for (unsigned int i = 0; i <= static_cast<unsigned int>(buckets) + 1; i++)
-  {
+  for (unsigned int i = 0; i <= static_cast<unsigned int>(buckets) + 1; i++) {
     if (values.at(i) > 0) {
       if (start_value == -1) {
         start_value = i;
@@ -191,22 +213,17 @@ void Output::lhist_prepare(const std::vector<uint64_t> &values, int min, int max
 std::string Output::get_helper_error_msg(int func_id, int retcode) const
 {
   std::string msg;
-  if (func_id == libbpf::BPF_FUNC_map_update_elem && retcode == -E2BIG)
-  {
+  if (func_id == libbpf::BPF_FUNC_map_update_elem && retcode == -E2BIG) {
     msg = "Map full; can't update element. Try increasing max_map_keys config";
-  }
-  else if (func_id == libbpf::BPF_FUNC_map_delete_elem && retcode == -ENOENT)
-  {
+  } else if (func_id == libbpf::BPF_FUNC_map_delete_elem &&
+             retcode == -ENOENT) {
     msg = "Can't delete map element because it does not exist.";
   }
   // bpftrace sets the return code to 0 for map_lookup_elem failures
   // which is why we're not also checking the retcode
-  else if (func_id == libbpf::BPF_FUNC_map_lookup_elem)
-  {
+  else if (func_id == libbpf::BPF_FUNC_map_lookup_elem) {
     msg = "Can't lookup map element because it does not exist.";
-  }
-  else
-  {
+  } else {
     msg = strerror(-retcode);
   }
   return msg;
@@ -243,29 +260,22 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
   else if (type.IsBufferTy())
     return bpftrace.resolve_buf(reinterpret_cast<char *>(value.data() + 1),
                                 *reinterpret_cast<uint8_t *>(value.data()));
-  else if (type.IsStringTy())
-  {
+  else if (type.IsStringTy()) {
     auto p = reinterpret_cast<const char *>(value.data());
     return std::string(p, strnlen(p, type.GetSize()));
-  }
-  else if (type.IsArrayTy())
-  {
+  } else if (type.IsArrayTy()) {
     size_t elem_size = type.GetElementTy()->GetSize();
     std::vector<std::string> elems;
-    for (size_t i = 0; i < type.GetNumElements(); i++)
-    {
+    for (size_t i = 0; i < type.GetNumElements(); i++) {
       std::vector<uint8_t> elem_data(value.begin() + i * elem_size,
                                      value.begin() + (i + 1) * elem_size);
       elems.push_back(value_to_str(
           bpftrace, *type.GetElementTy(), elem_data, is_per_cpu, div));
     }
     return array_to_str(elems);
-  }
-  else if (type.IsRecordTy())
-  {
+  } else if (type.IsRecordTy()) {
     std::vector<std::string> elems;
-    for (auto &field : type.GetFields())
-    {
+    for (auto &field : type.GetFields()) {
       std::vector<uint8_t> elem_data(value.begin() + field.offset,
                                      value.begin() + field.offset +
                                          field.type.GetSize());
@@ -274,12 +284,9 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
           value_to_str(bpftrace, field.type, elem_data, is_per_cpu, div)));
     }
     return struct_to_str(elems);
-  }
-  else if (type.IsTupleTy())
-  {
+  } else if (type.IsTupleTy()) {
     std::vector<std::string> elems;
-    for (auto &field : type.GetFields())
-    {
+    for (auto &field : type.GetFields()) {
       std::vector<uint8_t> elem_data(value.begin() + field.offset,
                                      value.begin() + field.offset +
                                          field.type.GetSize());
@@ -287,14 +294,11 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
           value_to_str(bpftrace, field.type, elem_data, is_per_cpu, div));
     }
     return tuple_to_str(elems);
-  }
-  else if (type.IsCountTy())
+  } else if (type.IsCountTy())
     return std::to_string(reduce_value<uint64_t>(value, nvalues) / div);
-  else if (type.IsIntTy())
-  {
+  else if (type.IsIntTy()) {
     auto sign = type.IsSigned();
-    switch (type.GetIntBitWidth())
-    {
+    switch (type.GetIntBitWidth()) {
       // clang-format off
       case 64:
         if (sign)
@@ -322,15 +326,12 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
         return {};
     }
     // lgtm[cpp/missing-return]
-  }
-  else if (type.IsSumTy() || type.IsIntTy())
-  {
+  } else if (type.IsSumTy() || type.IsIntTy()) {
     if (type.IsSigned())
       return std::to_string(reduce_value<int64_t>(value, nvalues) / div);
 
     return std::to_string(reduce_value<uint64_t>(value, nvalues) / div);
-  }
-  else if (type.IsMinTy())
+  } else if (type.IsMinTy())
     return std::to_string(min_value(value, nvalues) / div);
   else if (type.IsMaxTy())
     return std::to_string(max_value(value, nvalues) / div);
@@ -350,14 +351,11 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
         reinterpret_cast<AsyncEvent::CgroupPath *>(value.data())->cgroup_id);
   else if (type.IsStrerrorTy())
     return strerror(read_data<uint64_t>(value.data()));
-  else if (type.IsPtrTy())
-  {
+  else if (type.IsPtrTy()) {
     std::ostringstream res;
     res << "0x" << std::hex << read_data<uint64_t>(value.data());
     return res.str();
-  }
-  else
-  {
+  } else {
     assert(type.IsNoneTy());
     return "";
   }
@@ -384,13 +382,11 @@ std::string Output::map_to_str(
   std::vector<std::string> elems;
   uint32_t i = 0;
   size_t total = values_by_key.size();
-  for (auto &pair : values_by_key)
-  {
+  for (auto &pair : values_by_key) {
     auto key = pair.first;
     auto value = pair.second;
 
-    if (top)
-    {
+    if (top) {
       if (total > top && i++ < (total - top))
         continue;
     }
@@ -415,8 +411,7 @@ std::string Output::map_hist_to_str(
 {
   std::vector<std::string> elems;
   uint32_t i = 0;
-  for (auto &key_count : total_counts_by_key)
-  {
+  for (auto &key_count : total_counts_by_key) {
     auto &key = key_count.first;
     auto &value = values_by_key.at(key);
 
@@ -444,8 +439,7 @@ std::string Output::map_stats_to_str(
 {
   std::vector<std::string> elems;
   uint32_t i = 0;
-  for (auto &key_count : total_counts_by_key)
-  {
+  for (auto &key_count : total_counts_by_key) {
     auto &key = key_count.first;
     auto &value = values_by_key.at(key);
 
@@ -463,14 +457,12 @@ std::string Output::map_stats_to_str(
       average = total / count;
 
     std::string value_str;
-    if (map.type_.IsStatsTy())
-    {
+    if (map.type_.IsStatsTy()) {
       std::vector<std::pair<std::string, int64_t>> stats = {
         { "count", count }, { "average", average }, { "total", total }
       };
       value_str = key_value_pairs_to_str(stats);
-    }
-    else
+    } else
       value_str = std::to_string(average / div);
 
     elems.push_back(map_keyval_to_str(map, key_str, value_str));
@@ -501,8 +493,7 @@ std::string TextOutput::hist_to_str(const std::vector<uint64_t> &values,
     return "";
 
   std::ostringstream res;
-  for (int i = min_index; i <= max_index; i++)
-  {
+  for (int i = min_index; i <= max_index; i++) {
     std::ostringstream header;
 
     // Index 0 is for negative values. Following that, each sequence
@@ -518,23 +509,18 @@ std::string TextOutput::hist_to_str(const std::vector<uint64_t> &values,
     // Higher indexes contain multiple values and we use helpers to print
     // the range as open intervals.
 
-    if (i == 0)
-    {
+    if (i == 0) {
       header << "(..., 0)";
-    }
-    else if (i <= (2 << k))
-    {
+    } else if (i <= (2 << k)) {
       header << "[" << (i - 1) << "]";
-    }
-    else
-    {
+    } else {
       // Use a helper function to print the interval boundaries.
       header << "[" << hist_index_label(i - 1, k);
       header << ", " << hist_index_label(i, k) << ")";
     }
 
     int max_width = 52;
-    int bar_width = values.at(i)/(float)max_value*max_width;
+    int bar_width = values.at(i) / (float)max_value * max_width;
     std::string bar(bar_width, '@');
 
     res << std::setw(16) << std::left << header.str() << std::setw(8)
@@ -550,15 +536,22 @@ std::string TextOutput::lhist_to_str(const std::vector<uint64_t> &values,
                                      int step) const
 {
   int max_index, max_value, buckets, start_value, end_value;
-  lhist_prepare(values, min, max, step, max_index, max_value, buckets, start_value, end_value);
+  lhist_prepare(values,
+                min,
+                max,
+                step,
+                max_index,
+                max_value,
+                buckets,
+                start_value,
+                end_value);
   if (max_index == -1)
     return "";
 
   std::ostringstream res;
-  for (int i = start_value; i <= end_value; i++)
-  {
+  for (int i = start_value; i <= end_value; i++) {
     int max_width = 52;
-    int bar_width = values.at(i)/(float)max_value*max_width;
+    int bar_width = values.at(i) / (float)max_value * max_width;
     std::ostringstream header;
     if (i == 0) {
       header << "(..., " << lhist_index_label(min) << ")";
@@ -613,7 +606,9 @@ void TextOutput::value(BPFtrace &bpftrace,
   out_ << value_to_str(bpftrace, ty, value, false, 1) << std::endl;
 }
 
-void TextOutput::message(MessageType type __attribute__((unused)), const std::string& msg, bool nl) const
+void TextOutput::message(MessageType type __attribute__((unused)),
+                         const std::string &msg,
+                         bool nl) const
 {
   out_ << msg;
   if (nl)
@@ -695,10 +690,8 @@ std::string TextOutput::key_value_pairs_to_str(
 std::string JsonOutput::json_escape(const std::string &str) const
 {
   std::ostringstream escaped;
-  for (const char &c : str)
-  {
-    switch (c)
-    {
+  for (const char &c : str) {
+    switch (c) {
       case '"':
         escaped << "\\\"";
         break;
@@ -721,12 +714,10 @@ std::string JsonOutput::json_escape(const std::string &str) const
 
       default:
         // c always >= '\x00'
-        if (c <= '\x1f')
-        {
-          escaped << "\\u" << std::hex << std::setw(4) << std::setfill('0') << (int)c;
-        }
-        else
-        {
+        if (c <= '\x1f') {
+          escaped << "\\u" << std::hex << std::setw(4) << std::setfill('0')
+                  << (int)c;
+        } else {
           escaped << c;
         }
     }
@@ -768,8 +759,7 @@ std::string JsonOutput::hist_to_str(const std::vector<uint64_t> &values,
 
   std::ostringstream res;
   res << "[";
-  for (int i = min_index; i <= max_index; i++)
-  {
+  for (int i = min_index; i <= max_index; i++) {
     if (i > min_index)
       res << ", ";
 
@@ -779,16 +769,11 @@ std::string JsonOutput::hist_to_str(const std::vector<uint64_t> &values,
     // N = 2^k indexes have one value each (equal to i -1)
     // and remaining sets of N indexes each cover one power of 2,
     // whose ranges are computed as described in hist_index_label()
-    if (i == 0)
-    {
+    if (i == 0) {
       res << "\"max\": -1, ";
-    }
-    else if (i <= (2 << k))
-    {
+    } else if (i <= (2 << k)) {
       res << "\"min\": " << i - 1 << ", \"max\": " << i - 1 << ", ";
-    }
-    else
-    {
+    } else {
       const uint32_t n = 1 << k;
       uint32_t power = ((i - 1) >> k) - 1, bucket = (i - 1) & (n - 1);
       const long low = (1ULL << power) * (n + bucket);
@@ -811,14 +796,21 @@ std::string JsonOutput::lhist_to_str(const std::vector<uint64_t> &values,
                                      int step) const
 {
   int max_index, max_value, buckets, start_value, end_value;
-  lhist_prepare(values, min, max, step, max_index, max_value, buckets, start_value, end_value);
+  lhist_prepare(values,
+                min,
+                max,
+                step,
+                max_index,
+                max_value,
+                buckets,
+                start_value,
+                end_value);
   if (max_index == -1)
     return "[]";
 
   std::ostringstream res;
   res << "[";
-  for (int i = start_value; i <= end_value; i++)
-  {
+  for (int i = start_value; i <= end_value; i++) {
     if (i > start_value)
       res << ", ";
 
@@ -899,15 +891,21 @@ void JsonOutput::value(BPFtrace &bpftrace,
        << std::endl;
 }
 
-void JsonOutput::message(MessageType type, const std::string& msg, bool nl __attribute__((unused))) const
+void JsonOutput::message(MessageType type,
+                         const std::string &msg,
+                         bool nl __attribute__((unused))) const
 {
-  out_ << "{\"type\": \"" << type << "\", \"data\": \"" << json_escape(msg) << "\"}" << std::endl;
+  out_ << "{\"type\": \"" << type << "\", \"data\": \"" << json_escape(msg)
+       << "\"}" << std::endl;
 }
 
-void JsonOutput::message(MessageType type, const std::string& field, uint64_t value) const
+void JsonOutput::message(MessageType type,
+                         const std::string &field,
+                         uint64_t value) const
 {
-  out_ << "{\"type\": \"" << type << "\", \"data\": " <<  "{\"" << field
-       << "\": " << value << "}" << "}" << std::endl;
+  out_ << "{\"type\": \"" << type << "\", \"data\": "
+       << "{\"" << field << "\": " << value << "}"
+       << "}" << std::endl;
 }
 
 void JsonOutput::lost_events(uint64_t lost) const
@@ -961,8 +959,7 @@ std::string JsonOutput::map_key_to_str(BPFtrace &bpftrace,
                                        const std::vector<uint8_t> &key) const
 {
   std::vector<std::string> args = map.key_.argument_value_list(bpftrace, key);
-  if (!args.empty())
-  {
+  if (!args.empty()) {
     return "\"" + json_escape(str_join(args, ",")) + "\"";
   }
   return "";

--- a/src/output.h
+++ b/src/output.h
@@ -10,8 +10,7 @@
 
 namespace bpftrace {
 
-enum class MessageType
-{
+enum class MessageType {
   // don't forget to update std::ostream& operator<<(std::ostream& out,
   // MessageType type) in output.cpp
   map,
@@ -28,34 +27,50 @@ enum class MessageType
   helper_error,
 };
 
-std::ostream& operator<<(std::ostream& out, MessageType type);
+std::ostream &operator<<(std::ostream &out, MessageType type);
 
 // Abstract class (interface) for output
 // Provides default implementation of some methods for formatting map and
 // non-map values into strings.
 // All output formatters should extend this class and override (at least) pure
 // virtual methods.
-class Output
-{
+class Output {
 public:
-  explicit Output(std::ostream& out = std::cout, std::ostream& err = std::cerr) : out_(out),err_(err) { }
+  explicit Output(std::ostream &out = std::cout, std::ostream &err = std::cerr)
+      : out_(out), err_(err)
+  {
+  }
   Output(const Output &) = delete;
-  Output& operator=(const Output &) = delete;
+  Output &operator=(const Output &) = delete;
   virtual ~Output() = default;
 
-  virtual std::ostream& outputstream() const { return out_; };
+  virtual std::ostream &outputstream() const
+  {
+    return out_;
+  };
 
   // Write map to output
   // Ideally, the implementation should use map_to_str to convert a map into
   // a string, format it properly, and print it to out_.
-  virtual void map(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t div,
-                   const std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> &values_by_key) const = 0;
+  virtual void map(
+      BPFtrace &bpftrace,
+      IMap &map,
+      uint32_t top,
+      uint32_t div,
+      const std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
+          &values_by_key) const = 0;
   // Write map histogram to output
   // Ideally, the implementation should use map_hist_to_str to convert a map
   // histogram into a string, format it properly, and print it to out_.
-  virtual void map_hist(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t div,
-                        const std::map<std::vector<uint8_t>, std::vector<uint64_t>> &values_by_key,
-                        const std::vector<std::pair<std::vector<uint8_t>, uint64_t>> &total_counts_by_key) const = 0;
+  virtual void map_hist(
+      BPFtrace &bpftrace,
+      IMap &map,
+      uint32_t top,
+      uint32_t div,
+      const std::map<std::vector<uint8_t>, std::vector<uint64_t>>
+          &values_by_key,
+      const std::vector<std::pair<std::vector<uint8_t>, uint64_t>>
+          &total_counts_by_key) const = 0;
   // Write map statistics to output
   // Ideally, the implementation should use map_stats_to_str to convert map
   // statistics into a string, format it properly, and print it to out_.
@@ -74,7 +89,9 @@ public:
                      const SizedType &ty,
                      std::vector<uint8_t> &value) const = 0;
 
-  virtual void message(MessageType type, const std::string& msg, bool nl = true) const = 0;
+  virtual void message(MessageType type,
+                       const std::string &msg,
+                       bool nl = true) const = 0;
   virtual void lost_events(uint64_t lost) const = 0;
   virtual void attached_probes(uint64_t num_probes) const = 0;
   virtual void helper_error(int func_id,
@@ -84,8 +101,19 @@ public:
 protected:
   std::ostream &out_;
   std::ostream &err_;
-  void hist_prepare(const std::vector<uint64_t> &values, int &min_index, int &max_index, int &max_value) const;
-  void lhist_prepare(const std::vector<uint64_t> &values, int min, int max, int step, int &max_index, int &max_value, int &buckets, int &start_value, int &end_value) const;
+  void hist_prepare(const std::vector<uint64_t> &values,
+                    int &min_index,
+                    int &max_index,
+                    int &max_value) const;
+  void lhist_prepare(const std::vector<uint64_t> &values,
+                     int min,
+                     int max,
+                     int step,
+                     int &max_index,
+                     int &max_value,
+                     int &buckets,
+                     int &start_value,
+                     int &end_value) const;
   std::string get_helper_error_msg(int func_id, int retcode) const;
   // Convert a log2 histogram into string
   virtual std::string hist_to_str(const std::vector<uint64_t> &values,
@@ -173,13 +201,27 @@ protected:
 
 class TextOutput : public Output {
 public:
-  explicit TextOutput(std::ostream& out = std::cout, std::ostream& err = std::cerr) : Output(out, err) { }
+  explicit TextOutput(std::ostream &out = std::cout,
+                      std::ostream &err = std::cerr)
+      : Output(out, err)
+  {
+  }
 
-  void map(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t div,
-           const std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> &values_by_key) const override;
-  void map_hist(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t div,
-                const std::map<std::vector<uint8_t>, std::vector<uint64_t>> &values_by_key,
-                const std::vector<std::pair<std::vector<uint8_t>, uint64_t>> &total_counts_by_key) const override;
+  void map(
+      BPFtrace &bpftrace,
+      IMap &map,
+      uint32_t top,
+      uint32_t div,
+      const std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
+          &values_by_key) const override;
+  void map_hist(BPFtrace &bpftrace,
+                IMap &map,
+                uint32_t top,
+                uint32_t div,
+                const std::map<std::vector<uint8_t>, std::vector<uint64_t>>
+                    &values_by_key,
+                const std::vector<std::pair<std::vector<uint8_t>, uint64_t>>
+                    &total_counts_by_key) const override;
   void map_stats(
       BPFtrace &bpftrace,
       IMap &map,
@@ -192,7 +234,9 @@ public:
                      const SizedType &ty,
                      std::vector<uint8_t> &value) const override;
 
-  void message(MessageType type, const std::string& msg, bool nl = true) const override;
+  void message(MessageType type,
+               const std::string &msg,
+               bool nl = true) const override;
   void lost_events(uint64_t lost) const override;
   void attached_probes(uint64_t num_probes) const override;
   void helper_error(int func_id,
@@ -227,13 +271,27 @@ protected:
 
 class JsonOutput : public Output {
 public:
-  explicit JsonOutput(std::ostream& out = std::cout, std::ostream& err = std::cerr) : Output(out, err) { }
+  explicit JsonOutput(std::ostream &out = std::cout,
+                      std::ostream &err = std::cerr)
+      : Output(out, err)
+  {
+  }
 
-  void map(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t div,
-           const std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> &values_by_key) const override;
-  void map_hist(BPFtrace &bpftrace, IMap &map, uint32_t top, uint32_t div,
-                const std::map<std::vector<uint8_t>, std::vector<uint64_t>> &values_by_key,
-                const std::vector<std::pair<std::vector<uint8_t>, uint64_t>> &total_counts_by_key) const override;
+  void map(
+      BPFtrace &bpftrace,
+      IMap &map,
+      uint32_t top,
+      uint32_t div,
+      const std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
+          &values_by_key) const override;
+  void map_hist(BPFtrace &bpftrace,
+                IMap &map,
+                uint32_t top,
+                uint32_t div,
+                const std::map<std::vector<uint8_t>, std::vector<uint64_t>>
+                    &values_by_key,
+                const std::vector<std::pair<std::vector<uint8_t>, uint64_t>>
+                    &total_counts_by_key) const override;
   void map_stats(
       BPFtrace &bpftrace,
       IMap &map,
@@ -246,8 +304,12 @@ public:
                      const SizedType &ty,
                      std::vector<uint8_t> &value) const override;
 
-  void message(MessageType type, const std::string& msg, bool nl = true) const override;
-  void message(MessageType type, const std::string& field, uint64_t value) const;
+  void message(MessageType type,
+               const std::string &msg,
+               bool nl = true) const override;
+  void message(MessageType type,
+               const std::string &field,
+               uint64_t value) const;
   void lost_events(uint64_t lost) const override;
   void attached_probes(uint64_t num_probes) const override;
   void helper_error(int func_id,

--- a/src/pcap_writer.h
+++ b/src/pcap_writer.h
@@ -11,8 +11,7 @@ typedef struct pcap_dumper pcap_dumper_t;
 
 namespace bpftrace {
 
-class PCAPwriter
-{
+class PCAPwriter {
 public:
   PCAPwriter()
   {

--- a/src/printf.cpp
+++ b/src/printf.cpp
@@ -71,8 +71,7 @@ int PrintableInt::print(char *buf,
   // For example, an int64_t argument may be pushed onto the stack while an int
   // is stored in a register, in which case "%d" would print the wrong value if
   // we used value_ without an explicit cast.
-  switch (expected_type)
-  {
+  switch (expected_type) {
     case ArgumentType::CHAR:
       return snprintf(buf, size, fmt, static_cast<unsigned char>(value_));
     case ArgumentType::SHORT:
@@ -103,8 +102,7 @@ int PrintableSInt::print(char *buf,
                          const char *fmt,
                          ArgumentType expected_type)
 {
-  switch (expected_type)
-  {
+  switch (expected_type) {
     case ArgumentType::CHAR:
       return snprintf(buf, size, fmt, static_cast<char>(value_));
     case ArgumentType::SHORT:

--- a/src/printf.h
+++ b/src/printf.h
@@ -13,8 +13,7 @@ namespace bpftrace {
 static const std::string generate_pattern_string()
 {
   std::string pattern = "%-?[0-9]*(\\.[0-9]+)?(";
-  for (const auto& e : printf_format_types)
-  {
+  for (const auto& e : printf_format_types) {
     pattern += e.first + "|";
   }
   pattern.pop_back(); // for the last "|"
@@ -26,8 +25,7 @@ const std::regex format_specifier_re(generate_pattern_string());
 
 struct Field;
 
-enum class ArgumentType
-{
+enum class ArgumentType {
   UNKNOWN = 0,
   CHAR,
   SHORT,
@@ -40,18 +38,16 @@ enum class ArgumentType
   POINTER,
 };
 
-class IPrintable
-{
+class IPrintable {
 public:
-  virtual ~IPrintable() { };
+  virtual ~IPrintable(){};
   virtual int print(char* buf,
                     size_t size,
                     const char* fmt,
                     ArgumentType expected_type = ArgumentType::UNKNOWN) = 0;
 };
 
-class PrintableString : public virtual IPrintable
-{
+class PrintableString : public virtual IPrintable {
 public:
   PrintableString(std::string value,
                   std::optional<size_t> buffer_size = std::nullopt,
@@ -62,8 +58,7 @@ private:
   std::string value_;
 };
 
-class PrintableBuffer : public virtual IPrintable
-{
+class PrintableBuffer : public virtual IPrintable {
 public:
   PrintableBuffer(char* buffer, size_t size)
       : value_(std::vector<char>(buffer, buffer + size))
@@ -79,20 +74,22 @@ private:
   bool escape_hex_ = true;
 };
 
-class PrintableCString : public virtual IPrintable
-{
+class PrintableCString : public virtual IPrintable {
 public:
-  PrintableCString(char* value) : value_(value) { }
+  PrintableCString(char* value) : value_(value)
+  {
+  }
   int print(char* buf, size_t size, const char* fmt, ArgumentType) override;
 
 private:
   char* value_;
 };
 
-class PrintableInt : public virtual IPrintable
-{
+class PrintableInt : public virtual IPrintable {
 public:
-  PrintableInt(uint64_t value) : value_(value) { }
+  PrintableInt(uint64_t value) : value_(value)
+  {
+  }
   int print(char* buf,
             size_t size,
             const char* fmt,
@@ -102,8 +99,7 @@ private:
   uint64_t value_;
 };
 
-class PrintableSInt : public virtual IPrintable
-{
+class PrintableSInt : public virtual IPrintable {
 public:
   PrintableSInt(int64_t value) : value_(value)
   {

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -9,8 +9,7 @@
 
 namespace bpftrace {
 
-struct ProbeListItem
-{
+struct ProbeListItem {
   std::string path;
   std::string alias;
   uint32_t type;
@@ -52,8 +51,7 @@ class BPFtrace;
 
 typedef std::map<std::string, std::vector<std::string>> FuncParamLists;
 
-class ProbeMatcher
-{
+class ProbeMatcher {
 public:
   explicit ProbeMatcher(BPFtrace *bpftrace) : bpftrace_(bpftrace)
   {

--- a/src/procmon.cpp
+++ b/src/procmon.cpp
@@ -41,13 +41,10 @@ void ProcMon::setup(pid_t pid)
 
   int pidfd = pidfd_open(pid, 0);
   // Fall back to polling if pidfds or anon inodes are not supported
-  if (pidfd >= 0)
-  {
+  if (pidfd >= 0) {
     pidfd_ = pidfd;
     return;
-  }
-  else if (errno != ENOSYS)
-  {
+  } else if (errno != ENOSYS) {
     if (errno == ESRCH)
       throw SYS_ERROR(""); /* use default error message for ESRCH */
     throw SYS_ERROR("Failed to pidfd_open pid");
@@ -57,8 +54,7 @@ void ProcMon::setup(pid_t pid)
                      sizeof(proc_path_) / sizeof(proc_path_[0]),
                      "/proc/%d/status",
                      pid);
-  if (ret < 0)
-  {
+  if (ret < 0) {
     throw std::runtime_error("failed to snprintf");
   }
 
@@ -78,8 +74,7 @@ bool ProcMon::is_alive(void)
   if (died_)
     return false;
 
-  if (pidfd_ > -1)
-  {
+  if (pidfd_ > -1) {
     struct pollfd pollfd;
     pollfd.fd = pidfd_;
     pollfd.events = POLLIN;
@@ -98,10 +93,8 @@ bool ProcMon::is_alive(void)
   }
 
   int fd = open(proc_path_, 0, O_RDONLY);
-  if (fd < 0)
-  {
-    if (errno == ENOENT)
-    {
+  if (fd < 0) {
+    if (errno == ENOENT) {
       died_ = true;
       return false;
     }

--- a/src/procmon.h
+++ b/src/procmon.h
@@ -4,8 +4,7 @@
 
 namespace bpftrace {
 
-class ProcMonBase
-{
+class ProcMonBase {
 public:
   ProcMonBase() = default;
   virtual ~ProcMonBase() = default;
@@ -27,8 +26,7 @@ protected:
   int pid_ = -1;
 };
 
-class ProcMon : public ProcMonBase
-{
+class ProcMon : public ProcMonBase {
 public:
   ProcMon(pid_t pid);
   ProcMon(const std::string& pid);

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -21,14 +21,12 @@ namespace bpftrace {
 
 class BPFtrace;
 
-struct HelperErrorInfo
-{
+struct HelperErrorInfo {
   int func_id = -1;
   location loc;
 };
 
-struct LinearHistogramArgs
-{
+struct LinearHistogramArgs {
   long min = -1;
   long max = -1;
   long step = -1;
@@ -48,8 +46,7 @@ private:
 // needs such as maps, async printf argument metadata, etc. An instance of this
 // class plus the actual bpf bytecode should be all that's necessary to run a
 // script on another host.
-class RequiredResources
-{
+class RequiredResources {
 public:
   // Create maps in `maps` based on stored metadata
   //

--- a/src/struct.cpp
+++ b/src/struct.cpp
@@ -27,8 +27,7 @@ Bitfield::Bitfield(size_t bit_offset, size_t bit_width)
   //
   // `mask` tells codegen how to mask out the surrounding bitfields.
 
-  if (bit_width > BIFTIELD_BIT_WIDTH_MAX)
-  {
+  if (bit_width > BIFTIELD_BIT_WIDTH_MAX) {
     LOG(WARNING) << "bitfield bitwidth " << bit_width << "is not supported."
                  << " Use bitwidth " << BIFTIELD_BIT_WIDTH_MAX;
     bit_width = BIFTIELD_BIT_WIDTH_MAX;
@@ -46,13 +45,14 @@ Bitfield::Bitfield(size_t bit_offset, size_t bit_width)
 #endif
 }
 
-bool Bitfield::operator==(const Bitfield &other) const {
-  return read_bytes == other.read_bytes
-    && mask == other.mask
-    && access_rshift == other.access_rshift;
+bool Bitfield::operator==(const Bitfield &other) const
+{
+  return read_bytes == other.read_bytes && mask == other.mask &&
+         access_rshift == other.access_rshift;
 }
 
-bool Bitfield::operator!=(const Bitfield &other) const {
+bool Bitfield::operator!=(const Bitfield &other) const
+{
   return !(*this == other);
 }
 
@@ -63,8 +63,7 @@ std::unique_ptr<Struct> Struct::CreateTuple(std::vector<SizedType> fields)
   ssize_t offset = 0;
   ssize_t struct_align = 1;
 
-  for (auto &field : fields)
-  {
+  for (auto &field : fields) {
     auto align = field.GetInTupleAlignment();
     struct_align = std::max(align, struct_align);
     auto size = field.GetSize();
@@ -106,11 +105,9 @@ void Struct::Dump(std::ostream &os)
   };
 
   ssize_t offset = 0;
-  for (const auto &field : fields)
-  {
+  for (const auto &field : fields) {
     auto delta = field.offset - offset;
-    if (delta)
-    {
+    if (delta) {
       prefix(offset, os) << pad(delta) << std::endl;
     }
     prefix(offset + delta, os) << field.type << std::endl;
@@ -121,8 +118,7 @@ void Struct::Dump(std::ostream &os)
 
 bool Struct::HasField(const std::string &name) const
 {
-  for (auto &field : fields)
-  {
+  for (auto &field : fields) {
     if (field.name == name)
       return true;
   }
@@ -131,8 +127,7 @@ bool Struct::HasField(const std::string &name) const
 
 const Field &Struct::GetField(const std::string &name) const
 {
-  for (auto &field : fields)
-  {
+  for (auto &field : fields) {
     if (field.name == name)
       return field;
   }

--- a/src/struct.h
+++ b/src/struct.h
@@ -12,8 +12,7 @@
 
 namespace bpftrace {
 
-struct Bitfield
-{
+struct Bitfield {
   Bitfield(size_t byte_offset, size_t bit_width);
   Bitfield(size_t read_bytes, size_t access_rshift, uint64_t mask)
       : read_bytes(read_bytes), access_rshift(access_rshift), mask(mask)
@@ -42,8 +41,7 @@ private:
   }
 };
 
-struct Field
-{
+struct Field {
   std::string name;
   SizedType type;
   ssize_t offset;
@@ -75,8 +73,7 @@ private:
 
 using Fields = std::vector<Field>;
 
-struct Struct
-{
+struct Struct {
   int size = -1; // in bytes
   int align = 1; // in bytes, used for tuples only
   bool padded = false;
@@ -128,8 +125,7 @@ std::ostream &operator<<(std::ostream &os, const Fields &t);
 
 namespace std {
 template <>
-struct hash<bpftrace::Struct>
-{
+struct hash<bpftrace::Struct> {
   size_t operator()(const bpftrace::Struct &s) const
   {
     size_t hash = std::hash<int>()(s.size);
@@ -140,8 +136,7 @@ struct hash<bpftrace::Struct>
 };
 
 template <>
-struct hash<shared_ptr<bpftrace::Struct>>
-{
+struct hash<shared_ptr<bpftrace::Struct>> {
   size_t operator()(const std::shared_ptr<bpftrace::Struct> &s_ptr) const
   {
     return std::hash<bpftrace::Struct>()(*s_ptr);
@@ -149,8 +144,7 @@ struct hash<shared_ptr<bpftrace::Struct>>
 };
 
 template <>
-struct equal_to<shared_ptr<bpftrace::Struct>>
-{
+struct equal_to<shared_ptr<bpftrace::Struct>> {
   bool operator()(const std::shared_ptr<bpftrace::Struct> &lhs,
                   const std::shared_ptr<bpftrace::Struct> &rhs) const
   {
@@ -161,8 +155,7 @@ struct equal_to<shared_ptr<bpftrace::Struct>>
 
 namespace bpftrace {
 
-class StructManager
-{
+class StructManager {
 public:
   // struct map manipulation
   void Add(const std::string &name, size_t size, bool allow_override = true);

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -16,9 +16,8 @@ std::set<std::string> TracepointFormatParser::struct_list;
 
 bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
 {
-  std::vector<ast::Probe*> probes_with_tracepoint;
-  for (ast::Probe *probe : *program->probes)
-  {
+  std::vector<ast::Probe *> probes_with_tracepoint;
+  for (ast::Probe *probe : *program->probes) {
     if (probe->has_ap_of_probetype(ProbeType::tracepoint))
       probes_with_tracepoint.push_back(probe);
   }
@@ -29,29 +28,23 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
   ast::TracepointArgsVisitor n{};
   if (!bpftrace.has_btf_data())
     program->c_definitions += "#include <linux/types.h>\n";
-  for (ast::Probe *probe : probes_with_tracepoint)
-  {
+  for (ast::Probe *probe : probes_with_tracepoint) {
     n.visit(*probe);
 
-    for (ast::AttachPoint *ap : *probe->attach_points)
-    {
-      if (ap->provider == "tracepoint")
-      {
+    for (ast::AttachPoint *ap : *probe->attach_points) {
+      if (ap->provider == "tracepoint") {
         std::string &category = ap->target;
         std::string &event_name = ap->func;
         std::string format_file_path = tracefs::event_format_file(category,
                                                                   event_name);
         glob_t glob_result;
 
-        if (has_wildcard(category) || has_wildcard(event_name))
-        {
+        if (has_wildcard(category) || has_wildcard(event_name)) {
           // tracepoint wildcard expansion, part 1 of 3. struct definitions.
           memset(&glob_result, 0, sizeof(glob_result));
           int ret = glob(format_file_path.c_str(), 0, NULL, &glob_result);
-          if (ret != 0)
-          {
-            if (ret == GLOB_NOMATCH)
-            {
+          if (ret != 0) {
+            if (ret == GLOB_NOMATCH) {
               LOG(ERROR, ap->loc, std::cerr)
                   << "tracepoints not found: " << category << ":" << event_name;
               // helper message:
@@ -62,17 +55,14 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
                 LOG(ERROR) << strerror(errno) << ": " << format_file_path;
               }
               return false;
-            }
-            else
-            {
+            } else {
               // unexpected error
               LOG(ERROR, ap->loc, std::cerr) << std::string(strerror(errno));
               return false;
             }
           }
 
-          if (probe->tp_args_structs_level <= 0)
-          {
+          if (probe->tp_args_structs_level <= 0) {
             globfree(&glob_result);
             continue;
           }
@@ -88,24 +78,21 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
             std::string real_event = filename.substr(
                 pos, filename.length() - std::string("/format").length() - pos);
 
-            // Check to avoid adding the same struct more than once to definitions
+            // Check to avoid adding the same struct more than once to
+            // definitions
             std::string struct_name = get_struct_name(real_category,
                                                       real_event);
-            if (!TracepointFormatParser::struct_list.count(struct_name))
-            {
+            if (!TracepointFormatParser::struct_list.count(struct_name)) {
               program->c_definitions += get_tracepoint_struct(
                   format_file, real_category, real_event, bpftrace);
               TracepointFormatParser::struct_list.insert(struct_name);
             }
           }
           globfree(&glob_result);
-        }
-        else
-        {
+        } else {
           // single tracepoint
           std::ifstream format_file(format_file_path.c_str());
-          if (format_file.fail())
-          {
+          if (format_file.fail()) {
             // Errno might get clobbered by LOG().
             int saved_errno = errno;
 
@@ -123,8 +110,7 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
               LOG(WARNING, ap->loc, std::cerr)
                   << "Did you mean syscalls:" << event_name << "?";
 
-            if (fail && bt_verbose)
-            {
+            if (fail && bt_verbose) {
               // Having the location info isn't really useful here, so no
               // bpftrace.error
               LOG(ERROR) << strerror(saved_errno) << ": " << format_file_path;
@@ -150,7 +136,9 @@ bool TracepointFormatParser::parse(ast::Program *program, BPFtrace &bpftrace)
   return true;
 }
 
-std::string TracepointFormatParser::get_struct_name(const std::string &category, const std::string &event_name)
+std::string TracepointFormatParser::get_struct_name(
+    const std::string &category,
+    const std::string &event_name)
 {
   return "struct _tracepoint_" + category + "_" + event_name;
 }
@@ -199,27 +187,25 @@ std::string TracepointFormatParser::parse_field(const std::string &line,
 
   // If there'a gap between last field and this one,
   // generate padding fields
-  if (offset && *last_offset)
-  {
+  if (offset && *last_offset) {
     int i, gap = offset - *last_offset;
 
-    for (i = 0; i < gap; i++)
-    {
+    for (i = 0; i < gap; i++) {
       extra += "  char __pad_" + std::to_string(offset - gap + i) + ";\n";
     }
   }
 
   *last_offset = offset + size;
 
-  std::string field = line.substr(field_pos + 6, field_semi_pos - field_pos - 6);
+  std::string field = line.substr(field_pos + 6,
+                                  field_semi_pos - field_pos - 6);
   auto field_type_end_pos = field.find_last_of("\t ");
   if (field_type_end_pos == std::string::npos)
     return "";
   std::string field_type = field.substr(0, field_type_end_pos);
-  std::string field_name = field.substr(field_type_end_pos+1);
+  std::string field_name = field.substr(field_type_end_pos + 1);
 
-  if (field_type.find("__data_loc") != std::string::npos)
-  {
+  if (field_type.find("__data_loc") != std::string::npos) {
     // Note that the type here (ie `int`) does not matter. Later during parse
     // time the parser will rewrite this field type to a u64 so that it can
     // hold the pointer to the actual location of the data.
@@ -236,8 +222,7 @@ std::string TracepointFormatParser::parse_field(const std::string &line,
   // <linux/types.h> and request all the types we need from BTF.
   bpftrace.btf_set_.emplace(field_type);
 
-  if (arr_size_pos != std::string::npos)
-  {
+  if (arr_size_pos != std::string::npos) {
     auto arr_size = field_name.substr(arr_size_pos + 1,
                                       arr_size_end_pos - arr_size_pos - 1);
     if (arr_size.find_first_not_of("0123456789") != std::string::npos)
@@ -247,17 +232,18 @@ std::string TracepointFormatParser::parse_field(const std::string &line,
   return extra + "  " + field_type + " " + field_name + ";\n";
 }
 
-std::string TracepointFormatParser::adjust_integer_types(const std::string &field_type, int size)
+std::string TracepointFormatParser::adjust_integer_types(
+    const std::string &field_type,
+    int size)
 {
   std::string new_type = field_type;
   // Adjust integer fields to correctly sized types
-  if (size == 8)
-  {
+  if (size == 8) {
     if (field_type == "int")
       new_type = "s64";
     if (field_type == "unsigned int" || field_type == "unsigned" ||
-        field_type == "u32" || field_type == "pid_t" ||
-        field_type == "uid_t" || field_type == "gid_t")
+        field_type == "u32" || field_type == "pid_t" || field_type == "uid_t" ||
+        field_type == "gid_t")
       new_type = "u64";
   }
 
@@ -273,8 +259,7 @@ std::string TracepointFormatParser::get_tracepoint_struct(
   std::string format_struct = get_struct_name(category, event_name) + "\n{\n";
   int last_offset = 0;
 
-  for (std::string line; getline(format_file, line); )
-  {
+  for (std::string line; getline(format_file, line);) {
     format_struct += parse_field(line, &last_offset, bpftrace);
   }
 

--- a/src/tracepoint_format_parser.h
+++ b/src/tracepoint_format_parser.h
@@ -10,8 +10,7 @@ namespace bpftrace {
 
 namespace ast {
 
-class TracepointArgsVisitor : public Visitor
-{
+class TracepointArgsVisitor : public Visitor {
 public:
   void visit(Builtin &builtin) override
   {
@@ -27,7 +26,8 @@ public:
     if (probe_->tp_args_structs_level >= 0)
       probe_->tp_args_structs_level++;
   };
-  void visit(Probe &probe) override {
+  void visit(Probe &probe) override
+  {
     probe_ = &probe;
     Visitor::visit(probe);
   };
@@ -37,8 +37,7 @@ private:
 };
 } // namespace ast
 
-class TracepointFormatParser
-{
+class TracepointFormatParser {
 public:
   static bool parse(ast::Program *program, BPFtrace &bpftrace);
   static std::string get_struct_name(const std::string &category,

--- a/src/triggers.h
+++ b/src/triggers.h
@@ -11,14 +11,13 @@
 
 using trigger_fn_t = void (*)();
 
-extern "C"
+extern "C" {
+void __attribute__((noinline)) __target_attr BEGIN_trigger()
 {
-  void __attribute__((noinline)) __target_attr BEGIN_trigger()
-  {
-    asm("");
-  }
-  void __attribute__((noinline)) __target_attr END_trigger()
-  {
-    asm("");
-  }
+  asm("");
+}
+void __attribute__((noinline)) __target_attr END_trigger()
+{
+  asm("");
+}
 }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -29,42 +29,28 @@ std::ostream &operator<<(std::ostream &os, ProbeType type)
 
 std::ostream &operator<<(std::ostream &os, const SizedType &type)
 {
-  if (type.IsRecordTy())
-  {
+  if (type.IsRecordTy()) {
     os << type.GetName();
-  }
-  else if (type.IsPtrTy())
-  {
+  } else if (type.IsPtrTy()) {
     if (type.IsCtxAccess())
       os << "(ctx) ";
     os << *type.GetPointeeTy() << " *";
-  }
-  else if (type.IsIntTy())
-  {
+  } else if (type.IsIntTy()) {
     os << (type.is_signed_ ? "" : "unsigned ") << "int" << 8 * type.GetSize();
-  }
-  else if (type.IsArrayTy())
-  {
+  } else if (type.IsArrayTy()) {
     os << *type.GetElementTy() << "[" << type.GetNumElements() << "]";
-  }
-  else if (type.IsStringTy() || type.IsBufferTy())
-  {
+  } else if (type.IsStringTy() || type.IsBufferTy()) {
     os << type.type << "[" << type.GetSize() << "]";
-  }
-  else if (type.IsTupleTy())
-  {
+  } else if (type.IsTupleTy()) {
     os << "(";
     size_t n = type.GetFieldCount();
-    for (size_t i = 0; i < n; ++i)
-    {
+    for (size_t i = 0; i < n; ++i) {
       os << type.GetField(i).type;
       if (i != n - 1)
         os << ",";
     }
     os << ")";
-  }
-  else
-  {
+  } else {
     os << type.type;
   }
 
@@ -137,8 +123,7 @@ bool SizedType::IsStack() const
 
 std::string addrspacestr(AddrSpace as)
 {
-  switch (as)
-  {
+  switch (as) {
     case AddrSpace::kernel:
       return "kernel";
       break;
@@ -155,8 +140,7 @@ std::string addrspacestr(AddrSpace as)
 
 std::string typestr(Type t)
 {
-  switch (t)
-  {
+  switch (t) {
     // clang-format off
     case Type::none:     return "none";     break;
     case Type::integer:  return "integer";  break;
@@ -205,7 +189,7 @@ ProbeType probetype(const std::string &probeName)
                         });
 
   if (v != PROBE_LIST.end())
-    retType =  v->type;
+    retType = v->type;
 
   return retType;
 }
@@ -562,13 +546,11 @@ bool SizedType::FitsInto(const SizedType &t) const
   if (IsStringTy() && t.IsStringTy())
     return GetSize() <= t.GetSize();
 
-  if (IsTupleTy() && t.IsTupleTy())
-  {
+  if (IsTupleTy() && t.IsTupleTy()) {
     if (GetFieldCount() != t.GetFieldCount())
       return false;
 
-    for (ssize_t i = 0; i < GetFieldCount(); i++)
-    {
+    for (ssize_t i = 0; i < GetFieldCount(); i++) {
       if (!GetField(i).type.FitsInto(t.GetField(i).type))
         return false;
     }
@@ -586,8 +568,7 @@ size_t hash<bpftrace::SizedType>::operator()(
   auto hash = std::hash<unsigned>()(static_cast<unsigned>(type.type));
   bpftrace::hash_combine(hash, type.GetSize());
 
-  switch (type.type)
-  {
+  switch (type.type) {
     case bpftrace::Type::integer:
       bpftrace::hash_combine(hash, type.IsSigned());
       break;

--- a/src/types.h
+++ b/src/types.h
@@ -19,8 +19,7 @@ const int MAX_STACK_SIZE = 1024;
 const int DEFAULT_STACK_SIZE = 127;
 const int COMM_SIZE = 16;
 
-enum class Type : uint8_t
-{
+enum class Type : uint8_t {
   // clang-format off
   none,
   integer,
@@ -54,8 +53,7 @@ enum class Type : uint8_t
   // clang-format on
 };
 
-enum class AddrSpace : uint8_t
-{
+enum class AddrSpace : uint8_t {
   none,
   kernel,
   user,
@@ -64,15 +62,13 @@ enum class AddrSpace : uint8_t
 std::ostream &operator<<(std::ostream &os, Type type);
 std::ostream &operator<<(std::ostream &os, AddrSpace as);
 
-enum class UserSymbolCacheType
-{
+enum class UserSymbolCacheType {
   per_pid,
   per_program,
   none,
 };
 
-enum class StackMode : uint8_t
-{
+enum class StackMode : uint8_t {
   bpftrace,
   perf,
   raw,
@@ -84,12 +80,12 @@ const std::map<StackMode, std::string> STACK_MODE_NAME_MAP = {
   { StackMode::raw, "raw" },
 };
 
-struct StackType
-{
+struct StackType {
   uint16_t limit = DEFAULT_STACK_SIZE;
   StackMode mode = StackMode::bpftrace;
 
-  bool operator ==(const StackType &obj) const {
+  bool operator==(const StackType &obj) const
+  {
     return limit == obj.limit && mode == obj.mode;
   }
 
@@ -108,8 +104,7 @@ private:
   }
 };
 
-enum class TimestampMode : uint8_t
-{
+enum class TimestampMode : uint8_t {
   monotonic,
   boot,
   tai,
@@ -119,8 +114,7 @@ enum class TimestampMode : uint8_t
 struct Struct;
 struct Field;
 
-class SizedType
-{
+class SizedType {
 public:
   SizedType() : type(Type::none)
   {
@@ -242,8 +236,7 @@ public:
   void SetSize(size_t size)
   {
     size_bits_ = size * 8;
-    if (IsIntTy())
-    {
+    if (IsIntTy()) {
       assert(size == 0 || size == 1 || size == 8 || size == 16 || size == 32 ||
              size == 64);
     }
@@ -467,8 +460,7 @@ SizedType CreateTimestampMode();
 
 std::ostream &operator<<(std::ostream &os, const SizedType &type);
 
-enum class ProbeType
-{
+enum class ProbeType {
   invalid,
   special,
   kprobe,
@@ -491,8 +483,7 @@ enum class ProbeType
 
 std::ostream &operator<<(std::ostream &os, ProbeType type);
 
-struct ProbeItem
-{
+struct ProbeItem {
   std::string name;
   std::unordered_set<std::string> aliases;
   ProbeType type;
@@ -532,24 +523,23 @@ std::string typestr(Type t);
 std::string expand_probe_name(const std::string &orig_name);
 std::string probetypeName(ProbeType t);
 
-struct Probe
-{
+struct Probe {
   ProbeType type;
-  std::string path;             // file path if used
-  std::string attach_point;     // probe name (last component)
-  std::string orig_name;        // original full probe name,
-                                // before wildcard expansion
-  std::string name;             // full probe name
+  std::string path;         // file path if used
+  std::string attach_point; // probe name (last component)
+  std::string orig_name;    // original full probe name,
+                            // before wildcard expansion
+  std::string name;         // full probe name
   bool need_expansion;
-  std::string pin;              // pin file for iterator probes
-  std::string ns;               // for USDT probes, if provider namespace not from path
-  uint64_t loc = 0;             // for USDT probes
-  int usdt_location_idx = 0;    // to disambiguate duplicate USDT markers
+  std::string pin;  // pin file for iterator probes
+  std::string ns;   // for USDT probes, if provider namespace not from path
+  uint64_t loc = 0; // for USDT probes
+  int usdt_location_idx = 0; // to disambiguate duplicate USDT markers
   uint64_t log_size = 1000000;
   int index = 0;
   int freq = 0;
-  uint64_t len = 0;             // for watchpoint probes, size of region
-  std::string mode;             // for watchpoint probes, watch mode (rwx)
+  uint64_t len = 0;   // for watchpoint probes, size of region
+  std::string mode;   // for watchpoint probes, watch mode (rwx)
   bool async = false; // for watchpoint probes, if it's an async watchpoint
   uint64_t address = 0;
   uint64_t func_offset = 0;
@@ -583,8 +573,7 @@ private:
 
 const int RESERVED_IDS_PER_ASYNCACTION = 10000;
 
-enum class AsyncAction
-{
+enum class AsyncAction {
   // clang-format off
   printf  = 0,     // printf reserves 0-9999 for printf_ids
   syscall = 10000, // system reserves 10000-19999 for printf_ids
@@ -606,11 +595,7 @@ enum class AsyncAction
 
 uint64_t asyncactionint(AsyncAction a);
 
-enum class PositionalParameterType
-{
-  positional,
-  count
-};
+enum class PositionalParameterType { positional, count };
 
 } // namespace bpftrace
 
@@ -618,12 +603,10 @@ enum class PositionalParameterType
 // Allows to use SizedType in unordered_set/map.
 namespace std {
 template <>
-struct hash<bpftrace::StackType>
-{
+struct hash<bpftrace::StackType> {
   size_t operator()(const bpftrace::StackType &obj) const
   {
-    switch (obj.mode)
-    {
+    switch (obj.mode) {
       case bpftrace::StackMode::bpftrace:
         return std::hash<std::string>()("bpftrace#" + to_string(obj.limit));
       case bpftrace::StackMode::perf:
@@ -637,8 +620,7 @@ struct hash<bpftrace::StackType>
 };
 
 template <>
-struct hash<bpftrace::SizedType>
-{
+struct hash<bpftrace::SizedType> {
   size_t operator()(const bpftrace::SizedType &type) const;
 };
 

--- a/src/usdt.cpp
+++ b/src/usdt.cpp
@@ -58,18 +58,14 @@ std::optional<usdt_probe_entry> USDTHelper::find(int pid,
                                                  const std::string &name)
 {
   usdt_probe_list probes;
-  if (pid > 0)
-  {
+  if (pid > 0) {
     read_probes_for_pid(pid);
-    for (auto const &path : usdt_pid_to_paths_cache[pid])
-    {
+    for (auto const &path : usdt_pid_to_paths_cache[pid]) {
       probes.insert(probes.end(),
                     usdt_provider_cache[path][provider].begin(),
                     usdt_provider_cache[path][provider].end());
     }
-  }
-  else
-  {
+  } else {
     read_probes_for_path(target);
     probes = usdt_provider_cache[target][provider];
   }
@@ -79,12 +75,9 @@ std::optional<usdt_probe_entry> USDTHelper::find(int pid,
                          [&name](const usdt_probe_entry &e) {
                            return e.name == name;
                          });
-  if (it != probes.end())
-  {
+  if (it != probes.end()) {
     return *it;
-  }
-  else
-  {
+  } else {
     return std::nullopt;
   }
 }
@@ -94,10 +87,8 @@ usdt_probe_list USDTHelper::probes_for_pid(int pid, bool print_error)
   read_probes_for_pid(pid, print_error);
 
   usdt_probe_list probes;
-  for (auto const &path : usdt_pid_to_paths_cache[pid])
-  {
-    for (auto const &usdt_probes : usdt_provider_cache[path])
-    {
+  for (auto const &path : usdt_pid_to_paths_cache[pid]) {
+    for (auto const &usdt_probes : usdt_provider_cache[path]) {
       probes.insert(probes.end(),
                     usdt_probes.second.begin(),
                     usdt_probes.second.end());
@@ -109,10 +100,8 @@ usdt_probe_list USDTHelper::probes_for_pid(int pid, bool print_error)
 usdt_probe_list USDTHelper::probes_for_all_pids()
 {
   usdt_probe_list probes;
-  for (int pid : bpftrace::get_all_running_pids())
-  {
-    for (auto &probe : probes_for_pid(pid, false))
-    {
+  for (int pid : bpftrace::get_all_running_pids()) {
+    for (auto &probe : probes_for_pid(pid, false)) {
       probes.push_back(std::move(probe));
     }
   }
@@ -124,8 +113,7 @@ usdt_probe_list USDTHelper::probes_for_path(const std::string &path)
   read_probes_for_path(path);
 
   usdt_probe_list probes;
-  for (auto const &usdt_probes : usdt_provider_cache[path])
-  {
+  for (auto const &usdt_probes : usdt_provider_cache[path]) {
     probes.insert(probes.end(),
                   usdt_probes.second.begin(),
                   usdt_probes.second.end());
@@ -138,13 +126,10 @@ void USDTHelper::read_probes_for_pid(int pid, bool print_error)
   if (pid_cache.count(pid))
     return;
 
-  if (pid > 0)
-  {
+  if (pid > 0) {
     void *ctx = bcc_usdt_new_frompid(pid, nullptr);
-    if (ctx == nullptr)
-    {
-      if (print_error)
-      {
+    if (ctx == nullptr) {
+      if (print_error) {
         LOG(ERROR) << "failed to initialize usdt context for pid: " << pid;
 
         if (kill(pid, 0) == -1 && errno == ESRCH)
@@ -158,9 +143,7 @@ void USDTHelper::read_probes_for_pid(int pid, bool print_error)
     cache_current_pid_paths(pid);
 
     pid_cache.emplace(pid);
-  }
-  else
-  {
+  } else {
     LOG(ERROR) << "a pid must be specified to list USDT probes by PID";
   }
 }
@@ -171,8 +154,7 @@ void USDTHelper::read_probes_for_path(const std::string &path)
     return;
 
   void *ctx = bcc_usdt_new_frompath(path.c_str());
-  if (ctx == nullptr)
-  {
+  if (ctx == nullptr) {
     LOG(ERROR) << "failed to initialize usdt context for path " << path;
     return;
   }

--- a/src/usdt.h
+++ b/src/usdt.h
@@ -5,8 +5,7 @@
 #include <string>
 #include <vector>
 
-struct usdt_probe_entry
-{
+struct usdt_probe_entry {
   std::string path;
   std::string provider;
   std::string name;
@@ -18,8 +17,7 @@ typedef std::vector<usdt_probe_entry> usdt_probe_list;
 
 // Note this class is fully static because bcc_usdt_foreach takes a function
 // pointer callback without a context variable. So we must keep global state.
-class USDTHelper
-{
+class USDTHelper {
 public:
   static std::optional<usdt_probe_entry> find(int pid,
                                               const std::string &target,

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -42,7 +42,7 @@ namespace {
 
 std::vector<int> read_cpu_range(std::string path)
 {
-  std::ifstream cpus_range_stream { path };
+  std::ifstream cpus_range_stream{ path };
   std::vector<int> cpus;
   std::string cpu_range;
 
@@ -50,8 +50,7 @@ std::vector<int> read_cpu_range(std::string path)
     std::size_t rangeop = cpu_range.find('-');
     if (rangeop == std::string::npos) {
       cpus.push_back(std::stoi(cpu_range));
-    }
-    else {
+    } else {
       int start = std::stoi(cpu_range.substr(0, rangeop));
       int end = std::stoi(cpu_range.substr(rangeop + 1));
       for (int i = start; i <= end; i++)
@@ -61,7 +60,7 @@ std::vector<int> read_cpu_range(std::string path)
   return cpus;
 }
 
-std::vector<std::string> expand_wildcard_path(const std::string& path)
+std::vector<std::string> expand_wildcard_path(const std::string &path)
 {
   glob_t glob_result;
   memset(&glob_result, 0, sizeof(glob_result));
@@ -80,11 +79,11 @@ std::vector<std::string> expand_wildcard_path(const std::string& path)
   return matching_paths;
 }
 
-std::vector<std::string> expand_wildcard_paths(const std::vector<std::string>& paths)
+std::vector<std::string> expand_wildcard_paths(
+    const std::vector<std::string> &paths)
 {
   std::vector<std::string> expanded_paths;
-  for (const auto& p : paths)
-  {
+  for (const auto &p : paths) {
     auto ep = expand_wildcard_path(p);
     expanded_paths.insert(expanded_paths.end(), ep.begin(), ep.end());
   }
@@ -110,8 +109,9 @@ const struct vmlinux_location vmlinux_locs[] = {
 };
 
 static bool pid_in_different_mountns(int pid);
-static std::vector<std::string>
-resolve_binary_path(const std::string &cmd, const char *env_paths, int pid);
+static std::vector<std::string> resolve_binary_path(const std::string &cmd,
+                                                    const char *env_paths,
+                                                    int pid);
 
 void StdioSilencer::silence()
 {
@@ -119,8 +119,7 @@ void StdioSilencer::silence()
     return std::system_error(errno, std::generic_category(), msg);
   };
 
-  try
-  {
+  try {
     int fd = fileno(ofile);
     if (fd < 0)
       throw syserr("fileno()");
@@ -138,9 +137,7 @@ void StdioSilencer::silence()
       throw syserr("dup2(new_stdio_, fd)");
 
     close(new_stdio);
-  }
-  catch (const std::system_error &e)
-  {
+  } catch (const std::system_error &e) {
     if (errno == EMFILE)
       LOG(FATAL) << e.what() << ": please raise NOFILE";
     else
@@ -157,8 +154,7 @@ StdioSilencer::~StdioSilencer()
     return std::system_error(errno, std::generic_category(), msg);
   };
 
-  try
-  {
+  try {
     int fd = fileno(ofile);
     if (fd < 0)
       throw syserr("fileno()");
@@ -168,9 +164,7 @@ StdioSilencer::~StdioSilencer()
       throw syserr("dup2(old_stdio_)");
     close(old_stdio_);
     old_stdio_ = -1;
-  }
-  catch (const std::system_error &e)
-  {
+  } catch (const std::system_error &e) {
     LOG(BUG) << e.what();
   }
 }
@@ -184,8 +178,7 @@ KConfig::KConfig()
   const char *path_env = std::getenv("BPFTRACE_KCONFIG_TEST");
   if (path_env)
     config_locs = { std::string(path_env) };
-  else
-  {
+  else {
     struct utsname utsname;
     if (uname(&utsname) < 0)
       return;
@@ -195,19 +188,16 @@ KConfig::KConfig()
     };
   }
 
-  for (auto &path : config_locs)
-  {
+  for (auto &path : config_locs) {
     // gzopen/gzgets handle both uncompressed and compressed files
     gzFile file = gzopen(path.c_str(), "r");
     if (!file)
       continue;
 
     char buf[4096];
-    while (gzgets(file, buf, sizeof(buf)))
-    {
+    while (gzgets(file, buf, sizeof(buf))) {
       std::string option(buf);
-      if (option.find("CONFIG_") == 0)
-      {
+      if (option.find("CONFIG_") == 0) {
         // trim trailing '\n'
         if (option[option.length() - 1] == '\n')
           option = option.substr(0, option.length() - 1);
@@ -228,11 +218,9 @@ bool get_uint64_env_var(const ::std::string &str,
                         const std::function<void(uint64_t)> &cb)
 {
   uint64_t dest;
-  if (const char *env_p = std::getenv(str.c_str()))
-  {
+  if (const char *env_p = std::getenv(str.c_str())) {
     std::istringstream stringstream(env_p);
-    if (!(stringstream >> dest))
-    {
+    if (!(stringstream >> dest)) {
       LOG(ERROR) << "Env var '" << str
                  << "' did not contain a valid uint64_t, or was zero-valued.";
       return false;
@@ -245,16 +233,14 @@ bool get_uint64_env_var(const ::std::string &str,
 bool get_bool_env_var(const ::std::string &str,
                       const std::function<void(bool)> &cb)
 {
-  if (const char *env_p = std::getenv(str.c_str()))
-  {
+  if (const char *env_p = std::getenv(str.c_str())) {
     bool dest;
     std::string s(env_p);
     if (s == "1")
       dest = true;
     else if (s == "0")
       dest = false;
-    else
-    {
+    else {
       LOG(ERROR) << "Env var '" << str
                  << "' did not contain a "
                     "valid value (0 or 1).";
@@ -274,8 +260,7 @@ std::optional<std_filesystem::path> find_in_path(const std::string &name)
     return std::nullopt;
 
   auto paths = split_string(path_env, ':', true);
-  for (const auto &path : paths)
-  {
+  for (const auto &path : paths) {
     auto fpath = std_filesystem::path(path) / name;
     if (std_filesystem::exists(fpath, ec))
       return fpath;
@@ -291,12 +276,9 @@ std::string get_pid_exe(const std::string &pid)
   proc_path /= pid;
   proc_path /= "exe";
 
-  try
-  {
+  try {
     return std_filesystem::read_symlink(proc_path).string();
-  }
-  catch (const std_filesystem::filesystem_error &e)
-  {
+  } catch (const std_filesystem::filesystem_error &e) {
     auto err = e.code().value();
     if (err == ENOENT || err == EINVAL)
       return {};
@@ -333,8 +315,7 @@ std::vector<std::string> get_mapped_paths_for_pid(pid_t pid)
   static std::map<pid_t, std::vector<std::string>> paths_cache;
 
   auto it = paths_cache.find(pid);
-  if (it != paths_cache.end())
-  {
+  if (it != paths_cache.end()) {
     return it->second;
   }
 
@@ -347,15 +328,13 @@ std::vector<std::string> get_mapped_paths_for_pid(pid_t pid)
 
   // get all the mapped libraries
   std::string maps_path = get_proc_maps(pid);
-  if (maps_path.empty())
-  {
+  if (maps_path.empty()) {
     LOG(WARNING) << "Maps path is empty";
     return paths;
   }
 
   std::fstream fs(maps_path, std::ios_base::in);
-  if (!fs.is_open())
-  {
+  if (!fs.is_open()) {
     LOG(WARNING) << "Unable to open procfs mapfile: " << maps_path;
     return paths;
   }
@@ -365,18 +344,15 @@ std::vector<std::string> get_mapped_paths_for_pid(pid_t pid)
   std::string line;
   // Example mapping:
   // 7fc8ee4fa000-7fc8ee4fb000 r--p 00000000 00:1f 27168296 /usr/libc.so.6
-  while (std::getline(fs, line))
-  {
+  while (std::getline(fs, line)) {
     char buf[PATH_MAX + 1];
     buf[0] = '\0';
     auto res = std::sscanf(line.c_str(), "%*s %*s %*x %*s %*u %[^\n]", buf);
     // skip [heap], [vdso], and non file paths etc...
-    if (res == 1 && buf[0] == '/')
-    {
+    if (res == 1 && buf[0] == '/') {
       std::string name = buf;
       if (name.find("(deleted)") == std::string::npos &&
-          seen_mappings.count(name) == 0)
-      {
+          seen_mappings.count(name) == 0) {
         seen_mappings.emplace(name);
         paths.push_back(std::move(name));
       }
@@ -390,16 +366,13 @@ std::vector<std::string> get_mapped_paths_for_pid(pid_t pid)
 std::vector<std::string> get_mapped_paths_for_running_pids()
 {
   std::unordered_set<std::string> unique_paths;
-  for (auto pid : get_all_running_pids())
-  {
-    for (auto &path : get_mapped_paths_for_pid(pid))
-    {
+  for (auto pid : get_all_running_pids()) {
+    for (auto &path : get_mapped_paths_for_pid(pid)) {
       unique_paths.insert(std::move(path));
     }
   }
   std::vector<std::string> paths;
-  for (auto &path : unique_paths)
-  {
+  for (auto &path : unique_paths) {
     paths.emplace_back(std::move(path));
   }
   return paths;
@@ -419,7 +392,7 @@ std::vector<std::string> split_string(const std::string &str,
   std::vector<std::string> elems;
   std::stringstream ss(str);
   std::string value;
-  while(std::getline(ss, value, delimiter)) {
+  while (std::getline(ss, value, delimiter)) {
     if (remove_empty && value.empty())
       continue;
 
@@ -436,7 +409,11 @@ std::string erase_prefix(std::string &str)
   return prefix;
 }
 
-bool wildcard_match(const std::string &str, std::vector<std::string> &tokens, bool start_wildcard, bool end_wildcard) {
+bool wildcard_match(const std::string &str,
+                    std::vector<std::string> &tokens,
+                    bool start_wildcard,
+                    bool end_wildcard)
+{
   size_t next = 0;
 
   if (!start_wildcard)
@@ -516,9 +493,7 @@ std::vector<std::string> get_kernel_cflags(const char *uname_machine,
     arch = "sh";
   } else if (!strncmp(uname_machine, "aarch64", 7)) {
     arch = "arm64";
-  }
-  else if (!strncmp(uname_machine, "loongarch", 9))
-  {
+  } else if (!strncmp(uname_machine, "loongarch", 9)) {
     arch = "loongarch";
   }
 
@@ -532,12 +507,12 @@ std::vector<std::string> get_kernel_cflags(const char *uname_machine,
   cflags.push_back("/virtual/lib/clang/include");
 
   // see linux/Makefile for $(LINUXINCLUDE) + $(USERINCLUDE)
-  cflags.push_back("-I" + ksrc + "/arch/"+arch+"/include");
-  cflags.push_back("-I" + kobj + "/arch/"+arch+"/include/generated");
+  cflags.push_back("-I" + ksrc + "/arch/" + arch + "/include");
+  cflags.push_back("-I" + kobj + "/arch/" + arch + "/include/generated");
   cflags.push_back("-I" + ksrc + "/include");
   cflags.push_back("-I" + kobj + "/include");
-  cflags.push_back("-I" + ksrc + "/arch/"+arch+"/include/uapi");
-  cflags.push_back("-I" + kobj + "/arch/"+arch+"/include/generated/uapi");
+  cflags.push_back("-I" + ksrc + "/arch/" + arch + "/include/uapi");
+  cflags.push_back("-I" + kobj + "/arch/" + arch + "/include/generated/uapi");
   cflags.push_back("-I" + ksrc + "/include/uapi");
   cflags.push_back("-I" + kobj + "/include/generated/uapi");
 
@@ -554,19 +529,16 @@ std::vector<std::string> get_kernel_cflags(const char *uname_machine,
   if (archenv)
     cflags.push_back("-D__TARGET_ARCH_" + arch);
 
-  if (arch == "arm")
-  {
+  if (arch == "arm") {
     // Required by several header files in arch/arm/include
     cflags.push_back("-D__LINUX_ARM_ARCH__=7");
   }
 
-  if (arch == "arm64")
-  {
+  if (arch == "arm64") {
     // arm64 defines KASAN_SHADOW_SCALE_SHIFT in a Makefile instead of defining
     // it in a header file. Since we're not executing make, we need to set the
     // value manually (values are taken from arch/arm64/Makefile).
-    if (kconfig.has_value("CONFIG_KASAN", "y"))
-    {
+    if (kconfig.has_value("CONFIG_KASAN", "y")) {
       if (kconfig.has_value("CONFIG_KASAN_SW_TAGS", "y"))
         cflags.push_back("-DKASAN_SHADOW_SCALE_SHIFT=4");
       else
@@ -591,19 +563,16 @@ std::string get_cgroup_path_in_hierarchy(uint64_t cgroupid,
 
   // Check for root cgroup path separately, since recursive_directory_iterator
   // does not iterate over base directory
-  if (stat(base_path.c_str(), &path_st) >= 0 && path_st.st_ino == cgroupid)
-  {
+  if (stat(base_path.c_str(), &path_st) >= 0 && path_st.st_ino == cgroupid) {
     path_cache[{ cgroupid, base_path }] = "/";
     return "/";
   }
 
   for (auto &path_iter :
-       std_filesystem::recursive_directory_iterator(base_path))
-  {
+       std_filesystem::recursive_directory_iterator(base_path)) {
     if (stat(path_iter.path().c_str(), &path_st) < 0)
       return "";
-    if (path_st.st_ino == cgroupid)
-    {
+    if (path_st.st_ino == cgroupid) {
       // Base directory is not a part of cgroup path
       path_cache[{ cgroupid, base_path }] = path_iter.path().string().substr(
           base_path.length());
@@ -621,11 +590,9 @@ std::vector<std::pair<std::string, std::string>> get_cgroup_hierarchy_roots()
   std::vector<std::pair<std::string, std::string>> result;
 
   const std::regex cgroup_mount_regex("(cgroup[2]?) (\\S*)[ ]?.*");
-  for (std::string line; std::getline(mounts_file, line);)
-  {
+  for (std::string line; std::getline(mounts_file, line);) {
     std::smatch match;
-    if (std::regex_match(line, match, cgroup_mount_regex))
-    {
+    if (std::regex_match(line, match, cgroup_mount_regex)) {
       result.push_back({ match[1].str(), match[2].str() });
     }
   }
@@ -643,15 +610,11 @@ std::vector<std::pair<std::string, std::string>> get_cgroup_paths(
 
   // Replace cgroup version with cgroup mount point directory name for cgroupv1
   // roots and "unified" for cgroupv2 roots
-  for (auto &root : roots)
-  {
-    if (root.first == "cgroup")
-    {
+  for (auto &root : roots) {
+    if (root.first == "cgroup") {
       root = { std_filesystem::path(root.second).filename().string(),
                root.second };
-    }
-    else if (root.first == "cgroup2")
-    {
+    } else if (root.first == "cgroup2") {
       root = { "unified", root.second };
     }
   }
@@ -695,18 +658,15 @@ std::vector<std::pair<std::string, std::string>> get_cgroup_paths(
 
 bool is_module_loaded(const std::string &module)
 {
-  if (module == "vmlinux")
-  {
+  if (module == "vmlinux") {
     return true;
   }
 
   // This file lists all loaded modules
   std::ifstream modules_file("/proc/modules");
 
-  for (std::string line; std::getline(modules_file, line);)
-  {
-    if (line.compare(0, module.size() + 1, module + " ") == 0)
-    {
+  for (std::string line; std::getline(modules_file, line);) {
+    if (line.compare(0, module.size() + 1, module + " ") == 0) {
       modules_file.close();
       return true;
     }
@@ -716,7 +676,7 @@ bool is_module_loaded(const std::string &module)
   return false;
 }
 
-bool is_dir(const std::string& path)
+bool is_dir(const std::string &path)
 {
   std::error_code ec;
   std_filesystem::path buf{ path };
@@ -724,85 +684,85 @@ bool is_dir(const std::string& path)
 }
 
 namespace {
-  struct KernelHeaderTmpDir {
-    KernelHeaderTmpDir(const std::string& prefix) : path{prefix + "XXXXXX"}
-    {
-      if (::mkdtemp(&path[0]) == nullptr) {
-        throw std::runtime_error("creating temporary path for kheaders.tar.xz failed");
-      }
-    }
-
-    ~KernelHeaderTmpDir()
-    {
-      if (path.size() > 0) {
-        // move_to either did not succeed or did not run, so clean up after ourselves
-        exec_system(("rm -rf " + path).c_str());
-      }
-    }
-
-    void move_to(const std::string& new_path)
-    {
-      int err = ::rename(path.c_str(), new_path.c_str());
-      if (err == 0) {
-        path = "";
-      }
-    }
-
-    std::string path;
-  };
-
-  std::string unpack_kheaders_tar_xz(const struct utsname& utsname)
+struct KernelHeaderTmpDir {
+  KernelHeaderTmpDir(const std::string &prefix) : path{ prefix + "XXXXXX" }
   {
-    std::error_code ec;
+    if (::mkdtemp(&path[0]) == nullptr) {
+      throw std::runtime_error(
+          "creating temporary path for kheaders.tar.xz failed");
+    }
+  }
+
+  ~KernelHeaderTmpDir()
+  {
+    if (path.size() > 0) {
+      // move_to either did not succeed or did not run, so clean up after
+      // ourselves
+      exec_system(("rm -rf " + path).c_str());
+    }
+  }
+
+  void move_to(const std::string &new_path)
+  {
+    int err = ::rename(path.c_str(), new_path.c_str());
+    if (err == 0) {
+      path = "";
+    }
+  }
+
+  std::string path;
+};
+
+std::string unpack_kheaders_tar_xz(const struct utsname &utsname)
+{
+  std::error_code ec;
 #if defined(__ANDROID__)
-    std_filesystem::path path_prefix{ "/data/local/tmp" };
+  std_filesystem::path path_prefix{ "/data/local/tmp" };
 #else
-    std_filesystem::path path_prefix{ "/tmp" };
+  std_filesystem::path path_prefix{ "/tmp" };
 #endif
-    std_filesystem::path path_kheaders{ "/sys/kernel/kheaders.tar.xz" };
-    if (const char* tmpdir = ::getenv("TMPDIR")) {
-      path_prefix = tmpdir;
-    }
-    path_prefix /= "kheaders-";
-    std_filesystem::path shared_path{ path_prefix.string() + utsname.release };
+  std_filesystem::path path_kheaders{ "/sys/kernel/kheaders.tar.xz" };
+  if (const char *tmpdir = ::getenv("TMPDIR")) {
+    path_prefix = tmpdir;
+  }
+  path_prefix /= "kheaders-";
+  std_filesystem::path shared_path{ path_prefix.string() + utsname.release };
 
-    if (std_filesystem::exists(shared_path, ec))
-    {
-      // already unpacked
-      return shared_path.string();
-    }
+  if (std_filesystem::exists(shared_path, ec)) {
+    // already unpacked
+    return shared_path.string();
+  }
 
-    if (!std_filesystem::exists(path_kheaders, ec))
-    {
-      StderrSilencer silencer;
-      silencer.silence();
+  if (!std_filesystem::exists(path_kheaders, ec)) {
+    StderrSilencer silencer;
+    silencer.silence();
 
-      FILE* modprobe = ::popen("modprobe kheaders", "w");
-      if (modprobe == nullptr || pclose(modprobe) != 0) {
-        return "";
-      }
-
-      if (!std_filesystem::exists(path_kheaders, ec))
-      {
-        return "";
-      }
-    }
-
-    KernelHeaderTmpDir tmpdir{path_prefix};
-
-    FILE* tar = ::popen(("tar xf /sys/kernel/kheaders.tar.xz -C " + tmpdir.path).c_str(), "w");
-    if (!tar) {
+    FILE *modprobe = ::popen("modprobe kheaders", "w");
+    if (modprobe == nullptr || pclose(modprobe) != 0) {
       return "";
     }
 
-    int rc = ::pclose(tar);
-    if (rc == 0) {
-      tmpdir.move_to(shared_path);
-      return shared_path;
+    if (!std_filesystem::exists(path_kheaders, ec)) {
+      return "";
     }
+  }
 
+  KernelHeaderTmpDir tmpdir{ path_prefix };
+
+  FILE *tar = ::popen(
+      ("tar xf /sys/kernel/kheaders.tar.xz -C " + tmpdir.path).c_str(), "w");
+  if (!tar) {
     return "";
   }
+
+  int rc = ::pclose(tar);
+  if (rc == 0) {
+    tmpdir.move_to(shared_path);
+    return shared_path;
+  }
+
+  return "";
+}
 } // namespace
 
 // get_kernel_dirs returns {ksrc, kobj} - directories for pristine and
@@ -820,21 +780,20 @@ namespace {
 //   /lib/modules/`uname -r`/build/
 //
 // {"", ""} is returned if no trace of kernel headers was found at all.
-// Both ksrc and kobj are guaranteed to be != "", if at least some trace of kernel sources was found.
+// Both ksrc and kobj are guaranteed to be != "", if at least some trace of
+// kernel sources was found.
 std::tuple<std::string, std::string> get_kernel_dirs(
     const struct utsname &utsname,
     bool unpack_kheaders)
 {
 #ifdef KERNEL_HEADERS_DIR
-  return {KERNEL_HEADERS_DIR, KERNEL_HEADERS_DIR};
+  return { KERNEL_HEADERS_DIR, KERNEL_HEADERS_DIR };
 #endif
 
   const char *kpath_env = ::getenv("BPFTRACE_KERNEL_SOURCE");
-  if (kpath_env)
-  {
+  if (kpath_env) {
     const char *kpath_build_env = ::getenv("BPFTRACE_KERNEL_BUILD");
-    if (!kpath_build_env)
-    {
+    if (!kpath_build_env) {
       kpath_build_env = kpath_env;
     }
     return std::make_tuple(kpath_env, kpath_build_env);
@@ -844,29 +803,25 @@ std::tuple<std::string, std::string> get_kernel_dirs(
   auto ksrc = kdir + "/source";
   auto kobj = kdir + "/build";
 
-  // if one of source/ or build/ is not present - try to use the other one for both.
+  // if one of source/ or build/ is not present - try to use the other one for
+  // both.
   if (!is_dir(ksrc)) {
     ksrc = "";
   }
   if (!is_dir(kobj)) {
     kobj = "";
   }
-  if (ksrc.empty() && kobj.empty())
-  {
-    if (unpack_kheaders)
-    {
+  if (ksrc.empty() && kobj.empty()) {
+    if (unpack_kheaders) {
       const auto kheaders_tar_xz_path = unpack_kheaders_tar_xz(utsname);
       if (kheaders_tar_xz_path.size() > 0)
         return std::make_tuple(kheaders_tar_xz_path, kheaders_tar_xz_path);
     }
     return std::make_tuple("", "");
   }
-  if (ksrc.empty())
-  {
+  if (ksrc.empty()) {
     ksrc = kobj;
-  }
-  else if (kobj.empty())
-  {
+  } else if (kobj.empty()) {
     kobj = ksrc;
   }
 
@@ -875,15 +830,11 @@ std::tuple<std::string, std::string> get_kernel_dirs(
 
 const std::string &is_deprecated(const std::string &str)
 {
-
   std::vector<DeprecatedName>::iterator item;
 
-  for (item = DEPRECATED_LIST.begin(); item != DEPRECATED_LIST.end(); item++)
-  {
-    if (str == item->old_name)
-    {
-      if (item->show_warning)
-      {
+  for (item = DEPRECATED_LIST.begin(); item != DEPRECATED_LIST.end(); item++) {
+    if (str == item->old_name) {
+      if (item->show_warning) {
         LOG(WARNING) << item->old_name
                      << " is deprecated and will be removed in the future. Use "
                      << item->new_name << " instead.";
@@ -899,12 +850,9 @@ const std::string &is_deprecated(const std::string &str)
 
 bool is_unsafe_func(const std::string &func_name)
 {
-  return std::any_of(
-      UNSAFE_BUILTIN_FUNCS.begin(),
-      UNSAFE_BUILTIN_FUNCS.end(),
-      [&](const auto& cand) {
-        return func_name == cand;
-      });
+  return std::any_of(UNSAFE_BUILTIN_FUNCS.begin(),
+                     UNSAFE_BUILTIN_FUNCS.end(),
+                     [&](const auto &cand) { return func_name == cand; });
 }
 
 bool is_compile_time_func(const std::string &func_name)
@@ -926,7 +874,8 @@ std::string exec_system(const char *cmd)
   std::array<char, 128> buffer;
   std::string result;
   std::shared_ptr<FILE> pipe(popen(cmd, "r"), pclose);
-  if (!pipe) throw std::runtime_error("popen() failed!");
+  if (!pipe)
+    throw std::runtime_error("popen() failed!");
   while (!feof(pipe.get())) {
     if (fgets(buffer.data(), 128, pipe.get()) != nullptr)
       result += buffer.data();
@@ -937,7 +886,7 @@ std::string exec_system(const char *cmd)
 /*
 Original resolve_binary_path API defaulting to bpftrace's mount namespace
 */
-std::vector<std::string> resolve_binary_path(const std::string& cmd)
+std::vector<std::string> resolve_binary_path(const std::string &cmd)
 {
   const char *env_paths = getenv("PATH");
   return resolve_binary_path(cmd, env_paths, -1);
@@ -953,28 +902,22 @@ std::vector<std::string> resolve_binary_path(const std::string &cmd, int pid)
   std::string env_paths = "";
   std::ostringstream pid_environ_path;
 
-  if (pid > 0 && pid_in_different_mountns(pid))
-  {
+  if (pid > 0 && pid_in_different_mountns(pid)) {
     pid_environ_path << "/proc/" << pid << "/environ";
     std::ifstream environ(pid_environ_path.str());
 
-    if (environ)
-    {
+    if (environ) {
       std::string env_var;
       std::string pathstr = ("PATH=");
-      while (std::getline(environ, env_var, '\0'))
-      {
-        if (env_var.find(pathstr) != std::string::npos)
-        {
+      while (std::getline(environ, env_var, '\0')) {
+        if (env_var.find(pathstr) != std::string::npos) {
           env_paths = env_var.substr(pathstr.length());
           break;
         }
       }
     }
     return resolve_binary_path(cmd, env_paths.c_str(), pid);
-  }
-  else
-  {
+  } else {
     return resolve_binary_path(cmd, getenv("PATH"), pid);
   }
 }
@@ -983,21 +926,21 @@ std::vector<std::string> resolve_binary_path(const std::string &cmd, int pid)
 Private interface to resolve_binary_path, used for the exposed variants above,
 allowing for a PID whose mount namespace should be optionally considered.
 */
-static std::vector<std::string>
-resolve_binary_path(const std::string &cmd, const char *env_paths, int pid)
+static std::vector<std::string> resolve_binary_path(const std::string &cmd,
+                                                    const char *env_paths,
+                                                    int pid)
 {
   std::vector<std::string> candidate_paths = { cmd };
 
   if (env_paths != nullptr && cmd.find("/") == std::string::npos)
-    for (const auto& path : split_string(env_paths, ':'))
+    for (const auto &path : split_string(env_paths, ':'))
       candidate_paths.push_back(path + "/" + cmd);
 
   if (cmd.find("*") != std::string::npos)
     candidate_paths = ::expand_wildcard_paths(candidate_paths);
 
   std::vector<std::string> valid_executable_paths;
-  for (const auto &path : candidate_paths)
-  {
+  for (const auto &path : candidate_paths) {
     std::string rel_path;
     if (pid > 0 && pid_in_different_mountns(pid))
       rel_path = path_for_pid_mountns(pid, path);
@@ -1018,13 +961,10 @@ std::string path_for_pid_mountns(int pid, const std::string &path)
 
   snprintf(pid_root, sizeof(pid_root), "/proc/%d/root", pid);
 
-  if (path.find(pid_root) != 0)
-  {
+  if (path.find(pid_root) != 0) {
     std::string sep = (path.length() >= 1 && path.at(0) == '/') ? "" : "/";
     pid_relative_path << pid_root << sep << path;
-  }
-  else
-  {
+  } else {
     // The path is already relative to the pid's root
     pid_relative_path << path;
   }
@@ -1055,15 +995,13 @@ static bool pid_in_different_mountns(int pid)
   target_path /= std::to_string(pid);
   target_path /= "ns/mnt";
 
-  if (!std_filesystem::exists(self_path, ec))
-  {
+  if (!std_filesystem::exists(self_path, ec)) {
     throw MountNSException(
         "Failed to compare mount ns with PID " + std::to_string(pid) +
         ". The error was open (/proc/self/ns/mnt): " + ec.message());
   }
 
-  if (!std_filesystem::exists(target_path, ec))
-  {
+  if (!std_filesystem::exists(target_path, ec)) {
     throw MountNSException(
         "Failed to compare mount ns with PID " + std::to_string(pid) +
         ". The error was open (/proc/<pid>/ns/mnt): " + ec.message());
@@ -1071,8 +1009,7 @@ static bool pid_in_different_mountns(int pid)
 
   bool result = !std_filesystem::equivalent(self_path, target_path, ec);
 
-  if (ec)
-  {
+  if (ec) {
     throw MountNSException("Failed to compare mount ns with PID " +
                            std::to_string(pid) +
                            ". The error was (fstat): " + ec.message());
@@ -1086,7 +1023,7 @@ void cat_file(const char *filename, size_t max_bytes, std::ostream &out)
   std::ifstream file(filename);
   const size_t BUFSIZE = 4096;
 
-  if (file.fail()){
+  if (file.fail()) {
     LOG(ERROR) << "failed to open file '" << filename
                << "': " << strerror(errno);
     return;
@@ -1112,12 +1049,12 @@ void cat_file(const char *filename, size_t max_bytes, std::ostream &out)
   }
 }
 
-std::string str_join(const std::vector<std::string> &list, const std::string &delim)
+std::string str_join(const std::vector<std::string> &list,
+                     const std::string &delim)
 {
   std::string str;
   bool first = true;
-  for (const auto &elem : list)
-  {
+  for (const auto &elem : list) {
     if (first)
       first = false;
     else
@@ -1131,12 +1068,9 @@ std::string str_join(const std::vector<std::string> &list, const std::string &de
 bool is_numeric(const std::string &s)
 {
   std::size_t idx;
-  try
-  {
+  try {
     std::stoll(s, &idx, 0);
-  }
-  catch (...)
-  {
+  } catch (...) {
     return false;
   }
   return idx == s.size();
@@ -1152,8 +1086,7 @@ bool symbol_has_cpp_mangled_signature(const std::string &sym_name)
 
 pid_t parse_pid(const std::string &str)
 {
-  try
-  {
+  try {
     constexpr ssize_t pid_max = 4 * 1024 * 1024;
     std::size_t idx = 0;
     auto pid = std::stol(str, &idx, 10);
@@ -1165,13 +1098,9 @@ pid_t parse_pid(const std::string &str)
                                 "out of valid pid range [1," +
                                     std::to_string(pid_max) + "]");
     return pid;
-  }
-  catch (const std::out_of_range &e)
-  {
+  } catch (const std::out_of_range &e) {
     throw InvalidPIDException(str, "outside of integer range");
-  }
-  catch (const std::invalid_argument &e)
-  {
+  } catch (const std::invalid_argument &e) {
     throw InvalidPIDException(str, "is not a valid decimal number");
   }
 }
@@ -1212,10 +1141,8 @@ FuncsModulesMap parse_traceable_funcs()
                                       : tracefs::available_filter_functions();
 
   std::ifstream available_funs(kprobe_path);
-  if (available_funs.fail())
-  {
-    if (bt_debug != DebugLevel::kNone)
-    {
+  if (available_funs.fail()) {
+    if (bt_debug != DebugLevel::kNone) {
       std::cerr << "Error while reading traceable functions from "
                 << kprobe_path << ": " << strerror(errno);
     }
@@ -1224,8 +1151,7 @@ FuncsModulesMap parse_traceable_funcs()
 
   FuncsModulesMap result;
   std::string line;
-  while (std::getline(available_funs, line))
-  {
+  while (std::getline(available_funs, line)) {
     auto func_mod = split_symbol_module(line);
     if (func_mod.second.empty())
       func_mod.second = "vmlinux";
@@ -1235,11 +1161,9 @@ FuncsModulesMap parse_traceable_funcs()
   // Filter out functions from the kprobe blacklist.
   const std::string kprobes_blacklist_path = debugfs::kprobes_blacklist();
   std::ifstream kprobes_blacklist_funs(kprobes_blacklist_path);
-  while (std::getline(kprobes_blacklist_funs, line))
-  {
+  while (std::getline(kprobes_blacklist_funs, line)) {
     auto addr_func_mod = split_addrrange_symbol_module(line);
-    if (result.find(std::get<1>(addr_func_mod)) != result.end())
-    {
+    if (result.find(std::get<1>(addr_func_mod)) != result.end()) {
       result.erase(std::get<1>(addr_func_mod));
     }
   }
@@ -1255,18 +1179,15 @@ static uint32_t _find_version_note(unsigned long base)
 {
   auto ehdr = reinterpret_cast<const ElfW(Ehdr) *>(base);
 
-  for (int i = 0; i < ehdr->e_shnum; i++)
-  {
+  for (int i = 0; i < ehdr->e_shnum; i++) {
     auto shdr = reinterpret_cast<const ElfW(Shdr) *>(base + ehdr->e_shoff +
                                                      (i * ehdr->e_shentsize));
 
-    if (shdr->sh_type == SHT_NOTE)
-    {
+    if (shdr->sh_type == SHT_NOTE) {
       auto ptr = reinterpret_cast<const char *>(base + shdr->sh_offset);
       auto end = ptr + shdr->sh_size;
 
-      while (ptr < end)
-      {
+      while (ptr < end) {
         auto nhdr = reinterpret_cast<const ElfW(Nhdr) *>(ptr);
         ptr += sizeof *nhdr;
 
@@ -1335,22 +1256,18 @@ static uint32_t kernel_version_from_khdr(void)
 uint32_t kernel_version(int attempt)
 {
   static std::optional<uint32_t> a0, a1, a2;
-  switch (attempt)
-  {
-    case 0:
-    {
+  switch (attempt) {
+    case 0: {
       if (!a0)
         a0 = kernel_version_from_vdso();
       return *a0;
     }
-    case 1:
-    {
+    case 1: {
       if (!a1)
         a1 = kernel_version_from_uts();
       return *a1;
     }
-    case 2:
-    {
+    case 2: {
       if (!a2)
         a2 = kernel_version_from_khdr();
       return *a2;
@@ -1368,20 +1285,14 @@ std::optional<std::string> abs_path(const std::string &rel_path)
   // of processes in a different mount namespace (than the one bpftrace is
   // running in), failing during canonicalization. See iovisor:bpftrace#1595
   static auto re = std::regex("^/proc/\\d+/root/.*");
-  if (!std::regex_match(rel_path, re))
-  {
-    try
-    {
+  if (!std::regex_match(rel_path, re)) {
+    try {
       auto p = std_filesystem::path(rel_path);
       return std_filesystem::canonical(std_filesystem::absolute(p)).string();
-    }
-    catch (std_filesystem::filesystem_error &)
-    {
+    } catch (std_filesystem::filesystem_error &) {
       return {};
     }
-  }
-  else
-  {
+  } else {
     return rel_path;
   }
 }
@@ -1389,8 +1300,7 @@ std::optional<std::string> abs_path(const std::string &rel_path)
 int64_t min_value(const std::vector<uint8_t> &value, int nvalues)
 {
   int64_t val, max = 0;
-  for (int i = 0; i < nvalues; i++)
-  {
+  for (int i = 0; i < nvalues; i++) {
     val = read_data<int64_t>(value.data() + i * sizeof(int64_t));
     if (val > max)
       max = val;
@@ -1402,8 +1312,7 @@ int64_t min_value(const std::vector<uint8_t> &value, int nvalues)
 uint64_t max_value(const std::vector<uint8_t> &value, int nvalues)
 {
   uint64_t val, max = 0;
-  for (int i = 0; i < nvalues; i++)
-  {
+  for (int i = 0; i < nvalues; i++) {
     val = read_data<uint64_t>(value.data() + i * sizeof(uint64_t));
     if (val > max)
       max = val;
@@ -1486,8 +1395,7 @@ std::vector<int> get_pids_for_program(const std::string &program)
 {
   std::error_code ec;
   auto program_abs = std_filesystem::canonical(program, ec);
-  if (ec)
-  {
+  if (ec) {
     // std::filesystem::canonical will fail if we are attaching to a uprobe that
     // lives in another filesystem namespace. For example,
     // uprobe:/proc/12345/root/my_program:function1
@@ -1499,8 +1407,7 @@ std::vector<int> get_pids_for_program(const std::string &program)
   }
 
   std::vector<int> pids;
-  for (const auto &process : std_filesystem::directory_iterator("/proc"))
-  {
+  for (const auto &process : std_filesystem::directory_iterator("/proc")) {
     std::string filename = process.path().filename().string();
     if (!std::all_of(filename.begin(), filename.end(), ::isdigit))
       continue;
@@ -1516,8 +1423,7 @@ std::vector<int> get_pids_for_program(const std::string &program)
 std::vector<int> get_all_running_pids()
 {
   std::vector<int> pids;
-  for (const auto &process : std_filesystem::directory_iterator("/proc"))
-  {
+  for (const auto &process : std_filesystem::directory_iterator("/proc")) {
     std::string filename = process.path().filename().string();
     if (!std::all_of(filename.begin(), filename.end(), ::isdigit))
       continue;
@@ -1539,8 +1445,7 @@ std::string sanitise_bpf_program_name(const std::string &name)
 
   // Kernel KSYM_NAME_LEN is 128 until 6.1
   // If we'll exceed the limit, hash the string and cap at 127 (+ null byte).
-  if (sanitised_name.size() > 127)
-  {
+  if (sanitised_name.size() > 127) {
     size_t hash = std::hash<std::string>{}(sanitised_name);
 
     // std::hash returns size_t, so we reserve 2*sizeof(size_t)+1 characters

--- a/src/utils.h
+++ b/src/utils.h
@@ -19,15 +19,13 @@
 
 namespace bpftrace {
 
-struct vmlinux_location
-{
+struct vmlinux_location {
   const char *path; // path with possible "%s" format to be replaced current
                     // release
   bool raw;         // file is either as ELF (false) or raw BTF data (true)
 };
 extern const struct vmlinux_location vmlinux_locs[];
-class MountNSException : public std::exception
-{
+class MountNSException : public std::exception {
 public:
   MountNSException(const std::string &msg) : msg_(msg)
   {
@@ -42,8 +40,7 @@ private:
   std::string msg_;
 };
 
-class InvalidPIDException : public std::exception
-{
+class InvalidPIDException : public std::exception {
 public:
   InvalidPIDException(const std::string &pid, const std::string &msg)
   {
@@ -59,16 +56,14 @@ private:
   std::string msg_;
 };
 
-class EnospcException : public std::runtime_error
-{
+class EnospcException : public std::runtime_error {
 public:
   // C++11 feature: bring base class constructor into scope to automatically
   // forward constructor calls to base class
   using std::runtime_error::runtime_error;
 };
 
-class StdioSilencer
-{
+class StdioSilencer {
 public:
   StdioSilencer() = default;
   ~StdioSilencer();
@@ -81,8 +76,7 @@ private:
   int old_stdio_ = -1;
 };
 
-class StderrSilencer : public StdioSilencer
-{
+class StderrSilencer : public StdioSilencer {
 public:
   StderrSilencer()
   {
@@ -90,8 +84,7 @@ public:
   }
 };
 
-class StdoutSilencer : public StdioSilencer
-{
+class StdoutSilencer : public StdioSilencer {
 public:
   StdoutSilencer()
   {
@@ -100,8 +93,7 @@ public:
 };
 
 // Helper class to convert a pointer to an `std::istream`
-class Membuf : public std::streambuf
-{
+class Membuf : public std::streambuf {
 public:
   Membuf(uint8_t *begin, uint8_t *end)
   {
@@ -113,19 +105,19 @@ public:
 
 // Hack used to suppress build warning related to #474
 template <typename new_signature, typename old_signature>
-new_signature cast_signature(old_signature func) {
+new_signature cast_signature(old_signature func)
+{
 #if __GNUC__ >= 8
-_Pragma("GCC diagnostic push")
-_Pragma("GCC diagnostic ignored \"-Wcast-function-type\"")
+  _Pragma("GCC diagnostic push")
+      _Pragma("GCC diagnostic ignored \"-Wcast-function-type\"")
 #endif
-  return reinterpret_cast<new_signature>(func);
+          return reinterpret_cast<new_signature>(func);
 #if __GNUC__ >= 8
-_Pragma("GCC diagnostic pop")
+  _Pragma("GCC diagnostic pop")
 #endif
 }
 
-struct DeprecatedName
-{
+struct DeprecatedName {
   std::string old_name;
   std::string new_name;
   bool show_warning = true;
@@ -134,8 +126,7 @@ struct DeprecatedName
 typedef std::unordered_map<std::string, std::unordered_set<std::string>>
     FuncsModulesMap;
 
-struct KConfig
-{
+struct KConfig {
   KConfig();
   bool has_value(const std::string &name, const std::string &value) const
   {
@@ -146,9 +137,7 @@ struct KConfig
   std::unordered_map<std::string, std::string> config;
 };
 
-static std::vector<DeprecatedName> DEPRECATED_LIST =
-{
-};
+static std::vector<DeprecatedName> DEPRECATED_LIST = {};
 
 static std::vector<std::string> UNSAFE_BUILTIN_FUNCS = {
   "system",
@@ -227,8 +216,7 @@ std::tuple<std::string, std::string, std::string> split_addrrange_symbol_module(
 
 std::vector<std::string> get_mapped_paths_for_pid(pid_t pid);
 std::vector<std::string> get_mapped_paths_for_running_pids();
-struct elf_symbol
-{
+struct elf_symbol {
   std::string name;
   uintptr_t start;
   uintptr_t end;
@@ -307,8 +295,7 @@ template <typename T>
 T reduce_value(const std::vector<uint8_t> &value, int nvalues)
 {
   T sum = 0;
-  for (int i = 0; i < nvalues; i++)
-  {
+  for (int i = 0; i < nvalues; i++) {
     sum += read_data<T>(value.data() + i * sizeof(T));
   }
   return sum;

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -87,7 +87,9 @@ TEST(ast, probe_name_uprobe)
   ap3->address = 1000;
   auto attach_points3 = APL({ ap1, ap2, ap3 });
   Probe uprobe3(attach_points3, nullptr, nullptr);
-  EXPECT_EQ(uprobe3.name(), "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/sh:1000");
+  EXPECT_EQ(
+      uprobe3.name(),
+      "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/sh:1000");
 
   auto ap4 = new AttachPoint("");
   ap4->provider = "uprobe";
@@ -96,7 +98,9 @@ TEST(ast, probe_name_uprobe)
   ap4->func_offset = 10;
   auto attach_points4 = APL({ ap1, ap2, ap3, ap4 });
   Probe uprobe4(attach_points4, nullptr, nullptr);
-  EXPECT_EQ(uprobe4.name(), "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/sh:1000,uprobe:/bin/sh:somefunc+10");
+  EXPECT_EQ(uprobe4.name(),
+            "uprobe:/bin/sh:readline,uprobe:/bin/sh:somefunc,uprobe:/bin/"
+            "sh:1000,uprobe:/bin/sh:somefunc+10");
 
   auto ap5 = new AttachPoint("");
   ap5->provider = "uprobe";

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -23,8 +23,7 @@ static const std::string kprobe_name(const std::string &attach_point,
                                      uint64_t func_offset)
 {
   auto str = func_offset ? "+" + std::to_string(func_offset) : "";
-  if (!target.empty())
-  {
+  if (!target.empty()) {
     return "kprobe:" + target + ":" + attach_point + str;
   }
   return "kprobe:" + attach_point + str;
@@ -70,8 +69,7 @@ static auto parse_probe(const std::string &str)
   StrictMock<MockBPFtrace> b;
   Driver d(b);
 
-  if (d.parse_str(str))
-  {
+  if (d.parse_str(str)) {
     throw std::runtime_error("Parser failed");
   }
   auto probe = d.root->probes->front();
@@ -94,8 +92,12 @@ static const std::string uprobe_name(const std::string &path,
   }
 }
 
-void check_uprobe(Probe &p, const std::string &path, const std::string &attach_point, const std::string &orig_name,
-                  uint64_t address = 0, uint64_t func_offset = 0)
+void check_uprobe(Probe &p,
+                  const std::string &path,
+                  const std::string &attach_point,
+                  const std::string &orig_name,
+                  uint64_t address = 0,
+                  uint64_t func_offset = 0)
 {
   bool retprobe = orig_name.find("uretprobe:") == 0 ||
                   orig_name.find("ur:") == 0;
@@ -108,7 +110,11 @@ void check_uprobe(Probe &p, const std::string &path, const std::string &attach_p
   EXPECT_EQ(func_offset, p.func_offset);
 }
 
-void check_usdt(Probe &p, const std::string &path, const std::string &provider, const std::string &attach_point, const std::string &orig_name)
+void check_usdt(Probe &p,
+                const std::string &path,
+                const std::string &provider,
+                const std::string &attach_point,
+                const std::string &orig_name)
 {
   EXPECT_EQ(ProbeType::usdt, p.type);
   EXPECT_EQ(attach_point, p.attach_point);
@@ -116,7 +122,10 @@ void check_usdt(Probe &p, const std::string &path, const std::string &provider, 
   EXPECT_EQ("usdt:" + path + ":" + provider + ":" + attach_point, p.name);
 }
 
-void check_tracepoint(Probe &p, const std::string &target, const std::string &func, const std::string &orig_name)
+void check_tracepoint(Probe &p,
+                      const std::string &target,
+                      const std::string &func,
+                      const std::string &orig_name)
 {
   EXPECT_EQ(ProbeType::tracepoint, p.type);
   EXPECT_EQ(func, p.attach_point);
@@ -134,7 +143,10 @@ void check_rawtracepoint(Probe &p,
   EXPECT_EQ("rawtracepoint:" + func, p.name);
 }
 
-void check_profile(Probe &p, const std::string &unit, int freq, const std::string &orig_name)
+void check_profile(Probe &p,
+                   const std::string &unit,
+                   int freq,
+                   const std::string &orig_name)
 {
   EXPECT_EQ(ProbeType::profile, p.type);
   EXPECT_EQ(freq, p.freq);
@@ -142,7 +154,10 @@ void check_profile(Probe &p, const std::string &unit, int freq, const std::strin
   EXPECT_EQ("profile:" + unit + ":" + std::to_string(freq), p.name);
 }
 
-void check_interval(Probe &p, const std::string &unit, int freq, const std::string &orig_name)
+void check_interval(Probe &p,
+                    const std::string &unit,
+                    int freq,
+                    const std::string &orig_name)
 {
   EXPECT_EQ(ProbeType::interval, p.type);
   EXPECT_EQ(freq, p.freq);
@@ -150,7 +165,10 @@ void check_interval(Probe &p, const std::string &unit, int freq, const std::stri
   EXPECT_EQ("interval:" + unit + ":" + std::to_string(freq), p.name);
 }
 
-void check_software(Probe &p, const std::string &unit, int freq, const std::string &orig_name)
+void check_software(Probe &p,
+                    const std::string &unit,
+                    int freq,
+                    const std::string &orig_name)
 {
   EXPECT_EQ(ProbeType::software, p.type);
   EXPECT_EQ(freq, p.freq);
@@ -158,7 +176,10 @@ void check_software(Probe &p, const std::string &unit, int freq, const std::stri
   EXPECT_EQ("software:" + unit + ":" + std::to_string(freq), p.name);
 }
 
-void check_hardware(Probe &p, const std::string &unit, int freq, const std::string &orig_name)
+void check_hardware(Probe &p,
+                    const std::string &unit,
+                    int freq,
+                    const std::string &orig_name)
 {
   EXPECT_EQ(ProbeType::hardware, p.type);
   EXPECT_EQ(freq, p.freq);
@@ -166,7 +187,9 @@ void check_hardware(Probe &p, const std::string &unit, int freq, const std::stri
   EXPECT_EQ("hardware:" + unit + ":" + std::to_string(freq), p.name);
 }
 
-void check_special_probe(Probe &p, const std::string &attach_point, const std::string &orig_name)
+void check_special_probe(Probe &p,
+                         const std::string &attach_point,
+                         const std::string &orig_name)
 {
   EXPECT_EQ(ProbeType::special, p.type);
   EXPECT_EQ(attach_point, p.attach_point);
@@ -183,7 +206,9 @@ TEST(bpftrace, add_begin_probe)
   ASSERT_EQ(0U, bpftrace.get_probes().size());
   ASSERT_EQ(1U, bpftrace.get_special_probes().size());
 
-  check_special_probe(bpftrace.get_special_probes().at(0), "BEGIN_trigger", "BEGIN");
+  check_special_probe(bpftrace.get_special_probes().at(0),
+                      "BEGIN_trigger",
+                      "BEGIN");
 }
 
 TEST(bpftrace, add_end_probe)
@@ -195,7 +220,9 @@ TEST(bpftrace, add_end_probe)
   ASSERT_EQ(0U, bpftrace.get_probes().size());
   ASSERT_EQ(1U, bpftrace.get_special_probes().size());
 
-  check_special_probe(bpftrace.get_special_probes().at(0), "END_trigger", "END");
+  check_special_probe(bpftrace.get_special_probes().at(0),
+                      "END_trigger",
+                      "END");
 }
 
 TEST(bpftrace, add_probes_single)
@@ -281,7 +308,8 @@ TEST(bpftrace, add_probes_wildcard_no_matches)
   ASSERT_EQ(2U, bpftrace->get_probes().size());
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 
-  std::string probe_orig_name = "kprobe:sys_read,kprobe:not_here_*,kprobe:sys_write";
+  std::string probe_orig_name =
+      "kprobe:sys_read,kprobe:not_here_*,kprobe:sys_write";
   check_kprobe(bpftrace->get_probes().at(0), "sys_read", probe_orig_name);
   check_kprobe(bpftrace->get_probes().at(1), "sys_write", probe_orig_name);
 }
@@ -338,7 +366,8 @@ TEST(bpftrace, add_probes_uprobe)
   ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
-  check_uprobe(bpftrace.get_probes().at(0), "/bin/sh", "foo", "uprobe:/bin/sh:foo");
+  check_uprobe(
+      bpftrace.get_probes().at(0), "/bin/sh", "foo", "uprobe:/bin/sh:foo");
 }
 
 TEST(bpftrace, add_probes_uprobe_wildcard)
@@ -357,8 +386,10 @@ TEST(bpftrace, add_probes_uprobe_wildcard)
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 
   std::string probe_orig_name = "uprobe:/bin/sh:*open";
-  check_uprobe(bpftrace->get_probes().at(0), "/bin/sh", "first_open", probe_orig_name);
-  check_uprobe(bpftrace->get_probes().at(1), "/bin/sh", "second_open", probe_orig_name);
+  check_uprobe(
+      bpftrace->get_probes().at(0), "/bin/sh", "first_open", probe_orig_name);
+  check_uprobe(
+      bpftrace->get_probes().at(1), "/bin/sh", "second_open", probe_orig_name);
 }
 
 TEST(bpftrace, add_probes_uprobe_wildcard_uprobe_multi)
@@ -476,7 +507,8 @@ TEST(bpftrace, add_probes_uprobe_string_literal)
   ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
-  check_uprobe(bpftrace.get_probes().at(0), "/bin/sh", "foo*", "uprobe:/bin/sh:foo*");
+  check_uprobe(
+      bpftrace.get_probes().at(0), "/bin/sh", "foo*", "uprobe:/bin/sh:foo*");
 }
 
 TEST(bpftrace, add_probes_uprobe_address)
@@ -487,7 +519,8 @@ TEST(bpftrace, add_probes_uprobe_address)
   ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
-  check_uprobe(bpftrace.get_probes().at(0), "/bin/sh", "", "uprobe:/bin/sh:1024", 1024);
+  check_uprobe(
+      bpftrace.get_probes().at(0), "/bin/sh", "", "uprobe:/bin/sh:1024", 1024);
 }
 
 TEST(bpftrace, add_probes_uprobe_string_offset)
@@ -498,13 +531,17 @@ TEST(bpftrace, add_probes_uprobe_string_offset)
   ASSERT_EQ(0, bpftrace.add_probe(*probe));
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
-  check_uprobe(bpftrace.get_probes().at(0), "/bin/sh", "foo", "uprobe:/bin/sh:foo+10", 0, 10);
+  check_uprobe(bpftrace.get_probes().at(0),
+               "/bin/sh",
+               "foo",
+               "uprobe:/bin/sh:foo+10",
+               0,
+               10);
 }
 
 TEST(bpftrace, add_probes_uprobe_cpp_symbol)
 {
-  for (auto &provider : { "uprobe", "uretprobe" })
-  {
+  for (auto &provider : { "uprobe", "uretprobe" }) {
     std::stringstream prog;
     prog << provider << ":/bin/sh:cpp:cpp_mangled{}";
     ast::Probe *probe = parse_probe(prog.str());
@@ -612,7 +649,9 @@ TEST(bpftrace, add_probes_usdt)
   ASSERT_EQ(1U, bpftrace.get_probes().size());
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
   check_usdt(bpftrace.get_probes().at(0),
-             "/bin/sh", "prov1", "mytp",
+             "/bin/sh",
+             "prov1",
+             "mytp",
              "usdt:/bin/sh:prov1:mytp");
 }
 
@@ -753,7 +792,8 @@ TEST(bpftrace, add_probes_tracepoint)
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
 
   std::string probe_orig_name = "tracepoint:sched:sched_switch";
-  check_tracepoint(bpftrace.get_probes().at(0), "sched", "sched_switch", probe_orig_name);
+  check_tracepoint(
+      bpftrace.get_probes().at(0), "sched", "sched_switch", probe_orig_name);
 }
 
 TEST(bpftrace, add_probes_tracepoint_wildcard)
@@ -770,8 +810,10 @@ TEST(bpftrace, add_probes_tracepoint_wildcard)
   ASSERT_EQ(0U, bpftrace->get_special_probes().size());
 
   std::string probe_orig_name = "tracepoint:sched:sched_*";
-  check_tracepoint(bpftrace->get_probes().at(0), "sched", "sched_one", probe_orig_name);
-  check_tracepoint(bpftrace->get_probes().at(1), "sched", "sched_two", probe_orig_name);
+  check_tracepoint(
+      bpftrace->get_probes().at(0), "sched", "sched_one", probe_orig_name);
+  check_tracepoint(
+      bpftrace->get_probes().at(1), "sched", "sched_two", probe_orig_name);
 }
 
 TEST(bpftrace, add_probes_tracepoint_category_wildcard)
@@ -898,7 +940,10 @@ TEST(bpftrace, add_probes_hardware)
   ASSERT_EQ(0U, bpftrace.get_special_probes().size());
 
   std::string probe_orig_name = "hardware:cache-references:1000000";
-  check_hardware(bpftrace.get_probes().at(0), "cache-references", 1000000, probe_orig_name);
+  check_hardware(bpftrace.get_probes().at(0),
+                 "cache-references",
+                 1000000,
+                 probe_orig_name);
 }
 
 TEST(bpftrace, invalid_provider)
@@ -924,17 +969,18 @@ TEST(bpftrace, empty_attachpoints)
   ASSERT_EQ(driver.parse_str("{}"), 1);
 }
 
-std::pair<std::vector<uint8_t>, std::vector<uint8_t>> key_value_pair_int(std::vector<uint64_t> key, int val)
+std::pair<std::vector<uint8_t>, std::vector<uint8_t>> key_value_pair_int(
+    std::vector<uint64_t> key,
+    int val)
 {
   std::pair<std::vector<uint8_t>, std::vector<uint8_t>> pair;
-  pair.first  = std::vector<uint8_t>(sizeof(uint64_t)*key.size());
+  pair.first = std::vector<uint8_t>(sizeof(uint64_t) * key.size());
   pair.second = std::vector<uint8_t>(sizeof(uint64_t));
 
   uint8_t *key_data = pair.first.data();
   uint8_t *val_data = pair.second.data();
 
-  for (size_t i=0; i<key.size(); i++)
-  {
+  for (size_t i = 0; i < key.size(); i++) {
     uint64_t k = key.at(i);
     std::memcpy(key_data + sizeof(uint64_t) * i, &k, sizeof(k));
   }
@@ -944,18 +990,19 @@ std::pair<std::vector<uint8_t>, std::vector<uint8_t>> key_value_pair_int(std::ve
   return pair;
 }
 
-std::pair<std::vector<uint8_t>, std::vector<uint8_t>> key_value_pair_str(std::vector<std::string> key, int val)
+std::pair<std::vector<uint8_t>, std::vector<uint8_t>> key_value_pair_str(
+    std::vector<std::string> key,
+    int val)
 {
   std::pair<std::vector<uint8_t>, std::vector<uint8_t>> pair;
-  pair.first  = std::vector<uint8_t>(STRING_SIZE*key.size());
+  pair.first = std::vector<uint8_t>(STRING_SIZE * key.size());
   pair.second = std::vector<uint8_t>(sizeof(uint64_t));
 
   uint8_t *key_data = pair.first.data();
   uint8_t *val_data = pair.second.data();
 
-  for (size_t i=0; i<key.size(); i++)
-  {
-    strncpy((char*)key_data + STRING_SIZE*i, key.at(i).c_str(), STRING_SIZE);
+  for (size_t i = 0; i < key.size(); i++) {
+    strncpy((char *)key_data + STRING_SIZE * i, key.at(i).c_str(), STRING_SIZE);
   }
   uint64_t v = val;
   std::memcpy(val_data, &v, sizeof(v));
@@ -963,10 +1010,13 @@ std::pair<std::vector<uint8_t>, std::vector<uint8_t>> key_value_pair_str(std::ve
   return pair;
 }
 
-std::pair<std::vector<uint8_t>, std::vector<uint8_t>> key_value_pair_int_str(int myint, std::string mystr, int val)
+std::pair<std::vector<uint8_t>, std::vector<uint8_t>> key_value_pair_int_str(
+    int myint,
+    std::string mystr,
+    int val)
 {
   std::pair<std::vector<uint8_t>, std::vector<uint8_t>> pair;
-  pair.first  = std::vector<uint8_t>(sizeof(uint64_t) + STRING_SIZE);
+  pair.first = std::vector<uint8_t>(sizeof(uint64_t) + STRING_SIZE);
   pair.second = std::vector<uint8_t>(sizeof(uint64_t));
 
   uint8_t *key_data = pair.first.data();
@@ -974,7 +1024,7 @@ std::pair<std::vector<uint8_t>, std::vector<uint8_t>> key_value_pair_int_str(int
 
   uint64_t k = myint, v = val;
   std::memcpy(key_data, &k, sizeof(k));
-  strncpy((char*)key_data + sizeof(uint64_t), mystr.c_str(), STRING_SIZE);
+  strncpy((char *)key_data + sizeof(uint64_t), mystr.c_str(), STRING_SIZE);
   std::memcpy(val_data, &v, sizeof(v));
 
   return pair;
@@ -985,20 +1035,20 @@ TEST(bpftrace, sort_by_key_int)
   StrictMock<MockBPFtrace> bpftrace;
 
   std::vector<SizedType> key_args = { CreateUInt64() };
-  std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> values_by_key =
-  {
-    key_value_pair_int({2}, 12),
-    key_value_pair_int({3}, 11),
-    key_value_pair_int({1}, 10),
-  };
+  std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
+      values_by_key = {
+        key_value_pair_int({ 2 }, 12),
+        key_value_pair_int({ 3 }, 11),
+        key_value_pair_int({ 1 }, 10),
+      };
   bpftrace.sort_by_key(key_args, values_by_key);
 
-  std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> expected_values =
-  {
-    key_value_pair_int({1}, 10),
-    key_value_pair_int({2}, 12),
-    key_value_pair_int({3}, 11),
-  };
+  std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
+      expected_values = {
+        key_value_pair_int({ 1 }, 10),
+        key_value_pair_int({ 2 }, 12),
+        key_value_pair_int({ 3 }, 11),
+      };
 
   EXPECT_THAT(values_by_key, ContainerEq(expected_values));
 }
@@ -1012,26 +1062,20 @@ TEST(bpftrace, sort_by_key_int_int)
     CreateUInt64(),
     CreateUInt64(),
   };
-  std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> values_by_key =
-  {
-    key_value_pair_int({5,2,1}, 1),
-    key_value_pair_int({5,3,1}, 2),
-    key_value_pair_int({5,1,1}, 3),
-    key_value_pair_int({2,2,2}, 4),
-    key_value_pair_int({2,3,2}, 5),
-    key_value_pair_int({2,1,2}, 6),
-  };
+  std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
+      values_by_key = {
+        key_value_pair_int({ 5, 2, 1 }, 1), key_value_pair_int({ 5, 3, 1 }, 2),
+        key_value_pair_int({ 5, 1, 1 }, 3), key_value_pair_int({ 2, 2, 2 }, 4),
+        key_value_pair_int({ 2, 3, 2 }, 5), key_value_pair_int({ 2, 1, 2 }, 6),
+      };
   bpftrace.sort_by_key(key_args, values_by_key);
 
-  std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> expected_values =
-  {
-    key_value_pair_int({2,1,2}, 6),
-    key_value_pair_int({2,2,2}, 4),
-    key_value_pair_int({2,3,2}, 5),
-    key_value_pair_int({5,1,1}, 3),
-    key_value_pair_int({5,2,1}, 1),
-    key_value_pair_int({5,3,1}, 2),
-  };
+  std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
+      expected_values = {
+        key_value_pair_int({ 2, 1, 2 }, 6), key_value_pair_int({ 2, 2, 2 }, 4),
+        key_value_pair_int({ 2, 3, 2 }, 5), key_value_pair_int({ 5, 1, 1 }, 3),
+        key_value_pair_int({ 5, 2, 1 }, 1), key_value_pair_int({ 5, 3, 1 }, 2),
+      };
 
   EXPECT_THAT(values_by_key, ContainerEq(expected_values));
 }
@@ -1043,22 +1087,22 @@ TEST(bpftrace, sort_by_key_str)
   std::vector<SizedType> key_args = {
     CreateString(STRING_SIZE),
   };
-  std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> values_by_key =
-  {
-    key_value_pair_str({"z"}, 1),
-    key_value_pair_str({"a"}, 2),
-    key_value_pair_str({"x"}, 3),
-    key_value_pair_str({"d"}, 4),
-  };
+  std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
+      values_by_key = {
+        key_value_pair_str({ "z" }, 1),
+        key_value_pair_str({ "a" }, 2),
+        key_value_pair_str({ "x" }, 3),
+        key_value_pair_str({ "d" }, 4),
+      };
   bpftrace.sort_by_key(key_args, values_by_key);
 
-  std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> expected_values =
-  {
-    key_value_pair_str({"a"}, 2),
-    key_value_pair_str({"d"}, 4),
-    key_value_pair_str({"x"}, 3),
-    key_value_pair_str({"z"}, 1),
-  };
+  std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
+      expected_values = {
+        key_value_pair_str({ "a" }, 2),
+        key_value_pair_str({ "d" }, 4),
+        key_value_pair_str({ "x" }, 3),
+        key_value_pair_str({ "z" }, 1),
+      };
 
   EXPECT_THAT(values_by_key, ContainerEq(expected_values));
 }
@@ -1072,26 +1116,26 @@ TEST(bpftrace, sort_by_key_str_str)
     CreateString(STRING_SIZE),
     CreateString(STRING_SIZE),
   };
-  std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> values_by_key =
-  {
-    key_value_pair_str({"z", "a", "l"}, 1),
-    key_value_pair_str({"a", "a", "m"}, 2),
-    key_value_pair_str({"z", "c", "n"}, 3),
-    key_value_pair_str({"a", "c", "o"}, 4),
-    key_value_pair_str({"z", "b", "p"}, 5),
-    key_value_pair_str({"a", "b", "q"}, 6),
-  };
+  std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
+      values_by_key = {
+        key_value_pair_str({ "z", "a", "l" }, 1),
+        key_value_pair_str({ "a", "a", "m" }, 2),
+        key_value_pair_str({ "z", "c", "n" }, 3),
+        key_value_pair_str({ "a", "c", "o" }, 4),
+        key_value_pair_str({ "z", "b", "p" }, 5),
+        key_value_pair_str({ "a", "b", "q" }, 6),
+      };
   bpftrace.sort_by_key(key_args, values_by_key);
 
-  std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> expected_values =
-  {
-    key_value_pair_str({"a", "a", "m"}, 2),
-    key_value_pair_str({"a", "b", "q"}, 6),
-    key_value_pair_str({"a", "c", "o"}, 4),
-    key_value_pair_str({"z", "a", "l"}, 1),
-    key_value_pair_str({"z", "b", "p"}, 5),
-    key_value_pair_str({"z", "c", "n"}, 3),
-  };
+  std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
+      expected_values = {
+        key_value_pair_str({ "a", "a", "m" }, 2),
+        key_value_pair_str({ "a", "b", "q" }, 6),
+        key_value_pair_str({ "a", "c", "o" }, 4),
+        key_value_pair_str({ "z", "a", "l" }, 1),
+        key_value_pair_str({ "z", "b", "p" }, 5),
+        key_value_pair_str({ "z", "c", "n" }, 3),
+      };
 
   EXPECT_THAT(values_by_key, ContainerEq(expected_values));
 }
@@ -1104,33 +1148,25 @@ TEST(bpftrace, sort_by_key_int_str)
     CreateUInt64(),
     CreateString(STRING_SIZE),
   };
-  std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> values_by_key =
-  {
-    key_value_pair_int_str(1, "b", 1),
-    key_value_pair_int_str(2, "b", 2),
-    key_value_pair_int_str(3, "b", 3),
-    key_value_pair_int_str(1, "a", 4),
-    key_value_pair_int_str(2, "a", 5),
-    key_value_pair_int_str(3, "a", 6),
-  };
+  std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
+      values_by_key = {
+        key_value_pair_int_str(1, "b", 1), key_value_pair_int_str(2, "b", 2),
+        key_value_pair_int_str(3, "b", 3), key_value_pair_int_str(1, "a", 4),
+        key_value_pair_int_str(2, "a", 5), key_value_pair_int_str(3, "a", 6),
+      };
   bpftrace.sort_by_key(key_args, values_by_key);
 
-  std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>> expected_values =
-  {
-    key_value_pair_int_str(1, "a", 4),
-    key_value_pair_int_str(1, "b", 1),
-    key_value_pair_int_str(2, "a", 5),
-    key_value_pair_int_str(2, "b", 2),
-    key_value_pair_int_str(3, "a", 6),
-    key_value_pair_int_str(3, "b", 3),
-  };
+  std::vector<std::pair<std::vector<uint8_t>, std::vector<uint8_t>>>
+      expected_values = {
+        key_value_pair_int_str(1, "a", 4), key_value_pair_int_str(1, "b", 1),
+        key_value_pair_int_str(2, "a", 5), key_value_pair_int_str(2, "b", 2),
+        key_value_pair_int_str(3, "a", 6), key_value_pair_int_str(3, "b", 3),
+      };
 
   EXPECT_THAT(values_by_key, ContainerEq(expected_values));
 }
 
-class bpftrace_btf : public test_btf
-{
-};
+class bpftrace_btf : public test_btf {};
 
 void check_probe(Probe &p, ProbeType type, const std::string &name)
 {

--- a/tests/btf_common.h
+++ b/tests/btf_common.h
@@ -2,8 +2,7 @@
 
 #include "data/btf_data.h"
 
-class test_btf : public ::testing::Test
-{
+class test_btf : public ::testing::Test {
 protected:
   static bool create_tmp_with_data(char *path,
                                    const unsigned char *data,
@@ -13,14 +12,12 @@ protected:
       return false;
 
     int fd = mkstemp(path);
-    if (fd < 0)
-    {
+    if (fd < 0) {
       std::remove(path);
       return false;
     }
 
-    if (write(fd, data, data_len) != data_len)
-    {
+    if (write(fd, data, data_len) != data_len) {
       close(fd);
       std::remove(path);
       return false;
@@ -34,16 +31,14 @@ protected:
   {
     // BTF data file
     char *btf_path = strdup("/tmp/btf_dataXXXXXX");
-    if (create_tmp_with_data(btf_path, btf_data, btf_data_len))
-    {
+    if (create_tmp_with_data(btf_path, btf_data, btf_data_len)) {
       setenv("BPFTRACE_BTF", btf_path, true);
       btf_path_ = btf_path;
     }
 
     // available functions file
     char *funcs_path = strdup("/tmp/available_filter_functionsXXXXXX");
-    if (create_tmp_with_data(funcs_path, func_list, func_list_len))
-    {
+    if (create_tmp_with_data(funcs_path, func_list, func_list_len)) {
       setenv("BPFTRACE_AVAILABLE_FUNCTIONS_TEST", funcs_path, true);
       funcs_path_ = funcs_path;
     }

--- a/tests/child.cpp
+++ b/tests/child.cpp
@@ -28,13 +28,10 @@ using ::testing::HasSubstr;
 
 TEST(childproc, exe_does_not_exist)
 {
-  try
-  {
+  try {
     ChildProc child("/does/not/exist/abc/fed");
     FAIL();
-  }
-  catch (const std::runtime_error &e)
-  {
+  } catch (const std::runtime_error &e) {
     EXPECT_THAT(e.what(), HasSubstr("does not exist or is not executable"));
   }
 }
@@ -46,13 +43,10 @@ TEST(childproc, too_many_arguments)
   for (int i = 0; i < 280; i++)
     cmd << " a";
 
-  try
-  {
+  try {
     ChildProc child(cmd.str());
     FAIL();
-  }
-  catch (const std::runtime_error &e)
-  {
+  } catch (const std::runtime_error &e) {
     EXPECT_THAT(e.what(), HasSubstr("Too many arguments"));
   }
 }

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -13,8 +13,10 @@ namespace clang_parser {
 
 #include "btf_common.h"
 
-static void parse(const std::string &input, BPFtrace &bpftrace, bool result = true,
-                  const std::string& probe = "kprobe:sys_read { 1 }")
+static void parse(const std::string &input,
+                  BPFtrace &bpftrace,
+                  bool result = true,
+                  const std::string &probe = "kprobe:sys_read { 1 }")
 {
   auto extended_input = input + probe;
   Driver driver(bpftrace);
@@ -203,7 +205,8 @@ TEST(clang_parser, nested_struct_no_type)
   BPFtrace bpftrace;
   // bar and baz's struct/union do not have type names, but are not anonymous
   // since they are called bar and baz
-  parse("struct Foo { struct { int x; } bar; union { int y; } baz; }", bpftrace);
+  parse("struct Foo { struct { int x; } bar; union { int y; } baz; }",
+        bpftrace);
 
 #if LLVM_VERSION_MAJOR >= 13
   std::string bar_name = "struct Foo::(unnamed at definitions.h:2:14)";
@@ -519,9 +522,7 @@ TEST(clang_parser, parse_fail)
   parse("struct a { int a; struct b b; };", bpftrace, false);
 }
 
-class clang_parser_btf : public test_btf
-{
-};
+class clang_parser_btf : public test_btf {};
 
 TEST_F(clang_parser_btf, btf)
 {
@@ -666,7 +667,8 @@ TEST(clang_parser, struct_typedef)
   // "typedef struct {} max_align_t"
   BPFtrace bpftrace;
   parse("#include <__stddef_max_align_t.h>\n"
-        "struct max_align_t { int x; };", bpftrace);
+        "struct max_align_t { int x; };",
+        bpftrace);
 
   ASSERT_TRUE(bpftrace.structs.Has("struct max_align_t"));
   ASSERT_TRUE(bpftrace.structs.Has("max_align_t"));

--- a/tests/codegen/common.h
+++ b/tests/codegen/common.h
@@ -79,8 +79,7 @@ static void test(BPFtrace &bpftrace,
   uint64_t update_tests = 0;
   if (get_uint64_env_var("BPFTRACE_UPDATE_TESTS",
                          [&](uint64_t x) { update_tests = x; }) &&
-      update_tests >= 1)
-  {
+      update_tests >= 1) {
     std::cerr << "Running in update mode, test is skipped" << std::endl;
     std::ofstream file(TEST_CODEGEN_LOCATION + name + ".ll");
     file << out.str();

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -9,8 +9,7 @@ namespace codegen {
 
 using ::testing::_;
 
-class MockBPFtrace : public BPFtrace
-{
+class MockBPFtrace : public BPFtrace {
 public:
 #pragma GCC diagnostic push
 #ifdef __clang__

--- a/tests/codegen/map_args.cpp
+++ b/tests/codegen/map_args.cpp
@@ -7,9 +7,7 @@ namespace bpftrace {
 namespace test {
 namespace codegen {
 
-class codegen_dwarf : public test_dwarf
-{
-};
+class codegen_dwarf : public test_dwarf {};
 
 TEST_F(codegen_dwarf, map_args)
 {

--- a/tests/config_analyser.cpp
+++ b/tests/config_analyser.cpp
@@ -36,8 +36,7 @@ void test(BPFtrace &bpftrace,
   ast::ConfigAnalyser config_analyser(driver.root.get(), bpftrace, out);
   EXPECT_EQ(config_analyser.analyse(), expected_result)
       << msg.str() << out.str();
-  if (expected_error.data())
-  {
+  if (expected_error.data()) {
     if (!expected_error.empty() && expected_error[0] == '\n')
       expected_error.remove_prefix(1); // Remove initial '\n'
     EXPECT_EQ(out.str(), expected_error);

--- a/tests/data/data_source.c
+++ b/tests/data/data_source.c
@@ -1,25 +1,20 @@
-struct Foo1
-{
+struct Foo1 {
   int a;
   char b;
   long c;
 };
 
-struct Foo2
-{
+struct Foo2 {
   int a;
-  union
-  {
+  union {
     struct Foo1 f;
-    struct
-    {
+    struct {
       char g;
     };
   };
 };
 
-struct Foo3
-{
+struct Foo3 {
   struct Foo1 *foo1;
   const volatile struct Foo2 *restrict foo2;
 };
@@ -41,8 +36,7 @@ struct Foo3 *func_3(int a, int *b, struct Foo1 *foo1)
   return 0;
 }
 
-struct Arrays
-{
+struct Arrays {
   int int_arr[4];
   char char_arr[8];
   void *ptr_arr[2];
@@ -52,8 +46,7 @@ struct Arrays
 };
 struct Arrays arrays;
 
-struct task_struct
-{
+struct task_struct {
   int pid;
   int pgid;
   int : 12; // padding
@@ -63,30 +56,25 @@ struct task_struct
   int d : 20;
 };
 
-struct file
-{
+struct file {
   int ino;
 };
 
-struct vm_area_struct
-{
+struct vm_area_struct {
   unsigned long vm_start;
   unsigned long vm_end;
 };
 
-struct bpf_iter__task
-{
+struct bpf_iter__task {
   struct task_struct *task;
 };
 
-struct bpf_iter__task_file
-{
+struct bpf_iter__task_file {
   struct task_struct *task;
   struct file *file;
 };
 
-struct bpf_iter__task_vma
-{
+struct bpf_iter__task_vma {
   struct task_struct *task;
   struct vm_area_struct *vma;
 };

--- a/tests/dwarf_common.h
+++ b/tests/dwarf_common.h
@@ -8,8 +8,7 @@
 
 #include "data/dwarf_data.h"
 
-class test_dwarf : public ::testing::Test
-{
+class test_dwarf : public ::testing::Test {
 protected:
   static void SetUpTestSuite()
   {

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -30,9 +30,7 @@ void test(const std::string &input, int expected_result = 0)
   test(*bpftrace, input, expected_result);
 }
 
-class field_analyser_btf : public test_btf
-{
-};
+class field_analyser_btf : public test_btf {};
 
 TEST_F(field_analyser_btf, kfunc_args)
 {
@@ -262,9 +260,7 @@ TEST_F(field_analyser_btf, btf_types_bitfields)
 
 #include "dwarf_common.h"
 
-class field_analyser_dwarf : public test_dwarf
-{
-};
+class field_analyser_dwarf : public test_dwarf {};
 
 TEST_F(field_analyser_dwarf, uprobe_args)
 {
@@ -340,14 +336,11 @@ TEST_F(field_analyser_dwarf, dwarf_types_bitfields)
 
   EXPECT_TRUE(task_struct->GetField("a").offset == 8 ||
               task_struct->GetField("a").offset == 9);
-  if (task_struct->GetField("a").offset == 8)
-  { // DWARF < 4
+  if (task_struct->GetField("a").offset == 8) { // DWARF < 4
     EXPECT_EQ(task_struct->GetField("a").bitfield->read_bytes, 0x3U);
     EXPECT_EQ(task_struct->GetField("a").bitfield->access_rshift, 12U);
     EXPECT_EQ(task_struct->GetField("a").bitfield->mask, 0xFFU);
-  }
-  else
-  { // DWARF >= 4
+  } else { // DWARF >= 4
     EXPECT_EQ(task_struct->GetField("a").bitfield->read_bytes, 0x2U);
     EXPECT_EQ(task_struct->GetField("a").bitfield->access_rshift, 4U);
     EXPECT_EQ(task_struct->GetField("a").bitfield->mask, 0xFFU);
@@ -360,14 +353,11 @@ TEST_F(field_analyser_dwarf, dwarf_types_bitfields)
 
   EXPECT_TRUE(task_struct->GetField("b").offset == 8 ||
               task_struct->GetField("b").offset == 10);
-  if (task_struct->GetField("b").offset == 8)
-  { // DWARF < 4
+  if (task_struct->GetField("b").offset == 8) { // DWARF < 4
     EXPECT_EQ(task_struct->GetField("b").bitfield->read_bytes, 0x3U);
     EXPECT_EQ(task_struct->GetField("b").bitfield->access_rshift, 20U);
     EXPECT_EQ(task_struct->GetField("b").bitfield->mask, 0x1U);
-  }
-  else
-  { // DWARF >= 4
+  } else { // DWARF >= 4
     EXPECT_EQ(task_struct->GetField("b").bitfield->read_bytes, 0x1U);
     EXPECT_EQ(task_struct->GetField("b").bitfield->access_rshift, 4U);
     EXPECT_EQ(task_struct->GetField("b").bitfield->mask, 0x1U);
@@ -381,14 +371,11 @@ TEST_F(field_analyser_dwarf, dwarf_types_bitfields)
   EXPECT_TRUE(task_struct->GetField("c").offset == 8 ||
               task_struct->GetField("c").offset == 10);
 
-  if (task_struct->GetField("c").offset == 8)
-  { // DWARF < 4
+  if (task_struct->GetField("c").offset == 8) { // DWARF < 4
     EXPECT_EQ(task_struct->GetField("c").bitfield->read_bytes, 0x3U);
     EXPECT_EQ(task_struct->GetField("c").bitfield->access_rshift, 21U);
     EXPECT_EQ(task_struct->GetField("c").bitfield->mask, 0x7U);
-  }
-  else
-  { // DWARF >= 4
+  } else { // DWARF >= 4
     EXPECT_EQ(task_struct->GetField("c").bitfield->read_bytes, 0x1U);
     EXPECT_EQ(task_struct->GetField("c").bitfield->access_rshift, 5U);
     EXPECT_EQ(task_struct->GetField("c").bitfield->mask, 0x7U);

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,11 +1,9 @@
 #include "gtest/gtest.h"
 
-class ThrowListener : public testing::EmptyTestEventListener
-{
-  void OnTestPartResult(const testing::TestPartResult& result) override
+class ThrowListener : public testing::EmptyTestEventListener {
+  void OnTestPartResult(const testing::TestPartResult &result) override
   {
-    if (result.type() == testing::TestPartResult::kFatalFailure)
-    {
+    if (result.type() == testing::TestPartResult::kFatalFailure) {
       throw testing::AssertionException(result);
     }
   }

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -32,7 +32,8 @@ void setup_mock_probe_matcher(MockProbeMatcher &matcher)
                                   "notsched:bar\n"
                                   "file:filename\n"
                                   "tcp:some_tcp_tp\n";
-        return std::unique_ptr<std::istream>(new std::istringstream(tracepoints));
+        return std::unique_ptr<std::istream>(
+            new std::istringstream(tracepoints));
       });
 
   std::string sh_usyms = "/bin/sh:first_open\n"

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -11,8 +11,7 @@
 namespace bpftrace {
 namespace test {
 
-class MockProbeMatcher : public ProbeMatcher
-{
+class MockProbeMatcher : public ProbeMatcher {
 public:
   MockProbeMatcher(BPFtrace *bpftrace) : ProbeMatcher(bpftrace)
   {
@@ -34,8 +33,7 @@ public:
 #pragma GCC diagnostic pop
 };
 
-class MockBPFtrace : public BPFtrace
-{
+class MockBPFtrace : public BPFtrace {
 public:
   std::vector<Probe> get_probes()
   {
@@ -52,17 +50,12 @@ public:
   {
     (void)path;
     sym->name = name;
-    if (name == "cpp_mangled(int)")
-    {
+    if (name == "cpp_mangled(int)") {
       return -1;
-    }
-    else if (name[0] >= 'A' && name[0] <= 'z')
-    {
+    } else if (name[0] >= 'A' && name[0] <= 'z') {
       sym->address = 12345;
       sym->size = 4;
-    }
-    else
-    {
+    } else {
       auto fields = split_string(name, '_');
       sym->address = std::stoull(fields.at(0));
       sym->size = std::stoull(fields.at(1));
@@ -94,8 +87,7 @@ public:
 std::unique_ptr<MockBPFtrace> get_mock_bpftrace();
 std::unique_ptr<MockBPFtrace> get_strict_mock_bpftrace();
 
-class MockBPFfeature : public BPFfeature
-{
+class MockBPFfeature : public BPFfeature {
 public:
   MockBPFfeature(bool has_features = true)
   {
@@ -125,8 +117,7 @@ public:
   bool has_features_;
 };
 
-class MockChildProc : public ChildProcBase
-{
+class MockChildProc : public ChildProcBase {
 public:
   MockChildProc(std::string cmd __attribute__((unused)))
   {
@@ -147,8 +138,7 @@ public:
   };
 };
 
-class MockProcMon : public ProcMonBase
-{
+class MockProcMon : public ProcMonBase {
 public:
   MockProcMon(pid_t pid)
   {

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -19,8 +19,7 @@ void test_parse_failure(BPFtrace &bpftrace,
   Driver driver(bpftrace, out);
   ASSERT_EQ(driver.parse_str(input), 1);
 
-  if (expected_error.data())
-  {
+  if (expected_error.data()) {
     if (!expected_error.empty() && expected_error[0] == '\n')
       expected_error.remove_prefix(1); // Remove initial '\n'
     EXPECT_EQ(out.str(), expected_error);
@@ -175,92 +174,92 @@ TEST(Parser, comment)
 TEST(Parser, map_assign)
 {
   test("kprobe:sys_open { @x = 1; }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  =\n"
-      "   map: @x\n"
-      "   int: 1\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  =\n"
+       "   map: @x\n"
+       "   int: 1\n");
   test("kprobe:sys_open { @x = @y; }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  =\n"
-      "   map: @x\n"
-      "   map: @y\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  =\n"
+       "   map: @x\n"
+       "   map: @y\n");
   test("kprobe:sys_open { @x = arg0; }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  =\n"
-      "   map: @x\n"
-      "   builtin: arg0\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  =\n"
+       "   map: @x\n"
+       "   builtin: arg0\n");
   test("kprobe:sys_open { @x = count(); }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  =\n"
-      "   map: @x\n"
-      "   call: count\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  =\n"
+       "   map: @x\n"
+       "   call: count\n");
   test("kprobe:sys_read { @x = sum(arg2); }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  =\n"
-      "   map: @x\n"
-      "   call: sum\n"
-      "    builtin: arg2\n");
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  =\n"
+       "   map: @x\n"
+       "   call: sum\n"
+       "    builtin: arg2\n");
   test("kprobe:sys_read { @x = min(arg2); }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  =\n"
-      "   map: @x\n"
-      "   call: min\n"
-      "    builtin: arg2\n");
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  =\n"
+       "   map: @x\n"
+       "   call: min\n"
+       "    builtin: arg2\n");
   test("kprobe:sys_read { @x = max(arg2); }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  =\n"
-      "   map: @x\n"
-      "   call: max\n"
-      "    builtin: arg2\n");
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  =\n"
+       "   map: @x\n"
+       "   call: max\n"
+       "    builtin: arg2\n");
   test("kprobe:sys_read { @x = avg(arg2); }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  =\n"
-      "   map: @x\n"
-      "   call: avg\n"
-      "    builtin: arg2\n");
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  =\n"
+       "   map: @x\n"
+       "   call: avg\n"
+       "    builtin: arg2\n");
   test("kprobe:sys_read { @x = stats(arg2); }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  =\n"
-      "   map: @x\n"
-      "   call: stats\n"
-      "    builtin: arg2\n");
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  =\n"
+       "   map: @x\n"
+       "   call: stats\n"
+       "    builtin: arg2\n");
   test("kprobe:sys_open { @x = \"mystring\" }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  =\n"
-      "   map: @x\n"
-      "   string: mystring\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  =\n"
+       "   map: @x\n"
+       "   string: mystring\n");
   test("kprobe:sys_open { @x = $myvar; }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  =\n"
-      "   map: @x\n"
-      "   variable: $myvar\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  =\n"
+       "   map: @x\n"
+       "   variable: $myvar\n");
 }
 
 TEST(Parser, variable_assign)
 {
   test("kprobe:sys_open { $x = 1; }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  =\n"
-      "   variable: $x\n"
-      "   int: 1\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  =\n"
+       "   variable: $x\n"
+       "   int: 1\n");
   test("kprobe:sys_open { $x = -1; }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  =\n"
-      "   variable: $x\n"
-      "   int: -1\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  =\n"
+       "   variable: $x\n"
+       "   int: -1\n");
 
   char in_cstr[128];
   char out_cstr[128];
@@ -509,162 +508,163 @@ TEST(Parser, compound_map_assignment_binary_expr)
 TEST(Parser, integer_sizes)
 {
   test("kprobe:do_nanosleep { $x = 0x12345678; }",
-      "Program\n"
-      " kprobe:do_nanosleep\n"
-      "  =\n"
-      "   variable: $x\n"
-      "   int: 305419896\n");
+       "Program\n"
+       " kprobe:do_nanosleep\n"
+       "  =\n"
+       "   variable: $x\n"
+       "   int: 305419896\n");
   test("kprobe:do_nanosleep { $x = 0x4444444412345678; }",
-      "Program\n"
-      " kprobe:do_nanosleep\n"
-      "  =\n"
-      "   variable: $x\n"
-      "   int: 4919131752149309048\n");
+       "Program\n"
+       " kprobe:do_nanosleep\n"
+       "  =\n"
+       "   variable: $x\n"
+       "   int: 4919131752149309048\n");
 }
 
 TEST(Parser, map_key)
 {
   test("kprobe:sys_open { @x[0] = 1; @x[0,1,2] = 1; }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  =\n"
-      "   map: @x\n"
-      "    int: 0\n"
-      "   int: 1\n"
-      "  =\n"
-      "   map: @x\n"
-      "    int: 0\n"
-      "    int: 1\n"
-      "    int: 2\n"
-      "   int: 1\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  =\n"
+       "   map: @x\n"
+       "    int: 0\n"
+       "   int: 1\n"
+       "  =\n"
+       "   map: @x\n"
+       "    int: 0\n"
+       "    int: 1\n"
+       "    int: 2\n"
+       "   int: 1\n");
 
   test("kprobe:sys_open { @x[@a] = 1; @x[@a,@b,@c] = 1; }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  =\n"
-      "   map: @x\n"
-      "    map: @a\n"
-      "   int: 1\n"
-      "  =\n"
-      "   map: @x\n"
-      "    map: @a\n"
-      "    map: @b\n"
-      "    map: @c\n"
-      "   int: 1\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  =\n"
+       "   map: @x\n"
+       "    map: @a\n"
+       "   int: 1\n"
+       "  =\n"
+       "   map: @x\n"
+       "    map: @a\n"
+       "    map: @b\n"
+       "    map: @c\n"
+       "   int: 1\n");
 
   test("kprobe:sys_open { @x[pid] = 1; @x[tid,uid,arg9] = 1; }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  =\n"
-      "   map: @x\n"
-      "    builtin: pid\n"
-      "   int: 1\n"
-      "  =\n"
-      "   map: @x\n"
-      "    builtin: tid\n"
-      "    builtin: uid\n"
-      "    builtin: arg9\n"
-      "   int: 1\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  =\n"
+       "   map: @x\n"
+       "    builtin: pid\n"
+       "   int: 1\n"
+       "  =\n"
+       "   map: @x\n"
+       "    builtin: tid\n"
+       "    builtin: uid\n"
+       "    builtin: arg9\n"
+       "   int: 1\n");
 }
 
 TEST(Parser, predicate)
 {
   test("kprobe:sys_open / @x / { 1; }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  pred\n"
-      "   map: @x\n"
-      "  int: 1\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  pred\n"
+       "   map: @x\n"
+       "  int: 1\n");
 }
 
 TEST(Parser, predicate_containing_division)
 {
   test("kprobe:sys_open /100/25/ { 1; }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  pred\n"
-      "   /\n"
-      "    int: 100\n"
-      "    int: 25\n"
-      "  int: 1\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  pred\n"
+       "   /\n"
+       "    int: 100\n"
+       "    int: 25\n"
+       "  int: 1\n");
 }
 
 TEST(Parser, expressions)
 {
-  test("kprobe:sys_open / 1 <= 2 && (9 - 4 != 5*10 || ~0) || comm == \"string\" /\n"
+  test("kprobe:sys_open / 1 <= 2 && (9 - 4 != 5*10 || ~0) || comm == "
+       "\"string\" /\n"
        "{\n"
        "  1;\n"
        "}",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  pred\n"
-      "   ||\n"
-      "    &&\n"
-      "     <=\n"
-      "      int: 1\n"
-      "      int: 2\n"
-      "     ||\n"
-      "      !=\n"
-      "       -\n"
-      "        int: 9\n"
-      "        int: 4\n"
-      "       *\n"
-      "        int: 5\n"
-      "        int: 10\n"
-      "      ~\n"
-      "       int: 0\n"
-      "    ==\n"
-      "     builtin: comm\n"
-      "     string: string\n"
-      "  int: 1\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  pred\n"
+       "   ||\n"
+       "    &&\n"
+       "     <=\n"
+       "      int: 1\n"
+       "      int: 2\n"
+       "     ||\n"
+       "      !=\n"
+       "       -\n"
+       "        int: 9\n"
+       "        int: 4\n"
+       "       *\n"
+       "        int: 5\n"
+       "        int: 10\n"
+       "      ~\n"
+       "       int: 0\n"
+       "    ==\n"
+       "     builtin: comm\n"
+       "     string: string\n"
+       "  int: 1\n");
 }
 
 TEST(Parser, variable_post_increment_decrement)
 {
   test("kprobe:sys_open { $x++; }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  variable: $x\n"
-      "   ++\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  variable: $x\n"
+       "   ++\n");
   test("kprobe:sys_open { ++$x; }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  ++\n"
-      "   variable: $x\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  ++\n"
+       "   variable: $x\n");
   test("kprobe:sys_open { $x--; }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  variable: $x\n"
-      "   --\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  variable: $x\n"
+       "   --\n");
   test("kprobe:sys_open { --$x; }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  --\n"
-      "   variable: $x\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  --\n"
+       "   variable: $x\n");
 }
 
 TEST(Parser, map_increment_decrement)
 {
   test("kprobe:sys_open { @x++; }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  map: @x\n"
-      "   ++\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  map: @x\n"
+       "   ++\n");
   test("kprobe:sys_open { ++@x; }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  ++\n"
-      "   map: @x\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  ++\n"
+       "   map: @x\n");
   test("kprobe:sys_open { @x--; }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  map: @x\n"
-      "   --\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  map: @x\n"
+       "   --\n");
   test("kprobe:sys_open { --@x; }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  --\n"
-      "   map: @x\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  --\n"
+       "   map: @x\n");
 }
 
 TEST(Parser, bit_shifting)
@@ -699,7 +699,6 @@ TEST(Parser, bit_shifting)
        "   int: 1\n");
 }
 
-
 TEST(Parser, ternary_int)
 {
   test("kprobe:sys_open { @x = pid < 10000 ? 1 : 2 }",
@@ -717,7 +716,8 @@ TEST(Parser, ternary_int)
 
 TEST(Parser, if_block)
 {
-  test("kprobe:sys_open { if (pid > 10000) { printf(\"%d is high\\n\", pid); } }",
+  test("kprobe:sys_open { if (pid > 10000) { printf(\"%d is high\\n\", pid); } "
+       "}",
        "Program\n"
        " kprobe:sys_open\n"
        "  if\n"
@@ -732,7 +732,8 @@ TEST(Parser, if_block)
 
 TEST(Parser, if_stmt_if)
 {
-  test("kprobe:sys_open { if (pid > 10000) { printf(\"%d is high\\n\", pid); } @pid = pid; if (pid < 1000) { printf(\"%d is low\\n\", pid); } }",
+  test("kprobe:sys_open { if (pid > 10000) { printf(\"%d is high\\n\", pid); } "
+       "@pid = pid; if (pid < 1000) { printf(\"%d is low\\n\", pid); } }",
        "Program\n"
        " kprobe:sys_open\n"
        "  if\n"
@@ -773,7 +774,8 @@ TEST(Parser, if_block_variable)
 
 TEST(Parser, if_else)
 {
-  test("kprobe:sys_open { if (pid > 10000) { $s = \"a\"; } else { $s= \"b\"; } printf(\"%d is high\\n\", pid, $s); }",
+  test("kprobe:sys_open { if (pid > 10000) { $s = \"a\"; } else { $s= \"b\"; } "
+       "printf(\"%d is high\\n\", pid, $s); }",
        "Program\n"
        " kprobe:sys_open\n"
        "  if\n"
@@ -946,19 +948,19 @@ TEST(Parser, ternary_nested)
 TEST(Parser, call)
 {
   test("kprobe:sys_open { @x = count(); @y = hist(1,2,3); delete(@x); }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  =\n"
-      "   map: @x\n"
-      "   call: count\n"
-      "  =\n"
-      "   map: @y\n"
-      "   call: hist\n"
-      "    int: 1\n"
-      "    int: 2\n"
-      "    int: 3\n"
-      "  call: delete\n"
-      "   map: @x\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  =\n"
+       "   map: @x\n"
+       "   call: count\n"
+       "  =\n"
+       "   map: @y\n"
+       "   call: hist\n"
+       "    int: 1\n"
+       "    int: 2\n"
+       "    int: 3\n"
+       "  call: delete\n"
+       "   map: @x\n");
 }
 
 TEST(Parser, call_unknown_function)
@@ -978,38 +980,38 @@ TEST(Parser, call_builtin)
 TEST(Parser, call_kaddr)
 {
   test("kprobe:f { @ = kaddr(\"avenrun\") }",
-      "Program\n"
-      " kprobe:f\n"
-      "  =\n"
-      "   map: @\n"
-      "   call: kaddr\n"
-      "    string: avenrun\n");
+       "Program\n"
+       " kprobe:f\n"
+       "  =\n"
+       "   map: @\n"
+       "   call: kaddr\n"
+       "    string: avenrun\n");
 }
 
 TEST(Parser, multiple_probes)
 {
   test("kprobe:sys_open { 1; } kretprobe:sys_open { 2; }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  int: 1\n"
-      " kretprobe:sys_open\n"
-      "  int: 2\n");
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  int: 1\n"
+       " kretprobe:sys_open\n"
+       "  int: 2\n");
 }
 
 TEST(Parser, uprobe)
 {
   test("uprobe:/my/program:func { 1; }",
-      "Program\n"
-      " uprobe:/my/program:func\n"
-      "  int: 1\n");
+       "Program\n"
+       " uprobe:/my/program:func\n"
+       "  int: 1\n");
   test("uprobe:/my/go/program:\"pkg.func\u2C51\" { 1; }",
-      "Program\n"
-      " uprobe:/my/go/program:pkg.func\u2C51\n"
-      "  int: 1\n");
-  test ("uprobe:/with#hash:asdf { 1 }",
-      "Program\n"
-      " uprobe:/with#hash:asdf\n"
-      "  int: 1\n");
+       "Program\n"
+       " uprobe:/my/go/program:pkg.func\u2C51\n"
+       "  int: 1\n");
+  test("uprobe:/with#hash:asdf { 1 }",
+       "Program\n"
+       " uprobe:/with#hash:asdf\n"
+       "  int: 1\n");
   test("uprobe:/my/program:1234 { 1; }",
        "Program\n"
        " uprobe:/my/program:1234\n"
@@ -1044,9 +1046,9 @@ TEST(Parser, uprobe)
 TEST(Parser, usdt)
 {
   test("usdt:/my/program:probe { 1; }",
-      "Program\n"
-      " usdt:/my/program:probe\n"
-      "  int: 1\n");
+       "Program\n"
+       " usdt:/my/program:probe\n"
+       "  int: 1\n");
   // Without the escapes needed for C++ to compile:
   //    usdt:/my/program:"\"probe\"" { 1; }
   //
@@ -1061,37 +1063,39 @@ TEST(Parser, usdt)
 TEST(Parser, usdt_namespaced_probe)
 {
   test("usdt:/my/program:namespace:probe { 1; }",
-      "Program\n"
-      " usdt:/my/program:namespace:probe\n"
-      "  int: 1\n");
+       "Program\n"
+       " usdt:/my/program:namespace:probe\n"
+       "  int: 1\n");
   test("usdt:/my/program*:namespace:probe { 1; }",
-      "Program\n"
-      " usdt:/my/program*:namespace:probe\n"
-      "  int: 1\n");
+       "Program\n"
+       " usdt:/my/program*:namespace:probe\n"
+       "  int: 1\n");
   test("usdt:/my/*program:namespace:probe { 1; }",
-      "Program\n"
-      " usdt:/my/*program:namespace:probe\n"
-      "  int: 1\n");
+       "Program\n"
+       " usdt:/my/*program:namespace:probe\n"
+       "  int: 1\n");
   test("usdt:*my/program*:namespace:probe { 1; }",
-      "Program\n"
-      " usdt:*my/program*:namespace:probe\n"
-      "  int: 1\n");
+       "Program\n"
+       " usdt:*my/program*:namespace:probe\n"
+       "  int: 1\n");
 }
 
 TEST(Parser, escape_chars)
 {
-  test("kprobe:sys_open { \"newline\\nand tab\\tcr\\rbackslash\\\\quote\\\"here oct\\1009hex\\x309\" }",
-      "Program\n"
-      " kprobe:sys_open\n"
-      "  string: newline\\nand tab\\tcr\\rbackslash\\\\quote\\\"here oct@9hex09\n");
+  test("kprobe:sys_open { \"newline\\nand "
+       "tab\\tcr\\rbackslash\\\\quote\\\"here oct\\1009hex\\x309\" }",
+       "Program\n"
+       " kprobe:sys_open\n"
+       "  string: newline\\nand tab\\tcr\\rbackslash\\\\quote\\\"here "
+       "oct@9hex09\n");
 }
 
 TEST(Parser, begin_probe)
 {
   test("BEGIN { 1 }",
-      "Program\n"
-      " BEGIN\n"
-      "  int: 1\n");
+       "Program\n"
+       " BEGIN\n"
+       "  int: 1\n");
 
   test_parse_failure("BEGIN:f { 1 }");
   test_parse_failure("BEGIN:path:f { 1 }");
@@ -1111,9 +1115,9 @@ TEST(Parser, end_probe)
 TEST(Parser, tracepoint_probe)
 {
   test("tracepoint:sched:sched_switch { 1 }",
-      "Program\n"
-      " tracepoint:sched:sched_switch\n"
-      "  int: 1\n");
+       "Program\n"
+       " tracepoint:sched:sched_switch\n"
+       "  int: 1\n");
   test("tracepoint:* { 1 }",
        "Program\n"
        " tracepoint:*:*\n"
@@ -1126,9 +1130,9 @@ TEST(Parser, tracepoint_probe)
 TEST(Parser, profile_probe)
 {
   test("profile:ms:997 { 1 }",
-      "Program\n"
-      " profile:ms:997\n"
-      "  int: 1\n");
+       "Program\n"
+       " profile:ms:997\n"
+       "  int: 1\n");
 
   test_parse_failure("profile:ms:nan { 1 }");
   test_parse_failure("profile:f { 1 }");
@@ -1139,9 +1143,9 @@ TEST(Parser, profile_probe)
 TEST(Parser, interval_probe)
 {
   test("interval:s:1 { 1 }",
-      "Program\n"
-      " interval:s:1\n"
-      "  int: 1\n");
+       "Program\n"
+       " interval:s:1\n"
+       "  int: 1\n");
 
   test("interval:s:1e3 { 1 }",
        "Program\n"
@@ -1159,9 +1163,9 @@ TEST(Parser, interval_probe)
 TEST(Parser, software_probe)
 {
   test("software:faults:1000 { 1 }",
-      "Program\n"
-      " software:faults:1000\n"
-      "  int: 1\n");
+       "Program\n"
+       " software:faults:1000\n"
+       "  int: 1\n");
 
   test("software:faults:1e3 { 1 }",
        "Program\n"
@@ -1179,9 +1183,9 @@ TEST(Parser, software_probe)
 TEST(Parser, hardware_probe)
 {
   test("hardware:cache-references:1000000 { 1 }",
-      "Program\n"
-      " hardware:cache-references:1000000\n"
-      "  int: 1\n");
+       "Program\n"
+       " hardware:cache-references:1000000\n"
+       "  int: 1\n");
 
   test("hardware:cache-references:1e6 { 1 }",
        "Program\n"
@@ -1226,21 +1230,22 @@ TEST(Parser, asyncwatchpoint_probe)
 
 TEST(Parser, multiple_attach_points_kprobe)
 {
-  test("BEGIN,kprobe:sys_open,uprobe:/bin/sh:foo,tracepoint:syscalls:sys_enter_* { 1 }",
-      "Program\n"
-      " BEGIN\n"
-      " kprobe:sys_open\n"
-      " uprobe:/bin/sh:foo\n"
-      " tracepoint:syscalls:sys_enter_*\n"
-      "  int: 1\n");
+  test("BEGIN,kprobe:sys_open,uprobe:/bin/"
+       "sh:foo,tracepoint:syscalls:sys_enter_* { 1 }",
+       "Program\n"
+       " BEGIN\n"
+       " kprobe:sys_open\n"
+       " uprobe:/bin/sh:foo\n"
+       " tracepoint:syscalls:sys_enter_*\n"
+       "  int: 1\n");
 }
 
 TEST(Parser, character_class_attach_point)
 {
   test("kprobe:[Ss]y[Ss]_read { 1 }",
-      "Program\n"
-      " kprobe:[Ss]y[Ss]_read\n"
-      "  int: 1\n");
+       "Program\n"
+       " kprobe:[Ss]y[Ss]_read\n"
+       "  int: 1\n");
 }
 
 TEST(Parser, wildcard_probetype)
@@ -1265,72 +1270,72 @@ TEST(Parser, wildcard_probetype)
 TEST(Parser, wildcard_attach_points)
 {
   test("kprobe:sys_* { 1 }",
-      "Program\n"
-      " kprobe:sys_*\n"
-      "  int: 1\n");
+       "Program\n"
+       " kprobe:sys_*\n"
+       "  int: 1\n");
   test("kprobe:*blah { 1 }",
-      "Program\n"
-      " kprobe:*blah\n"
-      "  int: 1\n");
+       "Program\n"
+       " kprobe:*blah\n"
+       "  int: 1\n");
   test("kprobe:sys*blah { 1 }",
-      "Program\n"
-      " kprobe:sys*blah\n"
-      "  int: 1\n");
+       "Program\n"
+       " kprobe:sys*blah\n"
+       "  int: 1\n");
   test("kprobe:* { 1 }",
-      "Program\n"
-      " kprobe:*\n"
-      "  int: 1\n");
+       "Program\n"
+       " kprobe:*\n"
+       "  int: 1\n");
   test("kprobe:sys_* { @x = cpu*retval }",
-      "Program\n"
-      " kprobe:sys_*\n"
-      "  =\n"
-      "   map: @x\n"
-      "   *\n"
-      "    builtin: cpu\n"
-      "    builtin: retval\n");
+       "Program\n"
+       " kprobe:sys_*\n"
+       "  =\n"
+       "   map: @x\n"
+       "   *\n"
+       "    builtin: cpu\n"
+       "    builtin: retval\n");
   test("kprobe:sys_* { @x = *arg0 }",
-      "Program\n"
-      " kprobe:sys_*\n"
-      "  =\n"
-      "   map: @x\n"
-      "   dereference\n"
-      "    builtin: arg0\n");
+       "Program\n"
+       " kprobe:sys_*\n"
+       "  =\n"
+       "   map: @x\n"
+       "   dereference\n"
+       "    builtin: arg0\n");
 }
 
 TEST(Parser, wildcard_path)
 {
   test("uprobe:/my/program*:* { 1; }",
-      "Program\n"
-      " uprobe:/my/program*:*\n"
-      "  int: 1\n");
+       "Program\n"
+       " uprobe:/my/program*:*\n"
+       "  int: 1\n");
   test("uprobe:/my/program*:func { 1; }",
-      "Program\n"
-      " uprobe:/my/program*:func\n"
-      "  int: 1\n");
+       "Program\n"
+       " uprobe:/my/program*:func\n"
+       "  int: 1\n");
   test("uprobe:*my/program*:func { 1; }",
-      "Program\n"
-      " uprobe:*my/program*:func\n"
-      "  int: 1\n");
+       "Program\n"
+       " uprobe:*my/program*:func\n"
+       "  int: 1\n");
   test("uprobe:/my/program*foo:func { 1; }",
-      "Program\n"
-      " uprobe:/my/program*foo:func\n"
-      "  int: 1\n");
+       "Program\n"
+       " uprobe:/my/program*foo:func\n"
+       "  int: 1\n");
   test("usdt:/my/program*:* { 1; }",
-      "Program\n"
-      " usdt:/my/program*:*\n"
-      "  int: 1\n");
+       "Program\n"
+       " usdt:/my/program*:*\n"
+       "  int: 1\n");
   test("usdt:/my/program*:func { 1; }",
-      "Program\n"
-      " usdt:/my/program*:func\n"
-      "  int: 1\n");
+       "Program\n"
+       " usdt:/my/program*:func\n"
+       "  int: 1\n");
   test("usdt:*my/program*:func { 1; }",
-      "Program\n"
-      " usdt:*my/program*:func\n"
-      "  int: 1\n");
+       "Program\n"
+       " usdt:*my/program*:func\n"
+       "  int: 1\n");
   test("usdt:/my/program*foo:func { 1; }",
-      "Program\n"
-      " usdt:/my/program*foo:func\n"
-      "  int: 1\n");
+       "Program\n"
+       " usdt:/my/program*foo:func\n"
+       "  int: 1\n");
   // Make sure calls or builtins don't cause issues
   test("usdt:/my/program*avg:func { 1; }",
        "Program\n"
@@ -1384,75 +1389,79 @@ TEST(Parser, wildcard_func)
     "uprobe",
     "kprobe",
   };
-  for(auto kw : keywords)
-  {
-    test("usdt:/my/program:"+ kw +"*c*d { 1; }",
+  for (auto kw : keywords) {
+    test("usdt:/my/program:" + kw + "*c*d { 1; }",
          "Program\n"
-         " usdt:/my/program:"+ kw + "*c*d\n"
-         "  int: 1\n");
-    test("usdt:/my/program:abc*"+ kw +"*c*d { 1; }",
+         " usdt:/my/program:" +
+             kw +
+             "*c*d\n"
+             "  int: 1\n");
+    test("usdt:/my/program:abc*" + kw + "*c*d { 1; }",
          "Program\n"
-         " usdt:/my/program:abc*"+ kw + "*c*d\n"
-         "  int: 1\n");
+         " usdt:/my/program:abc*" +
+             kw +
+             "*c*d\n"
+             "  int: 1\n");
   }
 }
 
 TEST(Parser, short_map_name)
 {
   test("kprobe:sys_read { @ = 1 }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  =\n"
-      "   map: @\n"
-      "   int: 1\n");
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  =\n"
+       "   map: @\n"
+       "   int: 1\n");
 }
 
 TEST(Parser, include)
 {
   test("#include <stdio.h>\nkprobe:sys_read { @x = 1 }",
-      "#include <stdio.h>\n"
-      "\n"
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  =\n"
-      "   map: @x\n"
-      "   int: 1\n");
+       "#include <stdio.h>\n"
+       "\n"
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  =\n"
+       "   map: @x\n"
+       "   int: 1\n");
 }
 
 TEST(Parser, include_quote)
 {
   test("#include \"stdio.h\"\nkprobe:sys_read { @x = 1 }",
-      "#include \"stdio.h\"\n"
-      "\n"
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  =\n"
-      "   map: @x\n"
-      "   int: 1\n");
+       "#include \"stdio.h\"\n"
+       "\n"
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  =\n"
+       "   map: @x\n"
+       "   int: 1\n");
 }
 
 TEST(Parser, include_multiple)
 {
-  test("#include <stdio.h>\n#include \"blah\"\n#include <foo.h>\nkprobe:sys_read { @x = 1 }",
-      "#include <stdio.h>\n"
-      "#include \"blah\"\n"
-      "#include <foo.h>\n"
-      "\n"
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  =\n"
-      "   map: @x\n"
-      "   int: 1\n");
+  test("#include <stdio.h>\n#include \"blah\"\n#include "
+       "<foo.h>\nkprobe:sys_read { @x = 1 }",
+       "#include <stdio.h>\n"
+       "#include \"blah\"\n"
+       "#include <foo.h>\n"
+       "\n"
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  =\n"
+       "   map: @x\n"
+       "   int: 1\n");
 }
 
 TEST(Parser, brackets)
 {
   test("kprobe:sys_read { (arg0*arg1) }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  *\n"
-      "   builtin: arg0\n"
-      "   builtin: arg1\n");
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  *\n"
+       "   builtin: arg0\n"
+       "   builtin: arg1\n");
 }
 
 TEST(Parser, cast_simple_type)
@@ -1494,15 +1503,15 @@ TEST(Parser, cast_sized_type_pointer)
 TEST(Parser, cast_struct)
 {
   test("kprobe:sys_read { (struct mytype)arg0; }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  (struct mytype)\n"
-      "   builtin: arg0\n");
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  (struct mytype)\n"
+       "   builtin: arg0\n");
   test("kprobe:sys_read { (union mytype)arg0; }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  (union mytype)\n"
-      "   builtin: arg0\n");
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  (union mytype)\n"
+       "   builtin: arg0\n");
 }
 
 TEST(Parser, cast_struct_ptr)
@@ -1559,11 +1568,11 @@ TEST(Parser, cast_or_expr1)
 TEST(Parser, cast_or_expr2)
 {
   test("kprobe:sys_read { (arg1)*arg0; }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  *\n"
-      "   builtin: arg1\n"
-      "   builtin: arg0\n");
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  *\n"
+       "   builtin: arg1\n"
+       "   builtin: arg0\n");
 }
 
 TEST(Parser, cast_precedence)
@@ -1641,112 +1650,112 @@ TEST(Parser, offsetof_expression)
 TEST(Parser, dereference_precedence)
 {
   test("kprobe:sys_read { *@x+1 }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  +\n"
-      "   dereference\n"
-      "    map: @x\n"
-      "   int: 1\n");
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  +\n"
+       "   dereference\n"
+       "    map: @x\n"
+       "   int: 1\n");
 
   test("kprobe:sys_read { *@x**@y }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  *\n"
-      "   dereference\n"
-      "    map: @x\n"
-      "   dereference\n"
-      "    map: @y\n");
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  *\n"
+       "   dereference\n"
+       "    map: @x\n"
+       "   dereference\n"
+       "    map: @y\n");
 
   test("kprobe:sys_read { *@x*@y }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  *\n"
-      "   dereference\n"
-      "    map: @x\n"
-      "   map: @y\n");
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  *\n"
+       "   dereference\n"
+       "    map: @x\n"
+       "   map: @y\n");
 
   test("kprobe:sys_read { *@x.myfield }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  dereference\n"
-      "   .\n"
-      "    map: @x\n"
-      "    myfield\n");
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  dereference\n"
+       "   .\n"
+       "    map: @x\n"
+       "    myfield\n");
 }
 
 TEST(Parser, field_access)
 {
   test("kprobe:sys_read { @x.myfield; }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  .\n"
-      "   map: @x\n"
-      "   myfield\n");
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  .\n"
+       "   map: @x\n"
+       "   myfield\n");
 
   test("kprobe:sys_read { @x->myfield; }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  .\n"
-      "   dereference\n"
-      "    map: @x\n"
-      "   myfield\n");
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  .\n"
+       "   dereference\n"
+       "    map: @x\n"
+       "   myfield\n");
 }
 
 TEST(Parser, field_access_builtin)
 {
   test("kprobe:sys_read { @x.count; }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  .\n"
-      "   map: @x\n"
-      "   count\n");
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  .\n"
+       "   map: @x\n"
+       "   count\n");
 
   test("kprobe:sys_read { @x->count; }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  .\n"
-      "   dereference\n"
-      "    map: @x\n"
-      "   count\n");
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  .\n"
+       "   dereference\n"
+       "    map: @x\n"
+       "   count\n");
 }
 
 TEST(Parser, array_access)
 {
   test("kprobe:sys_read { x[index]; }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  []\n"
-      "   identifier: x\n"
-      "   identifier: index\n");
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  []\n"
+       "   identifier: x\n"
+       "   identifier: index\n");
 
   test("kprobe:sys_read { $val = x[index]; }",
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  =\n"
-      "   variable: $val\n"
-      "   []\n"
-      "    identifier: x\n"
-      "    identifier: index\n");
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  =\n"
+       "   variable: $val\n"
+       "   []\n"
+       "    identifier: x\n"
+       "    identifier: index\n");
 }
 
 TEST(Parser, cstruct)
 {
   test("struct Foo { int x, y; char *str; } kprobe:sys_read { 1; }",
-      "struct Foo { int x, y; char *str; };\n"
-      "\n"
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  int: 1\n");
+       "struct Foo { int x, y; char *str; };\n"
+       "\n"
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  int: 1\n");
 }
 
 TEST(Parser, cstruct_nested)
 {
   test("struct Foo { struct { int x; } bar; } kprobe:sys_read { 1; }",
-      "struct Foo { struct { int x; } bar; };\n"
-      "\n"
-      "Program\n"
-      " kprobe:sys_read\n"
-      "  int: 1\n");
+       "struct Foo { struct { int x; } bar; };\n"
+       "\n"
+       "Program\n"
+       " kprobe:sys_read\n"
+       "  int: 1\n");
 }
 
 TEST(Parser, unexpected_symbol)

--- a/tests/portability_analyser.cpp
+++ b/tests/portability_analyser.cpp
@@ -60,9 +60,7 @@ TEST(portability_analyser, tracepoint_field_access)
   test("tracepoint:sched:sched_one { args->common_field }", 0);
 }
 
-class portability_analyser_btf : public test_btf
-{
-};
+class portability_analyser_btf : public test_btf {};
 
 TEST_F(portability_analyser_btf, kfunc_field_access)
 {

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -70,14 +70,13 @@ TEST(probe, short_name)
   compare_bytecode("kretprobe:f { pid }", "kr:f { pid }");
   compare_bytecode("uprobe:sh:f { 1 }", "u:sh:f { 1 }");
   compare_bytecode("profile:hz:997 { 1 }", "p:hz:997 { 1 }");
-  compare_bytecode("hardware:cache-references:1000000 { 1 }", "h:cache-references:1000000 { 1 }");
+  compare_bytecode("hardware:cache-references:1000000 { 1 }",
+                   "h:cache-references:1000000 { 1 }");
   compare_bytecode("software:faults:1000 { 1 }", "s:faults:1000 { 1 }");
   compare_bytecode("interval:s:1 { 1 }", "i:s:1 { 1 }");
 }
 
-class probe_btf : public test_btf
-{
-};
+class probe_btf : public test_btf {};
 
 TEST_F(probe_btf, short_name)
 {

--- a/tests/procmon.cpp
+++ b/tests/procmon.cpp
@@ -16,13 +16,10 @@ using ::testing::HasSubstr;
 
 TEST(procmon, no_such_proc)
 {
-  try
-  {
+  try {
     ProcMon(1 << 21);
     FAIL();
-  }
-  catch (const std::runtime_error &e)
-  {
+  } catch (const std::runtime_error &e) {
     EXPECT_THAT(e.what(), HasSubstr("No such process"));
   }
 }

--- a/tests/required_resources.cpp
+++ b/tests/required_resources.cpp
@@ -138,8 +138,7 @@ TEST(required_resources, round_trip_set_stack_type)
     r.load_state(input);
 
     ASSERT_EQ(r.stackid_maps.size(), 1ul);
-    for (const auto &st : r.stackid_maps)
-    {
+    for (const auto &st : r.stackid_maps) {
       EXPECT_EQ(st.limit, 33ul);
       EXPECT_EQ(st.mode, StackMode::perf);
     }
@@ -196,8 +195,7 @@ TEST(required_resources, round_trip_multiple_members)
     ASSERT_EQ(r.join_args.size(), 1ul);
     EXPECT_EQ(r.join_args[0], "joinarg0");
     ASSERT_EQ(r.stackid_maps.size(), 1ul);
-    for (const auto &st : r.stackid_maps)
-    {
+    for (const auto &st : r.stackid_maps) {
       EXPECT_EQ(st.limit, 33ul);
       EXPECT_EQ(st.mode, StackMode::perf);
     }

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -17,12 +17,11 @@ namespace semantic_analyser {
 using ::testing::_;
 using ::testing::HasSubstr;
 
-void test_for_warning(
-          BPFtrace &bpftrace,
-          const std::string &input,
-          const std::string &warning,
-          bool invert = false,
-          bool safe_mode = true)
+void test_for_warning(BPFtrace &bpftrace,
+                      const std::string &input,
+                      const std::string &warning,
+                      bool invert = false,
+                      bool safe_mode = true)
 {
   Driver driver(bpftrace);
   bpftrace.safe_mode_ = safe_mode;
@@ -43,8 +42,7 @@ void test_for_warning(
     EXPECT_THAT(out.str(), HasSubstr(warning));
 }
 
-void test_for_warning(
-                      const std::string &input,
+void test_for_warning(const std::string &input,
                       const std::string &warning,
                       bool invert = false,
                       bool safe_mode = true)
@@ -81,8 +79,7 @@ void test(BPFtrace &bpftrace,
   bpftrace.feature_ = std::make_unique<MockBPFfeature>(mock_has_features);
   ast::SemanticAnalyser semantics(driver.root.get(), bpftrace, out, has_child);
   ASSERT_EQ(expected_result, semantics.analyse()) << msg.str() + out.str();
-  if (expected_error.data())
-  {
+  if (expected_error.data()) {
     if (!expected_error.empty() && expected_error[0] == '\n')
       expected_error.remove_prefix(1); // Remove initial '\n'
     EXPECT_EQ(out.str(), expected_error);
@@ -724,7 +721,8 @@ TEST(semantic_analyser, call_usym)
 
 TEST(semantic_analyser, call_ntop)
 {
-  std::string structs = "struct inet { unsigned char ipv4[4]; unsigned char ipv6[16]; unsigned char invalid[10]; } ";
+  std::string structs = "struct inet { unsigned char ipv4[4]; unsigned char "
+                        "ipv6[16]; unsigned char invalid[10]; } ";
 
   test("kprobe:f { ntop(2, arg0); }", 0);
   test("kprobe:f { ntop(arg0); }", 0);
@@ -786,7 +784,8 @@ TEST(semantic_analyser, call_kaddr)
 
 TEST(semantic_analyser, call_uaddr)
 {
-  test("u:/bin/bash:main { uaddr(\"github.com/golang/glog.severityName\"); }", 0);
+  test("u:/bin/bash:main { uaddr(\"github.com/golang/glog.severityName\"); }",
+       0);
   test("uprobe:/bin/bash:main { uaddr(\"glob_asciirange\"); }", 0);
   test("u:/bin/bash:main,u:/bin/bash:readline { uaddr(\"glob_asciirange\"); }",
        0);
@@ -816,8 +815,7 @@ TEST(semantic_analyser, call_uaddr)
 
   std::vector<int> sizes = { 8, 16, 32, 64, 64, 64 };
 
-  for (size_t i = 0; i < sizes.size(); i++)
-  {
+  for (size_t i = 0; i < sizes.size(); i++) {
     auto v = static_cast<ast::AssignVarStatement *>(
         driver.root->probes->at(0)->stmts->at(i));
     EXPECT_TRUE(v->var->type.IsPtrTy());
@@ -1030,7 +1028,8 @@ TEST(semantic_analyser, variables_are_local)
   test("kprobe:f { $x = 1 } kprobe:g { @y = $x }", 1);
 }
 
-TEST(semantic_analyser, array_access) {
+TEST(semantic_analyser, array_access)
+{
   test("kprobe:f { $s = arg0; @x = $s->y[0];}", 10);
   test("kprobe:f { $s = 0; @x = $s->y[0];}", 10);
   test("struct MyStruct { int y[4]; } kprobe:f { $s = (struct MyStruct *) "
@@ -1192,11 +1191,15 @@ TEST(semantic_analyser, variable_type)
 
 TEST(semantic_analyser, unroll)
 {
-  test("kprobe:f { $i = 0; unroll(5) { printf(\"i: %d\\n\", $i); $i = $i + 1; } }", 0);
+  test("kprobe:f { $i = 0; unroll(5) { printf(\"i: %d\\n\", $i); $i = $i + 1; "
+       "} }",
+       0);
   test("kprobe:f { $i = 0; unroll(101) { printf(\"i: %d\\n\", $i); $i = $i + "
        "1; } }",
        1);
-  test("kprobe:f { $i = 0; unroll(0) { printf(\"i: %d\\n\", $i); $i = $i + 1; } }", 1);
+  test("kprobe:f { $i = 0; unroll(0) { printf(\"i: %d\\n\", $i); $i = $i + 1; "
+       "} }",
+       1);
 
   BPFtrace bpftrace;
   bpftrace.add_param("10");
@@ -1327,7 +1330,9 @@ TEST(semantic_analyser, system)
   test("kprobe:f { system(\"ls\") }", 0, false /* safe_mode */);
   test("kprobe:f { system(1234) }", 1, false /* safe_mode */);
   test("kprobe:f { system() }", 1, false /* safe_mode */);
-  test("kprobe:f { $fmt = \"mystring\"; system($fmt) }", 1, false /* safe_mode */);
+  test("kprobe:f { $fmt = \"mystring\"; system($fmt) }",
+       1,
+       false /* safe_mode */);
 }
 
 TEST(semantic_analyser, printf_format_int)
@@ -1636,7 +1641,8 @@ TEST(semantic_analyser, interval)
 
 TEST(semantic_analyser, variable_cast_types)
 {
-  std::string structs = "struct type1 { int field; } struct type2 { int field; }";
+  std::string structs =
+      "struct type1 { int field; } struct type2 { int field; }";
   test(structs +
            "kprobe:f { $x = (struct type1*)cpu; $x = (struct type1*)cpu; }",
        0);
@@ -1647,7 +1653,8 @@ TEST(semantic_analyser, variable_cast_types)
 
 TEST(semantic_analyser, map_cast_types)
 {
-  std::string structs = "struct type1 { int field; } struct type2 { int field; }";
+  std::string structs =
+      "struct type1 { int field; } struct type2 { int field; }";
   test(structs +
            "kprobe:f { @x = *(struct type1*)cpu; @x = *(struct type1*)cpu; }",
        0);
@@ -1739,8 +1746,9 @@ TEST(semantic_analyser, field_access_pointer)
 
 TEST(semantic_analyser, field_access_sub_struct)
 {
-  std::string structs = "struct type2 { int field; } "
-                        "struct type1 { struct type2 *type2ptr; struct type2 type2; }";
+  std::string structs =
+      "struct type2 { int field; } "
+      "struct type1 { struct type2 *type2ptr; struct type2 type2; }";
 
   test(structs + "kprobe:f { (*(struct type1*)0).type2ptr->field }", 0);
   test(structs + "kprobe:f { (*(struct type1*)0).type2.field }", 0);
@@ -1979,10 +1987,10 @@ TEST(semantic_analyser, cast_sign)
   BPFtrace bpftrace;
   Driver driver(bpftrace);
   std::string prog =
-    "struct t { int s; unsigned int us; long l; unsigned long ul }; "
-    "kprobe:f { "
-    "  $t = ((struct t *)0xFF);"
-    "  $s = $t->s; $us = $t->us; $l = $t->l; $lu = $t->ul; }";
+      "struct t { int s; unsigned int us; long l; unsigned long ul }; "
+      "kprobe:f { "
+      "  $t = ((struct t *)0xFF);"
+      "  $s = $t->s; $us = $t->us; $l = $t->l; $lu = $t->ul; }";
   test(driver, prog, 0);
 
   auto s = static_cast<ast::AssignVarStatement *>(
@@ -2002,21 +2010,24 @@ TEST(semantic_analyser, cast_sign)
 TEST(semantic_analyser, binop_sign)
 {
   // Make sure types are correct
-  std::string prog_pre =
-    "struct t { long l; unsigned long ul }; "
-    "kprobe:f { "
-    "  $t = ((struct t *)0xFF); ";
+  std::string prog_pre = "struct t { long l; unsigned long ul }; "
+                         "kprobe:f { "
+                         "  $t = ((struct t *)0xFF); ";
 
-  std::string operators[] = { "==", "!=", "<", "<=", ">", ">=", "+", "-", "/", "*"};
-  for(std::string op : operators)
-  {
+  std::string operators[] = { "==", "!=", "<", "<=", ">",
+                              ">=", "+",  "-", "/",  "*" };
+  for (std::string op : operators) {
     BPFtrace bpftrace;
     Driver driver(bpftrace);
-    std::string prog = prog_pre +
-      "$varA = $t->l "  + op + " $t->l; "
-      "$varB = $t->ul " + op + " $t->l; "
-      "$varC = $t->ul " + op + " $t->ul;"
-      "}";
+    std::string prog = prog_pre + "$varA = $t->l " + op +
+                       " $t->l; "
+                       "$varB = $t->ul " +
+                       op +
+                       " $t->l; "
+                       "$varC = $t->ul " +
+                       op +
+                       " $t->ul;"
+                       "}";
 
     test(driver, prog, 0);
     auto varA = static_cast<ast::AssignVarStatement *>(
@@ -2270,8 +2281,7 @@ TEST(semantic_analyser, struct_member_keywords)
     "uprobe",
     "kprobe",
   };
-  for(auto kw : keywords)
-  {
+  for (auto kw : keywords) {
     test("struct S{ int " + kw + ";}; k:f { ((struct S*)arg0)->" + kw + "}", 0);
     test("struct S{ int " + kw + ";}; k:f { (*(struct S*)arg0)." + kw + "}", 0);
   }
@@ -2846,9 +2856,7 @@ TEST(semantic_analyser, config)
        0);
 }
 
-class semantic_analyser_btf : public test_btf
-{
-};
+class semantic_analyser_btf : public test_btf {};
 
 TEST_F(semantic_analyser_btf, kfunc)
 {

--- a/tests/testprogs/array_access.c
+++ b/tests/testprogs/array_access.c
@@ -1,23 +1,19 @@
 #include <stdint.h>
 
-struct A
-{
+struct A {
   int x[4];
   uint8_t y[4];
 };
 
-struct B
-{
+struct B {
   int y[2][2];
 };
 
-struct C
-{
+struct C {
   int *z[4];
 };
 
-struct D
-{
+struct D {
   int x;
   int y[0];
   int z;
@@ -45,7 +41,7 @@ void test_variable_array(struct D *d __attribute__((unused)))
 {
 }
 
-int main(int argc __attribute__((unused)), char ** argv __attribute__((unused)))
+int main(int argc __attribute__((unused)), char **argv __attribute__((unused)))
 {
   struct A a;
   a.x[0] = 1;

--- a/tests/testprogs/bitfield_test.c
+++ b/tests/testprogs/bitfield_test.c
@@ -1,14 +1,8 @@
-struct Foo
-{
-  unsigned int a:4,
-               b:8,
-               c:3,
-               d:1,
-               e:16;
+struct Foo {
+  unsigned int a : 4, b : 8, c : 3, d : 1, e : 16;
 };
 
-struct Bar
-{
+struct Bar {
   unsigned short a : 4, b : 8, c : 3, d : 1;
   unsigned int e : 9, f : 15, g : 1, h : 2, i : 5;
 };

--- a/tests/testprogs/complex_struct.c
+++ b/tests/testprogs/complex_struct.c
@@ -2,8 +2,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-struct Foo
-{
+struct Foo {
   char* a;
   char b[4];
   uint8_t c[4];

--- a/tests/testprogs/intptrcast.c
+++ b/tests/testprogs/intptrcast.c
@@ -11,7 +11,8 @@ int fn(short p1,
   return p1 + p2 + p3 + p4 + p5 + p6 + p7 + p8 + p9;
 }
 
-int main() {
+int main()
+{
   fn(0x123,
      0x456,
      0x789,

--- a/tests/testprogs/kfunc_args.c
+++ b/tests/testprogs/kfunc_args.c
@@ -5,8 +5,7 @@
 
 int main(int argc, char *argv[])
 {
-  if (argc != 3)
-  {
+  if (argc != 3) {
     return 1;
   }
   usleep(1000000);

--- a/tests/testprogs/mountns_pivot_wrapper.c
+++ b/tests/testprogs/mountns_pivot_wrapper.c
@@ -16,8 +16,7 @@
 #include <unistd.h>
 
 #define errExit(msg)                                                           \
-  do                                                                           \
-  {                                                                            \
+  do {                                                                         \
     perror(msg);                                                               \
     exit(EXIT_FAILURE);                                                        \
   } while (0)
@@ -90,8 +89,7 @@ int main(int argc, char *argv[])
   glob("/lib*", GLOB_NOSORT, NULL, &globbuf);
   glob("/usr/lib*", GLOB_NOSORT | GLOB_APPEND, NULL, &globbuf);
   glob("/nix/store", GLOB_NOSORT | GLOB_APPEND, NULL, &globbuf);
-  for (size_t i = 0; i < globbuf.gl_pathc; i++)
-  {
+  for (size_t i = 0; i < globbuf.gl_pathc; i++) {
     const char *global_lib_dir = globbuf.gl_pathv[i];
     char shared_dir_mount[PATH_MAX];
     snprintf(
@@ -110,13 +108,11 @@ int main(int argc, char *argv[])
   if (mkdir(oldroot, 0770) != 0 && (errno != EEXIST))
     errExit("Failed to make old root directory for pivot_root");
 
-  if (syscall(SYS_pivot_root, private_mount, oldroot) != 0)
-  {
+  if (syscall(SYS_pivot_root, private_mount, oldroot) != 0) {
     errExit("Couldn't pivot to new root");
   }
 
-  if (chdir("/") != 0)
-  {
+  if (chdir("/") != 0) {
     errExit("Couldn't chdir to new root");
   }
 

--- a/tests/testprogs/mountns_wrapper.c
+++ b/tests/testprogs/mountns_wrapper.c
@@ -14,8 +14,7 @@
 #include <unistd.h>
 
 #define errExit(msg)                                                           \
-  do                                                                           \
-  {                                                                            \
+  do {                                                                         \
     perror(msg);                                                               \
     exit(EXIT_FAILURE);                                                        \
   } while (0)
@@ -42,7 +41,6 @@ necessary yet.
 
 int main(int argc, char *argv[])
 {
-
   const char *private_mount = "/tmp/bpftrace-unshare-mountns-test";
   char dpath[PATH_MAX];
   char exe[PATH_MAX];

--- a/tests/testprogs/ptr_to_ptr.c
+++ b/tests/testprogs/ptr_to_ptr.c
@@ -1,5 +1,4 @@
-struct Foo
-{
+struct Foo {
   int a;
   char b[10];
 };

--- a/tests/testprogs/simple_struct.c
+++ b/tests/testprogs/simple_struct.c
@@ -1,5 +1,4 @@
-struct Foo
-{
+struct Foo {
   int m;
   int n;
 };

--- a/tests/testprogs/stack_args.c
+++ b/tests/testprogs/stack_args.c
@@ -1,4 +1,4 @@
-#define ARG(x) int (x) __attribute((unused))
+#define ARG(x) int(x) __attribute((unused))
 
 // Declare enough args that some are placed on the stack
 void too_many_args(ARG(a),

--- a/tests/testprogs/string_args.c
+++ b/tests/testprogs/string_args.c
@@ -1,7 +1,7 @@
-void print(char * a, char * b)
+void print(char *a, char *b)
 {
-  (void) a;
-  (void) b;
+  (void)a;
+  (void)b;
 }
 
 int main(void)

--- a/tests/testprogs/struct_array.c
+++ b/tests/testprogs/struct_array.c
@@ -1,20 +1,17 @@
 #include <stdint.h>
 #include <stdio.h>
 
-struct T
-{
+struct T {
   uint32_t a;
   uint32_t b[2];
 };
 
-struct W
-{
+struct W {
   uint32_t a;
   struct T t;
 };
 
-struct C
-{
+struct C {
   uint32_t a;
   void* b;
   struct W w[10];
@@ -22,8 +19,7 @@ struct C
 
 void clear(struct C* c)
 {
-  for (int x = 0; x < 10; x++)
-  {
+  for (int x = 0; x < 10; x++) {
     c->w[x].t.a = 0;
   }
 }
@@ -34,8 +30,7 @@ int main()
 
   c.a = 0x55555555;
   c.b = (void*)0x55555555;
-  for (int x = 0; x < 10; x++)
-  {
+  for (int x = 0; x < 10; x++) {
     c.w[x].a = 100 + x;
     c.w[x].t.a = x;
     c.w[x].t.b[0] = 100 - x;

--- a/tests/testprogs/struct_walk.c
+++ b/tests/testprogs/struct_walk.c
@@ -2,16 +2,14 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-struct C
-{
+struct C {
   uint32_t a;
   uint64_t b;
 };
 
 void clear(struct C* c, size_t size)
 {
-  for (size_t t = 0; t < size; t++)
-  {
+  for (size_t t = 0; t < size; t++) {
     c[t].a = 0;
     c[t].b = 0;
   }
@@ -30,8 +28,7 @@ int main()
   size_t size = 10;
   struct C* c = (struct C*)malloc(sizeof(struct C) * size);
 
-  for (size_t t = 0; t < size; t++)
-  {
+  for (size_t t = 0; t < size; t++) {
     c[t].a = t;
     c[t].b = 100;
   }

--- a/tests/testprogs/uprobe_fork_loop.c
+++ b/tests/testprogs/uprobe_fork_loop.c
@@ -9,8 +9,7 @@ int uprobeFunction1(int *n, char c __attribute__((unused)))
 
 void spin()
 {
-  while (1)
-  {
+  while (1) {
     int n = 13;
     char c = 'x';
     uprobeFunction1(&n, c);
@@ -21,8 +20,7 @@ void spin()
 int main(int argc __attribute__((unused)), char **argv __attribute__((unused)))
 {
   pid_t p = fork();
-  if (p < 0)
-  {
+  if (p < 0) {
     perror("fork fail");
     exit(1);
   }

--- a/tests/testprogs/uprobe_negative_retval.c
+++ b/tests/testprogs/uprobe_negative_retval.c
@@ -1,11 +1,12 @@
 #include <unistd.h>
 
-__attribute__ ((noinline)) int function1(int x)
+__attribute__((noinline)) int function1(int x)
 {
   return x;
 }
 
-int main(int argc __attribute__((unused)), char **argv __attribute__((unused))) {
+int main(int argc __attribute__((unused)), char **argv __attribute__((unused)))
+{
   for (int x = -120; x <= 100; x++) {
     function1(x);
   }

--- a/tests/testprogs/uprobe_test.c
+++ b/tests/testprogs/uprobe_test.c
@@ -5,8 +5,7 @@ int GLOBAL_B = 0x88888888;
 int GLOBAL_C = 0x33333333;
 char GLOBAL_D = 8;
 
-struct Foo
-{
+struct Foo {
   int a;
   char b[10];
   int c[3];

--- a/tests/testprogs/usdt_args.c
+++ b/tests/testprogs/usdt_args.c
@@ -26,8 +26,7 @@
 #define test_value 0xf7f6f5f4f3f2f1f0
 volatile uint64_t one = 1;
 
-typedef union all_types
-{
+typedef union all_types {
   int8_t i_8;
   uint8_t i_u8;
   uint16_t i_u16;
@@ -87,8 +86,7 @@ int main()
 {
   volatile all_types_t array[10];
 
-  for (volatile size_t i = 0; i < sizeof(array) / sizeof(array[0]); i++)
-  {
+  for (volatile size_t i = 0; i < sizeof(array) / sizeof(array[0]); i++) {
     array[i].i_u64 = test_value;
   }
 
@@ -125,8 +123,7 @@ int main()
   PROBE_ADDRESS(, 8);
 
   /* Base address + offset + (index * scale) */
-  for (volatile int i = 7; i <= 7; i++)
-  {
+  for (volatile int i = 7; i <= 7; i++) {
     PROBE_INDEX(u, 64);
     PROBE_INDEX(, 64);
     PROBE_INDEX(u, 32);

--- a/tests/testprogs/usdt_inlined.c
+++ b/tests/testprogs/usdt_inlined.c
@@ -25,8 +25,7 @@ static void mywrapper()
 
 static void loop()
 {
-  while (1)
-  {
+  while (1) {
     myclock(999);
     mywrapper();
     sleep(1);

--- a/tests/testprogs/usdt_lib.c
+++ b/tests/testprogs/usdt_lib.c
@@ -3,8 +3,7 @@
 
 int main()
 {
-  while (1)
-  {
+  while (1) {
     myclock();
   }
   return 0;

--- a/tests/testprogs/usdt_multiple_locations.c
+++ b/tests/testprogs/usdt_multiple_locations.c
@@ -21,8 +21,7 @@ static long myclock()
 
 int main()
 {
-  while (1)
-  {
+  while (1) {
     myclock();
   }
   return 0;

--- a/tests/testprogs/usdt_semaphore_test.c
+++ b/tests/testprogs/usdt_semaphore_test.c
@@ -5,19 +5,23 @@
 #else
 #define DTRACE_PROBE2(a, b, c, d) (void)0
 #endif
+#include <stdio.h>
 #include <sys/time.h>
 #include <unistd.h>
-#include <stdio.h>
 
-__extension__ unsigned short tracetest_testprobe_semaphore __attribute__ ((unused)) __attribute__ ((section (".probes"))) __attribute__ ((visibility ("hidden")));
+__extension__ unsigned short tracetest_testprobe_semaphore
+    __attribute__((unused)) __attribute__((section(".probes")))
+    __attribute__((visibility("hidden")));
 
-static long
-myclock() {
+static long myclock()
+{
   char buffer[100];
   struct timeval tv;
   gettimeofday(&tv, NULL);
-  sprintf(buffer, "tracetest_testprobe_semaphore: %d\n", tracetest_testprobe_semaphore);
-  DTRACE_PROBE2(tracetest,  testprobe,  tv.tv_sec, buffer);
+  sprintf(buffer,
+          "tracetest_testprobe_semaphore: %d\n",
+          tracetest_testprobe_semaphore);
+  DTRACE_PROBE2(tracetest, testprobe, tv.tv_sec, buffer);
   return tv.tv_sec;
 }
 

--- a/tests/testprogs/usdt_sized_args.c
+++ b/tests/testprogs/usdt_sized_args.c
@@ -14,8 +14,7 @@ int main()
   (void)b;
   (void)c;
 
-  while (1)
-  {
+  while (1) {
     DTRACE_PROBE1(test, probe1, a);
     DTRACE_PROBE1(test, probe2, b);
     DTRACE_PROBE1(test, probe3, c);

--- a/tests/testprogs/usdt_test.c
+++ b/tests/testprogs/usdt_test.c
@@ -3,16 +3,16 @@
 #else
 #define DTRACE_PROBE2(a, b, c, d) (void)0
 #endif
+#include <stdio.h>
 #include <sys/time.h>
 #include <unistd.h>
-#include <stdio.h>
 
-static long
-myclock() {
+static long myclock()
+{
   struct timeval tv;
   gettimeofday(&tv, NULL);
-  DTRACE_PROBE2(tracetest,  testprobe,  tv.tv_sec, "Hello world");
-  DTRACE_PROBE2(tracetest,  testprobe2, tv.tv_sec, "Hello world2");
+  DTRACE_PROBE2(tracetest, testprobe, tv.tv_sec, "Hello world");
+  DTRACE_PROBE2(tracetest, testprobe2, tv.tv_sec, "Hello world2");
   DTRACE_PROBE2(tracetest2, testprobe2, tv.tv_sec, "Hello world3");
   return tv.tv_sec;
 }

--- a/tests/testprogs/wait4_ru.c
+++ b/tests/testprogs/wait4_ru.c
@@ -1,10 +1,9 @@
-#include <sys/types.h>
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/time.h>
-#include <sys/resource.h>
-#include <sys/wait.h>
 #include <stdlib.h>
+#include <sys/resource.h>
+#include <sys/time.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 int main(void)
 {

--- a/tests/testprogs/watchpoint.c
+++ b/tests/testprogs/watchpoint.c
@@ -4,14 +4,14 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
-int main() {
-  volatile void* addr = mmap(
-      (void*)0x10000000,
-      2 << 20,
-      PROT_READ | PROT_WRITE,
-      MAP_PRIVATE | MAP_ANONYMOUS,
-      -1,
-      0);
+int main()
+{
+  volatile void* addr = mmap((void*)0x10000000,
+                             2 << 20,
+                             PROT_READ | PROT_WRITE,
+                             MAP_PRIVATE | MAP_ANONYMOUS,
+                             -1,
+                             0);
 
   if ((long)addr < 0) {
     perror("mmap");
@@ -28,8 +28,7 @@ int main() {
   fclose(addr_fp);
 
   uint8_t i = 0;
-  while (i < 10)
-  {
+  while (i < 10) {
     *((volatile uint8_t*)addr) = i++;
     // 250ms*10 sleep, enough for watchpoint trigger
     usleep(250 * 1000);

--- a/tests/testprogs/watchpoint_func.c
+++ b/tests/testprogs/watchpoint_func.c
@@ -10,8 +10,7 @@ __attribute__((noinline)) void increment(__attribute__((unused)) int _, int *i)
 int main()
 {
   int *i = malloc(sizeof(int));
-  while (1)
-  {
+  while (1) {
     increment(0, i);
     (*i)++;
     usleep(1000);

--- a/tests/testprogs/watchpoint_func_many_probes.c
+++ b/tests/testprogs/watchpoint_func_many_probes.c
@@ -9,8 +9,7 @@ __attribute__((noinline)) void increment(int *i)
 
 int main()
 {
-  for (int i = 0; i < 20; ++i)
-  {
+  for (int i = 0; i < 20; ++i) {
     increment(malloc(sizeof(int)));
   }
 }

--- a/tests/tracepoint_format_parser.cpp
+++ b/tests/tracepoint_format_parser.cpp
@@ -9,8 +9,7 @@ namespace bpftrace {
 namespace test {
 namespace tracepoint_format_parser {
 
-class MockTracepointFormatParser : public TracepointFormatParser
-{
+class MockTracepointFormatParser : public TracepointFormatParser {
 public:
   static std::string get_tracepoint_struct_public(std::istream &format_file,
                                                   const std::string &category,
@@ -24,20 +23,25 @@ public:
 TEST(tracepoint_format_parser, tracepoint_struct)
 {
   std::string input =
-    "name: sys_enter_read\n"
-    "ID: 650\n"
-    "format:\n"
-    "	field:unsigned short common_type;	offset:0;	size:2;	signed:0;\n"
-    "	field:unsigned char common_flags;	offset:2;	size:1;	signed:0;\n"
-    "	field:unsigned char common_preempt_count;	offset:3;	size:1;	signed:0;\n"
-    "	field:int common_pid;	offset:4;	size:4;	signed:1;\n"
-    "\n"
-    "	field:int __syscall_nr;	offset:8;	size:4;	signed:1;\n"
-    "	field:unsigned int fd;	offset:16;	size:8;	signed:0;\n"
-    "	field:char * buf;	offset:24;	size:8;	signed:0;\n"
-    "	field:size_t count;	offset:32;	size:8;	signed:0;\n"
-    "\n"
-    "print fmt: \"fd: 0x%08lx, buf: 0x%08lx, count: 0x%08lx\", ((unsigned long)(REC->fd)), ((unsigned long)(REC->buf)), ((unsigned long)(REC->count))\n";
+      "name: sys_enter_read\n"
+      "ID: 650\n"
+      "format:\n"
+      "	field:unsigned short common_type;	offset:0;	size:2;	"
+      "signed:0;\n"
+      "	field:unsigned char common_flags;	offset:2;	size:1;	"
+      "signed:0;\n"
+      "	field:unsigned char common_preempt_count;	offset:3;	"
+      "size:1;	signed:0;\n"
+      "	field:int common_pid;	offset:4;	size:4;	signed:1;\n"
+      "\n"
+      "	field:int __syscall_nr;	offset:8;	size:4;	signed:1;\n"
+      "	field:unsigned int fd;	offset:16;	size:8;	signed:0;\n"
+      "	field:char * buf;	offset:24;	size:8;	signed:0;\n"
+      "	field:size_t count;	offset:32;	size:8;	signed:0;\n"
+      "\n"
+      "print fmt: \"fd: 0x%08lx, buf: 0x%08lx, count: 0x%08lx\", ((unsigned "
+      "long)(REC->fd)), ((unsigned long)(REC->buf)), ((unsigned "
+      "long)(REC->count))\n";
 
   std::string expected = "struct _tracepoint_syscalls_sys_enter_read\n"
                          "{\n"
@@ -67,15 +71,14 @@ TEST(tracepoint_format_parser, tracepoint_struct)
 TEST(tracepoint_format_parser, array)
 {
   std::string input =
-    "	field:char char_array[8];	offset:0;	size:8;	signed:1;\n"
-    "	field:int int_array[2];	offset:8;	size:8;	signed:1;\n";
+      "	field:char char_array[8];	offset:0;	size:8;	signed:1;\n"
+      "	field:int int_array[2];	offset:8;	size:8;	signed:1;\n";
 
-  std::string expected =
-    "struct _tracepoint_syscalls_sys_enter_read\n"
-    "{\n"
-    "  char char_array[8];\n"
-    "  int int_array[2];\n"
-    "};\n";
+  std::string expected = "struct _tracepoint_syscalls_sys_enter_read\n"
+                         "{\n"
+                         "  char char_array[8];\n"
+                         "  int int_array[2];\n"
+                         "};\n";
 
   std::istringstream format_file(input);
 
@@ -88,7 +91,8 @@ TEST(tracepoint_format_parser, array)
 
 TEST(tracepoint_format_parser, data_loc)
 {
-  std::string input = "	field:__data_loc char[] msg;	offset:8;	size:4;	signed:1;";
+  std::string input =
+      "	field:__data_loc char[] msg;	offset:8;	size:4;	signed:1;";
 
   std::string expected =
       "struct _tracepoint_syscalls_sys_enter_read\n"
@@ -108,55 +112,54 @@ TEST(tracepoint_format_parser, data_loc)
 TEST(tracepoint_format_parser, adjust_integer_types)
 {
   std::string input =
-    "	field:int arr[8];	offset:0;	size:32;	signed:1;\n"
+      "	field:int arr[8];	offset:0;	size:32;	signed:1;\n"
 
-    "	field:int int_a;	offset:0;	size:4;	signed:1;\n"
-    "	field:int int_b;	offset:0;	size:8;	signed:1;\n"
+      "	field:int int_a;	offset:0;	size:4;	signed:1;\n"
+      "	field:int int_b;	offset:0;	size:8;	signed:1;\n"
 
-    "	field:u32 u32_a;	offset:0;	size:4;	signed:0;\n"
-    "	field:u32 u32_b;	offset:0;	size:8;	signed:0;\n"
+      "	field:u32 u32_a;	offset:0;	size:4;	signed:0;\n"
+      "	field:u32 u32_b;	offset:0;	size:8;	signed:0;\n"
 
-    "	field:unsigned int uint_a;	offset:0;	size:4;	signed:0;\n"
-    "	field:unsigned int uint_b;	offset:0;	size:8;	signed:0;\n"
+      "	field:unsigned int uint_a;	offset:0;	size:4;	signed:0;\n"
+      "	field:unsigned int uint_b;	offset:0;	size:8;	signed:0;\n"
 
-    "	field:unsigned unsigned_a;	offset:0;	size:4;	signed:0;\n"
-    "	field:unsigned unsigned_b;	offset:0;	size:8;	signed:0;\n"
+      "	field:unsigned unsigned_a;	offset:0;	size:4;	signed:0;\n"
+      "	field:unsigned unsigned_b;	offset:0;	size:8;	signed:0;\n"
 
-    "	field:uid_t uid_a;	offset:0;	size:4;	signed:0;\n"
-    "	field:uid_t uid_b;	offset:0;	size:8;	signed:0;\n"
+      "	field:uid_t uid_a;	offset:0;	size:4;	signed:0;\n"
+      "	field:uid_t uid_b;	offset:0;	size:8;	signed:0;\n"
 
-    "	field:gid_t gid_a;	offset:0;	size:4;	signed:0;\n"
-    "	field:gid_t gid_b;	offset:0;	size:8;	signed:0;\n"
+      "	field:gid_t gid_a;	offset:0;	size:4;	signed:0;\n"
+      "	field:gid_t gid_b;	offset:0;	size:8;	signed:0;\n"
 
-    "	field:pid_t pid_a;	offset:0;	size:4;	signed:1;\n"
-    "	field:pid_t pid_b;	offset:0;	size:8;	signed:0;\n";
+      "	field:pid_t pid_a;	offset:0;	size:4;	signed:1;\n"
+      "	field:pid_t pid_b;	offset:0;	size:8;	signed:0;\n";
 
-  std::string expected =
-    "struct _tracepoint_syscalls_sys_enter_read\n"
-    "{\n"
-    "  int arr[8];\n"
+  std::string expected = "struct _tracepoint_syscalls_sys_enter_read\n"
+                         "{\n"
+                         "  int arr[8];\n"
 
-    "  int int_a;\n"
-    "  s64 int_b;\n"
+                         "  int int_a;\n"
+                         "  s64 int_b;\n"
 
-    "  u32 u32_a;\n"
-    "  u64 u32_b;\n"
+                         "  u32 u32_a;\n"
+                         "  u64 u32_b;\n"
 
-    "  unsigned int uint_a;\n"
-    "  u64 uint_b;\n"
+                         "  unsigned int uint_a;\n"
+                         "  u64 uint_b;\n"
 
-    "  unsigned unsigned_a;\n"
-    "  u64 unsigned_b;\n"
+                         "  unsigned unsigned_a;\n"
+                         "  u64 unsigned_b;\n"
 
-    "  uid_t uid_a;\n"
-    "  u64 uid_b;\n"
+                         "  uid_t uid_a;\n"
+                         "  u64 uid_b;\n"
 
-    "  gid_t gid_a;\n"
-    "  u64 gid_b;\n"
+                         "  gid_t gid_a;\n"
+                         "  u64 gid_b;\n"
 
-    "  pid_t pid_a;\n"
-    "  u64 pid_b;\n"
-    "};\n";
+                         "  pid_t pid_a;\n"
+                         "  u64 pid_b;\n"
+                         "};\n";
 
   std::istringstream format_file(input);
 

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -18,13 +18,17 @@ namespace utils {
 TEST(utils, split_string)
 {
   std::vector<std::string> tokens_empty = {};
-  std::vector<std::string> tokens_one_empty = {""};
-  std::vector<std::string> tokens_two_empty = {"", ""};
-  std::vector<std::string> tokens_f = {"", "f"};
-  std::vector<std::string> tokens_foo_bar = {"foo", "bar"};
-  std::vector<std::string> tokens_empty_foo_bar = {"", "foo", "bar"};
-  std::vector<std::string> tokens_empty_foo_empty_bar = {"", "foo", "", "bar"};
-  std::vector<std::string> tokens_empty_foo_bar_biz = {"", "foo", "bar", "biz"};
+  std::vector<std::string> tokens_one_empty = { "" };
+  std::vector<std::string> tokens_two_empty = { "", "" };
+  std::vector<std::string> tokens_f = { "", "f" };
+  std::vector<std::string> tokens_foo_bar = { "foo", "bar" };
+  std::vector<std::string> tokens_empty_foo_bar = { "", "foo", "bar" };
+  std::vector<std::string> tokens_empty_foo_empty_bar = {
+    "", "foo", "", "bar"
+  };
+  std::vector<std::string> tokens_empty_foo_bar_biz = {
+    "", "foo", "bar", "biz"
+  };
 
   EXPECT_EQ(split_string("", '-'), tokens_empty);
   EXPECT_EQ(split_string("-", '-'), tokens_one_empty);
@@ -59,13 +63,12 @@ TEST(utils, split_addrrange_symbol_module)
 
 TEST(utils, wildcard_match)
 {
-  std::vector<std::string> tokens_not = {"not"};
-  std::vector<std::string> tokens_bar = {"bar"};
-  std::vector<std::string> tokens_bar_not = {"bar", "not"};
-  std::vector<std::string> tokens_foo = {"foo"};
-  std::vector<std::string> tokens_biz = {"biz"};
-  std::vector<std::string> tokens_foo_biz = {"foo", "biz"};
-
+  std::vector<std::string> tokens_not = { "not" };
+  std::vector<std::string> tokens_bar = { "bar" };
+  std::vector<std::string> tokens_bar_not = { "bar", "not" };
+  std::vector<std::string> tokens_foo = { "foo" };
+  std::vector<std::string> tokens_biz = { "biz" };
+  std::vector<std::string> tokens_foo_biz = { "foo", "biz" };
 
   // start: true, end: true
   EXPECT_EQ(wildcard_match("foobarbiz", tokens_not, true, true), false);
@@ -100,10 +103,9 @@ TEST(utils, wildcard_match)
   EXPECT_EQ(wildcard_match("foobarbiz", tokens_foo_biz, false, false), true);
 }
 
-static void symlink_test_binary(const std::string& destination)
+static void symlink_test_binary(const std::string &destination)
 {
-  if (symlink("/proc/self/exe", destination.c_str()))
-  {
+  if (symlink("/proc/self/exe", destination.c_str())) {
     throw std::runtime_error("Couldn't symlink /proc/self/exe to " +
                              destination + ": " + strerror(errno));
   }
@@ -112,8 +114,7 @@ static void symlink_test_binary(const std::string& destination)
 static std::string get_working_path()
 {
   char cwd_path[PATH_MAX];
-  if (::getcwd(cwd_path, PATH_MAX) == nullptr)
-  {
+  if (::getcwd(cwd_path, PATH_MAX) == nullptr) {
     throw std::runtime_error(
         "getting current working directory for tests failed");
   }
@@ -133,12 +134,15 @@ TEST(utils, resolve_binary_path)
   symlink_test_binary(path + "/executable2");
 
   int fd;
-  fd = open((path + "/nonexecutable").c_str(), O_CREAT, S_IRUSR); close(fd);
-  fd = open((path + "/nonexecutable2").c_str(), O_CREAT, S_IRUSR); close(fd);
+  fd = open((path + "/nonexecutable").c_str(), O_CREAT, S_IRUSR);
+  close(fd);
+  fd = open((path + "/nonexecutable2").c_str(), O_CREAT, S_IRUSR);
+  close(fd);
 
   std::vector<std::string> paths_empty = {};
-  std::vector<std::string> paths_one_executable = {path + "/executable"};
-  std::vector<std::string> paths_all_executables = {path + "/executable", path + "/executable2"};
+  std::vector<std::string> paths_one_executable = { path + "/executable" };
+  std::vector<std::string> paths_all_executables = { path + "/executable",
+                                                     path + "/executable2" };
 
   EXPECT_EQ(resolve_binary_path(path + "/does/not/exist"), paths_empty);
   EXPECT_EQ(resolve_binary_path(path + "/does/not/exist*"), paths_empty);
@@ -155,8 +159,7 @@ TEST(utils, abs_path)
 {
   std::string path = "/tmp/bpftrace-test-utils-XXXXXX";
   std::string rel_file = "bpftrace-test-utils-abs-path";
-  if (::mkdtemp(&path[0]) == nullptr)
-  {
+  if (::mkdtemp(&path[0]) == nullptr) {
     throw std::runtime_error("creating temporary path for tests failed");
   }
 
@@ -186,8 +189,7 @@ TEST(utils, get_cgroup_hierarchy_roots)
   auto roots = get_cgroup_hierarchy_roots();
 
   // Check that each entry is a proper cgroup filesystem
-  for (auto root : roots)
-  {
+  for (auto root : roots) {
     EXPECT_TRUE(root.first == "cgroup" || root.first == "cgroup2");
     std_filesystem::path root_path(root.second);
     EXPECT_TRUE(std_filesystem::exists(root_path / "cgroup.procs"));
@@ -198,8 +200,7 @@ TEST(utils, get_cgroup_path_in_hierarchy)
 {
   std::string tmpdir = "/tmp/bpftrace-test-utils-XXXXXX";
 
-  if (::mkdtemp(&tmpdir[0]) == nullptr)
-  {
+  if (::mkdtemp(&tmpdir[0]) == nullptr) {
     throw std::runtime_error("creating temporary path for tests failed");
   }
 
@@ -210,8 +211,7 @@ TEST(utils, get_cgroup_path_in_hierarchy)
 
   // Make a few files in the directory to imitate cgroup files and get their
   // inodes
-  if (!std_filesystem::create_directory(subdir))
-  {
+  if (!std_filesystem::create_directory(subdir)) {
     throw std::runtime_error("creating subdirectory for tests failed");
   }
   static_cast<std::ofstream &&>(std::ofstream(file_1) << "File 1 content")
@@ -220,14 +220,12 @@ TEST(utils, get_cgroup_path_in_hierarchy)
       .close();
   struct stat file_1_st, file_2_st;
   if (stat(file_1.c_str(), &file_1_st) < 0 ||
-      stat(file_2.c_str(), &file_2_st) < 0)
-  {
+      stat(file_2.c_str(), &file_2_st) < 0) {
     throw std::runtime_error("stat on test files failed");
   }
 
   // Look for both "cgroup files" by their inode twice (to test caching)
-  for (int i = 0; i < 2; i++)
-  {
+  for (int i = 0; i < 2; i++) {
     EXPECT_EQ(get_cgroup_path_in_hierarchy(file_1_st.st_ino, tmpdir), "/file1");
     EXPECT_EQ(get_cgroup_path_in_hierarchy(file_2_st.st_ino, tmpdir),
               "/subdir/file2");
@@ -281,12 +279,9 @@ static void with_env(const std::string &key,
                      std::function<void()> fn)
 {
   EXPECT_EQ(::setenv(key.c_str(), val.c_str(), 1), 0);
-  try
-  {
+  try {
     fn();
-  }
-  catch (const std::exception &ex)
-  {
+  } catch (const std::exception &ex) {
     EXPECT_EQ(::unsetenv(key.c_str()), 0);
     throw ex;
   }


### PR DESCRIPTION
This PR does a few things. I am happy to split it out into multiple PRs if necessary.

1. Simplify and make more reliable clang-format GHA job
2. Remove unused .clang-formoat config
3. Codemod the entire codebase to place opening braces on starting context

Note this PR does not yet update `.git-blame-ignore-revs`. That will come in a
separate PR cuz when this is merged the SHAs will be different. See
https://michaelheap.com/git-ignore-rev/ for more details on how it will work.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
