### PR TITLE
ast: drop `is_post_op` from `Binop`, use different operators

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -115,13 +115,13 @@ std::string opstr(const Unop &unop)
       return "-";
     case Operator::MUL:
       return "dereference";
-    case Operator::INCREMENT:
-      if (unop.is_post_op)
-        return "++ (post)";
+    case Operator::POST_INCREMENT:
+      return "++ (post)";
+    case Operator::PRE_INCREMENT:
       return "++ (pre)";
-    case Operator::DECREMENT:
-      if (unop.is_post_op)
-        return "-- (post)";
+    case Operator::POST_DECREMENT:
+      return "-- (post)";
+    case Operator::PRE_DECREMENT:
       return "-- (pre)";
     default:
       return {};
@@ -153,8 +153,10 @@ bool is_comparison_op(Operator op)
     case Operator::LEFT:
     case Operator::RIGHT:
     case Operator::ASSIGN:
-    case Operator::INCREMENT:
-    case Operator::DECREMENT:
+    case Operator::PRE_INCREMENT:
+    case Operator::PRE_DECREMENT:
+    case Operator::POST_INCREMENT:
+    case Operator::POST_DECREMENT:
     case Operator::LNOT:
     case Operator::BNOT:
       return false;

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -38,8 +38,10 @@ enum class Operator {
   LAND,
   LOR,
   PLUS,
-  INCREMENT,
-  DECREMENT,
+  PRE_INCREMENT,
+  PRE_DECREMENT,
+  POST_INCREMENT,
+  POST_DECREMENT,
   MINUS,
   MUL,
   DIV,
@@ -993,20 +995,12 @@ public:
 
 class Unop : public Node {
 public:
-  explicit Unop(ASTContext &ctx,
-                Expression expr,
-                Operator op,
-                bool is_post_op,
-                Location &&loc)
-      : Node(ctx, std::move(loc)),
-        expr(std::move(expr)),
-        op(op),
-        is_post_op(is_post_op) {};
+  explicit Unop(ASTContext &ctx, Expression expr, Operator op, Location &&loc)
+      : Node(ctx, std::move(loc)), expr(std::move(expr)), op(op) {};
   explicit Unop(ASTContext &ctx, const Unop &other, const Location &loc)
       : Node(ctx, loc + other.loc),
         expr(clone(ctx, other.expr, loc)),
-        op(other.op),
-        is_post_op(other.is_post_op) {};
+        op(other.op) {};
 
   const SizedType &type() const
   {
@@ -1015,14 +1009,12 @@ public:
 
   bool operator==(const Unop &other) const
   {
-    return op == other.op && is_post_op == other.is_post_op &&
-           expr == other.expr && result_type == other.result_type;
+    return op == other.op && expr == other.expr &&
+           result_type == other.result_type;
   }
   std::strong_ordering operator<=>(const Unop &other) const
   {
     if (auto cmp = op <=> other.op; cmp != 0)
-      return cmp;
-    if (auto cmp = is_post_op <=> other.is_post_op; cmp != 0)
       return cmp;
     if (auto cmp = expr <=> other.expr; cmp != 0)
       return cmp;
@@ -1031,7 +1023,6 @@ public:
 
   Expression expr;
   Operator op;
-  bool is_post_op;
   SizedType result_type;
 };
 

--- a/src/ast/passes/fold_literals.cpp
+++ b/src/ast/passes/fold_literals.cpp
@@ -145,8 +145,10 @@ static Expression make_boolean(ASTContext &ast, T left, T right, Binop &op)
     case Operator::LNOT:
     case Operator::BNOT:
     case Operator::ASSIGN:
-    case Operator::INCREMENT:
-    case Operator::DECREMENT:
+    case Operator::PRE_INCREMENT:
+    case Operator::PRE_DECREMENT:
+    case Operator::POST_INCREMENT:
+    case Operator::POST_DECREMENT:
       LOG(BUG) << "binary operator is not valid: " << static_cast<int>(op.op);
   }
 
@@ -346,8 +348,10 @@ static std::optional<std::variant<uint64_t, int64_t>> eval_binop(T left,
     case Operator::LAND:
     case Operator::LOR:
     case Operator::ASSIGN:
-    case Operator::INCREMENT:
-    case Operator::DECREMENT:
+    case Operator::PRE_INCREMENT:
+    case Operator::PRE_DECREMENT:
+    case Operator::POST_INCREMENT:
+    case Operator::POST_DECREMENT:
     case Operator::LNOT:
     case Operator::BNOT:
       break;

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2683,7 +2683,10 @@ void SemanticAnalyser::visit(Binop &binop)
 
 void SemanticAnalyser::visit(Unop &unop)
 {
-  if (unop.op == Operator::INCREMENT || unop.op == Operator::DECREMENT) {
+  if (unop.op == Operator::PRE_INCREMENT ||
+      unop.op == Operator::PRE_DECREMENT ||
+      unop.op == Operator::POST_INCREMENT ||
+      unop.op == Operator::POST_DECREMENT) {
     // Handle ++ and -- before visiting unop.expr, because these
     // operators should be able to work with undefined maps.
     if (auto *acc = unop.expr.as<MapAccess>()) {
@@ -2704,8 +2707,10 @@ void SemanticAnalyser::visit(Unop &unop)
 
   auto valid_ptr_op = false;
   switch (unop.op) {
-    case Operator::INCREMENT:
-    case Operator::DECREMENT:
+    case Operator::PRE_INCREMENT:
+    case Operator::PRE_DECREMENT:
+    case Operator::POST_INCREMENT:
+    case Operator::POST_DECREMENT:
     case Operator::MUL:
       valid_ptr_op = true;
       break;
@@ -3090,8 +3095,9 @@ void SemanticAnalyser::visit(FieldAccess &acc)
   // stores the underlying structs as pointers anyways. In the future, we will
   // likely want to do this in a different way if we are tracking l-values.
   while (acc.expr.type().IsPtrTy()) {
-    auto *unop = ctx_.make_node<Unop>(
-        acc.expr, Operator::MUL, false, Location(acc.expr.node().loc));
+    auto *unop = ctx_.make_node<Unop>(acc.expr,
+                                      Operator::MUL,
+                                      Location(acc.expr.node().loc));
     acc.expr.value = unop;
     visit(acc.expr);
   }

--- a/src/ast/passes/simplify_types.cpp
+++ b/src/ast/passes/simplify_types.cpp
@@ -112,8 +112,9 @@ std::optional<Expression> SimplifyTypes::visit(Binop &op)
 
   auto land_chain = create_land_chain(equal_exprs, op);
   if (op.op == Operator::NE) {
-    auto *not_binop = ast_.make_node<Unop>(
-        land_chain, Operator::LNOT, false, Location(op.loc));
+    auto *not_binop = ast_.make_node<Unop>(land_chain,
+                                           Operator::LNOT,
+                                           Location(op.loc));
     not_binop->result_type = CreateBool();
     return not_binop;
   } else {

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -632,24 +632,24 @@ primary_expr:
                 ;
 
 prefix_expr:
-                INCREMENT var        { $$ = driver.ctx.make_node<ast::Unop>($2, ast::Operator::INCREMENT, false, @1); }
-        |       DECREMENT var        { $$ = driver.ctx.make_node<ast::Unop>($2, ast::Operator::DECREMENT, false, @1); }
-        |       INCREMENT map        { $$ = driver.ctx.make_node<ast::Unop>($2, ast::Operator::INCREMENT, false, @1); }
-        |       DECREMENT map        { $$ = driver.ctx.make_node<ast::Unop>($2, ast::Operator::DECREMENT, false, @1); }
-        |       INCREMENT map_expr   { $$ = driver.ctx.make_node<ast::Unop>($2, ast::Operator::INCREMENT, false, @1); }
-        |       DECREMENT map_expr   { $$ = driver.ctx.make_node<ast::Unop>($2, ast::Operator::DECREMENT, false, @1); }
+                INCREMENT var        { $$ = driver.ctx.make_node<ast::Unop>($2, ast::Operator::PRE_INCREMENT, @1); }
+        |       DECREMENT var        { $$ = driver.ctx.make_node<ast::Unop>($2, ast::Operator::PRE_DECREMENT, @1); }
+        |       INCREMENT map        { $$ = driver.ctx.make_node<ast::Unop>($2, ast::Operator::PRE_INCREMENT, @1); }
+        |       DECREMENT map        { $$ = driver.ctx.make_node<ast::Unop>($2, ast::Operator::PRE_DECREMENT, @1); }
+        |       INCREMENT map_expr   { $$ = driver.ctx.make_node<ast::Unop>($2, ast::Operator::PRE_INCREMENT, @1); }
+        |       DECREMENT map_expr   { $$ = driver.ctx.make_node<ast::Unop>($2, ast::Operator::PRE_DECREMENT, @1); }
 /* errors */
         |       INCREMENT ident      { error(@1, "The ++ operator must be applied to a map or variable"); YYERROR; }
         |       DECREMENT ident      { error(@1, "The -- operator must be applied to a map or variable"); YYERROR; }
                 ;
 
 postfix_expr:
-                var INCREMENT        { $$ = driver.ctx.make_node<ast::Unop>($1, ast::Operator::INCREMENT, true, @2); }
-        |       var DECREMENT        { $$ = driver.ctx.make_node<ast::Unop>($1, ast::Operator::DECREMENT, true, @2); }
-        |       map      INCREMENT   { $$ = driver.ctx.make_node<ast::Unop>($1, ast::Operator::INCREMENT, true, @2); }
-        |       map      DECREMENT   { $$ = driver.ctx.make_node<ast::Unop>($1, ast::Operator::DECREMENT, true, @2); }
-        |       map_expr INCREMENT   { $$ = driver.ctx.make_node<ast::Unop>($1, ast::Operator::INCREMENT, true, @2); }
-        |       map_expr DECREMENT   { $$ = driver.ctx.make_node<ast::Unop>($1, ast::Operator::DECREMENT, true, @2); }
+                var INCREMENT        { $$ = driver.ctx.make_node<ast::Unop>($1, ast::Operator::POST_INCREMENT, @2); }
+        |       var DECREMENT        { $$ = driver.ctx.make_node<ast::Unop>($1, ast::Operator::POST_DECREMENT, @2); }
+        |       map      INCREMENT   { $$ = driver.ctx.make_node<ast::Unop>($1, ast::Operator::POST_INCREMENT, @2); }
+        |       map      DECREMENT   { $$ = driver.ctx.make_node<ast::Unop>($1, ast::Operator::POST_DECREMENT, @2); }
+        |       map_expr INCREMENT   { $$ = driver.ctx.make_node<ast::Unop>($1, ast::Operator::POST_INCREMENT, @2); }
+        |       map_expr DECREMENT   { $$ = driver.ctx.make_node<ast::Unop>($1, ast::Operator::POST_DECREMENT, @2); }
 /* errors */
         |       ident DECREMENT      { error(@1, "The -- operator must be applied to a map or variable"); YYERROR; }
         |       ident INCREMENT      { error(@1, "The ++ operator must be applied to a map or variable"); YYERROR; }
@@ -723,8 +723,8 @@ cast_expr:
                 ;
 
 unary_expr:
-                unary_op unary_expr    { $$ = driver.ctx.make_node<ast::Unop>($2, $1, false, @1); }
-        |       unary_op cast_expr     { $$ = driver.ctx.make_node<ast::Unop>($2, $1, false, @1); }
+                unary_op unary_expr    { $$ = driver.ctx.make_node<ast::Unop>($2, $1, @1); }
+        |       unary_op cast_expr     { $$ = driver.ctx.make_node<ast::Unop>($2, $1, @1); }
         |       primary_expr           { $$ = $1; }
         |       prefix_expr            { $$ = $1; }
         |       postfix_expr           { $$ = $1; }

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -215,12 +215,10 @@ std::vector<Unop *> variants<Unop>(ASTContext &c, SourceLocation l)
   Expression expr1 = c.make_node<Integer>(42UL, l);
   Expression expr2 = c.make_node<Integer>(24UL, l);
   Expression expr3 = c.make_node<Variable>(std::string("$x"), l);
-  Expression expr4 = c.make_node<Integer>(42UL, l);
 
-  return { c.make_node<Unop>(std::move(expr1), Operator::LNOT, false, l),
-           c.make_node<Unop>(std::move(expr2), Operator::BNOT, false, l),
-           c.make_node<Unop>(std::move(expr3), Operator::LNOT, false, l),
-           c.make_node<Unop>(std::move(expr4), Operator::LNOT, true, l) };
+  return { c.make_node<Unop>(std::move(expr1), Operator::LNOT, l),
+           c.make_node<Unop>(std::move(expr2), Operator::BNOT, l),
+           c.make_node<Unop>(std::move(expr3), Operator::LNOT, l) };
 }
 
 template <>

--- a/tests/collect_nodes.cpp
+++ b/tests/collect_nodes.cpp
@@ -34,8 +34,7 @@ TEST(CollectNodes, indirect)
 {
   ASTContext ctx;
   auto &var = *ctx.make_node<Variable>("myvar", Location());
-  auto &unop = *ctx.make_node<Unop>(
-      &var, Operator::INCREMENT, false, Location());
+  auto &unop = *ctx.make_node<Unop>(&var, Operator::PRE_INCREMENT, Location());
 
   CollectNodes<Variable> visitor;
   visitor.visit(unop);
@@ -47,8 +46,7 @@ TEST(CollectNodes, none)
 {
   ASTContext ctx;
   auto &map = *ctx.make_node<Map>("myvar", Location());
-  auto &unop = *ctx.make_node<Unop>(
-      &map, Operator::INCREMENT, false, Location());
+  auto &unop = *ctx.make_node<Unop>(&map, Operator::PRE_INCREMENT, Location());
 
   CollectNodes<Variable> visitor;
   visitor.visit(unop);
@@ -60,12 +58,14 @@ TEST(CollectNodes, multiple_runs)
 {
   ASTContext ctx;
   auto &var1 = *ctx.make_node<Variable>("myvar1", Location());
-  auto &unop1 = *ctx.make_node<Unop>(
-      &var1, Operator::INCREMENT, false, Location());
+  auto &unop1 = *ctx.make_node<Unop>(&var1,
+                                     Operator::PRE_INCREMENT,
+                                     Location());
 
   auto &var2 = *ctx.make_node<Variable>("myvar2", Location());
-  auto &unop2 = *ctx.make_node<Unop>(
-      &var2, Operator::INCREMENT, false, Location());
+  auto &unop2 = *ctx.make_node<Unop>(&var2,
+                                     Operator::PRE_INCREMENT,
+                                     Location());
 
   CollectNodes<Variable> visitor;
   visitor.visit(unop1);


### PR DESCRIPTION
Stacked PRs:
 * __->__#4680


--- --- ---

### ast: drop `is_post_op` from `Binop`, use different operators


Currently the `Binop` node has a boolean field `is_post_op`. This
doesn't apply to any operators except the `INCREMENT` and `DECREMENT`
operators. Despite this, it must be stored for all construction, and
compared in all comparisons. This means that two effectively identical
operators can technically be different with this irrelevant flag.

Instead, just introduce a `PRE_INCREMENT` and `POST_INCREMENT` operator
which must be explicitly handled by all paths. Do the same for
`DECREMENT`. This makes it easier to enforce correctness, and simplifies
the state that needs to be stored for the `Binop`.

Signed-off-by: Adin Scannell <amscanne@meta.com>
