### PR TITLE
Attaching a uprobe to a stripped binary using an offset is inherently…

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -291,13 +291,13 @@ Result<uint64_t> resolve_offset_uprobe(Probe &probe, bool safe_mode)
         ss << "0x" << std::hex << probe.address;
         return make_error<AttachError>(
             "Could not resolve address: " + probe.path + ":" + ss.str() +
-            " (binary appears stripped). Misaligned probes can lead to tracee "
+            " (binary is possibly stripped). Misaligned probes can lead to tracee "
             "crashes!" +
             std::string{ hint_unsafe });
       } else {
         LOG(WARNING) << "Could not determine instruction boundary for "
                      << probe.name
-                     << " (binary appears stripped). Misaligned probes "
+                     << " (binary is possibly stripped). Misaligned probes "
                         "can lead to tracee crashes!";
         return probe.address;
       }


### PR DESCRIPTION
Attaching a uprobe to a stripped binary using an offset is inherently unsafe as the instruction boundaries cannot be guaranteed. If an attempt to do so is made in safe made, the user gets  "Could not resolve address".

This change replaces that vague error message with a more informative one that is consistent with similar "unsafe" errors.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [X] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [X] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [X] The new behaviour is covered by tests

Signed-off-by: Armando Anglesey [bobbintb@gmail.com](mailto:bobbintb@gmail.com)
