### PR TITLE
ast: plumb parse debug flag correctly

### DIFF
--- a/src/ast/passes/parser.h
+++ b/src/ast/passes/parser.h
@@ -25,10 +25,11 @@ namespace bpftrace::ast {
 // the expected order. This should be used unless there's a reason not to.
 inline std::vector<Pass> AllParsePasses(
     std::vector<std::string> &&extra_flags = {},
-    std::vector<std::string> &&import_paths = {})
+    std::vector<std::string> &&import_paths = {},
+    bool debug = false)
 {
   std::vector<Pass> passes;
-  passes.emplace_back(CreateParsePass());
+  passes.emplace_back(CreateParsePass(0, debug));
   passes.emplace_back(CreateConfigPass());
   passes.emplace_back(CreateResolveImportsPass(std::move(import_paths)));
   // N.B. We expand the AST with all externally imported scripts, then check

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -880,7 +880,8 @@ int main(int argc, char* argv[])
   if (args.listing) {
     ast::CDefinitions no_c_defs; // See above.
     ast::TypeMetadata no_types;  // See above.
-    pm.add(CreateParsePass(bpftrace.max_ast_nodes_))
+    pm.add(CreateParsePass(bpftrace.max_ast_nodes_,
+                           bt_debug.contains(DebugStage::Parse)))
         .put(no_c_defs)
         .put(no_types)
         .add(ast::CreateParseAttachpointsPass(args.listing))
@@ -912,7 +913,9 @@ int main(int argc, char* argv[])
     }
   };
   // Start with all the basic parsing steps.
-  for (auto& pass : ast::AllParsePasses(std::move(flags))) {
+  for (auto& pass : ast::AllParsePasses(std::move(flags),
+                                        {},
+                                        bt_debug.contains(DebugStage::Parse))) {
     addPass(std::move(pass));
   }
   pm.add(ast::CreateLLVMInitPass());


### PR DESCRIPTION
Stacked PRs:
 * #4503
 * __->__#4502


--- --- ---

### ast: plumb parse debug flag correctly


During a previous refactor `-d parse` stopped working. This fixes that
and allows to access parser output directly.

Signed-off-by: Adin Scannell <amscanne@meta.com>
