### PR TITLE
Fix block expression handling inside print statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to
   - [#4698](https://github.com/bpftrace/bpftrace/pull/4698)
 - Fix resolution of enum-typed tracepoint args
   - [#4714](https://github.com/bpftrace/bpftrace/pull/4714)
+- Fix block expression handling inside print statements
+  - [#4704](https://github.com/bpftrace/bpftrace/issues/4704)
 #### Security
 #### Docs
 #### Tools

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -264,7 +264,7 @@ private:
                               async_action::AsyncAction async_action);
 
   void createPrintMapCall(Call &call);
-  void createPrintNonMapCall(Call &call, int id);
+  void createPrintNonMapCall(Call &call);
   void createJoinCall(Call &call, int id);
 
   void createMapDefinition(const std::string &name,
@@ -1715,7 +1715,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     if (call.vargs.at(0).is<Map>()) {
       createPrintMapCall(call);
     } else {
-      createPrintNonMapCall(call, async_ids_.non_map_print());
+      createPrintNonMapCall(call);
     }
     return ScopedExpr();
   } else if (call.func == "cgroup_path") {
@@ -4116,7 +4116,7 @@ void CodegenLLVM::createJoinCall(Call &call, int id)
   b_.SetInsertPoint(failure_callback);
 }
 
-void CodegenLLVM::createPrintNonMapCall(Call &call, int id)
+void CodegenLLVM::createPrintNonMapCall(Call &call)
 {
   auto &arg = call.vargs.at(0);
   auto scoped_arg = visit(arg);
@@ -4143,7 +4143,7 @@ void CodegenLLVM::createPrintNonMapCall(Call &call, int id)
 
   // Store print id
   b_.CreateStore(
-      b_.getInt64(id),
+      b_.getInt64(async_ids_.non_map_print()),
       b_.CreateGEP(print_struct, buf, { b_.getInt64(0), b_.getInt32(1) }));
 
   // Store content

--- a/tests/codegen/call_print_non_map.cpp
+++ b/tests/codegen/call_print_non_map.cpp
@@ -15,4 +15,12 @@ TEST(codegen, call_print_composit)
 
        NAME);
 }
+
+TEST(codegen, call_print_inside_print)
+{
+  test("k:f { print({ $x = 1; print(\"bob\"); $x > 1 }); }",
+
+       NAME);
+}
+
 } // namespace bpftrace::test::codegen

