### PR TITLE
 Fix passing custom blazesym lib/includes to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -224,6 +224,7 @@ endif()
 
 if(LIBBLAZESYM_FOUND)
   set(BPFTRACE_FLAGS "${BPFTRACE_FLAGS}" HAVE_BLAZESYM)
+  include_directories(SYSTEM ${LIBBLAZESYM_INCLUDE_DIRS})
 endif()
 
 add_subdirectory(src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -64,7 +64,6 @@ add_executable(bpftrace
 
 # TODO: Honor `STATIC_LINKING` properly.
 if(LIBBLAZESYM_FOUND)
-  target_include_directories(runtime PRIVATE ${LIBBLAZESYM_INCLUDE_DIRS})
   target_link_libraries(runtime ${LIBBLAZESYM_LIBRARIES})
 endif()
 


### PR DESCRIPTION
Right now, passing custom blazesym library/includes to cmake doesn't work because
we include blazesym directories only once for `runtime` target, but
in practice there are 4-5 places to include blazesym directories.

The main problem is that files `ksyms.h` and `usyms.h` are included in
`blazesym.h` header and we must ensure that all files that include it
will include blazesym directories as well.

This diff makes includes blazesym directories system-wide instead of only
during building of `runtime` target.