### PR TITLE
Don't filter interval probes by pid

### DIFF
--- a/src/ast/passes/pid_filter_pass.cpp
+++ b/src/ast/passes/pid_filter_pass.cpp
@@ -46,10 +46,10 @@ bool probe_needs_pid_filter(AttachPoint *ap)
     case ProbeType::invalid:
     case ProbeType::iter:
     case ProbeType::profile:
-    case ProbeType::interval:
     case ProbeType::software:
     case ProbeType::hardware:
-    // We don't filter by pid for begin/end probes
+    // We don't filter by pid at all for these special probes
+    case ProbeType::interval:
     case ProbeType::special:
     case ProbeType::benchmark:
       return false;

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -1005,8 +1005,7 @@ class AttachedIntervalProbe : public AttachedProbe {
 public:
   static Result<std::unique_ptr<AttachedIntervalProbe>> make(
       Probe &probe,
-      const BpfProgram &prog,
-      std::optional<int> pid);
+      const BpfProgram &prog);
   ~AttachedIntervalProbe() override;
 
   int link_fd() override;
@@ -1036,8 +1035,7 @@ int AttachedIntervalProbe::link_fd()
 
 Result<std::unique_ptr<AttachedIntervalProbe>> AttachedIntervalProbe::make(
     Probe &probe,
-    const BpfProgram &prog,
-    std::optional<int> pid)
+    const BpfProgram &prog)
 {
   int group_fd = -1;
   int cpu = 0;
@@ -1060,7 +1058,7 @@ Result<std::unique_ptr<AttachedIntervalProbe>> AttachedIntervalProbe::make(
                                       PERF_COUNT_SW_CPU_CLOCK,
                                       period,
                                       freq,
-                                      pid.has_value() ? *pid : -1,
+                                      -1,
                                       cpu,
                                       group_fd);
 
@@ -1541,7 +1539,7 @@ Result<std::unique_ptr<AttachedProbe>> AttachedProbe::make(
       return AttachedProfileProbe::make(probe, prog, pid);
     }
     case ProbeType::interval: {
-      return AttachedIntervalProbe::make(probe, prog, pid);
+      return AttachedIntervalProbe::make(probe, prog);
     }
     case ProbeType::software: {
       return AttachedSoftwareProbe::make(probe, prog, pid);


### PR DESCRIPTION
Stacked PRs:
 * __->__#4505


--- --- ---

### Don't filter interval probes by pid


This causes confusing and unwanted behavior
as this interval is mostly firing on kernel threads
which are of pid 0.

Issue:
- https://github.com/bpftrace/bpftrace/issues/4497

Signed-off-by: Jordan Rome <linux@jordanrome.com>