### PR TITLE
Allow array-style access for tuples

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,8 @@ and this project adheres to
   - [#4721](https://github.com/bpftrace/bpftrace/pull/4721)
 - Add `probetype` builtin
   - [#4712](https://github.com/bpftrace/bpftrace/pull/4712)
+- Allow array-style access for tuples
+  - [#4715](https://github.com/bpftrace/bpftrace/pull/4715)
 #### Changed
 - Apply `-B` buffering semantics to file outputs.
   - [#4637](https://github.com/bpftrace/bpftrace/pull/4637)

--- a/docs/language.md
+++ b/docs/language.md
@@ -1672,25 +1672,20 @@ kprobe:dummy {
 bpftrace has support for immutable N-tuples.
 A tuple is a sequence type (like an array) where, unlike an array, every element can have a different type.
 
-Tuples are a comma separated list of expressions, enclosed in brackets, `(1,2)`.
-Individual fields can be accessed with the `.` operator.
-Tuples are zero indexed like arrays are.
+Tuples are a comma separated list of expressions, enclosed in brackets, `(1,"hello")`.
+Individual fields can be accessed with the `.` operator or via array-style access.
+The array index expression must evaluate to an integer literal at compile time (no variables but this is ok `(1, "hello")[1 - 1]`).
+Tuples are zero indexed like arrays. Examples:
 
 ```
 interval:s:1 {
-  $a = (1,2);
+  $a = (1,"hello");
   $b = (3,4, $a);
-  print($a);
-  print($b);
-  print($b.0);
+  print($a);     // (1, "hello")
+  print($b);     // (3, 4, (1, "hello"))
+  print($b.0);   // 3
+  print($a[1]);  // "hello"
 }
-
-/*
- * Sample output:
- * (1, 2)
- * (3, 4, (1, 2))
- * 3
- */
 ```
 
 Single-element and empty tuples can be specified using Python-like syntax.

--- a/src/ast/passes/fold_literals.cpp
+++ b/src/ast/passes/fold_literals.cpp
@@ -821,6 +821,15 @@ std::optional<Expression> LiteralFolder::visit(ArrayAccess &acc)
       return ast_.make_node<Integer>(static_cast<uint64_t>(s[index->value]),
                                      Location(acc.loc));
     }
+  } else if (acc.expr.type().IsTupleTy()) {
+    if (auto *index = acc.indexpr.as<Integer>()) {
+      return ast_.make_node<TupleAccess>(acc.expr,
+                                         static_cast<ssize_t>(index->value),
+                                         Location(acc.loc));
+    } else {
+      acc.addError()
+          << "Array-style access for tuples only valid for integer literals";
+    }
   } else if (comptime) {
     acc.addError() << "Unable to evaluate at compile time.";
   }

--- a/tests/runtime/tuples
+++ b/tests/runtime/tuples
@@ -88,6 +88,10 @@ PROG struct A { int x[4]; } u:./testprogs/array_access:test_struct { $t = ((int3
 EXPECT 20
 AFTER ./testprogs/array_access
 
+NAME array-style tuple access
+PROG begin{ $a = (1, 2, 3); print($a[1 + 1]); }
+EXPECT 3
+
 NAME nested tuple
 PROG begin{ @ = ((int8)1, ((int8)-20, (int8)30)); exit(); }
 EXPECT @: (1, (-20, 30))


### PR DESCRIPTION
Stacked PRs:
 * __->__#4715


--- --- ---

### Allow array-style access for tuples


Example:
```
$a = (1, 2);
$b = 0;
$a[0]; // ok
$a[$b] // not ok ($b is not a literal)
```

This is primarily so we can do folding on tuple
access.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>