### PR TITLE
strlen: Fix ERROR: Type mismatch for '==': comparing string with int64

### DIFF
--- a/src/stdlib/strings.bpf.c
+++ b/src/stdlib/strings.bpf.c
@@ -14,7 +14,14 @@ long __bpf_strnlen(const char *ptr, size_t max_size)
   if (bpf_strnlen) {
     return bpf_strnlen(ptr, max_size);
   }
-  return -ENOSYS; // Not available, must fall back.
+  long sz = 0;
+  for (size_t i = 0; i < max_size; ++i) {
+    if (ptr[i] == 0) {
+      break;
+    }
+    ++sz;
+  }
+  return sz;
 }
 
 extern int bpf_strnstr(const char *s1__ign,

--- a/src/stdlib/strings.bt
+++ b/src/stdlib/strings.bt
@@ -39,14 +39,17 @@ macro default_str_length() {
 // :variant int64 strlen(int8 *exp)
 macro strlen($var) {
   assert_str($var);
+  let $sz = (int64)0;
   if comptime is_str($var) {
-    __strnlen(&$var, sizeof($var))
+    $sz = __strnlen(&$var, sizeof($var));
   } else if comptime is_array($var) {
-    __strnlen($var, sizeof($var))
+    $sz = __strnlen($var, sizeof($var));
   } else {
-    __strnlen($var, default_str_length())
+    $sz = __strnlen($var, default_str_length());
   }
+  (uint64)$sz
 }
+
 macro strlen(exp) {
   assert_str(exp);
   if comptime (is_str(exp) || is_array(exp)) {
@@ -54,23 +57,12 @@ macro strlen(exp) {
     let $x = exp;
     strlen($x)
   } else {
-    __strnlen(exp, default_str_length())
+    (uint64)__strnlen(exp, default_str_length())
   }
 }
+
 macro __strnlen(ptr, max_size) {
-  $sz = __bpf_strnlen(ptr, (int64)max_size);
-  if ($sz >= 0) {
-    (uint64)$sz
-  } else {
-    $sz = 0;
-    for ($i : ((uint64)0)..((uint64)max_size)) {
-      if (ptr[$i] == 0) {
-        break;
-      }
-      $sz += 1;
-    }
-    (uint64)$sz
-  }
+  __bpf_strnlen(ptr, (int64)max_size)
 }
 
 // Returns the "capacity" of a string-like object.

--- a/tests/codegen/llvm/strcontains.ll
+++ b/tests/codegen/llvm/strcontains.ll
@@ -146,4 +146,4 @@ attributes #5 = { alwaysinline nounwind }
 !38 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
 !39 = !{!40}
 !40 = !DILocalVariable(name: "ctx", arg: 1, scope: !35, file: !2, type: !38)
-!41 = !DILocation(line: 109, column: 5, scope: !35)
+!41 = !DILocation(line: 101, column: 5, scope: !35)

--- a/tests/codegen/llvm/strcontains_no_literals.ll
+++ b/tests/codegen/llvm/strcontains_no_literals.ll
@@ -174,4 +174,4 @@ attributes #4 = { memory(none) }
 !51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
 !52 = !{!53}
 !53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)
-!54 = !DILocation(line: 109, column: 5, scope: !48)
+!54 = !DILocation(line: 101, column: 5, scope: !48)

--- a/tests/codegen/llvm/strcontains_one_literal.ll
+++ b/tests/codegen/llvm/strcontains_one_literal.ll
@@ -172,4 +172,4 @@ attributes #6 = { memory(none) }
 !51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
 !52 = !{!53}
 !53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)
-!54 = !DILocation(line: 109, column: 5, scope: !48)
+!54 = !DILocation(line: 101, column: 5, scope: !48)


### PR DESCRIPTION
The use of `string` and `char *` with ptr in `__strnlen()` is incompatible, so a separate `__bpftrace_strnlen` macro has been extracted.

Error:

    $ sudo bpftrace -e 'begin {@a = strlen("abc");}'
    stdlib/strings.bt:67:19-21: ERROR: Type mismatch for '==': comparing string with int64
          if (ptr[$i] == 0) {
                      ~~
    stdlib/strings.bt:67:14-18: ERROR: left (string)
          if (ptr[$i] == 0) {
                 ~~~~
    stdlib/strings.bt:67:22-23: ERROR: right (int64)
          if (ptr[$i] == 0) {
                         ~
    stdlib/strings.bt:43:5-35: ERROR: expanded from
        __strnlen(&$var, sizeof($var))
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    stdlib/strings.bt:55:5-15: ERROR: expanded from
        strlen($x)
        ~~~~~~~~~~
    ./strlen.bt:55:7-20: ERROR: expanded from
        @a = strlen("abc");
             ~~~~~~~~~~~~~
