### PR TITLE
Fix up Binop checks considering new bool type

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -320,6 +320,10 @@ std::vector<std::unique_ptr<IPrintable>> BPFtrace::get_arg_values(
 
   for (auto arg : args) {
     switch (arg.type.GetTy()) {
+      case Type::boolean:
+        arg_values.push_back(std::make_unique<PrintableInt>(
+            *reinterpret_cast<uint8_t *>(arg_data + arg.offset)));
+        break;
       case Type::integer:
         if (arg.type.IsSigned()) {
           int64_t val = 0;

--- a/src/format_string.cpp
+++ b/src/format_string.cpp
@@ -122,6 +122,8 @@ std::string validate_format_string(const std::string &fmt,
       // Symbolizing enum
       arg_types.insert(Type::string);
       arg_types.insert(Type::integer);
+    } else if (arg_type == Type::boolean) {
+      arg_types.insert(Type::integer);
     } else {
       arg_types.insert(arg_type);
     }

--- a/tests/codegen/llvm/comparison_extend.ll
+++ b/tests/codegen/llvm/comparison_extend.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !23
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !37
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !47 {
 entry:
-  %"@_val" = alloca i64, align 8
+  %"@_val" = alloca i8, align 1
   %"@_key" = alloca i64, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
@@ -27,8 +27,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  %4 = zext i1 %3 to i64
-  store i64 %4, ptr %"@_val", align 8
+  store i1 %3, ptr %"@_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
@@ -48,8 +47,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!43}
+!llvm.module.flags = !{!45, !46}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -72,34 +71,34 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 64, elements: !15)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!43 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !44)
+!44 = !{!0, !7, !23, !37, !41}
+!45 = !{i32 2, !"Debug Info Version", i32 3}
+!46 = !{i32 7, !"uwtable", i32 0}
+!47 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !50)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!20, !22}
 !50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !47, file: !2, type: !22)

--- a/tests/codegen/llvm/logical_and.ll
+++ b/tests/codegen/llvm/logical_and.ll
@@ -8,19 +8,19 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !23
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !37
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !47 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
   %"@x_key" = alloca i64, align 8
-  %"&&_result" = alloca i64, align 8
+  %"&&_result" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"&&_result")
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
@@ -40,19 +40,19 @@ entry:
   br i1 %rhs_true_cond, label %"&&_true", label %"&&_false"
 
 "&&_true":                                        ; preds = %"&&_lhs_true"
-  store i64 1, ptr %"&&_result", align 8
+  store i8 1, ptr %"&&_result", align 1
   br label %"&&_merge"
 
 "&&_false":                                       ; preds = %"&&_lhs_true", %entry
-  store i64 0, ptr %"&&_result", align 8
+  store i8 0, ptr %"&&_result", align 1
   br label %"&&_merge"
 
 "&&_merge":                                       ; preds = %"&&_false", %"&&_true"
-  %7 = load i64, ptr %"&&_result", align 8
+  %7 = load i8, ptr %"&&_result", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 %7, ptr %"@x_val", align 8
+  store i8 %7, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -69,8 +69,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { memory(none) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!43}
+!llvm.module.flags = !{!45, !46}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -93,34 +93,34 @@ attributes #2 = { memory(none) }
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 64, elements: !15)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!43 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !44)
+!44 = !{!0, !7, !23, !37, !41}
+!45 = !{i32 2, !"Debug Info Version", i32 3}
+!46 = !{i32 7, !"uwtable", i32 0}
+!47 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !50)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!20, !22}
 !50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !47, file: !2, type: !22)

