### PR TITLE
semantic analyser: support native map types

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -647,11 +647,11 @@ public:
 
   const SizedType &type() const
   {
-    static SizedType voidptr = CreatePointer(CreateVoid());
-    return voidptr;
+    return map_type;
   }
 
   Map *map = nullptr;
+  SizedType map_type;
 };
 
 class Binop : public Node {


### PR DESCRIPTION
Stacked PRs:
 * __->__#4610


--- --- ---

### semantic analyser: support native map types


When the map address operator is used, the map type becomes the native
map type (C equivalent).

```
config = { unstable_typeinfo = true; }
begin {
  @ = 1;
  print(typeinfo(*(&@)->key));
}
```

```
Attached 1 probe
(int64, 0)
```

Signed-off-by: Adin Scannell <amscanne@meta.com>