### PR TITLE
Use BPF_ANY when initializing per-cpu map key/val

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to
   - [#3976](https://github.com/bpftrace/bpftrace/pull/3976)
 - Allow sized_type idents to be used for field access
   - [#4064](https://github.com/bpftrace/bpftrace/pull/4064)
+- Fix per-cpu map update warning
+  - [#4047](https://github.com/bpftrace/bpftrace/pull/4074)
 #### Security
 #### Docs
 #### Tools

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -2214,23 +2214,23 @@ void IRBuilderBPF::CreateAtomicIncCounter(const std::string &map_name,
   CreateLifetimeEnd(key);
 }
 
-void IRBuilderBPF::CreateMapElemInit(Value *ctx,
-                                     Map &map,
-                                     Value *key,
-                                     Value *val,
-                                     const Location &loc)
+void IRBuilderBPF::CreatePerCpuMapElemInit(Value *ctx,
+                                           Map &map,
+                                           Value *key,
+                                           Value *val,
+                                           const Location &loc)
 {
   AllocaInst *initValue = CreateAllocaBPF(val->getType(), "initial_value");
   CreateStore(val, initValue);
-  CreateMapUpdateElem(ctx, map.ident, key, initValue, loc, BPF_NOEXIST);
+  CreateMapUpdateElem(ctx, map.ident, key, initValue, loc, BPF_ANY);
   CreateLifetimeEnd(initValue);
 }
 
-void IRBuilderBPF::CreateMapElemAdd(Value *ctx,
-                                    Map &map,
-                                    Value *key,
-                                    Value *val,
-                                    const Location &loc)
+void IRBuilderBPF::CreatePerCpuMapElemAdd(Value *ctx,
+                                          Map &map,
+                                          Value *key,
+                                          Value *val,
+                                          const Location &loc)
 {
   CallInst *call = CreateMapLookup(map, key);
 
@@ -2262,7 +2262,7 @@ void IRBuilderBPF::CreateMapElemAdd(Value *ctx,
 
   SetInsertPoint(lookup_failure_block);
 
-  CreateMapElemInit(ctx, map, key, val, loc);
+  CreatePerCpuMapElemInit(ctx, map, key, val, loc);
 
   CreateBr(lookup_merge_block);
   SetInsertPoint(lookup_merge_block);

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -182,16 +182,16 @@ public:
                             const Location &loc);
   void CreateOutput(Value *ctx, Value *data, size_t size, const Location &loc);
   void CreateAtomicIncCounter(const std::string &map_name, uint32_t idx);
-  void CreateMapElemInit(Value *ctx,
-                         Map &map,
-                         Value *key,
-                         Value *val,
-                         const Location &loc);
-  void CreateMapElemAdd(Value *ctx,
-                        Map &map,
-                        Value *key,
-                        Value *val,
-                        const Location &loc);
+  void CreatePerCpuMapElemInit(Value *ctx,
+                               Map &map,
+                               Value *key,
+                               Value *val,
+                               const Location &loc);
+  void CreatePerCpuMapElemAdd(Value *ctx,
+                              Map &map,
+                              Value *key,
+                              Value *val,
+                              const Location &loc);
   void CreateDebugOutput(std::string fmt_str,
                          const std::vector<Value *> &values,
                          const Location &loc);

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -794,7 +794,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
   if (call.func == "count") {
     Map &map = *call.vargs.at(0).as<Map>();
     auto scoped_key = getMapKey(map, call.vargs.at(1));
-    b_.CreateMapElemAdd(
+    b_.CreatePerCpuMapElemAdd(
         ctx_, map, scoped_key.value(), b_.getInt64(1), call.loc);
     return ScopedExpr();
 
@@ -807,7 +807,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     Value *cast = b_.CreateIntCast(scoped_expr.value(),
                                    b_.getInt64Ty(),
                                    call.vargs.front().type().IsSigned());
-    b_.CreateMapElemAdd(ctx_, map, scoped_key.value(), cast, call.loc);
+    b_.CreatePerCpuMapElemAdd(ctx_, map, scoped_key.value(), cast, call.loc);
     return ScopedExpr();
 
   } else if (call.func == "max" || call.func == "min") {
@@ -1018,7 +1018,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     Value *log2 = b_.CreateCall(log2_func_, { expr, k }, "log2");
     ScopedExpr scoped_key = getMultiMapKey(
         map, call.vargs.at(1), { log2 }, call.loc);
-    b_.CreateMapElemAdd(
+    b_.CreatePerCpuMapElemAdd(
         ctx_, map, scoped_key.value(), b_.getInt64(1), call.loc);
 
     return ScopedExpr();
@@ -1059,7 +1059,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
 
     ScopedExpr scoped_key = getMultiMapKey(
         map, call.vargs.at(1), { linear }, call.loc);
-    b_.CreateMapElemAdd(
+    b_.CreatePerCpuMapElemAdd(
         ctx_, map, scoped_key.value(), b_.getInt64(1), call.loc);
 
     return ScopedExpr();

--- a/tests/codegen/llvm/call_count.ll
+++ b/tests/codegen/llvm/call_count.ll
@@ -38,7 +38,7 @@ lookup_success:                                   ; preds = %entry
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
   store i64 1, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
   br label %lookup_merge
 

--- a/tests/codegen/llvm/call_hist.ll
+++ b/tests/codegen/llvm/call_hist.ll
@@ -45,7 +45,7 @@ lookup_success:                                   ; preds = %entry
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
   store i64 1, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
   br label %lookup_merge
 

--- a/tests/codegen/llvm/call_lhist.ll
+++ b/tests/codegen/llvm/call_lhist.ll
@@ -45,7 +45,7 @@ lookup_success:                                   ; preds = %entry
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
   store i64 1, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
   br label %lookup_merge
 

--- a/tests/codegen/llvm/call_map_key_scratch_buf.ll
+++ b/tests/codegen/llvm/call_map_key_scratch_buf.ll
@@ -47,7 +47,7 @@ lookup_success:                                   ; preds = %entry
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
   store i64 1, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %2, ptr %initial_value, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %2, ptr %initial_value, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
   br label %lookup_merge
 
@@ -76,7 +76,7 @@ lookup_success4:                                  ; preds = %lookup_merge
 lookup_failure5:                                  ; preds = %lookup_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value9)
   store i64 1, ptr %initial_value9, align 8
-  %update_elem10 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %6, ptr %initial_value9, i64 1)
+  %update_elem10 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %6, ptr %initial_value9, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value9)
   br label %lookup_merge6
 

--- a/tests/codegen/llvm/call_map_key_stack.ll
+++ b/tests/codegen/llvm/call_map_key_stack.ll
@@ -45,7 +45,7 @@ lookup_success:                                   ; preds = %entry
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
   store i64 1, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
   br label %lookup_merge
 
@@ -72,7 +72,7 @@ lookup_success2:                                  ; preds = %lookup_merge
 lookup_failure3:                                  ; preds = %lookup_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value7)
   store i64 1, ptr %initial_value7, align 8
-  %update_elem8 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %initial_value7, i64 1)
+  %update_elem8 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %initial_value7, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value7)
   br label %lookup_merge4
 

--- a/tests/codegen/llvm/call_sum.ll
+++ b/tests/codegen/llvm/call_sum.ll
@@ -42,7 +42,7 @@ lookup_success:                                   ; preds = %entry
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
   store i64 %2, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
   br label %lookup_merge
 

--- a/tests/codegen/llvm/count_cast.ll
+++ b/tests/codegen/llvm/count_cast.ll
@@ -45,7 +45,7 @@ lookup_success:                                   ; preds = %entry
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
   store i64 1, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
   br label %lookup_merge
 

--- a/tests/codegen/llvm/count_cast_loop.ll
+++ b/tests/codegen/llvm/count_cast_loop.ll
@@ -39,7 +39,7 @@ lookup_success:                                   ; preds = %entry
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
   store i64 1, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
   br label %lookup_merge
 

--- a/tests/codegen/llvm/count_cast_loop_multi_key.ll
+++ b/tests/codegen/llvm/count_cast_loop_multi_key.ll
@@ -44,7 +44,7 @@ lookup_success:                                   ; preds = %entry
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
   store i64 1, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %tuple, ptr %initial_value, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %tuple, ptr %initial_value, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
   br label %lookup_merge
 

--- a/tests/codegen/llvm/count_cast_loop_stack_key.ll
+++ b/tests/codegen/llvm/count_cast_loop_stack_key.ll
@@ -79,7 +79,7 @@ lookup_success:                                   ; preds = %merge_block
 lookup_failure:                                   ; preds = %merge_block
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
   store i64 1, ptr %initial_value, align 8
-  %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %stack_key, ptr %initial_value, i64 1)
+  %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %stack_key, ptr %initial_value, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
   br label %lookup_merge
 

--- a/tests/codegen/llvm/count_no_cast_for_print.ll
+++ b/tests/codegen/llvm/count_no_cast_for_print.ll
@@ -41,7 +41,7 @@ lookup_success:                                   ; preds = %entry
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
   store i64 1, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %initial_value, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %initial_value, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
   br label %lookup_merge
 

--- a/tests/codegen/llvm/intcast_call.ll
+++ b/tests/codegen/llvm/intcast_call.ll
@@ -43,7 +43,7 @@ lookup_success:                                   ; preds = %entry
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
   store i64 %3, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %initial_value, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %initial_value, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
   br label %lookup_merge
 

--- a/tests/codegen/llvm/intptrcast_call.ll
+++ b/tests/codegen/llvm/intptrcast_call.ll
@@ -48,7 +48,7 @@ lookup_success:                                   ; preds = %entry
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
   store i64 %5, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %initial_value, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %initial_value, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
   br label %lookup_merge
 

--- a/tests/codegen/llvm/map_percpuarray.ll
+++ b/tests/codegen/llvm/map_percpuarray.ll
@@ -38,7 +38,7 @@ lookup_success:                                   ; preds = %entry
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
   store i64 1, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key", ptr %initial_value, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key", ptr %initial_value, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
   br label %lookup_merge
 

--- a/tests/codegen/llvm/map_percpuhash.ll
+++ b/tests/codegen/llvm/map_percpuhash.ll
@@ -38,7 +38,7 @@ lookup_success:                                   ; preds = %entry
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
   store i64 1, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key", ptr %initial_value, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key", ptr %initial_value, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
   br label %lookup_merge
 

--- a/tests/codegen/llvm/map_percpulruhash.ll
+++ b/tests/codegen/llvm/map_percpulruhash.ll
@@ -38,7 +38,7 @@ lookup_success:                                   ; preds = %entry
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
   store i64 1, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key", ptr %initial_value, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key", ptr %initial_value, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
   br label %lookup_merge
 

--- a/tests/codegen/llvm/runtime_error_check_lookup_percpu.ll
+++ b/tests/codegen/llvm/runtime_error_check_lookup_percpu.ll
@@ -50,7 +50,7 @@ lookup_success:                                   ; preds = %entry
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
   store i64 1, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %initial_value, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %initial_value, i64 0)
   %3 = trunc i64 %update_elem to i32
   %4 = icmp sge i32 %3, 0
   br i1 %4, label %helper_merge, label %helper_failure

--- a/tests/codegen/llvm/sum_cast.ll
+++ b/tests/codegen/llvm/sum_cast.ll
@@ -45,7 +45,7 @@ lookup_success:                                   ; preds = %entry
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
   store i64 2, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
   br label %lookup_merge
 

--- a/tests/codegen/llvm/sum_cast_loop.ll
+++ b/tests/codegen/llvm/sum_cast_loop.ll
@@ -39,7 +39,7 @@ lookup_success:                                   ; preds = %entry
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
   store i64 2, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 1)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %initial_value, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
   br label %lookup_merge
 


### PR DESCRIPTION
AFAICT, it doesn't matter if the key already exists when initializing/updating a per-cpu map because
another CPU may have already updated the key but the CPU slot for that key should still be 0 or empty
if the check for that element fails on the same thread.

The only weirdness I'm not sure of is if the check for the element fails, the thread is pre-empted,
then another thread (running the same bpf program?) runs on that same CPU and updates the value for the CPU slot. Then when the first thread comes back on it will replace that value in the CPU slot.
It would still be no different than what we have now, using BPF_NOEXIST, as we would still lose an update.

However, we would avoid showing the user an error
they can do nothing about:
https://github.com/bpftrace/bpftrace/issues/4068

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