--- a/tests/codegen/llvm/logical_and_or_different_type.ll
+++ b/tests/codegen/llvm/logical_and_or_different_type.ll
@@ -19,13 +19,13 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !42 {
 entry:
   %"struct Foo.m16" = alloca i32, align 4
-  %"||_result15" = alloca i64, align 8
+  %"||_result15" = alloca i8, align 1
   %"struct Foo.m8" = alloca i32, align 4
-  %"||_result" = alloca i64, align 8
+  %"||_result" = alloca i8, align 1
   %"struct Foo.m6" = alloca i32, align 4
-  %"&&_result5" = alloca i64, align 8
+  %"&&_result5" = alloca i8, align 1
   %"struct Foo.m" = alloca i32, align 4
-  %"&&_result" = alloca i64, align 8
+  %"&&_result" = alloca i8, align 1
   %"$foo" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$foo")
   store i64 0, ptr %"$foo", align 8
@@ -53,17 +53,17 @@ entry:
   br i1 false, label %"&&_true", label %"&&_false"
 
 "&&_true":                                        ; preds = %"&&_lhs_true"
-  store i64 1, ptr %"&&_result", align 8
+  store i8 1, ptr %"&&_result", align 1
   br label %"&&_merge"
 
 "&&_false":                                       ; preds = %"&&_lhs_true", %entry
-  store i64 0, ptr %"&&_result", align 8
+  store i8 0, ptr %"&&_result", align 1
   br label %"&&_merge"
 
 "&&_merge":                                       ; preds = %"&&_false", %"&&_true"
-  %9 = load i64, ptr %"&&_result", align 8
+  %9 = load i8, ptr %"&&_result", align 1
   %10 = getelementptr %printf_t, ptr %2, i32 0, i32 1
-  store i64 %9, ptr %10, align 8
+  store i8 %9, ptr %10, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"&&_result5")
   br i1 true, label %"&&_lhs_true1", label %"&&_false3"
 
@@ -80,17 +80,17 @@ entry:
   br i1 %rhs_true_cond, label %"&&_true2", label %"&&_false3"
 
 "&&_true2":                                       ; preds = %"&&_lhs_true1"
-  store i64 1, ptr %"&&_result5", align 8
+  store i8 1, ptr %"&&_result5", align 1
   br label %"&&_merge4"
 
 "&&_false3":                                      ; preds = %"&&_lhs_true1", %"&&_merge"
-  store i64 0, ptr %"&&_result5", align 8
+  store i8 0, ptr %"&&_result5", align 1
   br label %"&&_merge4"
 
 "&&_merge4":                                      ; preds = %"&&_false3", %"&&_true2"
-  %16 = load i64, ptr %"&&_result5", align 8
+  %16 = load i8, ptr %"&&_result5", align 1
   %17 = getelementptr %printf_t, ptr %2, i32 0, i32 2
-  store i64 %16, ptr %17, align 8
+  store i8 %16, ptr %17, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"||_result")
   %18 = load i64, ptr %"$foo", align 8
   %19 = inttoptr i64 %18 to ptr
@@ -107,17 +107,17 @@ entry:
   br i1 false, label %"||_true", label %"||_false"
 
 "||_false":                                       ; preds = %"||_lhs_false"
-  store i64 0, ptr %"||_result", align 8
+  store i8 0, ptr %"||_result", align 1
   br label %"||_merge"
 
 "||_true":                                        ; preds = %"||_lhs_false", %"&&_merge4"
-  store i64 1, ptr %"||_result", align 8
+  store i8 1, ptr %"||_result", align 1
   br label %"||_merge"
 
 "||_merge":                                       ; preds = %"||_true", %"||_false"
-  %23 = load i64, ptr %"||_result", align 8
+  %23 = load i8, ptr %"||_result", align 1
   %24 = getelementptr %printf_t, ptr %2, i32 0, i32 3
-  store i64 %23, ptr %24, align 8
+  store i8 %23, ptr %24, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"||_result15")
   br i1 false, label %"||_true13", label %"||_lhs_false11"
 
@@ -134,17 +134,17 @@ entry:
   br i1 %rhs_true_cond18, label %"||_true13", label %"||_false12"
 
 "||_false12":                                     ; preds = %"||_lhs_false11"
-  store i64 0, ptr %"||_result15", align 8
+  store i8 0, ptr %"||_result15", align 1
   br label %"||_merge14"
 
 "||_true13":                                      ; preds = %"||_lhs_false11", %"||_merge"
-  store i64 1, ptr %"||_result15", align 8
+  store i8 1, ptr %"||_result15", align 1
   br label %"||_merge14"
 
 "||_merge14":                                     ; preds = %"||_true13", %"||_false12"
