### PR TITLE
Fix ODR violation warning when compiling with LTO

### DIFF
--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -5,7 +5,10 @@
 #include "log.h"
 #include "parser.tab.hh"
 
-extern void *yy_scan_string(const char *yy_str, yyscan_t yyscanner);
+struct yy_buffer_state;
+
+extern struct yy_buffer_state *yy_scan_string(const char *yy_str,
+                                              yyscan_t yyscanner);
 extern int yylex_init(yyscan_t *scanner);
 extern int yylex_destroy(yyscan_t yyscanner);
 extern bpftrace::location loc;


### PR DESCRIPTION
I never noticed this before because clang/lld seems to eat everything :yum: but gcc/LTO complains - and rightfully so:
```
[76/77] : && /usr/bin/g++-15 -pipe -march=sandybridge -O2 -flto -fuse-linker-plugin -Wl,-O1,--as-needed,-z,now,-z,pack-relative-relocs -flto=4 -fuse-linker-plugin    -Wl,--dependency-file=src/CMakeFiles/bpftrace.dir/link.d src/CMakeFiles/bpftrace.dir/main.cpp.o -o src/bpftrace  -Wl,-rpath,/usr/lib/llvm/19/lib64:  src/libbpftrace.a  src/resources/libresources.a  src/libruntime.a  /usr/lib64/libbpf.so  /usr/lib64/libz.so  /usr/lib64/libbfd.so  /usr/lib64/libopcodes.so  /usr/lib64/libbcc_bpf.so  src/aot/libaot.a  /usr/lib64/libelf.so  src/librequired_resources.a  src/ast/libast.a  libparser.a  src/ast/libast_defs.a  /usr/lib/llvm/19/lib64/libclang.so.19.1.5  /usr/lib/llvm/19/lib64/libLLVM.so.19.1  src/arch/libarch.a  src/cxxdemangler/libcxxdemangler_llvm.a  /usr/lib64/libpcap.so && :
/tmp/portage/dev-debug/bpftrace-0.21.3/work/bpftrace-0.21.3/src/driver.cpp:8:14: warning: 'yy_scan_string' violates the C++ One Definition Rule [-Wodr]
    8 | extern void *yy_scan_string(const char *yy_str, yyscan_t yyscanner);
      |              ^
/tmp/portage/dev-debug/bpftrace-0.21.3/work/bpftrace-0.21.3_build/lex.yy.cc:2669:17: note: 'yy_scan_string' was previously declared here
 2669 |  */
      |                 ^
```

yy_scan_string is declared to return void* due to a lack of a proper type definition of struct yy_buffer_state, which is only available in lex.yy.cc. Provide a struct forward declaration so that a proper return type can be used. This fixes the LTO complaint.

This has been reported before (#801 #1613) but was never fixed properly.

None of the checklist items apply.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
