### PR TITLE
Automatically exit early if only BEGIN/END

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,6 +90,8 @@ and this project adheres to
   - [#4194](https://github.com/bpftrace/bpftrace/pull/4291)
 - Only cache symbols from targeted process
   - [#4315](https://github.com/bpftrace/bpftrace/pull/4315)
+- Automatically exit if only BEGIN/END probes are specified
+  - [#4358](https://github.com/bpftrace/bpftrace/pull/4358)
 #### Deprecated
 #### Removed
 #### Fixed

--- a/tests/runtime/array
+++ b/tests/runtime/array
@@ -140,17 +140,17 @@ EXPECT @y: 1
 AFTER ./testprogs/array_access
 
 NAME cast literal to int array
-PROG BEGIN { printf("first byte: %x\n", ((int8[8])12345)[0]); exit(); }
+PROG BEGIN { printf("first byte: %x\n", ((int8[8])12345)[0]); }
 EXPECT first byte: 39
 TIMEOUT 1
 
 NAME cast to int array with automatic size
-PROG BEGIN { printf("byte: %x\n", ((int8[])12345)[0]); exit(); }
+PROG BEGIN { printf("byte: %x\n", ((int8[])12345)[0]); }
 EXPECT byte: 39
 TIMEOUT 1
 
 NAME cast int array to int internal
-PROG BEGIN { printf("ip: %x\n", (uint32)pton("127.0.0.1")); exit(); }
+PROG BEGIN { printf("ip: %x\n", (uint32)pton("127.0.0.1")); }
 EXPECT ip: 100007f
 AFTER ./testprogs/array_access
 

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -223,62 +223,62 @@ TIMEOUT 1
 WILL_FAIL
 
 NAME libraries under /usr/include are in the search path
-RUN {{BPFTRACE}} -e "$(echo "#include <sys/xattr.h>"; echo "BEGIN { exit(); }")" 2>&1
+RUN {{BPFTRACE}} -e "$(echo "#include <sys/xattr.h>"; echo "BEGIN { }")" 2>&1
 EXPECT_NONE file not found
 REQUIRES ls /usr/include/sys/xattr.h
 TIMEOUT 1
 
 NAME non existent library include fails
-RUN {{BPFTRACE}} -e "$(echo "#include <lol/no.h>"; echo "BEGIN { exit(); }")" 2>&1
+RUN {{BPFTRACE}} -e "$(echo "#include <lol/no.h>"; echo "BEGIN { }")" 2>&1
 EXPECT definitions.h:2:10: fatal error: 'lol/no.h' file not found
 TIMEOUT 1
 WILL_FAIL
 
 NAME defines work
-RUN {{BPFTRACE}} -e "$(echo '#define _UNDERSCORE 314'; echo 'BEGIN { printf("%d\n", _UNDERSCORE); exit(); }')"
+RUN {{BPFTRACE}} -e "$(echo '#define _UNDERSCORE 314'; echo 'BEGIN { printf("%d\n", _UNDERSCORE); }')"
 EXPECT 314
 TIMEOUT 1
 
 NAME clear map
-PROG BEGIN { @ = 1; @a[1] = 1; clear(@); clear(@a); printf("ok\n"); exit(); }
+PROG BEGIN { @ = 1; @a[1] = 1; clear(@); clear(@a); printf("ok\n"); }
 EXPECT ok
 TIMEOUT 1
 
 NAME clear count-map
-PROG BEGIN { @ = count(); @a[1] = count(); clear(@); clear(@a); exit(); }
+PROG BEGIN { @ = count(); @a[1] = count(); clear(@); clear(@a); }
 EXPECT @: 0
 TIMEOUT 1
 
 NAME delete map
-PROG BEGIN { @ = 1; @a[1] = 1; @b[1, 2] = 2; if (delete(@)) { printf("ok1\n"); } delete(@a, 1); if (delete(@b, (1, 2))) { printf("ok2\n"); } if (!delete(@b, (5, 6))) { printf("ok3\n"); } exit(); }
+PROG BEGIN { @ = 1; @a[1] = 1; @b[1, 2] = 2; if (delete(@)) { printf("ok1\n"); } delete(@a, 1); if (delete(@b, (1, 2))) { printf("ok2\n"); } if (!delete(@b, (5, 6))) { printf("ok3\n"); } }
 EXPECT ok1
 EXPECT ok2
 EXPECT ok3
 TIMEOUT 1
 
 NAME delete count-map
-PROG BEGIN { @ = count(); @a[1] = count(); delete(@); delete(@a, 1); exit(); }
+PROG BEGIN { @ = count(); @a[1] = count(); delete(@); delete(@a, 1); }
 EXPECT @: 0
 TIMEOUT 1
 
 NAME delete deprecated
-PROG BEGIN { @a[1] = 1; @b[2, "hi"] = 2; delete(@a[1]); delete(@b[2, "hi"]); exit(); }
+PROG BEGIN { @a[1] = 1; @b[2, "hi"] = 2; delete(@a[1]); delete(@b[2, "hi"]); }
 EXPECT_NONE @a[1]: 1
 EXPECT_NONE @b[2, hi]: 2
 TIMEOUT 1
 
 NAME bad delete warning
-PROG BEGIN { @a[1] = 1; delete(@a, 2); exit(); }
+PROG BEGIN { @a[1] = 1; delete(@a, 2); }
 EXPECT stdin:1:20-33: WARNING: Can't delete map element because it does not exist.
 TIMEOUT 1
 
 NAME bad delete no warning
-PROG BEGIN { @a[1] = 1; $x = delete(@a, 2); if (1 && !delete(@a, 3)) {} exit(); }
+PROG BEGIN { @a[1] = 1; $x = delete(@a, 2); if (1 && !delete(@a, 3)) {} }
 EXPECT_NONE stdin:1:20-33: WARNING: Can't delete map element because it does not exist.
 TIMEOUT 1
 
 NAME increment/decrement map
-PROG BEGIN { @x = 10; printf("%d", @x++); printf(" %d", ++@x); printf(" %d", @x--); printf(" %d\n", --@x); delete(@x); exit(); }
+PROG BEGIN { @x = 10; printf("%d", @x++); printf(" %d", ++@x); printf(" %d", @x--); printf(" %d\n", --@x); delete(@x); }
 EXPECT 10 12 12 10
 TIMEOUT 1
 
@@ -288,7 +288,7 @@ EXPECT SUCCESS
 TIMEOUT 10
 
 NAME increment/decrement variable
-PROG BEGIN { $x = 10; printf("%d", $x++); printf(" %d", ++$x); printf(" %d", $x--); printf(" %d\n", --$x); exit(); }
+PROG BEGIN { $x = 10; printf("%d", $x++); printf(" %d", ++$x); printf(" %d", $x--); printf(" %d\n", --$x);  }
 EXPECT 10 12 12 10
 TIMEOUT 1
 
@@ -303,12 +303,12 @@ EXPECT_REGEX ringbuf: yes
 TIMEOUT 1
 
 NAME basic while loop
-PROG BEGIN { $a = 0; while ($a <= 100) { @=avg($a++) } exit(); }
+PROG BEGIN { $a = 0; while ($a <= 100) { @=avg($a++) }  }
 EXPECT @: 50
 REQUIRES_FEATURE loop
 
 NAME disable warnings
-RUN {{BPFTRACE}} --no-warnings -e 'BEGIN { @x = stats(10); print(@x, 2); clear(@x); exit();}' 2>&1| grep -c -E "WARNING|invalid option"
+RUN {{BPFTRACE}} --no-warnings -e 'BEGIN { @x = stats(10); print(@x, 2); clear(@x); }' 2>&1| grep -c -E "WARNING|invalid option"
 EXPECT_REGEX ^0$
 TIMEOUT 1
 WILL_FAIL
@@ -322,40 +322,40 @@ TIMEOUT 1
 WILL_FAIL
 
 NAME variable strings are memset
-PROG BEGIN { $x = "xxxxx"; $x = "a"; @[$x] = 1; $y = "yyyyy"; $y = "a"; @[$y] = 1; printf("len: %d\n", len(@)); exit(); }
+PROG BEGIN { $x = "xxxxx"; $x = "a"; @[$x] = 1; $y = "yyyyy"; $y = "a"; @[$y] = 1; printf("len: %d\n", len(@));  }
 EXPECT len: 1
 TIMEOUT 1
 
 NAME map strings are memset
-PROG BEGIN { @x = "xxxxx"; @x = "a"; @[@x] = 1; @y = "yyyyy"; @y = "a"; @[@y] = 1; printf("len: %d\n", len(@)); exit(); }
+PROG BEGIN { @x = "xxxxx"; @x = "a"; @[@x] = 1; @y = "yyyyy"; @y = "a"; @[@y] = 1; printf("len: %d\n", len(@));  }
 EXPECT len: 1
 TIMEOUT 1
 
 NAME print_per_cpu_map_vals
 REQUIRES_FEATURE lookup_percpu_elem
-PROG BEGIN { @a = avg(5); @c = count(); @s = sum(5); @mn = min(1); @mx = max(-1); print((@a, @c, @s, @mn, @mx)); exit(); }
+PROG BEGIN { @a = avg(5); @c = count(); @s = sum(5); @mn = min(1); @mx = max(-1); print((@a, @c, @s, @mn, @mx));  }
 EXPECT (5, 1, 5, 1, -1)
 TIMEOUT 3
 
 NAME print large int
-PROG BEGIN { $a = 10223372036854775807; print(($a)); exit(); }
+PROG BEGIN { $a = 10223372036854775807; print(($a));  }
 EXPECT 10223372036854775807
 TIMEOUT 1
 
 NAME has_key exists
-PROG BEGIN { @a[1] = 0; if (has_key(@a, 1)) { printf("ok\n"); } exit(); }
+PROG BEGIN { @a[1] = 0; if (has_key(@a, 1)) { printf("ok\n"); }  }
 EXPECT ok
 
 NAME has_key no_exists
-PROG BEGIN { @a[1] = 0; if (has_key(@a, 2)) { printf("ok\n"); } exit(); }
+PROG BEGIN { @a[1] = 0; if (has_key(@a, 2)) { printf("ok\n"); }  }
 EXPECT_NONE ok
 
 NAME has_key complex tuple
-PROG BEGIN { @a[1, ("hello", (int8)5)] = 0; if (has_key(@a, (1, ("hello", 5)))) { printf("ok\n"); } exit(); }
+PROG BEGIN { @a[1, ("hello", (int8)5)] = 0; if (has_key(@a, (1, ("hello", 5)))) { printf("ok\n"); }  }
 EXPECT ok
 
 NAME has_key map value as key
-PROG BEGIN { @g = 2; @a[2] = 0; if (has_key(@a, @g)) { printf("ok\n"); } exit(); }
+PROG BEGIN { @g = 2; @a[2] = 0; if (has_key(@a, @g)) { printf("ok\n"); }  }
 EXPECT ok
 
 NAME exit code
@@ -364,5 +364,5 @@ RETURN_CODE 69
 TIMEOUT 1
 
 NAME block expression
-PROG BEGIN { let $a = { let $b = 1; $b }; print($a); exit(); }
+PROG BEGIN { let $a = { let $b = 1; $b }; print($a);  }
 EXPECT 1

--- a/tests/runtime/bool
+++ b/tests/runtime/bool
@@ -1,21 +1,21 @@
 NAME bool values
-PROG BEGIN { print((true, false)); exit(); }
+PROG BEGIN { print((true, false));  }
 EXPECT (true, false)
 TIMEOUT 1
 
 NAME bool in conditional
-PROG BEGIN { if (true) { print(1); } if (false) { print(2); } exit(); }
+PROG BEGIN { if (true) { print(1); } if (false) { print(2); }  }
 EXPECT 1
 EXPECT_NONE 2
 TIMEOUT 1
 
 NAME bool as map keys and values
-PROG BEGIN { @a[true] = false; exit(); }
+PROG BEGIN { @a[true] = false;  }
 EXPECT @a[true]: false
 TIMEOUT 1
 
 NAME bool as a variable
-PROG BEGIN { $b = true; $c = false; print(($b, $c)); exit(); }
+PROG BEGIN { $b = true; $c = false; print(($b, $c));  }
 EXPECT (true, false)
 
 NAME cast int to bool
@@ -29,7 +29,7 @@ EXPECT (true, false)
 TIMEOUT 1
 
 NAME cast ptr to bool
-PROG BEGIN { $a = (int64*)0; $b = (int64*)1; print(((bool)$b, (bool)$a)); exit(); }
+PROG BEGIN { $a = (int64*)0; $b = (int64*)1; print(((bool)$b, (bool)$a));  }
 EXPECT (true, false)
 TIMEOUT 1
 
@@ -44,7 +44,7 @@ EXPECT (1, 0)
 TIMEOUT 1
 
 NAME bool array
-PROG BEGIN { @a = (bool[2])(uint16)1; exit(); }
+PROG BEGIN { @a = (bool[2])(uint16)1;  }
 EXPECT @a: [true,false]
 TIMEOUT 1
 
@@ -54,7 +54,7 @@ EXPECT (true, false)
 TIMEOUT 1
 
 NAME bool in resized tuples
-PROG BEGIN { @a[false, 1, true] = 1; @a[true, (int32)2, false] = 2; exit(); }
+PROG BEGIN { @a[false, 1, true] = 1; @a[true, (int32)2, false] = 2;  }
 EXPECT @a[false, 1, true]: 1
 EXPECT @a[true, 2, false]: 2
 TIMEOUT 1

--- a/tests/runtime/btf
+++ b/tests/runtime/btf
@@ -1,5 +1,5 @@
 NAME user_supplied_c_def_using_btf
-PROG struct foo { struct task_struct t; } BEGIN { exit(); }
+PROG struct foo { struct task_struct t; } BEGIN {  }
 EXPECT Attached 1 probe
 REQUIRES_FEATURE btf
 
@@ -14,7 +14,7 @@ EXPECT Attached 1 probe
 REQUIRES_FEATURE btf
 
 NAME enum_value_reference
-PROG BEGIN { printf("%d\n", sizeof(BTF_VAR_STATIC)); exit(); }
+PROG BEGIN { printf("%d\n", sizeof(BTF_VAR_STATIC));  }
 EXPECT_REGEX ^8$
 REQUIRES_FEATURE btf
 

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -31,19 +31,19 @@ PROG i:ms:1 { printf("SUCCESS %lu\n", cpu); exit(); }
 EXPECT_REGEX SUCCESS [0-9]+
 
 NAME ncpus
-PROG BEGIN { printf("%ld\n", ncpus); exit(); }
+PROG BEGIN { printf("%ld\n", ncpus);  }
 EXPECT_REGEX ^[1-9][0-9]*$
 
 NAME comm
-PROG BEGIN { printf("SUCCESS %s\n", comm); exit(); }
+PROG BEGIN { printf("SUCCESS %s\n", comm);  }
 EXPECT SUCCESS bpftrace
 
 NAME kstack
-PROG BEGIN { printf("%s\n", kstack); exit(); }
+PROG BEGIN { printf("%s\n", kstack);  }
 EXPECT Attached 1 probe
 
 NAME ustack
-PROG BEGIN { printf("%s\n", ustack); exit(); }
+PROG BEGIN { printf("%s\n", ustack);  }
 EXPECT Attached 1 probe
 
 NAME arg
@@ -105,7 +105,7 @@ EXPECT SUCCESS kprobe:do_nanosleep
 AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME begin probe
-PROG BEGIN { printf("%s", probe);exit(); } END{printf("-%s\n", probe); }
+PROG BEGIN { printf("%s", probe); } END{printf("-%s\n", probe); }
 EXPECT_REGEX ^BEGIN-END$
 AFTER ./testprogs/syscall nanosleep 1e8
 
@@ -160,25 +160,25 @@ PROG i:ms:1 { cat("/does/not/exist/file"); exit(); }
 EXPECT ERROR: failed to open file '/does/not/exist/file': No such file or directory
 
 NAME sizeof
-PROG struct Foo { int x; char c; } BEGIN { $x = 1; printf("%d %d %d %d %d\n", sizeof(struct Foo), sizeof((*(struct Foo*)0).x), sizeof((*(struct Foo*)0).c), sizeof(1 == 1), sizeof($x)); exit(); }
+PROG struct Foo { int x; char c; } BEGIN { $x = 1; printf("%d %d %d %d %d\n", sizeof(struct Foo), sizeof((*(struct Foo*)0).x), sizeof((*(struct Foo*)0).c), sizeof(1 == 1), sizeof($x));  }
 EXPECT 8 4 1 1 8
 
 NAME sizeof_ints
-PROG BEGIN { printf("%d %d %d %d %d %d\n", sizeof(uint8), sizeof(int8), sizeof(uint16), sizeof(int16), sizeof(uint32), sizeof(int32)); exit(); }
+PROG BEGIN { printf("%d %d %d %d %d %d\n", sizeof(uint8), sizeof(int8), sizeof(uint16), sizeof(int16), sizeof(uint32), sizeof(int32));  }
 EXPECT 1 1 2 2 4 4
 
 # printf only takes 7 args
 NAME sizeof_ints_pt2
-PROG BEGIN { printf("%d %d\n", sizeof(uint64), sizeof(int64)); exit(); }
+PROG BEGIN { printf("%d %d\n", sizeof(uint64), sizeof(int64));  }
 EXPECT 8 8
 
 NAME sizeof_btf
-PROG BEGIN { printf("size=%d\n", sizeof(struct task_struct)); exit(); }
+PROG BEGIN { printf("size=%d\n", sizeof(struct task_struct));  }
 EXPECT_REGEX ^size=
 REQUIRES_FEATURE btf
 
 NAME offsetof
-PROG struct Foo { int x; struct Bar { int x; } bar; } BEGIN { printf("%ld %ld\n", offsetof(struct Foo, x), offsetof(struct Foo, bar.x)); exit(); }
+PROG struct Foo { int x; struct Bar { int x; } bar; } BEGIN { printf("%ld %ld\n", offsetof(struct Foo, x), offsetof(struct Foo, bar.x));  }
 EXPECT_REGEX ^0 4$
 
 NAME print args in fentry
@@ -256,11 +256,11 @@ AFTER ./testprogs/uprobe_symres
 ARCH x86_64
 
 NAME usermode_builtin_in_BEGIN_END
-PROG BEGIN { printf("%d ", usermode); exit(); } END { print(usermode); }
+PROG BEGIN { printf("%d ", usermode);  } END { print(usermode); }
 EXPECT 1 1
 ARCH x86_64
 
 NAME usermode_builtin_in_unsupported_arch
-PROG BEGIN { printf("%d ", usermode); exit(); } END { print(usermode); }
+PROG BEGIN { printf("%d ", usermode);  } END { print(usermode); }
 EXPECT ERROR: 'usermode' builtin is only supported on x86_64
 ARCH aarch64

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -11,7 +11,7 @@ PROG i:ms:1 { printf("value: %dms100\n", 100); exit();}
 EXPECT value: 100ms100
 
 NAME printf_llu
-PROG BEGIN { @start = nsecs; } i:s:1 { printf("Elapsed time: %llus\n", (nsecs - @start)/1000000000); clear(@start); exit();}
+PROG BEGIN { @start = nsecs; } i:s:1 { printf("Elapsed time: %llus\n", (nsecs - @start)/1000000000); clear(@start); }
 EXPECT Elapsed time: 1s
 
 NAME printf_argument_alignment
@@ -19,15 +19,15 @@ RUN {{BPFTRACE}} -e 'struct Foo { int a; char b[10]; } uprobe:testprogs/uprobe_t
 EXPECT 123 hello 456 world
 
 NAME printf_more_arguments
-PROG BEGIN { printf("%dst: %sa; %dnd: %sb;; %drd: %sc;;; %dth: %sd;;;;\n", 1, "a", 2, "ab", 3, "abc", 4, "abcd"); exit(); }
+PROG BEGIN { printf("%dst: %sa; %dnd: %sb;; %drd: %sc;;; %dth: %sd;;;;\n", 1, "a", 2, "ab", 3, "abc", 4, "abcd");  }
 EXPECT 1st: aa; 2nd: abb;; 3rd: abcc;;; 4th: abcdd;;;;
 
 NAME printf_length_modifiers
-PROG BEGIN { $x = 0x12345678abcdef; printf("%hhx %hx %x %jx\n", $x, $x, $x, $x); exit(); }
+PROG BEGIN { $x = 0x12345678abcdef; printf("%hhx %hx %x %jx\n", $x, $x, $x, $x);  }
 EXPECT ef cdef 78abcdef 12345678abcdef
 
 NAME printf_char
-PROG BEGIN { printf("%c%c%c%c\n", 0x41, 0x42, 0x43, 0x44); exit(); }
+PROG BEGIN { printf("%c%c%c%c\n", 0x41, 0x42, 0x43, 0x44);  }
 EXPECT ABCD
 
 NAME printf_enum_symbolize
@@ -180,7 +180,7 @@ EXPECT (1, 1)
 
 # Verify enough buffer space is allocated for same variable name in multiple subprograms
 NAME variable_probe_subprog_scratch_buf
-PROG config = { on_stack_limit = 0 } BEGIN { $x = "XXXX" } i:ms:100 { $x = "YYYY"; exit(); }END { $x = "ZZZZ"; print($x) }
+PROG config = { on_stack_limit = 0 } BEGIN { $x = "XXXX" } i:ms:100 { $x = "YYYY";  }END { $x = "ZZZZ"; print($x) }
 EXPECT ZZZZ
 
 NAME scalar_map_scratch_buf
@@ -238,11 +238,11 @@ PROG i:ms:100 { @[buf("ok_key", 6)] = 1; exit(); }
 EXPECT @[ok_key]: 1
 
 NAME buf_map_multikey
-PROG BEGIN { @[buf("ok_key", 7), 1] = hist(1); exit(); }
+PROG BEGIN { @[buf("ok_key", 7), 1] = hist(1);  }
 EXPECT @[ok_key\x00, 1]:
 
 NAME buf_hist_map_key
-PROG BEGIN { @[buf("ok_key", 7)] = hist(1); exit(); }
+PROG BEGIN { @[buf("ok_key", 7)] = hist(1);  }
 EXPECT @[ok_key\x00]:
 
 NAME buf_map_value
@@ -250,11 +250,11 @@ PROG i:ms:100 { @ = buf("ok_value", 8); exit(); }
 EXPECT @: ok_value
 
 NAME buf_no_ascii
-PROG BEGIN { printf("%rx", buf("Hello\0", 6)); exit(); }
+PROG BEGIN { printf("%rx", buf("Hello\0", 6));  }
 EXPECT \x48\x65\x6c\x6c\x6f\x00
 
 NAME buf_no_ascii_no_escaping
-PROG BEGIN { printf("%rh", buf("Hello\0", 6)); exit(); }
+PROG BEGIN { printf("%rh", buf("Hello\0", 6));  }
 EXPECT 48 65 6c 6c 6f 00
 
 NAME ksym
@@ -294,37 +294,37 @@ PROG i:ms:100 { @ = count(); exit();}
 EXPECT_REGEX @:\s[0-9]+
 
 NAME sum
-PROG BEGIN { @sum = sum(1); @sum = sum(2); @sum = sum(3); exit();}
+PROG BEGIN { @sum = sum(1); @sum = sum(2); @sum = sum(3); }
 EXPECT @sum: 6
 
 NAME avg
-PROG BEGIN { @avg = avg(1); @avg = avg(2); @avg = avg(3); exit();}
+PROG BEGIN { @avg = avg(1); @avg = avg(2); @avg = avg(3); }
 EXPECT @avg: 2
 
 NAME min
-PROG BEGIN { @min = min(2); @min = min(1); @min = min(3); exit();}
+PROG BEGIN { @min = min(2); @min = min(1); @min = min(3); }
 EXPECT @min: 1
 
 NAME max
-PROG BEGIN { @max = max(1); @max = max(3); @max = max(2); exit();}
+PROG BEGIN { @max = max(1); @max = max(3); @max = max(2); }
 EXPECT @max: 3
 
 NAME stats
-PROG BEGIN { @stats = stats(1); @stats = stats(2); @stats = stats(3); exit();}
+PROG BEGIN { @stats = stats(1); @stats = stats(2); @stats = stats(3); }
 EXPECT @stats: count 3, average 2, total 6
 
 NAME hist
-PROG BEGIN { @=hist(-1); @=hist(2); @=hist(3); @=hist(7); @=hist(20); exit();}
+PROG BEGIN { @=hist(-1); @=hist(2); @=hist(3); @=hist(7); @=hist(20); }
 EXPECT_FILE runtime/outputs/hist.txt
 TIMEOUT 1
 
 NAME hist_2_values
-PROG BEGIN { @=hist(3);@=hist(20);exit();}
+PROG BEGIN { @=hist(3);@=hist(20);}
 EXPECT_FILE runtime/outputs/hist_2_values.txt
 TIMEOUT 1
 
 NAME hist_10g
-PROG BEGIN { @ = hist(10 * 1024 * 1024 * 1024); exit(); }
+PROG BEGIN { @ = hist(10 * 1024 * 1024 * 1024);  }
 EXPECT_JSON runtime/outputs/hist_10g.json
 TIMEOUT 1
 
@@ -487,46 +487,46 @@ EXPECT (1, 2, hi)
 TIMEOUT 1
 
 NAME strftime
-PROG BEGIN { $ts = strftime("%m/%d/%y", nsecs); printf("%s\n", $ts); exit(); }
+PROG BEGIN { $ts = strftime("%m/%d/%y", nsecs); printf("%s\n", $ts);  }
 EXPECT_REGEX [0-9]{2}\/[0-9]{2}\/[0-9]{2}
 
 NAME strftime_as_map_key
-PROG BEGIN { @[strftime("%m/%d/%y", nsecs)] = 1; exit();}
+PROG BEGIN { @[strftime("%m/%d/%y", nsecs)] = 1; }
 EXPECT_REGEX \[[0-9]{2}\/[0-9]{2}\/[0-9]{2}\]: 1
 
 NAME strftime_as_map_value
-PROG BEGIN { @[nsecs] = strftime("%m/%d/%y", nsecs); exit();}
+PROG BEGIN { @[nsecs] = strftime("%m/%d/%y", nsecs); }
 EXPECT_REGEX @\[[0-9]*\]: [0-9]{2}\/[0-9]{2}\/[0-9]{2}
 
 # Output two microsecond timestamps, 123000 nsecs apart. Use python to evaluate and verify there's a 123us delta
 NAME strftime_microsecond_extension
-RUN {{BPFTRACE}} -e 'BEGIN { printf("%s - %s\n", strftime("%s.%f", 123000), strftime("%s.%f", 0)); exit(); }' | tail -n +3 | bc
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%s - %s\n", strftime("%s.%f", 123000), strftime("%s.%f", 0));  }' | tail -n +3 | bc
 EXPECT .000123
 TIMEOUT 1
 
 # Similar to above test but test that rolling over past 1s works as expected
 NAME strftime_microsecond_extension_rollover
-RUN {{BPFTRACE}} -e 'BEGIN { printf("%s - %s\n", strftime("%s.%f", 1000123000), strftime("%s.%f", 0)); exit(); }' | tail -n +3 | bc
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%s - %s\n", strftime("%s.%f", 1000123000), strftime("%s.%f", 0));  }' | tail -n +3 | bc
 EXPECT 1.000123
 TIMEOUT 1
 
 NAME print_avg_map_args
-PROG BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 2, 10); clear(@); exit(); }
+PROG BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 2, 10); clear(@);  }
 EXPECT_FILE  runtime/outputs/print_avg_map_args.txt
 TIMEOUT 1
 
 NAME print_avg_map_with_large_top
