### PR TITLE
attached_probe: tracepoint: Use libbpf attachment API

### DIFF
--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -386,8 +386,9 @@ WILL_FAIL
 
 NAME tracepoint_multiattach_missing
 PROG t:syscalls:sys_exit_nanosleep,t:syscalls:nonsense { print("hit"); exit(); }
-EXPECT hit
-AFTER ./testprogs/syscall nanosleep 1e8
+EXPECT stdin:1:31-50: WARNING: tracepoint not found: syscalls:nonsense
+EXPECT ERROR: Unable to attach probe: tracepoint:syscalls:nonsense. If this is expected, set the 'missing_probes' config variable to 'warn'.
+WILL_FAIL
 
 NAME tracepoint args
 PROG tracepoint:syscalls:sys_enter_read { printf("%d\n", args.count); exit(); }


### PR DESCRIPTION
Summary:
Use libbpf API instead of bcc. libbpf is not only the maintained path forward, but it allows us to access APIs only available to link based kernel API.

This closes #4146

Test Plan:

Reviewers:

Subscribers:

Tasks:

Tags:

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
