### PR TITLE
Fix macros not visiting var decl typeof

### DIFF
--- a/src/ast/passes/macro_expansion.cpp
+++ b/src/ast/passes/macro_expansion.cpp
@@ -194,6 +194,7 @@ void MacroExpander::visit(VarDeclStatement &decl)
   }
   renamed_vars_.insert(var->ident);
 
+  visit(decl.typeof);
   visit(decl.var);
 }
 

--- a/tests/runtime/macro
+++ b/tests/runtime/macro
@@ -15,7 +15,7 @@ PROG macro set(@x) { @x = 2; } begin { @a = 1; set(@a);  }
 EXPECT @a: 2
 
 NAME it renames internal variables
-PROG macro add(x) { let $y; if (true) { $y = 1 } x + $y  } begin { print(add(1));  }
+PROG macro add(x) { let $y: typeof(x); if (true) { $y = 1 } x + $y  } begin { print(add(1));  }
 EXPECT 2
 
 NAME it reads the passed map


### PR DESCRIPTION
Stacked PRs:
 * #4751
 * __->__#4750


--- --- ---

### Fix macros not visiting var decl typeof


Updated a runtime test that surfaces the issue.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>