### PR TITLE
CI: Temporarily disable runqlen.bt in tools tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,33 +46,33 @@ jobs:
         - NAME: LLVM 17
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm17
-          TOOLS_TEST_OLDVERSION: runqlen.bt
+          TOOLS_TEST_DISABLE: runqlen.bt
         - NAME: LLVM 18
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm18
-          TOOLS_TEST_OLDVERSION: runqlen.bt
+          TOOLS_TEST_DISABLE: runqlen.bt
         - NAME: LLVM 19
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm19
-          TOOLS_TEST_OLDVERSION: runqlen.bt
+          TOOLS_TEST_DISABLE: runqlen.bt
         - NAME: LLVM 20
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm20
-          TOOLS_TEST_OLDVERSION: runqlen.bt
+          TOOLS_TEST_DISABLE: runqlen.bt
         - NAME: LLVM 21 Release
           CMAKE_BUILD_TYPE: Release
           NIX_TARGET: .#bpftrace-llvm21
-          TOOLS_TEST_OLDVERSION: runqlen.bt
+          TOOLS_TEST_DISABLE: runqlen.bt
         - NAME: LLVM 21 Debug
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm21
-          TOOLS_TEST_OLDVERSION: runqlen.bt
+          TOOLS_TEST_DISABLE: runqlen.bt
         - NAME: LLVM 21 Clang Debug
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm21
           CC: clang
           CXX: clang++
-          TOOLS_TEST_OLDVERSION: runqlen.bt
+          TOOLS_TEST_DISABLE: runqlen.bt
         - NAME: Fuzzing
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-fuzz
@@ -82,7 +82,7 @@ jobs:
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm21
           NIX_TARGET_KERNEL: .#kernel-6_14
-          TOOLS_TEST_OLDVERSION: runqlen.bt # Need host 6.14 kernel
+          TOOLS_TEST_DISABLE: runqlen.bt # Need host 6.14 kernel
         - NAME: AOT (LLVM 21 Debug)
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-llvm21


### PR DESCRIPTION
GitHub is in the middle of updating their runners to kernel 6.14 which is the version when runqlen.bt needs to be switched to the new version. Since only some of the runners have been updated, let's disable the test whatsoever until the update is fully finished.

Resolves #4736.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
