### PR TITLE
Add 'is_scalar' builtin function

### DIFF
--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -266,6 +266,8 @@ TEST_F(SemanticAnalyserTest, builtin_functions)
   test("kprobe:f { @x = 1; zero(@x) }");
   test("kprobe:f { @x[1] = 1; if (has_key(@x, 1)) {} }");
   test("kprobe:f { @x[1] = 1; @s = len(@x) }");
+  test("kprobe:f { @x = 1; @y[1] = 1; $a = is_scalar(@x); $b = is_scalar(@y); "
+       "}");
   test("kprobe:f { time() }");
   test("kprobe:f { exit() }");
   test("kprobe:f { str(0xffff) }");
@@ -5622,6 +5624,8 @@ TEST_F(SemanticAnalyserTest, if_comptime)
 {
   test(R"(kprobe:f { @a = 1; if (comptime false) { @a[1] = 1; } })");
   test(R"(kprobe:f { @a[1] = 1; if (comptime false) { @a = 1; } })");
+  test(R"(kprobe:f { @a[1] = 1; if (comptime is_scalar(@a)) { @a = 1; } })");
+  test(R"(kprobe:f { @a = 1; if (comptime !is_scalar(@a)) { @a[1] = 1; } })");
   test(R"(kprobe:f { @a = 1; if (comptime false) { for ($kv : @a) { } } })");
   test(R"(kprobe:f { @a[1] = 1; if (comptime true) { @a = 1; } })", Error{ R"(
 stdin:1:44-46: ERROR: @a used as a map without an explicit key (scalar map), previously used with an explicit key (non-scalar map)


### PR DESCRIPTION
Stacked PRs:
 * #4656
 * #4561
 * __->__#4619


--- --- ---

### Add 'is_scalar' builtin function


This is a simple function that gets evaluated
at compile time and just returns true
if the passed map arg is a scalar map and false
if it is not.

This will be used in future macros e.g. `has_key`.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>