### PR TITLE
Promote integers in tuples

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2870,13 +2870,6 @@ void CodegenLLVM::createTupleCopy(const SizedType &expr_type,
                               { b_.getInt32(0), b_.getInt32(i) });
     if (t_type.IsTupleTy() && !t_type.IsSameSizeRecursive(var_type)) {
       createTupleCopy(t_type, var_type.GetField(i).type, dst, offset_val);
-    } else if (t_type.IsIntTy() && t_type.GetSize() < 8) {
-      // Integers are always stored as 64-bit in map keys
-      b_.CreateStore(b_.CreateIntCast(b_.CreateLoad(b_.GetType(t_type),
-                                                    offset_val),
-                                      b_.getInt64Ty(),
-                                      t_type.IsSigned()),
-                     dst);
     } else {
       b_.CreateMemcpyBPF(dst, offset_val, t_type.GetSize());
     }

--- a/tests/codegen/llvm/tuple_bytearray.ll
+++ b/tests/codegen/llvm/tuple_bytearray.ll
@@ -5,7 +5,7 @@ target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.0" = type { ptr, ptr }
-%uint8_usym_t_int64__tuple_t = type { i8, [16 x i8], i64 }
+%uint64_usym_t_int64__tuple_t = type { i64, [16 x i8], i64 }
 %usym_t = type { i64, i32, i32 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
@@ -21,7 +21,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !55 {
 entry:
   %"@t_key" = alloca i64, align 8
-  %tuple = alloca %uint8_usym_t_int64__tuple_t, align 8
+  %tuple = alloca %uint64_usym_t_int64__tuple_t, align 8
   %usym = alloca %usym_t, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 128
@@ -38,11 +38,11 @@ entry:
   store i32 0, ptr %6, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
   call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 32, i1 false)
-  %7 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %tuple, i32 0, i32 0
-  store i8 1, ptr %7, align 1
-  %8 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %tuple, i32 0, i32 1
+  %7 = getelementptr %uint64_usym_t_int64__tuple_t, ptr %tuple, i32 0, i32 0
+  store i64 1, ptr %7, align 8
+  %8 = getelementptr %uint64_usym_t_int64__tuple_t, ptr %tuple, i32 0, i32 1
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %usym, i64 16, i1 false)
-  %9 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %tuple, i32 0, i32 2
+  %9 = getelementptr %uint64_usym_t_int64__tuple_t, ptr %tuple, i32 0, i32 2
   store i64 10, ptr %9, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@t_key")
   store i64 0, ptr %"@t_key", align 8
@@ -102,8 +102,8 @@ attributes #5 = { memory(none) }
 !22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
 !23 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !24)
 !24 = !{!25, !26, !30}
-!25 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !4, size: 8)
-!26 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !27, size: 128, offset: 8)
+!25 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !20, size: 64)
+!26 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !27, size: 128, offset: 64)
 !27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 128, elements: !28)
 !28 = !{!29}
 !29 = !DISubrange(count: 16, lowerBound: 0)

--- a/tests/runtime/tuples
+++ b/tests/runtime/tuples
@@ -49,7 +49,7 @@ EXPECT @a[1, (123, 1234)]: 1
 EXPECT @a[4, (1234, 123)]: 2
 
 NAME complex tuple 1
-PROG begin { print(((int8)-100, (int8) 100, "abcdef", 3, (int32) 1, (int64)-10, (int8)10, (int16)-555));  }
+PROG begin { print(((int8)-100, (int8)100, "abcdef", 3, (int32)1, (int64)-10, (int8)10, (int16)-555));  }
 EXPECT (-100, 100, abcdef, 3, 1, -10, 10, -555)
 
 NAME tuple struct sizing 1
@@ -58,15 +58,15 @@ EXPECT 32
 
 NAME tuple struct sizing 2
 PROG begin { $t = ((int8) 1, (int16) 1, (int32) 1); print(sizeof($t)); exit() }
-EXPECT 8
+EXPECT 24
 
 NAME tuple struct sizing 3
 PROG begin { $t = ((int32) 1, (int16) 1, (int8) 1); print(sizeof($t)); exit() }
-EXPECT 8
+EXPECT 24
 
 NAME complex tuple 4
 PROG begin { $a = ((int8)-100, (int8) 100, "abcdef", 3, (int32) 1, (int64)-10, (int8)10, (int16)-555, "abc"); print(sizeof($a));  }
-EXPECT 48
+EXPECT 72
 
 NAME struct in tuple
 PROG struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @t = (1, *((struct Foo *)arg0)); exit(); }
@@ -75,7 +75,7 @@ AFTER ./testprogs/simple_struct
 
 NAME struct in tuple sizing
 PROG struct Foo { int m; int n; } u:./testprogs/simple_struct:func { $t = ((int32)1, *((struct Foo *)arg0)); print(sizeof($t)); exit(); }
-EXPECT 12
+EXPECT 16
 AFTER ./testprogs/simple_struct
 
 NAME array in tuple
@@ -85,7 +85,7 @@ AFTER ./testprogs/array_access
 
 NAME array in tuple sizing
 PROG struct A { int x[4]; } u:./testprogs/array_access:test_struct { $t = ((int32)1, ((struct A *)arg0).x); print(sizeof($t)); exit(); }
