### PR TITLE
Allow string variable declarations to be resized

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -3526,11 +3526,7 @@ void SemanticAnalyser::visit(AssignVarStatement &assignment)
         pass_tracker_.inc_num_unresolved();
       }
     } else if (assignTy.IsStringTy()) {
-      if (foundVar.can_resize) {
-        update_string_size(storedTy, assignTy);
-      } else if (!assignTy.FitsInto(storedTy)) {
-        type_mismatch_error = true;
-      }
+      update_string_size(storedTy, assignTy);
     } else if (storedTy.IsIntegerTy()) {
       if (storedTy.IsEqual(assignTy)) {
         // No checks or casts needed.

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -5466,6 +5466,8 @@ TEST_F(SemanticAnalyserTest, typeof_decls)
 {
   test("kprobe:f { $x = (uint8)1; let $y : typeof($x); $y = 2; }");
   test(R"(kprobe:f { $x = "foo"; let $y : typeof($x); $y = "bar"; })");
+  test(
+      R"(kprobe:f { $x = "foo"; let $y : typeof($x); $y = "muchmuchlongerstr"; })");
 
   // These types should be enforced.
   test(R"(kprobe:f { $x = (uint8)1; let $y : typeof($x); $y = "foo"; })",
@@ -5478,12 +5480,6 @@ kprobe:f { $x = (uint8)1; let $y : typeof($x); $y = "foo"; }
 stdin:1:45-51: ERROR: Type mismatch for $y: trying to assign value of type 'int64' when variable already has a type 'string'
 kprobe:f { $x = "foo"; let $y : typeof($x); $y = 2; }
                                             ~~~~~~
-)" });
-  test(R"(kprobe:f { $x = "foo"; let $y : typeof($x); $y = "bazz"; })",
-       Error{ R"(
-stdin:1:45-56: ERROR: Type mismatch for $y: trying to assign value of type 'string' when variable already has a type 'string'
-kprobe:f { $x = "foo"; let $y : typeof($x); $y = "bazz"; }
-                                            ~~~~~~~~~~~
 )" });
 
   // But ordering should not matter, as long as the scope is the same.


### PR DESCRIPTION
Stacked PRs:
 * __->__#4755


--- --- ---

### Allow string variable declarations to be resized


string sizes are not user-facing so they are allowed
to be resized in the case of variable declarations
with types. Example:
```
$a = "hi";
let $b: typeof($a) = "longer_string";
```
On master this causes an error when it shouldn't.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>