### PR TITLE
Improve scratch buffer code

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -673,6 +673,9 @@ Value *IRBuilderBPF::createScratchBuffer(std::string_view global_var_name,
   // The last level is either an array of bytes (e.g. for strings)
   // or a single value (e.g. for ints like the EVENT_LOSS_COUNTER)
   const auto global_name = std::string(global_var_name);
+  bpftrace_.resources.global_vars.check_index(global_name,
+                                              bpftrace_.resources,
+                                              key);
   auto sized_type = bpftrace_.resources.global_vars.get_sized_type(
       global_name, bpftrace_.resources, *bpftrace_.config_);
   auto *cpu_id = CreateGetCpuId(loc);

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -379,14 +379,8 @@ void ResourceAnalyser::visit(Call &call)
                                                map_key_size);
       }
     } else {
-      auto &map = *call.vargs.at(0).as<Map>();
-      auto &key_expr = call.vargs.at(1);
-      if (needMapKeyAllocation(map, key_expr) &&
-          exceeds_stack_limit(map.key_type.GetSize())) {
-        resources_.map_key_buffers++;
-        resources_.max_map_key_size = std::max(resources_.max_map_key_size,
-                                               map.key_type.GetSize());
-      }
+      maybe_allocate_map_key_buffer(*call.vargs.at(0).as<Map>(),
+                                    call.vargs.at(1));
     }
   }
 

--- a/src/globalvars.cpp
+++ b/src/globalvars.cpp
@@ -276,6 +276,23 @@ SizedType GlobalVars::get_sized_type(const std::string &global_var_name,
   return CreateInt64();
 }
 
+void GlobalVars::check_index(const std::string &global_var_name,
+                             const RequiredResources &resources,
+                             size_t index) const
+{
+  if (global_var_name == TUPLE_BUFFER) {
+    assert(index < resources.tuple_buffers);
+  } else if (global_var_name == GET_STR_BUFFER) {
+    assert(index < resources.str_buffers);
+  } else if (global_var_name == READ_MAP_VALUE_BUFFER) {
+    assert(index < resources.read_map_value_buffers);
+  } else if (global_var_name == VARIABLE_BUFFER) {
+    assert(index < resources.variable_buffers);
+  } else if (global_var_name == MAP_KEY_BUFFER) {
+    assert(index < resources.map_key_buffers);
+  }
+}
+
 std::unordered_set<std::string> get_section_names()
 {
   std::unordered_set<std::string> ret;

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -166,6 +166,7 @@ public:
   SizedType get_sized_type(const std::string &global_var_name,
                            const RequiredResources &resources,
                            const Config &bpftrace_config) const;
+  void check_index(const std::string &global_var_name, const RequiredResources &resources, size_t index) const;
 
   const std::unordered_map<std::string, GlobalVarConfig> &global_var_map() const
   {


### PR DESCRIPTION
Stacked PRs:
 * __->__#4675


--- --- ---

### Improve scratch buffer code


- re-use maybe_allocate_map_key_buffer
- add index bounds check for global scratch buffers

Follow-up from this PR:
- https://github.com/bpftrace/bpftrace/pull/4670

Signed-off-by: Jordan Rome <linux@jordanrome.com>