### PR TITLE
Update the docs for min kernel version

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -23,17 +23,9 @@
 
 # Linux Kernel Requirements
 
-It is recommended that you are running a Linux 4.9 kernel or higher. Some tools may work on older kernels, but these old kernels are no longer tested. To explain this requirement, these are the kernel versions where major features were added:
+For minimum kernel version, see our [dependency support policy](docs/dependency_support.md#linux-kernel).
 
-- 4.1 - kprobes
-- 4.3 - uprobes
-- 4.6 - stack traces, count and hist builtins (use PERCPU maps for accuracy and efficiency)
-- 4.7 - tracepoints
-- 4.9 - timers/profiling
-
-Minor improvements have been added in later kernels, so newer than 4.9 is preferred.
-
-Your kernel also needs to be built with the following options:
+Your kernel needs to be built with the following options:
 
 ```
 CONFIG_BPF=y


### PR DESCRIPTION
As per Daniel's testing we are pretty much
broken on even 5.4. The tests from 5.10
look ok:
https://github.com/bpftrace/bpftrace/pull/3770/commits/3e95269e9cfb10dae5ce7007c45821f2abd9d1a2

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
