### PR TITLE
Restrict licenses to those that are GPL compatible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to
 #### Breaking Changes
 - `exit()` is no longer allowed inside loops. `return` was always disallowed, and `exit()` implicitly returns, which may result in undefined behavior.
   - [#4587](https://github.com/bpftrace/bpftrace/pull/4587)
+- Restrict bpftrace script licenses to those that are GPL compatible
+  - [#4677](https://github.com/bpftrace/bpftrace/pull/4677)
 #### Added
 - Add support for indexing string types
   - [#4540](https://github.com/bpftrace/bpftrace/pull/4540)

--- a/docs/language.md
+++ b/docs/language.md
@@ -250,7 +250,15 @@ For user space symbols, symbolicate lazily/on-demand (`true`) or symbolicate eve
 
 Default: "GPL"
 
-The license bpftrace will use to load BPF programs into the linux kernel.
+The license bpftrace will use to load BPF programs into the linux kernel. Here is the list of accepted license strings:
+- GPL
+- GPL v2
+- GPL and additional rights
+- Dual BSD/GPL
+- Dual MIT/GPL
+- Dual MPL/GPL
+
+[Read More about BPF licenses](#bpf-license)
 
 ### log_size
 

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -50,6 +50,7 @@
 #include "bpfmap.h"
 #include "bpftrace.h"
 #include "codegen_resources.h"
+#include "config.h"
 #include "globalvars.h"
 #include "log.h"
 #include "map_info.h"
@@ -507,7 +508,8 @@ CodegenLLVM::CodegenLLVM(ASTContext &ast,
   module_->setUwtable(llvm::UWTableKind::None);
 
   // Set license of BPF programs.
-  const std::string &license = bpftrace_.config_->license;
+  const std::string license = ::bpftrace::Config::get_license_str(
+      bpftrace_.config_->license);
   auto license_size = license.size() + 1;
   auto *license_var = llvm::dyn_cast<GlobalVariable>(
       module_->getOrInsertGlobal(LICENSE,

--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -258,17 +258,6 @@ void BpfBytecode::load_progs(const RequiredResources &resources,
           "pointer arithmetic on ptr_or_null_ prohibited, null-check it first",
           ": result needs to be null-checked before accessing fields");
 
-      auto err_pos = log.find("from non-GPL compatible program");
-      if (err_pos != std::string_view::npos) {
-        LOG(ERROR) << "Your bpftrace program cannot load because you are using "
-                      "a license that is non-GPL compatible. License: "
-                   << config.license;
-        LOG(HINT)
-            << "Read more about BPF programs and licensing: "
-               "https://docs.kernel.org/bpf/"
-               "bpf_licensing.html#using-bpf-programs-in-the-linux-kernel";
-      }
-
       std::stringstream errmsg;
       errmsg << "Error loading BPF program for " << name << ".";
       if (bt_verbose) {

--- a/tests/codegen/license.cpp
+++ b/tests/codegen/license.cpp
@@ -1,11 +1,12 @@
 #include "common.h"
+#include "config.h"
 
 namespace bpftrace::test::codegen {
 
 TEST(codegen, license)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->config_->license = "Dual BSD/GPL";
+  bpftrace->config_->license = CompatibleBPFLicense::DUAL_BSD_GPL;
 
   test(*bpftrace, "kprobe:f { @x = 1; }", NAME);
 }

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -363,6 +363,11 @@ NAME valid license
 PROG config={license="Dual BSD/GPL"} begin { @p[1] = 1; print(len(@p));  }
 EXPECT 1
 
+NAME invalid license
+PROG config={license="Potato"} begin { @p[1] = 1; print(len(@p));  }
+EXPECT_REGEX .*ERROR: Invalid value for license. Found: Potato. Valid values: Dual MIT/GPL, Dual BSD/GPL, Dual MPL/GPL, GPL and additional rights, GPL v2, GPL.*
+WILL_FAIL
+
 NAME named command line params
 RUN {{BPFTRACE}} -e 'begin { print((getopt("aa", 10), getopt("cc", true), getopt("dd"), getopt("ee", "hello")));  }' -- --dd --aa=20 --cc=False
 EXPECT (20, false, true, hello)


### PR DESCRIPTION
Stacked PRs:
 * __->__#4677


--- --- ---

### Restrict licenses to those that are GPL compatible


This is because we can't add passed/custom set
licenses to our pre-compiled stdlib bpf.c files
which contain calls to kfuncs so we need to make
sure all scripts are always "GPL" compatible.
Signed-off-by: Jordan Rome <linux@jordanrome.com>