### PR TITLE
Add optimization step to strip dead debug info

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -27,6 +27,7 @@
 #include <llvm/Support/raw_os_ostream.h>
 #include <llvm/Target/TargetMachine.h>
 #include <llvm/Transforms/IPO.h>
+#include <llvm/Transforms/IPO/StripSymbols.h>
 #include <llvm/Transforms/Utils/Cloning.h>
 
 #include "arch/arch.h"
@@ -5075,6 +5076,8 @@ Pass CreateOptimizePass()
 
     ModulePassManager mpm = pb.buildPerModuleDefaultPipeline(
         llvm::OptimizationLevel::O3);
+
+    mpm.addPass(llvm::StripDeadDebugInfoPass());
     mpm.run(*cm.module, mam);
   });
 }


### PR DESCRIPTION
Dead debug info was getting added from the import
of stdlib bpf.c files.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
