### PR TITLE
Add guards around referencing BPF_TRACE_KPROBE_SESSION

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -613,9 +613,12 @@ Result<std::unique_ptr<AttachedMultiKprobeProbe>> AttachedMultiKprobeProbe::
       LOG(V1) << " " << syms[i];
     }
   }
-
+#ifdef BPF_TRACE_KPROBE_SESSION
   auto attach_type = probe.is_session ? BPF_TRACE_KPROBE_SESSION
                                       : BPF_TRACE_KPROBE_MULTI;
+#else
+  auto attach_type = BPF_TRACE_KPROBE_MULTI;
+#endif
 
   int link_fd = bpf_link_create(prog.fd(), 0, attach_type, &opts);
   if (link_fd < 0) {

--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -397,6 +397,7 @@ bool BPFfeature::has_kprobe_session()
     return *has_kprobe_session_;
   }
 
+#ifdef BPF_TRACE_KPROBE_SESSION
   const char* sym = "ksys_read";
 
   DECLARE_LIBBPF_OPTS(bpf_link_create_opts, link_opts);
@@ -409,6 +410,9 @@ bool BPFfeature::has_kprobe_session()
                                         link_opts,
                                         std::nullopt);
   return *has_kprobe_session_;
+#else
+  return false;
+#endif
 }
 
 bool BPFfeature::has_uprobe_multi()

--- a/src/bpfprogram.cpp
+++ b/src/bpfprogram.cpp
@@ -44,9 +44,15 @@ void BpfProgram::set_expected_attach_type(const Probe &probe,
   // currently support the `module:function` syntax.
   if ((probe.type == ProbeType::kprobe || probe.type == ProbeType::kretprobe) &&
       !probe.funcs.empty() && probe.path.empty()) {
-    if (probe.is_session && feature.has_kprobe_session())
+    if (probe.is_session && feature.has_kprobe_session()) {
+#ifdef BPF_TRACE_KPROBE_SESSION
       attach_type = BPF_TRACE_KPROBE_SESSION;
-    else if (feature.has_kprobe_multi())
+#else
+      if (feature.has_kprobe_multi()) {
+        attach_type = BPF_TRACE_KPROBE_MULTI;
+      }
+#endif
+    } else if (feature.has_kprobe_multi())
       attach_type = BPF_TRACE_KPROBE_MULTI;
   }
 


### PR DESCRIPTION
We got a report that a user was unable to build on an older kernel (that didn't have BPF_TRACE_KPROBE_SESSION) so add ifdefs to guard against this.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
