### PR TITLE
tests: only run unit tests as cmake tests (#4574)

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,6 +76,7 @@ add_executable(bpftrace_test
   ${CODEGEN_SRC}
 )
 add_test(NAME bpftrace_test COMMAND bpftrace_test)
+file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/near_self_file "near_self_file")
 
 add_subdirectory(data)
 add_dependencies(bpftrace_test data_source_dwarf data_source_btf data_source_funcs parser)
@@ -120,7 +121,6 @@ add_custom_target(
     testlibs
     ${CMAKE_BINARY_DIR}/src/bpftrace
 )
-add_test(NAME runtime_tests COMMAND ./runtime-tests.sh)
 
 file(GLOB_RECURSE runtime_test_src_files
   RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
@@ -155,14 +155,12 @@ configure_file(runtime/engine/cmake_vars.py ${CMAKE_CURRENT_BINARY_DIR}/runtime/
 
 configure_file(tools-parsing-test.sh tools-parsing-test.sh COPYONLY)
 add_custom_target(tools-parsing-test COMMAND ./tools-parsing-test.sh)
-add_test(NAME tools-parsing-test COMMAND ./tools-parsing-test.sh)
 
 if(ENABLE_TEST_VALIDATE_CODEGEN)
   if(${LLVM_VERSION_MAJOR} VERSION_EQUAL 18)
     message(STATUS "Adding codegen-validator test")
     configure_file(codegen-validator.sh codegen-validator.sh COPYONLY)
     add_custom_target(codegen-validator COMMAND ./codegen-validator.sh)
-    add_test(NAME codegen-validator COMMAND ./codegen-validator.sh ${CMAKE_SOURCE_DIR})
   else()
     message(STATUS "Not building with LLVM 18, skipping codegen-validator test")
   endif()

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -403,11 +403,11 @@ TEST(utils, find_in_path)
 // Hopefully they are easy to maintain. If not, please delete.
 TEST(utils, find_near_self)
 {
-  auto runtime_tests = find_near_self("runtime-tests.sh");
+  auto runtime_tests = find_near_self("near_self_file");
   // clang-tidy is not aware ASSERT_*() terminates testcase
   // NOLINTBEGIN(bugprone-unchecked-optional-access)
   ASSERT_TRUE(runtime_tests.has_value());
-  EXPECT_TRUE(runtime_tests->filename() == "runtime-tests.sh");
+  EXPECT_TRUE(runtime_tests->filename() == "near_self_file");
   EXPECT_TRUE(std::filesystem::exists(*runtime_tests));
   // NOLINTEND(bugprone-unchecked-optional-access)
 


### PR DESCRIPTION
The runtime and tools tests are run together with the unit tests as cmake targets, but really should not be: unlike the unit tests they require specific kernel/userland configuration, need root privileges to run and are generally not suitable for running outside of the CI environment (e.g. regular dev workflows). SInce CI explicitly runs these tests via their specialized runners, there is no need to declare them as cmake tests. Also create a dedicated file to use in the unit tests instead of the runtime-tests.sh driver, which does not belong to the unit tests.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