-EXPECT 20
+EXPECT 24
 AFTER ./testprogs/array_access
 
 NAME array-style tuple access

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -3226,7 +3226,7 @@ kprobe:f { $x = -1; $x = 10223372036854775807; }
                     ~~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
   test("kprobe:f { $x = (0, (uint32)123); $x = (0, (int32)-123); }", Error{ R"(
-stdin:1:35-56: ERROR: Type mismatch for $x: trying to assign value of type '(int64,int32)' when variable already contains a value of type '(int64,uint32)'
+stdin:1:35-56: ERROR: Type mismatch for $x: trying to assign value of type '(int64,int64)' when variable already contains a value of type '(int64,uint64)'
 kprobe:f { $x = (0, (uint32)123); $x = (0, (int32)-123); }
                                   ~~~~~~~~~~~~~~~~~~~~~
 )" });
@@ -3823,12 +3823,7 @@ TEST_F(SemanticAnalyserTest, tuple)
   test(R"(begin { @t = (1, kstack()) })");
   test(R"(begin { @t = (1, (2,3)) })");
   test(R"(begin { $t = (1, (int64)2); $t = (2, (int32)3); })");
-
-  test(R"(begin { $t = (1, (int32)2); $t = (2, (int64)3); })", Error{ R"(
-stdin:1:29-47: ERROR: Type mismatch for $t: trying to assign value of type '(int64,int64)' when variable already contains a value of type '(int64,int32)'
-begin { $t = (1, (int32)2); $t = (2, (int64)3); }
-                            ~~~~~~~~~~~~~~~~~~
-)" });
+  test(R"(begin { $t = (1, (int32)2); $t = (2, (int64)3); })");
 
   test(R"(struct task_struct { int x; } begin { $t = (1, curtask); })");
   test(R"(struct task_struct { int x[4]; } begin { $t = (1, curtask->x); })");
@@ -3842,16 +3837,11 @@ begin { $t = (1, (int32)2); $t = (2, (int64)3); }
   test(R"(begin { @t = (1, count()) })", Error{});
 
   test(R"(begin { $t = (1, (2, 3)); $t = (4, ((int8)5, 6)); })");
-
-  test(R"(begin { $t = (1, ((int8)2, 3)); $t = (4, (5, 6)); })", Error{ R"(
-stdin:1:33-49: ERROR: Type mismatch for $t: trying to assign value of type '(int64,(int64,int64))' when variable already contains a value of type '(int64,(int8,int64))'
-begin { $t = (1, ((int8)2, 3)); $t = (4, (5, 6)); }
-                                ~~~~~~~~~~~~~~~~
-)" });
+  test(R"(begin { $t = (1, ((int8)2, 3)); $t = (4, (5, 6)); })");
 
   test(R"(begin { $t = ((uint8)1, (2, 3)); $t = (4, ((int8)5, 6)); })",
        Error{ R"(
-stdin:1:34-56: ERROR: Type mismatch for $t: trying to assign value of type '(int64,(int8,int64))' when variable already contains a value of type '(uint8,(int64,int64))'
+stdin:1:34-56: ERROR: Type mismatch for $t: trying to assign value of type '(int64,(int64,int64))' when variable already contains a value of type '(uint64,(int64,int64))'
 begin { $t = ((uint8)1, (2, 3)); $t = (4, ((int8)5, 6)); }
                                  ~~~~~~~~~~~~~~~~~~~~~~
 )" });
@@ -4866,6 +4856,7 @@ TEST_F(SemanticAnalyserTest, variable_declarations)
   test("begin { let $a: int16 = 1; }");
   test("begin { let $a: uint8 = 1; $a = 100; }");
   test("begin { let $a: int8 = 1; $a = -100; }");
+  test("begin { let $a: uint64 = (uint8)1; $a = 100000; }");
   test(R"(begin { let $a: string; $a = "hiya"; })");
   test("begin { let $a: int16; print($a); }");
   test("begin { let $a; print($a); $a = 1; }");
@@ -4955,6 +4946,14 @@ stdin:1:28-34: ERROR: Variable declarations need to occur before variable usage 
 begin { $x = 2; if (pid) { let $x; } }
                            ~~~~~~
 )" });
+
+  test("begin { $a = (1, 2); let $b: typeof($a) = ((uint64)1, 2); }", Error{ R"(
+stdin:1:22-57: ERROR: Type mismatch for $b: trying to assign value of type '(uint64,int64)' when variable already has a type '(int64,int64)'
+begin { $a = (1, 2); let $b: typeof($a) = ((uint64)1, 2); }
+                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+)" });
+
+  test("begin { $a = ((int8)1, 2); let $b: typeof($a) = (1, 2); }");
 }
 
 TEST_F(SemanticAnalyserTest, variable_address)


### PR DESCRIPTION
Stacked PRs:
 * __->__#4756
 * #4755


--- --- ---

### Promote integers in tuples


Similar to how we handle map keys and values,
promote all integer types inside of tuples
to 64 bits (8 bytes).

This alleviates issues with tuple comparisons
and padding considerations. It also clears
the way for re-adding `has_key` to the stdlib.

This change also fixes a related bug with variable
declaration types for ints.

Signed-off-by: Jordan Rome <linux@jordanrome.com>