### PR TITLE
tools: opensnoop: Fix @paths race condition

### DIFF
--- a/tools/opensnoop.bt
+++ b/tools/opensnoop.bt
@@ -79,12 +79,8 @@ macro printcwd(@paths) {
 	clear(@paths);
 }
 
-tracepoint:syscalls:sys_exit_open,
-tracepoint:syscalls:sys_exit_openat,
-tracepoint:syscalls:sys_exit_openat2
-/@filename[tid]/
-{
-	$ret = args.ret;
+macro sys_exit(ret, @filename, @paths) {
+	$ret = ret;
 	$fd = $ret >= 0 ? $ret : -1;
 	$errno = $ret >= 0 ? 0 : - $ret;
 
@@ -104,8 +100,28 @@ tracepoint:syscalls:sys_exit_openat2
 	delete(@filename, tid);
 }
 
+tracepoint:syscalls:sys_exit_open
+/@filename[tid]/
+{
+	sys_exit(args.ret, @filename, @open_paths);
+}
+
+tracepoint:syscalls:sys_exit_openat
+/@filename[tid]/
+{
+	sys_exit(args.ret, @filename, @openat_paths);
+}
+
+tracepoint:syscalls:sys_exit_openat2
+/@filename[tid]/
+{
+	sys_exit(args.ret, @filename, @openat2_paths);
+}
+
 END
 {
 	clear(@filename);
-	clear(@paths);
+	clear(@open_paths);
+	clear(@openat_paths);
+	clear(@openat2_paths);
 }


### PR DESCRIPTION
Sorry, I've been busy recently and only have time to develop. When trying to implement str_append,str_prepend,abspath(https://github.com/bpftrace/bpftrace/pull/4601 @amscanne ), I found a problem with opensnoop, better to solve it first.

The problem is as follows:

When all system calls share the same `@paths`, there will be race conditions for adding and removing `@paths` when open, openat, and openat2 system calls are made concurrently.

Thank you everyone :)
