### PR TITLE
Add location expansion for RuntimeErrorInfo

### DIFF
--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -441,10 +441,22 @@ int BPFtrace::run(output::Output &out,
     // callsite. After all, they all must be fixed.
     bool found = false;
     for (const auto &info : helper_use_loc_[e.func_id]) {
-      LOG(ERROR,
-          std::string(info.source_location),
-          std::vector(info.source_context))
-          << e.what();
+      bool first = true;
+      for (const auto &loc : info.locations) {
+        if (first) {
+          LOG(ERROR,
+              std::string(loc.source_location),
+              std::vector(loc.source_context))
+              << e.what();
+          first = false;
+        } else {
+          LOG(ERROR,
+              std::string(loc.source_location),
+              std::vector(loc.source_context))
+              << "expanded from";
+        }
+      }
+
       found = true;
     }
     if (!found) {

--- a/src/output/json.cpp
+++ b/src/output/json.cpp
@@ -459,12 +459,13 @@ void JsonOutput::runtime_error(int retcode, const RuntimeErrorInfo &info)
     }
   }
 
+  // Json only prints the top level location
   out_ << R"(, "filename": )";
-  JsonEmitter<std::string>::emit(out_, info.filename);
+  JsonEmitter<std::string>::emit(out_, info.locations.begin()->filename);
   out_ << R"(, "line": )";
-  JsonEmitter<uint64_t>::emit(out_, info.line);
+  JsonEmitter<uint64_t>::emit(out_, info.locations.begin()->line);
   out_ << R"(, "col": )";
-  JsonEmitter<uint64_t>::emit(out_, info.column);
+  JsonEmitter<uint64_t>::emit(out_, info.locations.begin()->column);
   out_ << R"(})" << std::endl;
 }
 

--- a/src/output/text.cpp
+++ b/src/output/text.cpp
@@ -586,21 +586,30 @@ void TextOutput::runtime_error(int retcode, const RuntimeErrorInfo &info)
       }
 
       LOG(WARNING,
-          std::string(info.source_location),
-          std::vector(info.source_context),
+          std::string(info.locations.begin()->source_location),
+          std::vector(info.locations.begin()->source_context),
           out_)
           << msg << "\nAdditional Info - helper: " << info.func_id
           << ", retcode: " << retcode;
-      return;
+      break;
     }
     default: {
       LOG(WARNING,
-          std::string(info.source_location),
-          std::vector(info.source_context),
+          std::string(info.locations.begin()->source_location),
+          std::vector(info.locations.begin()->source_context),
           out_)
           << info;
-      return;
+      break;
     }
+  }
+
+  // Print the chain
+  for (size_t i = 1; i < info.locations.size(); ++i) {
+    LOG(WARNING,
+        std::string(info.locations[i].source_location),
+        std::vector(info.locations[i].source_context),
+        out_)
+        << "expanded from";
   }
 }
 


### PR DESCRIPTION
Stacked PRs:
 * #4414
 * __->__#4413


--- --- ---

### Add location expansion for RuntimeErrorInfo


This is so runtime errors, helper errors,
verifier errors, and, the soon to be, `errorf`
calls show the call/macro chain.

Example:
```
bpftrace -e 'macro bad_div(@a) { print(10 / (uint64)@a); } BEGIN { @m0 = 0; bad_div(@m0); }'
Attached 1 probe
stdin:1:30-31: WARNING: Divide or modulo by 0 detected. This can lead to unexpected results. 1 is being used as the result.
macro bad_div(@a) { print(10 / (uint64)@a); } BEGIN { @m0 = 0; bad_div(@m0); }
                             ~
stdin:1:64-76: WARNING: expanded from
macro bad_div(@a) { print(10 / (uint64)@a); } BEGIN { @m0 = 0; bad_div(@m0); }
                                                               ~~~~~~~~~~~~
```

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>