### PR TITLE
TracepointFormatParser: put to the correct namespace

### DIFF
--- a/src/ast/passes/tracepoint_format_parser.cpp
+++ b/src/ast/passes/tracepoint_format_parser.cpp
@@ -9,7 +9,7 @@
 #include "tracefs/tracefs.h"
 #include "tracepoint_format_parser.h"
 
-namespace bpftrace {
+namespace bpftrace::ast {
 
 std::set<std::string> TracepointFormatParser::struct_list;
 
@@ -234,4 +234,4 @@ ast::Pass CreateParseTracepointFormatPass()
   });
 }
 
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/src/ast/passes/tracepoint_format_parser.h
+++ b/src/ast/passes/tracepoint_format_parser.h
@@ -8,7 +8,7 @@
 #include "ast/visitor.h"
 #include "bpftrace.h"
 
-namespace bpftrace {
+namespace bpftrace::ast {
 
 class TracepointFormatParser {
 public:
@@ -39,4 +39,4 @@ protected:
 
 ast::Pass CreateParseTracepointFormatPass();
 
-} // namespace bpftrace
+} // namespace bpftrace::ast

--- a/tests/tracepoint_format_parser.cpp
+++ b/tests/tracepoint_format_parser.cpp
@@ -7,7 +7,7 @@ using namespace testing;
 
 namespace bpftrace::test::tracepoint_format_parser {
 
-class MockTracepointFormatParser : public TracepointFormatParser {
+class MockTracepointFormatParser : public ast::TracepointFormatParser {
 public:
   static std::string get_tracepoint_struct_public(std::istream &format_file,
                                                   const std::string &category,


### PR DESCRIPTION
#4762 has moved `TracepointFormatParser` to `src/ast/passes`, however, it forgot to update the namespace from `bpftrace` to `bpftrace::ast`. Fix it.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
