### PR TITLE
refactor: remove unused structured binding to fix compiler warning

### DIFF
--- a/src/ast/passes/resolve_imports.cpp
+++ b/src/ast/passes/resolve_imports.cpp
@@ -150,7 +150,7 @@ Result<OK> ResolveImports::importObject([[maybe_unused]] Node &node,
     return OK(); // Already added.
   }
 
-  auto [_, added] = imports.objects.emplace(name, ExternalObject(path));
+  auto added = imports.objects.emplace(name, ExternalObject(path)).second;
   assert(added);
   return OK();
 }
@@ -163,7 +163,7 @@ Result<OK> ResolveImports::importBitcode([[maybe_unused]] Node &node,
     return OK(); // Already added.
   }
 
-  auto [_, added] = imports.bitcode.emplace(name, Bitcode(contents));
+  auto added = imports.bitcode.emplace(name, Bitcode(contents)).second;
   assert(added);
   return OK();
 }


### PR DESCRIPTION
This change eliminates the following compiler warning during build: 
```bash
...
[ 87%] Building CXX object src/ast/CMakeFiles/ast.dir/passes/resolve_imports.cpp.o
/bpftrace/src/ast/passes/resolve_imports.cpp: In member function 'bpftrace::Result<> bpftrace::ast::ResolveImports::importObject(bpftrace::ast::Node&, const std::string&, const std::filesystem::__cxx11::path&)':
/bpftrace/src/ast/passes/resolve_imports.cpp:153:8: warning: structured binding declaration set but not used [-Wunused-but-set-variable]
  153 |   auto [_, added] = imports.objects.emplace(name, ExternalObject(path));
      |        ^~~~~~~~~~
/bpftrace/src/ast/passes/resolve_imports.cpp: In member function 'bpftrace::Result<> bpftrace::ast::ResolveImports::importBitcode(bpftrace::ast::Node&, const std::string&, const std::string&)':
/bpftrace/src/ast/passes/resolve_imports.cpp:166:8: warning: structured binding declaration set but not used [-Wunused-but-set-variable]
  166 |   auto [_, added] = imports.bitcode.emplace(name, Bitcode(contents));
      |        ^~~~~~~~~~
[ 87%] Building CXX object src/ast/CMakeFiles/ast.dir/passes/return_path_analyser.cpp.o
...
```
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
