### PR TITLE
Revert moving has_key to the stdlib

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1314,6 +1314,16 @@ ScopedExpr CodegenLLVM::visit(Call &call)
       Value *expr = b_.CreateICmpEQ(ret, b_.getInt64(0), "delete_ret");
       return ScopedExpr(expr);
     }
+  } else if (call.func == "has_key") {
+    auto &arg = call.vargs.at(0);
+    auto &map = *arg.as<Map>();
+    auto scoped_key = getMapKey(map, call.vargs.at(1));
+
+    CallInst *lookup = b_.CreateMapLookup(map, scoped_key.value());
+    Value *expr = b_.CreateICmpNE(b_.CreateIntCast(lookup, b_.getPtrTy(), true),
+                                  b_.GetNull(),
+                                  "has_key");
+    return ScopedExpr(expr);
   } else if (call.func == "str") {
     const auto max_strlen = bpftrace_.config_->max_strlen;
     // Largest read we'll allow = our global string buffer size

--- a/src/ast/passes/map_sugar.cpp
+++ b/src/ast/passes/map_sugar.cpp
@@ -90,7 +90,7 @@ private:
 // specific function being called, and potentially respecting annotations on
 // these arguments.
 static std::unordered_set<std::string> RAW_MAP_ARG = {
-  "print", "clear", "zero", "len", "delete", "is_scalar",
+  "print", "clear", "zero", "len", "delete", "is_scalar", "has_key"
 };
 
 void MapDefaultKey::visit(Map &map)
@@ -222,6 +222,8 @@ void MapDefaultKey::visit(Call &call)
           call.addError() << "delete() requires 1 or 2 arguments ("
                           << call.vargs.size() << " provided)";
         }
