### PR TITLE
Move probe pruning until after semantic analysis

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -35,6 +35,7 @@ add_library(ast STATIC
   passes/portability_analyser.cpp
   passes/printer.cpp
   passes/probe_expansion.cpp
+  passes/probe_prune.cpp
   passes/resource_analyser.cpp
   passes/semantic_analyser.cpp
   passes/codegen_llvm.cpp

--- a/src/ast/passes/probe_expansion.cpp
+++ b/src/ast/passes/probe_expansion.cpp
@@ -242,8 +242,6 @@ void ProbeExpander::expand()
 void ProbeExpander::visit(Program &prog)
 {
   Visitor<ProbeExpander>::visit(prog);
-
-  prog.clear_empty_probes();
 }
 
 void ProbeExpander::visit(AttachPointList &aps)

--- a/src/ast/passes/probe_prune.cpp
+++ b/src/ast/passes/probe_prune.cpp
@@ -1,0 +1,33 @@
+#include "ast/passes/probe_prune.h"
+#include "ast/ast.h"
+#include "ast/visitor.h"
+#include "bpftrace.h"
+#include "log.h"
+
+namespace bpftrace::ast {
+
+Pass CreateProbePrunePass()
+{
+  static std::string missing_msg = " has no valid attach points.";
+  return Pass::create("ProbePrune", [](ASTContext &ast, BPFtrace &b) {
+    auto missing_config = b.config_->missing_probes;
+    for (Probe *probe : ast.root->probes) {
+      if (probe->attach_points.empty()) {
+        if (missing_config == ConfigMissingProbes::error) {
+          probe->addError() << "Probe" << missing_msg
+                            << " If this is expected, set the 'missing_probes' "
+                               "config variable to 'warn'.";
+        } else if (missing_config == ConfigMissingProbes::warn) {
+          LOG(WARNING) << probe->orig_name << missing_msg
+                       << " It is being removed which may cause issues with "
+                          "program behavior.";
+        }
+      }
+    };
+    if (missing_config != ConfigMissingProbes::error) {
+      ast.root->clear_empty_probes();
+    }
+  });
+};
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/probe_prune.h
+++ b/src/ast/passes/probe_prune.h
@@ -1,0 +1,9 @@
+#pragma once
+
+#include "ast/pass_manager.h"
+
+namespace bpftrace::ast {
+
+Pass CreateProbePrunePass();
+
+} // namespace bpftrace::ast

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,7 @@
 #include "ast/passes/pid_filter_pass.h"
 #include "ast/passes/portability_analyser.h"
 #include "ast/passes/printer.h"
+#include "ast/passes/probe_prune.h"
 #include "ast/passes/recursion_check.h"
 #include "ast/passes/resource_analyser.h"
 #include "ast/passes/return_path_analyser.h"
@@ -334,6 +335,7 @@ void CreateDynamicPasses(std::function<void(ast::Pass&& pass)> add)
   add(ast::CreateClangBuildPass());
   add(ast::CreateTypeSystemPass());
   add(ast::CreateSemanticPass());
+  add(ast::CreateProbePrunePass());
   add(ast::CreateResourcePass());
   add(ast::CreateRecursionCheckPass());
   add(ast::CreateReturnPathPass());
@@ -346,6 +348,7 @@ void CreateAotPasses(std::function<void(ast::Pass&& pass)> add)
   add(ast::CreateClangBuildPass());
   add(ast::CreateTypeSystemPass());
   add(ast::CreateSemanticPass());
+  add(ast::CreateProbePrunePass());
   add(ast::CreateResourcePass());
   add(ast::CreateRecursionCheckPass());
   add(ast::CreateReturnPathPass());

--- a/src/tracepoint_format_parser.cpp
+++ b/src/tracepoint_format_parser.cpp
@@ -85,9 +85,6 @@ bool TracepointFormatParser::parse(ast::ASTContext &ctx, BPFtrace &bpftrace)
     probe->attach_points = new_aps;
   }
 
-  // We may have ended with probes without attach points, remove them
-  program->clear_empty_probes();
-
   return true;
 }
 

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -144,7 +144,7 @@ REQUIRES_FEATURE kprobe_multi
 
 NAME kprobe_disallow_rcu_functions
 PROG kprobe:rcu_* { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT No probes to attach
+EXPECT_REGEX ERROR: Probe has no valid attach points.
 WILL_FAIL
 
 NAME kprobe_hide_ftrace_invalid_address
@@ -409,7 +409,7 @@ AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME rawtracepoint_missing
 PROG rawtracepoint:nonsense { print("hit"); exit(); }
-EXPECT No probes to attach
+EXPECT_REGEX ERROR: Probe has no valid attach points.
 REQUIRES_FEATURE btf
 WILL_FAIL
 

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -58,7 +58,7 @@ TIMEOUT 1
 
 # https://github.com/bpftrace/bpftrace/issues/1952
 NAME async_id_invalid_probe_expansion
-PROG kprobe:zzzzz { probe; printf("asdf\n") } begin { printf("_%s_\n", "success"); exit() }
+PROG config = { missing_probes=warn } kprobe:zzzzz { probe; printf("asdf\n") } begin { printf("_%s_\n", "success"); exit() }
 EXPECT _success_
 TIMEOUT 1
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2357,9 +2357,9 @@ TEST_F(SemanticAnalyserTest, tracepoint)
 
 TEST_F(SemanticAnalyserTest, rawtracepoint)
 {
-  test("rawtracepoint:event { 1 }");
-  test("rawtracepoint:event { arg0 }");
-  test("rawtracepoint:mod:event { arg0 }");
+  test("rawtracepoint:event_rt { 1 }");
+  test("rawtracepoint:event_rt { arg0 }");
+  test("rawtracepoint:vmlinux:event_rt { arg0 }");
 }
 
 TEST_F(SemanticAnalyserTest, watchpoint_invalid_modes)


### PR DESCRIPTION
Stacked PRs:
 * __->__#4576


--- --- ---

### Move probe pruning until after semantic analysis


This is just temporary to remove some confusing
errors whereby type resolving code can be removed
and surface strange errors to users if we prune
probe code before semantic analysis.

Eventually most probe and branch pruning will
be in the semantic analyser or whatever pass
handles type resolution.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>