### PR TITLE
errors: change order of expanded macros

### DIFF
--- a/src/ast/diagnostic.cpp
+++ b/src/ast/diagnostic.cpp
@@ -49,9 +49,6 @@ void Diagnostics::emit(std::ostream& out, Severity s, const Diagnostic& d) const
     }
   }
 
-  // reverse to print the initial parent first
-  std::ranges::reverse(parent_msgs);
-
   switch (s) {
     case Severity::Warning:
       if (msgs.empty()) {

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -5463,12 +5463,12 @@ macro add2($x) { $x + 1 } macro add1($x) { add2($x) } begin { $a = "string"; add
 stdin:1:23-24: ERROR: right (int64)
 macro add2($x) { $x + 1 } macro add1($x) { add2($x) } begin { $a = "string"; add1($a); }
                       ~
-stdin:1:78-86: ERROR: expanded from
-macro add2($x) { $x + 1 } macro add1($x) { add2($x) } begin { $a = "string"; add1($a); }
-                                                                             ~~~~~~~~
 stdin:1:44-52: ERROR: expanded from
 macro add2($x) { $x + 1 } macro add1($x) { add2($x) } begin { $a = "string"; add1($a); }
                                            ~~~~~~~~
+stdin:1:78-86: ERROR: expanded from
+macro add2($x) { $x + 1 } macro add1($x) { add2($x) } begin { $a = "string"; add1($a); }
+                                                                             ~~~~~~~~
 )" });
 }
 


### PR DESCRIPTION
Stacked PRs:
 * __->__#4582


--- --- ---

### errors: change order of expanded macros


The current order is confusing: it starts with the end, then goes to the
farthest distance and slowly walks towards the error. Instead, start
with the error and walk away towards the original call site.

Signed-off-by: Adin Scannell <amscanne@meta.com>