-  %30 = load i64, ptr %"||_result15", align 8
+  %30 = load i8, ptr %"||_result15", align 1
   %31 = getelementptr %printf_t, ptr %2, i32 0, i32 4
-  store i64 %30, ptr %31, align 8
+  store i8 %30, ptr %31, align 1
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %2, i64 40, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge

--- a/tests/codegen/llvm/logical_or.ll
+++ b/tests/codegen/llvm/logical_or.ll
@@ -8,19 +8,19 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !23
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !37
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !47 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
   %"@x_key" = alloca i64, align 8
-  %"||_result" = alloca i64, align 8
+  %"||_result" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"||_result")
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
@@ -40,19 +40,19 @@ entry:
   br i1 %rhs_true_cond, label %"||_true", label %"||_false"
 
 "||_false":                                       ; preds = %"||_lhs_false"
-  store i64 0, ptr %"||_result", align 8
+  store i8 0, ptr %"||_result", align 1
   br label %"||_merge"
 
 "||_true":                                        ; preds = %"||_lhs_false", %entry
-  store i64 1, ptr %"||_result", align 8
+  store i8 1, ptr %"||_result", align 1
   br label %"||_merge"
 
 "||_merge":                                       ; preds = %"||_true", %"||_false"
-  %7 = load i64, ptr %"||_result", align 8
+  %7 = load i8, ptr %"||_result", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 %7, ptr %"@x_val", align 8
+  store i8 %7, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -69,8 +69,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { memory(none) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!43}
+!llvm.module.flags = !{!45, !46}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -93,34 +93,34 @@ attributes #2 = { memory(none) }
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 64, elements: !15)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!43 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !44)
+!44 = !{!0, !7, !23, !37, !41}
+!45 = !{i32 2, !"Debug Info Version", i32 3}
+!46 = !{i32 7, !"uwtable", i32 0}
+!47 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !50)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!20, !22}
 !50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !47, file: !2, type: !22)

--- a/tests/codegen/llvm/pointer_logical_and.ll
+++ b/tests/codegen/llvm/pointer_logical_and.ll
@@ -16,7 +16,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
-  %"&&_result" = alloca i64, align 8
+  %"&&_result" = alloca i8, align 1
   %"$v" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$v")
   store i64 0, ptr %"$v", align 8
@@ -36,16 +36,16 @@ if_end:                                           ; preds = %if_body, %"&&_merge
   br i1 false, label %"&&_true", label %"&&_false"
 
 "&&_true":                                        ; preds = %"&&_lhs_true"
-  store i64 1, ptr %"&&_result", align 8
+  store i8 1, ptr %"&&_result", align 1
   br label %"&&_merge"
 
 "&&_false":                                       ; preds = %"&&_lhs_true", %entry
-  store i64 0, ptr %"&&_result", align 8
+  store i8 0, ptr %"&&_result", align 1
   br label %"&&_merge"
 
 "&&_merge":                                       ; preds = %"&&_false", %"&&_true"
-  %2 = load i64, ptr %"&&_result", align 8
-  %true_cond = icmp ne i64 %2, 0
+  %2 = load i8, ptr %"&&_result", align 1
+  %true_cond = icmp ne i8 %2, 0
   br i1 %true_cond, label %if_body, label %if_end
 }
 

--- a/tests/codegen/llvm/pointer_logical_or.ll
+++ b/tests/codegen/llvm/pointer_logical_or.ll
@@ -16,7 +16,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
-  %"||_result" = alloca i64, align 8
+  %"||_result" = alloca i8, align 1
   %"$v" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$v")
   store i64 0, ptr %"$v", align 8
@@ -36,16 +36,16 @@ if_end:                                           ; preds = %if_body, %"||_merge
   br i1 false, label %"||_true", label %"||_false"
 
 "||_false":                                       ; preds = %"||_lhs_false"
-  store i64 0, ptr %"||_result", align 8
+  store i8 0, ptr %"||_result", align 1
   br label %"||_merge"
 
 "||_true":                                        ; preds = %"||_lhs_false", %entry
