### PR TITLE
pass: add `LoopReturn` pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,8 @@ and this project adheres to
   - [#4126](https://github.com/bpftrace/bpftrace/pull/4126)
 - For loops now support `break` and `continue`
   - [#4250](https://github.com/bpftrace/bpftrace/pull/4250)
+- For loops now support `return`
+  - [#4255](https://github.com/bpftrace/bpftrace/pull/4255)
 - Add `pid` and `tid` functions for choosing between the initial or the current namespace
   - [#4254](https://github.com/bpftrace/bpftrace/pull/4254)
 - Add boolean values (`true` and `false`)

--- a/docs/language.md
+++ b/docs/language.md
@@ -581,6 +581,7 @@ Both `for` loops support the following control flow statements:
 | --- | --- |
 | continue | skip processing of the rest of the block and proceed to the next iteration |
 | break | terminate the loop |
+| return | return from the current probe |
 
 ### While
 

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -32,6 +32,7 @@ add_library(ast STATIC
   passes/fold_literals.cpp
   passes/import_scripts.cpp
   passes/link.cpp
+  passes/loop_return.cpp
   passes/map_sugar.cpp
   passes/macro_expansion.cpp
   passes/pid_filter_pass.cpp

--- a/src/ast/passes/loop_return.cpp
+++ b/src/ast/passes/loop_return.cpp
@@ -1,0 +1,232 @@
+#include "ast/passes/loop_return.h"
+#include "ast/ast.h"
+#include "ast/visitor.h"
+
+namespace bpftrace::ast {
+
+namespace {
+
+class LoopReturn : public Visitor<LoopReturn> {
+public:
+  LoopReturn(ASTContext &ast) : ast_(ast) {};
+
+  using Visitor<LoopReturn>::visit;
+
+  template <typename T>
+  void inject(T &node);
+
+  void visit(Subprog &subprog);
+  void visit(Probe &probe);
+  void visit(For &for_loop);
+  void visit(While &while_loop);
+  void visit(Statement &stmt);
+
+private:
+  Variable *get_return_var(const Node &node)
+  {
+    return ast_.make_node<Variable>(node.loc, "__return_value");
+  }
+  Variable *get_return_set_var(const Node &node)
+  {
+    return ast_.make_node<Variable>(node.loc, "__return_value_set");
+  }
+
+  ASTContext &ast_;
+  int loop_depth_ = 0;
+  std::optional<bool> loop_return_;
+};
+
+} // namespace
+
+void LoopReturn::visit(For &for_loop)
+{
+  loop_depth_++;
+  Visitor<LoopReturn>::visit(for_loop);
+  loop_depth_--;
+}
+
+void LoopReturn::visit(While &while_loop)
+{
+  loop_depth_++;
+  Visitor<LoopReturn>::visit(while_loop);
+  loop_depth_--;
+}
+
+void LoopReturn::visit(Statement &stmt)
+{
+  // Recursively visit the block statements.
+  Visitor<LoopReturn>::visit(stmt);
+
+  // First see if we have any loop statements, because we will inject an
+  // additional return into those statements if needed. This may be rewritten
+  // below, but only if this is within an inner loop.
+  //
+  // Consider that this takes:
+  //
+  // for (...) { }
+  //
+  // And turns it into:
+  //
+  // { for (...) { } if (__return_value_set) { return __return_value; } }
+  //
+  // The return may be subsequently rewritten below, if inside a loop.
+  bool is_loop = stmt.is<For>() || stmt.is<While>();
+  if (is_loop && loop_return_.has_value()) {
+    std::vector<Statement> ret_stmts;
+    if (loop_depth_ > 0) {
+      // We're still in a loop, so just break.
+      ret_stmts.emplace_back(
+          ast_.make_node<Jump>(stmt.node().loc, JumpType::BREAK));
+    } else if (loop_return_.value()) {
+      // The value was set within the loop, so return it.
+      ret_stmts.emplace_back(ast_.make_node<Jump>(stmt.node().loc,
+                                                  JumpType::RETURN,
+                                                  get_return_var(stmt.node())));
+    } else {
+      // The value was not set within the loop, so skip it.
+      ret_stmts.emplace_back(
+          ast_.make_node<Jump>(stmt.node().loc, JumpType::RETURN));
+    }
+    // Make an if contingent on the return value being set, and break
+    // from this local loop if that is the case.
+    auto *ret_block = ast_.make_node<BlockExpr>(stmt.node().loc,
+                                                std::move(ret_stmts),
+                                                ast_.make_node<None>(
+                                                    stmt.node().loc));
+    auto *ret_if = ast_.make_node<IfExpr>(stmt.node().loc,
+                                          get_return_set_var(stmt.node()),
+                                          ret_block,
+                                          ast_.make_node<None>(
+                                              stmt.node().loc));
+    auto *ret_stmt = ast_.make_node<ExprStatement>(stmt.node().loc, ret_if);
+    auto *block = ast_.make_node<BlockExpr>(
+        stmt.node().loc,
+        std::vector<Statement>({ stmt, ret_stmt }),
+        ast_.make_node<None>(stmt.node().loc));
+    auto *block_stmt = ast_.make_node<ExprStatement>(stmt.node().loc, block);
+    stmt = block_stmt; // Replace with the compound block.
+  } else if (auto *jmp = stmt.as<Jump>()) {
+    // This rewrites any return statements in a loop as something that will
+    // set the return value and then break the loop. Combined with the above,
+    // which checks this *outside* the loop and injects a return (possibly
+    // rewritten here if inside an inner loop), we have control flow logic
+    // that will be captured by the automatic context.
+    if (loop_depth_ > 0 && jmp->ident == JumpType::RETURN) {
+      if (!loop_return_.has_value()) {
+        loop_return_ = jmp->return_value.has_value();
+      } else if (loop_return_.value() != jmp->return_value.has_value()) {
+        // We cannot handle this case, but it's a more general error.
+        jmp->addError() << "Return value used in loop is inconsistent";
+        return;
+      }
+      std::vector<Statement> ret_stmts;
+      if (jmp->return_value.has_value()) {
+        ret_stmts.emplace_back(ast_.make_node<AssignVarStatement>(
+            jmp->loc, get_return_var(stmt.node()), jmp->return_value.value()));
+      }
+      // This (and the below declaration, *should* be a boolean. Unfortunately,
+      // the clang optimization passes are able to outsmart the by verifier by
+      // short-circuiting the return value. The compiler knows that this value
+      // contains either zero or one, and it is also the intended return value.
+      //
+      // if ($x == 1) { return 1; } else { return 0; }
+      //
+      //     gets transformed into:
+      //
+      // return $x;
+      //
+      // Unfortunately the verifier is *not* sure that this value is either
+      // zero or one, and bails out:
+      //
+      // 190: (73) *(u8 *)(r8 +0) = r7         ; frame2: R7_w=1 R8=fp[0]-49 cb
+      // 191: (bf) r0 = r7                     ; frame2: R0_w=1 R7_w=1 cb
+      // 192: (95) exit
+      // returning from callee:
+      //  frame2: R0_w=1 R1_w=3 R2=scalar() R6=fp[1]-48 R7_w=1 R8=fp[0]-49
+      //  R9=scalar(smin=smin32=0,smax=umax=smax32=umax32=1320,var_off=(0x0;
+      //  0x7f8)) R10=fp0 fp-8=???????m fp-16=mmmmmmmm fp-24=mmmmmmmm cb
+      // to caller at 124:
+      //  frame1:
+      //  R0=scalar(smin=smin32=0,smax=umax=smax32=umax32=165,var_off=(0x0;
+      //  0xff))
+      //  R1=scalar(smin=umin=smin32=umin32=1,smax=umax=smax32=umax32=127,var_off=(0x0;
+      //  0x7f)) R2=func() R3=fp-48 R4=0 R6=0 R7=fp[0]-49
+      //  R8=scalar(smin=smin32=0,smax=umax=smax32=umax32=1320,var_off=(0x0;
+      //  0x7f8)) R10=fp0 fp-32=scalar(id=8) fp-40=mmmmmmm1 fp-48=fp[0]-49 cb
+      // 124: (85) call bpf_loop#181           ; frame1: R0_w=scalar() R6=0
+      // R7=fp[0]-49
+      // R8=scalar(smin=smin32=0,smax=umax=smax32=umax32=1320,var_off=(0x0;
+      // 0x7f8)) R10=fp0 fp-32=scalar(id=8) fp-40=mmmmmmm1 fp-48=fp[0]-49 cb
+      // 125: (bf) r1 = r0                     ; frame1: R0_w=scalar(id=9)
+      // R1_w=scalar(id=9) cb 126: (67) r1 <<= 32                   ; frame1:
+      // R1_w=scalar(smax=0x7fffffff00000000,umax=0xffffffff00000000,smin32=0,smax32=umax32=0,var_off=(0x0;
+      // 0xffffffff00000000)) cb 127: (c7) r1 s>>= 32                  ; frame1:
+      // R1_w=scalar(smin=0xffffffff80000000,smax=0x7fffffff) cb 128: (6d) if r6
+      // s> r1 goto pc+2       ; frame1:
+      // R1_w=scalar(smin=smin32=0,smax=umax=umax32=0x7fffffff,var_off=(0x0;
+      // 0x7fffffff)) R6=0 cb 129: (71) r0 = *(u8 *)(r7 +0)         ; frame1:
+      // R0_w=scalar(smin=smin32=0,smax=umax=smax32=umax32=255,var_off=(0x0;
+      // 0xff)) R7=fp[0]-49 cb 130: (95) exit At callback return the register R0
+      // has smin=0 smax=255 should have been in [0, 1]
+      //
+      // We fix this by simply having a wider integer for this case, so we
+      // check if the value is set to anything, and a cast is forced.
+      ret_stmts.emplace_back(ast_.make_node<AssignVarStatement>(
+          jmp->loc,
+          get_return_set_var(stmt.node()),
+          ast_.make_node<Integer>(jmp->loc, 1)));
+      ret_stmts.emplace_back(ast_.make_node<Jump>(jmp->loc, JumpType::BREAK));
+      auto *block = ast_.make_node<BlockExpr>(jmp->loc,
+                                              std::move(ret_stmts),
+                                              ast_.make_node<None>(jmp->loc));
+      auto *block_stmt = ast_.make_node<ExprStatement>(jmp->loc, block);
+      stmt = block_stmt; // As above, replace with the compound block.
+    }
+  }
+}
+
+template <typename T>
+void LoopReturn::inject(T &node)
+{
+  loop_return_.reset();
+  Visitor<LoopReturn>::visit(node);
+
+  if (loop_return_.has_value()) {
+    // Declare the return variables at the top of the probe. These actually
+    // need to supercede all the other statements in the block.
+    if (loop_return_.value()) {
+      auto *ret_var_decl = ast_.make_node<VarDeclStatement>(
+          node.loc, get_return_var(node));
+      node.block->stmts.insert(node.block->stmts.begin(),
+                               Statement(ret_var_decl));
+    }
+    auto *ret_set_var_decl = ast_.make_node<AssignVarStatement>(
+        node.loc,
+        get_return_set_var(node),
+        ast_.make_node<Integer>(node.loc, 0));
+    node.block->stmts.insert(node.block->stmts.begin(),
+                             Statement(ret_set_var_decl));
+  }
+}
+
+void LoopReturn::visit(Subprog &subprog)
+{
+  inject(subprog);
+}
+
+void LoopReturn::visit(Probe &probe)
+{
+  inject(probe);
+}
+
+Pass CreateLoopReturnPass()
+{
+  auto fn = [](ASTContext &ast) {
+    LoopReturn lr(ast);
+    lr.visit(ast.root);
+  };
+
+  return Pass::create("LoopReturn", fn);
+}
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/loop_return.h
+++ b/src/ast/passes/loop_return.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "ast/pass_manager.h"
+
+namespace bpftrace::ast {
+
+Pass CreateLoopReturnPass();
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/parser.h
+++ b/src/ast/passes/parser.h
@@ -13,6 +13,7 @@
 #include "ast/passes/field_analyser.h"
 #include "ast/passes/fold_literals.h"
 #include "ast/passes/import_scripts.h"
+#include "ast/passes/loop_return.h"
 #include "ast/passes/macro_expansion.h"
 #include "ast/passes/map_sugar.h"
 #include "ast/passes/named_param.h"
@@ -46,6 +47,7 @@ inline std::vector<Pass> AllParsePasses(
   passes.emplace_back(CreateCheckAttachpointsPass());
   passes.emplace_back(CreateUSDTImportPass());
   passes.emplace_back(CreateImportInternalScriptsPass());
+  passes.emplace_back(CreateLoopReturnPass());
   passes.emplace_back(CreateControlFlowPass());
   passes.emplace_back(CreateMacroExpansionPass());
   passes.emplace_back(CreateParseBTFPass());

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -3087,7 +3087,7 @@ void SemanticAnalyser::visit(For &f)
   auto [iter, _] = for_vars_referenced_.try_emplace(&f);
   auto &collector = iter->second;
   for (const Variable &var : collector.nodes()) {
-    ctx_types.push_back(CreatePointer(var.var_type, AddrSpace::kernel));
+    ctx_types.push_back(CreatePointer(var.var_type, AddrSpace::none));
     ctx_idents.push_back(var.ident);
   }
   f.ctx_type = CreateRecord(Struct::CreateRecord(ctx_types, ctx_idents));

--- a/tests/control_flow_analyser.cpp
+++ b/tests/control_flow_analyser.cpp
@@ -67,9 +67,10 @@ TEST(control_flow_analyser, if_without_else)
 
 TEST(control_flow_analyser, while_loop)
 {
-  // This is allowed, as we can detect that this will always return. However,
-  // the verifier may reject it.
-  test("fn test($x: int64): int64 { while ($x) { return 0; } }", 0);
+  // This was previously allowed, but is no longer allowed. All loops
+  // are treated equally, and therefore we require all paths to return
+  // appropriately ahead of any folding, etc.
+  test("fn test($x: int64): int64 { while ($x) { return 0; } }", 1);
 }
 
 TEST(control_flow_analyser, if_branches)

--- a/tests/runtime/for
+++ b/tests/runtime/for
@@ -92,6 +92,11 @@ NAME map with continue
 PROG begin { @map["foo"] = 1; @map["bar"] = 2; print("start"); for ($i : @map) { if ($i.0 == "bar") { continue; } print($i.0); }  }
 EXPECT_REGEX .*start\nfoo\n\n
 
+NAME map with return
+PROG begin { @map["foo"] = 1; @map["bar"] = 2; for ($i : @map) { if ($i.0 == "bar") { print($i.0); return; } } print("end"); }
+EXPECT bar
+EXPECT_NONE end
+
 NAME range basic
 PROG begin { for ($i : 0..5) { print($i); }  }
 EXPECT_REGEX .*\n0\n1\n2\n3\n4\n\n
@@ -135,6 +140,13 @@ EXPECT_REGEX .*\n1\n5\n\n
 NAME range with continue
 PROG begin { for ($i : 1..4) { if ($i == 2) { continue; } print($i); }  }
 EXPECT_REGEX .*\n1\n3\n\n
+
+NAME range with nested return
+PROG begin { for ($i : 1..4) { for ($j : 1..$i) { print($j); if ($j == 2) { return; } } } print("end"); }
+EXPECT 1
+EXPECT 1
+EXPECT 2
+EXPECT_NONE end
 
 NAME external function call map
 PROG begin { @map[1] = 1; $x = 1; for ($kv : @map) { print(has_key(@map, $x)); }  }


### PR DESCRIPTION
Stacked PRs:
 * __->__#4255


--- --- ---

### pass: add `LoopReturn` pass


Since all the context building supports scratch variables, supporting
loop returns involved injecting logic directly into the program
structure to support chain-breaking out of loops. The variables use
non-`$` prefixes, and therefore cannot collide with user variables.

They will not be injected unless they are needed.

Note that this commit also tweaks the address space for the context,
ensuring that it is correctly marked as `none` (or BPF).

Signed-off-by: Adin Scannell <amscanne@meta.com>
