### PR TITLE
Fix generate_stdlib_docs

### DIFF
--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -1247,6 +1247,14 @@ uprobe:/bin/bash:readline
 ```
 
 
+### zero
+- `void zero(map m)`
+
+**async**
+
+Set all values (for all keys) in the map to zero.
+
+
 ## Map Value Functions
 
 Map value functions can only be assigned to maps (when scalar) or map keys.

--- a/scripts/generate_stdlib_docs.py
+++ b/scripts/generate_stdlib_docs.py
@@ -107,6 +107,9 @@ def read_file_lines(file_path: str) -> Optional[list[Helper]]:
                         helpers.append(current)
                     current = Helper()
 
+        if current.name and current.description:
+            helpers.append(current)
+
         return helpers
 
     except PermissionError:


### PR DESCRIPTION
Stacked PRs:
 * #4597
 * __->__#4596


--- --- ---

### Fix generate_stdlib_docs


This was missing the dangling helper
that didn't get added at the end of the loop
e.g. `zero` was missing.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>