-  store i64 1, ptr %"||_result", align 8
+  store i8 1, ptr %"||_result", align 1
   br label %"||_merge"
 
 "||_merge":                                       ; preds = %"||_true", %"||_false"
-  %2 = load i64, ptr %"||_result", align 8
-  %true_cond = icmp ne i64 %2, 0
+  %2 = load i8, ptr %"||_result", align 1
+  %true_cond = icmp ne i8 %2, 0
   br i1 %true_cond, label %if_body, label %if_end
 }
 

--- a/tests/codegen/llvm/string_equal_comparison.ll
+++ b/tests/codegen/llvm/string_equal_comparison.ll
@@ -8,19 +8,19 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !27
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !41
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !45
 @sshd = global [5 x i8] c"sshd\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !51 {
 entry:
   %"@_val" = alloca i64, align 8
-  %"@_key" = alloca i64, align 8
+  %"@_key" = alloca i8, align 1
   %strcmp.result = alloca i1, align 1
   %comm = alloca [16 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %comm)
@@ -40,7 +40,8 @@ strcmp.false:                                     ; preds = %strcmp.done, %strcm
   %5 = zext i1 %4 to i64
   call void @llvm.lifetime.end.p0(i64 -1, ptr %comm)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  store i64 %5, ptr %"@_key", align 8
+  %6 = trunc i64 %5 to i8
+  store i8 %6, ptr %"@_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
   store i64 1, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
@@ -53,10 +54,10 @@ strcmp.done:                                      ; preds = %strcmp.loop13, %str
   br label %strcmp.false
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
-  %6 = getelementptr i8, ptr %comm, i32 1
-  %7 = load i8, ptr %6, align 1
-  %8 = load i8, ptr getelementptr (i8, ptr @sshd, i32 1), align 1
-  %strcmp.cmp3 = icmp ne i8 %7, %8
+  %7 = getelementptr i8, ptr %comm, i32 1
+  %8 = load i8, ptr %7, align 1
+  %9 = load i8, ptr getelementptr (i8, ptr @sshd, i32 1), align 1
+  %strcmp.cmp3 = icmp ne i8 %8, %9
   br i1 %strcmp.cmp3, label %strcmp.false, label %strcmp.loop_null_cmp2
 
 strcmp.loop_null_cmp:                             ; preds = %entry
@@ -64,43 +65,43 @@ strcmp.loop_null_cmp:                             ; preds = %entry
   br i1 %strcmp.cmp_null, label %strcmp.done, label %strcmp.loop
 
 strcmp.loop1:                                     ; preds = %strcmp.loop_null_cmp2
-  %9 = getelementptr i8, ptr %comm, i32 2
-  %10 = load i8, ptr %9, align 1
-  %11 = load i8, ptr getelementptr (i8, ptr @sshd, i32 2), align 1
-  %strcmp.cmp7 = icmp ne i8 %10, %11
+  %10 = getelementptr i8, ptr %comm, i32 2
+  %11 = load i8, ptr %10, align 1
+  %12 = load i8, ptr getelementptr (i8, ptr @sshd, i32 2), align 1
+  %strcmp.cmp7 = icmp ne i8 %11, %12
   br i1 %strcmp.cmp7, label %strcmp.false, label %strcmp.loop_null_cmp6
 
 strcmp.loop_null_cmp2:                            ; preds = %strcmp.loop
-  %strcmp.cmp_null4 = icmp eq i8 %7, 0
+  %strcmp.cmp_null4 = icmp eq i8 %8, 0
   br i1 %strcmp.cmp_null4, label %strcmp.done, label %strcmp.loop1
 
 strcmp.loop5:                                     ; preds = %strcmp.loop_null_cmp6
