### PR TITLE
Nix: Update blazesym to v0.1.4

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     "blazesym": {
       "flake": false,
       "locked": {
-        "lastModified": 1750785918,
-        "narHash": "sha256-3xBEvLWE+UfLKHrnBrhM9iTF+cvD0shBheME2g+GeKY=",
+        "lastModified": 1756834804,
+        "narHash": "sha256-U25z9kq5PX3Rt55kQDWD79OSvZ0lfERzLVP7/q0XYdQ=",
         "owner": "libbpf",
         "repo": "blazesym",
-        "rev": "4d2e36289c647480bcea84e158aa852624bfac69",
+        "rev": "d815e0c322e7cbc90d14f787695a67ebbbf4d822",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Update the blazesym dependency to v0.1.4 to get the latest and greatest. Among other improvements, this change includes support for incorporating DWARF packages (*.dwp; a form of split DWARF) into the symbolization, which can be useful in contexts where binaries themselves otherwise did not retain all debug information.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] ~~Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`~~
- [ ] ~~User-visible and non-trivial changes updated in `CHANGELOG.md`~~
- [ ] ~~The new behaviour is covered by tests~~
