### PR TITLE
json: ensure the `data` field is still included for attached_probes and lost_events

### DIFF
--- a/src/output/json.cpp
+++ b/src/output/json.cpp
@@ -440,15 +440,17 @@ void JsonOutput::syscall(const std::string &syscall)
 
 void JsonOutput::lost_events(uint64_t lost)
 {
-  // This is a special case, it does not use the `data` field.
-  out_ << R"({"type":"lost_events", "count":)" << lost << "}" << std::endl;
+  // This is a special case, it emits both a count and the `data` field.
+  out_ << R"({"type": "lost_events", "count": )" << lost
+       << R"(, "data": {"events": )" << lost << "}}" << std::endl;
 }
 
 void JsonOutput::attached_probes(uint64_t num_probes)
 {
-  // As with lost_events, this is a special case.
-  out_ << R"({"type":"attached_probes", "count":)" << num_probes << "}"
-       << std::endl;
+  // As with lost_events, this is a special case, we do a `count` and `data`
+  // field.
+  out_ << R"({"type": "attached_probes", "count": )" << num_probes
+       << R"(, "data": {"probes": )" << num_probes << "}}" << std::endl;
 }
 
 void JsonOutput::runtime_error(int retcode, const RuntimeErrorInfo &info)

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -200,3 +200,8 @@ NAME bench multiple
 RUN {{BPFTRACE}} -q -f json --test-mode bench -e 'bench:a { @a++; } bench:b { @b++; } bench:c { @c++; }'
 EXPECT_REGEX {"type": "benchmark_results", "data": {"a": \d+, "b": \d+, "c": \d+}}
 TIMEOUT 5
+
+NAME attached probes
+RUN {{BPFTRACE}} -f json -e 'i:s:1 { exit(); }'
+EXPECT {"type": "attached_probes", "count": 1, "data": {"probes": 1}}
+TIMEOUT 5


### PR DESCRIPTION
Stacked PRs:
 * __->__#4481


--- --- ---

### json: ensure the `data` field is still included for attached_probes and lost_events


This preserves the previous format and adds a runtime test.

Signed-off-by: Adin Scannell <amscanne@meta.com>