### PR TITLE
Remove restriction on storing tp args in maps

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -4485,10 +4485,6 @@ void SemanticAnalyser::assign_map_type(Map &map,
 {
   const std::string &map_ident = map.ident;
 
-  if (type.IsRecordTy() && type.is_tparg) {
-    loc_node->addError() << "Storing tracepoint args in maps is not supported";
-  }
-
   auto *maptype = get_map_type(map);
   if (maptype) {
     if (maptype->IsNoneTy()) {


### PR DESCRIPTION
Stacked PRs:
 * #4659
 * __->__#4657


--- --- ---

### Remove restriction on storing tp args in maps


This seems to be working fine now.
Tested on a 5.12 kernel and a 6.09 kernel
with this command:
```
$ sudo bpftrace -e 'tracepoint:syscalls:sys_enter_read { @ = args }'
WARNING: Kernel version (5.12.0-0_fbk16_zion_7661_geb00762ce6d2) is lower than the minimum supported kernel version (5.15.0). Some features/scripts may not work as expected.
Attached 1 probe
^C

@: { .common_type = 0, .common_flags = 0, .common_preempt_count = 0, .common_pid = 0, .__syscall_nr = 0, .__pad_12 = 0, .__pad_13 = 0, .__pad_14 = 0, .__pad_15 = 0, .fd = 0, .buf = 0x0, .count = 0 }
```

This restriction was added here:
- https://github.com/bpftrace/bpftrace/pull/2578

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>