### PR TITLE
Fix tuple comparison edge cases

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -771,23 +771,6 @@ The following relation operators are available for comparing strings, integer ar
 | == | left-hand string equal to right-hand |
 | != | left-hand string not equal to right-hand |
 
-**Note:** Tuple comparison works by comparing each element of both tuples
-with a logical && chain, e.g., the comparison of these two tuples
-```
-$x = ("hello", -6);
-$y = ("bye", -6);
-```
-turns this:
-```
-$x == $y
-```
-into this
-```
-($x.0 == $y.0 && $x.1 == $y.1)
-```
-So if comparing literal tuples that have nested expression with side effects
-they may not execute due to short-circuiting if previous elements are not equal.
-
 ### Assignment Operators
 
 The following assignment operators can be used on both `map` and `scratch` variables:

--- a/src/ast/passes/simplify_types.cpp
+++ b/src/ast/passes/simplify_types.cpp
@@ -20,6 +20,7 @@ public:
 private:
   Expression create_land_chain(std::vector<Expression> &equal_exprs, Binop &op);
   ASTContext &ast_;
+  int var_id_ = 0;
 };
 
 std::optional<Expression> SimplifyTypes::visit(Expression &expr)
@@ -91,11 +92,49 @@ std::optional<Expression> SimplifyTypes::visit(Binop &op)
   // and alignment issus.
   // https://github.com/bpftrace/bpftrace/pull/4523#discussion_r2382109017
   std::vector<Expression> equal_exprs;
+  StatementList block_stmts;
+
+  Expression left_tuple;
+  Expression right_tuple;
+
+  // Assign tuples that aren't variables or map accesses to a temp variable
+  // so that the entire tuple can be evaluated before comparison --
+  // consider the case of `$a = 1; ({ 1 + $a }, 3) == (2, 3)`; these should
+  // be equal
+  var_id_++;
+  if (op.left.is<Variable>() || op.left.is<MapAccess>()) {
+    left_tuple = clone(ast_, op.left, op.left.loc());
+  } else {
+    left_tuple = ast_.make_node<Variable>("$$binop_tuple_left_" +
+                                              std::to_string(var_id_),
+                                          Location(op.left.loc()));
+    auto *left_var_assign = ast_.make_node<AssignVarStatement>(
+        clone(ast_, left_tuple.as<Variable>(), left_tuple.loc()),
+        clone(ast_, op.left, op.left.loc()),
+        Location(op.loc));
+    block_stmts.emplace_back(left_var_assign);
+  }
+
+  if (op.right.is<Variable>() || op.right.is<MapAccess>()) {
+    right_tuple = clone(ast_, op.right, op.right.loc());
+  } else {
+    right_tuple = ast_.make_node<Variable>("$$binop_tuple_right_" +
+                                               std::to_string(var_id_),
+                                           Location(op.right.loc()));
+    auto *right_var_assign = ast_.make_node<AssignVarStatement>(
+        clone(ast_, right_tuple.as<Variable>(), right_tuple.loc()),
+        clone(ast_, op.right, op.right.loc()),
+        Location(op.loc));
+    block_stmts.emplace_back(right_var_assign);
+  }
+
   for (size_t i = 0; i < left_fields.size(); ++i) {
-    auto *left_tpa = ast_.make_node<TupleAccess>(op.left, i, Location(op.loc));
+    auto *left_tpa = ast_.make_node<TupleAccess>(left_tuple,
+                                                 i,
+                                                 Location(op.loc));
     left_tpa->element_type = left_fields[i].type;
 
-    auto *right_tpa = ast_.make_node<TupleAccess>(op.right,
+    auto *right_tpa = ast_.make_node<TupleAccess>(right_tuple,
                                                   i,
                                                   Location(op.loc));
     right_tpa->element_type = right_fields[i].type;
@@ -116,9 +155,13 @@ std::optional<Expression> SimplifyTypes::visit(Binop &op)
                                            Operator::LNOT,
                                            Location(op.loc));
     not_binop->result_type = CreateBool();
-    return not_binop;
+    return ast_.make_node<BlockExpr>(std::move(block_stmts),
+                                     not_binop,
+                                     Location(op.loc));
   } else {
-    return land_chain;
+    return ast_.make_node<BlockExpr>(std::move(block_stmts),
+                                     land_chain,
+                                     Location(op.loc));
   }
 }
 


### PR DESCRIPTION
Stacked PRs:
 * __->__#4687


--- --- ---

### Fix tuple comparison edge cases


Create variables for the left and right
tuples for binop comparison if they are
not already variables or map accesses.
This fixes an issue I overlooked in this PR:
- https://github.com/bpftrace/bpftrace/pull/4523

This also fixes the error where we might
not evaluate the nested expressions
due to short circuiting because every tuple
is evaluated when we save it to another variable.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>