### PR TITLE
Add ability to attach to BPF progs and sub progs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,6 +69,8 @@ and this project adheres to
   - [#4345](https://github.com/bpftrace/bpftrace/pull/4345)
 - Introduce `tseries` for capturing time series data
   - [#3838](https://github.com/bpftrace/bpftrace/pull/3838)
+- Add ability to attach to running BPF programs and sub-programs via `fentry:bpf:prog_name` or `fentry:bpf:prog_id:prog_name`
+  - [#4354](https://github.com/bpftrace/bpftrace/pull/4354)
 #### Changed
 - kprobe: support verbose mode listing
   - [#4362](https://github.com/bpftrace/bpftrace/pull/4362)

--- a/man/adoc/bpftrace.adoc
+++ b/man/adoc/bpftrace.adoc
@@ -1441,6 +1441,8 @@ iter:task_file:/sys/fs/bpf/files {
 .variants
 * `fentry[:module]:fn`
 * `fexit[:module]:fn`
+* `fentry:bpf[:prog_id]:prog_name`
+* `fexit:bpf[:prog_id]:prog_name`
 
 .short names
 * `f` (`fentry`)
@@ -1460,6 +1462,15 @@ The original names are still supported for backwards compatibility.
 This removes the need for manual type casting and makes the code more resilient against small signature changes in the kernel.
 The function arguments are available in the `args` struct which can be inspected by doing verbose listing (see <<Listing Probes>>).
 These arguments are also available in the return probe (`fexit`), unlike `kretprobe`.
+
+The bpf variants (e.g. `fentry:bpf[:prog_id]:prog_name`) allow attaching to running BPF programs and sub-programs.
+For example, if bpftrace was already running with a script like `uprobe:./testprogs/uprobe_test:uprobeFunction1 { print("hello"); }` then you could attach to this program with `fexit:bpf:uprobe___testprogs_uprobe_test_uprobeFunction1_1 { print("bye"); }` and this probe would execute after (because it's `fexit`) the `print("hello")` probe executes.
+You can specify just the program name, and in this case bpftrace will attach to all running programs and sub-programs with that name.
+You can differentiate between them using the `probe` builtin.
+You can also specify the program id (e.g. `fentry:bpf:123:*`) to attach to a specific running BPF program or sub-programs called in that running BPF program.
+To see a list of running, valid BPF programs and sub-programs use `bpftrace -l 'fentry:bpf:*'`.
+Note: only BPF programs with a BTF Id can be attached to.
+Also, the `args` builtin is not yet available for this variant.
 
 ----
 # bpftrace -lv 'fentry:tcp_reset'

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1175,6 +1175,7 @@ public:
 
   uint64_t address = 0;
   uint64_t func_offset = 0;
+  uint64_t bpf_prog_id = 0;
   bool ignore_invalid = false;
 
   std::string name() const;

--- a/src/ast/passes/probe_expansion.cpp
+++ b/src/ast/passes/probe_expansion.cpp
@@ -74,7 +74,15 @@ void ExpansionAnalyser::visit(AttachPoint &ap)
       break;
 
     case ProbeType::fentry:
-    case ProbeType::fexit:
+    case ProbeType::fexit: {
+      if (ap.target == "bpf") {
+        if (!ap.bpf_prog_id || util::has_wildcard(ap.func)) {
+          expansion = ExpansionType::FULL;
+        }
+        break;
+      }
+      [[fallthrough]];
+    }
     case ProbeType::tracepoint:
     case ProbeType::rawtracepoint:
       if (util::has_wildcard(ap.target) || util::has_wildcard(ap.func))

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1115,6 +1115,13 @@ void SemanticAnalyser::visit(Builtin &builtin)
              "\"probe1,probe2 {args}\" is not.";
     } else if (type == ProbeType::fentry || type == ProbeType::fexit ||
                type == ProbeType::uprobe || type == ProbeType::rawtracepoint) {
+      for (auto *attach_point : probe->attach_points) {
+        if (attach_point->target == "bpf") {
+          builtin.addError() << "The args builtin cannot be used for "
+                                "'fentry/fexit:bpf' probes";
+          return;
+        }
+      }
       auto type_name = probe->args_typename();
       builtin.builtin_type = CreateRecord(type_name,
                                           bpftrace_.structs.Lookup(type_name));

--- a/src/bpfprogram.cpp
+++ b/src/bpfprogram.cpp
@@ -7,6 +7,7 @@
 #include "bpfprogram.h"
 #include "log.h"
 #include "util/exceptions.h"
+#include "util/fd.h"
 
 namespace bpftrace {
 
@@ -67,7 +68,7 @@ void BpfProgram::set_attach_target(const Probe &probe,
 
   const std::string &mod = probe.path;
   const std::string &fun = probe.attach_point;
-  const std::string attach_target = !mod.empty() ? mod + ":" + fun : fun;
+  std::string attach_target = !mod.empty() ? mod + ":" + fun : fun;
 
   std::string btf_fun;
   __u32 btf_kind = BTF_KIND_FUNC;
@@ -81,17 +82,34 @@ void BpfProgram::set_attach_target(const Probe &probe,
     btf_fun = fun;
   }
 
-  if (btf.get_btf_id(btf_fun, mod, btf_kind) < 0) {
-    const std::string msg = "No BTF found for " + attach_target + ".";
+  std::string err_msg;
+
+  if ((probe.type == ProbeType::fentry || probe.type == ProbeType::fexit) &&
+      mod == "bpf") {
+    int raw_fd = bpf_prog_get_fd_by_id(static_cast<__u32>(probe.bpf_prog_id));
+    if (raw_fd < 0) {
+      err_msg = "No valid BPF program found with name: " + fun +
+                " and id: " + std::to_string(probe.bpf_prog_id) + ".";
+    } else {
+      bpf_prog_fd_ = util::FD(raw_fd);
+      attach_target = fun;
+    }
+  } else if (btf.get_btf_id(btf_fun, mod, btf_kind) < 0) {
+    err_msg = "No BTF found for " + attach_target + ".";
+  }
+
+  if (!err_msg.empty()) {
     if (config.missing_probes == ConfigMissingProbes::error) {
-      LOG(ERROR) << msg;
+      LOG(ERROR) << err_msg;
     } else if (config.missing_probes == ConfigMissingProbes::warn) {
-      LOG(WARNING) << msg;
+      LOG(WARNING) << err_msg;
     }
     bpf_program__set_autoload(bpf_prog_, false);
   }
 
-  bpf_program__set_attach_target(bpf_prog_, 0, attach_target.c_str());
+  bpf_program__set_attach_target(bpf_prog_,
+                                 bpf_prog_fd_ ? *bpf_prog_fd_ : 0,
+                                 attach_target.c_str());
 }
 
 void BpfProgram::set_no_autoattach()

--- a/src/bpfprogram.h
+++ b/src/bpfprogram.h
@@ -6,6 +6,7 @@
 #include "btf.h"
 #include "config.h"
 #include "probe_types.h"
+#include "util/fd.h"
 
 namespace bpftrace {
 
@@ -35,6 +36,7 @@ public:
 
 private:
   struct bpf_program *bpf_prog_;
+  std::optional<util::FD> bpf_prog_fd_ = std::nullopt;
 };
 
 } // namespace bpftrace

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -129,6 +129,7 @@ Probe BPFtrace::generate_probe(const ast::AttachPoint &ap,
   probe.async = ap.async;
   probe.pin = ap.pin;
   probe.is_session = ap.expansion == ast::ExpansionType::SESSION;
+  probe.bpf_prog_id = ap.bpf_prog_id;
   return probe;
 }
 

--- a/src/probe_matcher.h
+++ b/src/probe_matcher.h
@@ -98,6 +98,7 @@ private:
   virtual std::unique_ptr<std::istream> get_symbols_from_list(
       const std::vector<ProbeListItem> &probes_list) const;
   virtual std::unique_ptr<std::istream> get_fentry_symbols() const;
+  virtual std::unique_ptr<std::istream> get_running_bpf_programs() const;
   virtual std::unique_ptr<std::istream> get_raw_tracepoint_symbols() const;
 
   std::unique_ptr<std::istream> get_iter_symbols() const;

--- a/src/probe_types.h
+++ b/src/probe_types.h
@@ -121,6 +121,7 @@ struct Probe {
   bool async = false; // for watchpoint probes, if it's an async watchpoint
   uint64_t address = 0;
   uint64_t func_offset = 0;
+  uint64_t bpf_prog_id = 0;
   std::vector<std::string> funcs;
   bool is_session = false;
 

--- a/src/util/CMakeLists.txt
+++ b/src/util/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_library(util STATIC
   bpf_funcs.cpp
   bpf_names.cpp
+  bpf_progs.cpp
   cgroup.cpp
   cpus.cpp
   env.cpp

--- a/src/util/bpf_progs.cpp
+++ b/src/util/bpf_progs.cpp
@@ -1,0 +1,138 @@
+#include <bpf/bpf.h>
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-qual"
+#include <bpf/btf.h>
+#pragma GCC diagnostic pop
+#include <limits>
+#include <linux/btf.h>
+#include <string>
+#include <unistd.h>
+#include <vector>
+
+#include "log.h"
+#include "scopeguard.h"
+#include "util/fd.h"
+
+namespace bpftrace::util {
+
+std::string get_prog_full_name(const struct bpf_prog_info *prog_info,
+                               int prog_fd)
+{
+  const char *prog_name = prog_info->name;
+  const struct btf_type *func_type;
+  struct bpf_func_info finfo = {};
+  struct bpf_prog_info info = {};
+  __u32 info_len = sizeof(info);
+
+  std::string name = std::string(prog_name);
+
+  if (!prog_info->btf_id || prog_info->nr_func_info == 0) {
+    return name;
+  }
+
+  info.nr_func_info = 1;
+  info.func_info_rec_size = prog_info->func_info_rec_size;
+  info.func_info_rec_size = std::min<unsigned long>(info.func_info_rec_size,
+                                                    sizeof(finfo));
+  info.func_info = reinterpret_cast<__u64>(&finfo);
+
+  if (bpf_prog_get_info_by_fd(prog_fd, &info, &info_len)) {
+    return name;
+  }
+
+  struct btf *prog_btf = btf__load_from_kernel_by_id(info.btf_id);
+  if (!prog_btf) {
+    return name;
+  }
+
+  func_type = btf__type_by_id(prog_btf, finfo.type_id);
+  if (!func_type || !btf_is_func(func_type)) {
+    btf__free(prog_btf);
+    return name;
+  }
+
+  prog_name = btf__name_by_offset(prog_btf, func_type->name_off);
+  name = std::string(prog_name);
+  btf__free(prog_btf);
+  return name;
+}
+
+std::vector<std::pair<__u32, std::string>> get_bpf_progs()
+{
+  std::vector<std::pair<__u32, std::string>> ids_and_syms;
+  __u32 id = 0;
+  while (bpf_prog_get_next_id(id, &id) == 0) {
+    int raw_fd = bpf_prog_get_fd_by_id(id);
+
+    if (raw_fd < 0) {
+      continue;
+    }
+
+    auto fd = FD(raw_fd);
+
+    struct bpf_prog_info info = {};
+    __u32 info_len = sizeof(info);
+
+    if (bpf_obj_get_info_by_fd(fd, &info, &info_len) != 0) {
+      continue;
+    }
+
+    if (!info.btf_id) {
+      // BPF programs that don't have a BTF id won't load
+      continue;
+    }
+
+    ids_and_syms.emplace_back(id, get_prog_full_name(&info, fd));
+
+    // Now let's look at the subprograms for this program
+    // if they exist
+    if (info.nr_func_info == 0) {
+      continue;
+    }
+
+    size_t nr_func_info = info.nr_func_info;
+    size_t rec_size = info.func_info_rec_size;
+
+    if (rec_size > std::numeric_limits<std::size_t>::max() / nr_func_info) {
+      // This shouldn't happen
+      continue;
+    }
+
+    std::vector<char> fi_mem(nr_func_info * rec_size);
+
+    struct btf *btf = btf__load_from_kernel_by_id(info.btf_id);
+    if (!btf) {
+      continue;
+    }
+
+    SCOPE_EXIT
+    {
+      btf__free(btf);
+    };
+
+    info = {};
+    info.nr_func_info = nr_func_info;
+    info.func_info_rec_size = rec_size;
+    info.func_info = reinterpret_cast<__u64>(fi_mem.data());
+
+    if (bpf_prog_get_info_by_fd(fd, &info, &info_len) != 0) {
+      continue;
+    }
+
+    auto *func_info = reinterpret_cast<struct bpf_func_info *>(fi_mem.data());
+
+    for (__u32 i = 0; i < nr_func_info; i++) {
+      const struct btf_type *t = btf__type_by_id(btf, (func_info + i)->type_id);
+      if (!t) {
+        continue;
+      }
+
+      const char *func_name = btf__name_by_offset(btf, t->name_off);
+      ids_and_syms.emplace_back(id, std::string(func_name));
+    }
+  }
+
+  return ids_and_syms;
+}
+
+} // namespace bpftrace::util

--- a/src/util/bpf_progs.h
+++ b/src/util/bpf_progs.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace bpftrace::util {
+
+// This includes all BPF programs and subprograms
+// the pair is (prog id, symbol)
+std::vector<std::pair<__u32, std::string>> get_bpf_progs();
+
+} // namespace bpftrace::util

--- a/src/util/fd.h
+++ b/src/util/fd.h
@@ -43,8 +43,7 @@ public:
 
   operator int() const noexcept
   {
-    assert(fd_ >= 0);
-    return fd_;
+    return get();
   }
 
 private:

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -1259,6 +1259,54 @@ TEST_F(bpftrace_btf, add_probes_fentry)
               "fexit:mock_vmlinux:func_1");
 }
 
+TEST_F(bpftrace_btf, add_probes_fentry_bpf_func)
+{
+  auto bpftrace = get_mock_bpftrace();
+
+  parse_probe("fentry:bpf:func_1 {}", *bpftrace);
+
+  ASSERT_EQ(2U, bpftrace->get_probes().size());
+  ASSERT_EQ(0U, bpftrace->get_special_probes().size());
+
+  check_probe(bpftrace->get_probes().at(0),
+              ProbeType::fentry,
+              "fentry:bpf:123:func_1");
+  check_probe(bpftrace->get_probes().at(1),
+              ProbeType::fentry,
+              "fentry:bpf:456:func_1");
+}
+
+TEST_F(bpftrace_btf, add_probes_fentry_bpf_id)
+{
+  auto bpftrace = get_mock_bpftrace();
+
+  parse_probe("fentry:bpf:123:func_* {}", *bpftrace);
+
+  ASSERT_EQ(2U, bpftrace->get_probes().size());
+  ASSERT_EQ(0U, bpftrace->get_special_probes().size());
+
+  check_probe(bpftrace->get_probes().at(0),
+              ProbeType::fentry,
+              "fentry:bpf:123:func_1");
+  check_probe(bpftrace->get_probes().at(1),
+              ProbeType::fentry,
+              "fentry:bpf:123:func_2");
+}
+
+TEST_F(bpftrace_btf, add_probes_fentry_bpf_exact)
+{
+  auto bpftrace = get_mock_bpftrace();
+
+  parse_probe("fentry:bpf:456:func_1 {}", *bpftrace);
+
+  ASSERT_EQ(1U, bpftrace->get_probes().size());
+  ASSERT_EQ(0U, bpftrace->get_special_probes().size());
+
+  check_probe(bpftrace->get_probes().at(0),
+              ProbeType::fentry,
+              "fentry:bpf:456:func_1");
+}
+
 TEST_F(bpftrace_btf, add_probes_kprobe)
 {
   auto bpftrace = get_strict_mock_bpftrace();

--- a/tests/mocks.cpp
+++ b/tests/mocks.cpp
@@ -97,6 +97,13 @@ void setup_mock_probe_matcher(MockProbeMatcher &matcher)
             return std::unique_ptr<std::istream>(
                 new std::istringstream(sh_usdts + bash_usdts));
           });
+
+  ON_CALL(matcher, get_running_bpf_programs()).WillByDefault([]() {
+    std::string bpf_progs = "bpf:123:func_1\n"
+                            "bpf:123:func_2\n"
+                            "bpf:456:func_1\n";
+    return std::unique_ptr<std::istream>(new std::istringstream(bpf_progs));
+  });
 }
 
 void setup_mock_bpftrace(MockBPFtrace &bpftrace)

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -36,6 +36,8 @@ public:
 
   MOCK_CONST_METHOD0(get_fentry_symbols, std::unique_ptr<std::istream>());
 
+  MOCK_CONST_METHOD0(get_running_bpf_programs, std::unique_ptr<std::istream>());
+
 #pragma GCC diagnostic pop
 };
 

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -615,3 +615,12 @@ EXPECT WARNING: Unable to attach probe: tracepoint:syscalls:nonsense. Skipping.
 EXPECT WARNING: Unable to attach probe: uprobe:./testprogs/uprobe_test:uprobeFunction3. Skipping.
 EXPECT ERROR: Attachment failed for all probes.
 WILL_FAIL
+
+# This is hacky because we can't easily run a separate bpftrace program in BEFORE
+# because it would require more hacks in the runtime runner.py
+# including waiting for probe attachment in the BEFORE program
+NAME attach_to_bpf_program
+RUN {{BPFTRACE}} runtime/scripts/bpf_attach.bt & sleep 3 && {{BPFTRACE}} -e 'fentry:bpf:interval_us_* { print(probe); if (@c >= 1) { exit(); } @c = count(); }'
+EXPECT_REGEX fentry:bpf:[0-9]+:interval_us_100000_1
+EXPECT_REGEX fentry:bpf:[0-9]+:interval_us_100000_2
+TIMEOUT 10

--- a/tests/runtime/scripts/bpf_attach.bt
+++ b/tests/runtime/scripts/bpf_attach.bt
@@ -1,0 +1,13 @@
+// This script is used to test attaching to other BPF programs
+interval:100ms {
+    @a = 1;
+}
+
+interval:100ms {
+    @a = 2;
+}
+
+interval:10s {
+    clear(@a);
+    exit();
+}


### PR DESCRIPTION
Examples:
- `fentry:bpf:prog_name { ... }`
- `fentry:bpf:prog_id:prog_name { ... }`

This requires obtaining the fd for the BPF
program and passing it to `bpf_program__set_attach_target`.

Code for `get_prog_full_name` was shamelessly
taken from bpftool.

Getting a list of running BPF programs and sub programs is
also supported:
```
bpftrace -l 'fentry:bpf:*'
fentry:bpf:4217779:dnswatch_kprobe_udp_recvmsg
fentry:bpf:4217779:populate_cmdline
fentry:bpf:4217780:armr_env_get_len
fentry:bpf:4217780:armr_get_cgroup_from_task
```

You'll notice the names are prefixed with
their program ids.

##### Checklist

- [x] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