-PROG BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 10, 10); clear(@); exit(); }
+PROG BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 10, 10); clear(@);  }
 EXPECT_FILE runtime/outputs/print_avg_map_with_large_top.txt
 TIMEOUT 1
 
 NAME print_hist_with_top_arg
-PROG BEGIN { print("BEGIN"); @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 2); print("END"); clear(@); exit(); }
+PROG BEGIN { print("BEGIN"); @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 2); print("END"); clear(@);  }
 EXPECT_REGEX BEGIN\n@\[2\]:(.*\n)+@\[3\]:(.*\n)+END
 TIMEOUT 1
 
 NAME print_hist_with_large_top_arg
-PROG BEGIN { print("BEGIN"); @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 10); print("END"); clear(@); exit(); }
+PROG BEGIN { print("BEGIN"); @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 10); print("END"); clear(@);  }
 EXPECT_REGEX BEGIN\n@\[1\]:(.*\n)+@\[2\]:(.*\n)+@\[3\]:(.*\n)+END
 TIMEOUT 1
 
@@ -587,48 +587,48 @@ EXPECT hello: 0
 REQUIRES_FEATURE iter
 
 NAME cgroup_path
-PROG BEGIN { print(cgroup_path(cgroup & ((1 << 32) - 1))); exit(); }
+PROG BEGIN { print(cgroup_path(cgroup & ((1 << 32) - 1)));  }
 EXPECT_REGEX ([a-z]*:\/.*;)*[a-z]*:\/.*
 REQUIRES grep -q '^cgroup2' /proc/mounts
 MIN_KERNEL 4.18
 
 NAME cgroup_path printf
