### PR TITLE
sanitize bpf_func_id casts

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -2289,7 +2289,7 @@ static bool return_zero_if_err(bpf_func_id func_id)
 void IRBuilderBPF::CreateRuntimeError(RuntimeErrorId rte_id,
                                       const Location &loc)
 {
-  CreateRuntimeError(rte_id, getInt64(0), static_cast<bpf_func_id>(-1), loc);
+  CreateRuntimeError(rte_id, getInt64(0), __BPF_FUNC_MAX_ID, loc);
 }
 
 void IRBuilderBPF::CreateRuntimeError(RuntimeErrorId rte_id,

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -105,11 +105,11 @@ public:
   }
 
   RuntimeErrorInfo(RuntimeErrorId error_id, const ast::Location &loc)
-      : RuntimeErrorInfo(error_id, static_cast<bpf_func_id>(-1), loc) {};
+      : RuntimeErrorInfo(error_id, __BPF_FUNC_MAX_ID, loc) {};
 
   RuntimeErrorInfo()
       : error_id(RuntimeErrorId::HELPER_ERROR),
-        func_id(static_cast<bpf_func_id>(-1)) {};
+        func_id(__BPF_FUNC_MAX_ID) {};
 
   RuntimeErrorId error_id;
   bpf_func_id func_id;


### PR DESCRIPTION
To initialize a runtime error, a bpf_func_id enum is set to -1 in a few places (if there is no helper function associated with it).

The clang sanitizer doesn't like a bpf_func_id set to -1, as it has picked an unsigned type for the enum.

Use another invalid value, __BPF_FUNC_MAX_ID, to appease the sanitizer.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
