### PR TITLE
Add support for `signal()` second argument choosing between `current_pid` and `current_tid`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ and this project adheres to
   - [#4540](https://github.com/bpftrace/bpftrace/pull/4540)
 - Automatic dereferencing is supported via `.`, now the preferred access operator
   - [#4673](https://github.com/bpftrace/bpftrace/pull/4673)
+- Allow `signal()` to target either the current process or the current thread via an optional second argument
+  - [#4721](https://github.com/bpftrace/bpftrace/pull/4721)
 #### Changed
 - Apply `-B` buffering semantics to file outputs.
   - [#4637](https://github.com/bpftrace/bpftrace/pull/4637)

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -837,22 +837,26 @@ For kretprobe and uretprobe, its type is uint64, but for fexit it depends. You c
 ### signal
 - `void signal(const string sig)`
 - `void signal(uint32 signum)`
+- `void signal(const string sig, [current_pid|current_tid])`
+- `void signal(uint32 signum, [current_pid|current_tid])`
 
 **unsafe**
 
-**Kernel** 5.3
+**Kernel** 5.3 (`current_pid`) / 5.6 (`current_tid`)
 
-This utilizes the BPF helper `bpf_send_signal`
+This utilizes either the BPF helper `bpf_send_signal` or the BPF helper `bpf_send_signal_thread`, depending on the second argument.
 
 Probe types: k(ret)probe, u(ret)probe, USDT, profile
 
-Send a signal to the process being traced.
+Send a signal to the process or thread being traced.
 The signal can either be identified by name, e.g. `SIGSTOP` or by ID, e.g. `19` as found in `kill -l`.
+Defaults to `current_pid` if the second argument is omitted.
+`current_pid` sends the signal to the process; `current_tid` sends it to the thread.
 
 ```
 kprobe:__x64_sys_execve
 /comm == "bash"/ {
-  signal(5);
+  signal(5); // same as `signal(5, current_pid)`
 }
 ```
 ```

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -178,7 +178,7 @@ public:
                          Value *fmt_size,
                          const std::vector<Value *> &values,
                          const Location &loc);
-  void CreateSignal(Value *sig, const Location &loc);
+  void CreateSignal(Value *sig, const Location &loc, bool target_thread);
   void CreateOverrideReturn(Value *ctx, Value *rc);
   void CreateRuntimeError(RuntimeErrorId rte_id, const Location &loc);
   void CreateRuntimeError(RuntimeErrorId rte_id,

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -874,22 +874,26 @@ macro retval() {
 // :function signal
 // :variant void signal(const string sig)
 // :variant void signal(uint32 signum)
+// :variant void signal(const string sig, [current_pid|current_tid])
+// :variant void signal(uint32 signum, [current_pid|current_tid])
 //
 // **unsafe**
 //
-// **Kernel** 5.3
+// **Kernel** 5.3 (`current_pid`) / 5.6 (`current_tid`)
 //
-// This utilizes the BPF helper `bpf_send_signal`
+// This utilizes either the BPF helper `bpf_send_signal` or the BPF helper `bpf_send_signal_thread`, depending on the second argument.
 //
 // Probe types: k(ret)probe, u(ret)probe, USDT, profile
 //
-// Send a signal to the process being traced.
+// Send a signal to the process or thread being traced.
 // The signal can either be identified by name, e.g. `SIGSTOP` or by ID, e.g. `19` as found in `kill -l`.
+// Defaults to `current_pid` if the second argument is omitted.
+// `current_pid` sends the signal to the process; `current_tid` sends it to the thread.
 //
 // ```
 // kprobe:__x64_sys_execve
 // /comm == "bash"/ {
-//   signal(5);
+//   signal(5); // same as `signal(5, current_pid)`
 // }
 // ```
 // ```

--- a/tests/codegen/call_signal_target.cpp
+++ b/tests/codegen/call_signal_target.cpp
@@ -1,0 +1,21 @@
+#include "common.h"
+
+namespace bpftrace::test::codegen {
+
+TEST(codegen, call_signal_target_default)
+{
+  test("k:f { signal(8); }", NAME, false);
+}
+
+TEST(codegen, call_signal_target_pid)
+{
+  // Defaults to `current_pid` if the second argument is omitted.
+  test("k:f { signal(8, current_pid); }", "call_signal_target_default", false);
+}
+
+TEST(codegen, call_signal_target_tid)
+{
+  test("k:f { signal(8, current_tid); }", NAME, false);
+}
+
+} // namespace bpftrace::test::codegen

--- a/tests/codegen/llvm/call_signal_target_default.ll
+++ b/tests/codegen/llvm/call_signal_target_default.ll
@@ -1,0 +1,68 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf"
+
+%"struct map_internal_repr_t" = type { ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
+@ringbuf = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !22
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !29
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+; Function Attrs: nounwind
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
+entry:
+  %signal = call i64 inttoptr (i64 109 to ptr)(i32 8)
+  ret i64 0
+}
+
+attributes #0 = { nounwind }
+
+!llvm.dbg.cu = !{!31}
+!llvm.module.flags = !{!33, !34}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 32, elements: !5)
+!4 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!5 = !{!6}
+!6 = !DISubrange(count: 4, lowerBound: 0)
+!7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
+!8 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !10)
+!10 = !{!11, !17}
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !15)
+!14 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!15 = !{!16}
+!16 = !DISubrange(count: 27, lowerBound: 0)
+!17 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !18, size: 64, offset: 64)
+!18 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !19, size: 64)
+!19 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !20)
+!20 = !{!21}
+!21 = !DISubrange(count: 262144, lowerBound: 0)
+!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
+!23 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!24 = !DICompositeType(tag: DW_TAG_array_type, baseType: !25, size: 64, elements: !27)
+!25 = !DICompositeType(tag: DW_TAG_array_type, baseType: !26, size: 64, elements: !27)
+!26 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!27 = !{!28}
+!28 = !DISubrange(count: 1, lowerBound: 0)
+!29 = !DIGlobalVariableExpression(var: !30, expr: !DIExpression())
+!30 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!31 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !32)
+!32 = !{!0, !7, !22, !29}
+!33 = !{i32 2, !"Debug Info Version", i32 3}
+!34 = !{i32 7, !"uwtable", i32 0}
+!35 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !36, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !31, retainedNodes: !39)
+!36 = !DISubroutineType(types: !37)
+!37 = !{!26, !38}
+!38 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!39 = !{!40}
+!40 = !DILocalVariable(name: "ctx", arg: 1, scope: !35, file: !2, type: !38)