-  %12 = getelementptr i8, ptr %comm, i32 3
-  %13 = load i8, ptr %12, align 1
-  %14 = load i8, ptr getelementptr (i8, ptr @sshd, i32 3), align 1
-  %strcmp.cmp11 = icmp ne i8 %13, %14
+  %13 = getelementptr i8, ptr %comm, i32 3
+  %14 = load i8, ptr %13, align 1
+  %15 = load i8, ptr getelementptr (i8, ptr @sshd, i32 3), align 1
+  %strcmp.cmp11 = icmp ne i8 %14, %15
   br i1 %strcmp.cmp11, label %strcmp.false, label %strcmp.loop_null_cmp10
 
 strcmp.loop_null_cmp6:                            ; preds = %strcmp.loop1
-  %strcmp.cmp_null8 = icmp eq i8 %10, 0
+  %strcmp.cmp_null8 = icmp eq i8 %11, 0
   br i1 %strcmp.cmp_null8, label %strcmp.done, label %strcmp.loop5
 
 strcmp.loop9:                                     ; preds = %strcmp.loop_null_cmp10
-  %15 = getelementptr i8, ptr %comm, i32 4
-  %16 = load i8, ptr %15, align 1
-  %17 = load i8, ptr getelementptr (i8, ptr @sshd, i32 4), align 1
-  %strcmp.cmp15 = icmp ne i8 %16, %17
+  %16 = getelementptr i8, ptr %comm, i32 4
+  %17 = load i8, ptr %16, align 1
+  %18 = load i8, ptr getelementptr (i8, ptr @sshd, i32 4), align 1
+  %strcmp.cmp15 = icmp ne i8 %17, %18
   br i1 %strcmp.cmp15, label %strcmp.false, label %strcmp.loop_null_cmp14
 
 strcmp.loop_null_cmp10:                           ; preds = %strcmp.loop5
-  %strcmp.cmp_null12 = icmp eq i8 %13, 0
+  %strcmp.cmp_null12 = icmp eq i8 %14, 0
   br i1 %strcmp.cmp_null12, label %strcmp.done, label %strcmp.loop9
 
 strcmp.loop13:                                    ; preds = %strcmp.loop_null_cmp14
   br label %strcmp.done
 
 strcmp.loop_null_cmp14:                           ; preds = %strcmp.loop9
-  %strcmp.cmp_null16 = icmp eq i8 %16, 0
+  %strcmp.cmp_null16 = icmp eq i8 %17, 0
   br i1 %strcmp.cmp_null16, label %strcmp.done, label %strcmp.loop13
 }
 
@@ -117,8 +118,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!46}
-!llvm.module.flags = !{!48, !49}
+!llvm.dbg.cu = !{!47}
+!llvm.module.flags = !{!49, !50}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -130,7 +131,7 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
@@ -143,36 +144,36 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !20 = !{!21}
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
-!29 = !{!30, !35}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 27, lowerBound: 0)
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
-!38 = !{!39}
-!39 = !DISubrange(count: 262144, lowerBound: 0)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
-!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
-!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
-!47 = !{!0, !7, !26, !40, !44}
-!48 = !{i32 2, !"Debug Info Version", i32 3}
-!49 = !{i32 7, !"uwtable", i32 0}
-!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
-!51 = !DISubroutineType(types: !52)
-!52 = !{!24, !53}
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !25, size: 64, offset: 192)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!27 = !DIGlobalVariableExpression(var: !28, expr: !DIExpression())
+!28 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
+!29 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !30)
+!30 = !{!31, !36}
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !32, size: 64)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !34)
+!34 = !{!35}
+!35 = !DISubrange(count: 27, lowerBound: 0)
+!36 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !37, size: 64, offset: 64)
+!37 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !38, size: 64)
+!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !39)
+!39 = !{!40}
+!40 = !DISubrange(count: 262144, lowerBound: 0)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !44, size: 64, elements: !15)
+!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !26, size: 64, elements: !15)
+!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
+!46 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!47 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !48)
+!48 = !{!0, !7, !27, !41, !45}
+!49 = !{i32 2, !"Debug Info Version", i32 3}
+!50 = !{i32 7, !"uwtable", i32 0}
+!51 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !54)
+!52 = !DISubroutineType(types: !53)
+!53 = !{!26, !23}
 !54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)
+!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !23)

