### PR TITLE
Some small fixes in various parts of bpftrace. (#4698)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.2] TBD
+
+#### Fixed
+- Fix off-by-one for function argument size comparison
+  - [#4698](https://github.com/bpftrace/bpftrace/pull/4698)
+
 ## [0.24.1] 2025-10-03
 
 #### Fixed

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -301,7 +301,7 @@ void FieldAnalyser::resolve_args(Probe &probe)
           ap->addWarning() << "No debuginfo found for " << ap->target;
         }
         if (probe_args &&
-            probe_args->fields.size() >= arch::Host::arguments().size()) {
+            probe_args->fields.size() > arch::Host::arguments().size()) {
           ap->addError() << "\'args\' builtin is not supported for "
                          << "probes with stack-passed arguments.";
         }

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -503,9 +503,10 @@ std::shared_ptr<Struct> BTF::resolve_args(std::string_view func,
 
   const struct btf_param *p = btf_params(t);
   __u16 vlen = btf_vlen(t);
-  if (vlen >= arch::Host::arguments().size()) {
-    err = "functions with more than 6 parameters are "
-          "not supported.";
+  if (vlen > arch::Host::arguments().size()) {
+    err = "functions with more than " +
+          std::to_string(arch::Host::arguments().size()) +
+          " parameters are not supported.";
     return nullptr;
   }
 
@@ -582,7 +583,7 @@ std::string BTF::get_all_funcs_from_btf(const BTFObj &btf_obj) const
     if (bpftrace_ && !bpftrace_->is_traceable_func(func_name))
       continue;
 
-    if (btf_vlen(t) >= arch::Host::arguments().size())
+    if (btf_vlen(t) > arch::Host::arguments().size())
       continue;
 
     funcs += btf_obj.name + ":" + func_name + "\n";
@@ -623,7 +624,7 @@ std::string BTF::get_all_raw_tracepoints_from_btf(const BTFObj &btf_obj) const
       break;
     }
 
-    if (btf_vlen(t) >= arch::Host::arguments().size())
+    if (btf_vlen(t) > arch::Host::arguments().size())
       continue;
 
     bool found = false;

--- a/src/util/opaque.cpp
+++ b/src/util/opaque.cpp
@@ -1,6 +1,7 @@
 #include <cstring>
 #include <functional>
 #include <iomanip>
+#include <iostream>
 
 #include "util/opaque.h"
 

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -809,6 +809,9 @@ TEST(bpftrace, resolve_timestamp)
   static const auto bootmode = static_cast<uint32_t>(TimestampMode::boot);
   auto bpftrace = get_strict_mock_bpftrace();
 
+  if (std::chrono::system_clock::period::den < 1000000000)
+    GTEST_SKIP() << "Timestamp test requires nanosecond precision";
+
   // Basic sanity check
   bpftrace->boottime_ = { .tv_sec = 3, .tv_nsec = 0 };
   bpftrace->resources.strftime_args.emplace_back("%s.%f");


### PR DESCRIPTION
* Fix off-by-one for function argument size comparison

Commit 4e2f3c793458 ("arch: ensure all code is built all the time") removed the arch::max_arg function and replaced its usage with arch::Host::arguments().size().

max_arg defined the maximum argument number (so, 0-based), unlike arch::Host::arguments().size(), which is the size of the array.

The comparisons against this value were thus converted from > to >=. However, comparisons to max_arg() + 1 were also converted to >=, which is incorrect - they can stay the same, as max_arg + 1 is equal to arch::Host::arguments().size().

This lead to BTF functions with the maximum number of register-passed arguments to be incorrectly rejected for use in fentry probes.

Change these comparisons back. Also fix an adjacent warning to not hardcode '6' (the x86 value) for the maximum number.

Fixes: 4e2f3c793458 ("arch: ensure all code is built all the time")


* explicitly include iostream in opaque.cpp

Explicitly include iostream, or, depending on the environment, clang might throw an error like:

error: invalid operands to binary expression ('std::ostream' (aka 'basic_ostream<char>') and 'ios_base &(ios_base &)')



* tests: skip resolve_timestamp test if < ns precision

The resolve_timestamp test assumes that system_clock has nanosecond precision. Which is a reasonable assumption for most Linux environments. But there are some that do not offer system_clock with that precision. Just skip the test in that case.


(cherry picked from commit 3cad905be18ecfe09018941e63a25a34ea90a0a5)

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
