### PR TITLE
builtins: add `__builtin_prog_type` and `__builtin_probe_type`

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -247,7 +247,7 @@ bool AttachPoint::check_available(const std::string &identifier) const
 {
   ProbeType type = probetype(provider);
 
-  if (identifier == "reg" || identifier == "__builtin_usermode") {
+  if (identifier == "reg") {
     switch (type) {
       case ProbeType::kprobe:
       case ProbeType::kretprobe:

--- a/src/ast/passes/builtins.cpp
+++ b/src/ast/passes/builtins.cpp
@@ -19,13 +19,138 @@ public:
   std::optional<Expression> visit(Identifier &identifier);
   std::optional<Expression> visit(Expression &expression);
   std::optional<Expression> check(const std::string &ident, Node &node);
+  std::optional<Expression> visit(Probe &probe);
+  std::optional<Expression> visit(Subprog &subprog);
 
 private:
   ASTContext &ast_;
   BPFtrace &bpftrace_;
+
+  std::optional<ProbeType> probe_type_;
+  std::optional<bpf_prog_type> prog_type_;
 };
 
 } // namespace
+
+static std::string probe_type_name(ProbeType t)
+{
+  switch (t) {
+    case ProbeType::invalid:
+      return "invalid";
+    case ProbeType::special:
+      return "special";
+    case ProbeType::benchmark:
+      return "benchmark";
+    case ProbeType::kprobe:
+      return "kprobe";
+    case ProbeType::kretprobe:
+      return "kretprobe";
+    case ProbeType::uprobe:
+      return "uprobe";
+    case ProbeType::uretprobe:
+      return "uretprobe";
+    case ProbeType::usdt:
+      return "usdt";
+    case ProbeType::tracepoint:
+      return "tracepoint";
+    case ProbeType::profile:
+      return "profile";
+    case ProbeType::interval:
+      return "interval";
+    case ProbeType::software:
+      return "software";
+    case ProbeType::hardware:
+      return "hardware";
+    case ProbeType::watchpoint:
+      return "watchpoint";
+    case ProbeType::asyncwatchpoint:
+      return "asyncwatchpoint";
+    case ProbeType::fentry:
+      return "fentry";
+    case ProbeType::fexit:
+      return "fexit";
+    case ProbeType::iter:
+      return "iter";
+    case ProbeType::rawtracepoint:
+      return "rawtracepoint";
+    default:
+      return "unknown";
+  }
+}
+
+static std::string prog_type_name(bpf_prog_type t)
+{
+  switch (t) {
+    case BPF_PROG_TYPE_UNSPEC:
+      return "unspec";
+    case BPF_PROG_TYPE_SOCKET_FILTER:
+      return "socket_filter";
+    case BPF_PROG_TYPE_KPROBE:
+      return "kprobe";
+    case BPF_PROG_TYPE_SCHED_CLS:
+      return "sched_cls";
+    case BPF_PROG_TYPE_SCHED_ACT:
+      return "sched_act";
+    case BPF_PROG_TYPE_TRACEPOINT:
+      return "tracepoint";
+    case BPF_PROG_TYPE_XDP:
+      return "xdp";
+    case BPF_PROG_TYPE_PERF_EVENT:
+      return "perf_event";
+    case BPF_PROG_TYPE_CGROUP_SKB:
+      return "cgroup_skb";
+    case BPF_PROG_TYPE_CGROUP_SOCK:
+      return "cgroup_sock";
+    case BPF_PROG_TYPE_LWT_IN:
+      return "lwt_in";
+    case BPF_PROG_TYPE_LWT_OUT:
+      return "lwt_out";
+    case BPF_PROG_TYPE_LWT_XMIT:
+      return "lwt_xmit";
+    case BPF_PROG_TYPE_SOCK_OPS:
+      return "sock_ops";
+    case BPF_PROG_TYPE_SK_SKB:
+      return "sk_skb";
+    case BPF_PROG_TYPE_CGROUP_DEVICE:
+      return "cgroup_device";
+    case BPF_PROG_TYPE_SK_MSG:
+      return "sk_msg";
+    case BPF_PROG_TYPE_RAW_TRACEPOINT:
+      return "raw_tracepoint";
+    case BPF_PROG_TYPE_CGROUP_SOCK_ADDR:
+      return "cgroup_sock_addr";
+    case BPF_PROG_TYPE_LWT_SEG6LOCAL:
+      return "lwt_seg6local";
+    case BPF_PROG_TYPE_LIRC_MODE2:
+      return "lirc_mode2";
+    case BPF_PROG_TYPE_SK_REUSEPORT:
+      return "sk_reuseport";
+    case BPF_PROG_TYPE_FLOW_DISSECTOR:
+      return "flow_dissector";
+    case BPF_PROG_TYPE_CGROUP_SYSCTL:
+      return "cgroup_sysctl";
+    case BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE:
+      return "raw_tracepoint_writable";
+    case BPF_PROG_TYPE_CGROUP_SOCKOPT:
+      return "cgroup_sockopt";
+    case BPF_PROG_TYPE_TRACING:
+      return "tracing";
+    case BPF_PROG_TYPE_STRUCT_OPS:
+      return "struct_ops";
+    case BPF_PROG_TYPE_EXT:
+      return "ext";
+    case BPF_PROG_TYPE_LSM:
+      return "lsm";
+    case BPF_PROG_TYPE_SK_LOOKUP:
+      return "sk_lookup";
+    case BPF_PROG_TYPE_SYSCALL:
+      return "syscall";
+    case BPF_PROG_TYPE_NETFILTER:
+      return "netfilter";
+    default:
+      return "unknown";
+  }
+}
 
 std::optional<Expression> Builtins::check(const std::string &ident, Node &node)
 {
@@ -43,6 +168,29 @@ std::optional<Expression> Builtins::check(const std::string &ident, Node &node)
   }
   if (ident == "__builtin_safe_mode") {
     return ast_.make_node<Boolean>(bpftrace_.safe_mode_, Location(node.loc));
+  }
+
+  // This is broken at the time of writing, but it's broken everywhere. In many
+  // places, the probe is generated based on the type of the first attachment,
+  // without regard for the fact that you may have multiple providers. This
+  // will be fixed by doing up front expansion, so these broken builtins will
+  // simply mirror the existing behavior temporarily. In the future, this
+  // comment will document older behavior (which hopefully does not apply).
+  if (ident == "__builtin_probe_type") {
+    if (probe_type_) {
+      return ast_.make_node<String>(probe_type_name(probe_type_.value()),
+                                    Location(node.loc));
+    } else {
+      node.addError() << "probe type not available";
+    }
+  }
+  if (ident == "__builtin_prog_type") {
+    if (prog_type_) {
+      return ast_.make_node<String>(prog_type_name(prog_type_.value()),
+                                    Location(node.loc));
+    } else {
+      node.addError() << "program type not available";
+    }
   }
   return std::nullopt;
 }
@@ -64,6 +212,28 @@ std::optional<Expression> Builtins::visit(Expression &expression)
     expression.value = replacement->value;
   }
   return std::nullopt;