--- a/tests/codegen/llvm/string_not_equal_comparison.ll
+++ b/tests/codegen/llvm/string_not_equal_comparison.ll
@@ -8,19 +8,19 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !26
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
+@ringbuf = dso_local global %"struct map_t.0" zeroinitializer, section ".maps", !dbg !27
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !41
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !45
 @sshd = global [5 x i8] c"sshd\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !51 {
 entry:
   %"@_val" = alloca i64, align 8
-  %"@_key" = alloca i64, align 8
+  %"@_key" = alloca i8, align 1
   %strcmp.result = alloca i1, align 1
   %comm = alloca [16 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %comm)
@@ -40,7 +40,8 @@ strcmp.false:                                     ; preds = %strcmp.done, %strcm
   %5 = zext i1 %4 to i64
   call void @llvm.lifetime.end.p0(i64 -1, ptr %comm)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  store i64 %5, ptr %"@_key", align 8
+  %6 = trunc i64 %5 to i8
+  store i8 %6, ptr %"@_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
   store i64 1, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
@@ -53,10 +54,10 @@ strcmp.done:                                      ; preds = %strcmp.loop13, %str
   br label %strcmp.false
 
 strcmp.loop:                                      ; preds = %strcmp.loop_null_cmp
-  %6 = getelementptr i8, ptr %comm, i32 1
-  %7 = load i8, ptr %6, align 1
-  %8 = load i8, ptr getelementptr (i8, ptr @sshd, i32 1), align 1
-  %strcmp.cmp3 = icmp ne i8 %7, %8
+  %7 = getelementptr i8, ptr %comm, i32 1
+  %8 = load i8, ptr %7, align 1
+  %9 = load i8, ptr getelementptr (i8, ptr @sshd, i32 1), align 1
+  %strcmp.cmp3 = icmp ne i8 %8, %9
   br i1 %strcmp.cmp3, label %strcmp.false, label %strcmp.loop_null_cmp2
 
 strcmp.loop_null_cmp:                             ; preds = %entry
@@ -64,43 +65,43 @@ strcmp.loop_null_cmp:                             ; preds = %entry
   br i1 %strcmp.cmp_null, label %strcmp.done, label %strcmp.loop
 
 strcmp.loop1:                                     ; preds = %strcmp.loop_null_cmp2
-  %9 = getelementptr i8, ptr %comm, i32 2
-  %10 = load i8, ptr %9, align 1
-  %11 = load i8, ptr getelementptr (i8, ptr @sshd, i32 2), align 1
-  %strcmp.cmp7 = icmp ne i8 %10, %11
+  %10 = getelementptr i8, ptr %comm, i32 2
+  %11 = load i8, ptr %10, align 1
+  %12 = load i8, ptr getelementptr (i8, ptr @sshd, i32 2), align 1
+  %strcmp.cmp7 = icmp ne i8 %11, %12
   br i1 %strcmp.cmp7, label %strcmp.false, label %strcmp.loop_null_cmp6
 
 strcmp.loop_null_cmp2:                            ; preds = %strcmp.loop
-  %strcmp.cmp_null4 = icmp eq i8 %7, 0
+  %strcmp.cmp_null4 = icmp eq i8 %8, 0
   br i1 %strcmp.cmp_null4, label %strcmp.done, label %strcmp.loop1
 
 strcmp.loop5:                                     ; preds = %strcmp.loop_null_cmp6
-  %12 = getelementptr i8, ptr %comm, i32 3
-  %13 = load i8, ptr %12, align 1
-  %14 = load i8, ptr getelementptr (i8, ptr @sshd, i32 3), align 1
-  %strcmp.cmp11 = icmp ne i8 %13, %14
+  %13 = getelementptr i8, ptr %comm, i32 3
+  %14 = load i8, ptr %13, align 1
+  %15 = load i8, ptr getelementptr (i8, ptr @sshd, i32 3), align 1
+  %strcmp.cmp11 = icmp ne i8 %14, %15
   br i1 %strcmp.cmp11, label %strcmp.false, label %strcmp.loop_null_cmp10
 
 strcmp.loop_null_cmp6:                            ; preds = %strcmp.loop1
