### PR TITLE
Add task_from_pid(pid) and task_release(task)

### DIFF
--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -3132,6 +3132,41 @@ tracepoint:syscalls:sys_enter_execve {
 }
 ----
 
+[#functions-task_from_pid]
+=== task_from_pid
+
+.variants
+* `struct task_struct *task_from_pid(pid)`
+
+*compile time*
+
+Get 'struct task_struct *' pointer from pid.
+
+`task_from_pid()` needs to be used together with `task_release()`, otherwise it will fail the verifier check.
+
+----
+tracepoint:syscalls:sys_enter_kill,
+tracepoint:syscalls:sys_enter_tkill,
+tracepoint:syscalls:sys_enter_tgkill
+{
+    $ttask = task_from_pid(args.pid);
+    if ($ttask) {
+        /* do something */
+        task_release($ttask);
+    }
+}
+----
+
+[#functions-task_release]
+=== task_release
+
+.variants
+* `void task_release(TASK_STRUCT)`
+
+*compile time*
+
+`task_release()` releases the 'struct task_struct *' pointer obtained by `task_from_pid()`.
+
 [#functions-time]
 === time
 

--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -285,6 +285,9 @@ DIType *DIBuilderBPF::GetType(const SizedType &stype, bool emit_codegen_types)
                                                           emit_codegen_types),
                                                   64);
 
+  if (stype.IsVoidTy())
+    return createUnspecifiedType("void");
+
   // Integer types and builtin types represented by integers
   switch (stype.GetSize()) {
     case 8:

--- a/src/kfuncs.h
+++ b/src/kfuncs.h
@@ -8,11 +8,15 @@ namespace bpftrace {
 enum class Kfunc {
   bpf_map_sum_elem_count,
   bpf_session_is_return,
+  bpf_task_from_pid,
+  bpf_task_release,
 };
 
 static const std::map<Kfunc, std::string> KFUNC_NAME_MAP = {
   { Kfunc::bpf_map_sum_elem_count, "bpf_map_sum_elem_count" },
   { Kfunc::bpf_session_is_return, "bpf_session_is_return" },
+  { Kfunc::bpf_task_from_pid, "bpf_task_from_pid" },
+  { Kfunc::bpf_task_release, "bpf_task_release" },
 };
 
 inline const std::string &kfunc_name(enum Kfunc kfunc)

--- a/tests/codegen/call_task_from_pid.cpp
+++ b/tests/codegen/call_task_from_pid.cpp
@@ -1,0 +1,19 @@
+#include "common.h"
+
+namespace bpftrace {
+namespace test {
+namespace codegen {
+
+TEST(codegen, call_task_from_pid)
+{
+  test("tracepoint:syscalls:sys_enter_kill {"
+       " $task = task_from_pid(1);"
+       " if ($task) { task_release($task); }"
+       " exit();"
+       "}",
+       NAME);
+}
+
+} // namespace codegen
+} // namespace test
+} // namespace bpftrace

--- a/tests/codegen/llvm/call_task_from_pid.ll
+++ b/tests/codegen/llvm/call_task_from_pid.ll
@@ -1,0 +1,107 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf-pc-linux"
+
+%"struct map_t" = type { ptr, ptr }
+%exit_t = type <{ i64, i8 }>
+
+@LICENSE = local_unnamed_addr global [4 x i8] c"GPL\00", section "license", !dbg !0
+@ringbuf = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
+@event_loss_counter = dso_local externally_initialized global i64 0, section ".data.event_loss_counter", !dbg !22
+
+; Function Attrs: nounwind
+define noundef i64 @tracepoint_syscalls_sys_enter_kill_1(ptr nocapture readnone %0) local_unnamed_addr #0 section "s_tracepoint_syscalls_sys_enter_kill_1" !dbg !29 {
+entry:
+  %exit = alloca %exit_t, align 8
+  %task_from_pid = tail call ptr @bpf_task_from_pid(i64 1)
+  %true_cond.not = icmp eq ptr %task_from_pid, null
+  br i1 %true_cond.not, label %if_end, label %if_body
+
+if_body:                                          ; preds = %entry
+  %1 = ptrtoint ptr %task_from_pid to i64
+  %task_release = tail call void @bpf_task_release(i64 %1)
+  br label %if_end
+
+if_end:                                           ; preds = %if_body, %entry
+  call void @llvm.lifetime.start.p0(i64 -1, ptr nonnull %exit)
+  store i64 30000, ptr %exit, align 8
+  %2 = getelementptr inbounds nuw i8, ptr %exit, i64 8
+  store i8 0, ptr %2, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr nonnull @ringbuf, ptr nonnull %exit, i64 9, i64 0) #0
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %if_end
+  %3 = atomicrmw add ptr @event_loss_counter, i64 1 seq_cst, align 8
+  br label %counter_merge
+
+counter_merge:                                    ; preds = %event_loss_counter, %if_end
+  call void @llvm.lifetime.end.p0(i64 -1, ptr nonnull %exit)
+  ret i64 1
+}
+
+; Function Attrs: nounwind
+declare !dbg !35 extern_weak ptr @bpf_task_from_pid(i32 %0) local_unnamed_addr #0 section ".ksyms"
+
+; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nounwind
+declare !dbg !42 extern_weak void @bpf_task_release(ptr %0) local_unnamed_addr #0 section ".ksyms"
+
+; Function Attrs: mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { mustprogress nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+
+!llvm.dbg.cu = !{!25}
+!llvm.module.flags = !{!27, !28}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 32, elements: !5)
+!4 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!5 = !{!6}
+!6 = !DISubrange(count: 4, lowerBound: 0)
+!7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
+!8 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !10)
+!10 = !{!11, !17}
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !15)
+!14 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!15 = !{!16}
+!16 = !DISubrange(count: 27, lowerBound: 0)
+!17 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !18, size: 64, offset: 64)
+!18 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !19, size: 64)
+!19 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !20)
+!20 = !{!21}
+!21 = !DISubrange(count: 262144, lowerBound: 0)
+!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
+!23 = distinct !DIGlobalVariable(name: "event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!25 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !26)
+!26 = !{!0, !7, !22}
+!27 = !{i32 2, !"Debug Info Version", i32 3}
+!28 = !{i32 7, !"uwtable", i32 0}
+!29 = distinct !DISubprogram(name: "tracepoint_syscalls_sys_enter_kill_1", linkageName: "tracepoint_syscalls_sys_enter_kill_1", scope: !2, file: !2, type: !30, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !25, retainedNodes: !33)
+!30 = !DISubroutineType(types: !31)
+!31 = !{!24, !32}
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!33 = !{!34}
+!34 = !DILocalVariable(name: "ctx", arg: 1, scope: !29, file: !2, type: !32)
+!35 = !DISubprogram(name: "bpf_task_from_pid", linkageName: "bpf_task_from_pid", scope: !2, file: !2, type: !36, flags: DIFlagPrototyped, spFlags: 0)
+!36 = !DISubroutineType(types: !37)
+!37 = !{!38, !41}
+!38 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !39, size: 64)
+!39 = !DICompositeType(tag: DW_TAG_structure_type, name: "task_struct", scope: !2, file: !2, size: 112128, elements: !40)
+!40 = !{}
+!41 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!42 = !DISubprogram(name: "bpf_task_release", linkageName: "bpf_task_release", scope: !2, file: !2, type: !43, flags: DIFlagPrototyped, spFlags: 0)
+!43 = !DISubroutineType(types: !44)
+!44 = !{!45, !38}
+!45 = !DIBasicType(tag: DW_TAG_unspecified_type, name: "void")

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -3901,6 +3901,14 @@ struct Foo { struct Bar { int a; } bar; }               BEGIN { @x = offsetof(st
   test("BEGIN { @x = offsetof(struct __notexiststruct__, x.y.z); }", 1);
 }
 
+TEST(semantic_analyser, call_task_from_pid)
+{
+  test("tracepoint:syscalls:sys_enter_kill {"
+       " $task = task_from_pid(1);"
+       " if ($task) { task_release($task); }"
+       "}");
+}
+
 TEST(semantic_analyser, int_ident)
 {
   test("BEGIN { sizeof(int32) }");


### PR DESCRIPTION
linux v6.1 commit 3f0e6f2b41d3 ("bpf: Add bpf_task_from_pid() kfunc") introduce bpf_task_from_pid() kfunc to get 'struct task_struct *' from pid.

For example, in killsnoop.bt, the 'struct task_struct *' pointer of the target process can be obtained through the pid information of the target process to obtain more information.

Example:

    tracepoint:syscalls:sys_enter_kill,
    tracepoint:syscalls:sys_enter_tkill,
    tracepoint:syscalls:sys_enter_tgkill
    {
        $pid = args.pid;
        printf("%-15s %-8d %-16s %-8d",
            strftime("%H:%M:%S.%f", nsecs),
            pid, comm, $pid);

        $ttask = task_from_pid($pid);
        if ($ttask) {
            printf(" %-16s", $ttask->comm);
            task_release($ttask);
        }

        printf(" %-4d\n", args.sig);
    }

    16:48:59.238166 1755268  tgkill           1755269  target-thread    15
    16:49:48.287715 1755507  tkill            1755508  target-thread    15

Test C:

```c
#include <stdio.h>
#include <stdlib.h>
#include <unistd.h>
#include <sys/syscall.h>
#include <pthread.h>
#include <signal.h>

static pid_t child_tid;

void *thread_func(void* arg)
{
	child_tid = syscall(SYS_gettid);
	while (1) {
		sleep(1);
		printf("child running...\n");
	}
	return NULL;
}

int main(void)
{
	pthread_t thread;
	pthread_create(&thread, NULL, thread_func, NULL);
	pthread_setname_np(thread, "target-thread");
	sleep(1);
#ifdef TGKILL
	tgkill(getpid(), child_tid, SIGTERM);
#else
	syscall(SYS_tkill, child_tid, SIGTERM);
#endif
	pthread_join(thread, NULL);
	return 0;
}
```