### PR TITLE
Increase the RLIMIT_NOFILE if needed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,8 @@ and this project adheres to
   - [#4637](https://github.com/bpftrace/bpftrace/pull/4637)
 - Link against libbpf vendored from a submodule by default
   - [#4688](https://github.com/bpftrace/bpftrace/pull/4688)
+- Increase RLIMIT_NOFILE on startup as needed
+  - [#4716](https://github.com/bpftrace/bpftrace/pull/4716)
 #### Deprecated
 #### Removed
 - Drop support for LLVM 16

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -166,7 +166,7 @@ void usage(std::ostream& out)
   // clang-format on
 }
 
-static void enforce_infinite_rlimit()
+static void enforce_infinite_rlimit_memlock()
 {
   struct rlimit rl = {};
   int err;
@@ -856,7 +856,7 @@ int main(int argc, char* argv[])
 
     // FIXME (mmarchini): maybe we don't want to always enforce an infinite
     // rlimit?
-    enforce_infinite_rlimit();
+    enforce_infinite_rlimit_memlock();
   }
 
   // Temporarily, we make the full `BPFTrace` object available via the pass

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -209,6 +209,10 @@ public:
   std::vector<Probe> signal_probes;
   std::vector<Probe> watchpoint_probes;
 
+  size_t num_probes() {
+    return probes.size() + special_probes.size() + benchmark_probes.size() + signal_probes.size() + watchpoint_probes.size();
+  }
+
   // List of probes using userspace symbol resolution
   std::unordered_set<const ast::Probe *> probes_using_usym;
 


### PR DESCRIPTION
If the current RLIMIT_NOFILE is lower than
the amount of fds bpftrace will need then raise
this limit.

Issue:
- https://github.com/bpftrace/bpftrace/issues/2110


##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
