### PR TITLE
clang-format: exclude JSON files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -83,5 +83,8 @@ SpacesInSquareBrackets: false
 Standard: Cpp11
 TabWidth: 8
 UseTab: Never
+---
+Language: Json
+DisableFormat: true
 ...
 


### PR DESCRIPTION
Running `git clang-format` on commits changing JSON files fails with:

    Configuration file(s) do(es) not support Json: /home/runner/work/bpftrace/bpftrace/.clang-format
    error: `clang-format -lines=1:5 tests/runtime/outputs/delete_wildcard_idx_0.json` failed

See [here](https://github.com/iovisor/bpftrace/actions/runs/7738638281/job/21099871828) for an example.

We don't need to run clang-format on JSON files so just ignore them.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc` and if needed in `docs/reference_guide.md`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
