### PR TITLE
test: add test probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to
   - [#4677](https://github.com/bpftrace/bpftrace/pull/4677)
 - Remove the deprecated `sarg` builtin
   - [#4686](https://github.com/bpftrace/bpftrace/pull/4686)
+- Benchmark formats changed slightly, to reflect gbenchmark
+  - [#4753](https://github.com/bpftrace/bpftrace/pull/4753)
 #### Added
 - Add `pcomm` to stdlib and `ppid` can be called without arguments.
   - [#4744](https://github.com/bpftrace/bpftrace/pull/4744)
@@ -28,6 +30,8 @@ and this project adheres to
   - [#4712](https://github.com/bpftrace/bpftrace/pull/4712)
 - Allow array-style access for tuples
   - [#4715](https://github.com/bpftrace/bpftrace/pull/4715)
+- Add `test` probes as means to improve runtime test latency
+  - [#4753](https://github.com/bpftrace/bpftrace/pull/4753)
 #### Changed
 - `uaddr` support PIE and dynamic library symbols.
   - [#4727](https://github.com/bpftrace/bpftrace/pull/4727)

--- a/docs/language.md
+++ b/docs/language.md
@@ -922,15 +922,30 @@ end {
 }
 ```
 
+### test
+
+`test` is a special built-in probe type for creating tests.
+bpftrace executes each `test` probe and checks the return value, error count and possible exit calls to determine a pass.
+If multiple `test` probes exist in a script, bpftrace executes them sequentially in the order they are specified.
+To run `test` probes, you must run bpftrace in test mode: `bpftrace --test ...`; otherwise `test` probes will be ignored.
+
+```
+test:okay {
+  print("I'm okay! This output will be suppressed.");
+}
+
+test:failure {
+  print("This is a failure! This output will be shown");
+  return 1;
+}
+```
+
 ### bench
 
 `bench` is a special built-in probe type for creating micro benchmarks.
-bpftrace executes each `bench` probe repeatedly to measure the average
-execution time of the contained code. If multiple `bench` probes exist
-in a script, bpftrace executes them sequentially in the order they are
-specified. To run `bench` probes, you must run bpftrace in bench mode:
-`bpftrace --test-mode bench ...`; otherwise, `bench` probes will be
-ignored.
+bpftrace executes each `bench` probe repeatedly to measure the average execution time of the contained code.
+If multiple `bench` probes exist in a script, bpftrace executes them sequentially in the order they are specified.
+To run `bench` probes, you must run bpftrace in bench mode: `bpftrace --bench ...`; otherwise, `bench` probes will be ignored.
 
 ```
 bench:lhist {

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -238,6 +238,7 @@ AttachPoint *AttachPoint::create_expansion_copy(ASTContext &ctx,
     case ProbeType::interval:
     case ProbeType::profile:
     case ProbeType::special:
+    case ProbeType::test:
     case ProbeType::benchmark:
     case ProbeType::iter:
     case ProbeType::invalid:
@@ -268,6 +269,7 @@ bool AttachPoint::check_available(const std::string &identifier) const
         return true;
       case ProbeType::invalid:
       case ProbeType::special:
+      case ProbeType::test:
       case ProbeType::benchmark:
       case ProbeType::tracepoint:
       case ProbeType::fentry:
@@ -284,6 +286,7 @@ bool AttachPoint::check_available(const std::string &identifier) const
         return true;
       case ProbeType::invalid:
       case ProbeType::special:
+      case ProbeType::test:
       case ProbeType::benchmark:
       case ProbeType::kprobe:
       case ProbeType::kretprobe:

--- a/src/ast/passes/attachpoint_passes.h
+++ b/src/ast/passes/attachpoint_passes.h
@@ -33,6 +33,7 @@ private:
   State lex_attachpoint(const AttachPoint &ap);
 
   State special_parser();
+  State test_parser();
   State benchmark_parser();
   State kprobe_parser(bool allow_offset = true);
   State kretprobe_parser();

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -3292,6 +3292,7 @@ int CodegenLLVM::getReturnValueForProbe(ProbeType probe_type)
       // programs bad citizens. Return 1 instead.
       return 1;
     case ProbeType::special:
+    case ProbeType::test:
     case ProbeType::benchmark:
     case ProbeType::kprobe:
     case ProbeType::kretprobe:

--- a/src/ast/passes/pid_filter_pass.cpp
+++ b/src/ast/passes/pid_filter_pass.cpp
@@ -51,6 +51,7 @@ bool probe_needs_pid_filter(AttachPoint *ap)
     // We don't filter by pid at all for these special probes
     case ProbeType::interval:
     case ProbeType::special:
+    case ProbeType::test:
     case ProbeType::benchmark:
       return false;
   }

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -854,6 +854,7 @@ AddrSpace SemanticAnalyser::find_addrspace(ProbeType pt)
     // if addrspace cannot be detected.
     case ProbeType::invalid:
     case ProbeType::special:
+    case ProbeType::test:
     case ProbeType::benchmark:
     case ProbeType::profile:
     case ProbeType::interval:

--- a/src/async_action.cpp
+++ b/src/async_action.cpp
@@ -35,7 +35,7 @@ static Result<std::vector<output::Primitive>> prepare_args(
 void AsyncHandlers::exit(const OpaqueValue &data)
 {
   auto exit = data.bitcast<AsyncEvent::Exit>();
-  BPFtrace::exit_code = exit.exit_code;
+  bpftrace.exit_code = exit.exit_code;
   bpftrace.request_finalize();
 }
 
@@ -52,7 +52,7 @@ void AsyncHandlers::join(const OpaqueValue &data)
       joined << delim;
     joined << (arg.data() + (i * bpftrace.join_argsize_));
   }
-  out.join(joined.str());
+  out->join(joined.str());
 }
 
 void AsyncHandlers::time(const OpaqueValue &data)
@@ -72,7 +72,7 @@ void AsyncHandlers::time(const OpaqueValue &data)
     LOG(WARNING) << "strftime returned 0";
     return;
   }
-  out.time(timestr);
+  out->time(timestr);
 }
 
 void AsyncHandlers::runtime_error(const OpaqueValue &data)
@@ -81,7 +81,7 @@ void AsyncHandlers::runtime_error(const OpaqueValue &data)
   auto error_id = runtime_error.error_id;
   const auto return_value = runtime_error.return_value;
   const auto &info = bpftrace.resources.runtime_error_info[error_id];
-  out.runtime_error(return_value, info);
+  out->runtime_error(return_value, info);
 }
 
 void AsyncHandlers::print_non_map(const OpaqueValue &data)
@@ -95,7 +95,7 @@ void AsyncHandlers::print_non_map(const OpaqueValue &data)
   if (!v) {
     LOG(BUG) << "error printing non-map value: " << v.takeError();
   }
-  out.value(*v);
+  out->value(*v);
 }
 
 void AsyncHandlers::print_map(const OpaqueValue &data)
@@ -109,7 +109,7 @@ void AsyncHandlers::print_map(const OpaqueValue &data)
              << "\": " << res.takeError();
   }
 
-  out.map(map.name(), *res);
+  out->map(map.name(), *res);
 }
 
 void AsyncHandlers::zero_map(const OpaqueValue &data)
@@ -241,7 +241,7 @@ void AsyncHandlers::syscall(const OpaqueValue &data)
     return;
   }
 
-  out.syscall(*result);
+  out->syscall(*result);
 }
 
 void AsyncHandlers::cat(const OpaqueValue &data)