-PROG BEGIN { printf("path: %s", cgroup_path(cgroup & ((1 << 32) - 1))); exit(); }
+PROG BEGIN { printf("path: %s", cgroup_path(cgroup & ((1 << 32) - 1)));  }
 EXPECT_REGEX path: ([a-z]*:\/.*;)*[a-z]*:\/.*
 REQUIRES grep -q '^cgroup2' /proc/mounts
 MIN_KERNEL 4.18
 
 NAME strerror
-RUN {{BPFTRACE}} --include "errno.h" -e 'BEGIN { print(strerror(EPERM)); exit(); }'
+RUN {{BPFTRACE}} --include "errno.h" -e 'BEGIN { print(strerror(EPERM));  }'
 EXPECT Operation not permitted
 
 NAME bswap_int64
-RUN {{BPFTRACE}} -e 'BEGIN { printf("%llx", bswap(0x1122334455667788)); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%llx", bswap(0x1122334455667788));  }'
 EXPECT 8877665544332211
 TIMEOUT 1
 
 NAME bswap_int32
-RUN {{BPFTRACE}} -e 'BEGIN { printf("%x", bswap((int32)0x12345678)); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%x", bswap((int32)0x12345678));  }'
 EXPECT 78563412
 TIMEOUT 1
 
 NAME bswap_int16
-RUN {{BPFTRACE}} -e 'BEGIN { printf("%x", bswap((int16)0x1234)); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%x", bswap((int16)0x1234));  }'
 EXPECT 3412
 TIMEOUT 1
 
 NAME bswap_int8
-RUN {{BPFTRACE}} -e 'BEGIN { printf("%x", bswap((int8)0x12)); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%x", bswap((int8)0x12));  }'
 EXPECT 12
 TIMEOUT 1
 
 NAME bswap_int64_op
-RUN {{BPFTRACE}} -e 'BEGIN { printf("%llx", bswap(0x12340000 + 0x5678)); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%llx", bswap(0x12340000 + 0x5678));  }'
 EXPECT 7856341200000000
 TIMEOUT 1
 
 NAME bswap_twice
-RUN {{BPFTRACE}} -e 'BEGIN { printf("%x", bswap(bswap(0x1234))); exit(); }'
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%x", bswap(bswap(0x1234)));  }'
 EXPECT 1234
 TIMEOUT 1
 
@@ -700,28 +700,28 @@ PROG i:ms:1 { printf("SUCCESS %llu\n", nsecs(sw_tai)); exit(); }
 EXPECT_REGEX SUCCESS [0-9]+
 
 NAME map len
-PROG BEGIN { @[0] = 0; @[1] = 1; printf("map len: %d\n", len(@)); exit(); }
+PROG BEGIN { @[0] = 0; @[1] = 1; printf("map len: %d\n", len(@));  }
 EXPECT map len: 2
 TIMEOUT 3
 
 NAME map lencmp
-PROG BEGIN { @[1] = 1; @[2] = 2; $count = len(@); if ($count > 1) { print("true"); } exit(); }
+PROG BEGIN { @[1] = 1; @[2] = 2; $count = len(@); if ($count > 1) { print("true"); }  }
 EXPECT true
 TIMEOUT 3
 
 NAME map len keyless
-PROG BEGIN { @ = 0; printf("map len: %d\n", len(@)); exit(); }
+PROG BEGIN { @ = 0; printf("map len: %d\n", len(@));  }
 EXPECT stdin:1:40-45: ERROR: call to len() expects a map with explicit keys (non-scalar map)
-       BEGIN { @ = 0; printf("map len: %d\n", len(@)); exit(); }
+       BEGIN { @ = 0; printf("map len: %d\n", len(@));  }
                                               ~~~~~
 WILL_FAIL
 
 NAME percpu_kaddr
-PROG BEGIN { printf("processes: %d\n", *percpu_kaddr("process_counts", 0)); exit(); }
+PROG BEGIN { printf("processes: %d\n", *percpu_kaddr("process_counts", 0));  }
 EXPECT_REGEX processes: -?[0-9]+
 
 NAME percpu_kaddr this cpu
-PROG BEGIN { if (*percpu_kaddr("process_counts") == *percpu_kaddr("process_counts", cpu)) { printf("SUCCESS\n") } exit(); }
+PROG BEGIN { if (*percpu_kaddr("process_counts") == *percpu_kaddr("process_counts", cpu)) { printf("SUCCESS\n") }  }
 EXPECT SUCCESS
 
 NAME percpu_kaddr field access
@@ -750,5 +750,5 @@ EXPECT_REGEX @: \d+$
 AFTER ./testprogs/syscall nanosleep  1e8
 
 NAME block expression with map assignment
-PROG BEGIN { @ = { let $a = 100; avg($a) }; exit(); }
+PROG BEGIN { @ = { let $a = 100; avg($a) };  }
 EXPECT @: 100

--- a/tests/runtime/config
+++ b/tests/runtime/config
@@ -25,17 +25,17 @@ EXPECT stdin:1:12-26: ERROR: debug_output: can only be set as an environment var
 WILL_FAIL
 
 NAME maps are printed by default
-PROG BEGIN { @["test"] = count(); exit(); }
+PROG BEGIN { @["test"] = count();  }
 EXPECT @[test]: 1
 
 NAME maps can be disabled
-PROG config = { print_maps_on_exit=0 } BEGIN { @["test"] = count(); exit(); }
+PROG config = { print_maps_on_exit=0 } BEGIN { @["test"] = count();  }
 EXPECT_NONE @[test]: 1
 
 NAME scalar maps are printed by default
-PROG BEGIN { @test = 1; exit(); }
+PROG BEGIN { @test = 1;  }
 EXPECT @test: 1
 
 NAME scalar maps can be disabled
-PROG config = { print_maps_on_exit=0 } BEGIN { @test = 1; exit(); }
+PROG config = { print_maps_on_exit=0 } BEGIN { @test = 1;  }
 EXPECT_NONE @test: 1

--- a/tests/runtime/for
+++ b/tests/runtime/for
@@ -1,137 +1,137 @@
 NAME map one key
-PROG BEGIN { @map[16] = 32; @map[64] = 128; for ($kv : @map) { print($kv); } exit(); }
+PROG BEGIN { @map[16] = 32; @map[64] = 128; for ($kv : @map) { print($kv); }  }
 EXPECT (16, 32)
 EXPECT (64, 128)
 
 NAME map two keys
-PROG BEGIN { @map[16,17] = 32; @map[64,65] = 128; for ($kv : @map) { print($kv); } exit(); }
+PROG BEGIN { @map[16,17] = 32; @map[64,65] = 128; for ($kv : @map) { print($kv); }  }
 EXPECT ((16, 17), 32)
 EXPECT ((64, 65), 128)
 
 NAME map one key elements
-PROG BEGIN { @map[16] = 32; for ($kv : @map) { printf("key: %d, val: %d\n", $kv.0, $kv.1); } exit(); }
+PROG BEGIN { @map[16] = 32; for ($kv : @map) { printf("key: %d, val: %d\n", $kv.0, $kv.1); }  }
 EXPECT key: 16, val: 32
 
 NAME map two key elements
-PROG BEGIN { @map[16,17] = 32; for ($kv : @map) { printf("key: (%d,%d), val: %d\n", $kv.0.0, $kv.0.1, $kv.1); } exit(); }
+PROG BEGIN { @map[16,17] = 32; for ($kv : @map) { printf("key: (%d,%d), val: %d\n", $kv.0.0, $kv.0.1, $kv.1); }  }
 EXPECT key: (16,17), val: 32
 
 NAME map strings
-PROG BEGIN { @map["abc"] = "aa"; @map["def"] = "dd"; for ($kv : @map) { print($kv); } exit(); }
+PROG BEGIN { @map["abc"] = "aa"; @map["def"] = "dd"; for ($kv : @map) { print($kv); }  }
 EXPECT (abc, aa)
 EXPECT (def, dd)
 
 NAME map create map in body
-PROG BEGIN { @map[16] = 32; @map[64] = 128; for ($kv : @map) { @new[$kv.1] = $kv.0; } print(@new); exit(); }
+PROG BEGIN { @map[16] = 32; @map[64] = 128; for ($kv : @map) { @new[$kv.1] = $kv.0; } print(@new);  }
 EXPECT @new[32]: 16
 EXPECT @new[128]: 64
 
 NAME map multiple loops
-PROG BEGIN { @mapA[16] = 32; @mapA[17] = 33; @mapB[64] = 128; @mapB[65] = 129; for ($kv : @mapA) { print($kv); } for ($kv : @mapB) { print($kv); } exit(); }
+PROG BEGIN { @mapA[16] = 32; @mapA[17] = 33; @mapB[64] = 128; @mapB[65] = 129; for ($kv : @mapA) { print($kv); } for ($kv : @mapB) { print($kv); }  }
 EXPECT (16, 32)
 EXPECT (17, 33)
 EXPECT (64, 128)
 EXPECT (65, 129)
 
 NAME map multiple probes
-PROG BEGIN { @mapA[16] = 32; @mapA[17] = 33; @mapB[64] = 128; @mapB[65] = 129; for ($kv : @mapA) { print($kv); } exit(); } END { for ($kv : @mapB) { print($kv); } }
+PROG BEGIN { @mapA[16] = 32; @mapA[17] = 33; @mapB[64] = 128; @mapB[65] = 129; for ($kv : @mapA) { print($kv); }  } END { for ($kv : @mapB) { print($kv); } }
 EXPECT (16, 32)
 EXPECT (17, 33)
 EXPECT (64, 128)
 EXPECT (65, 129)
 
 NAME map nested vals
-PROG BEGIN { @mapA[16] = 32; @mapB[64] = 128; @mapB[65] = 129; for ($kv : @mapA) { print($kv); for ($kv2 : @mapB) { print($kv2); } } exit(); }
+PROG BEGIN { @mapA[16] = 32; @mapB[64] = 128; @mapB[65] = 129; for ($kv : @mapA) { print($kv); for ($kv2 : @mapB) { print($kv2); } }  }
 EXPECT (16, 32)
 EXPECT (64, 128)
 EXPECT (65, 129)
 
 NAME map nested count
-PROG BEGIN { @mapA[16] = 32; @mapA[17] = 33; @mapB[64] = 128; @mapB[65] = 129; @mapB[66] = 130; for ($kv : @mapA) { printf("A"); for ($kv2 : @mapB) { printf("B"); } } exit(); }
+PROG BEGIN { @mapA[16] = 32; @mapA[17] = 33; @mapB[64] = 128; @mapB[65] = 129; @mapB[66] = 130; for ($kv : @mapA) { printf("A"); for ($kv2 : @mapB) { printf("B"); } }  }
 EXPECT ABBBABBB
 
 NAME map delete
-PROG BEGIN { @[0,0,0] = 1; @[0,0,1] = 1; @[0,1,0] = 1; @[1,0,0] = 1; for ($kv : @) { if ($kv.0.1 == 1) { delete(@, $kv.0); } } exit(); }
+PROG BEGIN { @[0,0,0] = 1; @[0,0,1] = 1; @[0,1,0] = 1; @[1,0,0] = 1; for ($kv : @) { if ($kv.0.1 == 1) { delete(@, $kv.0); } }  }
 EXPECT @[0, 0, 0]: 1
 EXPECT @[0, 0, 1]: 1
 EXPECT @[1, 0, 0]: 1
 EXPECT_NONE @[0, 1, 0]: 1
 
 NAME variable context read only
-PROG BEGIN { @map[0] = 0; $var = 123; for ($kv : @map) { print($var); } exit(); }
+PROG BEGIN { @map[0] = 0; $var = 123; for ($kv : @map) { print($var); }  }
 EXPECT 123
 
 NAME variable context update
-PROG BEGIN { @map[0] = 0; @map[1] = 1; $var = 123; for ($kv : @map) { print($var); $var *= 2; } print($var); exit(); }
+PROG BEGIN { @map[0] = 0; @map[1] = 1; $var = 123; for ($kv : @map) { print($var); $var *= 2; } print($var);  }
 EXPECT_REGEX ^123\n246\n492$
 
 NAME variable context string
-PROG BEGIN { @map[0] = 0; @map[1] = 1; $var = "abc"; for ($kv : @map) { print($var); $var = "def"; } print($var); exit(); }
+PROG BEGIN { @map[0] = 0; @map[1] = 1; $var = "abc"; for ($kv : @map) { print($var); $var = "def"; } print($var);  }
 EXPECT_REGEX ^abc\ndef\ndef$
 
 NAME variable context multiple
-PROG BEGIN { @map[0] = 0; $var1 = 123; $var2 = "abc"; for ($kv : @map) { print(($var1, $var2)); } exit(); }
+PROG BEGIN { @map[0] = 0; $var1 = 123; $var2 = "abc"; for ($kv : @map) { print(($var1, $var2)); }  }
 EXPECT (123, abc)
 
 NAME map two keys with a per cpu aggregation
 REQUIRES_FEATURE lookup_percpu_elem
-PROG BEGIN { @map[16,17] = count(); @map[16,17] = count(); @map[1,2] = count(); for ($kv : @map) { print($kv); } exit(); }
+PROG BEGIN { @map[16,17] = count(); @map[16,17] = count(); @map[1,2] = count(); for ($kv : @map) { print($kv); }  }
 EXPECT ((16, 17), 2)
 EXPECT ((1, 2), 1)
 
 NAME map stack key with a per cpu aggregation
 REQUIRES_FEATURE lookup_percpu_elem
-PROG BEGIN { @map[kstack(raw)] = count(); for ($kv : @map) { print($kv.1); } exit(); }
+PROG BEGIN { @map[kstack(raw)] = count(); for ($kv : @map) { print($kv.1); }  }
 EXPECT 1
 
 NAME map with break
