### PR TITLE
Add boolean value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to
   - [#3974](https://github.com/bpftrace/bpftrace/pull/3974)
 - Require kernel uprobe ref counting to be available for USDTs with semaphores
   - [#4199](https://github.com/bpftrace/bpftrace/pull/4199)
+- `strcontains` and `has_key` now return boolean values instead of 1 and 0
+  - [#4280](https://github.com/bpftrace/bpftrace/pull/4280)
 #### Added
 - Add ncpus builtin to get the number of CPUs.
   - [#4105](https://github.com/bpftrace/bpftrace/pull/4105)
@@ -57,6 +59,8 @@ and this project adheres to
   - [#4250](https://github.com/bpftrace/bpftrace/pull/4250)
 - Add `pid` and `tid` functions for choosing between the initial or the current namespace
   - [#4254](https://github.com/bpftrace/bpftrace/pull/4254)
+- Add boolean values (`true` and `false`)
+  - [#4280](https://github.com/bpftrace/bpftrace/pull/4280)
 #### Changed
 - `-p` CLI flag now applies to all probes (except BEGIN/END)
   - [#3800](https://github.com/bpftrace/bpftrace/pull/3800)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -347,6 +347,9 @@ the type upon declaration.
 |*Type*
 |*Description*
 
+|bool
+|`true` or `false`
+
 |uint8
 |Unsigned 8 bit integer
 
@@ -3813,17 +3816,17 @@ If there are many processes running, it will consume a lot of a memory.
 
 ==== cpp_demangle
 
-Default: 1
+Default: true
 
 C++ symbol demangling in userspace stack traces is enabled by default.
 
-This feature can be turned off by setting the value of this environment variable to `0`.
+This feature can be turned off by setting the value of this variable to `false`.
 
 ==== lazy_symbolication
 
-Default: 0
+Default: false
 
-For user space symbols, symbolicate lazily/on-demand (1) or symbolicate everything ahead of time (0).
+For user space symbols, symbolicate lazily/on-demand (`true`) or symbolicate everything ahead of time (`false`).
 
 ==== license
 
@@ -3907,7 +3910,7 @@ The tradeoff is that bpftrace will use more memory.
 
 ==== show_debug_info
 
-This is only available if the link:https://github.com/libbpf/blazesym[Blazesym] library is available at build time. If it is available this defaults to 1, meaning that when printing ustack and kstack symbols bpftrace will also show (if debug info is available) symbol file and line ('bpftrace' stack mode) and a label if the function was inlined ('bpftrace' and 'perf' stack modes).
+This is only available if the link:https://github.com/libbpf/blazesym[Blazesym] library is available at build time. If it is available this defaults to `true`, meaning that when printing ustack and kstack symbols bpftrace will also show (if debug info is available) symbol file and line ('bpftrace' stack mode) and a label if the function was inlined ('bpftrace' and 'perf' stack modes).
 There might be a performance difference when symbolicating, which is the only reason to disable this.
 
 ==== stack_mode
@@ -3932,9 +3935,9 @@ Set to empty string to disable truncation trailers.
 
 ==== print_maps_on_exit
 
-Default: 1
+Default: true
 
-Controls whether maps are printed on exit. Set to `0` in order to change the default behavior and not automatically print maps at program exit.
+Controls whether maps are printed on exit. Set to `false` in order to change the default behavior and not automatically print maps at program exit.
 
 ==== unstable_macro
 

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -116,6 +116,40 @@ std::string opstr(const Unop &unop)
   return {}; // unreached
 }
 
+bool is_comparison_op(Operator op)
+{
+  switch (op) {
+    case Operator::EQ:
+    case Operator::NE:
+    case Operator::LE:
+    case Operator::GE:
+    case Operator::LT:
+    case Operator::GT:
+    case Operator::LAND:
+    case Operator::LOR:
+      return true;
+    case Operator::PLUS:
+    case Operator::MINUS:
+    case Operator::MUL:
+    case Operator::DIV:
+    case Operator::MOD:
+    case Operator::BAND:
+    case Operator::BOR:
+    case Operator::BXOR:
+    case Operator::LEFT:
+    case Operator::RIGHT:
+    case Operator::INVALID:
+    case Operator::ASSIGN:
+    case Operator::INCREMENT:
+    case Operator::DECREMENT:
+    case Operator::LNOT:
+    case Operator::BNOT:
+      return false;
+  }
+
+  return false; // unreached
+}
+
 AttachPoint &AttachPoint::create_expansion_copy(ASTContext &ctx,
                                                 const std::string &match) const
 {

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -134,6 +134,7 @@ public:
 
 class Integer;
 class NegativeInteger;
+class Boolean;
 class PositionalParameter;
 class PositionalParameterCount;
 class String;
@@ -157,6 +158,7 @@ class BlockExpr;
 
 class Expression : public VariantNode<Integer,
                                       NegativeInteger,
+                                      Boolean,
                                       PositionalParameter,
                                       PositionalParameterCount,
                                       String,
@@ -269,6 +271,22 @@ public:
   }
 
   const int64_t value;
+};
+
+class Boolean : public Node {
+public:
+  explicit Boolean(ASTContext &ctx, bool val, Location &&loc)
+      : Node(ctx, std::move(loc)), value(val) {};
+  explicit Boolean(ASTContext &ctx, const Boolean &other, const Location &loc)
+      : Node(ctx, loc + other.loc), value(other.value) {};
+
+  const SizedType &type() const
+  {
+    static SizedType boolean = CreateBool();
+    return boolean;
+  }
+
+  const bool value;
 };
 
 class PositionalParameter : public Node {
@@ -852,12 +870,17 @@ public:
         var(std::move(var)),
         value(std::move(value)) {};
   explicit AssignConfigVarStatement(ASTContext &ctx,
+                                    std::string var,
+                                    bool value,
+                                    Location &&loc)
+      : Node(ctx, std::move(loc)), var(std::move(var)), value(value) {};
+  explicit AssignConfigVarStatement(ASTContext &ctx,
                                     const AssignConfigVarStatement &other,
                                     const Location &loc)
       : Node(ctx, loc + other.loc), var(other.var), value(other.value) {};
 
   std::string var;
-  std::variant<uint64_t, std::string> value;
+  std::variant<uint64_t, std::string, bool> value;
 };
 using ConfigStatementList = std::vector<AssignConfigVarStatement *>;
 
@@ -1332,6 +1355,7 @@ public:
 std::string opstr(const Binop &binop);
 std::string opstr(const Unop &unop);
 std::string opstr(const Jump &jump);
+bool is_comparison_op(Operator op);
 
 SizedType ident_to_record(const std::string &ident, int pointer_level = 0);
 SizedType ident_to_sized_type(const std::string &ident);

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -35,6 +35,12 @@ void Printer::visit(NegativeInteger &integer)
   out_ << indent << "signed int: " << integer.value << std::endl;
 }
 
+void Printer::visit(Boolean &boolean)
+{
+  std::string indent(depth_, ' ');
+  out_ << indent << "bool: " << (boolean.value ? "true" : "false") << std::endl;
+}
+
 void Printer::visit(PositionalParameter &param)
 {
   std::string indent(depth_, ' ');
@@ -330,6 +336,8 @@ void Printer::visit(AssignConfigVarStatement &assignment)
       [&](auto &v) {
         if constexpr (std::is_same_v<std::decay_t<decltype(v)>, std::string>) {
           out_ << indentVar << "string: " << v << std::endl;
+        } else if constexpr (std::is_same_v<std::decay_t<decltype(v)>, bool>) {
+          out_ << indentVar << "bool: " << (v ? "true" : "false") << std::endl;
         } else {
           out_ << indentVar << "int: " << v << std::endl;
         }

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -15,6 +15,7 @@ public:
   using Visitor<Printer>::visit;
   void visit(Integer &integer);
   void visit(NegativeInteger &integer);
+  void visit(Boolean &boolean);
   void visit(PositionalParameter &param);
   void visit(PositionalParameterCount &param);
   void visit(String &string);

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -29,6 +29,10 @@ public:
   {
     return default_value();
   }
+  R visit([[maybe_unused]] Boolean &boolean)
+  {
+    return default_value();
+  }
   R visit([[maybe_unused]] PositionalParameter &param)
   {
     return default_value();

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -33,6 +33,7 @@ int_size (([uU])|([uU]?[lL]?[lL]))
 
 /* Number with underscores in it, e.g. 1_000_000 */
 int      [0-9]([0-9_]*[0-9])?{int_size}?
+bool     true|false
 hex      0[xX][0-9a-fA-F]+
 /* scientific notation, e.g. 2e4 or 1e6 */
 exponent {int}[eE]{int}
@@ -101,6 +102,12 @@ oct_esc  [0-7]{1,3}
                           } else {
                             return Parser::make_UNSIGNED_INT(*res, driver.loc);
                           }
+                        }
+{bool}                  {
+                          if (std::string(yytext) == "true") {
+                            return Parser::make_BOOL(true, driver.loc);
+                          }
+                          return Parser::make_BOOL(false, driver.loc);
                         }
 {path}                  { return Parser::make_PATH(yytext, driver.loc); }
 {map}                   { return Parser::make_MAP(yytext, driver.loc); }

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -53,6 +53,7 @@ bool is_quoted_type(const SizedType &ty)
     case Type::timestamp_mode:
     case Type::tuple:
     case Type::voidtype:
+    case Type::boolean:
       return false;
   }
   return false;
@@ -372,6 +373,9 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
           return {};
       }
     }
+    case Type::boolean: {
+      return util::read_data<uint8_t>(value.data()) ? "true" : "false";
+    }
     case Type::sum_t: {
       if (type.IsSigned())
         return std::to_string(util::reduce_value<int64_t>(value, nvalues) /
@@ -439,6 +443,7 @@ std::string Output::map_key_str(BPFtrace &bpftrace,
   std::ostringstream ptr;
   switch (arg.GetTy()) {
     case Type::integer:
+    case Type::boolean:
     case Type::kstack_t:
     case Type::ustack_t:
     case Type::timestamp:

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -133,6 +133,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %token <std::string> OFFSETOF "offsetof"
 %token <std::string> LET "let"
 %token <std::string> IMPORT "import"
+%token <bool> BOOL "bool"
 
 %type <ast::Operator> unary_op compound_op
 %type <std::string> attach_point_def c_definitions ident keyword external_name
@@ -333,6 +334,7 @@ config_assign_stmt:
                 IDENT ASSIGN UNSIGNED_INT { $$ = driver.ctx.make_node<ast::AssignConfigVarStatement>($1, $3, @$); }
         |       IDENT ASSIGN IDENT        { $$ = driver.ctx.make_node<ast::AssignConfigVarStatement>($1, $3, @$); }
         |       IDENT ASSIGN STRING       { $$ = driver.ctx.make_node<ast::AssignConfigVarStatement>($1, $3, @$); }
+        |       IDENT ASSIGN BOOL         { $$ = driver.ctx.make_node<ast::AssignConfigVarStatement>($1, $3, @$); }
                 ;
 
 subprog:
@@ -547,6 +549,7 @@ var_decl_stmt:
 
 primary_expr:
                 UNSIGNED_INT       { $$ = driver.ctx.make_node<ast::Integer>($1, @$); }
+        |       BOOL               { $$ = driver.ctx.make_node<ast::Boolean>($1, @$); }
         |       STRING             { $$ = driver.ctx.make_node<ast::String>($1, @$); }
         |       BUILTIN            { $$ = driver.ctx.make_node<ast::Builtin>($1, @$); }
         |       LPAREN expr RPAREN { $$ = $2; }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -88,6 +88,7 @@ std::string typestr(const SizedType &type, bool debug)
     case Type::lhist_t:
     case Type::none:
     case Type::voidtype:
+    case Type::boolean:
       return typestr(type.GetTy());
   }
 
@@ -229,6 +230,7 @@ std::string typestr(Type t)
     case Type::cgroup_path_t: return "cgroup_path_t"; break;
     case Type::strerror_t: return "strerror_t"; break;
     case Type::timestamp_mode: return "timestamp_mode"; break;
+    case Type::boolean:     return "bool";     break;
       // clang-format on
   }
 
@@ -245,7 +247,7 @@ SizedType CreateInteger(size_t bits, bool is_signed)
 
 SizedType CreateBool()
 {
-  return CreateInteger(1, false);
+  return { Type::boolean, 1 };
 }
 
 SizedType CreateInt(size_t bits)

--- a/src/types.h
+++ b/src/types.h
@@ -24,6 +24,7 @@ enum class Type : uint8_t {
   none,
   voidtype,
   integer, // int is a protected keyword
+  boolean,
   pointer,
   record, // struct/union, as struct is a protected keyword
   hist_t,
@@ -350,10 +351,6 @@ public:
     return element_type_.get();
   }
 
-  bool IsBoolTy() const
-  {
-    return type_ == Type::integer && size_bits_ == 1;
-  };
   bool IsPtrTy() const
   {
     return type_ == Type::pointer;
@@ -362,6 +359,10 @@ public:
   {
     return type_ == Type::integer;
   };
+  bool IsBoolTy() const
+  {
+    return type_ == Type::boolean;
+  }
   bool IsEnumTy() const
   {
     return IsIntTy() && !name_.empty();

--- a/tests/codegen/llvm/block_expression_cond.ll
+++ b/tests/codegen/llvm/block_expression_cond.ll
@@ -17,12 +17,12 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !29 {
 entry:
   %exit = alloca %exit_t, align 8
-  %"$a" = alloca i64, align 8
+  %"$a" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$a")
-  store i64 0, ptr %"$a", align 8
-  store i64 1, ptr %"$a", align 8
-  %1 = load i64, ptr %"$a", align 8
-  %true_cond = icmp ne i64 %1, 0
+  store i8 0, ptr %"$a", align 1
+  store i8 1, ptr %"$a", align 1
+  %1 = load i8, ptr %"$a", align 1
+  %true_cond = icmp ne i8 %1, 0
   br i1 %true_cond, label %if_body, label %if_end
 
 if_body:                                          ; preds = %entry

--- a/tests/codegen/llvm/logical_not.ll
+++ b/tests/codegen/llvm/logical_not.ll
@@ -9,31 +9,31 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
-@AT_y = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
-@ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !24
-@__bt__event_loss_counter = dso_local externally_initialized global i64 0, section ".data.event_loss_counter", !dbg !38
+@AT_y = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !23
+@ringbuf = dso_local global %"struct map_t.1" zeroinitializer, section ".maps", !dbg !25
+@__bt__event_loss_counter = dso_local externally_initialized global i64 0, section ".data.event_loss_counter", !dbg !39
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @BEGIN_1(ptr %0) #0 section "s_BEGIN_1" !dbg !44 {
+define i64 @BEGIN_1(ptr %0) #0 section "s_BEGIN_1" !dbg !45 {
 entry:
-  %"@y_val" = alloca i64, align 8
+  %"@y_val" = alloca i8, align 1
   %"@y_key" = alloca i64, align 8
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 0, ptr %"@x_val", align 8
+  store i8 0, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
-  store i64 1, ptr %"@y_val", align 8
+  store i8 1, ptr %"@y_val", align 1
   %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
@@ -49,8 +49,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!40}
-!llvm.module.flags = !{!42, !43}
+!llvm.dbg.cu = !{!41}
+!llvm.module.flags = !{!43, !44}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -73,32 +73,32 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
-!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
-!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
-!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
-!27 = !{!28, !33}
-!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
-!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
-!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
-!31 = !{!32}
-!32 = !DISubrange(count: 27, lowerBound: 0)
-!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
-!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
-!36 = !{!37}
-!37 = !DISubrange(count: 262144, lowerBound: 0)
-!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
-!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!40 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !41)
-!41 = !{!0, !7, !22, !24, !38}
-!42 = !{i32 2, !"Debug Info Version", i32 3}
-!43 = !{i32 7, !"uwtable", i32 0}
-!44 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !45, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !40, retainedNodes: !48)
-!45 = !DISubroutineType(types: !46)
-!46 = !{!20, !47}
-!47 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
+!28 = !{!29, !34}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !30, size: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 27, lowerBound: 0)
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !35, size: 64, offset: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 262144, lowerBound: 0)
+!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
+!40 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!41 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !42)
+!42 = !{!0, !7, !23, !25, !39}
+!43 = !{i32 2, !"Debug Info Version", i32 3}
+!44 = !{i32 7, !"uwtable", i32 0}
+!45 = distinct !DISubprogram(name: "BEGIN_1", linkageName: "BEGIN_1", scope: !2, file: !2, type: !46, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !41, retainedNodes: !48)
+!46 = !DISubroutineType(types: !47)
+!47 = !{!20, !22}
 !48 = !{!49}
-!49 = !DILocalVariable(name: "ctx", arg: 1, scope: !44, file: !2, type: !47)
+!49 = !DILocalVariable(name: "ctx", arg: 1, scope: !45, file: !2, type: !22)

--- a/tests/fold_literals.cpp
+++ b/tests/fold_literals.cpp
@@ -62,87 +62,97 @@ void test_warning(const std::string& input, const std::string& warn)
 
 TEST(fold_literals, equals)
 {
-  test("0 == 0", "int: 1");
-  test("0 == 1", "int: 0");
-  test("-1 == 1", "int: 0");
-  test("-1 == -1", "int: 1");
-  test(R"("foo" == "bar")", "int: 0");
-  test(R"("foo" == "foo")", "int: 1");
-  test("\"foo\" == 1", "=="); // Left as is
-  test("str($1) == \"\"", "int: 1");
-  test("str($1) == \"foo\"", "int: 0");
-  test("$1 == 0", "int: 1");
-  test("$1 == 1", "int: 0");
+  test("0 == 0", "bool: true");
+  test("0 == 1", "bool: false");
+  test("-1 == 1", "bool: false");
+  test("-1 == -1", "bool: true");
+  test("true == true", "bool: true");
+  test("false == false", "bool: true");
+  test(R"("foo" == "bar")", "bool: false");
+  test(R"("foo" == "foo")", "bool: true");
+  test("\"foo\" == 1", "==");    // Left as is
+  test("\"foo\" == true", "=="); // Left as is
+  test("str($1) == \"\"", "bool: true");
+  test("str($1) == \"foo\"", "bool: false");
+  test("$1 == 0", "bool: true");
+  test("$1 == 1", "bool: false");
 }
 
 TEST(fold_literals, not_equals)
 {
-  test("0 != 0", "int: 0");
-  test("0 != 1", "int: 1");
-  test("-1 != 1", "int: 1");
-  test("-1 != -1", "int: 0");
-  test(R"("foo" != "bar")", "int: 1");
-  test(R"("foo" != "foo")", "int: 0");
-  test(R"("foo" != 1)", "!="); // Left as is
-  test(R"(str($1) != "")", "int: 0");
-  test(R"(str($1) != "foo")", "int: 1");
-  test("$1 != 0", "int: 0");
-  test("$1 != 1", "int: 1");
+  test("0 != 0", "bool: false");
+  test("0 != 1", "bool: true");
+  test("-1 != 1", "bool: true");
+  test("-1 != -1", "bool: false");
+  test("false != true", "bool: true");
+  test("false != false", "bool: false");
+  test(R"("foo" != "bar")", "bool: true");
+  test(R"("foo" != "foo")", "bool: false");
+  test(R"("foo" != 1)", "!=");     // Left as is
+  test(R"("foo" != false)", "!="); // Left as is
+  test(R"(str($1) != "")", "bool: false");
+  test(R"(str($1) != "foo")", "bool: true");
+  test("$1 != 0", "bool: false");
+  test("$1 != 1", "bool: true");
 }
 
 TEST(fold_literals, comparison)
 {
-  test("0 < 1", "int: 1");
-  test("1 < 0", "int: 0");
-  test("0 < 0", "int: 0");
-  test("-1 < 0", "int: 1");
-  test("-1 < -2", "int: 0");
-  test("0x7fffffffffffffff < 0x8000000000000000", "int: 1");
-  test("0xffffffffffffffff < 0", "int: 0");
-  test(R"("a" < "b")", "int: 1");
-  test(R"("b" < "a")", "int: 0");
-  test(R"("a" < "a")", "int: 0");
-  test(R"("" < "a")", "int: 1");
-  test(R"("abc" < "abd")", "int: 1");
+  test("0 < 1", "bool: true");
+  test("1 < 0", "bool: false");
+  test("0 < 0", "bool: false");
+  test("-1 < 0", "bool: true");
+  test("-1 < -2", "bool: false");
+  test("true < false", "bool: false");
+  test("0x7fffffffffffffff < 0x8000000000000000", "bool: true");
+  test("0xffffffffffffffff < 0", "bool: false");
+  test(R"("a" < "b")", "bool: true");
+  test(R"("b" < "a")", "bool: false");
+  test(R"("a" < "a")", "bool: false");
+  test(R"("" < "a")", "bool: true");
+  test(R"("abc" < "abd")", "bool: true");
 
-  test("0 > 1", "int: 0");
-  test("1 > 0", "int: 1");
-  test("0 > 0", "int: 0");
-  test("-1 > 0", "int: 0");
-  test("-1 > -2", "int: 1");
-  test("0x7fffffffffffffff > 0x8000000000000000", "int: 0");
-  test("0xffffffffffffffff > 0", "int: 1");
-  test(R"("a" > "b")", "int: 0");
-  test(R"("b" > "a")", "int: 1");
-  test(R"("a" > "a")", "int: 0");
-  test(R"("" > "a")", "int: 0");
-  test(R"("abc" > "abd")", "int: 0");
+  test("0 > 1", "bool: false");
+  test("1 > 0", "bool: true");
+  test("0 > 0", "bool: false");
+  test("-1 > 0", "bool: false");
+  test("-1 > -2", "bool: true");
+  test("true > false", "bool: true");
+  test("0x7fffffffffffffff > 0x8000000000000000", "bool: false");
+  test("0xffffffffffffffff > 0", "bool: true");
+  test(R"("a" > "b")", "bool: false");
+  test(R"("b" > "a")", "bool: true");
+  test(R"("a" > "a")", "bool: false");
+  test(R"("" > "a")", "bool: false");
+  test(R"("abc" > "abd")", "bool: false");
 
-  test("0 <= 1", "int: 1");
-  test("1 <= 0", "int: 0");
-  test("0 <= 0", "int: 1");
-  test("-1 <= 0", "int: 1");
-  test("-1 <= -1", "int: 1");
-  test("0x7fffffffffffffff <= 0x8000000000000000", "int: 1");
-  test("0xffffffffffffffff <= 0", "int: 0");
-  test(R"("a" <= "b")", "int: 1");
-  test(R"("b" <= "a")", "int: 0");
-  test(R"("a" <= "a")", "int: 1");
-  test(R"("" <= "a")", "int: 1");
-  test(R"("abc" <= "abd")", "int: 1");
+  test("0 <= 1", "bool: true");
+  test("1 <= 0", "bool: false");
+  test("0 <= 0", "bool: true");
+  test("-1 <= 0", "bool: true");
+  test("-1 <= -1", "bool: true");
+  test("false <= true", "bool: true");
+  test("0x7fffffffffffffff <= 0x8000000000000000", "bool: true");
+  test("0xffffffffffffffff <= 0", "bool: false");
+  test(R"("a" <= "b")", "bool: true");
+  test(R"("b" <= "a")", "bool: false");
+  test(R"("a" <= "a")", "bool: true");
+  test(R"("" <= "a")", "bool: true");
+  test(R"("abc" <= "abd")", "bool: true");
 
-  test("0 >= 1", "int: 0");
-  test("1 >= 0", "int: 1");
-  test("0 >= 0", "int: 1");
-  test("-1 >= 0", "int: 0");
-  test("-1 >= -1", "int: 1");
-  test("0x7fffffffffffffff >= 0x8000000000000000", "int: 0");
-  test("0xffffffffffffffff >= 0", "int: 1");
-  test(R"("a" >= "b")", "int: 0");
-  test(R"("b" >= "a")", "int: 1");
-  test(R"("a" >= "a")", "int: 1");
-  test(R"("" >= "a")", "int: 0");
-  test(R"("abc" >= "abd")", "int: 0");
+  test("0 >= 1", "bool: false");
+  test("1 >= 0", "bool: true");
+  test("0 >= 0", "bool: true");
+  test("-1 >= 0", "bool: false");
+  test("-1 >= -1", "bool: true");
+  test("true <= false", "bool: false");
+  test("0x7fffffffffffffff >= 0x8000000000000000", "bool: false");
+  test("0xffffffffffffffff >= 0", "bool: true");
+  test(R"("a" >= "b")", "bool: false");
+  test(R"("b" >= "a")", "bool: true");
+  test(R"("a" >= "a")", "bool: true");
+  test(R"("" >= "a")", "bool: false");
+  test(R"("abc" >= "abd")", "bool: false");
 }
 
 TEST(fold_literals, plus)
@@ -352,18 +362,42 @@ TEST(fold_literals, binary)
 
 TEST(fold_literals, logical)
 {
-  test("1 && 1", "int: 1");
-  test("0 && 1", "int: 0");
-  test("0 && 0", "int: 0");
-  test("-1 && 0", "int: 0");
-  test("1 && -1", "int: 1");
+  test("1 && 1", "bool: true");
+  test("0 && 1", "bool: false");
+  test("0 && 0", "bool: false");
+  test("-1 && 0", "bool: false");
+  test("1 && -1", "bool: true");
+  test("true && true", "bool: true");
+  test("true && false", "bool: false");
+  test("false && false", "bool: false");
+  test("\"foo\" && true", "bool: true");
+  test("\"\" && true", "bool: false");
+  test("\"\" && false", "bool: false");
+  test("1 && true", "bool: true");
+  test("0 && true", "bool: false");
+  test("1 && false", "bool: false");
+  test("0 && false", "bool: false");
+  test("-1 && true", "bool: true");
+  test("-1 && false", "bool: false");
   test("\"foo\" && 1", "&&"); // Left as is
 
-  test("1 || 1", "int: 1");
-  test("0 || 1", "int: 1");
-  test("0 || 0", "int: 0");
-  test("-1 || 0", "int: 1");
-  test("1 || -1", "int: 1");
+  test("1 || 1", "bool: true");
+  test("0 || 1", "bool: true");
+  test("0 || 0", "bool: false");
+  test("-1 || 0", "bool: true");
+  test("1 || -1", "bool: true");
+  test("true || true", "bool: true");
+  test("true || false", "bool: true");
+  test("false || false", "bool: false");
+  test("\"foo\" || true", "bool: true");
+  test("\"\" || true", "bool: true");
+  test("\"\" || false", "bool: false");
+  test("1 || true", "bool: true");
+  test("0 || true", "bool: true");
+  test("1 || false", "bool: true");
+  test("0 || false", "bool: false");
+  test("-1 || true", "bool: true");
+  test("-1 || false", "bool: true");
   test("\"foo\" || 1", "||"); // Left as is
 }
 
@@ -373,9 +407,11 @@ TEST(fold_literals, unary)
   test("~0xfffffffffffffffe", "int: 1");
   test("~0", "int: 18446744073709551615");
 
-  test("!0", "int: 1");
-  test("!1", "int: 0");
-  test("!-1", "int: 0");
+  test("!0", "bool: true");
+  test("!1", "bool: false");
+  test("!-1", "bool: false");
+  test("!false", "bool: true");
+  test("!true", "bool: false");
 
   test("-1", "signed int: -1");
   test("-0", "int: 0");

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -735,6 +735,22 @@ TEST(Parser, integer_sizes)
        "   int: 4919131752149309048\n");
 }
 
