### PR TITLE
tools: use has_key() to test map entry presence

### DIFF
--- a/tools/biosnoop.bt
+++ b/tools/biosnoop.bt
@@ -54,9 +54,9 @@ tracepoint:block:block_io_start
 }
 
 tracepoint:block:block_io_done
-/@start[args.dev, args.sector] != 0 &&
- @iopid[args.dev, args.sector] != 0 &&
- @iocomm[args.dev, args.sector] != ""/
+/has_key(@start, (args.dev, args.sector)) &&
+ has_key(@iopid, (args.dev, args.sector)) &&
+ has_key(@iocomm, (args.dev, args.sector))/
 
 {
 	$key = (args.dev, args.sector);

--- a/tools/ssllatency.bt
+++ b/tools/ssllatency.bt
@@ -126,7 +126,7 @@ uprobe:libssl:SSL_do_handshake
 uretprobe:libssl:SSL_read,
 uretprobe:libssl:SSL_write,
 uretprobe:libssl:SSL_do_handshake
-/@start_ssl[tid] != 0/
+/has_key(@start_ssl, tid)/
 {
 	$lat_us = (nsecs - @start_ssl[tid]) / 1000;
 	if ((int8)retval >= 1) {
@@ -163,7 +163,7 @@ uretprobe:libcrypto:RSA_verify,
 uretprobe:libcrypto:ossl_ecdsa_sign,
 uretprobe:libcrypto:ossl_ecdsa_verify,
 uretprobe:libcrypto:ecdh_simple_compute_key
-/@start_crypto[tid] != 0/
+/has_key(@start_crypto, tid)/
 {
 	$lat_us = (nsecs - @start_crypto[tid]) / 1000;
 	@hist[@func_crypto[tid]] = lhist($lat_us, 0, 1000, 200);

--- a/tools/sslsnoop.bt
+++ b/tools/sslsnoop.bt
@@ -71,7 +71,7 @@ uprobe:libssl:SSL_do_handshake
 uretprobe:libssl:SSL_read,
 uretprobe:libssl:SSL_write,
 uretprobe:libssl:SSL_do_handshake
-/@start_ssl[tid] != 0/
+/has_key(@start_ssl, tid)/
 {
 	printf("%-10u %-8d %-8s %7u %5d %s\n", elapsed/1000, tid, comm,
 	       (nsecs - @start_ssl[tid])/1000, retval, @func_ssl[tid]);
@@ -102,7 +102,7 @@ uretprobe:libcrypto:RSA_verify,
 uretprobe:libcrypto:ossl_ecdsa_sign,
 uretprobe:libcrypto:ossl_ecdsa_verify,
 uretprobe:libcrypto:ossl_ecdh_compute_key
-/@start_crypto[tid] != 0/
+/has_key(@start_crypto, tid)/
 {
 	printf("%-10u %-8d %-8s %7u %5d %s\n", elapsed/1000, tid, comm,
 	       (nsecs - @start_crypto[tid])/1000, retval, @func_crypto[tid]);


### PR DESCRIPTION
Some scripts used '@map[key] != 0' or '@map[key] != ""' to infer that an
entry exists. Switch to 'has_key(@map, key)' to explicitly test key
presence and make the intent clear.

No functional change intended.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