+}
+
+std::optional<Expression> Builtins::visit(Probe &probe)
+{
+  if (!probe.attach_points.empty()) {
+    auto &ap = probe.attach_points[0];
+    probe_type_ = probetype(ap->provider);
+    prog_type_ = progtype(probe_type_.value());
+  } else {
+    probe_type_.reset();
+    prog_type_.reset();
+  }
+
+  return Visitor<Builtins, std::optional<Expression>>::visit(probe);
+}
+
+std::optional<Expression> Builtins::visit(Subprog &subprog)
+{
+  probe_type_.reset();
+  prog_type_.reset();
+
+  return Visitor<Builtins, std::optional<Expression>>::visit(subprog);
 }
 
 Pass CreateBuiltinsPass()

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -716,28 +716,6 @@ ScopedExpr CodegenLLVM::visit(Builtin &builtin)
       return ScopedExpr(b_.CreateLShr(uidgid, 32));
     }
     __builtin_unreachable();
-  } else if (builtin.ident == "__builtin_usermode") {
-    if (arch::Host::Machine == arch::Machine::X86_64) {
-      auto cs_offset = arch::Host::register_to_pt_regs_offset("cs");
-      if (!cs_offset) {
-        builtin.addError() << "No CS register?";
-        return ScopedExpr(b_.getInt64(0));
-      }
-      Value *cs = b_.CreateRegisterRead(ctx_, cs_offset.value(), "reg_cs");
-      Value *mask = b_.getInt64(0x3);
-      Value *is_usermode = b_.CreateICmpEQ(b_.CreateAnd(cs, mask),
-                                           b_.getInt64(3),
-                                           "is_usermode");
-      Value *expr = b_.CreateZExt(is_usermode,
-                                  b_.GetType(builtin.builtin_type),
-                                  "usermode_result");
-      return ScopedExpr(expr);
-    } else {
-      // We lack an implementation.
-      builtin.addError() << "not supported on architecture "
-                         << arch::Host::Machine;
-      return ScopedExpr(b_.getInt64(0));
-    }
   } else if (builtin.ident == "__builtin_numaid") {
     return ScopedExpr(b_.CreateGetNumaId(builtin.loc));
   } else if (builtin.ident == "__builtin_cpu") {

--- a/src/ast/passes/fold_literals.cpp
+++ b/src/ast/passes/fold_literals.cpp
@@ -29,8 +29,6 @@ public:
   std::optional<Expression> visit(PositionalParameter &param);
   std::optional<Expression> visit(Call &call);
   std::optional<Expression> visit(Expression &expr);
-  std::optional<Expression> visit(Probe &probe);
-  std::optional<Expression> visit(Builtin &builtin);
   std::optional<Expression> visit(BlockExpr &block_expr);
   std::optional<Expression> visit(TupleAccess &acc);
 
@@ -41,8 +39,6 @@ private:
 
   ASTContext &ast_;
   std::optional<std::reference_wrapper<BPFtrace>> bpftrace_;
-
-  Node *top_level_node_ = nullptr;
 };
 
 } // namespace