+TEST(Parser, booleans)
+{
+  test("kprobe:do_nanosleep { $x = true; }",
+       "Program\n"
+       " kprobe:do_nanosleep\n"
+       "  =\n"
+       "   variable: $x\n"
+       "   bool: true\n");
+  test("kprobe:do_nanosleep { $x = false; }",
+       "Program\n"
+       " kprobe:do_nanosleep\n"
+       "  =\n"
+       "   variable: $x\n"
+       "   bool: false\n");
+}
+
 TEST(Parser, map_key)
 {
   test("kprobe:sys_open { @x[0] = 1; @x[0,1,2] = 1; }",
@@ -2655,6 +2671,24 @@ Program
   =
    var: blah
    int: 5
+ BEGIN
+)");
+
+  test("config = { blah = false; } BEGIN {}", R"(
+Program
+ config
+  =
+   var: blah
+   bool: false
+ BEGIN
+)");
+
+  test("config = { blah = tomato; } BEGIN {}", R"(
+Program
+ config
+  =
+   var: blah
+   string: tomato
  BEGIN
 )");
 

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -358,14 +358,6 @@ NAME has_key map value as key
 PROG BEGIN { @g = 2; @a[2] = 0; if (has_key(@a, @g)) { printf("ok\n"); } exit(); }
 EXPECT ok
 
-NAME has_key map keys and values
-PROG BEGIN { @a[1] = 1; @b[has_key(@a, 1)] = has_key(@a, 2); exit(); }
-EXPECT @b[1]: 0
-
-NAME has_key as a variable
-PROG BEGIN { @a[1] = 1; $b = has_key(@a, 1); $c = has_key(@a, 2); print(($b, $c)); exit(); }
-EXPECT (1, 0)
-
 NAME exit code
 PROG BEGIN { exit(69); }
 RETURN_CODE 69

--- a/tests/runtime/bool
+++ b/tests/runtime/bool
@@ -1,0 +1,60 @@
+NAME bool values
+PROG BEGIN { print((true, false)); exit(); }
+EXPECT (true, false)
+TIMEOUT 1
+
+NAME bool in conditional
+PROG BEGIN { if (true) { print(1); } if (false) { print(2); } exit(); }
+EXPECT 1
+EXPECT_NONE 2
+TIMEOUT 1
+
+NAME bool as map keys and values
+PROG BEGIN { @a[true] = false; exit(); }
+EXPECT @a[true]: false
+TIMEOUT 1
+
+NAME bool as a variable
+PROG BEGIN { $b = true; $c = false; print(($b, $c)); exit(); }
+EXPECT (true, false)
+
+NAME cast int to bool
+PROG BEGIN{ print(((bool)1, (bool)0)); exit(); }
+EXPECT (true, false)
+TIMEOUT 1
+
+NAME cast string to bool
+PROG BEGIN{ print(((bool)"hello", (bool)"")); exit(); }
+EXPECT (true, false)
+TIMEOUT 1
+
+NAME cast ptr to bool
+PROG BEGIN { $a = (int64*)0; $b = (int64*)1; print(((bool)$b, (bool)$a)); exit(); }
+EXPECT (true, false)
+TIMEOUT 1
+
+NAME cast castable map to bool
+PROG BEGIN{ @a = count(); @b = sum(0); print(((bool)@a, (bool)@b)); exit(); }
+EXPECT (true, false)
+TIMEOUT 1
+
+NAME cast bool to int
+PROG BEGIN{ print(((int64)true, (int64)false)); exit(); }
+EXPECT (1, 0)
+TIMEOUT 1
+
+NAME bool array
+PROG BEGIN { @a = (bool[2])(uint16)1; exit(); }
+EXPECT @a: [true,false]
+TIMEOUT 1
+
+NAME bool logical not
+PROG BEGIN{ print((!0, !10)); exit(); }
+EXPECT (true, false)
+TIMEOUT 1
+
+NAME bool in resized tuples
+PROG BEGIN { @a[false, 1, true] = 1; @a[true, (int32)2, false] = 2; exit(); }
+EXPECT @a[false, 1, true]: 1
+EXPECT @a[true, 2, false]: 2
+TIMEOUT 1

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -161,7 +161,7 @@ EXPECT ERROR: failed to open file '/does/not/exist/file': No such file or direct
 
 NAME sizeof
 PROG struct Foo { int x; char c; } BEGIN { $x = 1; printf("%d %d %d %d %d\n", sizeof(struct Foo), sizeof((*(struct Foo*)0).x), sizeof((*(struct Foo*)0).c), sizeof(1 == 1), sizeof($x)); exit(); }
-EXPECT 8 4 1 8 8
+EXPECT 8 4 1 1 8
 
 NAME sizeof_ints
 PROG BEGIN { printf("%d %d %d %d %d %d\n", sizeof(uint8), sizeof(int8), sizeof(uint16), sizeof(int16), sizeof(uint32), sizeof(int32)); exit(); }

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -185,3 +185,8 @@ NAME none type
 RUN {{BPFTRACE}} -q -f json -e 'union N { int i; float f; }; struct Foo { int m; union N n; }; uprobe:./testprogs/struct_with_union:func { print(*((struct Foo *) arg0)); exit(); }'
 EXPECT {"type": "value", "data": { "m": 2, "n": { "i": 5, "f": "" } }}
 AFTER ./testprogs/struct_with_union
+
+NAME print bool type
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { print((true, false)); exit(); }'
+EXPECT {"type": "value", "data": [true,false]}
+TIMEOUT 1

--- a/tests/runtime/strcontains
+++ b/tests/runtime/strcontains
@@ -12,7 +12,7 @@ TIMEOUT 1
 NAME no literals
 PROG tracepoint:syscalls:sys_enter_execve / str(args.argv[0]) == "./testprogs/true" / { print(strcontains(str(args.argv[1]), str(args.argv[2]))); exit(); }
 AFTER ./testprogs/true zztest test
-EXPECT 1
+EXPECT true
 TIMEOUT 1
 # Clamping is done to not blow verifier complexity limits
 ENV BPFTRACE_MAX_STRLEN=64
@@ -20,89 +20,89 @@ ENV BPFTRACE_MAX_STRLEN=64
 NAME string truncation does not affect matching
 PROG tracepoint:syscalls:sys_enter_execve / str(args.argv[0]) == "./testprogs/true" / { print(strcontains(str(args.argv[1], 6), str(args.argv[2], 4))); exit(); }
 AFTER ./testprogs/true zztest test
-EXPECT 1
+EXPECT true
 
 NAME basic substring match
 PROG BEGIN { print(strcontains("hello-test-world", "test")); exit(); }
-EXPECT 1
+EXPECT true
 TIMEOUT 1
 
 NAME substring at end
 PROG BEGIN { print(strcontains("hello-test-world", "world")); exit(); }
-EXPECT 1
+EXPECT true
 TIMEOUT 1
 
 NAME substring at beginning
 PROG BEGIN { print(strcontains("hello-test-world", "hello")); exit(); }
-EXPECT 1
+EXPECT true
 TIMEOUT 1
 
 NAME no match
 PROG BEGIN { print(strcontains("hello-test-world", "not-there")); exit(); }
-EXPECT 0
+EXPECT false
 TIMEOUT 1
 
 NAME empty haystack, empty needle
 PROG BEGIN { print(strcontains("", "")); exit(); }
-EXPECT 1
+EXPECT true
 TIMEOUT 1
 
 NAME non-empty haystack, empty needle
 PROG BEGIN { print(strcontains("hello", "")); exit(); }
-EXPECT 1
+EXPECT true
 TIMEOUT 1
 
 NAME empty haystack, non-empty needle
 PROG BEGIN { print(strcontains("", "test")); exit(); }
-EXPECT 0
+EXPECT false
 TIMEOUT 1
 
 NAME exact match
 PROG BEGIN { print(strcontains("hello", "hello")); exit(); }
-EXPECT 1
+EXPECT true
 TIMEOUT 1
 
 NAME needle longer than haystack
 PROG BEGIN { print(strcontains("hello", "hello-longer")); exit(); }
-EXPECT 0
+EXPECT false
 TIMEOUT 1
 
 NAME case sensitivity check
 PROG BEGIN { print(strcontains("Hello World", "hello")); exit(); }
-EXPECT 0
+EXPECT false
 TIMEOUT 1
 
 NAME multiple occurrences
 PROG BEGIN { print(strcontains("test-test-test", "test")); exit(); }
-EXPECT 1
+EXPECT true
 TIMEOUT 1
 
 NAME overlapping potential matches
 PROG BEGIN { print(strcontains("ababac", "abac")); exit(); }
-EXPECT 1
+EXPECT true
 TIMEOUT 1
 
 NAME special characters
 PROG BEGIN { print(strcontains("hello\tworld", "\two")); exit(); }
-EXPECT 1
+EXPECT true
 TIMEOUT 1
 
 NAME null terminator inside haystack
 PROG BEGIN { $str = "hello\0world"; print(strcontains($str, "world")); exit(); }
-EXPECT 0
+EXPECT false
 TIMEOUT 1
 
 NAME content after null terminator
 PROG BEGIN { $str = "hello\0test"; print(strcontains($str, "test")); exit(); }
-EXPECT 0
+EXPECT false
 TIMEOUT 1
 
 NAME null character in needle
 PROG BEGIN { $needle = "wo\0rld"; print(strcontains("hello world", $needle)); exit(); }
-EXPECT 1
+EXPECT true
 TIMEOUT 1
 
 NAME null character in both
 PROG BEGIN { $haystack = "hello\0world"; $needle = "wo\0rld"; print(strcontains($haystack, $needle)); exit(); }
-EXPECT 0
+EXPECT false
 TIMEOUT 1


### PR DESCRIPTION
This is so users can actually write out:
`true` and `false` instead of `1` or `0`.

This value is represented as a 8 bit int
in codegen.

This adds additional supporting for casting
to a bool type e.g. for ints, strings and
pointers.

This also fixes functions returning boolean
values e.g. `strcontains` and `has_key`,
which is technicially a breaking change but
should hopefully not have any real-world issues.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
