### PR TITLE
Remove AST location from unstable feature warning

### DIFF
--- a/tests/unstable_feature.cpp
+++ b/tests/unstable_feature.cpp
@@ -9,10 +9,7 @@ namespace bpftrace::test::unstable_feature {
 
 using ::testing::HasSubstr;
 
-void test(const std::string& input,
-          const std::string& error = "",
-          const std::string& warn = "",
-          bool invert = false)
+void test(const std::string& input, const std::string& error = "")
 {
   auto mock_bpftrace = get_mock_bpftrace();
   BPFtrace& bpftrace = *mock_bpftrace;
@@ -37,13 +34,6 @@ void test(const std::string& input,
 
   if (error.empty()) {
     ASSERT_TRUE(ok && ast.diagnostics().ok()) << msg.str() << out.str();
-    if (!warn.empty()) {
-      if (invert) {
-        EXPECT_THAT(out.str(), Not(HasSubstr(warn))) << msg.str() << out.str();
-      } else {
-        EXPECT_THAT(out.str(), HasSubstr(warn)) << msg.str() << out.str();
-      }
-    }
   } else {
     ASSERT_FALSE(ok && ast.diagnostics().ok()) << msg.str() << out.str();
     EXPECT_THAT(out.str(), HasSubstr(error)) << msg.str() << out.str();
@@ -55,62 +45,28 @@ void test_error(const std::string& input, const std::string& error)
   test(input, error);
 }
 
-void test_warning(const std::string& input, const std::string& warn)
-{
-  test(input, "", warn);
-}
-
-void test_no_warning(const std::string& input, const std::string& warn)
-{
-  test(input, "", warn, true);
-}
-
-TEST(unstable_feature, check_warnings)
-{
-  test_warning("let @a = lruhash(5); BEGIN { @a[0] = 0; }",
-               "Script is using an unstable feature. To prevent this "
-               "warning you must explicitly enable the unstable "
-               "feature in the config e.g. unstable_map_decl=enable");
-
-  test_warning("macro add_one($x) { $x } BEGIN { @a[0] = 0; }",
-               "Script is using an unstable feature. To prevent this "
-               "warning you must explicitly enable the unstable "
-               "feature in the config e.g. unstable_macro=enable");
-
-  test_warning("config = { unstable_map_decl=warn } macro add_one($x) { $x } "
-               "BEGIN { @a[0] = 0; }",
-               "Script is using an unstable feature. To prevent this "
-               "warning you must explicitly enable the unstable "
-               "feature in the config e.g. unstable_macro=enable");
-
-  test_no_warning(
-      "config = { unstable_map_decl=enable } let @a = lruhash(5); BEGIN "
-      "{ @a[0] = 0; }",
-      "Script is using an unstable feature");
-  test_no_warning("config = { unstable_map_decl=1 } let @a = lruhash(5); BEGIN "
-                  "{ @a[0] = 0; }",
-                  "Script is using an unstable feature");
-  test_no_warning(
-      "config = { unstable_macro=enable } macro add_one($x) { $x } BEGIN "
-      "{ @a[0] = 0; }",
-      "Script is using an unstable feature");
-}
-
 TEST(unstable_feature, check_error)
 {
   test_error("config = { unstable_map_decl=0 } let @a = lruhash(5); BEGIN { "
              "@a[0] = 0; }",
-             "Feature not enabled by default. To enable this unstable feature, "
+             "map declarations feature is not enabled by default. To enable "
+             "this unstable "
+             "feature, "
              "set the config flag to enable. unstable_map_decl=enable");
   test_error("config = { unstable_macro=0 } macro add_one($x) { $x } BEGIN { "
              "@a[0] = 0; }",
-             "Feature not enabled by default. To enable this unstable feature, "
+             "macros feature is not enabled by default. To enable this "
+             "unstable feature, "
              "set the config flag to enable. unstable_macro=enable");
   test_error(
       "config = { unstable_macro=error } macro add_one($x) { $x } BEGIN { "
       "@a[0] = 0; }",
-      "Feature not enabled by default. To enable this unstable feature, "
+      "macros feature is not enabled by default. To enable this unstable "
+      "feature, "
       "set the config flag to enable. unstable_macro=enable");
+
+  test("config = { unstable_macro=warn } macro add_one($x) { $x } BEGIN { "
+       "@a[0] = 0; }");
 }
 
 } // namespace bpftrace::test::unstable_feature


### PR DESCRIPTION
This is mostly so we can add new macros to base.bt and have the output be less noisy. Seems also like good general practice to remove the source line
for this warning as these features are enabled by
default and we don't need to beat our users over the head with some additional details of where the
unstable feature is being used.

Also made the warning and error message a little better.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