-PROG BEGIN { @map["foo"] = 1; @map["bar"] = 2; print("start"); for ($i : @map) { print($i.0); break; } print("done"); exit(); }
+PROG BEGIN { @map["foo"] = 1; @map["bar"] = 2; print("start"); for ($i : @map) { print($i.0); break; } print("done");  }
 EXPECT_REGEX .*start\n(foo|bar)\ndone\n\n
 
 NAME map with continue
-PROG BEGIN { @map["foo"] = 1; @map["bar"] = 2; print("start"); for ($i : @map) { if ($i.0 == "bar") { continue; } print($i.0); } exit(); }
+PROG BEGIN { @map["foo"] = 1; @map["bar"] = 2; print("start"); for ($i : @map) { if ($i.0 == "bar") { continue; } print($i.0); }  }
 EXPECT_REGEX .*start\nfoo\n\n
 
 NAME range basic
-PROG BEGIN { for ($i : 0..5) { print($i); } exit(); }
+PROG BEGIN { for ($i : 0..5) { print($i); }  }
 EXPECT_REGEX .*\n0\n1\n2\n3\n4\n\n
 
 NAME range with variables
-PROG BEGIN { $start = 2; $end = 7; for ($i : $start..$end) { print($i); } exit(); }
+PROG BEGIN { $start = 2; $end = 7; for ($i : $start..$end) { print($i); }  }
 EXPECT_REGEX .*\n2\n3\n4\n5\n6\n\n
 
 NAME range with expressions
-PROG BEGIN { for ($i : (1+1)..(2*4)) { print($i); } exit(); }
+PROG BEGIN { for ($i : (1+1)..(2*4)) { print($i); }  }
 EXPECT_REGEX .*\n2\n3\n4\n5\n6\n7\n\n
 
 NAME range with map as expression
-PROG BEGIN { @map[5] = 8; for ($i : 0..@map[5]) { print($i); } exit(); }
+PROG BEGIN { @map[5] = 8; for ($i : 0..@map[5]) { print($i); }  }
 EXPECT_REGEX .*\n2\n3\n4\n5\n6\n7\n\n
 
 NAME range with zero iterations
-PROG BEGIN { for ($i : 1..0) { print("here"); } exit(); }
+PROG BEGIN { for ($i : 1..0) { print("here"); }  }
 EXPECT_NONE here
 
 NAME range with negative start
-PROG BEGIN { for ($i : (-3)..3) { print($i); } exit(); }
+PROG BEGIN { for ($i : (-3)..3) { print($i); }  }
 EXPECT_REGEX .*\n-3\n-2\n-1\n0\n1\n2\n\n
 
 NAME range with same start and end
-PROG BEGIN { for ($i : 5..5) { print("here"); } exit(); }
+PROG BEGIN { for ($i : 5..5) { print("here"); }  }
 EXPECT_NONE here
 
 NAME range with variable modification
-PROG BEGIN { $sum = 0; for ($i : 1..5) { $sum += $i; } print($sum); exit(); }
+PROG BEGIN { $sum = 0; for ($i : 1..5) { $sum += $i; } print($sum);  }
 EXPECT_REGEX ^10
 
 NAME range using a map
-PROG BEGIN { @a = 10; for ($i : 0..@a) { print($i); @a += 1; } exit(); }
+PROG BEGIN { @a = 10; for ($i : 0..@a) { print($i); @a += 1; }  }
 EXPECT_REGEX @a: 20
 
 NAME range with break
-PROG BEGIN { for ($i : 1..4) { if ($i == 2) { break; } print($i); } print("5"); exit(); }
+PROG BEGIN { for ($i : 1..4) { if ($i == 2) { break; } print($i); } print("5");  }
 EXPECT_REGEX .*\n1\n5\n\n
 
 NAME range with continue
-PROG BEGIN { for ($i : 1..4) { if ($i == 2) { continue; } print($i); } exit(); }
+PROG BEGIN { for ($i : 1..4) { if ($i == 2) { continue; } print($i); }  }
 EXPECT_REGEX .*\n1\n3\n\n

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -1,82 +1,82 @@
 NAME invalid_format
-RUN {{BPFTRACE}} -q -f jsonx -e 'BEGIN { @scalar = 5; exit(); }'
+RUN {{BPFTRACE}} -q -f jsonx -e 'BEGIN { @scalar = 5;  }'
 EXPECT ERROR: Invalid output format "jsonx"
 WILL_FAIL
 
 NAME scalar
-PROG BEGIN { @scalar = 5; exit(); }
+PROG BEGIN { @scalar = 5;  }
 EXPECT_JSON runtime/outputs/scalar.json
 
 NAME scalar_str
-PROG BEGIN { @scalar_str = "a b \n d e"; exit(); }
+PROG BEGIN { @scalar_str = "a b \n d e";  }
 EXPECT_JSON runtime/outputs/scalar_str.json
 
 NAME complex
-PROG BEGIN { @complex[comm,2] = 5; exit(); }
+PROG BEGIN { @complex[comm,2] = 5;  }
 EXPECT_JSON runtime/outputs/complex.json
 
 NAME map
-PROG BEGIN { @map["key1"] = 2; @map["key2"] = 3; exit(); }
+PROG BEGIN { @map["key1"] = 2; @map["key2"] = 3;  }
 EXPECT_JSON runtime/outputs/map.json
 
 NAME multiple maps
-PROG BEGIN { @map1["key1"] = 2; @map2["key2"] = 3; exit(); }
+PROG BEGIN { @map1["key1"] = 2; @map2["key2"] = 3;  }
 EXPECT_JSON runtime/outputs/multiple_maps.ndjson
 
 NAME histogram
-PROG BEGIN { @hist = hist(2); @hist = hist(1025); exit(); }
+PROG BEGIN { @hist = hist(2); @hist = hist(1025);  }
 EXPECT_JSON runtime/outputs/hist.json
 
 NAME histogram zero
-PROG BEGIN { @hist = hist(2); zero(@hist); exit(); }
+PROG BEGIN { @hist = hist(2); zero(@hist);  }
 EXPECT_JSON runtime/outputs/hist_zero.json
 
 NAME multiple histograms
-PROG BEGIN { @["bpftrace"] = hist(2); @["curl"] = hist(-1); @["curl"] = hist(0); @["curl"] = hist(511); @["curl"] = hist(1024); @["curl"] = hist(1025); exit(); }
+PROG BEGIN { @["bpftrace"] = hist(2); @["curl"] = hist(-1); @["curl"] = hist(0); @["curl"] = hist(511); @["curl"] = hist(1024); @["curl"] = hist(1025);  }
 EXPECT_JSON runtime/outputs/hist_multiple.json
 
 NAME multiple histograms multiple keys
-PROG BEGIN { @["bpftrace", 2] = hist(2);@["curl", 3] = hist(511); @["curl", 3] = hist(1024); exit(); }
+PROG BEGIN { @["bpftrace", 2] = hist(2);@["curl", 3] = hist(511); @["curl", 3] = hist(1024);  }
 EXPECT_JSON runtime/outputs/hist_multiple_multiple_keys.json
 
 NAME histogram-finegrain
-PROG BEGIN { $i = 0; while ($i < 1024) { @ = hist($i, 3); $i++; } exit(); }
+PROG BEGIN { $i = 0; while ($i < 1024) { @ = hist($i, 3); $i++; }  }
 EXPECT_JSON runtime/outputs/hist_2args.json
 
 NAME linear histogram
-PROG BEGIN { @h = lhist(2, 0, 100, 10); @h = lhist(50, 0, 100, 10); @h = lhist(1000, 0, 100, 10); exit(); }
+PROG BEGIN { @h = lhist(2, 0, 100, 10); @h = lhist(50, 0, 100, 10); @h = lhist(1000, 0, 100, 10);  }
 EXPECT_JSON runtime/outputs/lhist.json
 
 NAME linear histogram zero
-PROG BEGIN { @h = lhist(2, 0, 100, 10); zero(@h); exit(); }
+PROG BEGIN { @h = lhist(2, 0, 100, 10); zero(@h);  }
 EXPECT_JSON runtime/outputs/lhist_zero.json
 
 NAME multiple linear histograms
-PROG BEGIN { @stats["bpftrace"] = lhist(2, 0, 100, 10); @stats["curl"] = lhist(50, 0, 100, 10); @stats["bpftrace"] = lhist(1000, 0, 100, 10); exit(); }
+PROG BEGIN { @stats["bpftrace"] = lhist(2, 0, 100, 10); @stats["curl"] = lhist(50, 0, 100, 10); @stats["bpftrace"] = lhist(1000, 0, 100, 10);  }
 EXPECT_JSON runtime/outputs/lhist_multiple.json
 
 NAME stats
-PROG BEGIN { @stats = stats(2); @stats = stats(10); exit(); }
+PROG BEGIN { @stats = stats(2); @stats = stats(10);  }
 EXPECT_JSON runtime/outputs/stats.json
 
 NAME multiple stats
-PROG BEGIN { @stats["curl"] = stats(2); @stats["zsh"] = stats(10); exit(); }
+PROG BEGIN { @stats["curl"] = stats(2); @stats["zsh"] = stats(10);  }
 EXPECT_JSON runtime/outputs/stats_multiple.json
 
 NAME printf
-RUN {{BPFTRACE}} -q -f json -e 'BEGIN { printf("test %d", 5); exit(); }'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { printf("test %d", 5);  }'
 EXPECT {"type": "printf", "data": "test 5"}
 
 NAME printf_escaping
-RUN {{BPFTRACE}} -q -f json -e 'BEGIN { printf("test \r \n \t \\ \" bar"); exit(); }'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { printf("test \r \n \t \\ \" bar");  }'
 EXPECT {"type": "printf", "data": "test \r \n \t \\ \" bar"}
 
 NAME time
-RUN {{BPFTRACE}} -q -f json -e 'BEGIN { time(); exit(); }'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { time();  }'
 EXPECT_REGEX ^{"type": "time", "data": "[0-9]*:[0-9]*:[0-9]*\\n"}$
 
 NAME syscall
-RUN {{BPFTRACE}} --unsafe -f json -e 'BEGIN { system("echo a b c"); exit(); }'
+RUN {{BPFTRACE}} --unsafe -f json -e 'BEGIN { system("echo a b c");  }'
 EXPECT {"type": "syscall", "data": "a b c\n"}
 
 NAME join_delim
@@ -84,17 +84,17 @@ RUN {{BPFTRACE}} --unsafe -f json -e 'tracepoint:syscalls:sys_enter_execve { joi
 EXPECT {"type": "join", "data": "/bin/echo,'A'"}
 
 NAME cat
-RUN {{BPFTRACE}} -f json -e 'BEGIN { cat("/proc/uptime"); exit(); }'
+RUN {{BPFTRACE}} -f json -e 'BEGIN { cat("/proc/uptime");  }'
 EXPECT_REGEX ^{"type": "cat", "data": "[0-9]*.[0-9]* [0-9]*.[0-9]*\\n"}$
 
 NAME strerror
-RUN {{BPFTRACE}} -f json -e 'BEGIN { print((strerror(7))); exit(); }'
+RUN {{BPFTRACE}} -f json -e 'BEGIN { print((strerror(7)));  }'
 EXPECT {"type": "value", "data": "Argument list too long"}
 
 # Careful with '[' and ']', they are read by the test engine as a regex
 # character class, so make sure to escape them.
 NAME tuple
-RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @ = (1, 2, "string", (4, 5)); exit(); }'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @ = (1, 2, "string", (4, 5));  }'
 EXPECT {"type": "map", "data": {"@": [1,2,"string",[4,5]]}}
 
 NAME tuple_with_struct
@@ -103,7 +103,7 @@ EXPECT {"type": "map", "data": {"@": [0,{ "m": 2, "n": 3 }]}}
 AFTER ./testprogs/simple_struct
 
 NAME tuple_with_escaped_string
-RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @ = (1, 2, "string with \"quotes\""); exit(); }'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @ = (1, 2, "string with \"quotes\"");  }'
 EXPECT {"type": "map", "data": {"@": [1,2,"string with \"quotes\""]}}
 
 NAME print_non_map
@@ -132,32 +132,32 @@ EXPECT {"type": "value", "data": { "y": { "m": [2] }, "a": { "n": 3 } }}
 AFTER ./testprogs/simple_struct
 
 NAME print_avg_map_args
-RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 2, 10); clear(@); exit(); }'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 2, 10); clear(@);  }'
 EXPECT {"type": "stats", "data": {"@": {"c": 3, "d": 4}}}
 TIMEOUT 1
 
 NAME print_avg_map_with_large_top
-RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 10, 10); clear(@); exit(); }'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @["a"] = avg(10); @["b"] = avg(20); @["c"] = avg(30); @["d"] = avg(40); print(@, 10, 10); clear(@);  }'
 EXPECT {"type": "stats", "data": {"@": {"a": 1, "b": 2, "c": 3, "d": 4}}}
 TIMEOUT 1
 
 NAME print_hist_with_top_arg
-RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 2); clear(@); exit(); }'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 2); clear(@);  }'
 EXPECT {"type": "hist", "data": {"@": {"2": [{"min": 16, "max": 31, "count": 1}], "3": [{"min": 16, "max": 31, "count": 1}]}}}
 TIMEOUT 1
 
 NAME print_hist_with_large_top_arg
-RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 10); clear(@); exit(); }'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @[1] = hist(10); @[2] = hist(20); @[3] = hist(30); print(@, 10); clear(@);  }'
 EXPECT {"type": "hist", "data": {"@": {"1": [{"min": 8, "max": 15, "count": 1}], "2": [{"min": 16, "max": 31, "count": 1}], "3": [{"min": 16, "max": 31, "count": 1}]}}}
 TIMEOUT 1
 
 NAME helper_error
-RUN {{BPFTRACE}} -k -q -f json -e 'struct foo {int a;}; BEGIN { $tmp = ((struct foo*) 0)->a; exit(); }'
+RUN {{BPFTRACE}} -k -q -f json -e 'struct foo {int a;}; BEGIN { $tmp = ((struct foo*) 0)->a;  }'
 EXPECT {"type": "helper_error", "msg": "Bad address", "helper": "probe_read", "retcode": -14, "filename": "stdin", "line": 1, "col": 37}
 TIMEOUT 1
 
 NAME cgroup_path
-RUN {{BPFTRACE}} -q -f json -e 'BEGIN { print(cgroup_path(cgroup)); exit(); }' | tail -n +2 | python3 -c 'import sys,json; print(json.load(sys.stdin))'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { print(cgroup_path(cgroup));  }' | tail -n +2 | python3 -c 'import sys,json; print(json.load(sys.stdin))'
 EXPECT_REGEX ^{'type': 'value', 'data': '.*'}$
 
 NAME strftime
