### PR TITLE
Add support for signed BTF integer types in compat

### DIFF
--- a/src/btf/btf.h
+++ b/src/btf/btf.h
@@ -297,6 +297,9 @@ public:
   bool is_bool() const {
     return btf_int_encoding(btf_type()) & BTF_INT_BOOL;
   }
+  bool is_signed() const {
+    return btf_int_encoding(btf_type()) & BTF_INT_SIGNED;
+  }
 
 private:
   static Result<Integer> add(HandleRef handle,

--- a/src/btf/compat.cpp
+++ b/src/btf/compat.cpp
@@ -20,7 +20,7 @@ Result<SizedType> getCompatType(const Integer &type)
   if (type.is_bool()) {
     return CreateBool();
   }
-  return CreateInt(8 * type.bytes());
+  return CreateInteger(8 * type.bytes(), type.is_signed());
 }
 
 Result<SizedType> getCompatType(const Pointer &type)

--- a/src/stdlib/strings.bt
+++ b/src/stdlib/strings.bt
@@ -98,7 +98,7 @@ macro strstr($haystack, $needle) {
     // Special case: the needle is empty.
     0
   } else {
-    __bpf_strnstr(&$haystack, &$needle, (int64)$haystack_size, (int64)$needle_size)
+    __bpf_strnstr(&$haystack, &$needle, (uint64)$haystack_size, (uint64)$needle_size)
   }
 }
 macro strstr($haystack, needle) {


### PR DESCRIPTION
Stacked PRs:
 * #4729
 * __->__#4731


--- --- ---

### Add support for signed BTF integer types in compat


Seems like this was used in `get_stype` but missing
in the compat.cpp

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>