### PR TITLE
create-assets.sh: Fix creating tools archive

### DIFF
--- a/scripts/create-assets.sh
+++ b/scripts/create-assets.sh
@@ -35,13 +35,8 @@ info "Creating tools archive"
 # bit of copying to avoid confusing tar flags not great but works
 mkdir -p "$TMP/bin"
 
-cp tools/*.bt tools/*.txt "$TMP/bin"
-rm -f "$TMP/bin/CMakeLists.txt"
+cp tools/*.bt "$TMP/bin"
 chmod +x "$TMP/bin/"*.bt
-
-tar --xz -cf "$OUT/tools-with-help.tar.xz" -C "$TMP/bin" "."
-
-rm "$TMP/bin/"*.txt
 tar --xz -cf "$OUT/tools.tar.xz" -C "$TMP/bin" "."
 
 info "Creating man archive"


### PR DESCRIPTION
Commit 579e0e9d ("remove tools example txt files (#4187)") has removed the txt files from the tools/ directory and moved the descriptions to the headers of the tools themselves. Reflect this change in scripts/create-assets.sh, otherwise it fails on `rm "$TMP/bin/"*.txt` (as there are no .txt files).

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