@@ -259,7 +259,7 @@ void AsyncHandlers::cat(const OpaqueValue &data)
   util::cat_file(fmt.format(*vals).c_str(),
                  bpftrace.config_->max_cat_bytes,
                  buf);
-  out.cat(buf.str());
+  out->cat(buf.str());
 }
 
 void AsyncHandlers::printf(const OpaqueValue &data)
@@ -280,7 +280,7 @@ void AsyncHandlers::printf(const OpaqueValue &data)
     return;
   }
 
-  out.printf(fmt.format(*vals), source_info, severity);
+  out->printf(fmt.format(*vals), source_info, severity);
 }
 
 } // namespace bpftrace::async_action

--- a/src/async_action.h
+++ b/src/async_action.h
@@ -36,7 +36,7 @@ public:
   AsyncHandlers(BPFtrace &bpftrace,
                 const ast::CDefinitions &c_definitions,
                 output::Output &output)
-      : bpftrace(bpftrace), c_definitions(c_definitions), out(output) {};
+      : bpftrace(bpftrace), c_definitions(c_definitions), out(&output) {};
 
   void exit(const OpaqueValue &data);
   void join(const OpaqueValue &data);
@@ -53,10 +53,15 @@ public:
   void cat(const OpaqueValue &data);
   void printf(const OpaqueValue &data);
 
+  void change_output(output::Output &out)
+  {
+    this->out = &out;
+  }
+
 private:
   BPFtrace &bpftrace;
   const ast::CDefinitions &c_definitions;
-  output::Output &out;
+  output::Output *out;
 };
 
 } // namespace bpftrace::async_action

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -48,6 +48,7 @@ bpf_probe_attach_type attachtype(ProbeType t)
     case ProbeType::kprobe:    return BPF_PROBE_ENTRY;  break;
     case ProbeType::kretprobe: return BPF_PROBE_RETURN; break;
     case ProbeType::special:   return BPF_PROBE_ENTRY;  break;
+    case ProbeType::test:      return BPF_PROBE_ENTRY;  break;
     case ProbeType::benchmark: return BPF_PROBE_ENTRY;  break;
     case ProbeType::uprobe:    return BPF_PROBE_ENTRY;  break;
     case ProbeType::uretprobe: return BPF_PROBE_RETURN; break;
