### PR TITLE
Ignore tree-wide clang-format commit

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Move opening brace to starting context
+453198bdabdaffdc1cb600038af60644e1326656


### PR DESCRIPTION
This teaches GH as well as git to ignore formatting changes when blaming. GH natively knows how to do this. Your local git needs to be configured with:

      git config --global blame.ignoreRevsFile .git-blame-ignore-revs

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
