### PR TITLE
Add Alpine to distro builds

### DIFF
--- a/.github/workflows/distros.yml
+++ b/.github/workflows/distros.yml
@@ -17,6 +17,7 @@ jobs:
     strategy:
       matrix:
         dockerfile:
+        - docker/Dockerfile.alpine
         - docker/Dockerfile.debian
         - docker/Dockerfile.fedora
         - docker/Dockerfile.ubuntu

--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -1,0 +1,45 @@
+# This Dockerfile is used to both document and test building bpftrace on the
+# development version of Alpine. We attempt to catch bugs as early as possible
+# which is why we are using the edge repository.
+
+FROM alpine:edge
+
+ARG LLVM_VERSION=20
+
+RUN apk add --update \
+  asciidoctor \
+  bcc-dev \
+  binutils-dev \
+  bison \
+  blazesym \
+  build-base \
+  cereal \
+  clang$LLVM_VERSION-dev \
+  clang$LLVM_VERSION-extra-tools \
+  clang$LLVM_VERSION-static \
+  cmake \
+  elfutils-dev \
+  flex-dev \
+  libbpf-dev \
+  linux-headers \
+  llvm$LLVM_VERSION-dev \
+  llvm$LLVM_VERSION-gtest \
+  llvm$LLVM_VERSION-static \
+  samurai \
+  libxml2-dev
+
+RUN ln -s "clang${LLVM_VERSION}" /usr/lib/cmake/clang
+
+COPY . /src
+WORKDIR /src
+
+RUN cmake -B /build -G Ninja \
+  -DCMAKE_INSTALL_PREFIX=/usr \
+  -DCMAKE_BUILD_TYPE=MinSizeRel \
+  -DBUILD_TESTING=OFF \
+  -DCMAKE_PREFIX_PATH=/usr/lib/llvm${LLVM_VERSION}/lib/cmake \
+  -DLLVM_REQUESTED_VERSION="$(/usr/lib/llvm${LLVM_VERSION}/bin/llvm-config --version)" \
+  -DUSE_SYSTEM_LIBBPF=1
+RUN cmake --build /build -j$(nproc)
+
+ENTRYPOINT ["/build/src/bpftrace"]


### PR DESCRIPTION
We've discussed adding a distro build for Alpine a couple of times, so here's a PR for that. It's modeled on the [upstream build](https://gitlab.alpinelinux.org/alpine/aports/-/blob/master/community/bpftrace/APKBUILD) that's used for the Alpine package and should catch any serious breakage.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