@@ -63,6 +64,7 @@ bpf_prog_type progtype(ProbeType t)
   switch (t) {
       // clang-format off
     case ProbeType::special:    return BPF_PROG_TYPE_RAW_TRACEPOINT; break;
+    case ProbeType::test:       return BPF_PROG_TYPE_XDP; break;
     case ProbeType::benchmark:  return BPF_PROG_TYPE_XDP; break;
     case ProbeType::kprobe:     return BPF_PROG_TYPE_KPROBE; break;
     case ProbeType::kretprobe:  return BPF_PROG_TYPE_KPROBE; break;
@@ -1547,6 +1549,7 @@ Result<std::unique_ptr<AttachedProbe>> AttachedProbe::make(
     }
     case ProbeType::invalid:
     case ProbeType::special:
+    case ProbeType::test:
     case ProbeType::benchmark: {
       LOG(BUG) << "invalid attached probe type \"" << probe.type << "\"";
     }

--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -201,6 +201,7 @@ void BpfBytecode::load_progs(const RequiredResources &resources,
   for (auto probe : resources.special_probes)
     special_probes.push_back(probe.second);
   prepare_progs(special_probes, btf, feature, config);
+  prepare_progs(resources.test_probes, btf, feature, config);
   prepare_progs(resources.benchmark_probes, btf, feature, config);
   prepare_progs(resources.signal_probes, btf, feature, config);
   prepare_progs(resources.probes, btf, feature, config);

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1,3 +1,4 @@
+#include "types_format.h"
 #include <arpa/inet.h>
 #include <bcc/bcc_elf.h>
 #include <bcc/bcc_syms.h>
@@ -33,7 +34,6 @@
 #include <systemd/sd-daemon.h>
 #endif
 
-#include "ast/async_event_types.h"
 #include "ast/context.h"
 #include "async_action.h"
 #include "attached_probe.h"
@@ -42,11 +42,12 @@
 #include "bpftrace.h"
 #include "btf.h"
 #include "log.h"
+#include "output/capture.h"
+#include "output/discard.h"
+#include "output/text.h"
 #include "scopeguard.h"
 #include "util/bpf_names.h"
 #include "util/cgroup.h"
-#include "util/cpus.h"
-#include "util/exceptions.h"
 #include "util/kernel.h"
 #include "util/paths.h"
 #include "util/strings.h"
@@ -61,7 +62,6 @@ std::set<DebugStage> bt_debug = {};
 bool bt_quiet = false;
 bool bt_verbose = false;
 bool dry_run = false;
-int BPFtrace::exit_code = 0;
 volatile sig_atomic_t BPFtrace::exitsig_recv = false;
 volatile sig_atomic_t BPFtrace::sigusr1_recv = false;
 
@@ -174,6 +174,8 @@ int BPFtrace::add_probe(const ast::AttachPoint &ap,
     auto target = ap.target.empty() ? "" : "_" + ap.target;
     auto name = ap.provider + target;
     resources.special_probes[name] = std::move(probe);
+  } else if (ap.provider == "test") {
+    resources.test_probes.emplace_back(std::move(probe));
   } else if (ap.provider == "bench") {
     resources.benchmark_probes.emplace_back(std::move(probe));
   } else if (ap.provider == "self") {
@@ -204,7 +206,8 @@ int BPFtrace::add_probe(const ast::AttachPoint &ap,
 int BPFtrace::num_probes() const
 {
   return resources.special_probes.size() + resources.probes.size() +
-         resources.signal_probes.size() + resources.benchmark_probes.size();
+         resources.signal_probes.size() + resources.benchmark_probes.size() +
+         resources.test_probes.size();
 }
 
 void BPFtrace::request_finalize()
@@ -361,6 +364,7 @@ bool attach_reverse(const Probe &p)
 {
   switch (p.type) {
     case ProbeType::special:
+    case ProbeType::test:
     case ProbeType::benchmark:
     case ProbeType::kprobe:
     case ProbeType::uprobe:
@@ -539,6 +543,8 @@ int BPFtrace::run(output::Output &out,
 
   int num_begin_end_attached = 0;
   int num_signal_attached = 0;
+  int num_test_attached = 0;
+  int num_benchmark_attached = 0;
 
   auto begin_probe = resources.special_probes.find("begin");
   if (begin_probe != resources.special_probes.end()) {
@@ -554,28 +560,144 @@ int BPFtrace::run(output::Output &out,
     ++num_begin_end_attached;
   }
 
-  if (run_benchmarks_) {
-    for (auto &probe : resources.benchmark_probes) {
-      auto &benchmark_prog = bytecode_.getProgramForProbe(probe);
-      // Note: on newer kernels you must provide a data_in buffer at least
-      // ETH_HLEN bytes long to make sure input validation works for
-      // opts. Otherwise, bpf_prog_test_run_opts will return -EINVAL for
-      // BPF_PROG_TYPE_XDP.
-      //
-      // https://github.com/torvalds/linux/commit/6b3d638ca897e099fa99bd6d02189d3176f80a47
-      constexpr size_t ETH_HLEN = 14;
-      char data_in[ETH_HLEN];
-      DECLARE_LIBBPF_OPTS(bpf_test_run_opts, opts);
-      opts.data_in = data_in;
-      opts.data_size_in = ETH_HLEN;
-      opts.repeat = 1'000'000;
+  int rval = 0; // Used for return below.
 
-      if (auto ret = ::bpf_prog_test_run_opts(benchmark_prog.fd(), &opts)) {
-        LOG(ERROR) << "bpf_prog_test_run_opts failed: " << ret;
-        return -1;
+  if (run_tests_ || run_benchmarks_) {
+    if (run_tests_) {
+      std::vector<std::string> all_tests;
+      std::vector<bool> all_passed;
+      for (auto &probe : resources.test_probes) {
+        all_tests.emplace_back(probe.path);
       }
 
-      benchmark_results.emplace_back(probe.path, opts.duration);
+      for (size_t index = 0; index < resources.test_probes.size(); index++) {
+        ++num_test_attached;
+        auto &probe = resources.test_probes[index];
+        auto &test_prog = bytecode_.getProgramForProbe(probe);
+
+        // We swap our output for something that will capture the
+        // result of executing this single test. `poll_output` should
+        // be called after each test, and `ss.str("")` to reset the
+        // output (or used as required).
+        std::stringstream ss;
+        auto text_output = std::make_unique<output::TextOutput>(ss, ss);
+        auto capture = std::make_unique<output::CaptureOutput>(*text_output);
+        handlers.change_output(*capture);
+
+        // See below; we must provide sufficient data.
+        constexpr size_t ETH_HLEN = 14;
+        char data_in[ETH_HLEN];
+        DECLARE_LIBBPF_OPTS(bpf_test_run_opts, opts);
+        opts.data_in = data_in;
+        opts.data_size_in = ETH_HLEN;
+        opts.repeat = 1;
+        if (auto ret = ::bpf_prog_test_run_opts(test_prog.fd(), &opts)) {
+          LOG(ERROR) << "bpf_prog_test_run_opts failed: " << ret;
+          return -1;
+        }
+
+        // See above; ensure the output is flushed.
+        poll_output(*capture, true);
+        bool passed = opts.retval == 0 && exit_code == 0 &&
+                      capture->error_count == 0;
+        all_passed.push_back(passed);
+        out.test_result(all_tests,
+                        index,
+                        std::chrono::nanoseconds(opts.duration),
+                        all_passed,
+                        ss.str());
+
+        // Override the return value.
+        if (rval == 0 && !passed) {
+          rval = 1;
+        }
+        exit_code = 0; // Reset for all tests.
+      }
+
+      // Return the original output.
+      handlers.change_output(out);
+    } else if (run_benchmarks_) {
+      std::vector<std::string> all_benches;
+      for (auto &probe : resources.benchmark_probes) {
+        all_benches.emplace_back(probe.path);
+      }
+
+      for (size_t index = 0; index < resources.benchmark_probes.size();
+           index++) {
+        ++num_benchmark_attached;
+        auto &probe = resources.benchmark_probes[index];
+        auto &benchmark_prog = bytecode_.getProgramForProbe(probe);
+
+        // Increase opts.repeat until we reach at least 1ms of run time. We
+        // double the repeat time each instance, so each probe should take
+        // a few milliseconds at most (plus loading time, etc).
+        size_t iters = 1;
+        while (true) {
+          // Benchmarks have all output suppressed.
+          auto discard = std::make_unique<output::DiscardOutput>();
+          auto capture = std::make_unique<output::CaptureOutput>(*discard);
+          handlers.change_output(*capture);
+
+          // Note: on newer kernels you must provide a data_in buffer at least
+          // ETH_HLEN bytes long to make sure input validation works for
+          // opts. Otherwise, bpf_prog_test_run_opts will return -EINVAL for
+          // BPF_PROG_TYPE_XDP.
+          //
+          // https://github.com/torvalds/linux/commit/6b3d638ca897e099fa99bd6d02189d3176f80a47
+          constexpr size_t ETH_HLEN = 14;
+          char data_in[ETH_HLEN];
+          DECLARE_LIBBPF_OPTS(bpf_test_run_opts, opts);
+          opts.data_in = data_in;
+          opts.data_size_in = ETH_HLEN;
+          opts.repeat = iters;
+
+          if (auto ret = ::bpf_prog_test_run_opts(benchmark_prog.fd(), &opts)) {
+            LOG(ERROR) << "bpf_prog_test_run_opts failed: " << ret;
+            return -1;
+          }
+
+          poll_output(*capture, true);
+          // Allow skipping benchmarks by returning 1.
+          if (exit_code == 0 && opts.retval != 0) {
+            break;
+          }
+          // Did we run for enough time?
+          auto total = std::chrono::nanoseconds(opts.duration) * iters;
+          if (total < std::chrono::microseconds(1)) {
+            iters *= 10'00;
+            continue;
+          }
+          if (total < std::chrono::microseconds(10)) {
+            iters *= 100;
+            continue;
+          }
+          if (total < std::chrono::microseconds(100)) {
+            iters *= 10;
+            continue;
+          }
+          if (total < std::chrono::milliseconds(1)) {
+            iters *= 2;
+            continue;
+          }
+
+          // We don't include any benchmark results that have failed, but
+          // they are allowed to skip by returning 1. If they explicitly
+          // use errorf or something similar, then we fail the run.
+          if (exit_code != 0 || capture->error_count != 0) {
+            LOG(ERROR) << "Benchmark '" << probe.path << "' failed.";
+            rval = 1;
+            exit_code = 0; // Always reset for tests.
+            break;
+          }
+
+          out.benchmark_result(all_benches,
+                               index,
+                               std::chrono::nanoseconds(opts.duration),
+                               iters);
+          handlers.change_output(out);
+          break;
+        }
+      }
     }
   } else {
     for (auto &probe : resources.signal_probes) {
@@ -637,7 +759,7 @@ int BPFtrace::run(output::Output &out,
 
     if (dry_run) {
       request_finalize();
-      return 0;
+      return rval;
     }
 
     // Kick the child to execute the command.
@@ -661,15 +783,25 @@ int BPFtrace::run(output::Output &out,
   }
 
   auto total_attached = num_attached + num_begin_end_attached +
-                        num_signal_attached + benchmark_results.size();
+                        num_signal_attached + num_test_attached +
+                        num_benchmark_attached;
 
   if (total_attached == 0) {
-    LOG(ERROR) << "Attachment failed for all probes.";
+    // Provide some helpful hints, there if there are test or benchmark probes
+    // defined, they won't be attached unless the appropriate mode is set.
+    if (!resources.test_probes.empty()) {
+      LOG(ERROR) << "No probes attached; use --test to run test probes.";
+    } else if (!resources.benchmark_probes.empty()) {
+      LOG(ERROR) << "No probes attached; use --bench to run benchmark probes.";
+    } else {
+      LOG(ERROR) << "Attachment failed for all probes.";
+    }
     return -1;
   }
 
-  if (!bt_quiet)
+  if (!bt_quiet && !run_tests_ && !run_benchmarks_) {
     out.attached_probes(total_attached);
+  }
 
   // Used by runtime test framework to know when to run AFTER directive
   if (std::getenv("__BPFTRACE_NOTIFY_PROBES_ATTACHED"))
@@ -687,7 +819,8 @@ int BPFtrace::run(output::Output &out,
     if (err)
       return err;
   } else {
-    bool should_drain = (num_begin_end_attached > 0 || run_benchmarks_) &&
+    bool should_drain = (num_begin_end_attached > 0 || run_benchmarks_ ||
+                         run_tests_) &&
                         num_signal_attached == 0 && num_attached == 0;
     poll_output(out, should_drain);
   }
@@ -726,7 +859,25 @@ int BPFtrace::run(output::Output &out,
     LOG(WARNING) << "Total lost event count: " << total_lost_events;
   }
 
-  return 0;
+  // Indicate that we are done the main loop.
+  out.end();
+
+  // Print maps if needed (true by default).
+  if (!err && !run_tests_ && !run_benchmarks_ && !dry_run &&
+      config_->print_maps_on_exit) {
+    for (const auto &[_, map] : bytecode_.maps()) {
+      if (!map.is_printable())
+        continue;
+      auto res = format(*this, c_definitions, map);
+      if (!res) {
+        std::cerr << "Error printing map: " << res.takeError();
+        continue;
+      }
+      out.map(map.name(), *res);
+    }
+  }
+
+  return rval;
 }
 
 int BPFtrace::setup_output(void *ctx)
@@ -784,8 +935,8 @@ void BPFtrace::poll_output(output::Output &out, bool drain)
   bool do_poll_ringbuf = true;
   auto should_retry = [](int ready) {
     // epoll_wait will set errno to EINTR if an interrupt received, it is
-    // retryable if not caused by SIGINT. ring_buffer__poll does not set errno,
-    // we will keep retrying till SIGINT.
+    // retryable if not caused by SIGINT. ring_buffer__poll does not set
+    // errno, we will keep retrying till SIGINT.
     return ready < 0 && (errno == 0 || errno == EINTR) &&
            !BPFtrace::exitsig_recv;
   };

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -173,9 +173,10 @@ public:
   virtual std::unordered_set<std::string> get_raw_tracepoint_modules(
       const std::string &name) const;
   virtual const std::optional<struct stat> &get_pidns_self_stat() const;
-  // This gets the number of perf or ring buffer pages in total across all cpus by first checking if the
-  // user set this manually with a config value (`perf_rb_pages`), then falling
-  // back to a dynamic default based on the amount of available system memory
+  // This gets the number of perf or ring buffer pages in total across all cpus
+  // by first checking if the user set this manually with a config value
+  // (`perf_rb_pages`), then falling back to a dynamic default based on the
+  // amount of available system memory
   virtual Result<uint64_t> get_buffer_pages(bool per_cpu = false) const;
   Result<uint64_t> get_buffer_pages_per_cpu() const;
 
@@ -187,9 +188,12 @@ public:
   std::set<std::string> list_modules(const ast::ASTContext &ctx);
 
   std::string cmd_;
+
+  // Set by the async `exit` handler.
   bool finalize_ = false;
-  static int exit_code;
-  // Global variables checking if an exit/usr1 signal was received
+  int exit_code = 0;
+
+  // Global variables checking if an exit/usr1 signal was received.
   static volatile sig_atomic_t exitsig_recv;
   static volatile sig_atomic_t sigusr1_recv;
 
@@ -207,7 +211,6 @@ public:
 
   unsigned int join_argnum_ = 16;
   unsigned int join_argsize_ = 1024;
-  std::unique_ptr<output::Output> out_;
   std::unique_ptr<BTF> btf_;
   std::unique_ptr<BPFfeature> feature_;
 
@@ -235,8 +238,8 @@ public:
   int ncpus_;
   int max_cpu_id_;
   std::unique_ptr<Config> config_;
+  bool run_tests_ = false;
   bool run_benchmarks_ = false;
-  std::vector<std::pair<std::string, uint32_t>> benchmark_results;
 
 private:
   Ksyms ksyms_;

--- a/src/output/capture.h
+++ b/src/output/capture.h
@@ -1,0 +1,92 @@
+#pragma once
+
+#include "output/output.h"
+
+namespace bpftrace::output {
+
+class CaptureOutput : public Output {
+public:
+  CaptureOutput(Output &output) : nested_(output) {};
+
+  // Simple passthrough.
+  void map(const std::string &name, const Value &value) override
+  {
+    nested_.map(name, value);
+  }
+  void value(const Value &value) override
+  {
+    nested_.value(value);
+  }
+  void time(const std::string &time) override
+  {
+    nested_.time(time);
+  }
+  void cat(const std::string &cat) override
+  {
+    nested_.cat(cat);
+  }
+  void join(const std::string &join) override
+  {
+    nested_.join(join);
+  }
+  void syscall(const std::string &syscall) override
+  {
+    nested_.syscall(syscall);
+  }
+
+  // Special case: treat errorf as errors.
+  void printf(const std::string &str,
+              const SourceInfo &info,
+              PrintfSeverity severity) override
+  {
+    if (severity == PrintfSeverity::ERROR) {
+      error_count++;
+    }
+    nested_.printf(str, info, severity);
+  }
+  void test_result(const std::vector<std::string> &all_tests,
+                   size_t index,
+                   std::chrono::nanoseconds duration,
+                   const std::vector<bool> &passed,
+                   std::string output) override
+  {
+    nested_.test_result(all_tests, index, duration, passed, output);
+  }
+  void benchmark_result(const std::vector<std::string> &all_benches,
+                        size_t index,
+                        std::chrono::nanoseconds average,
+                        size_t iters) override
+  {
+    nested_.benchmark_result(all_benches, index, average, iters);
+  }
+  void end() override
+  {
+    nested_.end();
+  }
+
+  // Increment our counters.
+  void lost_events(uint64_t lost) override
+  {
+    lost_events_count += lost;
+    nested_.lost_events(lost);
+  }
+  void attached_probes(uint64_t num_probes) override
+  {
+    attached_probes_count += num_probes;
+    nested_.attached_probes(num_probes);
+  }
+  void runtime_error(int retcode, const RuntimeErrorInfo &info) override
+  {
+    error_count++;
+    nested_.runtime_error(retcode, info);
+  }
+
+  size_t error_count = 0;
+  size_t lost_events_count = 0;
+  size_t attached_probes_count = 0;
+
+private:
+  Output &nested_;
+};
+
+} // namespace bpftrace::output

--- a/src/output/discard.h
+++ b/src/output/discard.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include "output/output.h"
+
+namespace bpftrace::output {
+
+class DiscardOutput : public Output {
+public:
+  DiscardOutput() = default;
+
+  void map([[maybe_unused]] const std::string &name,
+           [[maybe_unused]] const Value &value) override
+  {
+  }
+  void value([[maybe_unused]] const Value &value) override
+  {
+  }
+  void time([[maybe_unused]] const std::string &time) override
+  {
+  }
+  void cat([[maybe_unused]] const std::string &cat) override
+  {
+  }
+  void join([[maybe_unused]] const std::string &join) override
+  {
+  }
+  void syscall([[maybe_unused]] const std::string &syscall) override
+  {
+  }
+  void printf([[maybe_unused]] const std::string &str,
+              [[maybe_unused]] const SourceInfo &info,
+              [[maybe_unused]] PrintfSeverity severity) override
+  {
+  }
+  void test_result([[maybe_unused]] const std::vector<std::string> &all_tests,
+                   [[maybe_unused]] size_t index,
+                   [[maybe_unused]] std::chrono::nanoseconds duration,
+                   [[maybe_unused]] const std::vector<bool> &passed,
+                   [[maybe_unused]] std::string output) override
+  {
+  }
+  void benchmark_result(
+      [[maybe_unused]] const std::vector<std::string> &all_benches,
+      [[maybe_unused]] size_t index,
+      [[maybe_unused]] std::chrono::nanoseconds average,
+      [[maybe_unused]] size_t iters) override
+  {
+  }
+  void end() override
+  {
+  }
+  void lost_events([[maybe_unused]] uint64_t lost) override
+  {
+  }
+  void attached_probes([[maybe_unused]] uint64_t num_probes) override
+  {
+  }
+  void runtime_error([[maybe_unused]] int retcode,
+                     [[maybe_unused]] const RuntimeErrorInfo &info) override
+  {
+  }
+};
+
+} // namespace bpftrace::output

--- a/src/output/json.cpp
+++ b/src/output/json.cpp
@@ -507,10 +507,28 @@ void JsonOutput::runtime_error(int retcode, const RuntimeErrorInfo &info)
   out_ << R"(})" << std::endl;
 }
 
-void JsonOutput::benchmark_results(
-    const std::vector<std::pair<std::string, uint32_t>> &results)
+void JsonOutput::test_result(const std::vector<std::string> &all_tests,
+                             size_t index,
+                             std::chrono::nanoseconds duration,
+                             const std::vector<bool> &passed,
+                             std::string output)
 {
-  emit_data(out_, "benchmark_results", std::nullopt, results);
+  Primitive::Record result;
+  result.fields.emplace_back("duration", duration.count());
+  result.fields.emplace_back("passed", passed[index]);
+  result.fields.emplace_back("output", output);
+  emit_data(out_, "test_result", all_tests[index], result);
+}
+
+void JsonOutput::benchmark_result(const std::vector<std::string> &all_benches,
+                                  size_t index,
+                                  std::chrono::nanoseconds average,
+                                  size_t iters)
+{
+  Primitive::Record result;
+  result.fields.emplace_back("average", average.count());
+  result.fields.emplace_back("iters", iters);
+  emit_data(out_, "benchmark_result", all_benches[index], result);
 }
 
 void JsonOutput::end()

--- a/src/output/json.h
+++ b/src/output/json.h
@@ -12,17 +12,29 @@ public:
 
   void map(const std::string &name, const Value &value) override;
   void value(const Value &value) override;
-  void printf(const std::string &str, const SourceInfo &info, PrintfSeverity severity) override;
+  void printf(const std::string &str,
+              const SourceInfo &info,
+              PrintfSeverity severity) override;
   void time(const std::string &time) override;
   void cat(const std::string &cat) override;
   void join(const std::string &join) override;
   void syscall(const std::string &syscall) override;
+
   void lost_events(uint64_t lost) override;
   void attached_probes(uint64_t num_probes) override;
   void runtime_error(int retcode, const RuntimeErrorInfo &info) override;
-  void benchmark_results(
-      const std::vector<std::pair<std::string, uint32_t>> &results) override;
   void end() override;
+
+  void test_result(const std::vector<std::string> &all_tests,
+                   size_t index,
+                   std::chrono::nanoseconds duration,
+                   const std::vector<bool> &passed,
+                   std::string output) override;
+
+  void benchmark_result(const std::vector<std::string> &all_benches,
+                        size_t index,
+                        std::chrono::nanoseconds average,
+                        size_t iters) override;
 
 private:
   std::ostream &out_;

--- a/src/output/output.h
+++ b/src/output/output.h
@@ -148,17 +148,32 @@ public:
   virtual void value(const Value& value) = 0;
 
   // Specialized messages during execution.
-  virtual void printf(const std::string& str, const SourceInfo& info, PrintfSeverity severity) = 0;
+  virtual void printf(const std::string& str,
+                      const SourceInfo& info,
+                      PrintfSeverity severity) = 0;
   virtual void time(const std::string& time) = 0;
   virtual void cat(const std::string& cat) = 0;
   virtual void join(const std::string& join) = 0;
   virtual void syscall(const std::string& syscall) = 0;
+  virtual void end() = 0;
+
+  // General events.
   virtual void lost_events(uint64_t lost) = 0;
   virtual void attached_probes(uint64_t num_probes) = 0;
   virtual void runtime_error(int retcode, const RuntimeErrorInfo& info) = 0;
-  virtual void benchmark_results(
-      const std::vector<std::pair<std::string, uint32_t>>& results) = 0;
-  virtual void end() = 0;
+
+  // Testing hooks.
+  virtual void test_result(const std::vector<std::string>& all_tests,
+                           size_t index,
+                           std::chrono::nanoseconds result,
+                           const std::vector<bool>& passed,
+                           std::string output) = 0;
+
+  // Benchmark hooks.
+  virtual void benchmark_result(const std::vector<std::string>& all_benches,
+                                size_t index,
+                                std::chrono::nanoseconds average,
+                                size_t iters) = 0;
 };
 
 } // namespace bpftrace::output

--- a/src/output/text.h
+++ b/src/output/text.h
@@ -14,17 +14,29 @@ public:
 
   void map(const std::string &name, const Value &value) override;
   void value(const Value &value) override;
-  void printf(const std::string &str, const SourceInfo &info, PrintfSeverity severity) override;
+  void printf(const std::string &str,
+              const SourceInfo &info,
+              PrintfSeverity severity) override;
   void time(const std::string &time) override;
   void cat(const std::string &cat) override;
   void join(const std::string &join) override;
   void syscall(const std::string &syscall) override;
+
   void lost_events(uint64_t lost) override;
   void attached_probes(uint64_t num_probes) override;
   void runtime_error(int retcode, const RuntimeErrorInfo &info) override;
-  void benchmark_results(
-      const std::vector<std::pair<std::string, uint32_t>> &results) override;
   void end() override;
+
+  void test_result(const std::vector<std::string> &all_tests,
+                   size_t index,
+                   std::chrono::nanoseconds duration,
+                   const std::vector<bool> &passed,
+                   std::string output) override;
+
+  void benchmark_result(const std::vector<std::string> &all_benches,
+                        size_t index,
+                        std::chrono::nanoseconds average,
+                        size_t iters) override;
 
   // Allows formatting of a specific primitive.
   void primitive(const Primitive &p);

--- a/src/probe_matcher.cpp
+++ b/src/probe_matcher.cpp
@@ -190,6 +190,7 @@ std::set<std::string> ProbeMatcher::get_matches_for_probetype(
       break;
     }
     case ProbeType::special:
+    case ProbeType::test:
     case ProbeType::benchmark:
       return { target + ":" };
     default:
@@ -579,6 +580,7 @@ std::set<std::string> ProbeMatcher::get_matches_for_ap(
       [[fallthrough]];
     }
     case ProbeType::special:
+    case ProbeType::test:
     case ProbeType::benchmark:
     case ProbeType::uprobe:
     case ProbeType::uretprobe:

--- a/src/probe_types.cpp
+++ b/src/probe_types.cpp
@@ -50,7 +50,8 @@ std::string probetypeName(ProbeType t)
   {
     case ProbeType::invalid:     return "invalid";     break;
     case ProbeType::special:     return "special";     break;
-    case ProbeType::benchmark:   return "benchmark";     break;
+    case ProbeType::test:        return "test";        break;
+    case ProbeType::benchmark:   return "benchmark";   break;
     case ProbeType::kprobe:      return "kprobe";      break;
     case ProbeType::kretprobe:   return "kretprobe";   break;
     case ProbeType::uprobe:      return "uprobe";      break;

--- a/src/probe_types.h
+++ b/src/probe_types.h
@@ -15,6 +15,7 @@ namespace bpftrace {
 enum class ProbeType {
   invalid,
   special,
+  test,
   benchmark,
   kprobe,
   kretprobe,
@@ -64,6 +65,7 @@ const std::vector<ProbeItem> PROBE_LIST = {
   { .name = "begin", .aliases = {}, .type = ProbeType::special },
   { .name = "end", .aliases = {}, .type = ProbeType::special },
   { .name = "self", .aliases = {}, .type = ProbeType::special },
+  { .name = "test", .aliases = {}, .type = ProbeType::test },
   { .name = "bench", .aliases = {}, .type = ProbeType::benchmark },
   { .name = "tracepoint",
     .aliases = { "t" },

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -109,8 +109,7 @@ public:
       : RuntimeErrorInfo(error_id, __BPF_FUNC_MAX_ID, loc) {};
 
   RuntimeErrorInfo()
-      : error_id(RuntimeErrorId::HELPER_ERROR),
-        func_id(__BPF_FUNC_MAX_ID) {};
+      : error_id(RuntimeErrorId::HELPER_ERROR), func_id(__BPF_FUNC_MAX_ID) {};
 
   RuntimeErrorId error_id;
   bpf_func_id func_id;
@@ -206,12 +205,16 @@ public:
   // be collecting this, but it's complex to move the logic.
   std::vector<Probe> probes;
   std::unordered_map<std::string, Probe> special_probes;
+  std::vector<Probe> test_probes;
   std::vector<Probe> benchmark_probes;
   std::vector<Probe> signal_probes;
   std::vector<Probe> watchpoint_probes;
 
-  size_t num_probes() {
-    return probes.size() + special_probes.size() + benchmark_probes.size() + signal_probes.size() + watchpoint_probes.size();
+  size_t num_probes()
+  {
+    return probes.size() + special_probes.size() + test_probes.size() +
+           benchmark_probes.size() + signal_probes.size() +
+           watchpoint_probes.size();
   }
 
   // List of probes using userspace symbol resolution
@@ -238,6 +241,7 @@ private:
             probes,
             signal_probes,
             special_probes,
+            test_probes,
             benchmark_probes);
   }
 };

--- a/src/stdlib/CMakeLists.txt
+++ b/src/stdlib/CMakeLists.txt
@@ -13,9 +13,11 @@ include(Embed)
 
 file(GLOB_RECURSE STDLIB_SOURCES "*.c" "*.h" "*.bt")
 file(GLOB_RECURSE PUBLIC_HEADERS "include/*.h")
+file(GLOB_RECURSE TEST_SCRIPTS "*_test.bt")
 file(GLOB_RECURSE BPF_HEADERS "${LIBBPF_INCLUDE_DIRS}/bpf/*.h")
 list(REMOVE_ITEM STDLIB_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/stdlib.h")
 list(REMOVE_ITEM STDLIB_SOURCES ${PUBLIC_HEADERS})
+list(REMOVE_ITEM STDLIB_SOURCES ${TEST_SCRIPTS})
 
 function(add_stdlib_source PREFIX FILENAME)
   # Generate our embedded header.

--- a/tests/bpftrace.cpp
+++ b/tests/bpftrace.cpp
@@ -190,6 +190,16 @@ void check_special_probe(Probe &p, const std::string &orig_name)
   EXPECT_EQ(orig_name, p.name);
 }
 
+void check_test_probe(Probe &p,
+                      const std::string &orig_name,
+                      const std::string &test_name)
+{
+  EXPECT_EQ(ProbeType::test, p.type);
+  EXPECT_EQ(orig_name, p.orig_name);
+  EXPECT_EQ(orig_name, p.name);
+  EXPECT_EQ(test_name, p.path);
+}
+
 void check_benchmark_probe(Probe &p,
                            const std::string &orig_name,
                            const std::string &bench_name)
@@ -220,6 +230,20 @@ TEST(bpftrace, add_end_probe)
   ASSERT_EQ(1U, bpftrace->get_special_probes().size());
 
   check_special_probe(bpftrace->get_special_probes()["end"], "end");
+}
+
+TEST(bpftrace, add_test_probes)
+{
+  auto bpftrace = get_strict_mock_bpftrace();
+  parse_probe("test:a{} test:b{} test:c{}", *bpftrace);
+
+  ASSERT_EQ(0U, bpftrace->get_probes().size());
+  ASSERT_EQ(0U, bpftrace->get_special_probes().size());
+  ASSERT_EQ(3U, bpftrace->get_test_probes().size());
+
+  check_test_probe(bpftrace->get_test_probes().at(0), "test:a", "a");
+  check_test_probe(bpftrace->get_test_probes().at(1), "test:b", "b");
+  check_test_probe(bpftrace->get_test_probes().at(2), "test:c", "c");
 }
 
 TEST(bpftrace, add_bench_probes)

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -74,6 +74,10 @@ public:
   {
     return resources.special_probes;
   }
+  std::vector<::bpftrace::Probe> get_test_probes()
+  {
+    return resources.test_probes;
+  }
   std::vector<::bpftrace::Probe> get_benchmark_probes()
   {
     return resources.benchmark_probes;

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -223,12 +223,14 @@ TIMEOUT 1
 
 NAME bench
 RUN {{BPFTRACE}} -q -f json --test-mode bench -e 'bench:a { @ = count(); }'
-EXPECT_REGEX {"type": "benchmark_results", "data": {"a": \d+}}
+EXPECT_REGEX {"type": "benchmark_result", "data": {"a": {"average": \d+, "iters": \d+}}}
 TIMEOUT 2
 
 NAME bench multiple
 RUN {{BPFTRACE}} -q -f json --test-mode bench -e 'bench:a { @a++; } bench:b { @b++; } bench:c { @c++; }'
-EXPECT_REGEX {"type": "benchmark_results", "data": {"a": \d+, "b": \d+, "c": \d+}}
+EXPECT_REGEX {"type": "benchmark_result", "data": {"a": {"average": \d+, "iters": \d+}}}
+             {"type": "benchmark_result", "data": {"b": {"average": \d+, "iters": \d+}}}
+             {"type": "benchmark_result", "data": {"c": {"average": \d+, "iters": \d+}}}
 TIMEOUT 5
 
 NAME attached probes

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -507,28 +507,18 @@ TIMEOUT 2
 
 NAME bench
 RUN {{BPFTRACE}} --test-mode bench -e 'begin { print("begin\n"); } bench:a { @ = count(); } end { print(@); clear(@); }'
-EXPECT_REGEX begin\n
-             @: 1000000\n\n
-             \+-----------\+--------------\+
-             \| BENCHMARK \| AVERAGE TIME \|
-             \+-----------\+--------------\+
-             \| a         \| \d+ns[ ]+\|
-             \+-----------\+--------------\+
-TIMEOUT 2
+EXPECT_REGEX Benchmark                                Time\(ns\)       Iterations
+             ------------------------------------------------------------------
+             a                                        \d+[ ]+\d+
+TIMEOUT 5
 
 NAME bench multiple
 RUN {{BPFTRACE}} --test-mode bench -e 'begin { printf("begin\n"); } bench:a { @a++; } bench:b { if (@b == 0) { print(@a); } @b++; } bench:c { if(@c == 0) { print(@b);  } @c++; } end { print(@c); clear(@a); clear(@b); clear(@c); }'
-EXPECT_REGEX begin
-             @a: 1000000
-             @b: 1000000
-             @c: 1000000\n\n
-             \+-----------\+--------------\+
-             \| BENCHMARK \| AVERAGE TIME \|
-             \+-----------\+--------------\+
-             \| a         \| \d+ns[ ]+\|
-             \| b         \| \d+ns[ ]+\|
-             \| c         \| \d+ns[ ]+\|
-             \+-----------\+--------------\+
+EXPECT_REGEX Benchmark                                Time\(ns\)       Iterations
+             ------------------------------------------------------------------
+             a                                        \d+[ ]+\d+
+             b                                        \d+[ ]+\d+
+             c                                        \d+[ ]+\d+
 TIMEOUT 5
 
 # The "probe" builtin forces bpftrace to generate one BPF function for each


### PR DESCRIPTION
Stacked PRs:
 * __->__#4753


--- --- ---

### test: add test probes


These mirror the structure of the benchmark probes exactly. During
execution, the output of the program is captured and associated with the
test. It is considered failing if it returns a non-zero value.

Signed-off-by: Adin Scannell <amscanne@meta.com>
