### PR TITLE
imports: reload imports for late `import_any` bindings

### DIFF
--- a/src/ast/passes/import_scripts.cpp
+++ b/src/ast/passes/import_scripts.cpp
@@ -33,10 +33,15 @@ Pass CreateImportExternalScriptsPass()
 {
   return Pass::create("ImportExternalScripts",
                       [](ASTContext &ast, Imports &imports) {
+                        std::vector<std::string> imported;
                         for (const auto &[name, obj] : imports.scripts) {
                           if (!obj.internal) {
                             import_ast(ast, obj.ast);
+                            imported.emplace_back(name);
                           }
+                        }
+                        for (const auto &name : imported) {
+                          imports.scripts.erase(name);
                         }
                       });
 }
@@ -45,10 +50,15 @@ Pass CreateImportInternalScriptsPass()
 {
   return Pass::create("ImportInternalScripts",
                       [](ASTContext &ast, Imports &imports) {
+                        std::vector<std::string> imported;
                         for (const auto &[name, obj] : imports.scripts) {
                           if (obj.internal) {
                             import_ast(ast, obj.ast);
+                            imported.emplace_back(name);
                           }
+                        }
+                        for (const auto &name : imported) {
+                          imports.scripts.erase(name);
                         }
                       });
 }

--- a/src/ast/passes/parser.h
+++ b/src/ast/passes/parser.h
@@ -45,6 +45,10 @@ inline std::vector<Pass> AllParsePasses(
   passes.emplace_back(CreateParseBTFPass());
   passes.emplace_back(CreateProbeExpansionPass());
   passes.emplace_back(CreateParseTracepointFormatPass());
+  // Load any late-bound scripts and expand macros if needed.
+  passes.emplace_back(CreateImportInternalScriptsPass());
+  passes.emplace_back(CreateImportExternalScriptsPass());
+  passes.emplace_back(CreateMacroExpansionPass());
   passes.emplace_back(CreateFieldAnalyserPass());
   passes.emplace_back(CreateClangParsePass(std::move(extra_flags)));
   passes.emplace_back(CreateCMacroExpansionPass());


### PR DESCRIPTION
Stacked PRs:
 * __->__#4438


--- --- ---

### imports: reload imports for late `import_any` bindings


This may be used by intermediate passes to automatically import modules.
Ensure that these are resolved by re-importing scripts later in the
pipeline.

Signed-off-by: Adin Scannell <amscanne@meta.com>
