### PR TITLE
CMake: improve error message for missing libbpf.a

### DIFF
--- a/cmake/FindLibBpf.cmake
+++ b/cmake/FindLibBpf.cmake
@@ -21,7 +21,7 @@ find_library (LIBBPF_LIBRARIES
   PATHS
     ENV LIBRARY_PATH
     ENV LD_LIBRARY_PATH)
-set(LIBBPF_ERROR_MESSAGE "Please install the libbpf development package")
+set(LIBBPF_ERROR_MESSAGE "Please install the libbpf.a static library")
 
 include (FindPackageHandleStandardArgs)
 


### PR DESCRIPTION
Since we now require static linking of libbpf, the error message when `libbpf.a` is not found is not very informative. Improve it to explicitly state that we need `libbpf.a`.

Issue #4454.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
