### PR TITLE
imports: refactor to allow direct import calls in later passes

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -47,7 +47,6 @@
 #include "ast/passes/clang_build.h"
 #include "ast/passes/codegen_llvm.h"
 #include "ast/passes/link.h"
-#include "ast/passes/resolve_imports.h"
 #include "ast/signal_bt.h"
 #include "ast/visitor.h"
 #include "async_action.h"

--- a/src/ast/passes/named_param.cpp
+++ b/src/ast/passes/named_param.cpp
@@ -1,12 +1,8 @@
-#include <algorithm>
-
+#include "ast/passes/named_param.h"
 #include "ast/ast.h"
 #include "ast/context.h"
-#include "ast/passes/named_param.h"
 #include "ast/visitor.h"
-#include "clang_parser.h"
-#include "driver.h"
-#include "util/strings.h"
+#include "bpftrace.h"
 
 namespace bpftrace::ast {
 

--- a/src/ast/passes/resolve_imports.h
+++ b/src/ast/passes/resolve_imports.h
@@ -3,6 +3,7 @@
 #include <filesystem>
 #include <map>
 #include <string>
+#include <unordered_set>
 #include <utility>
 #include <variant>
 #include <vector>
@@ -58,8 +59,32 @@ public:
   std::map<std::string, LoadedObject> c_headers;
   std::map<std::string, ExternalObject> objects;
   std::map<std::string, ASTContext> scripts;
+
+  // Public import call.
+  Result<OK> import_any(Node &node,
+                        const std::string &name,
+                        const std::vector<std::filesystem::path> &paths = {});
+
+private:
+  Result<OK> import_any(Node &node,
+                        const std::string &name,
+                        const std::filesystem::path &path,
+                        const std::vector<std::filesystem::path> &paths,
+                        bool ignore_unknown,
+                        bool allow_directories);
+
+  Result<OK> import_any(Node &node,
+                        const std::string &name,
+                        const std::string_view &data,
+                        const std::vector<std::filesystem::path> &paths,
+                        bool ignore_unknown);
+
+  // Record full packages/directories that have been imported separately from
+  // the specific modules, in order to avoid re-importing these paths.
+  std::unordered_set<std::string> packages_;
 };
 
+// This pass resolves imports from the AST itself.
 Pass CreateResolveImportsPass(std::vector<std::string> &&import_paths);
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/unstable_feature.cpp
+++ b/src/ast/passes/unstable_feature.cpp
@@ -6,6 +6,7 @@
 #include "ast/visitor.h"
 #include "bpftrace.h"
 #include "config.h"
+#include "log.h"
 
 namespace bpftrace::ast {
 

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -53,9 +53,9 @@ void Driver::error(const location &l, const std::string &m)
   ctx.state_->diagnostics_->addError(ctx.wrap(l)) << m;
 }
 
-ast::Pass CreateParsePass(bool debug)
+ast::Pass CreateParsePass(uint32_t max_ast_nodes, bool debug)
 {
-  return ast::Pass::create("parse", [debug](ast::ASTContext &ast, BPFtrace &b) {
+  return ast::Pass::create("parse", [=](ast::ASTContext &ast) {
     Driver driver(ast, debug);
     ast.root = driver.parse_program();
 
@@ -68,10 +68,9 @@ ast::Pass CreateParsePass(bool debug)
     if (ast.diagnostics().ok()) {
       assert(ast.root != nullptr);
       auto node_count = ast.node_count();
-      if (node_count > b.max_ast_nodes_) {
-        ast.root->addError()
-            << "node count (" << node_count << ") exceeds the limit ("
-            << b.max_ast_nodes_ << ")";
+      if (max_ast_nodes > 0 && node_count > max_ast_nodes) {
+        ast.root->addError() << "node count (" << node_count
+                             << ") exceeds the limit (" << max_ast_nodes << ")";
       }
     }
   });

--- a/src/driver.h
+++ b/src/driver.h
@@ -1,12 +1,10 @@
 #pragma once
 
 #include <optional>
-#include <utility>
 
 #include "ast/ast.h"
 #include "ast/context.h"
 #include "ast/pass_manager.h"
-#include "bpftrace.h"
 #include "parser.tab.hh"
 
 using yyscan_t = void *;
@@ -45,6 +43,6 @@ private:
   void parse(Parser::symbol_type first_token);
 };
 
-ast::Pass CreateParsePass(bool debug = false);
+ast::Pass CreateParsePass(uint32_t max_ast_nodes = 0, bool debug = false);
 
 } // namespace bpftrace

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -1,9 +1,7 @@
 #pragma once
 
-#include "log.h"
 #include <bpf/bpf.h>
 #include <bpf/btf.h>
-#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -21,7 +21,6 @@
 #include "ast/passes/clang_build.h"
 #include "ast/passes/clang_parser.h"
 #include "ast/passes/codegen_llvm.h"
-#include "ast/passes/config_analyser.h"
 #include "ast/passes/fold_literals.h"
 #include "ast/passes/map_sugar.h"
 #include "ast/passes/named_param.h"
@@ -31,7 +30,6 @@
 #include "ast/passes/printer.h"
 #include "ast/passes/probe_analyser.h"
 #include "ast/passes/recursion_check.h"
-#include "ast/passes/resolve_imports.h"
 #include "ast/passes/resource_analyser.h"
 #include "ast/passes/return_path_analyser.h"
 #include "ast/passes/semantic_analyser.h"
@@ -876,7 +874,7 @@ int main(int argc, char* argv[])
 
   if (args.listing) {
     ast::CDefinitions no_c_defs; // See above.
-    pm.add(CreateParsePass())
+    pm.add(CreateParsePass(bpftrace.max_ast_nodes_))
         .put(no_c_defs)
         .add(ast::CreateParseAttachpointsPass(args.listing))
         .add(CreateParseBTFPass())


### PR DESCRIPTION
Stacked PRs:
 * #4276
 * __->__#4332


--- --- ---

### imports: refactor to allow direct import calls in later passes


This change is primarily a small refactoring of the `Imports` object and
the associated `ResolveImports` visitor. It makes the `import_any`
method available on the imports object so that later passes can do
direct imports without needing to modify the AST. If the import has
already happened, then it will still be correctly memoized.

Note that there is some minor header shuffling, primarily due to the
lack of consistent IWYU.

Signed-off-by: Adin Scannell <amscanne@meta.com>
