### PR TITLE
Use perf_buffer__new instead of the bcc version

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -320,9 +320,9 @@ This exists because the BPF stack is limited to 512 bytes and large objects make
 
 Default: Based on available system memory
 
-Number of pages to allocate per CPU perf ring buffer.
-The value must be a power of 2.
-If you’re getting a lot of dropped events bpftrace may not be processing events in the ring buffer fast enough.
+Number of pages to allocate for each created ring or perf buffer (there is only one of each max).
+The minimum is: 1 * the number of cpus on your machine.
+If you’re getting a lot of dropped events bpftrace may not be processing events in the ring buffer (or perf buffer if you're using `skboutput`) fast enough.
 It may be useful to bump the value higher so more events can be queued up.
 The tradeoff is that bpftrace will use more memory.
 The default value is based on available system memory; max is 4096 pages (16mb) and min is 64 pages (256kb), which presumes 4k page size.

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -105,7 +105,7 @@ public:
     return true;
   }
 
-  Result<uint64_t> get_buffer_pages() const override
+  Result<uint64_t> get_buffer_pages(bool __attribute__((unused)) /*per_cpu*/) const override
   {
     return 64;
   }


### PR DESCRIPTION
Stacked PRs:
 * __->__#4535


--- --- ---

### Use perf_buffer__new instead of the bcc version


This also fixes a bug in `get_buffer_pages`,
whereby we want to be able to get the number
of pages per cpu and in total as the callers
use this number differently.

Issue:
- https://github.com/bpftrace/bpftrace/issues/4494

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>