@@ -166,12 +166,12 @@ EXPECT_REGEX ^{'type': 'value', 'data': \[1, '[0-9]{2}\/[0-9]{2}\/[0-9]{2}'\]}$
 TIMEOUT 1
 
 NAME print_hex_values
-RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @=(int16*) 0x32; exit(); }'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { @=(int16*) 0x32;  }'
 EXPECT {"type": "map", "data": {"@": 50}}
 
 # To preserve backwards compat for machines parsing output, we do not symbolize enums in JSON output mode
 NAME enum_not_symbolized
-RUN {{BPFTRACE}} -q -f json -e 'enum { FOO = 333 }; BEGIN { $f = FOO; print($f); exit(); }'
+RUN {{BPFTRACE}} -q -f json -e 'enum { FOO = 333 }; BEGIN { $f = FOO; print($f);  }'
 EXPECT {"type": "value", "data": 333}
 
 # But if user explicitly asks for enum symbolization, we provide it in JSON output
@@ -187,6 +187,6 @@ EXPECT {"type": "value", "data": { "m": 2, "n": { "i": 5, "f": "" } }}
 AFTER ./testprogs/struct_with_union
 
 NAME print bool type
-RUN {{BPFTRACE}} -q -f json -e 'BEGIN { print((true, false)); exit(); }'
+RUN {{BPFTRACE}} -q -f json -e 'BEGIN { print((true, false));  }'
 EXPECT {"type": "value", "data": [true,false]}
 TIMEOUT 1

--- a/tests/runtime/macro
+++ b/tests/runtime/macro
@@ -1,25 +1,25 @@
 NAME it mutates the passed variable
-PROG macro inc($x) { $x += 1; } BEGIN { $a = 1; inc($a); print($a); exit(); }
+PROG macro inc($x) { $x += 1; } BEGIN { $a = 1; inc($a); print($a);  }
 EXPECT 2
 
 NAME it assigns to the last expression
-PROG macro inc($x) { $x += 1; $x } BEGIN { $a = 1; $b = inc($a); print(($a, $b)); exit(); }
+PROG macro inc($x) { $x += 1; $x } BEGIN { $a = 1; $b = inc($a); print(($a, $b));  }
 EXPECT (2, 2)
 
 NAME it mutates the passed non-scalar map
-PROG macro set(@x) { @x[1] = 2; } BEGIN { @a[1] = 1; set(@a); exit(); }
+PROG macro set(@x) { @x[1] = 2; } BEGIN { @a[1] = 1; set(@a);  }
 EXPECT @a[1]: 2
 
 NAME it mutates the passed scalar map
-PROG macro set(@x) { @x = 2; } BEGIN { @a = 1; set(@a); exit(); }
+PROG macro set(@x) { @x = 2; } BEGIN { @a = 1; set(@a);  }
 EXPECT @a: 2
 
 NAME it reads the passed map
-PROG macro get(@x) { 1 + @x[1] } BEGIN { @a[1] = 1; print(get(@a)); exit(); }
+PROG macro get(@x) { 1 + @x[1] } BEGIN { @a[1] = 1; print(get(@a));  }
 EXPECT 2
 
 NAME it can have side effects
-PROG macro print_me($x) { print(("me", $x)); } BEGIN { $a = 1; print_me($a); exit(); }
+PROG macro print_me($x) { print(("me", $x)); } BEGIN { $a = 1; print_me($a);  }
 EXPECT (me, 1)
 
 NAME it can exit early
@@ -27,53 +27,53 @@ PROG macro early() { exit(); } BEGIN { early(); print(1); }
 EXPECT_NONE 1
 
 NAME it can call other macros as expressions
-PROG macro add1($x) { $x + 1 } macro add2($y) { $y + add1($y) } macro add3($z) { $z + add2($z) } BEGIN { print(add3(1)); exit(); }
+PROG macro add1($x) { $x + 1 } macro add2($y) { $y + add1($y) } macro add3($z) { $z + add2($z) } BEGIN { print(add3(1));  }
 EXPECT 4
 
 NAME it can call other macros as statements
-PROG macro add1($x) { $x += 1; } macro add2($y) { add1($y); $y += 1; } macro add3($z) { add2($z); $z += 1; } BEGIN { $a = 1; add3($a); print($a); exit(); }
+PROG macro add1($x) { $x += 1; } macro add2($y) { add1($y); $y += 1; } macro add3($z) { add2($z); $z += 1; } BEGIN { $a = 1; add3($a); print($a);  }
 EXPECT 4
 
 NAME macro definition order does not matter
-PROG macro add2($x) { $x + add1($x) } macro add3($x) { $x + add2($x) } macro add1($x) { $x + 1 } BEGIN { print(add3(1)); exit(); }
+PROG macro add2($x) { $x + add1($x) } macro add3($x) { $x + add2($x) } macro add1($x) { $x + 1 } BEGIN { print(add3(1));  }
 EXPECT 4
 
 NAME it accepts arbitrary expressions without variables or maps
-PROG macro add_one($x) { $x + 1 } BEGIN { $a = 1; print(add_one(1 + 1)); exit(); }
+PROG macro add_one($x) { $x + 1 } BEGIN { $a = 1; print(add_one(1 + 1));  }
 EXPECT 3
 
 NAME it accepts arbitrary expressions with variables
-PROG macro add_one($x) { $x + 1 } BEGIN { $a = 1; print(add_one($a + 1)); exit(); }
+PROG macro add_one($x) { $x + 1 } BEGIN { $a = 1; print(add_one($a + 1));  }
 EXPECT 3
 
 NAME it accepts arbitrary expressions with variables nested
-PROG macro add_two($x) { $x + 2 } macro add_one($x) { add_two($x + 1) + 1 } BEGIN { $a = 1; print(add_one($a + 1)); exit(); }
+PROG macro add_two($x) { $x + 2 } macro add_one($x) { add_two($x + 1) + 1 } BEGIN { $a = 1; print(add_one($a + 1));  }
 EXPECT 6
 
 NAME it accepts arbitrary expressions with maps
-PROG macro add_one($x) { $x + 1 } BEGIN { @a = 1; print(add_one(@a + 1)); exit(); }
+PROG macro add_one($x) { $x + 1 } BEGIN { @a = 1; print(add_one(@a + 1));  }
 EXPECT 3
 
 NAME can call the same macro multiple times
-PROG macro inc($x) { $x += 1; } BEGIN { $a = 1; inc($a); inc($a); inc($a); print($a); exit(); }
+PROG macro inc($x) { $x += 1; } BEGIN { $a = 1; inc($a); inc($a); inc($a); print($a);  }
 EXPECT 4
 
 NAME for loops can be in macros
-PROG macro loop_map(@a) { let $x = 1; for ($kv : @a) { $x += $kv.1;} $x } BEGIN { @x[1] = 5; @x[2] = 10; print(loop_map(@x)); exit(); }
+PROG macro loop_map(@a) { let $x = 1; for ($kv : @a) { $x += $kv.1;} $x } BEGIN { @x[1] = 5; @x[2] = 10; print(loop_map(@x));  }
 EXPECT 16
 
 NAME it works in nested scopes
-PROG macro add1($x) { $x + 1 } macro add2($x) { $x + 2 } BEGIN { $a = 1; if ($a == 1) { print(add2($a)); } else { print(add1($a)); } exit(); }
+PROG macro add1($x) { $x + 1 } macro add2($x) { $x + 2 } BEGIN { $a = 1; if ($a == 1) { print(add2($a)); } else { print(add1($a)); }  }
 EXPECT 3
 
 NAME it re-names variables to prevent collision
-PROG macro inc($x) { $y = $x + 1; $y } BEGIN { $y = 2; $z = inc(5); print(($y, $z)); exit(); }
+PROG macro inc($x) { $y = $x + 1; $y } BEGIN { $y = 2; $z = inc(5); print(($y, $z));  }
 EXPECT (2, 6)
 
 NAME it re-names decl variables to prevent collision
-PROG macro inc($x) { let $y = $x + 1; $y } BEGIN { $y = 2; $z = inc(5); print(($y, $z)); exit(); }
+PROG macro inc($x) { let $y = $x + 1; $y } BEGIN { $y = 2; $z = inc(5); print(($y, $z));  }
 EXPECT (2, 6)
 
 NAME it can be part of an expression passed to a macro
-PROG macro add_one($x) { $x + 1 } BEGIN { $a = add_one(add_one(1) + 1); print($a); exit(); }
+PROG macro add_one($x) { $x + 1 } BEGIN { $a = add_one(add_one(1) + 1); print($a);  }
 EXPECT 4

--- a/tests/runtime/map
+++ b/tests/runtime/map
@@ -1,65 +1,65 @@
 NAME map indexed
-PROG BEGIN { @a[0] = 0; @a[1] = 1; exit(); }
+PROG BEGIN { @a[0] = 0; @a[1] = 1;  }
 EXPECT @a[0]: 0
 EXPECT @a[1]: 1
 
 NAME map indexed, scalar-like
-PROG BEGIN { @a[0] = 0; exit(); }
+PROG BEGIN { @a[0] = 0;  }
 EXPECT @a[0]: 0
 
 NAME map non-zero index
-PROG BEGIN { @a[1] = 0; exit(); }
+PROG BEGIN { @a[1] = 0;  }
 EXPECT @a[1]: 0
 
 NAME map scalar
-PROG BEGIN { @a = 0; exit(); }
+PROG BEGIN { @a = 0;  }
 EXPECT @a: 0
 
 NAME map indexed, scalar-like, with decl
-PROG let @a = hash(1); BEGIN { @a[0] = 0; exit(); }
+PROG let @a = hash(1); BEGIN { @a[0] = 0;  }
 EXPECT @a[0]: 0
 
 NAME uint64 key
-PROG BEGIN { @a[18446744073709551615] = 0; exit(); }
+PROG BEGIN { @a[18446744073709551615] = 0;  }
 EXPECT @a[18446744073709551615]: 0
 
 # Unfortunately there are some issues when evicting lruhash entries. We can't
 # know exactly which elements will be present. See #3992 for more information.
 NAME map declaration lruhash
-PROG let @a = lruhash(2); BEGIN { @a[0] = 0; @a[1] = 1; @a[2] = 2; exit(); }
+PROG let @a = lruhash(2); BEGIN { @a[0] = 0; @a[1] = 1; @a[2] = 2;  }
 EXPECT_REGEX_NONE .*WARNING: Map full; can't update element.*
 EXPECT_REGEX @a\[.\]: .
 
 NAME map declaration lruhash
-PROG let @a = lruhash(1); BEGIN { @a[1] = 1; exit(); }
+PROG let @a = lruhash(1); BEGIN { @a[1] = 1;  }
 EXPECT_REGEX_NONE .*WARNING: Map full; can't update element.*
 EXPECT @a[1]: 1
 
 NAME map declaration lruhash, scalar-like
-PROG let @a = lruhash(1); BEGIN { @a[0] = 1; exit(); }
+PROG let @a = lruhash(1); BEGIN { @a[0] = 1;  }
 EXPECT_REGEX_NONE .*WARNING: Map full; can't update element.*
 EXPECT @a[0]: 1
 
 NAME map declaration hash
-PROG let @a = hash(1); BEGIN { @a[1] = 1; @a[2] = 2; exit(); }
+PROG let @a = hash(1); BEGIN { @a[1] = 1; @a[2] = 2;  }
 EXPECT_REGEX .*WARNING: Map full; can't update element.*
 EXPECT @a[1]: 1
 
 NAME map declaration hash, scalar-like
-PROG let @a = hash(1); BEGIN { @a[0] = 0; @a[0] = 1; exit(); }
+PROG let @a = hash(1); BEGIN { @a[0] = 0; @a[0] = 1;  }
 EXPECT_REGEX_NONE .*WARNING: Map full; can't update element.*
 EXPECT @a[0]: 1
 
 NAME map declaration percpuhash
-PROG let @a = percpuhash(1); BEGIN { @a[1] = count(); @a[2] = count(); exit(); }
+PROG let @a = percpuhash(1); BEGIN { @a[1] = count(); @a[2] = count();  }
 EXPECT_REGEX .*WARNING: Map full; can't update element.*
 EXPECT @a[1]: 1
 
 NAME map declaration percpulruhash
-PROG let @a = percpulruhash(1); BEGIN { @a[1] = count(); @a[2] = count(); exit(); }
+PROG let @a = percpulruhash(1); BEGIN { @a[1] = count(); @a[2] = count();  }
 EXPECT_REGEX_NONE .*WARNING: Map full; can't update element.*
 EXPECT @a[2]: 1
 
 NAME map declaration unused
-PROG let @a = percpuhash(1); BEGIN { exit(); }
+PROG let @a = percpuhash(1); BEGIN {  }
 EXPECT_REGEX .*WARNING: Unused map: @a.*

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -73,31 +73,31 @@ RUN {{BPFTRACE}} -e 'i:ms:1 {$a = 1; unroll ($1) { $a = $a + 1; } printf("a=%d\n
 EXPECT a=11
 
 NAME unroll_printf
-PROG BEGIN { unroll (1) { printf("a"); } printf("b\n"); exit(); }
+PROG BEGIN { unroll (1) { printf("a"); } printf("b\n");  }
 EXPECT ab
 
 NAME if_compare_and_print_string
-PROG BEGIN { if (comm == "bpftrace") { printf("comm: %s\n", comm);} exit();}
+PROG BEGIN { if (comm == "bpftrace") { printf("comm: %s\n", comm);} }
 EXPECT comm: bpftrace
 
 NAME struct positional string compare - equal returns true
-RUN {{BPFTRACE}} -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} exit();}' "hello" "hello"
+RUN {{BPFTRACE}} -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} }' "hello" "hello"
 EXPECT I got hello
 
 NAME struct positional string compare - equal returns false
-RUN {{BPFTRACE}} -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hi" "hello"
+RUN {{BPFTRACE}} -e 'BEGIN { if (str($1) == str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} }' "hi" "hello"
 EXPECT not equal
 
 NAME struct positional string compare - not equal
-RUN {{BPFTRACE}} -e 'BEGIN { if (str($1) != str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} exit();}' "hello" "hello"
+RUN {{BPFTRACE}} -e 'BEGIN { if (str($1) != str($2)) { printf("I got %s\n", str($1));} else { printf("not equal\n");} }' "hello" "hello"
 EXPECT not equal
 
 NAME positional string compare via variable - equal
-RUN {{BPFTRACE}} -e 'BEGIN { $x = str($1, 6); if ($x == "hello") { printf("I got %s\n", "hello");} else { printf("not equal\n");} exit();}' "hello"
+RUN {{BPFTRACE}} -e 'BEGIN { $x = str($1, 6); if ($x == "hello") { printf("I got %s\n", "hello");} else { printf("not equal\n");} }' "hello"
 EXPECT I got hello
 
 NAME positional string compare via variable - not equal
-RUN {{BPFTRACE}} -e 'BEGIN { $x = str($1, 5); if ($x == "hello") { printf("I got hello\n");} else { printf("not %s\n", "equal");} exit();}' "hell"
+RUN {{BPFTRACE}} -e 'BEGIN { $x = str($1, 5); if ($x == "hello") { printf("I got hello\n");} else { printf("not %s\n", "equal");} }' "hell"
 EXPECT not equal
 
 NAME positional attachpoint
@@ -125,11 +125,11 @@ RUN {{BPFTRACE}} -e 't:syscalls:sys_enter_openat /comm == "syscall"/ { @[comm] =
 EXPECT @[syscall]: 1
 
 NAME struct partial string compare - pass
-RUN {{BPFTRACE}} -e 'BEGIN { if (strncmp(str($1), str($2), 4) == 0) { printf("I got %s\n", str($1));} exit();}' "hhvm" "hhvm-proc"
+RUN {{BPFTRACE}} -e 'BEGIN { if (strncmp(str($1), str($2), 4) == 0) { printf("I got %s\n", str($1));} }' "hhvm" "hhvm-proc"
 EXPECT I got hhvm
 
 NAME struct partial string compare - pass reverse
-RUN {{BPFTRACE}} -e 'BEGIN { if (strncmp(str($1), str($2), 4) == 0) { printf("I got %s\n", str($1));} exit();}' "hhvm-proc" "hhvm"
+RUN {{BPFTRACE}} -e 'BEGIN { if (strncmp(str($1), str($2), 4) == 0) { printf("I got %s\n", str($1));} }' "hhvm-proc" "hhvm"
 EXPECT I got hhvm-proc
 
 NAME strncmp function argument
@@ -160,7 +160,7 @@ RUN {{BPFTRACE}} -e 'BEGIN { @ = kaddr(str($1)); exit() }' vfs_read
 EXPECT Attached 1 probe
 
 NAME positional arg count
-RUN {{BPFTRACE}} -e 'BEGIN { printf("got %d args: %s %d\n", $#, str($1), $2); exit();}' "one" 2
+RUN {{BPFTRACE}} -e 'BEGIN { printf("got %d args: %s %d\n", $#, str($1), $2); }' "one" 2
 EXPECT got 2 args: one 2
 
 NAME positional multiple bases
@@ -168,12 +168,12 @@ RUN {{BPFTRACE}} -e 'BEGIN { printf("got: %d %o 0x%x\n", $1, $2, $3); exit() }' 
 EXPECT got: 123 775 0x123
 
 NAME positional pointer arithmetic
-RUN {{BPFTRACE}} -e 'BEGIN { printf("%s", str($1 + 1)); exit(); }' hello
+RUN {{BPFTRACE}} -e 'BEGIN { printf("%s", str($1 + 1));  }' hello
 EXPECT ello
 TIMEOUT 1
 
 NAME positional strncmp
-RUN {{BPFTRACE}} -e 'BEGIN { if (strncmp("hello", "hell", $1) == 0) { printf("ok\n"); } exit(); }' 3
+RUN {{BPFTRACE}} -e 'BEGIN { if (strncmp("hello", "hell", $1) == 0) { printf("ok\n"); }  }' 3
 EXPECT ok
 TIMEOUT 1
 
