### PR TITLE
Fix linking against libbpf.a

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,7 +69,7 @@ target_compile_definitions(bpftrace PRIVATE ${BPFTRACE_FLAGS})
 if(STATIC_LINKING)
   target_link_libraries(bpftrace libbpftrace)
 else()
-  target_link_libraries(bpftrace libbpftrace libbpf.a)
+  target_link_libraries(bpftrace libbpftrace ${LIBBPF_LIBRARIES})
 endif(STATIC_LINKING)
 
 # compile definitions


### PR DESCRIPTION
Commit 85d25d06 ("fix: libbpf.a symbols shadow by libbcc_bpf.so (#4429)") added explicit linking against libbpf.a to prevent dynamic libbpf linked by bcc from shadowing symbols in the static libbpf (which we need). However, since just `libbpf.a` is used, `target_link_libraries` will prefer system static libbpf over custom-installed one. This may lead to compilation errors such as:

    [ 95%] Linking CXX executable bpftrace
    /usr/bin/ld: /usr/local/lib64/libbpf.a(str_error.o): in function `libbpf_strerror_r':
    ~/src/bpf/libbpf/src/str_error.c:21: multiple definition of `libbpf_strerror_r'; /usr/lib/gcc/x86_64-redhat-linux/15/../../../../lib64/libbpf.a(str_error.o):(.text+0x0): first defined here

Use `${LIBBPF_LIBRARIES}` instead of `libbpf.a` to fix the issue.

Note: this code will probably go away once we move to libbpf submodule but until then, it fixes build failures on systems with custom-installed libbpf.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
