### PR TITLE
btf: add external type support for semantic analysis

### DIFF
--- a/src/ast/dibuilderbpf.h
+++ b/src/ast/dibuilderbpf.h
@@ -3,6 +3,7 @@
 #include <linux/bpf.h>
 #include <llvm/IR/DIBuilder.h>
 
+#include "ast/location.h"
 #include "types.h"
 
 namespace libbpf {
@@ -17,11 +18,11 @@ class DIBuilderBPF : public DIBuilder {
 public:
   DIBuilderBPF(Module &module);
 
-  void createFunctionDebugInfo(llvm::Function &func,
-                               const SizedType &ret_type,
-                               const Struct &args,
-                               bool is_declaration = false);
-  void createProbeDebugInfo(llvm::Function &probe_func);
+  DILocalScope *createFunctionDebugInfo(llvm::Function &func,
+                                        const SizedType &ret_type,
+                                        const Struct &args,
+                                        bool is_declaration = false);
+  DILocalScope *createProbeDebugInfo(llvm::Function &probe_func);
 
   DIType *getInt8Ty();
   DIType *getInt16Ty();
@@ -52,6 +53,9 @@ public:
                                              const SizedType &value_type);
   DIGlobalVariableExpression *createGlobalVariable(std::string_view name,
                                                    const SizedType &stype);
+  DILocation *createDebugLocation(llvm::LLVMContext &ctx,
+                                  DILocalScope *scope,
+                                  const ast::Location &loc);
 
   DIFile *file = nullptr;
 

--- a/src/stdlib/base.c
+++ b/src/stdlib/base.c
@@ -1,4 +1,0 @@
-int always_true()
-{
-  return 1;
-}

--- a/src/stdlib/test/test.bpf.c
+++ b/src/stdlib/test/test.bpf.c
@@ -1,0 +1,3 @@
+// __always_true is a built-in test function to validate C interop is working
+// as expected.
+int __always_true() { return 1; }

--- a/tests/runtime/interop
+++ b/tests/runtime/interop
@@ -1,0 +1,3 @@
+NAME interop return types
+PROG config = { unstable_import=true; } import "stdlib/test"; BEGIN { print(__always_true()); exit(); }
+EXPECT 1


### PR DESCRIPTION
Stacked PRs:
 * __->__#4340


--- --- ---

### btf: add external type support for semantic analysis


With this metadata, there is no longer any need to manually specify
functions in the semantic analyzer for external cases. We can start to
peel away static helpers into standard library files and pull code out
of codegen.

Signed-off-by: Adin Scannell <amscanne@meta.com>
