### PR TITLE
update for upstream LLVM argument removal to createSourceManager

### DIFF
--- a/src/ast/passes/clang_build.cpp
+++ b/src/ast/passes/clang_build.cpp
@@ -132,7 +132,11 @@ static Result<> build(CompileContext &ctx,
   ci.getInvocation() = *inv;
   ci.setDiagnostics(diags.release());
   ci.setFileManager(new clang::FileManager(clang::FileSystemOptions(), vfs));
+#if LLVM_VERSION_MAJOR >= 22
+  ci.createSourceManager();
+#else
   ci.createSourceManager(ci.getFileManager());
+#endif
 
   // Generate the object file, which should include the required BTF
   // debug information. This also generates the module as a


### PR DESCRIPTION
clang::CompilerInstance.createSourceManager lost its FileManager argument upstream, as it wasn't needed (llvm-project commit b86ddae1da65).

This change will appear in LLVM 22. Adjust the code to match.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

A small fix to compile/link with llvm-project HEAD (which will become LLVM 22).

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