@@ -744,31 +740,6 @@ std::optional<Expression> LiteralFolder::visit(Expression &expr)
   if (r) {
     expr.value = r->value;
   }
-  return std::nullopt;
-}
-
-std::optional<Expression> LiteralFolder::visit(Probe &probe)
-{
-  top_level_node_ = &probe;
-  return Visitor<LiteralFolder, std::optional<Expression>>::visit(probe);
-}
-
-std::optional<Expression> LiteralFolder::visit(Builtin &builtin)
-{
-  if (builtin.ident == "__builtin_usermode") {
-    if (auto *probe = dynamic_cast<Probe *>(top_level_node_)) {
-      for (auto *ap : probe->attach_points) {
-        if (!ap->check_available(builtin.ident)) {
-          auto probe_type = probetype(ap->provider);
-          if (probe_type == ProbeType::special) {
-            return ast_.make_node<Integer>(1, Location(builtin.loc));
-          }
-          return ast_.make_node<Integer>(0, Location(builtin.loc));
-        }
-      }
-    }
-  }
-
   return std::nullopt;
 }
 

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -1113,12 +1113,6 @@ void SemanticAnalyser::visit(Builtin &builtin)
     builtin.builtin_type = CreateString(str_size + 1);
   } else if (builtin.ident == "__builtin_username") {
     builtin.builtin_type = CreateUsername();
-  } else if (builtin.ident == "__builtin_usermode") {
-    if (arch::Host::Machine != arch::Machine::X86_64) {
-      builtin.addError() << "'usermode' builtin is only supported on x86_64";
-      return;
-    }
-    builtin.builtin_type = CreateUInt8();
   } else if (builtin.ident == "__builtin_cpid") {
     if (!has_child_) {
       builtin.addError() << "cpid cannot be used without child command";
@@ -2815,8 +2809,8 @@ void SemanticAnalyser::visit(IfExpr &if_expr)
 
   if (!lhs.IsSameType(rhs)) {
     if (is_final_pass()) {
-      if_expr.addError() << "Branches must return the same type: "
-                         << "have '" << lhs << "' and '" << rhs << "'";
+      if_expr.addError() << "Branches must return the same type: " << "have '"
+                         << lhs << "' and '" << rhs << "'";
     }
     // This assignment is just temporary to prevent errors
     // before the final pass

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -46,7 +46,7 @@ vspace   [\n\r]
 space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#$+\*])+
 /* Most of the builtins are prefixed with __builtin_ as they are exposed to users via macros e.g. macro cpu() { __builtin_cpu } */
-builtin  arg[0-9]+|args|ctx|kstack|nsecs|pid|sarg[0-9]|tid|ustack|__builtin_cgroup|__builtin_comm|__builtin_cpid|__builtin_cpu|__builtin_curtask|__builtin_elapsed|__builtin_func|__builtin_gid|__builtin_jiffies|__builtin_ncpus|__builtin_numaid|__builtin_probe|__builtin_rand|__builtin_retval|__builtin_uid|__builtin_usermode|__builtin_username
+builtin  arg[0-9]+|args|ctx|kstack|nsecs|pid|sarg[0-9]|tid|ustack|__builtin_cgroup|__builtin_comm|__builtin_cpid|__builtin_cpu|__builtin_curtask|__builtin_elapsed|__builtin_func|__builtin_gid|__builtin_jiffies|__builtin_ncpus|__builtin_numaid|__builtin_probe|__builtin_rand|__builtin_retval|__builtin_uid|__builtin_username
 
 int_type        bool|(u)?int(8|16|32|64)
 builtin_type    void|(u)?(min|max|sum|avg|stats)_t|count_t|probe_t|username_t|lhist_t|hist_t|usym_t|ksym_t|timestamp|macaddr_t|cgroup_path_t|strerror_t|kstack_t|ustack_t|string|tseries_t

--- a/src/stdlib/arch.bt
+++ b/src/stdlib/arch.bt
@@ -1,0 +1,24 @@
+// :variant uint8 usermode()
+// Returns 1 if the current process is in user mode, 0 otherwise
+//
+// Currently only available on x86_64.
+macro usermode() {
+  if (arch == "x86_64") {
+    if (__builtin_probe_type == "special") {
+      (uint8)1
+    } else if (__builtin_probe_type == "benchmark") {
+      (uint8)1
+    } else if (__builtin_probe_type == "watchpoint" ||
+               __builtin_probe_type == "asyncwatchpoint" ||
+               __builtin_probe_type == "profile" ||
+               __builtin_probe_type == "interval" ||
+               __builtin_probe_type == "software" ||
+               __builtin_probe_type == "hardware") {
+      (uint8)(ctx.cs & 0x3 == 0x3)
+    } else {
+      (uint8)0
+    }
+  } else {
+    fail("'usermode' builtin is only supported on x86_64")
+  }
+}

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -1139,14 +1139,6 @@ macro uid() {
 // See the address-spaces section for more information on address-spaces.
 // The pointer type is left unchanged.
 
-// :variant uint8 usermode()
-// Returns 1 if the current process is in user mode, 0 otherwise
-//
-// Currently only available on x86_64.
-macro usermode() {
-  __builtin_usermode
-}
-
 // :variant string username()
 // Get the current username
 //

--- a/tests/runtime/macro
+++ b/tests/runtime/macro
@@ -176,11 +176,6 @@ NAME builtin wrapper uid
 PROG begin { if (__builtin_uid == uid() && __builtin_uid == uid) { printf("SUCCESS %d\n", uid); } }
 EXPECT_REGEX SUCCESS [0-9]+
 
-NAME builtin wrapper usermode
-PROG begin { if (__builtin_usermode == usermode() && __builtin_usermode == usermode) { printf("SUCCESS %d\n", usermode); } }
-EXPECT_REGEX SUCCESS 1
-ARCH x86_64
-
 NAME builtin wrapper username
 PROG begin { if (__builtin_username == username() && __builtin_username == username) { printf("SUCCESS %s\n", username); } }
 EXPECT_REGEX SUCCESS .*


### PR DESCRIPTION
Stacked PRs:
 * __->__#4586


--- --- ---

### builtins: add `__builtin_prog_type` and `__builtin_probe_type`


As an examplar, this convers the `__builtin_usermode` macro which was
previously in the constant folder into a macro. These two additional
builtins will enable migration of many provider-dependent builtins.

Note that most of the code in these paths is broken: probes may have
multiple providers, yet checking is often done against only the first.
This change set will not concern itself with these problem; this will be
fixed by doing full up front expansion ahead of semantic analysis, but
doing full expansion requires that these builtins are pulled forward
first. This change should not affect any existing bugs.

Signed-off-by: Adin Scannell <amscanne@meta.com>