### PR TITLE
Update macro error messages to include their name

### DIFF
--- a/src/ast/passes/macro_expansion.cpp
+++ b/src/ast/passes/macro_expansion.cpp
@@ -244,7 +244,8 @@ std::string MacroExpander::get_new_var_ident(std::string original_ident)
 std::optional<BlockExpr *> MacroExpander::expand(Macro &macro, Call &call)
 {
   if (macro.vargs.size() != call.vargs.size()) {
-    call.addError() << "Call to macro has wrong number arguments. Expected: "
+    call.addError() << "Call to " << macro.name
+                    << "() has the wrong number of arguments. Expected: "
                     << macro.vargs.size() << " but got " << call.vargs.size();
     return std::nullopt;
   }
@@ -266,25 +267,25 @@ std::optional<BlockExpr *> MacroExpander::expand(Macro &macro, Call &call)
       if (auto *cvar = call.vargs.at(i).as<Variable>()) {
         vars_[mvar->ident] = cvar->ident;
       } else if (call.vargs.at(i).is<Map>()) {
-        call.addError()
-            << "Mismatched arg to macro call. Macro expects a variable for arg "
-            << mvar->ident << " but got a map.";
+        call.addError() << "Mismatched arg. " << macro.name
+                        << "() expects a variable for arg " << mvar->ident
+                        << " but got a map.";
       } else {
-        call.addError()
-            << "Mismatched arg to macro call. Macro expects a variable for arg "
-            << mvar->ident << " but got an expression.";
+        call.addError() << "Mismatched arg. " << macro.name
+                        << "() expects a variable for arg " << mvar->ident
+                        << " but got an expression.";
       }
     } else if (auto *mmap = macro.vargs.at(i).as<Map>()) {
       if (auto *cmap = call.vargs.at(i).as<Map>()) {
         maps_[mmap->ident] = cmap->ident;
       } else if (call.vargs.at(i).is<Variable>()) {
-        call.addError()
-            << "Mismatched arg to macro call. Macro expects a map for arg "
-            << mmap->ident << " but got a variable.";
+        call.addError() << "Mismatched arg. " << macro.name
+                        << "() expects a map for arg " << mmap->ident
+                        << " but got a variable.";
       } else {
-        call.addError()
-            << "Mismatched arg to macro call. Macro expects a map for arg "
-            << mmap->ident << " but got an expression.";
+        call.addError() << "Mismatched arg. " << macro.name
+                        << "() expects a map for arg " << mmap->ident
+                        << " but got an expression.";
       }
     }
   }
@@ -298,8 +299,9 @@ std::optional<BlockExpr *> MacroExpander::expand(Macro &macro,
                                                  Identifier &ident)
 {
   if (!macro.vargs.empty()) {
-    ident.addError() << "Call to macro has no number arguments. Expected: "
-                     << macro.vargs.size();
+    ident.addError() << "Call to " << macro.name
+                     << "() has the wrong number of arguments. Expected: "
+                     << macro.vargs.size() << " but got 0.";
     return std::nullopt;
   }
 

--- a/tests/macro_expansion.cpp
+++ b/tests/macro_expansion.cpp
@@ -78,8 +78,9 @@ TEST(macro_expansion, basic_checks)
   test("macro add2($y) { $y += 1; } macro add1($x) { $x += add2($x); } begin { "
        "$y = 1; add1($y); }");
 
-  test_error("macro set($x) { $x += 1; $x } begin { $a = 1; set($a, 1); }",
-             "Call to macro has wrong number arguments. Expected: 1 but got 2");
+  test_error(
+      "macro set($x) { $x += 1; $x } begin { $a = 1; set($a, 1); }",
+      "Call to set() has the wrong number of arguments. Expected: 1 but got 2");
   test_error("macro set($x, $x) { $x += 1; $x } begin { $a = 1; set($a, 1); }",
              "Variable for macro argument has already been used: $x");
   test_error("macro set($x) { $x += 1; $x } macro set($x) { $x } begin { $a = "
@@ -89,8 +90,10 @@ TEST(macro_expansion, basic_checks)
       "macro add1($x) { $x + add3($x) } macro add2($x) { $x + add1($x) } macro "
       "add3($x) { $x + add2($x) } begin { print(add3(1)); }",
       "Recursive macro call detected. Call chain: add3 > add2 > add1 > add3");
-  test_error("macro add1($x) { $x += 1; $x } begin { $y = 1; $z = add1; }",
-             "ERROR: Call to macro has no number arguments. Expected: 1");
+  test_error(
+      "macro add1($x) { $x += 1; $x } begin { $y = 1; $z = add1; }",
+      "ERROR: Call to add1() has the wrong number of arguments. Expected: 1 "
+      "but got 0.");
 }
 
 TEST(macro_expansion, variables)
@@ -100,13 +103,12 @@ TEST(macro_expansion, variables)
   test("macro set($x) { $b = $x + 1; $b } begin { $a = 1; set($a); }");
   test("macro set($x) { let $b = $x + 1; $b } begin { $a = 1; set($a); }");
 
-  test_error(
-      "macro set($x) { $x += 1; $x } begin { @a = 1; set(@a); }",
-      "Mismatched arg to macro call. Macro expects a variable for arg $x "
-      "but got a map.");
+  test_error("macro set($x) { $x += 1; $x } begin { @a = 1; set(@a); }",
+             "Mismatched arg. set() expects a variable for arg $x "
+             "but got a map.");
 
   test_error("macro add1($x) { $x += 1; $x } begin { add1(1 + 1); }",
-             "Mismatched arg to macro call. Macro expects a variable for arg "
+             "Mismatched arg. add1() expects a variable for arg "
              "$x but got an expression.");
 
   test_error("macro set($x) { let $x; $x } begin { $y = 1; set($y); }",
@@ -119,10 +121,10 @@ TEST(macro_expansion, maps)
   test("macro set(@x) { @x[1] = 1; @x[1] } begin { @a[1] = 0; set(@a); }");
 
   test_error("macro set(@x) { @x[1] = 1; @x[1] } begin { $a = 0; set($a); }",
-             "Mismatched arg to macro call. Macro expects a map for arg @x but "
+             "Mismatched arg. set() expects a map for arg @x but "
              "got a variable.");
   test_error("macro set(@x) { @x[1] = 1; @x[1] } begin { $a = 0; set(1); }",
-             "Mismatched arg to macro call. Macro expects a map for arg @x but "
+             "Mismatched arg. set() expects a map for arg @x but "
              "got an expression.");
   test_error("macro set() { @x[1] = 1; 1 } begin { @x[0] = 0; set(); }",
              "Unhygienic access to map: @x. Maps must be passed into the macro "


### PR DESCRIPTION
Stacked PRs:
 * __->__#4564


--- --- ---

### Update macro error messages to include their name


This just makes the error messages more specific
and further blurs the line between macros and calls.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>