### PR TITLE
Use macro for usdt_arg instead of codegen

### DIFF
--- a/.clang-format-ignore
+++ b/.clang-format-ignore
@@ -1,2 +1,3 @@
 tests/data/data_source.c
 tests/testprogs/*.c
+src/stdlib/**/*.c

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -1115,6 +1115,14 @@ See the address-spaces section for more information on address-spaces.
 The pointer type is left unchanged.
 
 
+### usdt_arg
+- `int64 usdt_arg(int arg_num)`
+
+Returns the argument of an USDT probe at the given index
+
+This is equivalent to using the `argN` builtins
+
+
 ### usermode
 - `uint8 usermode()`
 - `uint8 usermode`

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2091,45 +2091,6 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     auto scoped_arg = visit(call.vargs.at(0));
 
     return ScopedExpr(b_.CreateGetSocketCookie(scoped_arg.value(), call.loc));
-  } else if (call.func == "__usdt_arg") {
-    // Special handling for __usdt_arg function calls
-    // Convert ctx (struct pt_regs *) to long for compatibility with BTF
-    // declaration
-    auto scoped_ctx = visit(call.vargs.at(0));
-    auto scoped_arg_num = visit(call.vargs.at(1));
-
-    // Convert pointer to integer for BTF compatibility
-    Value *ctx_as_int = b_.CreatePtrToInt(scoped_ctx.value(), b_.getInt64Ty());
-
-    // Get or create the function with correct signature (i64, i64) -> i64
-    auto *func = extern_funcs_[call.func];
-    if (!func) {
-      SmallVector<llvm::Type *> arg_types = { b_.getInt64Ty(),
-                                              b_.getInt64Ty() };
-      FunctionType *function_type = FunctionType::get(b_.getInt64Ty(),
-                                                      arg_types,
-                                                      false);
-      func = llvm::Function::Create(function_type,
-                                    llvm::Function::ExternalLinkage,
-                                    call.func,
-                                    module_.get());
-      func->addFnAttr(Attribute::AlwaysInline);
-      func->addFnAttr(Attribute::NoUnwind);
-      func->setDSOLocal(true);
-
-      for (auto &arg : func->args()) {
-        arg.addAttr(Attribute::NoUndef);
-      }
-      extern_funcs_[call.func] = func;
-    }
-
-    SmallVector<llvm::Value *> arg_values = { ctx_as_int,
-                                              scoped_arg_num.value() };
-    auto *inst = b_.CreateCall(func, arg_values, call.func);
-    return ScopedExpr(inst, [this, inst, &call] {
-      inst->setDebugLoc(
-          debug_.createDebugLocation(llvm_ctx_, scope_, call.loc));
-    });
   } else {
     auto *func = extern_funcs_[call.func];
     if (!func) {

--- a/src/ast/passes/parser.h
+++ b/src/ast/passes/parser.h
@@ -37,10 +37,10 @@ inline std::vector<Pass> AllParsePasses(
   passes.emplace_back(CreateImportExternalScriptsPass());
   passes.emplace_back(CreateUnstableFeaturePass());
   passes.emplace_back(CreateImportInternalScriptsPass());
-  passes.emplace_back(CreateMacroExpansionPass());
   passes.emplace_back(CreateDeprecatedPass());
   passes.emplace_back(CreateParseAttachpointsPass());
   passes.emplace_back(CreateUSDTImportPass()); // Import USDT stdlib if needed
+  passes.emplace_back(CreateMacroExpansionPass());
   passes.emplace_back(CreateParseBTFPass());
   passes.emplace_back(CreateProbeExpansionPass());
   passes.emplace_back(CreateParseTracepointFormatPass());

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1887,36 +1887,6 @@ If you're seeing errors, try clamping the string sizes. For example:
       return;
     }
     call.return_type = CreateUInt64();
-  } else if (call.func == "__usdt_arg") {
-    // Special handling for __usdt_arg function in USDT context
-    // This function expects (long, long) but we pass (struct pt_regs *, int64)
-    // The ctx parameter should be treated as a pointer value (long)
-    if (call.vargs.size() != 2) {
-      call.addError() << "__usdt_arg() requires exactly 2 arguments ("
-                      << call.vargs.size() << " provided)";
-      return;
-    }
-
-    // First argument should be ctx (struct pt_regs * in USDT context)
-    const auto &ctx_type = call.vargs.at(0).type();
-    if (!ctx_type.IsPtrTy() || !ctx_type.GetPointeeTy() ||
-        !ctx_type.GetPointeeTy()->IsRecordTy() ||
-        !ctx_type.GetPointeeTy()->IsSameType(CreateRecord("struct pt_regs"))) {
-      call.addError()
-          << "__usdt_arg() first argument must be ctx (struct pt_regs *), got "
-          << typestr(ctx_type);
-      return;
-    }
-
-    // Second argument should be int64
-    const auto &arg_num_type = call.vargs.at(1).type();
-    if (!arg_num_type.IsIntTy()) {
-      call.addError() << "__usdt_arg() second argument must be int64, got "
-                      << typestr(arg_num_type);
-      return;
-    }
-
-    call.return_type = CreateInt64();
   } else {
     // Check here if this corresponds to an external function. We convert the
     // external type metadata into the internal `SizedType` representation and

--- a/src/ast/passes/usdt_arguments.cpp
+++ b/src/ast/passes/usdt_arguments.cpp
@@ -26,11 +26,10 @@ public:
   }
   ast::AssignVarStatement *var_decl(size_t arg, Node &node)
   {
-    auto *ctx_arg = ast_.make_node<Builtin>("ctx", Location(node.loc));
     auto *int_arg = ast_.make_node<ast::Integer>(static_cast<uint64_t>(arg),
                                                  Location(node.loc));
-    std::vector<Expression> args = { ctx_arg, int_arg };
-    Expression expr = ast_.make_node<ast::Call>("__usdt_arg",
+    std::vector<Expression> args = { int_arg };
+    Expression expr = ast_.make_node<ast::Call>("usdt_arg",
                                                 std::move(args),
                                                 Location(node.loc));
     return ast_.make_node<AssignVarStatement>(var(arg, node),

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -1253,6 +1253,14 @@ macro username() {
 //
 // Removes a watchpoint
 
+// Returns the argument of an USDT probe at the given index
+//
+// This is equivalent to using the `argN` builtins
+// :variant int64 usdt_arg(int arg_num)
+macro usdt_arg(x) {
+   __usdt_arg(ctx, x)
+}
+
 // :function zero
 // :variant void zero(map m)
 //

--- a/src/stdlib/usdt/usdt.bpf.c
+++ b/src/stdlib/usdt/usdt.bpf.c
@@ -2,9 +2,9 @@
 #include <vmlinux.h>
 #include <bpf/usdt.bpf.h>
 
-long __usdt_arg(long ctx, long arg_num)
+long __usdt_arg(struct pt_regs * ctx, long arg_num)
 {
   long _x;
-  bpf_usdt_arg((void *)ctx, arg_num, &_x);
+  bpf_usdt_arg(ctx, arg_num, &_x);
   return _x;
 }


### PR DESCRIPTION
Also remove checks in semantic analyser.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
