### PR TITLE
Set USE_SYSTEM_LIBBPF=On in distro builds

### DIFF
--- a/docker/Dockerfile.alpine
+++ b/docker/Dockerfile.alpine
@@ -33,6 +33,8 @@ RUN ln -s "clang${LLVM_VERSION}" /usr/lib/cmake/clang
 COPY . /src
 WORKDIR /src
 
+# We set USE_SYSTEM_LIBBPF=On to test that bpftrace can build with system libbpf
+# (i.e. not using libbpf from the submodule)
 RUN cmake -B /build -G Ninja \
   -DCMAKE_INSTALL_PREFIX=/usr \
   -DCMAKE_BUILD_TYPE=MinSizeRel \

--- a/docker/Dockerfile.debian
+++ b/docker/Dockerfile.debian
@@ -32,7 +32,9 @@ COPY . /src
 WORKDIR /src
 
 # Use CMAKE_BUILD_TYPE=Release if you don't plan on developing bpftrace
-RUN cmake -B /build -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Debug
+# We set USE_SYSTEM_LIBBPF=On to test that bpftrace can build with system libbpf
+# (i.e. not using libbpf from the submodule)
+RUN cmake -B /build -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Debug -DUSE_SYSTEM_LIBBPF=On
 RUN make -C /build -j$(nproc)
 
 ENTRYPOINT ["/build/src/bpftrace"]

--- a/docker/Dockerfile.fedora
+++ b/docker/Dockerfile.fedora
@@ -33,7 +33,9 @@ COPY . /src
 WORKDIR /src
 
 # Use CMAKE_BUILD_TYPE=Release if you don't plan on developing bpftrace
-RUN cmake -B /build -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Debug
+# We set USE_SYSTEM_LIBBPF=On to test that bpftrace can build with system libbpf
+# (i.e. not using libbpf from the submodule)
+RUN cmake -B /build -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Debug  -DUSE_SYSTEM_LIBBPF=On
 RUN make -C /build -j$(nproc)
 
 ENTRYPOINT ["/build/src/bpftrace"]

--- a/docker/Dockerfile.ubuntu
+++ b/docker/Dockerfile.ubuntu
@@ -32,7 +32,9 @@ COPY . /src
 WORKDIR /src
 
 # Use CMAKE_BUILD_TYPE=Release if you don't plan on developing bpftrace
-RUN cmake -B /build -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Debug
+# We set USE_SYSTEM_LIBBPF=On to test that bpftrace can build with system libbpf
+# (i.e. not using libbpf from the submodule)
+RUN cmake -B /build -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Debug -DUSE_SYSTEM_LIBBPF=On
 RUN make -C /build -j$(nproc)
 
 ENTRYPOINT ["/build/src/bpftrace"]


### PR DESCRIPTION
The value of distro builds is in checking that all the dependencies exist and that bpftrace can be built. That includes libbpf since most distros have a policy to link against system libraries instead of vendoring them. So, make sure system libbpf is used in out distro builds.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
