### PR TITLE
Update docs for PERCPU map types

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -2003,9 +2003,9 @@ end {
 }
 ```
 
-### PER_CPU types
+### PERCPU types
 
-For bpftrace PER_CPU types (search this document for "PER_CPU"), you may coerce
+For bpftrace PERCPU map types (e.g., those created by using [`count()`](stdlib.md#count) or [`sum()`](stdlib.md#sum)) you may coerce
 (and thus force a more expensive synchronous read) the type to an integer using
 a cast or by doing a comparison. This is useful for when you need an integer
 during comparisons, `printf()`, or other.

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -1343,7 +1343,7 @@ Count how often this function is called.
 
 Using `@=count()` is conceptually similar to `@++`.
 The difference is that the `count()` function uses a map type optimized for
-performance and correctness using cheap, thread-safe writes (PER_CPU). However, sync reads
+performance and correctness using cheap, thread-safe writes ([PERCPU](./language.md#percpu-types)). However, sync reads
 can be expensive as bpftrace needs to iterate over all the cpus to collect and
 sum these values.
 
@@ -1447,7 +1447,7 @@ Prints:
 * `max_t max(int64 n)`
 
 Update the map with `n` if `n` is bigger than the current value held.
-Similar to `count` this uses a PER_CPU map (thread-safe, fast writes, slow reads).
+Similar to `count` this uses a [PERCPU](./language.md#percpu-types) map (thread-safe, fast writes, slow reads).
 
 Note: this is different than the typical userspace `max()` in that bpftrace’s `max()`
 only takes a single argument. The logical "other" argument to compare to is the value
@@ -1475,7 +1475,7 @@ be returned.
 * `min_t min(int64 n)`
 
 Update the map with `n` if `n` is smaller than the current value held.
-Similar to `count` this uses a PER_CPU map (thread-safe, fast writes, slow reads).
+Similar to `count` this uses a [PERCPU](./language.md#percpu-types) map (thread-safe, fast writes, slow reads).
 
 See `max()` above for how this differs from the typical userspace `min()`.
 
@@ -1506,7 +1506,7 @@ Calculate the sum of all `n` passed.
 
 Using `@=sum(5)` is conceptually similar to `@+=5`.
 The difference is that the `sum()` function uses a map type optimized for
-performance and correctness using cheap, thread-safe writes (PER_CPU). However, sync reads
+performance and correctness using cheap, thread-safe writes ([PERCPU](./language.md#percpu-types)). However, sync reads
 can be expensive as bpftrace needs to iterate over all the cpus to collect and
 sum these values.
 


### PR DESCRIPTION
PER_CPU -> PERCPU (as this is how they like
in kernel code).

And add links to the stdlib from the PERCPU
section of the langauge doc and vice-versa.

Issue:
- https://github.com/bpftrace/bpftrace/issues/4645


##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
