### PR TITLE
Add some delay to debugf runtime tests

### DIFF
--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -705,18 +705,19 @@ NAME socket_cookie rawtracepoint
 RUN {{BPFTRACE}} -e 'rawtracepoint:tcp_probe { $ret = socket_cookie(args->sk); printf("ret: %llu\n", $ret); exit(); }'
 EXPECT Attached 1 probe
 
+# debugf can be slow so add some time before checking the trace pipe
 NAME debugf
-RUN echo > /sys/kernel/debug/tracing/trace; {{BPFTRACE}} -e 'i:ms:1 { debugf("debugf"); exit();}'; cat /sys/kernel/debug/tracing/trace
+RUN echo > /sys/kernel/debug/tracing/trace; {{BPFTRACE}} -e 'i:500ms { debugf("debugf"); @a = count(); if (@a > 2) { exit(); } }'; cat /sys/kernel/debug/tracing/trace
 EXPECT_REGEX bpf_trace_printk: debugf
 TIMEOUT 3
 
 NAME debugf_with_arguments
-RUN echo > /sys/kernel/debug/tracing/trace; {{BPFTRACE}} -e 'i:ms:1 { debugf("debugf %s %d %x", "a", 1, 16); exit();}'; cat /sys/kernel/debug/tracing/trace
+RUN echo > /sys/kernel/debug/tracing/trace; {{BPFTRACE}} -e 'i:500ms { debugf("debugf %s %d %x", "a", 1, 16); @a = count(); if (@a > 2) { exit(); } }'; cat /sys/kernel/debug/tracing/trace
 EXPECT_REGEX bpf_trace_printk: debugf a 1 10
 TIMEOUT 3
 
 NAME debugf_with_seq_printf
-RUN echo > /sys/kernel/debug/tracing/trace; {{BPFTRACE}} -e 'i:ms:1 { printf("printf %d", 0); debugf("debugf %d", 1); exit();}'; cat /sys/kernel/debug/tracing/trace
+RUN echo > /sys/kernel/debug/tracing/trace; {{BPFTRACE}} -e 'i:500ms { printf("printf %d", 0); debugf("debugf %d", 1); @a = count(); if (@a > 2) { exit(); } }'; cat /sys/kernel/debug/tracing/trace
 EXPECT_REGEX bpf_trace_printk: debugf 1
 TIMEOUT 3
 


### PR DESCRIPTION
This is to address possible flakyness
as debugf can be slow.

Issue:
- https://github.com/bpftrace/bpftrace/issues/4638

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
