### PR TITLE
ClangParser: Include enums in incomplete types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ and this project adheres to
   - [#4523](https://github.com/bpftrace/bpftrace/pull/4523)
 - Fix off-by-one for function argument size comparison
   - [#4698](https://github.com/bpftrace/bpftrace/pull/4698)
+- Fix resolution of enum-typed tracepoint args
+  - [#4714](https://github.com/bpftrace/bpftrace/pull/4714)
 #### Security
 #### Docs
 #### Tools

--- a/src/ast/passes/clang_parser.cpp
+++ b/src/ast/passes/clang_parser.cpp
@@ -577,7 +577,8 @@ std::unordered_set<std::string> ClangParser::get_incomplete_types()
       // We need layouts of pointee types because users could dereference
       if (cursor_type.kind == CXType_Pointer)
         cursor_type = clang_getPointeeType(cursor_type);
-      if (cursor_type.kind == CXType_Record) {
+      if (cursor_type.kind == CXType_Record ||
+          cursor_type.kind == CXType_Enum) {
         auto type_name = get_unqualified_type_name(cursor_type);
         if (!type_data.complete_types.contains(type_name))
           type_data.incomplete_types.emplace(std::move(type_name));

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -712,6 +712,14 @@ TEST_F(clang_parser_btf, btf)
   EXPECT_EQ(foo2_field.offset, 8);
 }
 
+TEST_F(clang_parser_btf, struct_enum_fields)
+{
+  auto bpftrace = get_mock_bpftrace();
+  auto defs = parse("struct Foo { enum FooEnum e; }", *bpftrace);
+
+  ASSERT_TRUE(defs.enum_defs.contains("FooEnum"));
+}
+
 // Disabled because BTF flattens multi-dimensional arrays #3082.
 TEST_F(clang_parser_btf, DISABLED_btf_arrays_multi_dim)
 {

--- a/tests/data/data_source.c
+++ b/tests/data/data_source.c
@@ -31,6 +31,10 @@ struct Foo4 {
   unsigned int d : 20;
 };
 
+enum FooEnum {
+  VALUE
+};
+
 struct Foo3 *func_1(int a,
                     struct Foo1 *foo1,
                     struct Foo2 *foo2,
@@ -159,6 +163,7 @@ int main(void)
   struct bpf_iter__task_vma iter_task_vma;
   struct bpf_map bpf_map;
   struct sock sk;
+  enum FooEnum e;
 
   func_1(0, 0, 0, 0, 0);
 

--- a/tests/type_system.cpp
+++ b/tests/type_system.cpp
@@ -42,6 +42,7 @@ TEST(TypeSystemTest, basic)
     "restrict volatile const struct Foo2*",
     "struct Foo4",
     "unsigned int",
+    "enum FooEnum",
     "struct FirstFieldsAreAnonUnion",
     "struct Arrays",
     "int[4]",


### PR DESCRIPTION
When collecting incomplete types to be resolved from BTF, account also for enums. This is useful for resolving struct fields having enum types, especially tracepoint args which use this code path:

    # bpftrace -lv 'tracepoint:syscalls:sys_enter_landlock_add_rule'
    tracepoint:syscalls:sys_enter_landlock_add_rule
        int __syscall_nr
        const int ruleset_fd
        const enum landlock_rule_type rule_type     <-- enum typed arg
        const void *const rule_attr
        const __u32 flags

Previously, the following script would fail:

    # bpftrace -e 'tracepoint:syscalls:sys_enter_landlock_add_rule { print(args.rule_type) }'
    definitions.h:14:33: error: field has incomplete type 'const enum landlock_rule_type'
    definitions.h:14:14: note: forward declaration of 'enum landlock_rule_type'

With this change, the type of `args.rule_type` is successfully resolved.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