+      } else if (call.func == "has_key") {
+        checkCall(*map, true);
       } else if (call.func == "len") {
         checkCall(*map, true);
       } else if (call.func == "is_scalar") {

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -367,7 +367,8 @@ void ResourceAnalyser::visit(Call &call)
   // a slightly different type due to type promotion in an earlier pass.
   // This requires us to allocate a new map key (or create a scratch buffer)
   // and copy individual elements of the tuple instead of the whole thing.
-  if (getAssignRewriteFuncs().contains(call.func) || call.func == "delete") {
+  if (getAssignRewriteFuncs().contains(call.func) || call.func == "delete" ||
+      call.func == "has_key") {
     if (call.func == "lhist" || call.func == "hist" || call.func == "tseries") {
       auto &map = *call.vargs.at(0).as<Map>();
       // Allocation is always needed for lhist/hist/tseries but we need to

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -379,6 +379,15 @@ static const std::map<std::string, call_spec> CALL_SPEC = {
       .max_args=1,
       .arg_types={
         arg_type_spec{ .type=Type::integer } } } },
+  { "has_key",
+    { .min_args=2,
+      .max_args=2,
+      .discard_ret_warn = true,
+      .arg_types={
+        map_type_spec{},
+        map_key_spec{ .map_index=0 },
+      }
+    } },
   { "hist",
     { .min_args=3,
       .max_args=4,
@@ -1314,6 +1323,8 @@ void SemanticAnalyser::visit(Call &call)
     call.return_type = CreateStats(true);
   } else if (call.func == "delete") {
     call.return_type = CreateUInt8();
+  } else if (call.func == "has_key") {
+    call.return_type = CreateBool();
   } else if (call.func == "str") {
     auto &arg = call.vargs.at(0);
     const auto &t = arg.type();

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -299,6 +299,7 @@ macro gid() {
   __builtin_gid
 }
 
+// :function has_key
 // :variant boolean has_key(map m, mapkey k)
 //
 // Return `true` if the key exists in this map.
@@ -318,19 +319,6 @@ macro gid() {
 //     }
 // }
 // ```
-macro has_key(@map, key) {
-  $key = key;
-  if comptime is_scalar(@map) {
-    fail("call to has_key() expects a map with explicit keys (non-scalar map)");
-    false
-  } else {
-    if comptime (typeinfo($key) != typeinfo(@map)) {
-      fail("Mismatch for has_key(): key param has type '%s' when map key type is '%s'",
-        typeinfo($key).2, typeinfo(@map).2);
-    }
-    __has_key((void *)&@map, (void *)&$key)
-  }
-}
 
 // :variant uint64 jiffies()
 // Jiffies of the kernel

--- a/src/stdlib/map.bpf.c
+++ b/src/stdlib/map.bpf.c
@@ -7,13 +7,6 @@
 struct bpf_map;
 extern __s64 bpf_map_sum_elem_count(const struct bpf_map *map) __ksym __weak;
 
-_Bool __has_key(void * map, void * key) {
-    if (bpf_map_lookup_elem(map, key) == NULL) {
-        return 0;
-    }
-    return 1;
-}
-
 static long __empty_map_elem_cb(void *map, const void *key, void *value, void *ctx)
 {
     return 0;

--- a/tests/codegen/llvm/call_has_key.ll
+++ b/tests/codegen/llvm/call_has_key.ll
@@ -18,9 +18,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
 entry:
-  %"$$has_key_$key" = alloca i64, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$$has_key_$key")
-  store i64 0, ptr %"$$has_key_$key", align 8
+  %"@x_key1" = alloca i64, align 8
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
@@ -30,8 +28,11 @@ entry:
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
-  store i64 1, ptr %"$$has_key_$key", align 8
-  %__has_key = call i1 @__has_key(ptr @AT_x, ptr %"$$has_key_$key"), !dbg !56
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
+  store i64 1, ptr %"@x_key1", align 8
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key1")
+  %has_key = icmp ne ptr %lookup_elem, null
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
   ret i64 0
 }
 
@@ -41,12 +42,8 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
-; Function Attrs: alwaysinline nounwind
-declare dso_local i1 @__has_key(ptr noundef %0, ptr noundef %1) #2
-
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
-attributes #2 = { alwaysinline nounwind }
 
 !llvm.dbg.cu = !{!46}
 !llvm.module.flags = !{!48, !49}
@@ -107,4 +104,3 @@ attributes #2 = { alwaysinline nounwind }
 !53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
 !54 = !{!55}
 !55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)
-!56 = !DILocation(line: 331, column: 5, scope: !50)

--- a/tests/codegen/llvm/call_map_key_scratch_buf.ll
+++ b/tests/codegen/llvm/call_map_key_scratch_buf.ll
@@ -12,47 +12,41 @@ target triple = "bpf"
 @AT_y = dso_local global %"struct map_internal_repr_t.0" zeroinitializer, section ".maps", !dbg !26
 @ringbuf = dso_local global %"struct map_internal_repr_t.1" zeroinitializer, section ".maps", !dbg !35
 @__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !49
-@__bt__var_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.var_buf", !dbg !51
-@__bt__write_map_val_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.write_map_val_buf", !dbg !60
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !62
-@__bt__map_key_buf = dso_local externally_initialized global [1 x [3 x [16 x i8]]] zeroinitializer, section ".data.map_key_buf", !dbg !66
-@__bt__num_cpus = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !72
+@__bt__write_map_val_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.write_map_val_buf", !dbg !51
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !60
+@__bt__map_key_buf = dso_local externally_initialized global [1 x [4 x [16 x i8]]] zeroinitializer, section ".data.map_key_buf", !dbg !64
+@__bt__num_cpus = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !68
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !78 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !74 {
 entry:
-  %get_cpu_id11 = call i64 inttoptr (i64 8 to ptr)() #3
-  %1 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded12 = and i64 %get_cpu_id11, %1
-  %2 = getelementptr [1 x [1 x [8 x i8]]], ptr @__bt__var_buf, i64 0, i64 %cpu.id.bounded12, i64 0, i64 0
-  store i64 0, ptr %2, align 8
   %initial_value9 = alloca i64, align 8
   %lookup_elem_val7 = alloca i64, align 8
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
-  %3 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %3
-  %4 = getelementptr [1 x [3 x [16 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  store i64 1, ptr %4, align 8
-  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %4)
+  %1 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %1
+  %2 = getelementptr [1 x [4 x [16 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  store i64 1, ptr %2, align 8
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %5 = load i64, ptr %lookup_elem, align 8
-  %6 = add i64 %5, 1
-  store i64 %6, ptr %lookup_elem, align 8
+  %3 = load i64, ptr %lookup_elem, align 8
+  %4 = add i64 %3, 1
+  store i64 %4, ptr %lookup_elem, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value)
   store i64 1, ptr %initial_value, align 8
-  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %4, ptr %initial_value, i64 0)
+  %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %2, ptr %initial_value, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value)
   br label %lookup_merge
 
@@ -60,40 +54,45 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
   %log2 = call i64 @log2(i64 10, i64 0)
   %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)() #3
-  %7 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded2 = and i64 %get_cpu_id1, %7
-  %8 = getelementptr [1 x [3 x [16 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded2, i64 1, i64 0
-  %9 = getelementptr [16 x i8], ptr %8, i64 0, i64 0
-  store i64 0, ptr %9, align 8
-  %10 = getelementptr [16 x i8], ptr %8, i64 0, i64 8
-  store i64 %log2, ptr %10, align 8
-  %lookup_elem3 = call ptr inttoptr (i64 1 to ptr)(ptr @AT_y, ptr %8)
+  %5 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded2 = and i64 %get_cpu_id1, %5
+  %6 = getelementptr [1 x [4 x [16 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded2, i64 1, i64 0
+  %7 = getelementptr [16 x i8], ptr %6, i64 0, i64 0
+  store i64 0, ptr %7, align 8
+  %8 = getelementptr [16 x i8], ptr %6, i64 0, i64 8
+  store i64 %log2, ptr %8, align 8
+  %lookup_elem3 = call ptr inttoptr (i64 1 to ptr)(ptr @AT_y, ptr %6)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val7)
   %map_lookup_cond8 = icmp ne ptr %lookup_elem3, null
   br i1 %map_lookup_cond8, label %lookup_success4, label %lookup_failure5
 
 lookup_success4:                                  ; preds = %lookup_merge
-  %11 = load i64, ptr %lookup_elem3, align 8
-  %12 = add i64 %11, 1
-  store i64 %12, ptr %lookup_elem3, align 8
+  %9 = load i64, ptr %lookup_elem3, align 8
+  %10 = add i64 %9, 1
+  store i64 %10, ptr %lookup_elem3, align 8
   br label %lookup_merge6
 
 lookup_failure5:                                  ; preds = %lookup_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %initial_value9)
   store i64 1, ptr %initial_value9, align 8
-  %update_elem10 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %8, ptr %initial_value9, i64 0)
+  %update_elem10 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %6, ptr %initial_value9, i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %initial_value9)
   br label %lookup_merge6
 
 lookup_merge6:                                    ; preds = %lookup_failure5, %lookup_success4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val7)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %8)
-  store i64 1, ptr %2, align 8
-  %__has_key = call i1 @__has_key(ptr @AT_x, ptr %2), !dbg !84
-  %get_cpu_id13 = call i64 inttoptr (i64 8 to ptr)() #3
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %6)
+  %get_cpu_id11 = call i64 inttoptr (i64 8 to ptr)() #3
+  %11 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded12 = and i64 %get_cpu_id11, %11
+  %12 = getelementptr [1 x [4 x [16 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded12, i64 2, i64 0
+  store i64 1, ptr %12, align 8
+  %lookup_elem13 = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %12)
+  %has_key = icmp ne ptr %lookup_elem13, null
+  %get_cpu_id14 = call i64 inttoptr (i64 8 to ptr)() #3
   %13 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded14 = and i64 %get_cpu_id13, %13
-  %14 = getelementptr [1 x [3 x [16 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded14, i64 2, i64 0
+  %cpu.id.bounded15 = and i64 %get_cpu_id14, %13
+  %14 = getelementptr [1 x [4 x [16 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded15, i64 3, i64 0
   store i64 1, ptr %14, align 8
   %delete_elem = call i64 inttoptr (i64 3 to ptr)(ptr @AT_x, ptr %14)
   %delete_ret = icmp eq i64 %delete_elem, 0
@@ -175,16 +174,13 @@ hist.is_not_zero:                                 ; preds = %hist.is_not_less_th
   ret i64 %48
 }
 
-; Function Attrs: alwaysinline nounwind
-declare dso_local i1 @__has_key(ptr noundef %0, ptr noundef %1) #2
-
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { alwaysinline nounwind }
 attributes #3 = { memory(none) }
 
-!llvm.dbg.cu = !{!74}
-!llvm.module.flags = !{!76, !77}
+!llvm.dbg.cu = !{!70}
+!llvm.module.flags = !{!72, !73}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -238,7 +234,7 @@ attributes #3 = { memory(none) }
 !49 = !DIGlobalVariableExpression(var: !50, expr: !DIExpression())
 !50 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
 !51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
-!52 = distinct !DIGlobalVariable(name: "__bt__var_buf", linkageName: "global", scope: !2, file: !2, type: !53, isLocal: false, isDefinition: true)
+!52 = distinct !DIGlobalVariable(name: "__bt__write_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !53, isLocal: false, isDefinition: true)
 !53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !54, size: 64, elements: !58)
 !54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !55, size: 64, elements: !58)
 !55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 64, elements: !56)
@@ -247,27 +243,22 @@ attributes #3 = { memory(none) }
 !58 = !{!59}
 !59 = !DISubrange(count: 1, lowerBound: 0)
 !60 = !DIGlobalVariableExpression(var: !61, expr: !DIExpression())
-!61 = distinct !DIGlobalVariable(name: "__bt__write_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !53, isLocal: false, isDefinition: true)
-!62 = !DIGlobalVariableExpression(var: !63, expr: !DIExpression())
-!63 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !64, isLocal: false, isDefinition: true)
-!64 = !DICompositeType(tag: DW_TAG_array_type, baseType: !65, size: 64, elements: !58)
-!65 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !58)
-!66 = !DIGlobalVariableExpression(var: !67, expr: !DIExpression())
-!67 = distinct !DIGlobalVariable(name: "__bt__map_key_buf", linkageName: "global", scope: !2, file: !2, type: !68, isLocal: false, isDefinition: true)
-!68 = !DICompositeType(tag: DW_TAG_array_type, baseType: !69, size: 384, elements: !58)
-!69 = !DICompositeType(tag: DW_TAG_array_type, baseType: !32, size: 384, elements: !70)
-!70 = !{!71}
-!71 = !DISubrange(count: 3, lowerBound: 0)
-!72 = !DIGlobalVariableExpression(var: !73, expr: !DIExpression())
-!73 = distinct !DIGlobalVariable(name: "__bt__num_cpus", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!74 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !75)
-!75 = !{!0, !7, !26, !35, !49, !51, !60, !62, !66, !72}
-!76 = !{i32 2, !"Debug Info Version", i32 3}
-!77 = !{i32 7, !"uwtable", i32 0}
-!78 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !79, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !74, retainedNodes: !82)
-!79 = !DISubroutineType(types: !80)
-!80 = !{!24, !81}
-!81 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!82 = !{!83}
-!83 = !DILocalVariable(name: "ctx", arg: 1, scope: !78, file: !2, type: !81)
-!84 = !DILocation(line: 331, column: 5, scope: !78)
+!61 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !62, isLocal: false, isDefinition: true)
+!62 = !DICompositeType(tag: DW_TAG_array_type, baseType: !63, size: 64, elements: !58)
+!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !58)
+!64 = !DIGlobalVariableExpression(var: !65, expr: !DIExpression())
+!65 = distinct !DIGlobalVariable(name: "__bt__map_key_buf", linkageName: "global", scope: !2, file: !2, type: !66, isLocal: false, isDefinition: true)
+!66 = !DICompositeType(tag: DW_TAG_array_type, baseType: !67, size: 512, elements: !58)
+!67 = !DICompositeType(tag: DW_TAG_array_type, baseType: !32, size: 512, elements: !5)
+!68 = !DIGlobalVariableExpression(var: !69, expr: !DIExpression())
+!69 = distinct !DIGlobalVariable(name: "__bt__num_cpus", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!70 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !71)
+!71 = !{!0, !7, !26, !35, !49, !51, !60, !64, !68}
+!72 = !{i32 2, !"Debug Info Version", i32 3}
+!73 = !{i32 7, !"uwtable", i32 0}
+!74 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !75, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !70, retainedNodes: !78)
+!75 = !DISubroutineType(types: !76)
+!76 = !{!24, !77}
+!77 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!78 = !{!79}
+!79 = !DILocalVariable(name: "ctx", arg: 1, scope: !74, file: !2, type: !77)

--- a/tests/codegen/llvm/call_map_key_stack.ll
+++ b/tests/codegen/llvm/call_map_key_stack.ll
@@ -21,10 +21,8 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !63 {
 entry:
+  %"@x_key11" = alloca i64, align 8
   %"@x_key9" = alloca i64, align 8
-  %"$$has_key_$key" = alloca i64, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$$has_key_$key")
-  store i64 0, ptr %"$$has_key_$key", align 8
   %initial_value7 = alloca i64, align 8
   %lookup_elem_val5 = alloca i64, align 8
   %"@y_key" = alloca [16 x i8], align 1
@@ -81,13 +79,16 @@ lookup_failure3:                                  ; preds = %lookup_merge
 lookup_merge4:                                    ; preds = %lookup_failure3, %lookup_success2
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val5)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
-  store i64 1, ptr %"$$has_key_$key", align 8
-  %__has_key = call i1 @__has_key(ptr @AT_x, ptr %"$$has_key_$key"), !dbg !69
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key9")
   store i64 1, ptr %"@x_key9", align 8
-  %delete_elem = call i64 inttoptr (i64 3 to ptr)(ptr @AT_x, ptr %"@x_key9")
-  %delete_ret = icmp eq i64 %delete_elem, 0
+  %lookup_elem10 = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key9")
+  %has_key = icmp ne ptr %lookup_elem10, null
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key9")
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key11")
+  store i64 1, ptr %"@x_key11", align 8
+  %delete_elem = call i64 inttoptr (i64 3 to ptr)(ptr @AT_x, ptr %"@x_key11")
+  %delete_ret = icmp eq i64 %delete_elem, 0
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key11")
   ret i64 0
 }
 
@@ -166,9 +167,6 @@ hist.is_not_zero:                                 ; preds = %hist.is_not_less_th
   ret i64 %48
 }
 
-; Function Attrs: alwaysinline nounwind
-declare dso_local i1 @__has_key(ptr noundef %0, ptr noundef %1) #2
-
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { alwaysinline nounwind }
@@ -245,4 +243,3 @@ attributes #2 = { alwaysinline nounwind }
 !66 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
 !67 = !{!68}
 !68 = !DILocalVariable(name: "ctx", arg: 1, scope: !63, file: !2, type: !66)
-!69 = !DILocation(line: 331, column: 5, scope: !63)

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -355,7 +355,7 @@ WILL_FAIL
 
 NAME has_key error type mismatch
 PROG begin { @g[1, "hi"] = 2; if (has_key(@g, (1, 2))) { printf("ok\n"); }  }
-EXPECT_REGEX .* ERROR: Mismatch for has_key\(\): key param has type '\(int64,int64\)' when map key type is '\(int64,string\)'.*
+EXPECT_REGEX .* ERROR: Argument mismatch for @g: trying to access with arguments: '\(int64,int64\)' when map expects arguments: '\(int64,string\)'.*
 WILL_FAIL
 
 NAME exit code

--- a/tests/runtime/scripts/has_key.bt
+++ b/tests/runtime/scripts/has_key.bt
@@ -31,7 +31,7 @@ begin {
         ++$count;
     }
 
-    if (!has_key(@c, (1, ("bye", 5)))) {
+    if (!has_key(@c, (1, ("bye", (int8)5)))) {
         ++$count;
     }
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -268,6 +268,7 @@ TEST_F(SemanticAnalyserTest, builtin_functions)
   test("kprobe:f { @x = 1; print(@x) }");
   test("kprobe:f { @x = 1; clear(@x) }");
   test("kprobe:f { @x = 1; zero(@x) }");
+  test("kprobe:f { @x[1] = 1; if (has_key(@x, 1)) {} }");
   test("kprobe:f { @x = 1; @y[1] = 1; $a = is_scalar(@x); $b = is_scalar(@y); "
        "}");
   test("kprobe:f { time() }");
@@ -1204,6 +1205,77 @@ TEST_F(SemanticAnalyserTest, call_zero)
   test("kprobe:f { @x = count(); @[zero(@x)] = 1; }", Error{});
   test("kprobe:f { @x = count(); if(zero(@x)) { 123 } }", Error{});
   test("kprobe:f { @x = count(); zero(@x) ? 0 : 1; }", Error{});
+}
+
+TEST_F(SemanticAnalyserTest, call_has_key)
+{
+  test("kprobe:f { @x[1] = 0; if "
+       "(has_key(@x, 1)) {} }");
+  test("kprobe:f { @x[1, 2] = 0; if "
+       "(has_key(@x, (3, 4))) {} }");
+  test("kprobe:f { @x[1, (int8)2] = 0; if "
+       "(has_key(@x, (3, 4))) {} }");
+  test(R"(kprobe:f { @x[1, "hi"] = 0; if (has_key(@x, (2, "bye"))) {} })");
+  test(
+      R"(kprobe:f { @x[1, "hi"] = 0; if (has_key(@x, (2, "longerstr"))) {} })");
+  test(
+      R"(kprobe:f { @x[1, "longerstr"] = 0; if (has_key(@x, (2, "hi"))) {} })");
+  test("kprobe:f { @x[1, 2] = 0; $a = (3, "
+       "4); if (has_key(@x, $a)) {} }");
+  test("kprobe:f { @x[1, 2] = 0; @a = (3, "
+       "4); if (has_key(@x, @a)) {} }");
+  test("kprobe:f { @x[1, 2] = 0; @a[1] = "
+       "(3, 4); if (has_key(@x, @a[1])) {} "
+       "}");
+  test("kprobe:f { @x[1] = 0; @a = "
+       "has_key(@x, 1); }");
+  test("kprobe:f { @x[1] = 0; $a = "
+       "has_key(@x, 1); }");
+  test("kprobe:f { @x[1] = 0; "
+       "@a[has_key(@x, 1)] = 1; }");
+
+  test("kprobe:f { @x[1] = 1;  if (has_key(@x)) {} }", Error{ R"(
+stdin:1:28-39: ERROR: has_key() requires 2 arguments (1 provided)
+kprobe:f { @x[1] = 1;  if (has_key(@x)) {} }
+                           ~~~~~~~~~~~
+)" });
+
+  test("kprobe:f { @x[1] = 1;  if (has_key(@x[1], 1)) {} }", Error{ R"(
+stdin:1:36-41: ERROR: has_key() expects a map argument
+kprobe:f { @x[1] = 1;  if (has_key(@x[1], 1)) {} }
+                                   ~~~~~
+)" });
+
+  test("kprobe:f { @x = 1;  if (has_key(@x, 1)) {} }", Error{ R"(
+stdin:1:33-35: ERROR: call to has_key() expects a map with explicit keys (non-scalar map)
+kprobe:f { @x = 1;  if (has_key(@x, 1)) {} }
+                                ~~
+)" });
+
+  test("kprobe:f { @x[1, 2] = 1;  if (has_key(@x, 1)) {} }", Error{ R"(
+stdin:1:43-44: ERROR: Argument mismatch for @x: trying to access with arguments: 'int64' when map expects arguments: '(int64,int64)'
+kprobe:f { @x[1, 2] = 1;  if (has_key(@x, 1)) {} }
+                                          ~
+)" });
+
+  test(R"(kprobe:f { @x[1, "hi"] = 0; if (has_key(@x, (2, 1))) {} })",
+       Error{ R"(
+stdin:1:45-51: ERROR: Argument mismatch for @x: trying to access with arguments: '(int64,int64)' when map expects arguments: '(int64,string)'
+kprobe:f { @x[1, "hi"] = 0; if (has_key(@x, (2, 1))) {} }
+                                            ~~~~~~
+)" });
+
+  test("kprobe:f { @x[1] = 1; $a = 1; if (has_key($a, 1)) {} }", Error{ R"(
+stdin:1:43-45: ERROR: has_key() expects a map argument
+kprobe:f { @x[1] = 1; $a = 1; if (has_key($a, 1)) {} }
+                                          ~~
+)" });
+
+  test("kprobe:f { @a[1] = 1; has_key(@a, @a); }", Error{ R"(
+stdin:1:35-37: ERROR: @a used as a map without an explicit key (scalar map), previously used with an explicit key (non-scalar map)
+kprobe:f { @a[1] = 1; has_key(@a, @a); }
+                                  ~~
+)" });
 }
 
 TEST_F(SemanticAnalyserTest, call_time)
@@ -4629,6 +4701,7 @@ TEST_F(SemanticAnalyserTest, castable_map_missing_feature)
   test("k:f {  @a = count(); clear(@a) }", NoFeatures::Enable);
   test("k:f {  @a = count(); zero(@a) }", NoFeatures::Enable);
   test("k:f {  @a[1] = count(); delete(@a, 1) }", NoFeatures::Enable);
+  test("k:f { @a[1] = count(); has_key(@a, 1) }", NoFeatures::Enable);
 
   test("begin { @a = count(); print((uint64)@a) }",
        NoFeatures::Enable,
@@ -5216,6 +5289,9 @@ TEST_F(SemanticAnalyserTest, warning_for_discared_return_value)
                 "should be used" });
   test("k:f { ustack(raw); }",
        Warning{ "Return value discarded for ustack. "
+                "It should be used" });
+  test("k:f { @x[1] = 0; has_key(@x, 1); }",
+       Warning{ "Return value discarded for has_key. "
                 "It should be used" });
 }
 


### PR DESCRIPTION
This partially reverts the changes in this
commit: 1ebe31a402ff1e3574d4fe1f7929037610b1b8f5

The reason is that I didn't account for the
automatic size promotion that happens with map
keys. So if you try and use `has_key` with a type
that doesn't exactly match you get a compile time
error. Additionally, even if we added a builtin
to check if these two types were compatible we
would still need to modify the passed in expression if it required additional padding (in the case
of tuples).

Modified the runtime tests to check for this
(it, as expected, fails on master).

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