--- a/tests/codegen/llvm/call_print_inside_print.ll
+++ b/tests/codegen/llvm/call_print_inside_print.ll
@@ -1,0 +1,142 @@
+; ModuleID = 'bpftrace'
+source_filename = "bpftrace"
+target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
+target triple = "bpf"
+
+%"struct map_internal_repr_t" = type { ptr, ptr }
+%print_bool_1_t = type <{ i64, i64, [1 x i8] }>
+%print_string_4_t = type <{ i64, i64, [4 x i8] }>
+
+@LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
+@ringbuf = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !22
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !29
+@bob = global [4 x i8] c"bob\00"
+
+; Function Attrs: nounwind
+declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
+
+; Function Attrs: nounwind
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
+entry:
+  %print_bool_1_t = alloca %print_bool_1_t, align 8
+  %print_string_4_t = alloca %print_string_4_t, align 8
+  %"$x" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
+  store i64 0, ptr %"$x", align 8
+  store i64 1, ptr %"$x", align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %print_string_4_t)
+  %1 = getelementptr %print_string_4_t, ptr %print_string_4_t, i64 0, i32 0
+  store i64 30007, ptr %1, align 8
+  %2 = getelementptr %print_string_4_t, ptr %print_string_4_t, i64 0, i32 1
+  store i64 0, ptr %2, align 8
+  %3 = getelementptr %print_string_4_t, ptr %print_string_4_t, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %3, i8 0, i64 4, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %3, ptr align 1 @bob, i64 4, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_string_4_t, i64 20, i64 0)
+  %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
+  br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
+
+event_loss_counter:                               ; preds = %entry
+  %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #4
+  %4 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %4
+  %5 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %6 = load i64, ptr %5, align 8
+  %7 = add i64 %6, 1
+  store i64 %7, ptr %5, align 8
+  br label %counter_merge
+
+counter_merge:                                    ; preds = %event_loss_counter, %entry
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %print_string_4_t)
+  %8 = load i64, ptr %"$x", align 8
+  %9 = icmp sgt i64 %8, 1
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %print_bool_1_t)
+  %10 = getelementptr %print_bool_1_t, ptr %print_bool_1_t, i64 0, i32 0
+  store i64 30007, ptr %10, align 8
+  %11 = getelementptr %print_bool_1_t, ptr %print_bool_1_t, i64 0, i32 1
+  store i64 1, ptr %11, align 8
+  %12 = getelementptr %print_bool_1_t, ptr %print_bool_1_t, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %12, i8 0, i64 1, i1 false)
+  store i1 %9, ptr %12, align 1
+  %ringbuf_output1 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_bool_1_t, i64 17, i64 0)
+  %ringbuf_loss4 = icmp slt i64 %ringbuf_output1, 0
+  br i1 %ringbuf_loss4, label %event_loss_counter2, label %counter_merge3
+
+event_loss_counter2:                              ; preds = %counter_merge
+  %get_cpu_id5 = call i64 inttoptr (i64 8 to ptr)() #4
+  %13 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded6 = and i64 %get_cpu_id5, %13
+  %14 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded6, i64 0
+  %15 = load i64, ptr %14, align 8
+  %16 = add i64 %15, 1
+  store i64 %16, ptr %14, align 8
+  br label %counter_merge3
+
+counter_merge3:                                   ; preds = %event_loss_counter2, %counter_merge
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %print_bool_1_t)
+  ret i64 0
+}
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: write)
+declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
+
+; Function Attrs: nocallback nofree nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noalias nocapture readonly %1, i64 %2, i1 immarg %3) #3
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
+
+attributes #0 = { nounwind }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
+attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
+attributes #4 = { memory(none) }
+
+!llvm.dbg.cu = !{!31}
+!llvm.module.flags = !{!33, !34}
+
+!0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
+!1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
+!2 = !DIFile(filename: "bpftrace.bpf.o", directory: ".")
+!3 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 32, elements: !5)
+!4 = !DIBasicType(name: "int8", size: 8, encoding: DW_ATE_signed)
+!5 = !{!6}
+!6 = !DISubrange(count: 4, lowerBound: 0)
+!7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
+!8 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !10)
+!10 = !{!11, !17}
+!11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
+!12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
+!13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !15)
+!14 = !DIBasicType(name: "int", size: 32, encoding: DW_ATE_signed)
+!15 = !{!16}
+!16 = !DISubrange(count: 27, lowerBound: 0)
+!17 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !18, size: 64, offset: 64)
+!18 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !19, size: 64)
+!19 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !20)
+!20 = !{!21}
+!21 = !DISubrange(count: 262144, lowerBound: 0)
+!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
+!23 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!24 = !DICompositeType(tag: DW_TAG_array_type, baseType: !25, size: 64, elements: !27)
+!25 = !DICompositeType(tag: DW_TAG_array_type, baseType: !26, size: 64, elements: !27)
+!26 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!27 = !{!28}
+!28 = !DISubrange(count: 1, lowerBound: 0)
+!29 = !DIGlobalVariableExpression(var: !30, expr: !DIExpression())
+!30 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!31 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !32)
+!32 = !{!0, !7, !22, !29}
+!33 = !{i32 2, !"Debug Info Version", i32 3}
+!34 = !{i32 7, !"uwtable", i32 0}
+!35 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !36, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !31, retainedNodes: !39)
+!36 = !DISubroutineType(types: !37)
+!37 = !{!26, !38}
+!38 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!39 = !{!40}
+!40 = !DILocalVariable(name: "ctx", arg: 1, scope: !35, file: !2, type: !38)

--- a/tests/resource_analyser.cpp
+++ b/tests/resource_analyser.cpp
@@ -8,6 +8,7 @@
 namespace bpftrace::test::resource_analyser {
 
 using ::testing::_;
+using ::testing::ElementsAre;
 
 void test(BPFtrace &bpftrace,
           const std::string &input,
@@ -115,6 +116,16 @@ TEST(resource_analyser, fmt_string_args_non_map_print_arr)
 
   // See clang_parser.cpp; the increase signal well-formedness.
   EXPECT_EQ(resources.max_fmtstring_args_size, 40U + 1U);
+}
+
+TEST(resource_analyser, print_non_map_print_correct_args_order)
+{
+  RequiredResources resources;
+  test(R"(begin { print({ $x = 1; print("bob"); $x > 1}) })", true, &resources);
+
+  EXPECT_THAT(resources.non_map_print_args,
+              ElementsAre(SizedType(Type::string, 4),
+                          SizedType(Type::boolean, 1)));
 }
 
 } // namespace bpftrace::test::resource_analyser

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -366,3 +366,8 @@ TIMEOUT 1
 NAME block expression
 PROG begin { let $a = { let $b = 1; $b }; print($a);  }
 EXPECT 1
+
+NAME print block expression with print
+PROG begin { print({ $x = 1; print ("bob"); $x > 1 }); }
+EXPECT bob
+EXPECT false


### PR DESCRIPTION
After adding simple block expressions they were not fully handled inside print statements. The fundamental problem is that the async id assignment for print is basically parent to child, whereas inside resource analyser we collect sized types from children to parent. This was causing problems in some cases, especially if we have two print statements and they print different types.

With this change we correctly handle nested print statements even with different types.

```
~ sudo ./src/bpftrace -e 'begin { print({ $x = 1; print("bob"); $x > 1 });  }'

Attached 1 probe
bob
false
```

There is a similar (albeit independent) issue with `join`. I'll create a separate issue/pull request for it if we are good with the direction of the fix here.

##### Changes
- Implement all the necessary changes
- Cover codegen with a unit test
- Cover resource analyser with a unit test. Not necessary strictly speaking, but nice to do explicitly establish the behaviour.
 
##### Checklist

- [x] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
