### PR TITLE
Use bytes to create ints and enums

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -390,7 +390,7 @@ SizedType ident_to_sized_type(const std::string &ident)
     // int and cause an ERROR: Integer size mismatch.
     // This could potentially be revisited or the cast relaxed
     // if we check the variant values during semantic analysis.
-    return CreateEnum(64, enum_name);
+    return CreateEnum(8, enum_name);
   }
   return ident_to_record(ident);
 }

--- a/src/ast/passes/clang_parser.cpp
+++ b/src/ast/passes/clang_parser.cpp
@@ -241,7 +241,7 @@ static std::string get_unqualified_type_name(CXType clang_type)
 
 static SizedType get_sized_type(CXType clang_type, StructManager &structs)
 {
-  auto size = 8 * clang_Type_getSizeOf(clang_type);
+  auto byte_size = clang_Type_getSizeOf(clang_type);
   auto typestr = get_unqualified_type_name(clang_type);
 
   switch (clang_type.kind) {
@@ -252,11 +252,11 @@ static SizedType get_sized_type(CXType clang_type, StructManager &structs)
     case CXType_UInt:
     case CXType_ULong:
     case CXType_ULongLong:
-      return CreateUInt(size);
+      return CreateUInt(byte_size);
     case CXType_Record: {
       // Struct map entry may not exist for forward declared types so we
       // create it now and fill it later
-      auto s = structs.LookupOrAdd(typestr, size / 8);
+      auto s = structs.LookupOrAdd(typestr, byte_size);
       return CreateRecord(typestr, s);
     }
     case CXType_Char_S:
@@ -265,13 +265,13 @@ static SizedType get_sized_type(CXType clang_type, StructManager &structs)
     case CXType_Long:
     case CXType_LongLong:
     case CXType_Int:
-      return CreateInt(size);
+      return CreateInt(byte_size);
     case CXType_Enum: {
       // The pretty printed type name contains `enum` prefix. That's not
       // helpful for us, so remove it. We have our own metadata.
       static std::regex re("enum ");
       auto enum_name = std::regex_replace(typestr, re, "");
-      return CreateEnum(size, enum_name);
+      return CreateEnum(byte_size, enum_name);
     }
     case CXType_Pointer: {
       auto pointee_type = clang_getPointeeType(clang_type);

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -601,14 +601,14 @@ static const std::map<std::string, call_spec> CALL_SPEC = {
 static const std::map<std::string, std::tuple<size_t, bool>> &getIntcasts()
 {
   static const std::map<std::string, std::tuple<size_t, bool>> intcasts = {
-    { "uint8", std::tuple<size_t, bool>{ 8, false } },
-    { "int8", std::tuple<size_t, bool>{ 8, true } },
-    { "uint16", std::tuple<size_t, bool>{ 16, false } },
-    { "int16", std::tuple<size_t, bool>{ 16, true } },
-    { "uint32", std::tuple<size_t, bool>{ 32, false } },
-    { "int32", std::tuple<size_t, bool>{ 32, true } },
-    { "uint64", std::tuple<size_t, bool>{ 64, false } },
-    { "int64", std::tuple<size_t, bool>{ 64, true } },
+    { "uint8", std::tuple<size_t, bool>{ 1, false } },
+    { "int8", std::tuple<size_t, bool>{ 1, true } },
+    { "uint16", std::tuple<size_t, bool>{ 2, false } },
+    { "int16", std::tuple<size_t, bool>{ 2, true } },
+    { "uint32", std::tuple<size_t, bool>{ 4, false } },
+    { "int32", std::tuple<size_t, bool>{ 4, true } },
+    { "uint64", std::tuple<size_t, bool>{ 8, false } },
+    { "int64", std::tuple<size_t, bool>{ 8, true } },
   };
   return intcasts;
 }
@@ -740,7 +740,7 @@ void SemanticAnalyser::visit(Identifier &identifier)
 {
   if (c_definitions_.enums.contains(identifier.ident)) {
     const auto &enum_name = std::get<1>(c_definitions_.enums[identifier.ident]);
-    identifier.ident_type = CreateEnum(64, enum_name);
+    identifier.ident_type = CreateEnum(8, enum_name);
   } else if (bpftrace_.structs.Has(identifier.ident)) {
     identifier.ident_type = CreateRecord(
         identifier.ident, bpftrace_.structs.Lookup(identifier.ident));
@@ -1472,10 +1472,10 @@ void SemanticAnalyser::visit(Call &call)
       case 1:
       case 2:
       case 4:
-        pointee_size = sizes.at(0) * 8;
+        pointee_size = sizes.at(0);
         break;
       default:
-        pointee_size = 64;
+        pointee_size = 8;
     }
     call.return_type = CreatePointer(CreateInt(pointee_size), AddrSpace::user);
   } else if (call.func == "cgroupid") {
@@ -1719,7 +1719,7 @@ If you're seeing errors, try clamping the string sizes. For example:
                       << arg.type().GetTy() << " provided)";
       return;
     }
-    call.return_type = CreateUInt(arg.type().GetIntBitWidth());
+    call.return_type = CreateUInt(arg.type().GetIntByteWidth());
   } else if (call.func == "skboutput") {
     if (!bpftrace_.feature_->has_skb_output()) {
       call.addError() << "BPF_FUNC_skb_output is not available for your kernel "
@@ -2166,7 +2166,7 @@ void SemanticAnalyser::binop_ptr(Binop &binop)
   // Binop on two pointers
   if (other.IsPtrTy()) {
     if (compare) {
-      binop.result_type = CreateUInt(64);
+      binop.result_type = CreateUInt(8);
 
       if (is_final_pass()) {
         const auto *le = lht.GetPointeeTy();
@@ -2180,7 +2180,7 @@ void SemanticAnalyser::binop_ptr(Binop &binop)
         }
       }
     } else if (logical) {
-      binop.result_type = CreateUInt(64);
+      binop.result_type = CreateUInt(8);
     } else {
       invalid_op();
     }
@@ -2194,7 +2194,7 @@ void SemanticAnalyser::binop_ptr(Binop &binop)
     else if (binop.op == Operator::PLUS || binop.op == Operator::MINUS)
       binop.result_type = CreatePointer(*ptr.GetPointeeTy(), ptr.GetAS());
     else if (compare || logical)
-      binop.result_type = CreateInt(64);
+      binop.result_type = CreateInt(8);
     else
       invalid_op();
   }
@@ -2240,10 +2240,10 @@ void SemanticAnalyser::visit(Binop &binop)
   if (is_int_binop) {
     // Implicit size promotion to larger of the two
     auto size = std::max(lht.GetSize(), rht.GetSize());
-    binop.result_type = CreateInteger(size * 8, is_signed);
+    binop.result_type = CreateInteger(size, is_signed);
   } else {
     // Default type - will be overriden below as necessary
-    binop.result_type = CreateInteger(64, is_signed);
+    binop.result_type = CreateInteger(8, is_signed);
   }
 
   auto addr_lhs = binop.left.type().GetAS();
@@ -2363,12 +2363,12 @@ void SemanticAnalyser::visit(Unop &unop)
                       << " operator can not be used on expressions of type '"
                       << type << "'";
     } else {
-      unop.result_type = CreateUInt(8 * type.GetSize());
+      unop.result_type = CreateUInt(type.GetSize());
     }
   } else if (type.IsPtrTy() && valid_ptr_op) {
     unop.result_type = unop.expr.type();
   } else {
-    unop.result_type = CreateInteger(64, type.IsSigned());
+    unop.result_type = CreateInteger(8, type.IsSigned());
   }
 }
 
@@ -2408,7 +2408,7 @@ void SemanticAnalyser::visit(Ternary &ternary)
   }
 
   if (lhs.IsIntegerTy()) {
-    ternary.result_type = CreateInteger(64, lhs.IsSigned());
+    ternary.result_type = CreateInteger(8, lhs.IsSigned());
   } else {
     auto lsize = lhs.GetSize();
     auto rsize = rhs.GetSize();
@@ -3207,7 +3207,7 @@ void SemanticAnalyser::visit(AssignVarStatement &assignment)
           } else {
             assignTy = storedTy;
             assignment.expr = ctx_.make_node<Cast>(
-                CreateInteger(storedTy.GetSize() * 8, true),
+                CreateInteger(storedTy.GetSize(), true),
                 assignment.expr,
                 Location(assignment.loc));
             visit(assignment.expr);
@@ -3226,7 +3226,7 @@ void SemanticAnalyser::visit(AssignVarStatement &assignment)
         if (can_fit) {
           assignTy = storedTy;
           assignment.expr = ctx_.make_node<Cast>(
-              CreateInteger(storedTy.GetSize() * 8, storedTy.IsSigned()),
+              CreateInteger(storedTy.GetSize(), storedTy.IsSigned()),
               assignment.expr,
               Location(assignment.loc));
           visit(assignment.expr);
@@ -4058,7 +4058,7 @@ SizedType SemanticAnalyser::create_key_type(const SizedType &expr_type,
     // be space for any integer in the map key later
     // This should have a better solution.
     new_key_type.SetSign(expr_type.IsSigned());
-    new_key_type.SetIntBitWidth(64);
+    new_key_type.SetIntByteWidth(8);
   }
 
   validate_map_key(new_key_type, node);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -320,18 +320,15 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(
       case Type::integer:
         if (arg.type.IsSigned()) {
           int64_t val = 0;
-          switch (arg.type.GetIntBitWidth()) {
-            case 64:
+          switch (arg.type.GetIntByteWidth()) {
+            case 8:
               val = *reinterpret_cast<int64_t *>(arg_data + arg.offset);
               break;
-            case 32:
+            case 4:
               val = *reinterpret_cast<int32_t *>(arg_data + arg.offset);
               break;
-            case 16:
+            case 2:
               val = *reinterpret_cast<int16_t *>(arg_data + arg.offset);
-              break;
-            case 8:
-              val = *reinterpret_cast<int8_t *>(arg_data + arg.offset);
               break;
             case 1:
               val = *reinterpret_cast<int8_t *>(arg_data + arg.offset);
@@ -345,18 +342,15 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(
           arg_values.push_back(std::make_unique<PrintableSInt>(val));
         } else {
           uint64_t val = 0;
-          switch (arg.type.GetIntBitWidth()) {
-            case 64:
+          switch (arg.type.GetIntByteWidth()) {
+            case 8:
               val = *reinterpret_cast<uint64_t *>(arg_data + arg.offset);
               break;
-            case 32:
+            case 4:
               val = *reinterpret_cast<uint32_t *>(arg_data + arg.offset);
               break;
-            case 16:
+            case 2:
               val = *reinterpret_cast<uint16_t *>(arg_data + arg.offset);
-              break;
-            case 8:
-              val = *reinterpret_cast<uint8_t *>(arg_data + arg.offset);
               break;
             case 1:
               val = *reinterpret_cast<uint8_t *>(arg_data + arg.offset);

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -424,10 +424,10 @@ SizedType BTF::get_stype(const BTFId &btf_id, bool resolve_structs)
   auto stype = CreateNone();
 
   if (btf_is_int(t)) {
-    stype = CreateInteger(btf_int_bits(t),
+    stype = CreateInteger(btf_int_bits(t) / 8,
                           btf_int_encoding(t) & BTF_INT_SIGNED);
   } else if (btf_is_enum(t)) {
-    stype = CreateInteger(t->size * 8, false);
+    stype = CreateInteger(t->size, false);
   } else if (btf_is_composite(t)) {
     std::string cast = btf_str(btf_id.btf, t->name_off);
     if (cast.empty() || cast == "(anon)")

--- a/src/output.cpp
+++ b/src/output.cpp
@@ -340,31 +340,31 @@ std::string Output::value_to_str(BPFtrace &bpftrace,
     }
     case Type::integer: {
       auto sign = type.IsSigned();
-      switch (type.GetIntBitWidth()) {
+      switch (type.GetIntByteWidth()) {
           // clang-format off
-          case 64:
+          case 8:
             if (sign)
               return std::to_string(util::reduce_value<int64_t>(value, nvalues) / static_cast<int64_t>(div));
             return std::to_string(util::reduce_value<uint64_t>(value, nvalues) / div);
-          case 32:
+          case 4:
             if (sign)
               return std::to_string(
                   util::reduce_value<int32_t>(value, nvalues) / static_cast<int32_t>(div));
             return std::to_string(util::reduce_value<uint32_t>(value, nvalues) / div);
-          case 16:
+          case 2:
             if (sign)
               return std::to_string(
                   util::reduce_value<int16_t>(value, nvalues) / static_cast<int16_t>(div));
             return std::to_string(util::reduce_value<uint16_t>(value, nvalues) / div);
-          case 8:
+          case 1:
             if (sign)
               return std::to_string(
                   util::reduce_value<int8_t>(value, nvalues) / static_cast<int8_t>(div));
             return std::to_string(util::reduce_value<uint8_t>(value, nvalues) / div);
-            // clang-format on
+          // clang-format on
         default:
-          LOG(BUG) << "value_to_str: Invalid int bitwidth: "
-                   << type.GetIntBitWidth() << "provided";
+          LOG(BUG) << "value_to_str: Invalid int byte width: "
+                   << type.GetIntByteWidth() << "provided";
           return {};
       }
     }
@@ -781,22 +781,22 @@ std::string TextOutput::value_to_str(BPFtrace &bpftrace,
         const auto *data = value.data();
         const auto &enum_name = type.GetName();
         uint64_t enum_val;
-        switch (type.GetIntBitWidth()) {
-          case 64:
+        switch (type.GetIntByteWidth()) {
+          case 8:
             enum_val = util::read_data<uint64_t>(data);
             break;
-          case 32:
+          case 4:
             enum_val = util::read_data<uint32_t>(data);
             break;
-          case 16:
+          case 2:
             enum_val = util::read_data<uint16_t>(data);
             break;
-          case 8:
+          case 1:
             enum_val = util::read_data<uint8_t>(data);
             break;
           default:
             LOG(BUG) << "value_to_str: Invalid int bitwidth: "
-                     << type.GetIntBitWidth() << "provided";
+                     << type.GetIntByteWidth() << "provided";
             return {};
         }
 

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -293,14 +293,14 @@ int_type:
                 INT_TYPE {
                     static std::unordered_map<std::string, SizedType> type_map = {
                         {"bool", CreateBool()},
-                        {"uint8", CreateUInt(8)},
-                        {"uint16", CreateUInt(16)},
-                        {"uint32", CreateUInt(32)},
-                        {"uint64", CreateUInt(64)},
-                        {"int8", CreateInt(8)},
-                        {"int16", CreateInt(16)},
-                        {"int32", CreateInt(32)},
-                        {"int64", CreateInt(64)},
+                        {"uint8", CreateUInt(1)},
+                        {"uint16", CreateUInt(2)},
+                        {"uint32", CreateUInt(4)},
+                        {"uint64", CreateUInt(8)},
+                        {"int8", CreateInt(1)},
+                        {"int16", CreateInt(2)},
+                        {"int32", CreateInt(4)},
+                        {"int64", CreateInt(8)},
                     };
                     $$ = type_map[$1];
                 }

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -235,10 +235,10 @@ std::string typestr(Type t)
 }
 
 // Type wrappers
-SizedType CreateInteger(size_t bits, bool is_signed)
+SizedType CreateInteger(size_t bytes, bool is_signed)
 {
   auto t = SizedType(Type::integer, 0, is_signed);
-  t.SetIntBitWidth(bits);
+  t.SetIntByteWidth(bytes);
   return t;
 }
 
@@ -247,59 +247,59 @@ SizedType CreateBool()
   return { Type::boolean, 1 };
 }
 
-SizedType CreateInt(size_t bits)
+SizedType CreateInt(size_t bytes)
 {
-  return CreateInteger(bits, true);
+  return CreateInteger(bytes, true);
 };
 
-SizedType CreateUInt(size_t bits)
+SizedType CreateUInt(size_t bytes)
 {
-  return CreateInteger(bits, false);
+  return CreateInteger(bytes, false);
 }
 
 SizedType CreateInt8()
 {
-  return CreateInt(8);
+  return CreateInt(1);
 }
 
 SizedType CreateInt16()
 {
-  return CreateInt(16);
+  return CreateInt(2);
 }
 
 SizedType CreateInt32()
 {
-  return CreateInt(32);
+  return CreateInt(4);
 }
 
 SizedType CreateInt64()
 {
-  return CreateInt(64);
+  return CreateInt(8);
 }
 
 SizedType CreateUInt8()
 {
-  return CreateUInt(8);
+  return CreateUInt(1);
 }
 
 SizedType CreateUInt16()
 {
-  return CreateUInt(16);
+  return CreateUInt(2);
 }
 
 SizedType CreateUInt32()
 {
-  return CreateUInt(32);
+  return CreateUInt(4);
 }
 
 SizedType CreateUInt64()
 {
-  return CreateUInt(64);
+  return CreateUInt(8);
 }
 
-SizedType CreateEnum(size_t bits, const std::string &name)
+SizedType CreateEnum(size_t bytes, const std::string &name)
 {
-  auto ty = CreateUInt(bits);
+  auto ty = CreateUInt(bytes);
   ty.name_ = name;
   return ty;
 }

--- a/src/types.h
+++ b/src/types.h
@@ -290,29 +290,34 @@ public:
   void SetSize(size_t byte_size)
   {
     if (IsIntTy())
-      SetIntBitWidth(byte_size * 8);
+      SetIntByteWidth(byte_size);
     else
       size_bits_ = byte_size * 8;
   }
 
-  void SetIntBitWidth(size_t bits)
+  void SetIntByteWidth(size_t bytes)
   {
     assert(IsIntTy());
     // Truncate integers too large to fit in BPF registers (64-bits).
-    bits = std::min<size_t>(bits, 64);
+    bytes = std::min<size_t>(bytes, 8);
     // Zero sized integers are not usually valid. However, during semantic
     // analysis when we're inferring types, the first pass may not have
     // enough information to figure out the exact size of the integer. Later
     // passes infer the exact size.
-    assert(bits == 0 || bits == 1 || bits == 8 || bits == 16 || bits == 32 ||
-           bits == 64);
-    size_bits_ = bits;
+    assert(bytes == 0 || bytes == 1 || bytes == 2 || bytes == 4 || bytes == 8);
+    size_bits_ = bytes * 8;
   }
 
   size_t GetIntBitWidth() const
   {
     assert(IsIntTy());
     return size_bits_;
+  };
+
+  size_t GetIntByteWidth() const
+  {
+    assert(IsIntTy());
+    return size_bits_ / 8;
   };
 
   size_t GetNumElements() const
@@ -505,7 +510,7 @@ public:
 
   // Factories
 
-  friend SizedType CreateEnum(size_t bits, const std::string &name);
+  friend SizedType CreateEnum(size_t bytes, const std::string &name);
   friend SizedType CreateArray(size_t num_elements,
                                const SizedType &element_type);
 
@@ -514,7 +519,7 @@ public:
   friend SizedType CreateRecord(std::shared_ptr<Struct> &&record);
   friend SizedType CreateRecord(const std::string &name,
                                 std::weak_ptr<Struct> record);
-  friend SizedType CreateInteger(size_t bits, bool is_signed);
+  friend SizedType CreateInteger(size_t bytes, bool is_signed);
   friend SizedType CreateTuple(std::shared_ptr<Struct> &&tuple);
 };
 
@@ -522,9 +527,9 @@ public:
 SizedType CreateNone();
 SizedType CreateVoid();
 SizedType CreateBool();
-SizedType CreateInteger(size_t bits, bool is_signed);
-SizedType CreateInt(size_t bits);
-SizedType CreateUInt(size_t bits);
+SizedType CreateInteger(size_t bytes, bool is_signed);
+SizedType CreateInt(size_t bytes);
+SizedType CreateUInt(size_t bytes);
 SizedType CreateInt8();
 SizedType CreateInt16();
 SizedType CreateInt32();
@@ -533,7 +538,7 @@ SizedType CreateUInt8();
 SizedType CreateUInt16();
 SizedType CreateUInt32();
 SizedType CreateUInt64();
-SizedType CreateEnum(size_t bits, const std::string &name);
+SizedType CreateEnum(size_t bytes, const std::string &name);
 
 // Create a string of `size` bytes, inclusive of NUL terminator.
 SizedType CreateString(size_t size);

--- a/tests/async_action.cpp
+++ b/tests/async_action.cpp
@@ -61,7 +61,7 @@ void process_arg(std::vector<Field> &fields,
   size_t arg_size = sizeof(T);
 
   fields.push_back(Field{ .name = "arg",
-                          .type = CreateInt(arg_size * 8),
+                          .type = CreateInt(arg_size),
                           .offset = offset,
                           .bitfield = std::nullopt });
 

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -213,8 +213,8 @@ TEST(clang_parser, integer_ptr)
   ASSERT_TRUE(foo->HasField("x"));
 
   EXPECT_TRUE(foo->GetField("x").type.IsPtrTy());
-  EXPECT_EQ(foo->GetField("x").type.GetPointeeTy()->GetIntBitWidth(),
-            8 * sizeof(int));
+  EXPECT_EQ(foo->GetField("x").type.GetPointeeTy()->GetIntByteWidth(),
+            sizeof(int));
   EXPECT_EQ(foo->GetField("x").offset, 0);
 }
 
@@ -233,7 +233,7 @@ TEST(clang_parser, string_ptr)
   const auto &ty = foo->GetField("str").type;
   const auto *pointee = ty.GetPointeeTy();
   EXPECT_TRUE(pointee->IsIntTy());
-  EXPECT_EQ(pointee->GetIntBitWidth(), 8 * sizeof(char));
+  EXPECT_EQ(pointee->GetIntByteWidth(), sizeof(char));
   EXPECT_EQ(foo->GetField("str").offset, 0);
 }
 

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -130,7 +130,7 @@ void setup_mock_bpftrace(MockBPFtrace &bpftrace)
   bpftrace.structs.Lookup("struct _tracepoint_tcp_some_tcp_tp")
       .lock()
       ->AddField(
-          "saddr_v6", CreateArray(16, CreateUInt(8)), 8, std::nullopt, false);
+          "saddr_v6", CreateArray(16, CreateUInt(1)), 8, std::nullopt, false);
 
   auto ptr_type = CreatePointer(CreateInt8());
   bpftrace.structs.Add("struct _tracepoint_file_filename", 8);

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1415,7 +1415,7 @@ TEST(semantic_analyser, call_uaddr)
 
   auto ast = test(prog);
 
-  std::vector<int> sizes = { 8, 16, 32, 64, 64, 64 };
+  std::vector<int> sizes = { 1, 2, 4, 8, 8, 8 };
 
   for (size_t i = 0; i < sizes.size(); i++) {
     auto *v = ast.root->probes.at(0)
@@ -1424,7 +1424,7 @@ TEST(semantic_analyser, call_uaddr)
     EXPECT_TRUE(v->var()->var_type.IsPtrTy());
     EXPECT_TRUE(v->var()->var_type.GetPointeeTy()->IsIntTy());
     EXPECT_EQ((unsigned long int)sizes.at(i),
-              v->var()->var_type.GetPointeeTy()->GetIntBitWidth());
+              v->var()->var_type.GetPointeeTy()->GetIntByteWidth());
   }
 }
 


### PR DESCRIPTION
Small refactor so we don't have to multiply
or divide values by 8 around the codebase
as much.

I also don't think we actually support any
int types of 1 bit.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