-  %strcmp.cmp_null8 = icmp eq i8 %10, 0
+  %strcmp.cmp_null8 = icmp eq i8 %11, 0
   br i1 %strcmp.cmp_null8, label %strcmp.done, label %strcmp.loop5
 
 strcmp.loop9:                                     ; preds = %strcmp.loop_null_cmp10
-  %15 = getelementptr i8, ptr %comm, i32 4
-  %16 = load i8, ptr %15, align 1
-  %17 = load i8, ptr getelementptr (i8, ptr @sshd, i32 4), align 1
-  %strcmp.cmp15 = icmp ne i8 %16, %17
+  %16 = getelementptr i8, ptr %comm, i32 4
+  %17 = load i8, ptr %16, align 1
+  %18 = load i8, ptr getelementptr (i8, ptr @sshd, i32 4), align 1
+  %strcmp.cmp15 = icmp ne i8 %17, %18
   br i1 %strcmp.cmp15, label %strcmp.false, label %strcmp.loop_null_cmp14
 
 strcmp.loop_null_cmp10:                           ; preds = %strcmp.loop5
-  %strcmp.cmp_null12 = icmp eq i8 %13, 0
+  %strcmp.cmp_null12 = icmp eq i8 %14, 0
   br i1 %strcmp.cmp_null12, label %strcmp.done, label %strcmp.loop9
 
 strcmp.loop13:                                    ; preds = %strcmp.loop_null_cmp14
   br label %strcmp.done
 
 strcmp.loop_null_cmp14:                           ; preds = %strcmp.loop9
-  %strcmp.cmp_null16 = icmp eq i8 %16, 0
+  %strcmp.cmp_null16 = icmp eq i8 %17, 0
   br i1 %strcmp.cmp_null16, label %strcmp.done, label %strcmp.loop13
 }
 
@@ -117,8 +118,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!46}
-!llvm.module.flags = !{!48, !49}
+!llvm.dbg.cu = !{!47}
+!llvm.module.flags = !{!49, !50}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -130,7 +131,7 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
@@ -143,36 +144,36 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !20 = !{!21}
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
-!29 = !{!30, !35}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 27, lowerBound: 0)
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
-!38 = !{!39}
-!39 = !DISubrange(count: 262144, lowerBound: 0)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
-!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
-!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
-!47 = !{!0, !7, !26, !40, !44}
-!48 = !{i32 2, !"Debug Info Version", i32 3}
-!49 = !{i32 7, !"uwtable", i32 0}
-!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
-!51 = !DISubroutineType(types: !52)
-!52 = !{!24, !53}
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !25, size: 64, offset: 192)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!27 = !DIGlobalVariableExpression(var: !28, expr: !DIExpression())
+!28 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
+!29 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !30)
+!30 = !{!31, !36}
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !32, size: 64)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !34)
+!34 = !{!35}
+!35 = !DISubrange(count: 27, lowerBound: 0)
+!36 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !37, size: 64, offset: 64)
+!37 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !38, size: 64)
+!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !39)
+!39 = !{!40}
+!40 = !DISubrange(count: 262144, lowerBound: 0)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !44, size: 64, elements: !15)
+!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !26, size: 64, elements: !15)
+!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
+!46 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!47 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !48)
+!48 = !{!0, !7, !27, !41, !45}
+!49 = !{i32 2, !"Debug Info Version", i32 3}
+!50 = !{i32 7, !"uwtable", i32 0}
+!51 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !54)
+!52 = !DISubroutineType(types: !53)
+!53 = !{!26, !23}
 !54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)
+!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !23)

--- a/tests/fold_literals.cpp
+++ b/tests/fold_literals.cpp
@@ -177,6 +177,10 @@ TEST(fold_literals, plus)
   test(R"("" + "test")", "string: test");
   test(R"("hello" + 3)", "string: lo");
   test_warning(R"("hello" + 8)", "literal string will always be empty");
+
+  test("false + false", "bool: false");
+  test("false + true", "bool: true");
+  test("true + true", "bool: true");
 }
 
 TEST(fold_literals, minus)
