### PR TITLE
Add probetype builtin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ and this project adheres to
   - [#4673](https://github.com/bpftrace/bpftrace/pull/4673)
 - Allow `signal()` to target either the current process or the current thread via an optional second argument
   - [#4721](https://github.com/bpftrace/bpftrace/pull/4721)
+- Add `probetype` builtin
+  - [#4712](https://github.com/bpftrace/bpftrace/pull/4712)
 #### Changed
 - Apply `-B` buffering semantics to file outputs.
   - [#4637](https://github.com/bpftrace/bpftrace/pull/4637)

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -792,6 +792,16 @@ Name of the fully expanded probe
 For example: `kprobe:do_nanosleep`
 
 
+### probetype
+- `string probetype()`
+- `string probetype`
+
+Name of the probe type.
+Note: `begin` and `end` probes are of type `special`.
+
+For example: `kprobe`, `special`, `tracepoint`
+
+
 ### pton
 - `char addr[4] pton(const string *addr_v4)`
 - `char addr[16] pton(const string *addr_v6)`

--- a/src/ast/passes/builtins.cpp
+++ b/src/ast/passes/builtins.cpp
@@ -53,6 +53,13 @@ std::optional<Expression> Builtins::check(const std::string &ident, Node &node)
                                     Location(node.loc));
     }
   }
+  if (ident == "__builtin_probetype") {
+    if (auto *probe = dynamic_cast<Probe *>(top_level_node_)) {
+      return ast_.make_node<String>(
+          probetypeName(probetype(probe->attach_points.front()->provider)),
+          Location(node.loc));
+    }
+  }
   return std::nullopt;
 }
 

--- a/src/ast/passes/probe_expansion.cpp
+++ b/src/ast/passes/probe_expansion.cpp
@@ -88,6 +88,7 @@ public:
 
   using Visitor<ProbeExpansion>::visit;
   void visit(Builtin &builtin);
+  void visit(Identifier &identifier);
   void visit(Program &prog);
 
 private:
@@ -156,6 +157,22 @@ void ArgsResolver::visit(Probe &probe)
 {
   probe_ = &probe;
   visit(probe.block);
+}
+
+void ProbeExpansion::visit(Identifier &identifier)
+{
+  if (identifier.ident == "__builtin_probetype") {
+    ProbeType prev_probe_type = ProbeType::invalid;
+    for (auto *ap : probe_->attach_points) {
+      auto probe_type = probetype(ap->provider);
+      if (prev_probe_type == ProbeType::invalid) {
+        prev_probe_type = probe_type;
+      } else if (prev_probe_type != probe_type) {
+        needs_expansion_ = true;
+        break;
+      }
+    }
+  }
 }
 
 void ProbeExpansion::visit(Builtin &builtin)

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -833,6 +833,15 @@ macro probe() {
   __builtin_probe
 }
 
+// :variant string probetype()
+// Name of the probe type.
+// Note: `begin` and `end` probes are of type `special`.
+//
+// For example: `kprobe`, `special`, `tracepoint`
+macro probetype() {
+  __builtin_probetype
+}
+
 // :function pton
 // :variant char addr[4] pton(const string *addr_v4)
 // :variant char addr[16] pton(const string *addr_v6)

--- a/tests/probe_expansion.cpp
+++ b/tests/probe_expansion.cpp
@@ -193,6 +193,52 @@ Program
 )");
 }
 
+TEST_F(probe_expansion_btf, builtin_probetype)
+{
+  test("fentry:vmlinux:func_1, fentry:vmlinux:func_2 { __builtin_probetype }",
+       R"(
+Program
+ fentry:vmlinux:func_1
+ fentry:vmlinux:func_2
+  identifier: __builtin_probetype
+)");
+
+  test("fentry:vmlinux:func_* { __builtin_probetype }", R"(
+Program
+ fentry:vmlinux:func_1
+ fentry:vmlinux:func_2
+ fentry:vmlinux:func_3
+  identifier: __builtin_probetype
+)");
+
+  test("fentry:vmlinux:func_1, tracepoint:sched:sched_one { "
+       "__builtin_probetype }",
+       R"(
+Program
+ fentry:vmlinux:func_1
+  identifier: __builtin_probetype
+ tracepoint:sched:sched_one
+  identifier: __builtin_probetype
+)");
+
+  test("begin, end { __builtin_probetype }", R"(
+Program
+ begin
+ end
+  identifier: __builtin_probetype
+)");
+
+  test("begin, end, interval:1s { __builtin_probetype }", R"(
+Program
+ begin
+  identifier: __builtin_probetype
+ end
+  identifier: __builtin_probetype
+ interval:us:1000000
+  identifier: __builtin_probetype
+)");
+}
+
 #ifdef HAVE_LIBDW
 
 class probe_expansion_dwarf : public test_dwarf {};

--- a/tests/runtime/macro
+++ b/tests/runtime/macro
@@ -161,6 +161,10 @@ PROG k:do_nanosleep { if (__builtin_probe == probe() && __builtin_probe == probe
 EXPECT kprobe:do_nanosleep
 AFTER ./testprogs/syscall nanosleep 1e8
 
+NAME builtin wrapper probetype
+PROG begin { if (__builtin_probetype == probetype() && __builtin_probetype == probetype) { print(probetype); } exit(); }
+EXPECT special
+
 NAME builtin wrapper rand
 PROG begin { printf("SUCCESS1 %llu\n", __builtin_rand); printf("SUCCESS2 %llu\n", rand); printf("SUCCESS3 %llu\n", rand()); }
 EXPECT_REGEX SUCCESS1 [0-9]+


### PR DESCRIPTION
Stacked PRs:
 * __->__#4712


--- --- ---

### Add probetype builtin


This will be used in the standard library
so we can check if certain builtins/functions
can be used within the context of certain
probes, e.g., "signal".

Currently this logic lives in ast.cpp.
Signed-off-by: Jordan Rome <linux@jordanrome.com>