--- a/tests/codegen/llvm/call_signal_target_tid.ll
+++ b/tests/codegen/llvm/call_signal_target_tid.ll
@@ -1,0 +1,68 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf"
+
+%"struct map_internal_repr_t" = type { ptr, ptr }
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
+@ringbuf = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !22
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !29
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+; Function Attrs: nounwind
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
+entry:
+  %signal_thread = call i64 inttoptr (i64 117 to ptr)(i32 8)
+  ret i64 0
+}
+
+attributes #0 = { nounwind }
+
+!llvm.dbg.cu = !{!31}
+!llvm.module.flags = !{!33, !34}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 32, elements: !5)
+!4 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!5 = !{!6}
+!6 = !DISubrange(count: 4, lowerBound: 0)
+!7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
+!8 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !10)
+!10 = !{!11, !17}
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !15)
+!14 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!15 = !{!16}
+!16 = !DISubrange(count: 27, lowerBound: 0)
+!17 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !18, size: 64, offset: 64)
+!18 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !19, size: 64)
+!19 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !20)
+!20 = !{!21}
+!21 = !DISubrange(count: 262144, lowerBound: 0)
+!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
+!23 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!24 = !DICompositeType(tag: DW_TAG_array_type, baseType: !25, size: 64, elements: !27)
+!25 = !DICompositeType(tag: DW_TAG_array_type, baseType: !26, size: 64, elements: !27)
+!26 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!27 = !{!28}
+!28 = !DISubrange(count: 1, lowerBound: 0)
+!29 = !DIGlobalVariableExpression(var: !30, expr: !DIExpression())
+!30 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!31 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !32)
+!32 = !{!0, !7, !22, !29}
+!33 = !{i32 2, !"Debug Info Version", i32 3}
+!34 = !{i32 7, !"uwtable", i32 0}
+!35 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !36, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !31, retainedNodes: !39)
+!36 = !DISubroutineType(types: !37)
+!37 = !{!26, !38}
+!38 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!39 = !{!40}
+!40 = !DILocalVariable(name: "ctx", arg: 1, scope: !35, file: !2, type: !38)

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -3298,6 +3298,22 @@ TEST_F(SemanticAnalyserTest, signal)
   bpftrace->add_param("hello");
   test("k:f { signal($1) }", UnsafeMode::Enable, Mock{ *bpftrace });
   test("k:f { signal($2) }", UnsafeMode::Enable, Mock{ *bpftrace }, Error{});
+
+  // signal target
+  test("k:f { signal(1, current_pid); }", UnsafeMode::Enable);
+  test("k:f { signal(1, current_tid); }", UnsafeMode::Enable);
+
+  // invalid signal target
+  test("k:f { signal(1, xxx); }", UnsafeMode::Enable, Error{ R"(
+stdin:1:17-20: ERROR: Invalid signal target: xxx (expects: current_pid or current_tid)
+k:f { signal(1, xxx); }
+                ~~~
+)" });
+  test("k:f { signal(1, 1); }", UnsafeMode::Enable, Error{ R"(
+stdin:1:7-19: ERROR: signal() only supports current_pid or current_tid as the second argument (int provided)
+k:f { signal(1, 1); }
+      ~~~~~~~~~~~~
+)" });
 }
 
 TEST_F(SemanticAnalyserTest, strncmp)


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

## Abstract

Resolves https://github.com/bpftrace/bpftrace/issues/3537

Defaults to `current_pid` if the second argument is omitted.
- `current_pid`: use the BPF helper `bpf_send_signal`
- `current_tid`: use the BPF helper `bpf_send_signal_thread`

## Tests
- **No regressions:** `tests/codegen/call_signal_literal.cpp` and `tests/codegen/call_signal_string_literal.cpp` show that, when the second argument is omitted, the generated llvm IR matches the previous one.
- **current_pid:** `tests/codegen/call_signal_target.cpp` shows that `current_pid` and the default (no second argument) produce identical llvm IR.
- **current_tid:** `tests/codegen/call_signal_target.cpp` and the diff below show that the llvm IR generated for `current_pid` and `current_tid` differs only in:
  - name: `%signal` → `%signal_thread`
  - BPF helper used: `109` → `117`
    - `117` corresponds to `bpf_send_signal_thread` (see https://github.com/bpftrace/bpftrace/blob/befac22deb829823bd07b91c0a1e43b3f2a45465/src/stdlib/include/linux/bpf.h#L5940).
```diff
$ diff tests/codegen/llvm/call_signal_target_default.ll tests/codegen/llvm/call_signal_target_tid.ll
19c19
<   %signal = call i64 inttoptr (i64 109 to ptr)(i32 8)
---
>   %signal_thread = call i64 inttoptr (i64 117 to ptr)(i32 8)
$ 
```

##### Checklist

- [x] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests