### PR TITLE
Skip watchpoint test using mode 'x' on PowerPC

### DIFF
--- a/tests/runtime/watchpoint
+++ b/tests/runtime/watchpoint
@@ -65,7 +65,7 @@ REQUIRES_FEATURE signal
 NAME execution breakpoint
 RUN {{BPFTRACE}} -e 'watchpoint:0x10000000:1:x { printf("hit!\n"); exit() }' -c ./testprogs/watchpoint_exec
 EXPECT hit!
-ARCH aarch64|ppc64|ppc64le|x86_64
+ARCH aarch64|x86_64
 
 NAME watchpoint absolute address threaded
 BEFORE ./testprogs/watchpoint_threaded


### PR DESCRIPTION
PowerPC does not support the 'x' mode for watchpoints so we need to skip the "watchpoint:execution breakpoint" test which uses this mode.

See [src/arch/ppc64.cpp:151](https://github.com/bpftrace/bpftrace/blob/master/src/arch/ppc64.cpp#L151-L155).

cc @jordalgo 

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