@@ -182,7 +182,7 @@ RUN {{BPFTRACE}} -e 'BEGIN { @ = lhist(0, $1, $2, $3); exit()}' 0 10000 1000
 EXPECT_REGEX @: *\n[\[(].*
 
 NAME positional buf
-RUN {{BPFTRACE}} -e 'BEGIN { @ = buf("hello", $1); exit(); }' 5
+RUN {{BPFTRACE}} -e 'BEGIN { @ = buf("hello", $1);  }' 5
 EXPECT @: hello
 TIMEOUT 1
 
@@ -276,32 +276,32 @@ EXPECT done
 
 NAME per_cpu_map_min_if
 REQUIRES_FEATURE lookup_percpu_elem
-PROG BEGIN { @ = 10; } i:ms:1 { @--; @mn = min(@); if (@mn < 5) { printf("done\n"); exit(); }}
+PROG BEGIN { @ = 10; } i:ms:1 { @--; @mn = min(@); if (@mn < 5) { printf("done\n");  }}
 EXPECT done
 
 NAME per_cpu_map_max_if
 REQUIRES_FEATURE lookup_percpu_elem
-PROG BEGIN { @ = 1; } i:ms:1 { @++; @mx = max(@); if (@mx > 5) { printf("done\n"); exit(); }}
+PROG BEGIN { @ = 1; } i:ms:1 { @++; @mx = max(@); if (@mx > 5) { printf("done\n");  }}
 EXPECT done
 
 NAME per_cpu_map_avg_if
 REQUIRES_FEATURE lookup_percpu_elem
-PROG BEGIN { @ = avg(1); @ = avg(1); @ = avg(10); if (@ == 4) { printf("done\n"); exit(); }}
+PROG BEGIN { @ = avg(1); @ = avg(1); @ = avg(10); if (@ == 4) { printf("done\n");  }}
 EXPECT done
 
 NAME per_cpu_map_arithmetic
 REQUIRES_FEATURE lookup_percpu_elem
-PROG BEGIN { @a = sum(10); @b = count(); $c = @a + @b; if ($c == 11) { printf("done\n"); } exit();}
+PROG BEGIN { @a = sum(10); @b = count(); $c = @a + @b; if ($c == 11) { printf("done\n"); } }
 EXPECT done
 
 NAME per_cpu_map_cast
 REQUIRES_FEATURE lookup_percpu_elem
-PROG BEGIN { @a = count(); @b = sum(10); printf("%d-%d\n", (uint64)@a, (int64)@b); exit();}
+PROG BEGIN { @a = count(); @b = sum(10); printf("%d-%d\n", (uint64)@a, (int64)@b); }
 EXPECT 1-10
 
 NAME per_cpu_map_as_map_key
 REQUIRES_FEATURE lookup_percpu_elem
-PROG BEGIN {@a = count(); @b = sum(5); @c = min(1); @d = max(10); @e = avg(7); @[@a, @b, @c, @d, @e] = 1; exit(); }
+PROG BEGIN {@a = count(); @b = sum(5); @c = min(1); @d = max(10); @e = avg(7); @[@a, @b, @c, @d, @e] = 1;  }
 EXPECT @[1, 5, 1, 10, 7]: 1
 
 NAME dry run empty output
@@ -310,70 +310,70 @@ EXPECT_NONE hello
 EXPECT_NONE @: 0
 
 NAME symbolize enum in map key
-PROG enum { ONE = 1, TWO = 2 }; BEGIN { @[ONE] = 11; @[TWO] = 22; @m[ONE] = 333; exit(); }
+PROG enum { ONE = 1, TWO = 2 }; BEGIN { @[ONE] = 11; @[TWO] = 22; @m[ONE] = 333;  }
 EXPECT @[ONE]: 11
 EXPECT @[TWO]: 22
 EXPECT @m[ONE]: 333
 
 NAME symbolize enum in tuple map key
-PROG enum { ONE = 1, TWO = 2 }; BEGIN { @[ONE,TWO,ONE] = -1; exit(); }
+PROG enum { ONE = 1, TWO = 2 }; BEGIN { @[ONE,TWO,ONE] = -1;  }
 EXPECT @[ONE, TWO, ONE]: -1
 
 NAME symbolize enum in map value
-PROG enum { ONE = 1, TWO = 2 }; BEGIN { @ = ONE; exit(); }
+PROG enum { ONE = 1, TWO = 2 }; BEGIN { @ = ONE;  }
 EXPECT @: ONE
 
 NAME symbolize enum in tuple map value
-PROG enum { ONE = 1, TWO = 2 }; BEGIN { @ = (ONE, TWO); exit(); }
+PROG enum { ONE = 1, TWO = 2 }; BEGIN { @ = (ONE, TWO);  }
 EXPECT @: (ONE, TWO)
 
 NAME no symbolize enum after arithmetic
-PROG enum { ONE = 1, TWO = 2 }; BEGIN { @[ONE+1] = TWO-1; exit(); }
+PROG enum { ONE = 1, TWO = 2 }; BEGIN { @[ONE+1] = TWO-1;  }
 EXPECT @[2]: 1
 
 NAME no symbolize enum after arithmetic mixed
-PROG enum { ONE = 1, TWO = 2 }; BEGIN { @[ONE+1] = TWO-1; @[ONE] = ONE; exit(); }
+PROG enum { ONE = 1, TWO = 2 }; BEGIN { @[ONE+1] = TWO-1; @[ONE] = ONE;  }
 EXPECT @[2]: 1
 EXPECT @[1]: 1
 
 NAME symbolize enum in scratch variable
-PROG enum { FOO = 333 }; BEGIN { $f = FOO; print($f); exit(); }
+PROG enum { FOO = 333 }; BEGIN { $f = FOO; print($f);  }
 EXPECT FOO
 
 NAME symbolize enum in scratch variable tuple
-PROG enum { FOO = 333, BAR }; BEGIN { $t = (FOO, BAR); print($t); exit(); }
+PROG enum { FOO = 333, BAR }; BEGIN { $t = (FOO, BAR); print($t);  }
 EXPECT (FOO, BAR)
 
 NAME symbolize int cast to enum
-PROG enum BAZ { FOO = 333, BAR }; BEGIN { print((enum BAZ)333); exit(); }
+PROG enum BAZ { FOO = 333, BAR }; BEGIN { print((enum BAZ)333);  }
 EXPECT FOO
 
 NAME no symbolize int cast to unknown enum variant
-PROG enum BAZ { FOO = 333, BAR }; BEGIN { $x = 444; print((enum BAZ)$x); exit(); }
+PROG enum BAZ { FOO = 333, BAR }; BEGIN { $x = 444; print((enum BAZ)$x);  }
 EXPECT 444
 
 NAME valid license
-PROG config={license="Dual BSD/GPL"} BEGIN { @p[1] = 1; print(len(@p)); exit(); }
+PROG config={license="Dual BSD/GPL"} BEGIN { @p[1] = 1; print(len(@p));  }
 EXPECT 1
 
 NAME invalid license
-PROG config={license="Potato"} BEGIN { @p[1] = 1; print(len(@p)); exit(); }
+PROG config={license="Potato"} BEGIN { @p[1] = 1; print(len(@p));  }
 EXPECT ERROR: Your bpftrace program cannot load because you are using a license that is non-GPL compatible. License: Potato
 WILL_FAIL
 
 NAME named command line params
-RUN {{BPFTRACE}} -e 'BEGIN { print((getopt("aa", 10), getopt("cc", true), getopt("dd"), getopt("ee", "hello"))); exit(); }' -- --dd --aa=20 --cc=False
+RUN {{BPFTRACE}} -e 'BEGIN { print((getopt("aa", 10), getopt("cc", true), getopt("dd"), getopt("ee", "hello")));  }' -- --dd --aa=20 --cc=False
 EXPECT (20, false, true, hello)
 TIMEOUT 1
 
 NAME named and positional params
-RUN {{BPFTRACE}} -e 'BEGIN { print(($1, getopt("aa", 10), $2, getopt("bb", "hello"), getopt("cc"))); exit(); }' pos1 -- --aa=20 --bb=bye pos2 --cc
+RUN {{BPFTRACE}} -e 'BEGIN { print(($1, getopt("aa", 10), $2, getopt("bb", "hello"), getopt("cc")));  }' pos1 -- --aa=20 --bb=bye pos2 --cc
 EXPECT (pos1, 20, pos2, bye, true)
 TIMEOUT 1
 
 # Can't run through the standard AOT path because we need to pass CLI args
 NAME named command line params aot
-RUN {{BPFTRACE}} -e 'BEGIN { print((getopt("aa", 10), getopt("cc", true), getopt("dd"), getopt("ee", "hello"))); exit(); }' --aot /tmp/tmpprog.btaot && /tmp/tmpprog.btaot -- --dd --aa=20 --cc=False
+RUN {{BPFTRACE}} -e 'BEGIN { print((getopt("aa", 10), getopt("cc", true), getopt("dd"), getopt("ee", "hello")));  }' --aot /tmp/tmpprog.btaot && /tmp/tmpprog.btaot -- --dd --aa=20 --cc=False
 EXPECT (20, false, true, hello)
 TIMEOUT 1
 
@@ -383,18 +383,18 @@ EXPECT 20
 TIMEOUT 1
 
 NAME named command line params before double dash
-RUN {{BPFTRACE}} -e 'BEGIN { exit(); }' --aa=20
+RUN {{BPFTRACE}} -e 'BEGIN {  }' --aa=20
 EXPECT USAGE:
 WILL_FAIL
 
 NAME named command line params wrong value type
-RUN {{BPFTRACE}} -e 'BEGIN { print(getopt("aa", 10)); exit(); }' -- --aa=False
+RUN {{BPFTRACE}} -e 'BEGIN { print(getopt("aa", 10));  }' -- --aa=False
 EXPECT ERROR: program command line option --aa invalid integer (value: False)
 EXPECT_NONE USAGE:
 WILL_FAIL
 
 NAME unexpected named command line params
-RUN {{BPFTRACE}} -e 'BEGIN { print(getopt("aa", 10)); exit(); }' -- --bb
+RUN {{BPFTRACE}} -e 'BEGIN { print(getopt("aa", 10));  }' -- --bb
 EXPECT ERROR: unexpected program command line options: --bb
 EXPECT HINT: expected program options: --aa
 EXPECT_NONE USAGE:

--- a/tests/runtime/pointers
+++ b/tests/runtime/pointers
@@ -1,73 +1,73 @@
 NAME u8 pointer increment
-PROG BEGIN { @=(int8*) 0x32; @+=1; exit(); }
+PROG BEGIN { @=(int8*) 0x32; @+=1;  }
 EXPECT @: 0x33
 
 NAME u16 pointer increment
-PROG BEGIN { @=(int16*) 0x32; @+=1; exit(); }
+PROG BEGIN { @=(int16*) 0x32; @+=1;  }
 EXPECT @: 0x34
 
 NAME u32 pointer increment
-PROG BEGIN { @=(int32*) 0x32; @+=1; exit(); }
+PROG BEGIN { @=(int32*) 0x32; @+=1;  }
 EXPECT @: 0x36
 
 NAME u64 pointer increment
-PROG BEGIN { @=(int64*) 0x32; @+=1; exit(); }
+PROG BEGIN { @=(int64*) 0x32; @+=1;  }
 EXPECT @: 0x3a
 
 NAME u8 pointer unop post increment
-PROG BEGIN { @=(int8*) 0x32; @++; exit(); }
+PROG BEGIN { @=(int8*) 0x32; @++;  }
 EXPECT @: 0x33
 
 NAME u16 pointer unop post increment
-PROG BEGIN { @=(int16*) 0x32; @++; exit(); }
+PROG BEGIN { @=(int16*) 0x32; @++;  }
 EXPECT @: 0x34
 
 NAME u32 pointer unop post increment
-PROG BEGIN { @=(int32*) 0x32; @++; exit(); }
+PROG BEGIN { @=(int32*) 0x32; @++;  }
 EXPECT @: 0x36
 
 NAME u64 pointer unop post increment
-PROG BEGIN { @=(int64*) 0x32; @++; exit(); }
+PROG BEGIN { @=(int64*) 0x32; @++;  }
 EXPECT @: 0x3a
 
 NAME u8 pointer unop pre increment
-PROG BEGIN { @=(int8*) 0x32; @++; exit(); }
+PROG BEGIN { @=(int8*) 0x32; @++;  }
 EXPECT @: 0x33
 
 NAME u16 pointer unop pre increment
-PROG BEGIN { @=(int16*) 0x32; @++; exit(); }
+PROG BEGIN { @=(int16*) 0x32; @++;  }
 EXPECT @: 0x34
 
 NAME u32 pointer unop pre increment
-PROG BEGIN { @=(int32*) 0x32; @++; exit(); }
+PROG BEGIN { @=(int32*) 0x32; @++;  }
 EXPECT @: 0x36
 
 NAME u64 pointer unop pre increment
-PROG BEGIN { @=(int64*) 0x32; @++; exit(); }
+PROG BEGIN { @=(int64*) 0x32; @++;  }
 EXPECT @: 0x3a
 
 NAME Pointer decrement 1
-PROG BEGIN { @=(int32*) 0x32; @-=1; exit(); }
+PROG BEGIN { @=(int32*) 0x32; @-=1;  }
 EXPECT @: 0x2e
 
 NAME Pointer decrement
-PROG BEGIN { @=(int32*) 0x32; @--; exit(); }
+PROG BEGIN { @=(int32*) 0x32; @--;  }
 EXPECT @: 0x2e
 
 NAME Pointer increment 6
-PROG BEGIN { @=(int32*) 0x32; @+=6; exit(); }
+PROG BEGIN { @=(int32*) 0x32; @+=6;  }
 EXPECT @: 0x4a
 
 NAME Pointer decrement 6
-PROG BEGIN { @=(int32*) 0x32; @-=6; exit(); }
+PROG BEGIN { @=(int32*) 0x32; @-=6;  }
 EXPECT @: 0x1a
 
 NAME Struct pointer math
-PROG struct A {int32_t a; int32_t b; char c[28] }; BEGIN { $a=(struct A*) 1024; printf("%lu - 5 x %lu = %lu\n", $a, sizeof(struct A), $a-5); exit(); }
+PROG struct A {int32_t a; int32_t b; char c[28] }; BEGIN { $a=(struct A*) 1024; printf("%lu - 5 x %lu = %lu\n", $a, sizeof(struct A), $a-5);  }
 EXPECT 1024 - 5 x 36 = 844
 
 NAME Pointer decrement with map
-PROG BEGIN { @dec = 4; @=(int32*) 0x32; @-=@dec; exit(); }
+PROG BEGIN { @dec = 4; @=(int32*) 0x32; @-=@dec;  }
 EXPECT @: 0x22
 
 NAME Pointer walk through struct
@@ -85,17 +85,17 @@ EXPECT @x: 2
 AFTER ./testprogs/array_access
 
 NAME Pointer is truthy for if conditions
-PROG BEGIN { if (curtask) { @ = 1; } exit(); }
+PROG BEGIN { if (curtask) { @ = 1; }  }
 EXPECT @: 1
 
 NAME Pointer is truthy for tenary expressions
-PROG BEGIN { @ = curtask ? 1 : 2; exit(); }
+PROG BEGIN { @ = curtask ? 1 : 2;  }
 EXPECT @: 1
 
 NAME Pointer is useable in logical and expressions
-PROG BEGIN { @ = (curtask && 0) ? 1 : 2; exit(); }
+PROG BEGIN { @ = (curtask && 0) ? 1 : 2;  }
 EXPECT @: 2
 
 NAME Pointer is useable in logical or expressions
-PROG BEGIN { @ = (curtask || 0) ? 1 : 2; exit(); }
+PROG BEGIN { @ = (curtask || 0) ? 1 : 2;  }
 EXPECT @: 1

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -499,7 +499,7 @@ PROG config = { on_stack_limit = 0 } software:cpu:100000 { print(probe); exit();
 EXPECT software:cpu:100000
 
 NAME BEGIN
-PROG BEGIN { printf("Hello\n"); exit();}
+PROG BEGIN { printf("Hello\n"); }
 EXPECT Hello
 TIMEOUT 2
 

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -1,6 +1,6 @@
 # https://github.com/bpftrace/bpftrace/pull/566#issuecomment-487295113
 NAME codegen_struct_save_nested
-PROG struct Foo { int m; struct { int x; int y; } bar; int n; } BEGIN { @foo = (struct Foo *)0; @bar = @foo->bar; @x = @foo->bar.x; printf("_%s_\n", "done"); exit(); }
+PROG struct Foo { int m; struct { int x; int y; } bar; int n; } BEGIN { @foo = (struct Foo *)0; @bar = @foo->bar; @x = @foo->bar.x; printf("_%s_\n", "done");  }
 EXPECT _done_
 TIMEOUT 1
 
@@ -53,17 +53,17 @@ EXPECT _1_
 TIMEOUT 1
 
 NAME string compare with empty
-PROG BEGIN { if ("hello" == "") { printf("equal"); } else { printf("not equal"); } exit(); }
+PROG BEGIN { if ("hello" == "") { printf("equal"); } else { printf("not equal"); }  }
 EXPECT not equal
 TIMEOUT 3
 
 NAME string compare with prefix
-PROG BEGIN { if ("hello" == "hell") { printf("equal"); } else { printf("not equal"); } exit(); }
+PROG BEGIN { if ("hello" == "hell") { printf("equal"); } else { printf("not equal"); }  }
 EXPECT not equal
 TIMEOUT 3
 
 NAME strncmp with prefix
-PROG BEGIN { if (strncmp("hello", "hell", 5) == 0) { printf("equal"); } else { printf("not equal"); } exit(); }
+PROG BEGIN { if (strncmp("hello", "hell", 5) == 0) { printf("equal"); } else { printf("not equal"); }  }
 EXPECT not equal
 TIMEOUT 3
 
@@ -115,6 +115,6 @@ TIMEOUT 1
 # doesn't happen, but this runtime test exercises a pattern that previously
 # produced code that failed to verify.
 NAME preserve context pointer
-PROG BEGIN { @test[(uint64)1] = (uint64)1; } tracepoint:syscalls:sys_enter_kill { if (strcontains(comm, "test")) { @test[args.pid] = 1; } if (args.pid == @test[1]) { print((1)); } if (args.pid == @test[1]) { print((1)); exit(); } }
+PROG BEGIN { @test[(uint64)1] = (uint64)1; } tracepoint:syscalls:sys_enter_kill { if (strcontains(comm, "test")) { @test[args.pid] = 1; } if (args.pid == @test[1]) { print((1)); } if (args.pid == @test[1]) { print((1));  } }
 EXPECT Attached 2 probes
 TIMEOUT 1

--- a/tests/runtime/scripts/named_params.bt
+++ b/tests/runtime/scripts/named_params.bt
@@ -1,1 +1,1 @@
-BEGIN { print(getopt("aa", 10)); exit(); }
+BEGIN { print(getopt("aa", 10));  }

--- a/tests/runtime/signed_ints
+++ b/tests/runtime/signed_ints
@@ -3,16 +3,16 @@ PROG BEGIN { @=stats(-10); @=stats(-5); @=stats(5); exit() }
 EXPECT @: count 3, average -3, total -10
 
 NAME avg with negative values
-PROG BEGIN { @=avg(-30); @=avg(-10); exit(); }
+PROG BEGIN { @=avg(-30); @=avg(-10);  }
 EXPECT @: -20
 
 NAME avg cast negative values
 REQUIRES_FEATURE lookup_percpu_elem
-PROG BEGIN { @ = avg(-1); @ = avg(-1); @ = avg(-10); if (@ == -4) { printf("done\n"); exit(); }}
+PROG BEGIN { @ = avg(-1); @ = avg(-1); @ = avg(-10); if (@ == -4) { printf("done\n");  }}
 EXPECT done
 
 NAME negative map value
-PROG BEGIN { @ = -11; exit(); }
+PROG BEGIN { @ = -11;  }
 EXPECT @: -11
 TIMEOUT 1
 
@@ -22,15 +22,15 @@ EXPECT @: -22
 TIMEOUT 1
 
 NAME Comparison should print as 0 or 1
-PROG struct x { uint64_t x; }; BEGIN { $a = (*(struct x*)0).x; printf("%d %d\n", $a > -1, $a < 1); exit(); }
+PROG struct x { uint64_t x; }; BEGIN { $a = (*(struct x*)0).x; printf("%d %d\n", $a > -1, $a < 1);  }
 EXPECT 0 1
 TIMEOUT 1
 
 NAME sum with negative value
-PROG BEGIN { @=sum(10); @=sum(-20); exit(); }
+PROG BEGIN { @=sum(10); @=sum(-20);  }
 EXPECT @: -10
 TIMEOUT 1
 
 NAME mixed values
-PROG BEGIN { printf("%d %d %d %d\n", (int8) -10, -5555, (int16)-123, 100); exit(); }
+PROG BEGIN { printf("%d %d %d %d\n", (int8) -10, -5555, (int16)-123, 100);  }
 EXPECT -10 -5555 -123 100

--- a/tests/runtime/strcontains
+++ b/tests/runtime/strcontains
@@ -5,7 +5,7 @@ REQUIRES_FEATURE dpath fentry
 AFTER TMPDIR=/tmp ./testprogs/syscall open
 
 NAME literals
-PROG BEGIN { if (strcontains("abc", "a")) { printf("OK\n"); exit(); } }
+PROG BEGIN { if (strcontains("abc", "a")) { printf("OK\n");  } }
 EXPECT OK
 TIMEOUT 1
 
@@ -23,86 +23,86 @@ AFTER ./testprogs/true zztest test
 EXPECT true
 
 NAME basic substring match
-PROG BEGIN { print(strcontains("hello-test-world", "test")); exit(); }
+PROG BEGIN { print(strcontains("hello-test-world", "test"));  }
 EXPECT true
 TIMEOUT 1
 
 NAME substring at end
-PROG BEGIN { print(strcontains("hello-test-world", "world")); exit(); }
+PROG BEGIN { print(strcontains("hello-test-world", "world"));  }
 EXPECT true
 TIMEOUT 1
 
 NAME substring at beginning
-PROG BEGIN { print(strcontains("hello-test-world", "hello")); exit(); }
+PROG BEGIN { print(strcontains("hello-test-world", "hello"));  }
 EXPECT true
 TIMEOUT 1
 
 NAME no match
-PROG BEGIN { print(strcontains("hello-test-world", "not-there")); exit(); }
+PROG BEGIN { print(strcontains("hello-test-world", "not-there"));  }
 EXPECT false
 TIMEOUT 1
 
 NAME empty haystack, empty needle
-PROG BEGIN { print(strcontains("", "")); exit(); }
+PROG BEGIN { print(strcontains("", ""));  }
 EXPECT true
 TIMEOUT 1
 
 NAME non-empty haystack, empty needle
-PROG BEGIN { print(strcontains("hello", "")); exit(); }
+PROG BEGIN { print(strcontains("hello", ""));  }
 EXPECT true
 TIMEOUT 1
 
 NAME empty haystack, non-empty needle
-PROG BEGIN { print(strcontains("", "test")); exit(); }
+PROG BEGIN { print(strcontains("", "test"));  }
 EXPECT false
 TIMEOUT 1
 
 NAME exact match
-PROG BEGIN { print(strcontains("hello", "hello")); exit(); }
+PROG BEGIN { print(strcontains("hello", "hello"));  }
 EXPECT true
 TIMEOUT 1
 
 NAME needle longer than haystack
-PROG BEGIN { print(strcontains("hello", "hello-longer")); exit(); }
+PROG BEGIN { print(strcontains("hello", "hello-longer"));  }
 EXPECT false
 TIMEOUT 1
 
 NAME case sensitivity check
-PROG BEGIN { print(strcontains("Hello World", "hello")); exit(); }
+PROG BEGIN { print(strcontains("Hello World", "hello"));  }
 EXPECT false
 TIMEOUT 1
 
 NAME multiple occurrences
-PROG BEGIN { print(strcontains("test-test-test", "test")); exit(); }
+PROG BEGIN { print(strcontains("test-test-test", "test"));  }
 EXPECT true
 TIMEOUT 1
 
 NAME overlapping potential matches
-PROG BEGIN { print(strcontains("ababac", "abac")); exit(); }
+PROG BEGIN { print(strcontains("ababac", "abac"));  }
 EXPECT true
 TIMEOUT 1
 
 NAME special characters
-PROG BEGIN { print(strcontains("hello\tworld", "\two")); exit(); }
+PROG BEGIN { print(strcontains("hello\tworld", "\two"));  }
 EXPECT true
 TIMEOUT 1
 
 NAME null terminator inside haystack
-PROG BEGIN { $str = "hello\0world"; print(strcontains($str, "world")); exit(); }
+PROG BEGIN { $str = "hello\0world"; print(strcontains($str, "world"));  }
 EXPECT false
 TIMEOUT 1
 
 NAME content after null terminator
-PROG BEGIN { $str = "hello\0test"; print(strcontains($str, "test")); exit(); }
+PROG BEGIN { $str = "hello\0test"; print(strcontains($str, "test"));  }
 EXPECT false
 TIMEOUT 1
 
 NAME null character in needle
-PROG BEGIN { $needle = "wo\0rld"; print(strcontains("hello world", $needle)); exit(); }
+PROG BEGIN { $needle = "wo\0rld"; print(strcontains("hello world", $needle));  }
 EXPECT true
 TIMEOUT 1
 
 NAME null character in both
-PROG BEGIN { $haystack = "hello\0world"; $needle = "wo\0rld"; print(strcontains($haystack, $needle)); exit(); }
+PROG BEGIN { $haystack = "hello\0world"; $needle = "wo\0rld"; print(strcontains($haystack, $needle));  }
 EXPECT false
 TIMEOUT 1

--- a/tests/runtime/tuples
+++ b/tests/runtime/tuples
@@ -1,55 +1,55 @@
 NAME basic tuple
-PROG BEGIN { $v = 99; $t = (0, 1, "str", (5, 6), $v); printf("%d %d %s %d %d %d\n", $t.0, $t.1, $t.2, $t.3.0, $t.3.1, $t.4); exit(); }
+PROG BEGIN { $v = 99; $t = (0, 1, "str", (5, 6), $v); printf("%d %d %s %d %d %d\n", $t.0, $t.1, $t.2, $t.3.0, $t.3.1, $t.4);  }
 EXPECT 0 1 str 5 6 99
 
 NAME basic tuple map
-PROG BEGIN { $v = 99; @t = (0, 1, "str"); printf("%d %d %s\n", @t.0, @t.1, @t.2); exit(); }
+PROG BEGIN { $v = 99; @t = (0, 1, "str"); printf("%d %d %s\n", @t.0, @t.1, @t.2);  }
 EXPECT 0 1 str
 
 NAME mixed int tuple map
-PROG BEGIN { @ = ( (int32) -100, (int8) 10, 50 ); exit();}
+PROG BEGIN { @ = ( (int32) -100, (int8) 10, 50 ); }
 EXPECT @: (-100, 10, 50)
 
 NAME mixed int tuple map 2
-PROG BEGIN { @ = ( -100, (int8) 10, (int32) 50 ); exit();}
+PROG BEGIN { @ = ( -100, (int8) 10, (int32) 50 ); }
 EXPECT @: (-100, 10, 50)
 
 NAME mixed int tuple map 3
-PROG BEGIN { @ = ( -100, (int8) 10, (int32) 50, 100 ); exit();}
+PROG BEGIN { @ = ( -100, (int8) 10, (int32) 50, 100 ); }
 EXPECT @: (-100, 10, 50, 100)
 
 NAME tuple map key
-PROG BEGIN { @[(1, "hello")] = 1; exit();}
+PROG BEGIN { @[(1, "hello")] = 1; }
 EXPECT @[1, hello]: 1
 
 NAME tuple map key and value
-PROG BEGIN { @[(1, 2)] = (3, 4); exit();}
+PROG BEGIN { @[(1, 2)] = (3, 4); }
 EXPECT @[1, 2]: (3, 4)
 
 NAME implicit conversion of multi map key to tuple
-PROG BEGIN { @["abcd", 2] = (3, 4, 5); exit();}
+PROG BEGIN { @["abcd", 2] = (3, 4, 5); }
 EXPECT @[abcd, 2]: (3, 4, 5)
 
 NAME tuple map key same as assoc array
-PROG BEGIN { @[(1, "hello")] = 1;  @[2, "hello"] = 2; delete(@, (1, "hello")); exit();}
+PROG BEGIN { @[(1, "hello")] = 1;  @[2, "hello"] = 2; delete(@, (1, "hello")); }
 EXPECT @[2, hello]: 2
 
 NAME tuple map key variable
-PROG BEGIN { $a = (1, "hello"); @[(1, "hello")] = 1; @[$a] = 2; exit();}
+PROG BEGIN { $a = (1, "hello"); @[(1, "hello")] = 1; @[$a] = 2; }
 EXPECT @[1, hello]: 2
 
 NAME tuple map key string resize
-PROG BEGIN { @a["hellotherelongstr", 4] = 1; @a["by", 6] = 2; exit(); }
+PROG BEGIN { @a["hellotherelongstr", 4] = 1; @a["by", 6] = 2;  }
 EXPECT @a[hellotherelongstr, 4]: 1
 EXPECT @a[by, 6]: 2
 
 NAME tuple map key compatible int sizes
-PROG BEGIN { $a = (1,(123,(uint64)1234)); $b = (4,(1234,(uint8)123)); @a[$a] = 1; @a[$b] = 2; exit(); }
+PROG BEGIN { $a = (1,(123,(uint64)1234)); $b = (4,(1234,(uint8)123)); @a[$a] = 1; @a[$b] = 2;  }
 EXPECT @a[1, (123, 1234)]: 1
 EXPECT @a[4, (1234, 123)]: 2
 
 NAME complex tuple 1
-PROG BEGIN { print(((int8)-100, (int8) 100, "abcdef", 3, (int32) 1, (int64)-10, (int8)10, (int16)-555)); exit(); }
+PROG BEGIN { print(((int8)-100, (int8) 100, "abcdef", 3, (int32) 1, (int64)-10, (int8)10, (int16)-555));  }
 EXPECT (-100, 100, abcdef, 3, 1, -10, 10, -555)
 
 NAME tuple struct sizing 1
@@ -65,7 +65,7 @@ PROG BEGIN { $t = ((int32) 1, (int16) 1, (int8) 1); print(sizeof($t)); exit() }
 EXPECT 8
 
 NAME complex tuple 4
-PROG BEGIN { $a = ((int8)-100, (int8) 100, "abcdef", 3, (int32) 1, (int64)-10, (int8)10, (int16)-555, "abc"); print(sizeof($a)); exit(); }
+PROG BEGIN { $a = ((int8)-100, (int8) 100, "abcdef", 3, (int32) 1, (int64)-10, (int8)10, (int16)-555, "abc"); print(sizeof($a));  }
 EXPECT 48
 
 NAME struct in tuple
@@ -95,11 +95,11 @@ EXPECT @: (1, (-20, 30))
 # Careful with '(' and ')', they are read by the test engine as a regex group,
 # so make sure to escape them.
 NAME tuple print
-PROG BEGIN { @ = (1, 2, "string", (4, 5)); exit(); }
+PROG BEGIN { @ = (1, 2, "string", (4, 5));  }
 EXPECT @: (1, 2, string, (4, 5))
 
 NAME tuple strftime type is packed
-PROG BEGIN { @ = (nsecs, strftime("%M:%S", nsecs)); exit(); }
+PROG BEGIN { @ = (nsecs, strftime("%M:%S", nsecs));  }
 EXPECT_REGEX ^@: \(\d+, \d+:\d+\)$
 
 NAME bytearray in tuple
@@ -115,9 +115,9 @@ ARCH ppc64|ppc64le
 AFTER ./testprogs/uprobe_test
 
 NAME ustack in tuple
-PROG BEGIN { print((ustack, "a")); exit(); }
+PROG BEGIN { print((ustack, "a"));  }
 EXPECT Attached 1 probe
 
 NAME kstack in tuple
-PROG BEGIN { print((kstack, "a")); exit(); }
+PROG BEGIN { print((kstack, "a"));  }
 EXPECT Attached 1 probe

--- a/tests/runtime/variable
+++ b/tests/runtime/variable
@@ -27,11 +27,11 @@ PROG i:ms:1 {$a = buf("hi", 2); $b = buf("bye", 3); printf("equal=%d, unequal=%d
 EXPECT equal=1, unequal=1
 
 NAME global_associative_arrays
-PROG BEGIN { @map[123] = 456; } END { printf("val: %d\n", @map[123]); exit(); }
+PROG BEGIN { @map[123] = 456; } END { printf("val: %d\n", @map[123]);  }
 EXPECT val: 456
 
 NAME scratch
-PROG BEGIN { @map[123] = 456; } END { $val = @map[123]; printf("val: %d\n", $val); exit(); }
+PROG BEGIN { @map[123] = 456; } END { $val = @map[123]; printf("val: %d\n", $val);  }
 EXPECT val: 456
 
 NAME 32-bit tracepoint arg
@@ -44,82 +44,82 @@ RUN {{BPFTRACE}} -e 'tracepoint:syscalls:sys_enter_wait4 /args.ru/ { @ru[tid] = 
 EXPECT_REGEX @: [1-9][0-9]*
 
 NAME variable string type resize
-PROG BEGIN { $x = "hello"; $x = "hi"; printf("%s\n", $x); exit(); }
+PROG BEGIN { $x = "hello"; $x = "hi"; printf("%s\n", $x);  }
 EXPECT hi
 TIMEOUT 2
 
 NAME map string type resize
-PROG BEGIN { @ = "hello"; } i:ms:1 { @ = "hi"; exit(); }
+PROG BEGIN { @ = "hello"; } i:ms:1 { @ = "hi";  }
 EXPECT @: hi
 TIMEOUT 2
 
 NAME map key string type resize
-PROG BEGIN { @["hello"] = 0; } i:ms:1 { @["hi"] = 1; exit(); }
+PROG BEGIN { @["hello"] = 0; } i:ms:1 { @["hi"] = 1;  }
 EXPECT @[hi]: 1
 TIMEOUT 2
 
 NAME map multi-key string type resize
-PROG BEGIN { @["hello", 0] = 0; } i:ms:1 { @["hi", 1] = 1; exit(); }
+PROG BEGIN { @["hello", 0] = 0; } i:ms:1 { @["hi", 1] = 1;  }
 EXPECT @[hi, 1]: 1
 TIMEOUT 2
 
 NAME map tuple string resize
-PROG BEGIN { @[1] = ("hi", 1); @[1] = ("hellolongstr", 2); @[1] = ("by", 3); exit(); }
+PROG BEGIN { @[1] = ("hi", 1); @[1] = ("hellolongstr", 2); @[1] = ("by", 3);  }
 EXPECT @[1]: (by, 3)
 TIMEOUT 2
 
 NAME map key tuple string resize
-PROG BEGIN { @["hi", 1] = 1; @["hellolongstr", 2] = 2; @["by", 3] = 3; exit(); }
+PROG BEGIN { @["hi", 1] = 1; @["hellolongstr", 2] = 2; @["by", 3] = 3;  }
 EXPECT @[hi, 1]: 1
 EXPECT @[hellolongstr, 2]: 2
 EXPECT @[by, 3]: 3
 TIMEOUT 2
 
 NAME variable tuple string resize
-PROG BEGIN { $a = ("hi", 1); print(($a)); $a = ("hellolongstr", 2); print(($a)); $a = ("by", 3); print(($a)); exit(); }
+PROG BEGIN { $a = ("hi", 1); print(($a)); $a = ("hellolongstr", 2); print(($a)); $a = ("by", 3); print(($a));  }
 EXPECT (hi, 1)
 EXPECT (hellolongstr, 2)
 EXPECT (by, 3)
 TIMEOUT 2
 
 NAME variable nested tuple string resize
-PROG BEGIN { $a = ("hi", ("hellolongstr", 2)); print(($a)); $a = ("hellolongstr", ("hi", 5)); print(($a)); exit(); }
+PROG BEGIN { $a = ("hi", ("hellolongstr", 2)); print(($a)); $a = ("hellolongstr", ("hi", 5)); print(($a));  }
 EXPECT (hi, (hellolongstr, 2))
 EXPECT (hellolongstr, (hi, 5))
 TIMEOUT 2
 
 NAME map nested tuple string resize
-PROG BEGIN { @[1] = ("hi", ("hellolongstr", 2)); @[1] = ("hellolongstr", ("hi", 5)); exit(); }
+PROG BEGIN { @[1] = ("hi", ("hellolongstr", 2)); @[1] = ("hellolongstr", ("hi", 5));  }
 EXPECT @[1]: (hellolongstr, (hi, 5))
 TIMEOUT 2
 
 NAME map key nested tuple string resize
-PROG BEGIN { @["hi", ("hellolongstr", 2)] = 1; @["hellolongstr", ("hi", 5)] = 2; exit(); }
+PROG BEGIN { @["hi", ("hellolongstr", 2)] = 1; @["hellolongstr", ("hi", 5)] = 2;  }
 EXPECT @[hi, (hellolongstr, 2)]: 1
 EXPECT @[hellolongstr, (hi, 5)]: 2
 TIMEOUT 2
 
 NAME map key tuple with casted ints
-PROG BEGIN { @a[(int16)-1, ((int32)-2, 3)] = 10; @a[5, (6, 7)] = 11; $c = ((int8)-4, ((int16)-5, -6)); @a[$c] = 12; exit(); }
+PROG BEGIN { @a[(int16)-1, ((int32)-2, 3)] = 10; @a[5, (6, 7)] = 11; $c = ((int8)-4, ((int16)-5, -6)); @a[$c] = 12;  }
 EXPECT @a[-4, (-5, -6)]: 12
 EXPECT @a[-1, (-2, 3)]: 10
 EXPECT @a[5, (6, 7)]: 11
 TIMEOUT 2
 
 NAME variable declaration
-PROG BEGIN { let $a; $a = 10; printf("a=%d\n", $a); exit();}
+PROG BEGIN { let $a; $a = 10; printf("a=%d\n", $a); }
 EXPECT a=10
 
 NAME variable declaration with builtin
-PROG BEGIN { let $f: struct task_struct *; $f = curtask; print($f->pid); exit();}
+PROG BEGIN { let $f: struct task_struct *; $f = curtask; print($f->pid); }
 EXPECT_REGEX [0-9]+
 
 NAME variable declaration with unresolved type
-PROG BEGIN { let $x: struct Foo[1]; exit(); }
+PROG BEGIN { let $x: struct Foo[1];  }
 EXPECT Attached 1 probe
 
 NAME variable declaration not initialized
-PROG BEGIN { let $a; if (false) { $a = 1; } @b = $a; exit();}
+PROG BEGIN { let $a; if (false) { $a = 1; } @b = $a; }
 EXPECT @b: 0
 
 NAME variable doesn't escape scope


### PR DESCRIPTION
Now users who are testing programs don't have
to explicitly add an 'exit' in their BEGIN
probes. This also removes a lot of extra "exit()"
calls in the runtime tests.

##### Checklist

- [ ] Language changes are updated in `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
