### PR TITLE
Allow non-const array access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,8 @@ and this project adheres to
   - [#4414](https://github.com/bpftrace/bpftrace/pull/4414)
 - Add ability to call most builtins with call-style syntax e.g. `comm()`
   - [#4420](https://github.com/bpftrace/bpftrace/pull/4420)
+- Allow non-constant array access
+  - [#4491](https://github.com/bpftrace/bpftrace/pull/4491)
 #### Changed
 - kprobe: support verbose mode listing
   - [#4362](https://github.com/bpftrace/bpftrace/pull/4362)

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2753,6 +2753,27 @@ ScopedExpr CodegenLLVM::visit(ArrayAccess &arr)
   auto scoped_expr = visit(arr.expr);
   auto scoped_index = visit(arr.indexpr);
 
+  if (type.IsArrayTy()) {
+    llvm::Function *parent = b_.GetInsertBlock()->getParent();
+    BasicBlock *is_oob = BasicBlock::Create(module_->getContext(),
+                                            "is_oob",
+                                            parent);
+    BasicBlock *merge = BasicBlock::Create(module_->getContext(),
+                                           "oob_merge",
+                                           parent);
+
+    Value *cond = b_.CreateICmpUGT(
+        b_.CreateIntCast(scoped_index.value(), b_.getInt64Ty(), false),
+        b_.getInt64(type.GetNumElements() - 1),
+        "oob_cond");
+
+    b_.CreateCondBr(cond, is_oob, merge);
+    b_.SetInsertPoint(is_oob);
+    b_.CreateRuntimeError(RuntimeErrorId::ARRAY_ACCESS_OOB, arr.loc);
+    b_.CreateBr(merge);
+    b_.SetInsertPoint(merge);
+  }
+
   if (inBpfMemory(arr.element_type) && !type.IsPtrTy())
     return readDatastructElemFromStack(
         std::move(scoped_expr), scoped_index.value(), type, arr.element_type);

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2301,9 +2301,10 @@ void SemanticAnalyser::visit(ArrayAccess &arr)
                          << " is out of bounds for array of size " << num;
         }
       }
-    } else {
+    } else if (!arr.indexpr.type().IsIntTy() || arr.indexpr.type().IsSigned()) {
       arr.addError() << "The array index operator [] only "
-                        "accepts positive literal integer indices.";
+                        "accepts positive (unsigned) integer indices. Got: "
+                     << arr.indexpr.type();
     }
   }
 

--- a/src/required_resources.cpp
+++ b/src/required_resources.cpp
@@ -46,6 +46,10 @@ std::ostream &operator<<(std::ostream &os, const RuntimeErrorInfo &info)
       os << DIVIDE_BY_ZERO_MSG;
       break;
     }
+    case RuntimeErrorId::ARRAY_ACCESS_OOB: {
+      os << ARRAY_ACCESS_OOB_MSG;
+      break;
+    }
   }
   return os;
 }

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -27,9 +27,14 @@ static const auto DIVIDE_BY_ZERO_MSG =
     "Divide or modulo by 0 detected. This can lead to unexpected "
     "results. 1 is being used as the result.";
 
+static const auto ARRAY_ACCESS_OOB_MSG =
+    "Array access out of bounds. This can lead to unexpected "
+    "results.";
+
 enum class RuntimeErrorId {
   DIVIDE_BY_ZERO,
   HELPER_ERROR,
+  ARRAY_ACCESS_OOB,
 };
 
 enum class PrintfSeverity {

--- a/tests/codegen/llvm/cast_int_to_arr.ll
+++ b/tests/codegen/llvm/cast_int_to_arr.ll
@@ -5,6 +5,7 @@ target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.0" = type { ptr, ptr }
+%runtime_error_t = type <{ i64, i64, i32 }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
@@ -20,6 +21,7 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
 entry:
   %"@_val" = alloca i64, align 8
   %"@_key" = alloca i64, align 8
+  %runtime_error_t = alloca %runtime_error_t, align 8
   %"$a" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$a")
   store i0 0, ptr %"$a", align 1
@@ -29,17 +31,46 @@ entry:
   %2 = ptrtoint ptr %1 to i64
   store i64 %2, ptr %"$a", align 8
   %3 = load ptr, ptr %"$a", align 8
-  %4 = getelementptr [8 x i8], ptr %3, i32 0, i64 0
-  %5 = load volatile i8, ptr %4, align 1
+  br i1 false, label %is_oob, label %oob_merge
+
+is_oob:                                           ; preds = %entry
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
+  %4 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
+  store i64 30006, ptr %4, align 8
+  %5 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
+  store i64 0, ptr %5, align 8
+  %6 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
+  store i64 0, ptr %6, align 8
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t, i64 20, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+oob_merge:                                        ; preds = %counter_merge, %entry
+  %7 = getelementptr [8 x i8], ptr %3, i32 0, i64 0
+  %8 = load volatile i8, ptr %7, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  %6 = zext i8 %5 to i64
-  store i64 %6, ptr %"@_val", align 8
+  %9 = zext i8 %8 to i64
+  store i64 %9, ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
   ret i64 0
+
+event_loss_counter:                               ; preds = %is_oob
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #2
+  %10 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %10
+  %11 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %12 = load i64, ptr %11, align 8
+  %13 = add i64 %12, 1
+  store i64 %13, ptr %11, align 8
+  br label %counter_merge
+
+counter_merge:                                    ; preds = %event_loss_counter, %is_oob
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %runtime_error_t)
+  br label %oob_merge
 }
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
@@ -50,6 +81,7 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { memory(none) }
 
 !llvm.dbg.cu = !{!42}
 !llvm.module.flags = !{!44, !45}

--- a/tests/runtime/array
+++ b/tests/runtime/array
@@ -3,6 +3,11 @@ PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (
 EXPECT @x: 1
 AFTER ./testprogs/array_access
 
+NAME array element access - with variable index
+PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $y = (uint64)0; $a = (struct A *) arg0; @x = $a->x[$y]; exit(); }
+EXPECT @x: 1
+AFTER ./testprogs/array_access
+
 NAME array element access - assign to var
 PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (struct A *) arg0; $x = $a->x[0]; printf("Result: %d\n", $x); exit(); }
 EXPECT Result: 1
@@ -13,6 +18,11 @@ PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = (
 EXPECT stdin:1:100-108: ERROR: the index 5 is out of bounds for array of size 4
 AFTER ./testprogs/array_access
 WILL_FAIL
+
+NAME array element access - out of bounds runtime
+PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $y = (uint64)100; $a = (struct A *) arg0; @x = $a->x[$y]; exit(); }
+EXPECT stdin:1:118-127: WARNING: Array access out of bounds. This can lead to unexpected results.
+AFTER ./testprogs/array_access
 
 NAME array element access via assignment into var
 PROG struct A { int x[4]; } uprobe:./testprogs/array_access:test_struct { $a = ((struct A *) arg0)->x; $x = $a[0]; printf("Result: %d\n", $x); exit(); }


### PR DESCRIPTION
Stacked PRs:
 * __->__#4492


--- --- ---

### Allow non-const array access


Ensure the variable/expression is an unsigned int
and perform a runtime check if there is an
out of bounds access (a runtime warning will
be issued).

This is to prevent users from having to write
some really awful code if they access arrays
inside a loop.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>