### PR TITLE
Use Overload of lookupTarget Accepting Triple

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -74,8 +74,13 @@ static auto getTargetMachine()
 {
   static auto *target = []() {
     std::string error_str;
-    const auto *target = llvm::TargetRegistry::lookupTarget(LLVMTargetTriple,
-                                                            error_str);
+    const auto *target = llvm::TargetRegistry::lookupTarget(
+#if LLVM_VERSION_MAJOR >= 22
+        Triple(LLVMTargetTriple),
+#else
+        LLVMTargetTriple,
+#endif
+        error_str);
     if (!target) {
       throw util::FatalUserException(
           "Could not find bpf llvm target, does your llvm support it?");


### PR DESCRIPTION
The overload accepting a llvm::StringRef is deprecated and will be removed when LLVM 22 branches.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc` - N/A, no language changes
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md` - N/A - no non-trivial changes
- [ ] The new behaviour is covered by tests - N/A - This change is NFC