@@ -210,6 +214,11 @@ TEST(fold_literals, minus)
   test_error("0x7fffffffffffffff - (-1)", "overflow"); // Coerced to signed
   test_error("0xffffffffffffffff - (-1)", "overflow");
   test_error("0 - 0xffffffffffffffff", "underflow");
+
+  test("false - false", "bool: false");
+  test("false - true", "bool: true");
+  test("true - true", "bool: false");
+  test("true - false", "bool: true");
 }
 
 TEST(fold_literals, multiply)
@@ -233,6 +242,10 @@ TEST(fold_literals, multiply)
   test("9223372036854775808 * 1", "int: 9223372036854775808");
   test_error("0x8000000000000000 * 0x2", "overflow");
   test_error("0xffffffffffffffff * 0xffffffffffffffff", "overflow");
+
+  test("false * false", "bool: false");
+  test("false * true", "bool: false");
+  test("true * true", "bool: true");
 }
 
 TEST(fold_literals, divide)
@@ -252,6 +265,11 @@ TEST(fold_literals, divide)
   test("0xffffffffffffffff / 1", "int: 18446744073709551615");
   test_error("123 / 0", "unable to fold");
   test_error("-123 / 0", "unable to fold");
+
+  test("false / true", "bool: false");
+  test("true / true", "bool: true");
+  test_error("false / false", "unable to fold");
+  test_error("true / false", "unable to fold");
 }
 
 TEST(fold_literals, mod)
@@ -268,6 +286,11 @@ TEST(fold_literals, mod)
   test("0x8000000000000000 % 0xff", "int: 128");
   test_error("123 % 0", "unable to fold");
   test_error("-123 % 0", "unable to fold");
+
+  test("false % true", "bool: false");
+  test("true % true", "bool: false");
+  test_error("false % false", "unable to fold");
+  test_error("true % false", "unable to fold");
 }
 
 TEST(fold_literals, binary)
@@ -358,6 +381,22 @@ TEST(fold_literals, binary)
   test("-8 >> 2", "signed int: -2"); // Sign extension
   test("0x8000000000000000 >> 1", "int: 4611686018427387904");
   test("0x8000000000000000 >> 63", "int: 1");
+
+  test("true & true", "bool: true");
+  test("true & false", "bool: false");
+  test("false & false", "bool: false");
+  test("true | true", "bool: true");
+  test("true | false", "bool: true");
+  test("false | false", "bool: false");
+  test("true ^ true", "bool: false");
+  test("true ^ false", "bool: true");
+  test("false ^ false", "bool: false");
+  test("true << false", "bool: false");
+  test("true << true", "bool: false");
+  test("false << false", "bool: false");
+  test("true >> false", "bool: true");
+  test("true >> true", "bool: false");
+  test("false >> false", "bool: false");
 }
 
 TEST(fold_literals, logical)

--- a/tests/runtime/bool
+++ b/tests/runtime/bool
@@ -58,3 +58,8 @@ PROG begin { @a[false, 1, true] = 1; @a[true, (int32)2, false] = 2;  }
 EXPECT @a[false, 1, true]: 1
 EXPECT @a[true, 2, false]: 2
 TIMEOUT 1
+
+NAME complex bool logical
+PROG BEGIN { $a = 100000; $b = 0; $c = $a > $b; $d = $a && $b; $e = $c || $d; $f = (uint64)$c; print(($c, $d, $e, $f)); }
+EXPECT (true, false, true, 1)
+TIMEOUT 1


### PR DESCRIPTION
This fixes two issues (that were a bit coupled):
1.Treat bool types similar to int types when validating binops

These are now valid
```
$a = true;
$b = false;
$c = $a && $b;
$d = $a > $b;
$e = $a >> 1;
$f = $a + $b;
```

This wasn't caught due to lack of test coverage
and too much reliance on fold_literals code
which, obviously, doesn't fold variables.

2.Make the result of all comparison binops of type Bool

The previous type was an integer but this is incorrect, e.g., these should all evaluate to a boolean.
```
$a = 1 && 2;
$b = 1 > 2;
$c = 1 != 2;
$d = true != false;
```

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
