### PR TITLE
Remove automatic integer promotion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to
 - Root user check replaced with check for required capabilities
   (CAP_BPF, CAP_PERFMON, CAP_DAC_READ_SEARCH, CAP_DAC_OVERRIDE)
   - [#4773](https://github.com/bpftrace/bpftrace/pull/4773)
+- Remove automatic type promotion for integers, making them more flexible
+  - [#4768](https://github.com/bpftrace/bpftrace/pull/4768)
 #### Deprecated
 #### Removed
 - Drop support for LLVM 16

--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -2,6 +2,7 @@ add_library(ast_defs STATIC
   ast.cpp
   context.cpp
   helpers.cpp
+  integer_types.cpp
   location.cpp
 )
 add_dependencies(ast_defs parser)

--- a/src/ast/integer_types.cpp
+++ b/src/ast/integer_types.cpp
@@ -1,0 +1,55 @@
+#include <climits>
+#include <cstdint>
+#include <optional>
+
+#include "integer_types.h"
+
+namespace bpftrace::ast {
+
+SizedType get_integer_type(uint64_t n)
+{
+  // Make the smallest possible sizedType based on n
+  if (n <= std::numeric_limits<uint8_t>::max()) {
+    return CreateUInt8();
+  } else if (n <= std::numeric_limits<uint16_t>::max()) {
+    return CreateUInt16();
+  } else if (n <= std::numeric_limits<uint32_t>::max()) {
+    return CreateUInt32();
+  } else {
+    return CreateUInt64();
+  }
+}
+
+std::optional<SizedType> get_signed_integer_type(uint64_t n)
+{
+  if (n <= std::numeric_limits<int8_t>::max()) {
+    return CreateInt8();
+  } else if (n <= std::numeric_limits<int16_t>::max()) {
+    return CreateInt16();
+  } else if (n <= std::numeric_limits<int32_t>::max()) {
+    return CreateInt32();
+  } else if (n <= std::numeric_limits<int64_t>::max()) {
+    return CreateInt64();
+  } else {
+    return std::nullopt;
+  }
+}
+
+SizedType get_signed_integer_type(int64_t n)
+{
+  // Make the smallest possible sizedType based on n
+  if (std::numeric_limits<int8_t>::min() <= n &&
+      n <= std::numeric_limits<int8_t>::max()) {
+    return CreateInt8();
+  } else if (std::numeric_limits<int16_t>::min() <= n &&
+             n <= std::numeric_limits<int16_t>::max()) {
+    return CreateInt16();
+  } else if (std::numeric_limits<int32_t>::min() <= n &&
+             n <= std::numeric_limits<int32_t>::max()) {
+    return CreateInt32();
+  } else {
+    return CreateInt64();
+  }
+}
+
+} // namespace bpftrace::ast

--- a/src/ast/integer_types.h
+++ b/src/ast/integer_types.h
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <optional>
+
+#include "types.h"
+
+namespace bpftrace::ast {
+
+SizedType get_integer_type(uint64_t n);
+std::optional<SizedType> get_signed_integer_type(uint64_t n);
+SizedType get_signed_integer_type(int64_t n);
+
+} // namespace bpftrace::ast

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -791,7 +791,7 @@ Value *IRBuilderBPF::CreateMapLookupElem(const std::string &map_name,
   if (needMemcpy(type))
     CreateMemcpyBPF(value, call, type.GetSize());
   else {
-    CreateStore(CreateLoad(getPtrTy(), call), value);
+    CreateStore(CreateLoad(GetType(type), call), value);
   }
   CreateBr(lookup_merge_block);
 
@@ -1887,7 +1887,7 @@ CallInst *IRBuilderBPF::CreatePerCpuPtr(Value *var,
   //    A pointer pointing to the kernel percpu variable on
   //    cpu, or NULL, if cpu is invalid.
   FunctionType *percpuptr_func_type = FunctionType::get(
-      getPtrTy(), { getPtrTy(), getInt64Ty() }, false);
+      getPtrTy(), { getPtrTy(), getInt32Ty() }, false);
   return CreateHelperCall(BPF_FUNC_per_cpu_ptr,
                           percpuptr_func_type,
                           { var, cpu },

--- a/src/ast/passes/map_sugar.cpp
+++ b/src/ast/passes/map_sugar.cpp
@@ -158,7 +158,7 @@ void MapDefaultKey::visit(Statement &stmt)
   // Replace with a statement that has the default index, in the same way as
   // above. This will be type-checked during semantic analysis.
   if (auto *map = stmt.as<AssignScalarMapStatement>()) {
-    auto *index = ast_.make_node<Integer>(map->loc, 0);
+    auto *index = ast_.make_node<Integer>(map->loc, 0, CreateInt64());
     stmt.value = ast_.make_node<AssignMapStatement>(
         map->loc, map->map, index, map->expr);
   }

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -26,14 +26,15 @@ std::string Printer::type(const SizedType &ty)
 void Printer::visit(Integer &integer)
 {
   std::string indent(depth_, ' ');
-  out_ << indent << "int: " << integer.value << type(integer.integer_type)
+  out_ << indent << "int: " << integer.value << type(integer.type())
        << std::endl;
 }
 
 void Printer::visit(NegativeInteger &integer)
 {
   std::string indent(depth_, ' ');
-  out_ << indent << "negative int: " << integer.value << std::endl;
+  out_ << indent << "negative int: " << integer.value << type(integer.type())
+       << std::endl;
 }
 
 void Printer::visit(Boolean &boolean)

--- a/src/ast/passes/usdt_arguments.cpp
+++ b/src/ast/passes/usdt_arguments.cpp
@@ -26,8 +26,10 @@ public:
   }
   ast::AssignVarStatement *var_decl(size_t arg, Node &node)
   {
+    // The USDT arg function expects an long int type
     auto *int_arg = ast_.make_node<ast::Integer>(node.loc,
-                                                 static_cast<uint64_t>(arg));
+                                                 static_cast<uint64_t>(arg),
+                                                 CreateInt64());
     std::vector<Expression> args = { int_arg };
     Expression expr = ast_.make_node<ast::Call>(node.loc,
                                                 "usdt_arg",

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -643,7 +643,7 @@ integer:
                     YYERROR;
                   } else {
                     // Construct with the original string, which will be preserved.
-                    $$ = driver.ctx.make_node<ast::Integer>(@1, *res, false, std::move($1));
+                    $$ = driver.ctx.make_node<ast::Integer>(@1, *res, std::move($1));
                   }
                 }
                 ;

--- a/src/stdlib/strings.bt
+++ b/src/stdlib/strings.bt
@@ -98,7 +98,7 @@ macro strstr($haystack, $needle) {
     // Special case: the needle is empty.
     0
   } else {
-    __bpf_strnstr(&$haystack, &$needle, (uint64)$haystack_size, (uint64)$needle_size)
+    __bpf_strnstr(&$haystack, &$needle, $haystack_size, $needle_size)
   }
 }
 macro strstr($haystack, needle) {

--- a/src/types_format.cpp
+++ b/src/types_format.cpp
@@ -440,9 +440,14 @@ void sort_by_key(
           sort_by_key_type<int64_t>(values_by_key, field.offset);
         } else if (field.type.GetSize() == 4) {
           sort_by_key_type<int32_t>(values_by_key, field.offset);
+        } else if (field.type.GetSize() == 2) {
+          sort_by_key_type<int16_t>(values_by_key, field.offset);
+        } else if (field.type.GetSize() == 1) {
+          sort_by_key_type<int8_t>(values_by_key, field.offset);
         } else {
-          LOG(BUG) << "invalid integer argument size. 4 or 8  expected, but "
-                   << field.type.GetSize() << " provided";
+          LOG(BUG)
+              << "invalid integer argument size. 1, 2, 4, or 8 expected, but "
+              << field.type.GetSize() << " provided";
         }
       } else if (field.type.IsStringTy()) {
         std::ranges::stable_sort(values_by_key, [&](auto &a, auto &b) {
@@ -458,8 +463,12 @@ void sort_by_key(
       sort_by_key_type<int64_t>(values_by_key, 0);
     } else if (key.GetSize() == 4) {
       sort_by_key_type<int32_t>(values_by_key, 0);
+    } else if (key.GetSize() == 2) {
+      sort_by_key_type<int16_t>(values_by_key, 0);
+    } else if (key.GetSize() == 1) {
+      sort_by_key_type<int8_t>(values_by_key, 0);
     } else {
-      LOG(BUG) << "invalid integer argument size. 4 or 8  expected, but "
+      LOG(BUG) << "invalid integer argument size. 1, 2, 4, or 8 expected, but "
                << key.GetSize() << " provided";
     }
   } else if (key.IsStringTy()) {

--- a/tests/codegen/general.cpp
+++ b/tests/codegen/general.cpp
@@ -92,8 +92,8 @@ kprobe:f
   EXPECT_EQ(args[2].offset, 8);
 
   EXPECT_TRUE(args[3].type.IsIntTy());
-  EXPECT_EQ(args[3].type.GetSize(), 8U);
-  EXPECT_EQ(args[3].offset, 24);
+  EXPECT_EQ(args[3].type.GetSize(), 1U);
+  EXPECT_EQ(args[3].offset, 19);
 }
 
 } // namespace bpftrace::test::codegen

--- a/tests/codegen/llvm/argN_rawtracepoint.ll
+++ b/tests/codegen/llvm/argN_rawtracepoint.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !27
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !41
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !45
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @rawtracepoint_vmlinux_sched_switch_1(ptr %0) #0 section "s_rawtracepoint_vmlinux_sched_switch_1" !dbg !50 {
+define i64 @rawtracepoint_vmlinux_sched_switch_1(ptr %0) #0 section "s_rawtracepoint_vmlinux_sched_switch_1" !dbg !51 {
 entry:
-  %"@_val" = alloca i64, align 8
+  %"@_val" = alloca i8, align 1
   %"@_key" = alloca i64, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i64, ptr %1, i64 0
@@ -26,7 +26,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 %arg0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  store i64 1, ptr %"@_val", align 8
+  store i8 1, ptr %"@_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
@@ -46,8 +46,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!46}
-!llvm.module.flags = !{!48, !49}
+!llvm.dbg.cu = !{!47}
+!llvm.module.flags = !{!49, !50}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -74,34 +74,34 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
 !23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
 !24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
-!29 = !{!30, !35}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 27, lowerBound: 0)
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
-!38 = !{!39}
-!39 = !DISubrange(count: 262144, lowerBound: 0)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
-!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
-!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
-!47 = !{!0, !7, !26, !40, !44}
-!48 = !{i32 2, !"Debug Info Version", i32 3}
-!49 = !{i32 7, !"uwtable", i32 0}
-!50 = distinct !DISubprogram(name: "rawtracepoint_vmlinux_sched_switch_1", linkageName: "rawtracepoint_vmlinux_sched_switch_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
-!51 = !DISubroutineType(types: !52)
-!52 = !{!24, !53}
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !26, size: 64, offset: 192)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!27 = !DIGlobalVariableExpression(var: !28, expr: !DIExpression())
+!28 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
+!29 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !30)
+!30 = !{!31, !36}
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !32, size: 64)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !34)
+!34 = !{!35}
+!35 = !DISubrange(count: 27, lowerBound: 0)
+!36 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !37, size: 64, offset: 64)
+!37 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !38, size: 64)
+!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !39)
+!39 = !{!40}
+!40 = !DISubrange(count: 262144, lowerBound: 0)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !44, size: 64, elements: !15)
+!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
+!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
+!46 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!47 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !48)
+!48 = !{!0, !7, !27, !41, !45}
+!49 = !{i32 2, !"Debug Info Version", i32 3}
+!50 = !{i32 7, !"uwtable", i32 0}
+!51 = distinct !DISubprogram(name: "rawtracepoint_vmlinux_sched_switch_1", linkageName: "rawtracepoint_vmlinux_sched_switch_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !54)
+!52 = !DISubroutineType(types: !53)
+!53 = !{!24, !26}
 !54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)
+!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !26)

--- a/tests/codegen/llvm/args_rawtracepoint.ll
+++ b/tests/codegen/llvm/args_rawtracepoint.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !27
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !41
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !45
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !25
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !39
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @rawtracepoint_vmlinux_sched_switch_1(ptr %0) #0 section "s_rawtracepoint_vmlinux_sched_switch_1" !dbg !51 {
+define i64 @rawtracepoint_vmlinux_sched_switch_1(ptr %0) #0 section "s_rawtracepoint_vmlinux_sched_switch_1" !dbg !50 {
 entry:
-  %"@_val" = alloca i64, align 8
+  %"@_val" = alloca i8, align 1
   %"@_key" = alloca i1, align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i64, ptr %1, i64 0
@@ -27,7 +27,7 @@ entry:
   %3 = zext i1 %preempt to i8
   store i8 %3, ptr %"@_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  store i64 1, ptr %"@_val", align 8
+  store i8 1, ptr %"@_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
@@ -47,8 +47,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!47}
-!llvm.module.flags = !{!49, !50}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48, !49}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -74,35 +74,34 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
 !23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !25, size: 64, offset: 192)
-!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
-!26 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!27 = !DIGlobalVariableExpression(var: !28, expr: !DIExpression())
-!28 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
-!29 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !30)
-!30 = !{!31, !36}
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !32, size: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 27, lowerBound: 0)
-!36 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !37, size: 64, offset: 64)
-!37 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !38, size: 64)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !39)
-!39 = !{!40}
-!40 = !DISubrange(count: 262144, lowerBound: 0)
-!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
-!42 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !44, size: 64, elements: !15)
-!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !26, size: 64, elements: !15)
-!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
-!46 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
-!47 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !48)
-!48 = !{!0, !7, !27, !41, !45}
-!49 = !{i32 2, !"Debug Info Version", i32 3}
-!50 = !{i32 7, !"uwtable", i32 0}
-!51 = distinct !DISubprogram(name: "rawtracepoint_vmlinux_sched_switch_1", linkageName: "rawtracepoint_vmlinux_sched_switch_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !54)
-!52 = !DISubroutineType(types: !53)
-!53 = !{!26, !23}
-!54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !23)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
+!28 = !{!29, !34}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !30, size: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 27, lowerBound: 0)
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !35, size: 64, offset: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 262144, lowerBound: 0)
+!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
+!40 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 64, elements: !15)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
+!43 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
+!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !7, !25, !39, !44}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = !{i32 7, !"uwtable", i32 0}
+!50 = distinct !DISubprogram(name: "rawtracepoint_vmlinux_sched_switch_1", linkageName: "rawtracepoint_vmlinux_sched_switch_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
+!51 = !DISubroutineType(types: !52)
+!52 = !{!43, !23}
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !23)

--- a/tests/codegen/llvm/args_tracepoint.ll
+++ b/tests/codegen/llvm/args_tracepoint.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !27
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !41
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !45
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @tracepoint_sched_sched_one_1(ptr %0) #0 section "s_tracepoint_sched_sched_one_1" !dbg !50 {
+define i64 @tracepoint_sched_sched_one_1(ptr %0) #0 section "s_tracepoint_sched_sched_one_1" !dbg !51 {
 entry:
-  %"@_val" = alloca i64, align 8
+  %"@_val" = alloca i8, align 1
   %"@_key" = alloca i64, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 8
@@ -26,7 +26,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 %3, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  store i64 1, ptr %"@_val", align 8
+  store i8 1, ptr %"@_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
@@ -46,8 +46,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!46}
-!llvm.module.flags = !{!48, !49}
+!llvm.dbg.cu = !{!47}
+!llvm.module.flags = !{!49, !50}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -74,34 +74,34 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
 !23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
 !24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
-!29 = !{!30, !35}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 27, lowerBound: 0)
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
-!38 = !{!39}
-!39 = !DISubrange(count: 262144, lowerBound: 0)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
-!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
-!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
-!47 = !{!0, !7, !26, !40, !44}
-!48 = !{i32 2, !"Debug Info Version", i32 3}
-!49 = !{i32 7, !"uwtable", i32 0}
-!50 = distinct !DISubprogram(name: "tracepoint_sched_sched_one_1", linkageName: "tracepoint_sched_sched_one_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
-!51 = !DISubroutineType(types: !52)
-!52 = !{!24, !53}
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !26, size: 64, offset: 192)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!27 = !DIGlobalVariableExpression(var: !28, expr: !DIExpression())
+!28 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
+!29 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !30)
+!30 = !{!31, !36}
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !32, size: 64)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !34)
+!34 = !{!35}
+!35 = !DISubrange(count: 27, lowerBound: 0)
+!36 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !37, size: 64, offset: 64)
+!37 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !38, size: 64)
+!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !39)
+!39 = !{!40}
+!40 = !DISubrange(count: 262144, lowerBound: 0)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !44, size: 64, elements: !15)
+!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
+!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
+!46 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!47 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !48)
+!48 = !{!0, !7, !27, !41, !45}
+!49 = !{i32 2, !"Debug Info Version", i32 3}
+!50 = !{i32 7, !"uwtable", i32 0}
+!51 = distinct !DISubprogram(name: "tracepoint_sched_sched_one_1", linkageName: "tracepoint_sched_sched_one_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !54)
+!52 = !DISubroutineType(types: !53)
+!53 = !{!24, !26}
 !54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)
+!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !26)

--- a/tests/codegen/llvm/avg_cast.ll
+++ b/tests/codegen/llvm/avg_cast.ll
@@ -86,63 +86,42 @@ while_body:                                       ; preds = %while_cond
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %ret)
-  %14 = load i64, ptr %val_1, align 8
-  %is_negative_cond = icmp slt i64 %14, 0
-  br i1 %is_negative_cond, label %is_negative, label %is_positive
+  %14 = load i64, ptr %val_2, align 8
+  %15 = load i64, ptr %val_1, align 8
+  %16 = udiv i64 %15, %14
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
+  store i64 %16, ptr %"$res", align 8
+  ret i64 0
 
 lookup_success2:                                  ; preds = %while_body
-  %15 = getelementptr %avg_stas_val, ptr %lookup_percpu_elem, i64 0, i32 0
-  %16 = load i64, ptr %15, align 8
-  %17 = getelementptr %avg_stas_val, ptr %lookup_percpu_elem, i64 0, i32 1
+  %17 = getelementptr %avg_stas_val, ptr %lookup_percpu_elem, i64 0, i32 0
   %18 = load i64, ptr %17, align 8
-  %19 = load i64, ptr %val_1, align 8
-  %20 = add i64 %16, %19
-  store i64 %20, ptr %val_1, align 8
-  %21 = load i64, ptr %val_2, align 8
+  %19 = getelementptr %avg_stas_val, ptr %lookup_percpu_elem, i64 0, i32 1
+  %20 = load i64, ptr %19, align 8
+  %21 = load i64, ptr %val_1, align 8
   %22 = add i64 %18, %21
-  store i64 %22, ptr %val_2, align 8
-  %23 = load i32, ptr %i, align 4
-  %24 = add i32 %23, 1
-  store i32 %24, ptr %i, align 4
+  store i64 %22, ptr %val_1, align 8
+  %23 = load i64, ptr %val_2, align 8
+  %24 = add i64 %20, %23
+  store i64 %24, ptr %val_2, align 8
+  %25 = load i32, ptr %i, align 4
+  %26 = add i32 %25, 1
+  store i32 %26, ptr %i, align 4
   br label %while_cond
 
 lookup_failure3:                                  ; preds = %while_body
-  %25 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %25, 0
+  %27 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %27, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 error_success:                                    ; preds = %lookup_failure3
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure3
-  %26 = load i32, ptr %i, align 4
+  %28 = load i32, ptr %i, align 4
   br label %while_end
-
-is_negative:                                      ; preds = %while_end
-  %27 = load i64, ptr %val_1, align 8
-  %28 = xor i64 %27, -1
-  %29 = add i64 %28, 1
-  %30 = load i64, ptr %val_2, align 8
-  %31 = udiv i64 %29, %30
-  %32 = sub i64 0, %31
-  store i64 %32, ptr %ret, align 8
-  br label %is_negative_merge_block
-
-is_positive:                                      ; preds = %while_end
-  %33 = load i64, ptr %val_2, align 8
-  %34 = load i64, ptr %val_1, align 8
-  %35 = udiv i64 %34, %33
-  store i64 %35, ptr %ret, align 8
-  br label %is_negative_merge_block
-
-is_negative_merge_block:                          ; preds = %is_positive, %is_negative
-  %36 = load i64, ptr %ret, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %ret)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
-  store i64 %36, ptr %"$res", align 8
-  ret i64 0
 }
 
 ; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)

--- a/tests/codegen/llvm/avg_cast_loop.ll
+++ b/tests/codegen/llvm/avg_cast_loop.ll
@@ -6,7 +6,7 @@ target triple = "bpf"
 %"struct map_internal_repr_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.163" = type { ptr, ptr }
 %avg_stas_val = type { i64, i64 }
-%int64_avg_t__tuple_t = type { i64, i64 }
+%uint8_uavg_t__tuple_t = type { i8, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
@@ -22,9 +22,9 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !60 {
 entry:
   %avg_struct = alloca %avg_stas_val, align 8
-  %"@x_key" = alloca i64, align 8
+  %"@x_key" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
-  store i64 1, ptr %"@x_key", align 8
+  store i8 1, ptr %"@x_key", align 1
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
   %lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %lookup_cond, label %lookup_success, label %lookup_failure
@@ -65,17 +65,17 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 ; Function Attrs: nounwind
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !66 {
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !65 {
 for_body:
   %"$res" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$res")
   store i64 0, ptr %"$res", align 8
-  %"$kv" = alloca %int64_avg_t__tuple_t, align 8
+  %"$kv" = alloca %uint8_uavg_t__tuple_t, align 8
   %ret = alloca i64, align 8
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
-  %key = load i64, ptr %1, align 8
+  %key = load i8, ptr %1, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
@@ -99,72 +99,51 @@ while_body:                                       ; preds = %while_cond
 while_end:                                        ; preds = %error_failure, %error_success, %while_cond
   call void @llvm.lifetime.end.p0(i64 -1, ptr %i)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %ret)
-  %7 = load i64, ptr %val_1, align 8
-  %is_negative_cond = icmp slt i64 %7, 0
-  br i1 %is_negative_cond, label %is_negative, label %is_positive
+  %7 = load i64, ptr %val_2, align 8
+  %8 = load i64, ptr %val_1, align 8
+  %9 = udiv i64 %8, %7
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
+  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
+  %10 = getelementptr %uint8_uavg_t__tuple_t, ptr %"$kv", i32 0, i32 0
+  store i8 %key, ptr %10, align 1
+  %11 = getelementptr %uint8_uavg_t__tuple_t, ptr %"$kv", i32 0, i32 1
+  store i64 %9, ptr %11, align 8
+  %12 = getelementptr %uint8_uavg_t__tuple_t, ptr %"$kv", i32 0, i32 1
+  %13 = load i64, ptr %12, align 8
+  store i64 %13, ptr %"$res", align 8
+  br label %for_continue
 
 lookup_success:                                   ; preds = %while_body
-  %8 = getelementptr %avg_stas_val, ptr %lookup_percpu_elem, i64 0, i32 0
-  %9 = load i64, ptr %8, align 8
-  %10 = getelementptr %avg_stas_val, ptr %lookup_percpu_elem, i64 0, i32 1
-  %11 = load i64, ptr %10, align 8
-  %12 = load i64, ptr %val_1, align 8
-  %13 = add i64 %9, %12
-  store i64 %13, ptr %val_1, align 8
-  %14 = load i64, ptr %val_2, align 8
-  %15 = add i64 %11, %14
-  store i64 %15, ptr %val_2, align 8
-  %16 = load i32, ptr %i, align 4
-  %17 = add i32 %16, 1
-  store i32 %17, ptr %i, align 4
+  %14 = getelementptr %avg_stas_val, ptr %lookup_percpu_elem, i64 0, i32 0
+  %15 = load i64, ptr %14, align 8
+  %16 = getelementptr %avg_stas_val, ptr %lookup_percpu_elem, i64 0, i32 1
+  %17 = load i64, ptr %16, align 8
+  %18 = load i64, ptr %val_1, align 8
+  %19 = add i64 %15, %18
+  store i64 %19, ptr %val_1, align 8
+  %20 = load i64, ptr %val_2, align 8
+  %21 = add i64 %17, %20
+  store i64 %21, ptr %val_2, align 8
+  %22 = load i32, ptr %i, align 4
+  %23 = add i32 %22, 1
+  store i32 %23, ptr %i, align 4
   br label %while_cond
 
 lookup_failure:                                   ; preds = %while_body
-  %18 = load i32, ptr %i, align 4
-  %error_lookup_cond = icmp eq i32 %18, 0
+  %24 = load i32, ptr %i, align 4
+  %error_lookup_cond = icmp eq i32 %24, 0
   br i1 %error_lookup_cond, label %error_success, label %error_failure
 
 error_success:                                    ; preds = %lookup_failure
   br label %while_end
 
 error_failure:                                    ; preds = %lookup_failure
-  %19 = load i32, ptr %i, align 4
+  %25 = load i32, ptr %i, align 4
   br label %while_end
 
-is_negative:                                      ; preds = %while_end
-  %20 = load i64, ptr %val_1, align 8
-  %21 = xor i64 %20, -1
-  %22 = add i64 %21, 1
-  %23 = load i64, ptr %val_2, align 8
-  %24 = udiv i64 %22, %23
-  %25 = sub i64 0, %24
-  store i64 %25, ptr %ret, align 8
-  br label %is_negative_merge_block
-
-is_positive:                                      ; preds = %while_end
-  %26 = load i64, ptr %val_2, align 8
-  %27 = load i64, ptr %val_1, align 8
-  %28 = udiv i64 %27, %26
-  store i64 %28, ptr %ret, align 8
-  br label %is_negative_merge_block
-
-is_negative_merge_block:                          ; preds = %is_positive, %is_negative
-  %29 = load i64, ptr %ret, align 8
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %ret)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %30 = getelementptr %int64_avg_t__tuple_t, ptr %"$kv", i32 0, i32 0
-  store i64 %key, ptr %30, align 8
-  %31 = getelementptr %int64_avg_t__tuple_t, ptr %"$kv", i32 0, i32 1
-  store i64 %29, ptr %31, align 8
-  %32 = getelementptr %int64_avg_t__tuple_t, ptr %"$kv", i32 0, i32 1
-  %33 = load i64, ptr %32, align 8
-  store i64 %33, ptr %"$res", align 8
-  br label %for_continue
-
-for_continue:                                     ; preds = %is_negative_merge_block
+for_continue:                                     ; preds = %while_end
   ret i64 0
 }
 
@@ -188,7 +167,7 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 160, elements: !15)
@@ -201,13 +180,13 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !20 = !{!21}
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !26, size: 64, offset: 192)
-!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
-!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
-!28 = !{!29, !30}
-!29 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !24, size: 64)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !25, size: 64, offset: 192)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
+!27 = !{!28, !30}
+!28 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !30 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !31, size: 64, offset: 64)
 !31 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !32 = !DIGlobalVariableExpression(var: !33, expr: !DIExpression())
@@ -225,30 +204,29 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !44 = !{!45}
 !45 = !DISubrange(count: 262144, lowerBound: 0)
 !46 = !DIGlobalVariableExpression(var: !47, expr: !DIExpression())
-!47 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!47 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
 !48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
 !49 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !50, isLocal: false, isDefinition: true)
 !50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !51, size: 64, elements: !52)
-!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !52)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !29, size: 64, elements: !52)
 !52 = !{!53}
 !53 = !DISubrange(count: 1, lowerBound: 0)
 !54 = !DIGlobalVariableExpression(var: !55, expr: !DIExpression())
-!55 = distinct !DIGlobalVariable(name: "__bt__num_cpus", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!55 = distinct !DIGlobalVariable(name: "__bt__num_cpus", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
 !56 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !57)
 !57 = !{!0, !7, !32, !46, !48, !54}
 !58 = !{i32 2, !"Debug Info Version", i32 3}
 !59 = !{i32 7, !"uwtable", i32 0}
-!60 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !61, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !56, retainedNodes: !64)
+!60 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !61, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !56, retainedNodes: !63)
 !61 = !DISubroutineType(types: !62)
-!62 = !{!24, !63}
-!63 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!64 = !{!65}
-!65 = !DILocalVariable(name: "ctx", arg: 1, scope: !60, file: !2, type: !63)
-!66 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !67, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !56, retainedNodes: !69)
-!67 = !DISubroutineType(types: !68)
-!68 = !{!24, !63, !63, !63, !63}
-!69 = !{!70, !71, !72, !73}
-!70 = !DILocalVariable(name: "map", arg: 1, scope: !66, file: !2, type: !63)
-!71 = !DILocalVariable(name: "key", arg: 2, scope: !66, file: !2, type: !63)
-!72 = !DILocalVariable(name: "value", arg: 3, scope: !66, file: !2, type: !63)
-!73 = !DILocalVariable(name: "ctx", arg: 4, scope: !66, file: !2, type: !63)
+!62 = !{!29, !23}
+!63 = !{!64}
+!64 = !DILocalVariable(name: "ctx", arg: 1, scope: !60, file: !2, type: !23)
+!65 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !66, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !56, retainedNodes: !68)
+!66 = !DISubroutineType(types: !67)
+!67 = !{!29, !23, !23, !23, !23}
+!68 = !{!69, !70, !71, !72}
+!69 = !DILocalVariable(name: "map", arg: 1, scope: !65, file: !2, type: !23)
+!70 = !DILocalVariable(name: "key", arg: 2, scope: !65, file: !2, type: !23)
+!71 = !DILocalVariable(name: "value", arg: 3, scope: !65, file: !2, type: !23)
+!72 = !DILocalVariable(name: "ctx", arg: 4, scope: !65, file: !2, type: !23)

--- a/tests/codegen/llvm/basic_while_loop.ll
+++ b/tests/codegen/llvm/basic_while_loop.ll
@@ -28,7 +28,7 @@ entry:
 
 while_cond:                                       ; preds = %while_body, %entry
   %1 = load i64, ptr %"$a", align 8
-  %2 = icmp sle i64 %1, 150
+  %2 = icmp ule i64 %1, 150
   %true_cond = icmp ne i1 %2, false
   br i1 %true_cond, label %while_body, label %while_end, !llvm.loop !52
 

--- a/tests/codegen/llvm/binop_int_promotion.ll
+++ b/tests/codegen/llvm/binop_int_promotion.ll
@@ -16,13 +16,13 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kretprobe_f_1(ptr %0) #0 section "s_kretprobe_f_1" !dbg !35 {
 entry:
-  %"$x" = alloca i32, align 4
+  %"$x" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
-  store i32 0, ptr %"$x", align 4
-  store i32 5, ptr %"$x", align 4
-  %1 = load i32, ptr %"$x", align 4
-  %2 = add i32 %1, 1
-  store i32 %2, ptr %"$x", align 4
+  store i64 0, ptr %"$x", align 8
+  store i64 5, ptr %"$x", align 8
+  %1 = load i64, ptr %"$x", align 8
+  %2 = add i64 %1, 1
+  store i64 %2, ptr %"$x", align 8
   ret i64 0
 }
 

--- a/tests/codegen/llvm/bitshift_left.ll
+++ b/tests/codegen/llvm/bitshift_left.ll
@@ -8,22 +8,22 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i16, align 2
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 1024, ptr %"@x_val", align 8
+  store i16 1024, ptr %"@x_val", align 2
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -39,8 +39,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!44}
+!llvm.module.flags = !{!46, !47}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -63,34 +63,36 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int16", size: 16, encoding: DW_ATE_signed)
+!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
+!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
+!27 = !{!28, !33}
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
+!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
+!31 = !{!32}
+!32 = !DISubrange(count: 27, lowerBound: 0)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 262144, lowerBound: 0)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
+!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
+!45 = !{!0, !7, !24, !38, !42}
+!46 = !{i32 2, !"Debug Info Version", i32 3}
+!47 = !{i32 7, !"uwtable", i32 0}
+!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
+!49 = !DISubroutineType(types: !50)
+!50 = !{!20, !51}
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!52 = !{!53}
+!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)

--- a/tests/codegen/llvm/bitshift_right.ll
+++ b/tests/codegen/llvm/bitshift_right.ll
@@ -8,22 +8,22 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !37
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !47 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 2, ptr %"@x_val", align 8
+  store i8 2, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -39,8 +39,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!43}
+!llvm.module.flags = !{!45, !46}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -63,34 +63,34 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 64, elements: !15)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!43 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !44)
+!44 = !{!0, !7, !23, !37, !41}
+!45 = !{i32 2, !"Debug Info Version", i32 3}
+!46 = !{i32 7, !"uwtable", i32 0}
+!47 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !50)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!20, !22}
 !50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !47, file: !2, type: !22)

--- a/tests/codegen/llvm/block_expression.ll
+++ b/tests/codegen/llvm/block_expression.ll
@@ -16,15 +16,15 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
-  %"$a" = alloca i64, align 8
+  %"$a" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$a")
-  store i64 0, ptr %"$a", align 8
-  %"$b" = alloca i64, align 8
+  store i8 0, ptr %"$a", align 1
+  %"$b" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$b")
-  store i64 0, ptr %"$b", align 8
-  store i64 4, ptr %"$b", align 8
-  %1 = load i64, ptr %"$b", align 8
-  store i64 %1, ptr %"$a", align 8
+  store i8 0, ptr %"$b", align 1
+  store i8 4, ptr %"$b", align 1
+  %1 = load i8, ptr %"$b", align 1
+  store i8 %1, ptr %"$a", align 1
   ret i64 0
 }
 

--- a/tests/codegen/llvm/builtin_cpid.ll
+++ b/tests/codegen/llvm/builtin_cpid.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
 entry:
-  %"@_val" = alloca i64, align 8
+  %"@_val" = alloca i32, align 4
   %"@_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
@@ -39,8 +39,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!44}
+!llvm.module.flags = !{!46, !47}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -63,34 +63,36 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
+!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
+!27 = !{!28, !33}
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
+!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
+!31 = !{!32}
+!32 = !DISubrange(count: 27, lowerBound: 0)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 262144, lowerBound: 0)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
+!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
+!45 = !{!0, !7, !24, !38, !42}
+!46 = !{i32 2, !"Debug Info Version", i32 3}
+!47 = !{i32 7, !"uwtable", i32 0}
+!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
+!49 = !DISubroutineType(types: !50)
+!50 = !{!20, !51}
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!52 = !{!53}
+!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)

--- a/tests/codegen/llvm/builtin_ctx_field.ll
+++ b/tests/codegen/llvm/builtin_ctx_field.ll
@@ -14,27 +14,27 @@ target triple = "bpf"
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_a = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
 @AT_b = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@AT_c = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !24
-@AT_d = dso_local global %"struct map_internal_repr_t.165" zeroinitializer, section ".maps", !dbg !26
-@AT_e = dso_local global %"struct map_internal_repr_t.166" zeroinitializer, section ".maps", !dbg !28
-@ringbuf = dso_local global %"struct map_internal_repr_t.167" zeroinitializer, section ".maps", !dbg !37
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !51
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !55
+@AT_c = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !29
+@AT_d = dso_local global %"struct map_internal_repr_t.165" zeroinitializer, section ".maps", !dbg !35
+@AT_e = dso_local global %"struct map_internal_repr_t.166" zeroinitializer, section ".maps", !dbg !37
+@ringbuf = dso_local global %"struct map_internal_repr_t.167" zeroinitializer, section ".maps", !dbg !46
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !60
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !64
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !61 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !70 {
 entry:
   %"@e_key" = alloca i64, align 8
   %"struct x.e" = alloca [5 x i8], align 1
-  %"@d_val" = alloca i64, align 8
+  %"@d_val" = alloca i8, align 1
   %"@d_key" = alloca i64, align 8
   %"struct c.c" = alloca i8, align 1
-  %"@c_val" = alloca i64, align 8
+  %"@c_val" = alloca i8, align 1
   %"@c_key" = alloca i64, align 8
-  %"@b_val" = alloca i64, align 8
+  %"@b_val" = alloca i16, align 2
   %"@b_key" = alloca i64, align 8
   %runtime_error_t = alloca %runtime_error_t, align 8
   %"@a_val" = alloca i64, align 8
@@ -80,48 +80,45 @@ oob_merge:                                        ; preds = %counter_merge, %ent
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@b_key")
   store i64 0, ptr %"@b_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@b_val")
-  %16 = sext i16 %15 to i64
-  store i64 %16, ptr %"@b_val", align 8
+  store i16 %15, ptr %"@b_val", align 2
   %update_elem1 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_b, ptr %"@b_key", ptr %"@b_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@b_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@b_key")
-  %17 = load ptr, ptr %"$x", align 8
-  %18 = call ptr @llvm.preserve.static.offset(ptr %17)
-  %19 = getelementptr i8, ptr %18, i64 16
-  %20 = call ptr @llvm.preserve.static.offset(ptr %19)
-  %21 = getelementptr i8, ptr %20, i64 0
-  %22 = load volatile i8, ptr %21, align 1
+  %16 = load ptr, ptr %"$x", align 8
+  %17 = call ptr @llvm.preserve.static.offset(ptr %16)
+  %18 = getelementptr i8, ptr %17, i64 16
+  %19 = call ptr @llvm.preserve.static.offset(ptr %18)
+  %20 = getelementptr i8, ptr %19, i64 0
+  %21 = load volatile i8, ptr %20, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@c_key")
   store i64 0, ptr %"@c_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@c_val")
-  %23 = sext i8 %22 to i64
-  store i64 %23, ptr %"@c_val", align 8
+  store i8 %21, ptr %"@c_val", align 1
   %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_c, ptr %"@c_key", ptr %"@c_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@c_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@c_key")
-  %24 = load ptr, ptr %"$x", align 8
-  %25 = call ptr @llvm.preserve.static.offset(ptr %24)
-  %26 = getelementptr i8, ptr %25, i64 24
-  %27 = load volatile ptr, ptr %26, align 8
-  %28 = call ptr @llvm.preserve.static.offset(ptr %27)
-  %29 = getelementptr i8, ptr %28, i64 0
+  %22 = load ptr, ptr %"$x", align 8
+  %23 = call ptr @llvm.preserve.static.offset(ptr %22)
+  %24 = getelementptr i8, ptr %23, i64 24
+  %25 = load volatile ptr, ptr %24, align 8
+  %26 = call ptr @llvm.preserve.static.offset(ptr %25)
+  %27 = getelementptr i8, ptr %26, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct c.c")
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct c.c", i32 1, ptr %29)
-  %30 = load i8, ptr %"struct c.c", align 1
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"struct c.c", i32 1, ptr %27)
+  %28 = load i8, ptr %"struct c.c", align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct c.c")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@d_key")
   store i64 0, ptr %"@d_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@d_val")
-  %31 = sext i8 %30 to i64
-  store i64 %31, ptr %"@d_val", align 8
+  store i8 %28, ptr %"@d_val", align 1
   %update_elem3 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_d, ptr %"@d_key", ptr %"@d_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@d_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@d_key")
-  %32 = load ptr, ptr %"$x", align 8
-  %33 = call ptr @llvm.preserve.static.offset(ptr %32)
-  %34 = getelementptr i8, ptr %33, i64 32
+  %29 = load ptr, ptr %"$x", align 8
+  %30 = call ptr @llvm.preserve.static.offset(ptr %29)
+  %31 = getelementptr i8, ptr %30, i64 32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"struct x.e")
-  %probe_read_kernel4 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct x.e", i32 5, ptr %34)
+  %probe_read_kernel4 = call i64 inttoptr (i64 113 to ptr)(ptr %"struct x.e", i32 5, ptr %31)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@e_key")
   store i64 0, ptr %"@e_key", align 8
   %update_elem5 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_e, ptr %"@e_key", ptr %"struct x.e", i64 0)
@@ -131,12 +128,12 @@ oob_merge:                                        ; preds = %counter_merge, %ent
 
 event_loss_counter:                               ; preds = %is_oob
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
-  %35 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %35
-  %36 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
-  %37 = load i64, ptr %36, align 8
-  %38 = add i64 %37, 1
-  store i64 %38, ptr %36, align 8
+  %32 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %32
+  %33 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %34 = load i64, ptr %33, align 8
+  %35 = add i64 %34, 1
+  store i64 %35, ptr %33, align 8
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %is_oob
@@ -158,8 +155,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #3 = { memory(none) }
 
-!llvm.dbg.cu = !{!57}
-!llvm.module.flags = !{!59, !60}
+!llvm.dbg.cu = !{!66}
+!llvm.module.flags = !{!68, !69}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -184,47 +181,55 @@ attributes #3 = { memory(none) }
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
 !22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "AT_b", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
-!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
-!25 = distinct !DIGlobalVariable(name: "AT_c", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "AT_d", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
-!28 = !DIGlobalVariableExpression(var: !29, expr: !DIExpression())
-!29 = distinct !DIGlobalVariable(name: "AT_e", linkageName: "global", scope: !2, file: !2, type: !30, isLocal: false, isDefinition: true)
-!30 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !31)
-!31 = !{!11, !17, !18, !32}
-!32 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !33, size: 64, offset: 192)
-!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
-!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 40, elements: !35)
-!35 = !{!36}
-!36 = !DISubrange(count: 5, lowerBound: 0)
+!23 = distinct !DIGlobalVariable(name: "AT_b", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !25)
+!25 = !{!11, !17, !18, !26}
+!26 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !27, size: 64, offset: 192)
+!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
+!28 = !DIBasicType(name: "int16", size: 16, encoding: DW_ATE_signed)
+!29 = !DIGlobalVariableExpression(var: !30, expr: !DIExpression())
+!30 = distinct !DIGlobalVariable(name: "AT_c", linkageName: "global", scope: !2, file: !2, type: !31, isLocal: false, isDefinition: true)
+!31 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !32)
+!32 = !{!11, !17, !18, !33}
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!35 = !DIGlobalVariableExpression(var: !36, expr: !DIExpression())
+!36 = distinct !DIGlobalVariable(name: "AT_d", linkageName: "global", scope: !2, file: !2, type: !31, isLocal: false, isDefinition: true)
 !37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
-!38 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
-!39 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !40)
-!40 = !{!41, !46}
-!41 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !42, size: 64)
+!38 = distinct !DIGlobalVariable(name: "AT_e", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !40)
+!40 = !{!11, !17, !18, !41}
+!41 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !42, size: 64, offset: 192)
 !42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !44)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 40, elements: !44)
 !44 = !{!45}
-!45 = !DISubrange(count: 27, lowerBound: 0)
-!46 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !47, size: 64, offset: 64)
-!47 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!48 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !49)
-!49 = !{!50}
-!50 = !DISubrange(count: 262144, lowerBound: 0)
-!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
-!52 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !53, isLocal: false, isDefinition: true)
-!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !54, size: 64, elements: !15)
-!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!55 = !DIGlobalVariableExpression(var: !56, expr: !DIExpression())
-!56 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!57 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !58)
-!58 = !{!0, !7, !22, !24, !26, !28, !37, !51, !55}
-!59 = !{i32 2, !"Debug Info Version", i32 3}
-!60 = !{i32 7, !"uwtable", i32 0}
-!61 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !62, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !57, retainedNodes: !65)
-!62 = !DISubroutineType(types: !63)
-!63 = !{!20, !64}
-!64 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!65 = !{!66}
-!66 = !DILocalVariable(name: "ctx", arg: 1, scope: !61, file: !2, type: !64)
+!45 = !DISubrange(count: 5, lowerBound: 0)
+!46 = !DIGlobalVariableExpression(var: !47, expr: !DIExpression())
+!47 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !48, isLocal: false, isDefinition: true)
+!48 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !49)
+!49 = !{!50, !55}
+!50 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !51, size: 64)
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !52, size: 64)
+!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !53)
+!53 = !{!54}
+!54 = !DISubrange(count: 27, lowerBound: 0)
+!55 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !56, size: 64, offset: 64)
+!56 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !57, size: 64)
+!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !58)
+!58 = !{!59}
+!59 = !DISubrange(count: 262144, lowerBound: 0)
+!60 = !DIGlobalVariableExpression(var: !61, expr: !DIExpression())
+!61 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !62, isLocal: false, isDefinition: true)
+!62 = !DICompositeType(tag: DW_TAG_array_type, baseType: !63, size: 64, elements: !15)
+!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!64 = !DIGlobalVariableExpression(var: !65, expr: !DIExpression())
+!65 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!66 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !67)
+!67 = !{!0, !7, !22, !29, !35, !37, !46, !60, !64}
+!68 = !{i32 2, !"Debug Info Version", i32 3}
+!69 = !{i32 7, !"uwtable", i32 0}
+!70 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !71, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !66, retainedNodes: !73)
+!71 = !DISubroutineType(types: !72)
+!72 = !{!20, !34}
+!73 = !{!74}
+!74 = !DILocalVariable(name: "ctx", arg: 1, scope: !70, file: !2, type: !34)

--- a/tests/codegen/llvm/builtin_elapsed.ll
+++ b/tests/codegen/llvm/builtin_elapsed.ll
@@ -32,8 +32,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load ptr, ptr %lookup_elem, align 8
-  store ptr %1, ptr %lookup_elem_val, align 8
+  %1 = load i64, ptr %lookup_elem, align 8
+  store i64 %1, ptr %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry

--- a/tests/codegen/llvm/builtin_pid_tid.ll
+++ b/tests/codegen/llvm/builtin_pid_tid.ll
@@ -9,20 +9,20 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !24
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
+@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !26
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
 entry:
-  %"@y_val" = alloca i64, align 8
+  %"@y_val" = alloca i32, align 4
   %"@y_key" = alloca i64, align 8
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i32, align 4
   %"@x_key" = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
@@ -30,8 +30,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %2 = zext i32 %pid to i64
-  store i64 %2, ptr %"@x_val", align 8
+  store i32 %pid, ptr %"@x_val", align 4
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -40,8 +39,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
-  %3 = zext i32 %tid to i64
-  store i64 %3, ptr %"@y_val", align 8
+  store i32 %tid, ptr %"@y_val", align 4
   %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
@@ -58,8 +56,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { memory(none) }
 
-!llvm.dbg.cu = !{!44}
-!llvm.module.flags = !{!46, !47}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48, !49}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -82,36 +80,38 @@ attributes #2 = { memory(none) }
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
-!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
-!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
-!27 = !{!28, !33}
-!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
-!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
-!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
-!31 = !{!32}
-!32 = !DISubrange(count: 27, lowerBound: 0)
-!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
-!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
-!36 = !{!37}
-!37 = !DISubrange(count: 262144, lowerBound: 0)
-!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
-!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
-!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
-!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
-!45 = !{!0, !7, !22, !24, !38, !42}
-!46 = !{i32 2, !"Debug Info Version", i32 3}
-!47 = !{i32 7, !"uwtable", i32 0}
-!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
-!49 = !DISubroutineType(types: !50)
-!50 = !{!20, !51}
-!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!52 = !{!53}
-!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)
+!25 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
+!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !7, !24, !26, !40, !44}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = !{i32 7, !"uwtable", i32 0}
+!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
+!51 = !DISubroutineType(types: !52)
+!52 = !{!20, !53}
+!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!54 = !{!55}
+!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)

--- a/tests/codegen/llvm/builtin_pid_tid_namespace.ll
+++ b/tests/codegen/llvm/builtin_pid_tid_namespace.ll
@@ -10,21 +10,21 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !24
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
+@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !26
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
 entry:
-  %"@y_val" = alloca i64, align 8
+  %"@y_val" = alloca i32, align 4
   %"@y_key" = alloca i64, align 8
   %bpf_pidns_info1 = alloca %bpf_pidns_info, align 8
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i32, align 4
   %"@x_key" = alloca i64, align 8
   %bpf_pidns_info = alloca %bpf_pidns_info, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %bpf_pidns_info)
@@ -35,21 +35,19 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %3 = zext i32 %2 to i64
-  store i64 %3, ptr %"@x_val", align 8
+  store i32 %2, ptr %"@x_val", align 4
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %bpf_pidns_info1)
   %get_ns_pid_tgid2 = call i64 inttoptr (i64 120 to ptr)(i64 0, i64 4026531857, ptr %bpf_pidns_info1, i32 8)
-  %4 = getelementptr %bpf_pidns_info, ptr %bpf_pidns_info1, i32 0, i32 1
-  %5 = load i32, ptr %4, align 4
+  %3 = getelementptr %bpf_pidns_info, ptr %bpf_pidns_info1, i32 0, i32 1
+  %4 = load i32, ptr %3, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %bpf_pidns_info1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
-  %6 = zext i32 %5 to i64
-  store i64 %6, ptr %"@y_val", align 8
+  store i32 %4, ptr %"@y_val", align 4
   %update_elem3 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
@@ -65,8 +63,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!44}
-!llvm.module.flags = !{!46, !47}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48, !49}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -89,36 +87,38 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
-!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
-!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
-!27 = !{!28, !33}
-!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
-!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
-!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
-!31 = !{!32}
-!32 = !DISubrange(count: 27, lowerBound: 0)
-!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
-!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
-!36 = !{!37}
-!37 = !DISubrange(count: 262144, lowerBound: 0)
-!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
-!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
-!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
-!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
-!45 = !{!0, !7, !22, !24, !38, !42}
-!46 = !{i32 2, !"Debug Info Version", i32 3}
-!47 = !{i32 7, !"uwtable", i32 0}
-!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
-!49 = !DISubroutineType(types: !50)
-!50 = !{!20, !51}
-!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!52 = !{!53}
-!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)
+!25 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
+!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !7, !24, !26, !40, !44}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = !{i32 7, !"uwtable", i32 0}
+!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
+!51 = !DISubroutineType(types: !52)
+!52 = !{!20, !53}
+!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!54 = !{!55}
+!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)

--- a/tests/codegen/llvm/call_clear.ll
+++ b/tests/codegen/llvm/call_clear.ll
@@ -9,22 +9,22 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !37
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !46 {
+define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !47 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 1, ptr %"@x_val", align 8
+  store i8 1, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -69,8 +69,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { memory(none) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!43}
+!llvm.module.flags = !{!45, !46}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -93,37 +93,37 @@ attributes #2 = { memory(none) }
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 64, elements: !15)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!43 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !44)
+!44 = !{!0, !7, !23, !37, !41}
+!45 = !{i32 2, !"Debug Info Version", i32 3}
+!46 = !{i32 7, !"uwtable", i32 0}
+!47 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !50)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!20, !22}
 !50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
-!52 = distinct !DISubprogram(name: "kprobe_f_2", linkageName: "kprobe_f_2", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !53)
+!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !47, file: !2, type: !22)
+!52 = distinct !DISubprogram(name: "kprobe_f_2", linkageName: "kprobe_f_2", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !53)
 !53 = !{!54}
-!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !52, file: !2, type: !49)
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !52, file: !2, type: !22)

--- a/tests/codegen/llvm/call_delete.ll
+++ b/tests/codegen/llvm/call_delete.ll
@@ -8,8 +8,8 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !25
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !39
 @__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
 
 ; Function Attrs: nounwind
@@ -18,18 +18,18 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
 entry:
-  %"@x_key1" = alloca i64, align 8
-  %"@x_val" = alloca i64, align 8
-  %"@x_key" = alloca i64, align 8
+  %"@x_key1" = alloca i8, align 1
+  %"@x_val" = alloca i8, align 1
+  %"@x_key" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
-  store i64 1, ptr %"@x_key", align 8
+  store i8 1, ptr %"@x_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 1, ptr %"@x_val", align 8
+  store i8 1, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
-  store i64 1, ptr %"@x_key1", align 8
+  store i8 1, ptr %"@x_key1", align 1
   %delete_elem = call i64 inttoptr (i64 3 to ptr)(ptr @AT_x, ptr %"@x_key1")
   %delete_ret = icmp eq i64 %delete_elem, 0
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
@@ -58,7 +58,7 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
@@ -71,36 +71,35 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !20 = !{!21}
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
-!29 = !{!30, !35}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 27, lowerBound: 0)
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
-!38 = !{!39}
-!39 = !DISubrange(count: 262144, lowerBound: 0)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
+!28 = !{!29, !34}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !30, size: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 27, lowerBound: 0)
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !35, size: 64, offset: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 262144, lowerBound: 0)
+!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
+!40 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 64, elements: !15)
 !42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
+!43 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
-!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
 !46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
-!47 = !{!0, !7, !26, !40, !44}
+!47 = !{!0, !7, !25, !39, !44}
 !48 = !{i32 2, !"Debug Info Version", i32 3}
 !49 = !{i32 7, !"uwtable", i32 0}
-!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
+!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
 !51 = !DISubroutineType(types: !52)
-!52 = !{!24, !53}
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)
+!52 = !{!43, !23}
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !23)

--- a/tests/codegen/llvm/call_delete_deprecated.ll
+++ b/tests/codegen/llvm/call_delete_deprecated.ll
@@ -8,8 +8,8 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !25
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !39
 @__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
 
 ; Function Attrs: nounwind
@@ -18,18 +18,18 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
 entry:
-  %"@x_key1" = alloca i64, align 8
-  %"@x_val" = alloca i64, align 8
-  %"@x_key" = alloca i64, align 8
+  %"@x_key1" = alloca i8, align 1
+  %"@x_val" = alloca i8, align 1
+  %"@x_key" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
-  store i64 1, ptr %"@x_key", align 8
+  store i8 1, ptr %"@x_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 1, ptr %"@x_val", align 8
+  store i8 1, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
-  store i64 1, ptr %"@x_key1", align 8
+  store i8 1, ptr %"@x_key1", align 1
   %delete_elem = call i64 inttoptr (i64 3 to ptr)(ptr @AT_x, ptr %"@x_key1")
   %delete_ret = icmp eq i64 %delete_elem, 0
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
@@ -58,7 +58,7 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
@@ -71,36 +71,35 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !20 = !{!21}
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
-!29 = !{!30, !35}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 27, lowerBound: 0)
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
-!38 = !{!39}
-!39 = !DISubrange(count: 262144, lowerBound: 0)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
+!28 = !{!29, !34}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !30, size: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 27, lowerBound: 0)
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !35, size: 64, offset: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 262144, lowerBound: 0)
+!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
+!40 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 64, elements: !15)
 !42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
+!43 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
-!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
 !46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
-!47 = !{!0, !7, !26, !40, !44}
+!47 = !{!0, !7, !25, !39, !44}
 !48 = !{i32 2, !"Debug Info Version", i32 3}
 !49 = !{i32 7, !"uwtable", i32 0}
-!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
+!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
 !51 = !DISubroutineType(types: !52)
-!52 = !{!24, !53}
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)
+!52 = !{!43, !23}
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !23)

--- a/tests/codegen/llvm/call_exit_with_error_code.ll
+++ b/tests/codegen/llvm/call_exit_with_error_code.ll
@@ -22,7 +22,7 @@ entry:
   %1 = getelementptr %exit_t, ptr %exit, i64 0, i32 0
   store i64 30000, ptr %1, align 8
   %2 = getelementptr %exit_t, ptr %exit, i64 0, i32 1
-  store i64 1, ptr %2, align 8
+  store i8 1, ptr %2, align 1
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %exit, i64 9, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge

--- a/tests/codegen/llvm/call_has_key.ll
+++ b/tests/codegen/llvm/call_has_key.ll
@@ -8,8 +8,8 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !25
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !39
 @__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
 
 ; Function Attrs: nounwind
@@ -18,18 +18,18 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
 entry:
-  %"@x_key1" = alloca i64, align 8
-  %"@x_val" = alloca i64, align 8
-  %"@x_key" = alloca i64, align 8
+  %"@x_key1" = alloca i8, align 1
+  %"@x_val" = alloca i8, align 1
+  %"@x_key" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
-  store i64 1, ptr %"@x_key", align 8
+  store i8 1, ptr %"@x_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 1, ptr %"@x_val", align 8
+  store i8 1, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
-  store i64 1, ptr %"@x_key1", align 8
+  store i8 1, ptr %"@x_key1", align 1
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key1")
   %has_key = icmp ne ptr %lookup_elem, null
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
@@ -58,7 +58,7 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
@@ -71,36 +71,35 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !20 = !{!21}
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
-!29 = !{!30, !35}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 27, lowerBound: 0)
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
-!38 = !{!39}
-!39 = !DISubrange(count: 262144, lowerBound: 0)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
+!28 = !{!29, !34}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !30, size: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 27, lowerBound: 0)
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !35, size: 64, offset: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 262144, lowerBound: 0)
+!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
+!40 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 64, elements: !15)
 !42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
+!43 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
-!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
 !46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
-!47 = !{!0, !7, !26, !40, !44}
+!47 = !{!0, !7, !25, !39, !44}
 !48 = !{i32 2, !"Debug Info Version", i32 3}
 !49 = !{i32 7, !"uwtable", i32 0}
-!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
+!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
 !51 = !DISubroutineType(types: !52)
-!52 = !{!24, !53}
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)
+!52 = !{!43, !23}
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !23)

--- a/tests/codegen/llvm/call_map_key_scratch_buf.ll
+++ b/tests/codegen/llvm/call_map_key_scratch_buf.ll
@@ -9,19 +9,19 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !35
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !49
-@__bt__write_map_val_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.write_map_val_buf", !dbg !51
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !60
-@__bt__map_key_buf = dso_local externally_initialized global [1 x [4 x [16 x i8]]] zeroinitializer, section ".data.map_key_buf", !dbg !64
-@__bt__num_cpus = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !68
+@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !27
+@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !36
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !50
+@__bt__write_map_val_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.write_map_val_buf", !dbg !52
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !61
+@__bt__map_key_buf = dso_local externally_initialized global [1 x [4 x [16 x i8]]] zeroinitializer, section ".data.map_key_buf", !dbg !65
+@__bt__num_cpus = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !69
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !74 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !75 {
 entry:
   %initial_value9 = alloca i64, align 8
   %lookup_elem_val7 = alloca i64, align 8
@@ -31,7 +31,7 @@ entry:
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
   %2 = getelementptr [1 x [4 x [16 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  store i64 1, ptr %2, align 8
+  store i8 1, ptr %2, align 1
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
@@ -86,14 +86,14 @@ lookup_merge6:                                    ; preds = %lookup_failure5, %l
   %11 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded12 = and i64 %get_cpu_id11, %11
   %12 = getelementptr [1 x [4 x [16 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded12, i64 2, i64 0
-  store i64 1, ptr %12, align 8
+  store i8 1, ptr %12, align 1
   %lookup_elem13 = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %12)
   %has_key = icmp ne ptr %lookup_elem13, null
   %get_cpu_id14 = call i64 inttoptr (i64 8 to ptr)() #3
   %13 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded15 = and i64 %get_cpu_id14, %13
   %14 = getelementptr [1 x [4 x [16 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded15, i64 3, i64 0
-  store i64 1, ptr %14, align 8
+  store i8 1, ptr %14, align 1
   %delete_elem = call i64 inttoptr (i64 3 to ptr)(ptr @AT_x, ptr %14)
   %delete_ret = icmp eq i64 %delete_elem, 0
   ret i64 0
@@ -179,8 +179,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { alwaysinline nounwind }
 attributes #3 = { memory(none) }
 
-!llvm.dbg.cu = !{!70}
-!llvm.module.flags = !{!72, !73}
+!llvm.dbg.cu = !{!71}
+!llvm.module.flags = !{!73, !74}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -192,7 +192,7 @@ attributes #3 = { memory(none) }
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 160, elements: !15)
@@ -205,60 +205,60 @@ attributes #3 = { memory(none) }
 !20 = !{!21}
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !29)
-!29 = !{!11, !17, !30, !25}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 128, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 16, lowerBound: 0)
-!35 = !DIGlobalVariableExpression(var: !36, expr: !DIExpression())
-!36 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !37, isLocal: false, isDefinition: true)
-!37 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !38)
-!38 = !{!39, !44}
-!39 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !40, size: 64)
-!40 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !41, size: 64)
-!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !42)
-!42 = !{!43}
-!43 = !DISubrange(count: 27, lowerBound: 0)
-!44 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !45, size: 64, offset: 64)
-!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
-!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !47)
-!47 = !{!48}
-!48 = !DISubrange(count: 262144, lowerBound: 0)
-!49 = !DIGlobalVariableExpression(var: !50, expr: !DIExpression())
-!50 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
-!52 = distinct !DIGlobalVariable(name: "__bt__write_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !53, isLocal: false, isDefinition: true)
-!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !54, size: 64, elements: !58)
-!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !55, size: 64, elements: !58)
-!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 64, elements: !56)
-!56 = !{!57}
-!57 = !DISubrange(count: 8, lowerBound: 0)
-!58 = !{!59}
-!59 = !DISubrange(count: 1, lowerBound: 0)
-!60 = !DIGlobalVariableExpression(var: !61, expr: !DIExpression())
-!61 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !62, isLocal: false, isDefinition: true)
-!62 = !DICompositeType(tag: DW_TAG_array_type, baseType: !63, size: 64, elements: !58)
-!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !58)
-!64 = !DIGlobalVariableExpression(var: !65, expr: !DIExpression())
-!65 = distinct !DIGlobalVariable(name: "__bt__map_key_buf", linkageName: "global", scope: !2, file: !2, type: !66, isLocal: false, isDefinition: true)
-!66 = !DICompositeType(tag: DW_TAG_array_type, baseType: !67, size: 512, elements: !58)
-!67 = !DICompositeType(tag: DW_TAG_array_type, baseType: !32, size: 512, elements: !5)
-!68 = !DIGlobalVariableExpression(var: !69, expr: !DIExpression())
-!69 = distinct !DIGlobalVariable(name: "__bt__num_cpus", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!70 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !71)
-!71 = !{!0, !7, !26, !35, !49, !51, !60, !64, !68}
-!72 = !{i32 2, !"Debug Info Version", i32 3}
-!73 = !{i32 7, !"uwtable", i32 0}
-!74 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !75, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !70, retainedNodes: !78)
-!75 = !DISubroutineType(types: !76)
-!76 = !{!24, !77}
-!77 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !25, size: 64, offset: 192)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!27 = !DIGlobalVariableExpression(var: !28, expr: !DIExpression())
+!28 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
+!29 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !30)
+!30 = !{!11, !17, !31, !24}
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !32, size: 64, offset: 128)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 128, elements: !34)
+!34 = !{!35}
+!35 = !DISubrange(count: 16, lowerBound: 0)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !39)
+!39 = !{!40, !45}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 27, lowerBound: 0)
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !46, size: 64, offset: 64)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !48)
+!48 = !{!49}
+!49 = !DISubrange(count: 262144, lowerBound: 0)
+!50 = !DIGlobalVariableExpression(var: !51, expr: !DIExpression())
+!51 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!52 = !DIGlobalVariableExpression(var: !53, expr: !DIExpression())
+!53 = distinct !DIGlobalVariable(name: "__bt__write_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !54, isLocal: false, isDefinition: true)
+!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !55, size: 64, elements: !59)
+!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !56, size: 64, elements: !59)
+!56 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 64, elements: !57)
+!57 = !{!58}
+!58 = !DISubrange(count: 8, lowerBound: 0)
+!59 = !{!60}
+!60 = !DISubrange(count: 1, lowerBound: 0)
+!61 = !DIGlobalVariableExpression(var: !62, expr: !DIExpression())
+!62 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !63, isLocal: false, isDefinition: true)
+!63 = !DICompositeType(tag: DW_TAG_array_type, baseType: !64, size: 64, elements: !59)
+!64 = !DICompositeType(tag: DW_TAG_array_type, baseType: !26, size: 64, elements: !59)
+!65 = !DIGlobalVariableExpression(var: !66, expr: !DIExpression())
+!66 = distinct !DIGlobalVariable(name: "__bt__map_key_buf", linkageName: "global", scope: !2, file: !2, type: !67, isLocal: false, isDefinition: true)
+!67 = !DICompositeType(tag: DW_TAG_array_type, baseType: !68, size: 512, elements: !59)
+!68 = !DICompositeType(tag: DW_TAG_array_type, baseType: !33, size: 512, elements: !5)
+!69 = !DIGlobalVariableExpression(var: !70, expr: !DIExpression())
+!70 = distinct !DIGlobalVariable(name: "__bt__num_cpus", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!71 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !72)
+!72 = !{!0, !7, !27, !36, !50, !52, !61, !65, !69}
+!73 = !{i32 2, !"Debug Info Version", i32 3}
+!74 = !{i32 7, !"uwtable", i32 0}
+!75 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !76, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !71, retainedNodes: !78)
+!76 = !DISubroutineType(types: !77)
+!77 = !{!26, !23}
 !78 = !{!79}
-!79 = !DILocalVariable(name: "ctx", arg: 1, scope: !74, file: !2, type: !77)
+!79 = !DILocalVariable(name: "ctx", arg: 1, scope: !75, file: !2, type: !23)

--- a/tests/codegen/llvm/call_map_key_stack.ll
+++ b/tests/codegen/llvm/call_map_key_stack.ll
@@ -9,28 +9,28 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !35
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !49
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !51
-@__bt__num_cpus = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !57
+@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !27
+@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !36
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !50
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !52
+@__bt__num_cpus = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !58
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !63 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !64 {
 entry:
-  %"@x_key11" = alloca i64, align 8
-  %"@x_key9" = alloca i64, align 8
+  %"@x_key11" = alloca i8, align 1
+  %"@x_key9" = alloca i8, align 1
   %initial_value7 = alloca i64, align 8
   %lookup_elem_val5 = alloca i64, align 8
   %"@y_key" = alloca [16 x i8], align 1
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
-  %"@x_key" = alloca i64, align 8
+  %"@x_key" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
-  store i64 1, ptr %"@x_key", align 8
+  store i8 1, ptr %"@x_key", align 1
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
@@ -80,12 +80,12 @@ lookup_merge4:                                    ; preds = %lookup_failure3, %l
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val5)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key9")
-  store i64 1, ptr %"@x_key9", align 8
+  store i8 1, ptr %"@x_key9", align 1
   %lookup_elem10 = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key9")
   %has_key = icmp ne ptr %lookup_elem10, null
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key9")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key11")
-  store i64 1, ptr %"@x_key11", align 8
+  store i8 1, ptr %"@x_key11", align 1
   %delete_elem = call i64 inttoptr (i64 3 to ptr)(ptr @AT_x, ptr %"@x_key11")
   %delete_ret = icmp eq i64 %delete_elem, 0
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key11")
@@ -171,8 +171,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { alwaysinline nounwind }
 
-!llvm.dbg.cu = !{!59}
-!llvm.module.flags = !{!61, !62}
+!llvm.dbg.cu = !{!60}
+!llvm.module.flags = !{!62, !63}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -184,7 +184,7 @@ attributes #2 = { alwaysinline nounwind }
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 160, elements: !15)
@@ -197,49 +197,49 @@ attributes #2 = { alwaysinline nounwind }
 !20 = !{!21}
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !29)
-!29 = !{!11, !17, !30, !25}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 128, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 16, lowerBound: 0)
-!35 = !DIGlobalVariableExpression(var: !36, expr: !DIExpression())
-!36 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !37, isLocal: false, isDefinition: true)
-!37 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !38)
-!38 = !{!39, !44}
-!39 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !40, size: 64)
-!40 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !41, size: 64)
-!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !42)
-!42 = !{!43}
-!43 = !DISubrange(count: 27, lowerBound: 0)
-!44 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !45, size: 64, offset: 64)
-!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
-!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !47)
-!47 = !{!48}
-!48 = !DISubrange(count: 262144, lowerBound: 0)
-!49 = !DIGlobalVariableExpression(var: !50, expr: !DIExpression())
-!50 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
-!52 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !53, isLocal: false, isDefinition: true)
-!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !54, size: 64, elements: !55)
-!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !55)
-!55 = !{!56}
-!56 = !DISubrange(count: 1, lowerBound: 0)
-!57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
-!58 = distinct !DIGlobalVariable(name: "__bt__num_cpus", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!59 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !60)
-!60 = !{!0, !7, !26, !35, !49, !51, !57}
-!61 = !{i32 2, !"Debug Info Version", i32 3}
-!62 = !{i32 7, !"uwtable", i32 0}
-!63 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !64, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !59, retainedNodes: !67)
-!64 = !DISubroutineType(types: !65)
-!65 = !{!24, !66}
-!66 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !25, size: 64, offset: 192)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!27 = !DIGlobalVariableExpression(var: !28, expr: !DIExpression())
+!28 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
+!29 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !30)
+!30 = !{!11, !17, !31, !24}
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !32, size: 64, offset: 128)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 128, elements: !34)
+!34 = !{!35}
+!35 = !DISubrange(count: 16, lowerBound: 0)
+!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
+!37 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
+!38 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !39)
+!39 = !{!40, !45}
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !41, size: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 27, lowerBound: 0)
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !46, size: 64, offset: 64)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !48)
+!48 = !{!49}
+!49 = !DISubrange(count: 262144, lowerBound: 0)
+!50 = !DIGlobalVariableExpression(var: !51, expr: !DIExpression())
+!51 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!52 = !DIGlobalVariableExpression(var: !53, expr: !DIExpression())
+!53 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !54, isLocal: false, isDefinition: true)
+!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !55, size: 64, elements: !56)
+!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !26, size: 64, elements: !56)
+!56 = !{!57}
+!57 = !DISubrange(count: 1, lowerBound: 0)
+!58 = !DIGlobalVariableExpression(var: !59, expr: !DIExpression())
+!59 = distinct !DIGlobalVariable(name: "__bt__num_cpus", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!60 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !61)
+!61 = !{!0, !7, !27, !36, !50, !52, !58}
+!62 = !{i32 2, !"Debug Info Version", i32 3}
+!63 = !{i32 7, !"uwtable", i32 0}
+!64 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !65, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !60, retainedNodes: !67)
+!65 = !DISubroutineType(types: !66)
+!66 = !{!26, !23}
 !67 = !{!68}
-!68 = !DILocalVariable(name: "ctx", arg: 1, scope: !63, file: !2, type: !66)
+!68 = !DILocalVariable(name: "ctx", arg: 1, scope: !64, file: !2, type: !23)

--- a/tests/codegen/llvm/call_ntop_key.ll
+++ b/tests/codegen/llvm/call_ntop_key.ll
@@ -9,8 +9,8 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !30
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !44
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !29
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !43
 @__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !48
 
 ; Function Attrs: nounwind
@@ -19,7 +19,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !54 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
   %inet = alloca %inet, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %inet)
   %1 = getelementptr %inet, ptr %inet, i64 0, i32 0
@@ -28,7 +28,7 @@ entry:
   call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
   store i32 -1, ptr %2, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 1, ptr %"@x_val", align 8
+  store i8 1, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %inet, ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %inet)
@@ -79,35 +79,34 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !25 = !{!26}
 !26 = !DISubrange(count: 24, lowerBound: 0)
 !27 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !28, size: 64, offset: 192)
-!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
-!29 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!30 = !DIGlobalVariableExpression(var: !31, expr: !DIExpression())
-!31 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !32, isLocal: false, isDefinition: true)
-!32 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !33)
-!33 = !{!34, !39}
-!34 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !35, size: 64)
-!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
-!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !37)
-!37 = !{!38}
-!38 = !DISubrange(count: 27, lowerBound: 0)
-!39 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !40, size: 64, offset: 64)
-!40 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !41, size: 64)
-!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !42)
-!42 = !{!43}
-!43 = !DISubrange(count: 262144, lowerBound: 0)
-!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
-!45 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !46, isLocal: false, isDefinition: true)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!29 = !DIGlobalVariableExpression(var: !30, expr: !DIExpression())
+!30 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !31, isLocal: false, isDefinition: true)
+!31 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !32)
+!32 = !{!33, !38}
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !34, size: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 27, lowerBound: 0)
+!38 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !39, size: 64, offset: 64)
+!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !41)
+!41 = !{!42}
+!42 = !DISubrange(count: 262144, lowerBound: 0)
+!43 = !DIGlobalVariableExpression(var: !44, expr: !DIExpression())
+!44 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !45, isLocal: false, isDefinition: true)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !46, size: 64, elements: !15)
 !46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !47, size: 64, elements: !15)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !29, size: 64, elements: !15)
+!47 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
-!49 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
+!49 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !47, isLocal: false, isDefinition: true)
 !50 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !51)
-!51 = !{!0, !7, !30, !44, !48}
+!51 = !{!0, !7, !29, !43, !48}
 !52 = !{i32 2, !"Debug Info Version", i32 3}
 !53 = !{i32 7, !"uwtable", i32 0}
-!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !50, retainedNodes: !58)
+!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !50, retainedNodes: !57)
 !55 = !DISubroutineType(types: !56)
-!56 = !{!29, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
+!56 = !{!47, !28}
+!57 = !{!58}
+!58 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !28)

--- a/tests/codegen/llvm/call_offsetof.ll
+++ b/tests/codegen/llvm/call_offsetof.ll
@@ -9,23 +9,23 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !37
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !46 {
+define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !47 {
 entry:
   %exit = alloca %exit_t, align 8
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 0, ptr %"@x_val", align 8
+  store i8 0, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -63,8 +63,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { memory(none) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!43}
+!llvm.module.flags = !{!45, !46}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -87,34 +87,34 @@ attributes #2 = { memory(none) }
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 64, elements: !15)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!43 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !44)
+!44 = !{!0, !7, !23, !37, !41}
+!45 = !{i32 2, !"Debug Info Version", i32 3}
+!46 = !{i32 7, !"uwtable", i32 0}
+!47 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !50)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!20, !22}
 !50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !47, file: !2, type: !22)

--- a/tests/codegen/llvm/call_offsetof_sub_field.ll
+++ b/tests/codegen/llvm/call_offsetof_sub_field.ll
@@ -9,23 +9,23 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !37
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !46 {
+define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !47 {
 entry:
   %exit = alloca %exit_t, align 8
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 0, ptr %"@x_val", align 8
+  store i8 0, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -63,8 +63,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { memory(none) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!43}
+!llvm.module.flags = !{!45, !46}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -87,34 +87,34 @@ attributes #2 = { memory(none) }
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 64, elements: !15)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!43 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !44)
+!44 = !{!0, !7, !23, !37, !41}
+!45 = !{i32 2, !"Debug Info Version", i32 3}
+!46 = !{i32 7, !"uwtable", i32 0}
+!47 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !50)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!20, !22}
 !50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !47, file: !2, type: !22)

--- a/tests/codegen/llvm/call_override_literal.ll
+++ b/tests/codegen/llvm/call_override_literal.ll
@@ -16,7 +16,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
-  %__override = call void @__override(ptr %0, i64 -1), !dbg !41
+  %__override = call void @__override(ptr %0, i64 255), !dbg !41
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_percpu_kaddr.ll
+++ b/tests/codegen/llvm/call_percpu_kaddr.ll
@@ -17,7 +17,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !37 {
 entry:
-  %per_cpu_ptr = call ptr inttoptr (i64 153 to ptr)(ptr @process_counts, i64 0) #1
+  %per_cpu_ptr = call ptr inttoptr (i64 153 to ptr)(ptr @process_counts, i32 0) #1
   %1 = ptrtoint ptr %per_cpu_ptr to i64
   ret i64 0
 }

--- a/tests/codegen/llvm/call_pid_tid.ll
+++ b/tests/codegen/llvm/call_pid_tid.ll
@@ -9,20 +9,20 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !24
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
+@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !26
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
 entry:
-  %"@y_val" = alloca i64, align 8
+  %"@y_val" = alloca i32, align 4
   %"@y_key" = alloca i64, align 8
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i32, align 4
   %"@x_key" = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
@@ -30,8 +30,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %2 = zext i32 %pid to i64
-  store i64 %2, ptr %"@x_val", align 8
+  store i32 %pid, ptr %"@x_val", align 4
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -40,8 +39,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
-  %3 = zext i32 %tid to i64
-  store i64 %3, ptr %"@y_val", align 8
+  store i32 %tid, ptr %"@y_val", align 4
   %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
@@ -58,8 +56,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { memory(none) }
 
-!llvm.dbg.cu = !{!44}
-!llvm.module.flags = !{!46, !47}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48, !49}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -82,36 +80,38 @@ attributes #2 = { memory(none) }
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
-!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
-!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
-!27 = !{!28, !33}
-!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
-!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
-!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
-!31 = !{!32}
-!32 = !DISubrange(count: 27, lowerBound: 0)
-!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
-!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
-!36 = !{!37}
-!37 = !DISubrange(count: 262144, lowerBound: 0)
-!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
-!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
-!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
-!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
-!45 = !{!0, !7, !22, !24, !38, !42}
-!46 = !{i32 2, !"Debug Info Version", i32 3}
-!47 = !{i32 7, !"uwtable", i32 0}
-!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
-!49 = !DISubroutineType(types: !50)
-!50 = !{!20, !51}
-!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!52 = !{!53}
-!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)
+!25 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
+!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !7, !24, !26, !40, !44}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = !{i32 7, !"uwtable", i32 0}
+!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
+!51 = !DISubroutineType(types: !52)
+!52 = !{!20, !53}
+!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!54 = !{!55}
+!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)

--- a/tests/codegen/llvm/call_pid_tid_curr_ns.ll
+++ b/tests/codegen/llvm/call_pid_tid_curr_ns.ll
@@ -9,20 +9,20 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !24
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
+@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !26
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
 entry:
-  %"@y_val" = alloca i64, align 8
+  %"@y_val" = alloca i32, align 4
   %"@y_key" = alloca i64, align 8
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i32, align 4
   %"@x_key" = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
@@ -30,8 +30,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %2 = zext i32 %pid to i64
-  store i64 %2, ptr %"@x_val", align 8
+  store i32 %pid, ptr %"@x_val", align 4
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -40,8 +39,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
-  %3 = zext i32 %tid to i64
-  store i64 %3, ptr %"@y_val", align 8
+  store i32 %tid, ptr %"@y_val", align 4
   %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
@@ -58,8 +56,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { memory(none) }
 
-!llvm.dbg.cu = !{!44}
-!llvm.module.flags = !{!46, !47}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48, !49}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -82,36 +80,38 @@ attributes #2 = { memory(none) }
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
-!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
-!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
-!27 = !{!28, !33}
-!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
-!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
-!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
-!31 = !{!32}
-!32 = !DISubrange(count: 27, lowerBound: 0)
-!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
-!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
-!36 = !{!37}
-!37 = !DISubrange(count: 262144, lowerBound: 0)
-!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
-!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
-!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
-!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
-!45 = !{!0, !7, !22, !24, !38, !42}
-!46 = !{i32 2, !"Debug Info Version", i32 3}
-!47 = !{i32 7, !"uwtable", i32 0}
-!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
-!49 = !DISubroutineType(types: !50)
-!50 = !{!20, !51}
-!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!52 = !{!53}
-!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)
+!25 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
+!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !7, !24, !26, !40, !44}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = !{i32 7, !"uwtable", i32 0}
+!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
+!51 = !DISubroutineType(types: !52)
+!52 = !{!20, !53}
+!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!54 = !{!55}
+!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)

--- a/tests/codegen/llvm/call_pid_tid_curr_ns_in_child_ns.ll
+++ b/tests/codegen/llvm/call_pid_tid_curr_ns_in_child_ns.ll
@@ -10,21 +10,21 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !24
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
+@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !26
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
 entry:
-  %"@y_val" = alloca i64, align 8
+  %"@y_val" = alloca i32, align 4
   %"@y_key" = alloca i64, align 8
   %bpf_pidns_info1 = alloca %bpf_pidns_info, align 8
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i32, align 4
   %"@x_key" = alloca i64, align 8
   %bpf_pidns_info = alloca %bpf_pidns_info, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %bpf_pidns_info)
@@ -35,21 +35,19 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %3 = zext i32 %2 to i64
-  store i64 %3, ptr %"@x_val", align 8
+  store i32 %2, ptr %"@x_val", align 4
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %bpf_pidns_info1)
   %get_ns_pid_tgid2 = call i64 inttoptr (i64 120 to ptr)(i64 0, i64 4026531857, ptr %bpf_pidns_info1, i32 8)
-  %4 = getelementptr %bpf_pidns_info, ptr %bpf_pidns_info1, i32 0, i32 1
-  %5 = load i32, ptr %4, align 4
+  %3 = getelementptr %bpf_pidns_info, ptr %bpf_pidns_info1, i32 0, i32 1
+  %4 = load i32, ptr %3, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %bpf_pidns_info1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
-  %6 = zext i32 %5 to i64
-  store i64 %6, ptr %"@y_val", align 8
+  store i32 %4, ptr %"@y_val", align 4
   %update_elem3 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
@@ -65,8 +63,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!44}
-!llvm.module.flags = !{!46, !47}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48, !49}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -89,36 +87,38 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
-!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
-!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
-!27 = !{!28, !33}
-!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
-!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
-!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
-!31 = !{!32}
-!32 = !DISubrange(count: 27, lowerBound: 0)
-!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
-!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
-!36 = !{!37}
-!37 = !DISubrange(count: 262144, lowerBound: 0)
-!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
-!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
-!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
-!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
-!45 = !{!0, !7, !22, !24, !38, !42}
-!46 = !{i32 2, !"Debug Info Version", i32 3}
-!47 = !{i32 7, !"uwtable", i32 0}
-!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
-!49 = !DISubroutineType(types: !50)
-!50 = !{!20, !51}
-!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!52 = !{!53}
-!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)
+!25 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
+!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !7, !24, !26, !40, !44}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = !{i32 7, !"uwtable", i32 0}
+!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
+!51 = !DISubroutineType(types: !52)
+!52 = !{!20, !53}
+!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!54 = !{!55}
+!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)

--- a/tests/codegen/llvm/call_pid_tid_in_child_ns.ll
+++ b/tests/codegen/llvm/call_pid_tid_in_child_ns.ll
@@ -10,21 +10,21 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !24
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
+@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !26
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
 entry:
-  %"@y_val" = alloca i64, align 8
+  %"@y_val" = alloca i32, align 4
   %"@y_key" = alloca i64, align 8
   %bpf_pidns_info1 = alloca %bpf_pidns_info, align 8
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i32, align 4
   %"@x_key" = alloca i64, align 8
   %bpf_pidns_info = alloca %bpf_pidns_info, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %bpf_pidns_info)
@@ -35,21 +35,19 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %3 = zext i32 %2 to i64
-  store i64 %3, ptr %"@x_val", align 8
+  store i32 %2, ptr %"@x_val", align 4
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %bpf_pidns_info1)
   %get_ns_pid_tgid2 = call i64 inttoptr (i64 120 to ptr)(i64 0, i64 4026531857, ptr %bpf_pidns_info1, i32 8)
-  %4 = getelementptr %bpf_pidns_info, ptr %bpf_pidns_info1, i32 0, i32 1
-  %5 = load i32, ptr %4, align 4
+  %3 = getelementptr %bpf_pidns_info, ptr %bpf_pidns_info1, i32 0, i32 1
+  %4 = load i32, ptr %3, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %bpf_pidns_info1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
-  %6 = zext i32 %5 to i64
-  store i64 %6, ptr %"@y_val", align 8
+  store i32 %4, ptr %"@y_val", align 4
   %update_elem3 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
@@ -65,8 +63,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!44}
-!llvm.module.flags = !{!46, !47}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48, !49}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -89,36 +87,38 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
-!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
-!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
-!27 = !{!28, !33}
-!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
-!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
-!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
-!31 = !{!32}
-!32 = !DISubrange(count: 27, lowerBound: 0)
-!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
-!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
-!36 = !{!37}
-!37 = !DISubrange(count: 262144, lowerBound: 0)
-!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
-!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
-!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
-!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
-!45 = !{!0, !7, !22, !24, !38, !42}
-!46 = !{i32 2, !"Debug Info Version", i32 3}
-!47 = !{i32 7, !"uwtable", i32 0}
-!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
-!49 = !DISubroutineType(types: !50)
-!50 = !{!20, !51}
-!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!52 = !{!53}
-!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)
+!25 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
+!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !7, !24, !26, !40, !44}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = !{i32 7, !"uwtable", i32 0}
+!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
+!51 = !DISubroutineType(types: !52)
+!52 = !{!20, !53}
+!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!54 = !{!55}
+!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)

--- a/tests/codegen/llvm/call_pid_tid_init.ll
+++ b/tests/codegen/llvm/call_pid_tid_init.ll
@@ -9,20 +9,20 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !24
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
+@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !26
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
 entry:
-  %"@y_val" = alloca i64, align 8
+  %"@y_val" = alloca i32, align 4
   %"@y_key" = alloca i64, align 8
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i32, align 4
   %"@x_key" = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
@@ -30,8 +30,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %2 = zext i32 %pid to i64
-  store i64 %2, ptr %"@x_val", align 8
+  store i32 %pid, ptr %"@x_val", align 4
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -40,8 +39,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
-  %3 = zext i32 %tid to i64
-  store i64 %3, ptr %"@y_val", align 8
+  store i32 %tid, ptr %"@y_val", align 4
   %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
@@ -58,8 +56,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { memory(none) }
 
-!llvm.dbg.cu = !{!44}
-!llvm.module.flags = !{!46, !47}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48, !49}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -82,36 +80,38 @@ attributes #2 = { memory(none) }
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
-!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
-!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
-!27 = !{!28, !33}
-!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
-!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
-!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
-!31 = !{!32}
-!32 = !DISubrange(count: 27, lowerBound: 0)
-!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
-!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
-!36 = !{!37}
-!37 = !DISubrange(count: 262144, lowerBound: 0)
-!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
-!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
-!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
-!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
-!45 = !{!0, !7, !22, !24, !38, !42}
-!46 = !{i32 2, !"Debug Info Version", i32 3}
-!47 = !{i32 7, !"uwtable", i32 0}
-!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
-!49 = !DISubroutineType(types: !50)
-!50 = !{!20, !51}
-!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!52 = !{!53}
-!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)
+!25 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
+!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !7, !24, !26, !40, !44}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = !{i32 7, !"uwtable", i32 0}
+!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
+!51 = !DISubroutineType(types: !52)
+!52 = !{!20, !53}
+!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!54 = !{!55}
+!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)

--- a/tests/codegen/llvm/call_pid_tid_init_ns_in_child_ns.ll
+++ b/tests/codegen/llvm/call_pid_tid_init_ns_in_child_ns.ll
@@ -9,20 +9,20 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !24
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
+@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !26
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
 entry:
-  %"@y_val" = alloca i64, align 8
+  %"@y_val" = alloca i32, align 4
   %"@y_key" = alloca i64, align 8
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i32, align 4
   %"@x_key" = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
@@ -30,8 +30,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %2 = zext i32 %pid to i64
-  store i64 %2, ptr %"@x_val", align 8
+  store i32 %pid, ptr %"@x_val", align 4
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -40,8 +39,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
-  %3 = zext i32 %tid to i64
-  store i64 %3, ptr %"@y_val", align 8
+  store i32 %tid, ptr %"@y_val", align 4
   %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
@@ -58,8 +56,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { memory(none) }
 
-!llvm.dbg.cu = !{!44}
-!llvm.module.flags = !{!46, !47}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48, !49}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -82,36 +80,38 @@ attributes #2 = { memory(none) }
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
-!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
-!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
-!27 = !{!28, !33}
-!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
-!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
-!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
-!31 = !{!32}
-!32 = !DISubrange(count: 27, lowerBound: 0)
-!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
-!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
-!36 = !{!37}
-!37 = !DISubrange(count: 262144, lowerBound: 0)
-!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
-!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
-!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
-!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
-!45 = !{!0, !7, !22, !24, !38, !42}
-!46 = !{i32 2, !"Debug Info Version", i32 3}
-!47 = !{i32 7, !"uwtable", i32 0}
-!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
-!49 = !DISubroutineType(types: !50)
-!50 = !{!20, !51}
-!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!52 = !{!53}
-!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)
+!25 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
+!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !7, !24, !26, !40, !44}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = !{i32 7, !"uwtable", i32 0}
+!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
+!51 = !DISubroutineType(types: !52)
+!52 = !{!20, !53}
+!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!54 = !{!55}
+!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)

--- a/tests/codegen/llvm/call_print.ll
+++ b/tests/codegen/llvm/call_print.ll
@@ -9,22 +9,22 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !37
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !46 {
+define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !47 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 1, ptr %"@x_val", align 8
+  store i8 1, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -73,8 +73,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { memory(none) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!43}
+!llvm.module.flags = !{!45, !46}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -97,37 +97,37 @@ attributes #2 = { memory(none) }
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 64, elements: !15)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!43 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !44)
+!44 = !{!0, !7, !23, !37, !41}
+!45 = !{i32 2, !"Debug Info Version", i32 3}
+!46 = !{i32 7, !"uwtable", i32 0}
+!47 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !50)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!20, !22}
 !50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
-!52 = distinct !DISubprogram(name: "kprobe_f_2", linkageName: "kprobe_f_2", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !53)
+!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !47, file: !2, type: !22)
+!52 = distinct !DISubprogram(name: "kprobe_f_2", linkageName: "kprobe_f_2", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !53)
 !53 = !{!54}
-!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !52, file: !2, type: !49)
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !52, file: !2, type: !22)

--- a/tests/codegen/llvm/call_print_composit.ll
+++ b/tests/codegen/llvm/call_print_composit.ll
@@ -4,8 +4,8 @@ target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr }
-%print_tuple_16_t = type <{ i64, i64, [16 x i8] }>
-%"int64_string[4]__tuple_t" = type { i64, [4 x i8] }
+%print_tuple_5_t = type <{ i64, i64, [5 x i8] }>
+%"uint8_string[4]__tuple_t" = type { i8, [4 x i8] }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @ringbuf = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
@@ -19,23 +19,23 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
-  %print_tuple_16_t = alloca %print_tuple_16_t, align 8
-  %tuple = alloca %"int64_string[4]__tuple_t", align 8
+  %print_tuple_5_t = alloca %print_tuple_5_t, align 8
+  %tuple = alloca %"uint8_string[4]__tuple_t", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %1 = getelementptr %"int64_string[4]__tuple_t", ptr %tuple, i32 0, i32 0
-  store i64 1, ptr %1, align 8
-  %2 = getelementptr %"int64_string[4]__tuple_t", ptr %tuple, i32 0, i32 1
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 5, i1 false)
+  %1 = getelementptr %"uint8_string[4]__tuple_t", ptr %tuple, i32 0, i32 0
+  store i8 1, ptr %1, align 1
+  %2 = getelementptr %"uint8_string[4]__tuple_t", ptr %tuple, i32 0, i32 1
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 @abc, i64 4, i1 false)
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %print_tuple_16_t)
-  %3 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i64 0, i32 0
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %print_tuple_5_t)
+  %3 = getelementptr %print_tuple_5_t, ptr %print_tuple_5_t, i64 0, i32 0
   store i64 30007, ptr %3, align 8
-  %4 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i64 0, i32 1
+  %4 = getelementptr %print_tuple_5_t, ptr %print_tuple_5_t, i64 0, i32 1
   store i64 0, ptr %4, align 8
-  %5 = getelementptr %print_tuple_16_t, ptr %print_tuple_16_t, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 16, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %5, ptr align 1 %tuple, i64 16, i1 false)
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_tuple_16_t, i64 32, i64 0)
+  %5 = getelementptr %print_tuple_5_t, ptr %print_tuple_5_t, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %5, i8 0, i64 5, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %5, ptr align 1 %tuple, i64 5, i1 false)
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_tuple_5_t, i64 21, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -50,7 +50,7 @@ event_loss_counter:                               ; preds = %entry
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %entry
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %print_tuple_16_t)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %print_tuple_5_t)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   ret i64 0
 }

--- a/tests/codegen/llvm/call_print_inside_print.ll
+++ b/tests/codegen/llvm/call_print_inside_print.ll
@@ -21,10 +21,10 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
   %print_bool_1_t = alloca %print_bool_1_t, align 8
   %print_string_4_t = alloca %print_string_4_t, align 8
-  %"$x" = alloca i64, align 8
+  %"$x" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
-  store i64 0, ptr %"$x", align 8
-  store i64 1, ptr %"$x", align 8
+  store i8 0, ptr %"$x", align 1
+  store i8 1, ptr %"$x", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %print_string_4_t)
   %1 = getelementptr %print_string_4_t, ptr %print_string_4_t, i64 0, i32 0
   store i64 30007, ptr %1, align 8
@@ -49,8 +49,8 @@ event_loss_counter:                               ; preds = %entry
 
 counter_merge:                                    ; preds = %event_loss_counter, %entry
   call void @llvm.lifetime.end.p0(i64 -1, ptr %print_string_4_t)
-  %8 = load i64, ptr %"$x", align 8
-  %9 = icmp sgt i64 %8, 1
+  %8 = load i8, ptr %"$x", align 1
+  %9 = icmp ugt i8 %8, 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %print_bool_1_t)
   %10 = getelementptr %print_bool_1_t, ptr %print_bool_1_t, i64 0, i32 0
   store i64 30007, ptr %10, align 8

--- a/tests/codegen/llvm/call_print_int.ll
+++ b/tests/codegen/llvm/call_print_int.ll
@@ -4,7 +4,7 @@ target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr }
-%print_int_8_t = type <{ i64, i64, [8 x i8] }>
+%print_int_1_t = type <{ i64, i64, [1 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @ringbuf = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
@@ -17,16 +17,16 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
-  %print_int_8_t = alloca %print_int_8_t, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %print_int_8_t)
-  %1 = getelementptr %print_int_8_t, ptr %print_int_8_t, i64 0, i32 0
+  %print_int_1_t = alloca %print_int_1_t, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %print_int_1_t)
+  %1 = getelementptr %print_int_1_t, ptr %print_int_1_t, i64 0, i32 0
   store i64 30007, ptr %1, align 8
-  %2 = getelementptr %print_int_8_t, ptr %print_int_8_t, i64 0, i32 1
+  %2 = getelementptr %print_int_1_t, ptr %print_int_1_t, i64 0, i32 1
   store i64 0, ptr %2, align 8
-  %3 = getelementptr %print_int_8_t, ptr %print_int_8_t, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %3, i8 0, i64 8, i1 false)
-  store i64 3, ptr %3, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_int_8_t, i64 24, i64 0)
+  %3 = getelementptr %print_int_1_t, ptr %print_int_1_t, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %3, i8 0, i64 1, i1 false)
+  store i8 3, ptr %3, align 1
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_int_1_t, i64 17, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -41,7 +41,7 @@ event_loss_counter:                               ; preds = %entry
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %entry
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %print_int_8_t)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %print_int_1_t)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/call_signal.ll
+++ b/tests/codegen/llvm/call_signal.ll
@@ -32,43 +32,42 @@ entry:
   store i32 0, ptr %"$$__signal_2_$sig", align 4
   store i32 8, ptr %"$$__signal_2_$sig", align 4
   %1 = load i32, ptr %"$$__signal_2_$sig", align 4
-  %2 = sext i32 %1 to i64
-  %3 = icmp slt i64 %2, 1
-  %true_cond = icmp ne i1 %3, false
+  %2 = icmp slt i32 %1, 1
+  %true_cond = icmp ne i1 %2, false
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %errorf_args)
   call void @llvm.memset.p0.i64(ptr align 1 %errorf_args, i8 0, i64 24, i1 false)
-  %4 = getelementptr %errorf_t, ptr %errorf_args, i32 0, i32 0
-  store i64 0, ptr %4, align 8
-  %5 = getelementptr %errorf_t, ptr %errorf_args, i32 0, i32 1
-  %6 = getelementptr %errorf_args_t, ptr %5, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 @"signal()", i64 9, i1 false)
-  %7 = load i32, ptr %"$$__signal_2_$sig", align 4
-  %8 = getelementptr %errorf_args_t, ptr %5, i32 0, i32 1
-  store i32 %7, ptr %8, align 4
+  %3 = getelementptr %errorf_t, ptr %errorf_args, i32 0, i32 0
+  store i64 0, ptr %3, align 8
+  %4 = getelementptr %errorf_t, ptr %errorf_args, i32 0, i32 1
+  %5 = getelementptr %errorf_args_t, ptr %4, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %5, ptr align 1 @"signal()", i64 9, i1 false)
+  %6 = load i32, ptr %"$$__signal_2_$sig", align 4
+  %7 = getelementptr %errorf_args_t, ptr %4, i32 0, i32 1
+  store i32 %6, ptr %7, align 4
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %errorf_args, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 right:                                            ; preds = %entry
-  %9 = load i32, ptr %"$$__signal_2_$sig", align 4
-  %__signal_process = call i64 @__signal_process(i32 %9), !dbg !41
+  %8 = load i32, ptr %"$$__signal_2_$sig", align 4
+  %__signal_process = call i64 @__signal_process(i32 %8), !dbg !41
   store i64 %__signal_process, ptr %"$$__signal_2_$ret", align 8
-  %10 = load i64, ptr %"$$__signal_2_$ret", align 8
-  %11 = icmp ne i64 %10, 0
-  %true_cond3 = icmp ne i1 %11, false
+  %9 = load i64, ptr %"$$__signal_2_$ret", align 8
+  %10 = icmp ne i64 %9, 0
+  %true_cond3 = icmp ne i1 %10, false
   br i1 %true_cond3, label %left1, label %right2
 
 event_loss_counter:                               ; preds = %left
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #5
-  %12 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %12
-  %13 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
-  %14 = load i64, ptr %13, align 8
-  %15 = add i64 %14, 1
-  store i64 %15, ptr %13, align 8
+  %11 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %11
+  %12 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %13 = load i64, ptr %12, align 8
+  %14 = add i64 %13, 1
+  store i64 %14, ptr %12, align 8
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %left
@@ -81,12 +80,12 @@ done:                                             ; preds = %done10, %counter_me
 left1:                                            ; preds = %right
   call void @llvm.lifetime.start.p0(i64 -1, ptr %warnf_args)
   call void @llvm.memset.p0.i64(ptr align 1 %warnf_args, i8 0, i64 16, i1 false)
-  %16 = getelementptr %warnf_t, ptr %warnf_args, i32 0, i32 0
-  store i64 1, ptr %16, align 8
-  %17 = getelementptr %warnf_t, ptr %warnf_args, i32 0, i32 1
-  %18 = load i64, ptr %"$$__signal_2_$ret", align 8
-  %19 = getelementptr %warnf_args_t, ptr %17, i32 0, i32 0
-  store i64 %18, ptr %19, align 8
+  %15 = getelementptr %warnf_t, ptr %warnf_args, i32 0, i32 0
+  store i64 1, ptr %15, align 8
+  %16 = getelementptr %warnf_t, ptr %warnf_args, i32 0, i32 1
+  %17 = load i64, ptr %"$$__signal_2_$ret", align 8
+  %18 = getelementptr %warnf_args_t, ptr %16, i32 0, i32 0
+  store i64 %17, ptr %18, align 8
   %ringbuf_output4 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %warnf_args, i64 16, i64 0)
   %ringbuf_loss7 = icmp slt i64 %ringbuf_output4, 0
   br i1 %ringbuf_loss7, label %event_loss_counter5, label %counter_merge6
@@ -96,12 +95,12 @@ right2:                                           ; preds = %right
 
 event_loss_counter5:                              ; preds = %left1
   %get_cpu_id8 = call i64 inttoptr (i64 8 to ptr)() #5
-  %20 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded9 = and i64 %get_cpu_id8, %20
-  %21 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded9, i64 0
-  %22 = load i64, ptr %21, align 8
-  %23 = add i64 %22, 1
-  store i64 %23, ptr %21, align 8
+  %19 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded9 = and i64 %get_cpu_id8, %19
+  %20 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded9, i64 0
+  %21 = load i64, ptr %20, align 8
+  %22 = add i64 %21, 1
+  store i64 %22, ptr %20, align 8
   br label %counter_merge6
 
 counter_merge6:                                   ; preds = %event_loss_counter5, %left1

--- a/tests/codegen/llvm/call_signal_string_literal.ll
+++ b/tests/codegen/llvm/call_signal_string_literal.ll
@@ -32,43 +32,42 @@ entry:
   store i32 0, ptr %"$$__signal_2_$sig", align 4
   store i32 9, ptr %"$$__signal_2_$sig", align 4
   %1 = load i32, ptr %"$$__signal_2_$sig", align 4
-  %2 = sext i32 %1 to i64
-  %3 = icmp slt i64 %2, 1
-  %true_cond = icmp ne i1 %3, false
+  %2 = icmp slt i32 %1, 1
+  %true_cond = icmp ne i1 %2, false
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %errorf_args)
   call void @llvm.memset.p0.i64(ptr align 1 %errorf_args, i8 0, i64 24, i1 false)
-  %4 = getelementptr %errorf_t, ptr %errorf_args, i32 0, i32 0
-  store i64 0, ptr %4, align 8
-  %5 = getelementptr %errorf_t, ptr %errorf_args, i32 0, i32 1
-  %6 = getelementptr %errorf_args_t, ptr %5, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 @"signal()", i64 9, i1 false)
-  %7 = load i32, ptr %"$$__signal_2_$sig", align 4
-  %8 = getelementptr %errorf_args_t, ptr %5, i32 0, i32 1
-  store i32 %7, ptr %8, align 4
+  %3 = getelementptr %errorf_t, ptr %errorf_args, i32 0, i32 0
+  store i64 0, ptr %3, align 8
+  %4 = getelementptr %errorf_t, ptr %errorf_args, i32 0, i32 1
+  %5 = getelementptr %errorf_args_t, ptr %4, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %5, ptr align 1 @"signal()", i64 9, i1 false)
+  %6 = load i32, ptr %"$$__signal_2_$sig", align 4
+  %7 = getelementptr %errorf_args_t, ptr %4, i32 0, i32 1
+  store i32 %6, ptr %7, align 4
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %errorf_args, i64 24, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 right:                                            ; preds = %entry
-  %9 = load i32, ptr %"$$__signal_2_$sig", align 4
-  %__signal_process = call i64 @__signal_process(i32 %9), !dbg !41
+  %8 = load i32, ptr %"$$__signal_2_$sig", align 4
+  %__signal_process = call i64 @__signal_process(i32 %8), !dbg !41
   store i64 %__signal_process, ptr %"$$__signal_2_$ret", align 8
-  %10 = load i64, ptr %"$$__signal_2_$ret", align 8
-  %11 = icmp ne i64 %10, 0
-  %true_cond3 = icmp ne i1 %11, false
+  %9 = load i64, ptr %"$$__signal_2_$ret", align 8
+  %10 = icmp ne i64 %9, 0
+  %true_cond3 = icmp ne i1 %10, false
   br i1 %true_cond3, label %left1, label %right2
 
 event_loss_counter:                               ; preds = %left
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #5
-  %12 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %12
-  %13 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
-  %14 = load i64, ptr %13, align 8
-  %15 = add i64 %14, 1
-  store i64 %15, ptr %13, align 8
+  %11 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %11
+  %12 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %13 = load i64, ptr %12, align 8
+  %14 = add i64 %13, 1
+  store i64 %14, ptr %12, align 8
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %left
@@ -81,12 +80,12 @@ done:                                             ; preds = %done10, %counter_me
 left1:                                            ; preds = %right
   call void @llvm.lifetime.start.p0(i64 -1, ptr %warnf_args)
   call void @llvm.memset.p0.i64(ptr align 1 %warnf_args, i8 0, i64 16, i1 false)
-  %16 = getelementptr %warnf_t, ptr %warnf_args, i32 0, i32 0
-  store i64 1, ptr %16, align 8
-  %17 = getelementptr %warnf_t, ptr %warnf_args, i32 0, i32 1
-  %18 = load i64, ptr %"$$__signal_2_$ret", align 8
-  %19 = getelementptr %warnf_args_t, ptr %17, i32 0, i32 0
-  store i64 %18, ptr %19, align 8
+  %15 = getelementptr %warnf_t, ptr %warnf_args, i32 0, i32 0
+  store i64 1, ptr %15, align 8
+  %16 = getelementptr %warnf_t, ptr %warnf_args, i32 0, i32 1
+  %17 = load i64, ptr %"$$__signal_2_$ret", align 8
+  %18 = getelementptr %warnf_args_t, ptr %16, i32 0, i32 0
+  store i64 %17, ptr %18, align 8
   %ringbuf_output4 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %warnf_args, i64 16, i64 0)
   %ringbuf_loss7 = icmp slt i64 %ringbuf_output4, 0
   br i1 %ringbuf_loss7, label %event_loss_counter5, label %counter_merge6
@@ -96,12 +95,12 @@ right2:                                           ; preds = %right
 
 event_loss_counter5:                              ; preds = %left1
   %get_cpu_id8 = call i64 inttoptr (i64 8 to ptr)() #5
-  %20 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded9 = and i64 %get_cpu_id8, %20
-  %21 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded9, i64 0
-  %22 = load i64, ptr %21, align 8
-  %23 = add i64 %22, 1
-  store i64 %23, ptr %21, align 8
+  %19 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded9 = and i64 %get_cpu_id8, %19
+  %20 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded9, i64 0
+  %21 = load i64, ptr %20, align 8
+  %22 = add i64 %21, 1
+  store i64 %22, ptr %20, align 8
   br label %counter_merge6
 
 counter_merge6:                                   ; preds = %event_loss_counter5, %left1

--- a/tests/codegen/llvm/call_signal_thread.ll
+++ b/tests/codegen/llvm/call_signal_thread.ll
@@ -32,43 +32,42 @@ entry:
   store i32 0, ptr %"$$__signal_2_$sig", align 4
   store i32 8, ptr %"$$__signal_2_$sig", align 4
   %1 = load i32, ptr %"$$__signal_2_$sig", align 4
-  %2 = sext i32 %1 to i64
-  %3 = icmp slt i64 %2, 1
-  %true_cond = icmp ne i1 %3, false
+  %2 = icmp slt i32 %1, 1
+  %true_cond = icmp ne i1 %2, false
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %errorf_args)
   call void @llvm.memset.p0.i64(ptr align 1 %errorf_args, i8 0, i64 32, i1 false)
-  %4 = getelementptr %errorf_t, ptr %errorf_args, i32 0, i32 0
-  store i64 0, ptr %4, align 8
-  %5 = getelementptr %errorf_t, ptr %errorf_args, i32 0, i32 1
-  %6 = getelementptr %errorf_args_t, ptr %5, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 @"signal_thread()", i64 16, i1 false)
-  %7 = load i32, ptr %"$$__signal_2_$sig", align 4
-  %8 = getelementptr %errorf_args_t, ptr %5, i32 0, i32 1
-  store i32 %7, ptr %8, align 4
+  %3 = getelementptr %errorf_t, ptr %errorf_args, i32 0, i32 0
+  store i64 0, ptr %3, align 8
+  %4 = getelementptr %errorf_t, ptr %errorf_args, i32 0, i32 1
+  %5 = getelementptr %errorf_args_t, ptr %4, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %5, ptr align 1 @"signal_thread()", i64 16, i1 false)
+  %6 = load i32, ptr %"$$__signal_2_$sig", align 4
+  %7 = getelementptr %errorf_args_t, ptr %4, i32 0, i32 1
+  store i32 %6, ptr %7, align 4
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %errorf_args, i64 32, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 right:                                            ; preds = %entry
-  %9 = load i32, ptr %"$$__signal_2_$sig", align 4
-  %__signal_thread = call i64 @__signal_thread(i32 %9), !dbg !41
+  %8 = load i32, ptr %"$$__signal_2_$sig", align 4
+  %__signal_thread = call i64 @__signal_thread(i32 %8), !dbg !41
   store i64 %__signal_thread, ptr %"$$__signal_2_$ret", align 8
-  %10 = load i64, ptr %"$$__signal_2_$ret", align 8
-  %11 = icmp ne i64 %10, 0
-  %true_cond3 = icmp ne i1 %11, false
+  %9 = load i64, ptr %"$$__signal_2_$ret", align 8
+  %10 = icmp ne i64 %9, 0
+  %true_cond3 = icmp ne i1 %10, false
   br i1 %true_cond3, label %left1, label %right2
 
 event_loss_counter:                               ; preds = %left
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #5
-  %12 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %12
-  %13 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
-  %14 = load i64, ptr %13, align 8
-  %15 = add i64 %14, 1
-  store i64 %15, ptr %13, align 8
+  %11 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %11
+  %12 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %13 = load i64, ptr %12, align 8
+  %14 = add i64 %13, 1
+  store i64 %14, ptr %12, align 8
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %left
@@ -81,12 +80,12 @@ done:                                             ; preds = %done10, %counter_me
 left1:                                            ; preds = %right
   call void @llvm.lifetime.start.p0(i64 -1, ptr %warnf_args)
   call void @llvm.memset.p0.i64(ptr align 1 %warnf_args, i8 0, i64 16, i1 false)
-  %16 = getelementptr %warnf_t, ptr %warnf_args, i32 0, i32 0
-  store i64 1, ptr %16, align 8
-  %17 = getelementptr %warnf_t, ptr %warnf_args, i32 0, i32 1
-  %18 = load i64, ptr %"$$__signal_2_$ret", align 8
-  %19 = getelementptr %warnf_args_t, ptr %17, i32 0, i32 0
-  store i64 %18, ptr %19, align 8
+  %15 = getelementptr %warnf_t, ptr %warnf_args, i32 0, i32 0
+  store i64 1, ptr %15, align 8
+  %16 = getelementptr %warnf_t, ptr %warnf_args, i32 0, i32 1
+  %17 = load i64, ptr %"$$__signal_2_$ret", align 8
+  %18 = getelementptr %warnf_args_t, ptr %16, i32 0, i32 0
+  store i64 %17, ptr %18, align 8
   %ringbuf_output4 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %warnf_args, i64 16, i64 0)
   %ringbuf_loss7 = icmp slt i64 %ringbuf_output4, 0
   br i1 %ringbuf_loss7, label %event_loss_counter5, label %counter_merge6
@@ -96,12 +95,12 @@ right2:                                           ; preds = %right
 
 event_loss_counter5:                              ; preds = %left1
   %get_cpu_id8 = call i64 inttoptr (i64 8 to ptr)() #5
-  %20 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded9 = and i64 %get_cpu_id8, %20
-  %21 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded9, i64 0
-  %22 = load i64, ptr %21, align 8
-  %23 = add i64 %22, 1
-  store i64 %23, ptr %21, align 8
+  %19 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded9 = and i64 %get_cpu_id8, %19
+  %20 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded9, i64 0
+  %21 = load i64, ptr %20, align 8
+  %22 = add i64 %21, 1
+  store i64 %22, ptr %20, align 8
   br label %counter_merge6
 
 counter_merge6:                                   ; preds = %event_loss_counter5, %left1

--- a/tests/codegen/llvm/call_sizeof.ll
+++ b/tests/codegen/llvm/call_sizeof.ll
@@ -8,22 +8,22 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !37
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !46 {
+define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !47 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 8, ptr %"@x_val", align 8
+  store i8 8, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -39,8 +39,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!43}
+!llvm.module.flags = !{!45, !46}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -63,34 +63,34 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 64, elements: !15)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!43 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !44)
+!44 = !{!0, !7, !23, !37, !41}
+!45 = !{i32 2, !"Debug Info Version", i32 3}
+!46 = !{i32 7, !"uwtable", i32 0}
+!47 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !50)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!20, !22}
 !50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !47, file: !2, type: !22)

--- a/tests/codegen/llvm/call_system.ll
+++ b/tests/codegen/llvm/call_system.ll
@@ -5,7 +5,7 @@ target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr }
 %system_t = type { i64, %system_args_t }
-%system_args_t = type { i64 }
+%system_args_t = type { i8 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @ringbuf = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
@@ -25,7 +25,7 @@ entry:
   store i64 10000, ptr %1, align 8
   %2 = getelementptr %system_t, ptr %system_args, i32 0, i32 1
   %3 = getelementptr %system_args_t, ptr %2, i32 0, i32 0
-  store i64 100, ptr %3, align 8
+  store i8 100, ptr %3, align 1
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %system_args, i64 16, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge

--- a/tests/codegen/llvm/call_tseries.ll
+++ b/tests/codegen/llvm/call_tseries.ll
@@ -10,29 +10,29 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_a = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@AT_x = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !48
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !62
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !66
+@AT_x = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !49
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !63
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !67
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !72 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !73 {
 entry:
-  %lookup_elem_val = alloca i64, align 8
+  %lookup_elem_val = alloca i8, align 1
   %"@a_key1" = alloca i64, align 8
   %ts_struct = alloca %t_series_val, align 8
   %key_exists = alloca i8, align 1
   %"@x_key" = alloca [16 x i8], align 1
   %ts_struct_ptr = alloca ptr, align 8
-  %"@a_val" = alloca i64, align 8
+  %"@a_val" = alloca i8, align 1
   %"@a_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key")
   store i64 0, ptr %"@a_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_val")
-  store i64 4, ptr %"@a_val", align 8
+  store i8 4, ptr %"@a_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key", ptr %"@a_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key")
@@ -95,23 +95,24 @@ exit:                                             ; preds = %update, %lookup_mer
   ret i64 0
 
 lookup_success3:                                  ; preds = %merge
-  %13 = load ptr, ptr %lookup_elem2, align 8
-  store ptr %13, ptr %lookup_elem_val, align 8
+  %13 = load i8, ptr %lookup_elem2, align 1
+  store i8 %13, ptr %lookup_elem_val, align 1
   br label %lookup_merge
 
 lookup_failure4:                                  ; preds = %merge
-  store i64 0, ptr %lookup_elem_val, align 8
+  store i8 0, ptr %lookup_elem_val, align 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure4, %lookup_success3
-  %14 = load i64, ptr %lookup_elem_val, align 8
+  %14 = load i8, ptr %lookup_elem_val, align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key1")
-  store i64 %14, ptr %10, align 8
+  %15 = zext i8 %14 to i64
+  store i64 %15, ptr %10, align 8
   store i64 %1, ptr %11, align 8
   store i64 %2, ptr %12, align 8
-  %15 = load i8, ptr %key_exists, align 1
-  %needs_update = icmp ne i8 %15, 1
+  %16 = load i8, ptr %key_exists, align 1
+  %needs_update = icmp ne i8 %16, 1
   br i1 %needs_update, label %update, label %exit
 }
 
@@ -124,8 +125,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!68}
-!llvm.module.flags = !{!70, !71}
+!llvm.dbg.cu = !{!69}
+!llvm.module.flags = !{!71, !72}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -148,60 +149,60 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !25)
-!25 = !{!26, !31, !36, !41}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 160, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 5, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 131072, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 4096, lowerBound: 0)
-!36 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !37, size: 64, offset: 128)
-!37 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !38, size: 64)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 128, elements: !39)
-!39 = !{!40}
-!40 = !DISubrange(count: 16, lowerBound: 0)
-!41 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !42, size: 64, offset: 192)
-!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
-!43 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 192, elements: !44)
-!44 = !{!45, !46, !47}
-!45 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !20, size: 64)
-!46 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !20, size: 64, offset: 64)
-!47 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !20, size: 64, offset: 128)
-!48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
-!49 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !50, isLocal: false, isDefinition: true)
-!50 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !51)
-!51 = !{!52, !57}
-!52 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !53, size: 64)
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !54, size: 64)
-!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !55)
-!55 = !{!56}
-!56 = !DISubrange(count: 27, lowerBound: 0)
-!57 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !58, size: 64, offset: 64)
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !59, size: 64)
-!59 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !60)
-!60 = !{!61}
-!61 = !DISubrange(count: 262144, lowerBound: 0)
-!62 = !DIGlobalVariableExpression(var: !63, expr: !DIExpression())
-!63 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !64, isLocal: false, isDefinition: true)
-!64 = !DICompositeType(tag: DW_TAG_array_type, baseType: !65, size: 64, elements: !15)
-!65 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!66 = !DIGlobalVariableExpression(var: !67, expr: !DIExpression())
-!67 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!68 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !69)
-!69 = !{!0, !7, !22, !48, !62, !66}
-!70 = !{i32 2, !"Debug Info Version", i32 3}
-!71 = !{i32 7, !"uwtable", i32 0}
-!72 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !73, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !68, retainedNodes: !76)
-!73 = !DISubroutineType(types: !74)
-!74 = !{!20, !75}
-!75 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !26)
+!26 = !{!27, !32, !37, !42}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 160, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 5, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 131072, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 4096, lowerBound: 0)
+!37 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !38, size: 64, offset: 128)
+!38 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !39, size: 64)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 128, elements: !40)
+!40 = !{!41}
+!41 = !DISubrange(count: 16, lowerBound: 0)
+!42 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !43, size: 64, offset: 192)
+!43 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !44, size: 64)
+!44 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 192, elements: !45)
+!45 = !{!46, !47, !48}
+!46 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !20, size: 64)
+!47 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !20, size: 64, offset: 64)
+!48 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !20, size: 64, offset: 128)
+!49 = !DIGlobalVariableExpression(var: !50, expr: !DIExpression())
+!50 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !51, isLocal: false, isDefinition: true)
+!51 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !52)
+!52 = !{!53, !58}
+!53 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !54, size: 64)
+!54 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !55, size: 64)
+!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !56)
+!56 = !{!57}
+!57 = !DISubrange(count: 27, lowerBound: 0)
+!58 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !59, size: 64, offset: 64)
+!59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !60, size: 64)
+!60 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !61)
+!61 = !{!62}
+!62 = !DISubrange(count: 262144, lowerBound: 0)
+!63 = !DIGlobalVariableExpression(var: !64, expr: !DIExpression())
+!64 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !65, isLocal: false, isDefinition: true)
+!65 = !DICompositeType(tag: DW_TAG_array_type, baseType: !66, size: 64, elements: !15)
+!66 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!67 = !DIGlobalVariableExpression(var: !68, expr: !DIExpression())
+!68 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!69 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !70)
+!70 = !{!0, !7, !23, !49, !63, !67}
+!71 = !{i32 2, !"Debug Info Version", i32 3}
+!72 = !{i32 7, !"uwtable", i32 0}
+!73 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !74, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !69, retainedNodes: !76)
+!74 = !DISubroutineType(types: !75)
+!75 = !{!20, !22}
 !76 = !{!77}
-!77 = !DILocalVariable(name: "ctx", arg: 1, scope: !72, file: !2, type: !75)
+!77 = !DILocalVariable(name: "ctx", arg: 1, scope: !73, file: !2, type: !22)

--- a/tests/codegen/llvm/call_uptr_1.ll
+++ b/tests/codegen/llvm/call_uptr_1.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
 entry:
-  %"@_val" = alloca i64, align 8
+  %"@_val" = alloca i16, align 2
   %"@_key" = alloca i64, align 8
   %deref = alloca i16, align 2
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
@@ -32,8 +32,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  %5 = sext i16 %4 to i64
-  store i64 %5, ptr %"@_val", align 8
+  store i16 %4, ptr %"@_val", align 2
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
@@ -53,8 +52,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!44}
+!llvm.module.flags = !{!46, !47}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -77,34 +76,36 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int16", size: 16, encoding: DW_ATE_signed)
+!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
+!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
+!27 = !{!28, !33}
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
+!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
+!31 = !{!32}
+!32 = !DISubrange(count: 27, lowerBound: 0)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 262144, lowerBound: 0)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
+!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
+!45 = !{!0, !7, !24, !38, !42}
+!46 = !{i32 2, !"Debug Info Version", i32 3}
+!47 = !{i32 7, !"uwtable", i32 0}
+!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
+!49 = !DISubroutineType(types: !50)
+!50 = !{!20, !51}
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!52 = !{!53}
+!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)

--- a/tests/codegen/llvm/call_uptr_2.ll
+++ b/tests/codegen/llvm/call_uptr_2.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
 entry:
-  %"@_val" = alloca i64, align 8
+  %"@_val" = alloca i32, align 4
   %"@_key" = alloca i64, align 8
   %deref = alloca i32, align 4
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
@@ -32,8 +32,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  %5 = sext i32 %4 to i64
-  store i64 %5, ptr %"@_val", align 8
+  store i32 %4, ptr %"@_val", align 4
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
@@ -53,8 +52,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!44}
+!llvm.module.flags = !{!46, !47}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -77,34 +76,36 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
+!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
+!27 = !{!28, !33}
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
+!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
+!31 = !{!32}
+!32 = !DISubrange(count: 27, lowerBound: 0)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 262144, lowerBound: 0)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
+!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
+!45 = !{!0, !7, !24, !38, !42}
+!46 = !{i32 2, !"Debug Info Version", i32 3}
+!47 = !{i32 7, !"uwtable", i32 0}
+!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
+!49 = !DISubroutineType(types: !50)
+!50 = !{!20, !51}
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!52 = !{!53}
+!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)

--- a/tests/codegen/llvm/call_usym_key.ll
+++ b/tests/codegen/llvm/call_usym_key.ll
@@ -9,8 +9,8 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !30
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !44
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !29
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !43
 @__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !48
 
 ; Function Attrs: nounwind
@@ -19,7 +19,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !54 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
   %usym = alloca %usym_t, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %usym)
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
@@ -32,7 +32,7 @@ entry:
   store i32 %pid, ptr %3, align 4
   store i32 0, ptr %4, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 1, ptr %"@x_val", align 8
+  store i8 1, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %usym, ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   ret i64 0
@@ -79,35 +79,34 @@ attributes #2 = { memory(none) }
 !25 = !{!26}
 !26 = !DISubrange(count: 16, lowerBound: 0)
 !27 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !28, size: 64, offset: 192)
-!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
-!29 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!30 = !DIGlobalVariableExpression(var: !31, expr: !DIExpression())
-!31 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !32, isLocal: false, isDefinition: true)
-!32 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !33)
-!33 = !{!34, !39}
-!34 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !35, size: 64)
-!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
-!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !37)
-!37 = !{!38}
-!38 = !DISubrange(count: 27, lowerBound: 0)
-!39 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !40, size: 64, offset: 64)
-!40 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !41, size: 64)
-!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !42)
-!42 = !{!43}
-!43 = !DISubrange(count: 262144, lowerBound: 0)
-!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
-!45 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !46, isLocal: false, isDefinition: true)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!29 = !DIGlobalVariableExpression(var: !30, expr: !DIExpression())
+!30 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !31, isLocal: false, isDefinition: true)
+!31 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !32)
+!32 = !{!33, !38}
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !34, size: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 27, lowerBound: 0)
+!38 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !39, size: 64, offset: 64)
+!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !41)
+!41 = !{!42}
+!42 = !DISubrange(count: 262144, lowerBound: 0)
+!43 = !DIGlobalVariableExpression(var: !44, expr: !DIExpression())
+!44 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !45, isLocal: false, isDefinition: true)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !46, size: 64, elements: !15)
 !46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !47, size: 64, elements: !15)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !29, size: 64, elements: !15)
+!47 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
-!49 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
+!49 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !47, isLocal: false, isDefinition: true)
 !50 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !51)
-!51 = !{!0, !7, !30, !44, !48}
+!51 = !{!0, !7, !29, !43, !48}
 !52 = !{i32 2, !"Debug Info Version", i32 3}
 !53 = !{i32 7, !"uwtable", i32 0}
-!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !50, retainedNodes: !58)
+!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !50, retainedNodes: !57)
 !55 = !DISubroutineType(types: !56)
-!56 = !{!29, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
+!56 = !{!47, !28}
+!57 = !{!58}
+!58 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !28)

--- a/tests/codegen/llvm/call_zero.ll
+++ b/tests/codegen/llvm/call_zero.ll
@@ -9,22 +9,22 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !37
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !46 {
+define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !47 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 1, ptr %"@x_val", align 8
+  store i8 1, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -69,8 +69,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { memory(none) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!43}
+!llvm.module.flags = !{!45, !46}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -93,37 +93,37 @@ attributes #2 = { memory(none) }
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 64, elements: !15)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!43 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !44)
+!44 = !{!0, !7, !23, !37, !41}
+!45 = !{i32 2, !"Debug Info Version", i32 3}
+!46 = !{i32 7, !"uwtable", i32 0}
+!47 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !50)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!20, !22}
 !50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
-!52 = distinct !DISubprogram(name: "kprobe_f_2", linkageName: "kprobe_f_2", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !53)
+!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !47, file: !2, type: !22)
+!52 = distinct !DISubprogram(name: "kprobe_f_2", linkageName: "kprobe_f_2", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !53)
 !53 = !{!54}
-!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !52, file: !2, type: !49)
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !52, file: !2, type: !22)

--- a/tests/codegen/llvm/cast_arr_to_int.ll
+++ b/tests/codegen/llvm/cast_arr_to_int.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
 entry:
-  %"@_val" = alloca i64, align 8
+  %"@_val" = alloca i32, align 4
   %"@_key" = alloca i64, align 8
   %addr4 = alloca [4 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %addr4)
@@ -35,8 +35,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  %6 = zext i32 %5 to i64
-  store i64 %6, ptr %"@_val", align 8
+  store i32 %5, ptr %"@_val", align 4
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
@@ -52,8 +51,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!44}
+!llvm.module.flags = !{!46, !47}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -76,34 +75,36 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
+!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
+!27 = !{!28, !33}
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
+!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
+!31 = !{!32}
+!32 = !DISubrange(count: 27, lowerBound: 0)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 262144, lowerBound: 0)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
+!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
+!45 = !{!0, !7, !24, !38, !42}
+!46 = !{i32 2, !"Debug Info Version", i32 3}
+!47 = !{i32 7, !"uwtable", i32 0}
+!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
+!49 = !DISubroutineType(types: !50)
+!50 = !{!20, !51}
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!52 = !{!53}
+!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)

--- a/tests/codegen/llvm/cast_int_to_arr.ll
+++ b/tests/codegen/llvm/cast_int_to_arr.ll
@@ -9,17 +9,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !37
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !47 {
 entry:
-  %"@_val" = alloca i64, align 8
+  %"@_val" = alloca i8, align 1
   %"@_key" = alloca i64, align 8
   %runtime_error_t = alloca %runtime_error_t, align 8
   %"$a" = alloca ptr, align 8
@@ -46,13 +46,12 @@ is_oob:                                           ; preds = %entry
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 oob_merge:                                        ; preds = %counter_merge, %entry
-  %7 = getelementptr [8 x i8], ptr %3, i32 0, i64 0
+  %7 = getelementptr [8 x i8], ptr %3, i32 0, i8 0
   %8 = load volatile i8, ptr %7, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  %9 = zext i8 %8 to i64
-  store i64 %9, ptr %"@_val", align 8
+  store i8 %8, ptr %"@_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
@@ -60,12 +59,12 @@ oob_merge:                                        ; preds = %counter_merge, %ent
 
 event_loss_counter:                               ; preds = %is_oob
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #2
-  %10 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %10
-  %11 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
-  %12 = load i64, ptr %11, align 8
-  %13 = add i64 %12, 1
-  store i64 %13, ptr %11, align 8
+  %9 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %9
+  %10 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %11 = load i64, ptr %10, align 8
+  %12 = add i64 %11, 1
+  store i64 %12, ptr %10, align 8
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %is_oob
@@ -83,8 +82,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { memory(none) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!43}
+!llvm.module.flags = !{!45, !46}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -107,34 +106,34 @@ attributes #2 = { memory(none) }
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 64, elements: !15)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!43 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !44)
+!44 = !{!0, !7, !23, !37, !41}
+!45 = !{i32 2, !"Debug Info Version", i32 3}
+!46 = !{i32 7, !"uwtable", i32 0}
+!47 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !50)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!20, !22}
 !50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !47, file: !2, type: !22)

--- a/tests/codegen/llvm/count_cast_loop.ll
+++ b/tests/codegen/llvm/count_cast_loop.ll
@@ -5,26 +5,26 @@ target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.163" = type { ptr, ptr }
-%int64_count_t__tuple_t = type { i64, i64 }
+%uint8_count_t__tuple_t = type { i8, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !42
-@__bt__num_cpus = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !48
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !27
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !43
+@__bt__num_cpus = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !49
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !54 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !55 {
 entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
-  %"@x_key" = alloca i64, align 8
+  %"@x_key" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
-  store i64 1, ptr %"@x_key", align 8
+  store i8 1, ptr %"@x_key", align 1
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
@@ -62,11 +62,11 @@ for_body:
   %"$res" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$res")
   store i64 0, ptr %"$res", align 8
-  %"$kv" = alloca %int64_count_t__tuple_t, align 8
+  %"$kv" = alloca %uint8_count_t__tuple_t, align 8
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
-  %key = load i64, ptr %1, align 8
+  %key = load i8, ptr %1, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
@@ -94,11 +94,11 @@ while_end:                                        ; preds = %error_failure, %err
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
   call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %8 = getelementptr %int64_count_t__tuple_t, ptr %"$kv", i32 0, i32 0
-  store i64 %key, ptr %8, align 8
-  %9 = getelementptr %int64_count_t__tuple_t, ptr %"$kv", i32 0, i32 1
+  %8 = getelementptr %uint8_count_t__tuple_t, ptr %"$kv", i32 0, i32 0
+  store i8 %key, ptr %8, align 1
+  %9 = getelementptr %uint8_count_t__tuple_t, ptr %"$kv", i32 0, i32 1
   store i64 %7, ptr %9, align 8
-  %10 = getelementptr %int64_count_t__tuple_t, ptr %"$kv", i32 0, i32 1
+  %10 = getelementptr %uint8_count_t__tuple_t, ptr %"$kv", i32 0, i32 1
   %11 = load i64, ptr %10, align 8
   store i64 %11, ptr %"$res", align 8
   br label %for_continue
@@ -136,8 +136,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!50}
-!llvm.module.flags = !{!52, !53}
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!53, !54}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -149,7 +149,7 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 160, elements: !15)
@@ -162,48 +162,48 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !20 = !{!21}
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
-!29 = !{!30, !35}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 27, lowerBound: 0)
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
-!38 = !{!39}
-!39 = !DISubrange(count: 262144, lowerBound: 0)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
-!43 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !44, isLocal: false, isDefinition: true)
-!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !45, size: 64, elements: !46)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 1, lowerBound: 0)
-!48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
-!49 = distinct !DIGlobalVariable(name: "__bt__num_cpus", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!50 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !51)
-!51 = !{!0, !7, !26, !40, !42, !48}
-!52 = !{i32 2, !"Debug Info Version", i32 3}
-!53 = !{i32 7, !"uwtable", i32 0}
-!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !50, retainedNodes: !58)
-!55 = !DISubroutineType(types: !56)
-!56 = !{!24, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !25, size: 64, offset: 192)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!27 = !DIGlobalVariableExpression(var: !28, expr: !DIExpression())
+!28 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
+!29 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !30)
+!30 = !{!31, !36}
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !32, size: 64)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !34)
+!34 = !{!35}
+!35 = !DISubrange(count: 27, lowerBound: 0)
+!36 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !37, size: 64, offset: 64)
+!37 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !38, size: 64)
+!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !39)
+!39 = !{!40}
+!40 = !DISubrange(count: 262144, lowerBound: 0)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!43 = !DIGlobalVariableExpression(var: !44, expr: !DIExpression())
+!44 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !45, isLocal: false, isDefinition: true)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !46, size: 64, elements: !47)
+!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !26, size: 64, elements: !47)
+!47 = !{!48}
+!48 = !DISubrange(count: 1, lowerBound: 0)
+!49 = !DIGlobalVariableExpression(var: !50, expr: !DIExpression())
+!50 = distinct !DIGlobalVariable(name: "__bt__num_cpus", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
+!52 = !{!0, !7, !27, !41, !43, !49}
+!53 = !{i32 2, !"Debug Info Version", i32 3}
+!54 = !{i32 7, !"uwtable", i32 0}
+!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
+!56 = !DISubroutineType(types: !57)
+!57 = !{!26, !23}
 !58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
-!60 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !61, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !50, retainedNodes: !63)
+!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !23)
+!60 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !61, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !51, retainedNodes: !63)
 !61 = !DISubroutineType(types: !62)
-!62 = !{!24, !57, !57, !57, !57}
+!62 = !{!26, !23, !23, !23, !23}
 !63 = !{!64, !65, !66, !67}
-!64 = !DILocalVariable(name: "map", arg: 1, scope: !60, file: !2, type: !57)
-!65 = !DILocalVariable(name: "key", arg: 2, scope: !60, file: !2, type: !57)
-!66 = !DILocalVariable(name: "value", arg: 3, scope: !60, file: !2, type: !57)
-!67 = !DILocalVariable(name: "ctx", arg: 4, scope: !60, file: !2, type: !57)
+!64 = !DILocalVariable(name: "map", arg: 1, scope: !60, file: !2, type: !23)
+!65 = !DILocalVariable(name: "key", arg: 2, scope: !60, file: !2, type: !23)
+!66 = !DILocalVariable(name: "value", arg: 3, scope: !60, file: !2, type: !23)
+!67 = !DILocalVariable(name: "ctx", arg: 4, scope: !60, file: !2, type: !23)

--- a/tests/codegen/llvm/count_cast_loop_multi_key.ll
+++ b/tests/codegen/llvm/count_cast_loop_multi_key.ll
@@ -5,8 +5,8 @@ target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.163" = type { ptr, ptr }
-%int64_int64__tuple_t = type { i64, i64 }
-%"(int64,int64)_count_t__tuple_t" = type { %int64_int64__tuple_t, i64 }
+%uint8_uint8__tuple_t = type { i8, i8 }
+%"(uint8,uint8)_count_t__tuple_t" = type { %uint8_uint8__tuple_t, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
@@ -23,13 +23,13 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !59 {
 entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
-  %tuple = alloca %int64_int64__tuple_t, align 8
+  %tuple = alloca %uint8_uint8__tuple_t, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %1 = getelementptr %int64_int64__tuple_t, ptr %tuple, i32 0, i32 0
-  store i64 1, ptr %1, align 8
-  %2 = getelementptr %int64_int64__tuple_t, ptr %tuple, i32 0, i32 1
-  store i64 2, ptr %2, align 8
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 2, i1 false)
+  %1 = getelementptr %uint8_uint8__tuple_t, ptr %tuple, i32 0, i32 0
+  store i8 1, ptr %1, align 1
+  %2 = getelementptr %uint8_uint8__tuple_t, ptr %tuple, i32 0, i32 1
+  store i8 2, ptr %2, align 1
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %tuple)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
@@ -70,7 +70,7 @@ for_body:
   %"$res" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$res")
   store i64 0, ptr %"$res", align 8
-  %"$kv" = alloca %"(int64,int64)_count_t__tuple_t", align 8
+  %"$kv" = alloca %"(uint8,uint8)_count_t__tuple_t", align 8
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
@@ -100,12 +100,12 @@ while_end:                                        ; preds = %error_failure, %err
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_1)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 24, i1 false)
-  %8 = getelementptr %"(int64,int64)_count_t__tuple_t", ptr %"$kv", i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %1, i64 16, i1 false)
-  %9 = getelementptr %"(int64,int64)_count_t__tuple_t", ptr %"$kv", i32 0, i32 1
+  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
+  %8 = getelementptr %"(uint8,uint8)_count_t__tuple_t", ptr %"$kv", i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %1, i64 2, i1 false)
+  %9 = getelementptr %"(uint8,uint8)_count_t__tuple_t", ptr %"$kv", i32 0, i32 1
   store i64 %7, ptr %9, align 8
-  %10 = getelementptr %"(int64,int64)_count_t__tuple_t", ptr %"$kv", i32 0, i32 1
+  %10 = getelementptr %"(uint8,uint8)_count_t__tuple_t", ptr %"$kv", i32 0, i32 1
   %11 = load i64, ptr %10, align 8
   store i64 %11, ptr %"$res", align 8
   br label %for_continue
@@ -157,7 +157,7 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !29}
+!10 = !{!11, !17, !22, !28}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 160, elements: !15)
@@ -171,13 +171,13 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
 !23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !28}
-!26 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!28 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !27, size: 64, offset: 64)
-!29 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !30, size: 64, offset: 192)
-!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
+!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 16, elements: !25)
+!25 = !{!26, !27}
+!26 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !4, size: 8)
+!27 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !4, size: 8, offset: 8)
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !29, size: 64, offset: 192)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
+!30 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !31 = !DIGlobalVariableExpression(var: !32, expr: !DIExpression())
 !32 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !33, isLocal: false, isDefinition: true)
 !33 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !34)
@@ -193,28 +193,28 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !43 = !{!44}
 !44 = !DISubrange(count: 262144, lowerBound: 0)
 !45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
-!46 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!46 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !30, isLocal: false, isDefinition: true)
 !47 = !DIGlobalVariableExpression(var: !48, expr: !DIExpression())
 !48 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !49, isLocal: false, isDefinition: true)
 !49 = !DICompositeType(tag: DW_TAG_array_type, baseType: !50, size: 64, elements: !51)
-!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !27, size: 64, elements: !51)
+!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !30, size: 64, elements: !51)
 !51 = !{!52}
 !52 = !DISubrange(count: 1, lowerBound: 0)
 !53 = !DIGlobalVariableExpression(var: !54, expr: !DIExpression())
-!54 = distinct !DIGlobalVariable(name: "__bt__num_cpus", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!54 = distinct !DIGlobalVariable(name: "__bt__num_cpus", linkageName: "global", scope: !2, file: !2, type: !30, isLocal: false, isDefinition: true)
 !55 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !56)
 !56 = !{!0, !7, !31, !45, !47, !53}
 !57 = !{i32 2, !"Debug Info Version", i32 3}
 !58 = !{i32 7, !"uwtable", i32 0}
 !59 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !60, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !55, retainedNodes: !63)
 !60 = !DISubroutineType(types: !61)
-!61 = !{!27, !62}
+!61 = !{!30, !62}
 !62 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
 !63 = !{!64}
 !64 = !DILocalVariable(name: "ctx", arg: 1, scope: !59, file: !2, type: !62)
 !65 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !66, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !55, retainedNodes: !68)
 !66 = !DISubroutineType(types: !67)
-!67 = !{!27, !62, !62, !62, !62}
+!67 = !{!30, !62, !62, !62, !62}
 !68 = !{!69, !70, !71, !72}
 !69 = !DILocalVariable(name: "map", arg: 1, scope: !65, file: !2, type: !62)
 !70 = !DILocalVariable(name: "key", arg: 2, scope: !65, file: !2, type: !62)

--- a/tests/codegen/llvm/dereference.ll
+++ b/tests/codegen/llvm/dereference.ll
@@ -20,15 +20,16 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
 entry:
   %"@x_val" = alloca i64, align 8
   %"@x_key" = alloca i64, align 8
-  %deref = alloca i64, align 8
+  %deref = alloca i16, align 2
   call void @llvm.lifetime.start.p0(i64 -1, ptr %deref)
-  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %deref, i32 8, i64 1234)
-  %1 = load i64, ptr %deref, align 8
+  %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %deref, i32 2, i16 1234)
+  %1 = load i16, ptr %deref, align 2
+  %2 = zext i16 %1 to i64
   call void @llvm.lifetime.end.p0(i64 -1, ptr %deref)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 %1, ptr %"@x_val", align 8
+  store i64 %2, ptr %"@x_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/fentry_dereference.ll
+++ b/tests/codegen/llvm/fentry_dereference.ll
@@ -8,18 +8,18 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !27
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !41
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !46
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @fentry_mock_vmlinux_tcp_sendmsg_1(ptr %0) #0 section "s_fentry_mock_vmlinux_tcp_sendmsg_1" !dbg !50 {
+define i64 @fentry_mock_vmlinux_tcp_sendmsg_1(ptr %0) #0 section "s_fentry_mock_vmlinux_tcp_sendmsg_1" !dbg !52 {
 entry:
-  %"@_val" = alloca i64, align 8
-  %"@_key" = alloca i64, align 8
+  %"@_val" = alloca i8, align 1
+  %"@_key" = alloca i32, align 4
   %"struct sock_common.skc_daddr" = alloca i32, align 4
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i64, ptr %1, i64 0
@@ -33,10 +33,9 @@ entry:
   %7 = load i32, ptr %"struct sock_common.skc_daddr", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct sock_common.skc_daddr")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  %8 = zext i32 %7 to i64
-  store i64 %8, ptr %"@_key", align 8
+  store i32 %7, ptr %"@_key", align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  store i64 1, ptr %"@_val", align 8
+  store i8 1, ptr %"@_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
@@ -56,8 +55,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!46}
-!llvm.module.flags = !{!48, !49}
+!llvm.dbg.cu = !{!48}
+!llvm.module.flags = !{!50, !51}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -83,35 +82,36 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
 !23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
-!29 = !{!30, !35}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 27, lowerBound: 0)
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
-!38 = !{!39}
-!39 = !DISubrange(count: 262144, lowerBound: 0)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
-!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
-!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
-!47 = !{!0, !7, !26, !40, !44}
-!48 = !{i32 2, !"Debug Info Version", i32 3}
-!49 = !{i32 7, !"uwtable", i32 0}
-!50 = distinct !DISubprogram(name: "fentry_mock_vmlinux_tcp_sendmsg_1", linkageName: "fentry_mock_vmlinux_tcp_sendmsg_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
-!51 = !DISubroutineType(types: !52)
-!52 = !{!24, !53}
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)
+!24 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !26, size: 64, offset: 192)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!27 = !DIGlobalVariableExpression(var: !28, expr: !DIExpression())
+!28 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
+!29 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !30)
+!30 = !{!31, !36}
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !32, size: 64)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !34)
+!34 = !{!35}
+!35 = !DISubrange(count: 27, lowerBound: 0)
+!36 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !37, size: 64, offset: 64)
+!37 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !38, size: 64)
+!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !39)
+!39 = !{!40}
+!40 = !DISubrange(count: 262144, lowerBound: 0)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !44, size: 64, elements: !15)
+!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !45, size: 64, elements: !15)
+!45 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!46 = !DIGlobalVariableExpression(var: !47, expr: !DIExpression())
+!47 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !45, isLocal: false, isDefinition: true)
+!48 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !49)
+!49 = !{!0, !7, !27, !41, !46}
+!50 = !{i32 2, !"Debug Info Version", i32 3}
+!51 = !{i32 7, !"uwtable", i32 0}
+!52 = distinct !DISubprogram(name: "fentry_mock_vmlinux_tcp_sendmsg_1", linkageName: "fentry_mock_vmlinux_tcp_sendmsg_1", scope: !2, file: !2, type: !53, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !48, retainedNodes: !55)
+!53 = !DISubroutineType(types: !54)
+!54 = !{!45, !26}
+!55 = !{!56}
+!56 = !DILocalVariable(name: "ctx", arg: 1, scope: !52, file: !2, type: !26)

--- a/tests/codegen/llvm/fentry_recursion_check_with_predicate.ll
+++ b/tests/codegen/llvm/fentry_recursion_check_with_predicate.ll
@@ -41,19 +41,18 @@ lookup_merge:                                     ; preds = %lookup_success
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %2 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %2 to i32
-  %3 = zext i32 %pid to i64
-  %4 = icmp eq i64 %3, 1234
-  %true_cond = icmp ne i1 %4, false
+  %3 = icmp eq i32 %pid, 1234
+  %true_cond = icmp ne i1 %3, false
   br i1 %true_cond, label %left, label %right
 
 value_is_set:                                     ; preds = %lookup_success
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #2
-  %5 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %5
-  %6 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
-  %7 = load i64, ptr %6, align 8
-  %8 = add i64 %7, 1
-  store i64 %8, ptr %6, align 8
+  %4 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %4
+  %5 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %6 = load i64, ptr %5, align 8
+  %7 = add i64 %6, 1
+  store i64 %7, ptr %5, align 8
   ret i64 0
 
 left:                                             ; preds = %lookup_merge

--- a/tests/codegen/llvm/fexit_dereference.ll
+++ b/tests/codegen/llvm/fexit_dereference.ll
@@ -8,18 +8,18 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !27
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !41
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !46
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @fexit_mock_vmlinux_sk_alloc_1(ptr %0) #0 section "s_fexit_mock_vmlinux_sk_alloc_1" !dbg !50 {
+define i64 @fexit_mock_vmlinux_sk_alloc_1(ptr %0) #0 section "s_fexit_mock_vmlinux_sk_alloc_1" !dbg !52 {
 entry:
-  %"@_val" = alloca i64, align 8
-  %"@_key" = alloca i64, align 8
+  %"@_val" = alloca i8, align 1
+  %"@_key" = alloca i32, align 4
   %"struct sock_common.skc_daddr" = alloca i32, align 4
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i64, ptr %1, i64 5
@@ -33,10 +33,9 @@ entry:
   %7 = load i32, ptr %"struct sock_common.skc_daddr", align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"struct sock_common.skc_daddr")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  %8 = zext i32 %7 to i64
-  store i64 %8, ptr %"@_key", align 8
+  store i32 %7, ptr %"@_key", align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  store i64 1, ptr %"@_val", align 8
+  store i8 1, ptr %"@_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
@@ -56,8 +55,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!46}
-!llvm.module.flags = !{!48, !49}
+!llvm.dbg.cu = !{!48}
+!llvm.module.flags = !{!50, !51}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -83,35 +82,36 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
 !23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
-!29 = !{!30, !35}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 27, lowerBound: 0)
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
-!38 = !{!39}
-!39 = !DISubrange(count: 262144, lowerBound: 0)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
-!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
-!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
-!47 = !{!0, !7, !26, !40, !44}
-!48 = !{i32 2, !"Debug Info Version", i32 3}
-!49 = !{i32 7, !"uwtable", i32 0}
-!50 = distinct !DISubprogram(name: "fexit_mock_vmlinux_sk_alloc_1", linkageName: "fexit_mock_vmlinux_sk_alloc_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
-!51 = !DISubroutineType(types: !52)
-!52 = !{!24, !53}
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)
+!24 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !26, size: 64, offset: 192)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!27 = !DIGlobalVariableExpression(var: !28, expr: !DIExpression())
+!28 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
+!29 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !30)
+!30 = !{!31, !36}
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !32, size: 64)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !34)
+!34 = !{!35}
+!35 = !DISubrange(count: 27, lowerBound: 0)
+!36 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !37, size: 64, offset: 64)
+!37 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !38, size: 64)
+!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !39)
+!39 = !{!40}
+!40 = !DISubrange(count: 262144, lowerBound: 0)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !44, size: 64, elements: !15)
+!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !45, size: 64, elements: !15)
+!45 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!46 = !DIGlobalVariableExpression(var: !47, expr: !DIExpression())
+!47 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !45, isLocal: false, isDefinition: true)
+!48 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !49)
+!49 = !{!0, !7, !27, !41, !46}
+!50 = !{i32 2, !"Debug Info Version", i32 3}
+!51 = !{i32 7, !"uwtable", i32 0}
+!52 = distinct !DISubprogram(name: "fexit_mock_vmlinux_sk_alloc_1", linkageName: "fexit_mock_vmlinux_sk_alloc_1", scope: !2, file: !2, type: !53, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !48, retainedNodes: !55)
+!53 = !DISubroutineType(types: !54)
+!54 = !{!45, !26}
+!55 = !{!56}
+!56 = !DILocalVariable(name: "ctx", arg: 1, scope: !52, file: !2, type: !26)

--- a/tests/codegen/llvm/fmt_str_args_scratch_buf.ll
+++ b/tests/codegen/llvm/fmt_str_args_scratch_buf.ll
@@ -5,13 +5,13 @@ target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr }
 %printf_t = type { i64, %printf_args_t }
-%printf_args_t = type { [5 x i8], i64 }
+%printf_args_t = type { [5 x i8], i8 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @ringbuf = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
 @__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !22
 @__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !29
-@__bt__fmt_str_buf = dso_local externally_initialized global [1 x [1 x [24 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !31
+@__bt__fmt_str_buf = dso_local externally_initialized global [1 x [1 x [16 x i8]]] zeroinitializer, section ".data.fmt_str_buf", !dbg !31
 @xxxx = global [5 x i8] c"xxxx\00"
 
 ; Function Attrs: nounwind
@@ -23,16 +23,16 @@ entry:
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
-  %2 = getelementptr [1 x [1 x [24 x i8]]], ptr @__bt__fmt_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 24, i1 false)
+  %2 = getelementptr [1 x [1 x [16 x i8]]], ptr @__bt__fmt_str_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
   %3 = getelementptr %printf_t, ptr %2, i32 0, i32 0
   store i64 0, ptr %3, align 8
   %4 = getelementptr %printf_t, ptr %2, i32 0, i32 1
   %5 = getelementptr %printf_args_t, ptr %4, i32 0, i32 0
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %5, ptr align 1 @xxxx, i64 5, i1 false)
   %6 = getelementptr %printf_args_t, ptr %4, i32 0, i32 1
-  store i64 1, ptr %6, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %2, i64 24, i64 0)
+  store i8 1, ptr %6, align 1
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %2, i64 16, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -97,11 +97,11 @@ attributes #3 = { memory(none) }
 !30 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
 !31 = !DIGlobalVariableExpression(var: !32, expr: !DIExpression())
 !32 = distinct !DIGlobalVariable(name: "__bt__fmt_str_buf", linkageName: "global", scope: !2, file: !2, type: !33, isLocal: false, isDefinition: true)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !34, size: 192, elements: !27)
-!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !35, size: 192, elements: !27)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 192, elements: !36)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !34, size: 128, elements: !27)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !35, size: 128, elements: !27)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 128, elements: !36)
 !36 = !{!37}
-!37 = !DISubrange(count: 24, lowerBound: 0)
+!37 = !DISubrange(count: 16, lowerBound: 0)
 !38 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !39)
 !39 = !{!0, !7, !22, !29, !31}
 !40 = !{i32 2, !"Debug Info Version", i32 3}

--- a/tests/codegen/llvm/fmt_str_args_stack.ll
+++ b/tests/codegen/llvm/fmt_str_args_stack.ll
@@ -5,7 +5,7 @@ target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr }
 %printf_t = type { i64, %printf_args_t }
-%printf_args_t = type { [5 x i8], i64 }
+%printf_args_t = type { [5 x i8], i8 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @ringbuf = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
@@ -21,15 +21,15 @@ define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
   %printf_args = alloca %printf_t, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args)
-  call void @llvm.memset.p0.i64(ptr align 1 %printf_args, i8 0, i64 24, i1 false)
+  call void @llvm.memset.p0.i64(ptr align 1 %printf_args, i8 0, i64 16, i1 false)
   %1 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
   store i64 0, ptr %1, align 8
   %2 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 1
   %3 = getelementptr %printf_args_t, ptr %2, i32 0, i32 0
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %3, ptr align 1 @xxxx, i64 5, i1 false)
   %4 = getelementptr %printf_args_t, ptr %2, i32 0, i32 1
-  store i64 1, ptr %4, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args, i64 24, i64 0)
+  store i8 1, ptr %4, align 1
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args, i64 16, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 

--- a/tests/codegen/llvm/for_map_one_key.ll
+++ b/tests/codegen/llvm/for_map_one_key.ll
@@ -6,27 +6,27 @@ target triple = "bpf"
 %"struct map_internal_repr_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.163" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.164" = type { ptr, ptr }
-%int64_int64__tuple_t = type { i64, i64 }
+%uint8_uint8__tuple_t = type { i8, i8 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_map = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@AT_x = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !37
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !51
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !55
+@AT_x = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !25
+@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !39
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !53
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !57
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !61 {
+define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !63 {
 entry:
-  %"@map_val" = alloca i64, align 8
-  %"@map_key" = alloca i64, align 8
+  %"@map_val" = alloca i8, align 1
+  %"@map_key" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_key")
-  store i64 16, ptr %"@map_key", align 8
+  store i8 16, ptr %"@map_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_val")
-  store i64 32, ptr %"@map_val", align 8
+  store i8 32, ptr %"@map_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_map, ptr %"@map_key", ptr %"@map_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@map_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@map_key")
@@ -41,18 +41,18 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 ; Function Attrs: nounwind
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !67 {
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !68 {
 for_body:
   %"@x_key" = alloca i64, align 8
-  %"$kv" = alloca %int64_int64__tuple_t, align 8
-  %key = load i64, ptr %1, align 8
-  %val = load i64, ptr %2, align 8
+  %"$kv" = alloca %uint8_uint8__tuple_t, align 8
+  %key = load i8, ptr %1, align 1
+  %val = load i8, ptr %2, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %4 = getelementptr %int64_int64__tuple_t, ptr %"$kv", i32 0, i32 0
-  store i64 %key, ptr %4, align 8
-  %5 = getelementptr %int64_int64__tuple_t, ptr %"$kv", i32 0, i32 1
-  store i64 %val, ptr %5, align 8
+  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 2, i1 false)
+  %4 = getelementptr %uint8_uint8__tuple_t, ptr %"$kv", i32 0, i32 0
+  store i8 %key, ptr %4, align 1
+  %5 = getelementptr %uint8_uint8__tuple_t, ptr %"$kv", i32 0, i32 1
+  store i8 %val, ptr %5, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"$kv", i64 0)
@@ -70,8 +70,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!57}
-!llvm.module.flags = !{!59, !60}
+!llvm.dbg.cu = !{!59}
+!llvm.module.flags = !{!61, !62}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -83,7 +83,7 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_map", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
@@ -96,55 +96,56 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !20 = !{!21}
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !29)
-!29 = !{!11, !30, !22, !31}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !32, size: 64, offset: 192)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !34)
-!34 = !{!35, !36}
-!35 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !24, size: 64)
-!36 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !24, size: 64, offset: 64)
-!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
-!38 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
-!39 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !40)
-!40 = !{!41, !46}
-!41 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !42, size: 64)
-!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !44)
-!44 = !{!45}
-!45 = !DISubrange(count: 27, lowerBound: 0)
-!46 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !47, size: 64, offset: 64)
-!47 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!48 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !49)
-!49 = !{!50}
-!50 = !DISubrange(count: 262144, lowerBound: 0)
-!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
-!52 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !53, isLocal: false, isDefinition: true)
-!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !54, size: 64, elements: !15)
-!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
-!55 = !DIGlobalVariableExpression(var: !56, expr: !DIExpression())
-!56 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!57 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !58)
-!58 = !{!0, !7, !26, !37, !51, !55}
-!59 = !{i32 2, !"Debug Info Version", i32 3}
-!60 = !{i32 7, !"uwtable", i32 0}
-!61 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !62, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !57, retainedNodes: !65)
-!62 = !DISubroutineType(types: !63)
-!63 = !{!24, !64}
-!64 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!65 = !{!66}
-!66 = !DILocalVariable(name: "ctx", arg: 1, scope: !61, file: !2, type: !64)
-!67 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !68, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !57, retainedNodes: !70)
-!68 = !DISubroutineType(types: !69)
-!69 = !{!24, !64, !64, !64, !64}
-!70 = !{!71, !72, !73, !74}
-!71 = !DILocalVariable(name: "map", arg: 1, scope: !67, file: !2, type: !64)
-!72 = !DILocalVariable(name: "key", arg: 2, scope: !67, file: !2, type: !64)
-!73 = !DILocalVariable(name: "value", arg: 3, scope: !67, file: !2, type: !64)
-!74 = !DILocalVariable(name: "ctx", arg: 4, scope: !67, file: !2, type: !64)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !28)
+!28 = !{!11, !29, !30, !33}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 16, elements: !36)
+!36 = !{!37, !38}
+!37 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !4, size: 8)
+!38 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !4, size: 8, offset: 8)
+!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
+!40 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!41 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !42)
+!42 = !{!43, !48}
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !44, size: 64)
+!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !46)
+!46 = !{!47}
+!47 = !DISubrange(count: 27, lowerBound: 0)
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !49, size: 64, offset: 64)
+!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
+!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !51)
+!51 = !{!52}
+!52 = !DISubrange(count: 262144, lowerBound: 0)
+!53 = !DIGlobalVariableExpression(var: !54, expr: !DIExpression())
+!54 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !55, isLocal: false, isDefinition: true)
+!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !56, size: 64, elements: !15)
+!56 = !DICompositeType(tag: DW_TAG_array_type, baseType: !32, size: 64, elements: !15)
+!57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
+!58 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !32, isLocal: false, isDefinition: true)
+!59 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !60)
+!60 = !{!0, !7, !25, !39, !53, !57}
+!61 = !{i32 2, !"Debug Info Version", i32 3}
+!62 = !{i32 7, !"uwtable", i32 0}
+!63 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !64, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !59, retainedNodes: !66)
+!64 = !DISubroutineType(types: !65)
+!65 = !{!32, !23}
+!66 = !{!67}
+!67 = !DILocalVariable(name: "ctx", arg: 1, scope: !63, file: !2, type: !23)
+!68 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !69, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !59, retainedNodes: !71)
+!69 = !DISubroutineType(types: !70)
+!70 = !{!32, !23, !23, !23, !23}
+!71 = !{!72, !73, !74, !75}
+!72 = !DILocalVariable(name: "map", arg: 1, scope: !68, file: !2, type: !23)
+!73 = !DILocalVariable(name: "key", arg: 2, scope: !68, file: !2, type: !23)
+!74 = !DILocalVariable(name: "value", arg: 3, scope: !68, file: !2, type: !23)
+!75 = !DILocalVariable(name: "ctx", arg: 4, scope: !68, file: !2, type: !23)

--- a/tests/codegen/llvm/for_map_two_keys.ll
+++ b/tests/codegen/llvm/for_map_two_keys.ll
@@ -6,32 +6,32 @@ target triple = "bpf"
 %"struct map_internal_repr_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.163" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.164" = type { ptr, ptr }
-%int64_int64__tuple_t = type { i64, i64 }
-%"(int64,int64)_int64__tuple_t" = type { %int64_int64__tuple_t, i64 }
+%uint8_uint8__tuple_t = type { i8, i8 }
+%"(uint8,uint8)_uint8__tuple_t" = type { %uint8_uint8__tuple_t, i8 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_map = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@AT_x = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !31
-@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !43
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !57
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !61
+@AT_x = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !30
+@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !44
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !58
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !62
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !67 {
+define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !68 {
 entry:
-  %"@map_val" = alloca i64, align 8
-  %tuple = alloca %int64_int64__tuple_t, align 8
+  %"@map_val" = alloca i8, align 1
+  %tuple = alloca %uint8_uint8__tuple_t, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %1 = getelementptr %int64_int64__tuple_t, ptr %tuple, i32 0, i32 0
-  store i64 16, ptr %1, align 8
-  %2 = getelementptr %int64_int64__tuple_t, ptr %tuple, i32 0, i32 1
-  store i64 17, ptr %2, align 8
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 2, i1 false)
+  %1 = getelementptr %uint8_uint8__tuple_t, ptr %tuple, i32 0, i32 0
+  store i8 16, ptr %1, align 1
+  %2 = getelementptr %uint8_uint8__tuple_t, ptr %tuple, i32 0, i32 1
+  store i8 17, ptr %2, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_val")
-  store i64 32, ptr %"@map_val", align 8
+  store i8 32, ptr %"@map_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_map, ptr %tuple, ptr %"@map_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@map_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
@@ -52,14 +52,14 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !73 {
 for_body:
   %"@x_key" = alloca i64, align 8
-  %"$kv" = alloca %"(int64,int64)_int64__tuple_t", align 8
-  %val = load i64, ptr %2, align 8
+  %"$kv" = alloca %"(uint8,uint8)_uint8__tuple_t", align 8
+  %val = load i8, ptr %2, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 24, i1 false)
-  %4 = getelementptr %"(int64,int64)_int64__tuple_t", ptr %"$kv", i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %1, i64 16, i1 false)
-  %5 = getelementptr %"(int64,int64)_int64__tuple_t", ptr %"$kv", i32 0, i32 1
-  store i64 %val, ptr %5, align 8
+  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 3, i1 false)
+  %4 = getelementptr %"(uint8,uint8)_uint8__tuple_t", ptr %"$kv", i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %1, i64 2, i1 false)
+  %5 = getelementptr %"(uint8,uint8)_uint8__tuple_t", ptr %"$kv", i32 0, i32 1
+  store i8 %val, ptr %5, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"$kv", i64 0)
@@ -78,8 +78,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!63}
-!llvm.module.flags = !{!65, !66}
+!llvm.dbg.cu = !{!64}
+!llvm.module.flags = !{!66, !67}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -91,7 +91,7 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_map", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !29}
+!10 = !{!11, !17, !22, !28}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
@@ -105,60 +105,60 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
 !23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !28}
-!26 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!28 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !27, size: 64, offset: 64)
-!29 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !30, size: 64, offset: 192)
-!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
-!31 = !DIGlobalVariableExpression(var: !32, expr: !DIExpression())
-!32 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !33, isLocal: false, isDefinition: true)
-!33 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !34)
-!34 = !{!11, !35, !36, !37}
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
-!36 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !30, size: 64, offset: 128)
-!37 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !38, size: 64, offset: 192)
-!38 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !39, size: 64)
-!39 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 192, elements: !40)
-!40 = !{!41, !42}
-!41 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !24, size: 128)
-!42 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !27, size: 64, offset: 128)
-!43 = !DIGlobalVariableExpression(var: !44, expr: !DIExpression())
-!44 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !45, isLocal: false, isDefinition: true)
-!45 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !46)
-!46 = !{!47, !52}
-!47 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !48, size: 64)
-!48 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !49, size: 64)
-!49 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !50)
-!50 = !{!51}
-!51 = !DISubrange(count: 27, lowerBound: 0)
-!52 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !53, size: 64, offset: 64)
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !54, size: 64)
-!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !55)
-!55 = !{!56}
-!56 = !DISubrange(count: 262144, lowerBound: 0)
-!57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
-!58 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !59, isLocal: false, isDefinition: true)
-!59 = !DICompositeType(tag: DW_TAG_array_type, baseType: !60, size: 64, elements: !15)
-!60 = !DICompositeType(tag: DW_TAG_array_type, baseType: !27, size: 64, elements: !15)
-!61 = !DIGlobalVariableExpression(var: !62, expr: !DIExpression())
-!62 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
-!63 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !64)
-!64 = !{!0, !7, !31, !43, !57, !61}
-!65 = !{i32 2, !"Debug Info Version", i32 3}
-!66 = !{i32 7, !"uwtable", i32 0}
-!67 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !68, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !63, retainedNodes: !71)
-!68 = !DISubroutineType(types: !69)
-!69 = !{!27, !70}
-!70 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 16, elements: !25)
+!25 = !{!26, !27}
+!26 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !4, size: 8)
+!27 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !4, size: 8, offset: 8)
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !29, size: 64, offset: 192)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!30 = !DIGlobalVariableExpression(var: !31, expr: !DIExpression())
+!31 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !32, isLocal: false, isDefinition: true)
+!32 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !33)
+!33 = !{!11, !34, !35, !38}
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !36, size: 64, offset: 128)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!38 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !39, size: 64, offset: 192)
+!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
+!40 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 24, elements: !41)
+!41 = !{!42, !43}
+!42 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !24, size: 16)
+!43 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !4, size: 8, offset: 16)
+!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
+!45 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !46, isLocal: false, isDefinition: true)
+!46 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !47)
+!47 = !{!48, !53}
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !49, size: 64)
+!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
+!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !51)
+!51 = !{!52}
+!52 = !DISubrange(count: 27, lowerBound: 0)
+!53 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !54, size: 64, offset: 64)
+!54 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !55, size: 64)
+!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !56)
+!56 = !{!57}
+!57 = !DISubrange(count: 262144, lowerBound: 0)
+!58 = !DIGlobalVariableExpression(var: !59, expr: !DIExpression())
+!59 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !60, isLocal: false, isDefinition: true)
+!60 = !DICompositeType(tag: DW_TAG_array_type, baseType: !61, size: 64, elements: !15)
+!61 = !DICompositeType(tag: DW_TAG_array_type, baseType: !37, size: 64, elements: !15)
+!62 = !DIGlobalVariableExpression(var: !63, expr: !DIExpression())
+!63 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !37, isLocal: false, isDefinition: true)
+!64 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !65)
+!65 = !{!0, !7, !30, !44, !58, !62}
+!66 = !{i32 2, !"Debug Info Version", i32 3}
+!67 = !{i32 7, !"uwtable", i32 0}
+!68 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !69, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !64, retainedNodes: !71)
+!69 = !DISubroutineType(types: !70)
+!70 = !{!37, !29}
 !71 = !{!72}
-!72 = !DILocalVariable(name: "ctx", arg: 1, scope: !67, file: !2, type: !70)
-!73 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !74, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !63, retainedNodes: !76)
+!72 = !DILocalVariable(name: "ctx", arg: 1, scope: !68, file: !2, type: !29)
+!73 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !74, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !64, retainedNodes: !76)
 !74 = !DISubroutineType(types: !75)
-!75 = !{!27, !70, !70, !70, !70}
+!75 = !{!37, !29, !29, !29, !29}
 !76 = !{!77, !78, !79, !80}
-!77 = !DILocalVariable(name: "map", arg: 1, scope: !73, file: !2, type: !70)
-!78 = !DILocalVariable(name: "key", arg: 2, scope: !73, file: !2, type: !70)
-!79 = !DILocalVariable(name: "value", arg: 3, scope: !73, file: !2, type: !70)
-!80 = !DILocalVariable(name: "ctx", arg: 4, scope: !73, file: !2, type: !70)
+!77 = !DILocalVariable(name: "map", arg: 1, scope: !73, file: !2, type: !29)
+!78 = !DILocalVariable(name: "key", arg: 2, scope: !73, file: !2, type: !29)
+!79 = !DILocalVariable(name: "value", arg: 3, scope: !73, file: !2, type: !29)
+!80 = !DILocalVariable(name: "ctx", arg: 4, scope: !73, file: !2, type: !29)

--- a/tests/codegen/llvm/for_map_variables.ll
+++ b/tests/codegen/llvm/for_map_variables.ll
@@ -7,14 +7,14 @@ target triple = "bpf"
 %"struct map_internal_repr_t.163" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.164" = type { ptr, ptr }
 %ctx_t = type { ptr, ptr }
-%int64_int64__tuple_t = type { i64, i64 }
+%uint8_uint8__tuple_t = type { i8, i8 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_len = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
 @AT_map = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !31
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !45
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !49
+@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !34
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !48
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !52
 @abc = global [4 x i8] c"abc\00"
 @def = global [4 x i8] c"def\00"
 
@@ -22,7 +22,7 @@ target triple = "bpf"
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !55 {
+define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !58 {
 entry:
   %"@len_val" = alloca i64, align 8
   %"@len_key" = alloca i64, align 8
@@ -36,12 +36,12 @@ entry:
   %"$var1" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$var1")
   store i64 0, ptr %"$var1", align 8
-  %"@map_val" = alloca i64, align 8
-  %"@map_key" = alloca i64, align 8
+  %"@map_val" = alloca i8, align 1
+  %"@map_key" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_key")
-  store i64 16, ptr %"@map_key", align 8
+  store i8 16, ptr %"@map_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_val")
-  store i64 32, ptr %"@map_val", align 8
+  store i8 32, ptr %"@map_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_map, ptr %"@map_key", ptr %"@map_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@map_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@map_key")
@@ -83,20 +83,20 @@ declare void @llvm.memcpy.p0.p0.i64(ptr noalias nocapture writeonly %0, ptr noal
 declare ptr @llvm.preserve.static.offset(ptr readnone %0) #4
 
 ; Function Attrs: nounwind
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !61 {
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !63 {
 for_body:
   %"$can_read" = alloca [4 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$can_read")
   call void @llvm.memset.p0.i64(ptr align 1 %"$can_read", i8 0, i64 4, i1 false)
-  %"$kv" = alloca %int64_int64__tuple_t, align 8
-  %key = load i64, ptr %1, align 8
-  %val = load i64, ptr %2, align 8
+  %"$kv" = alloca %uint8_uint8__tuple_t, align 8
+  %key = load i8, ptr %1, align 1
+  %val = load i8, ptr %2, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %4 = getelementptr %int64_int64__tuple_t, ptr %"$kv", i32 0, i32 0
-  store i64 %key, ptr %4, align 8
-  %5 = getelementptr %int64_int64__tuple_t, ptr %"$kv", i32 0, i32 1
-  store i64 %val, ptr %5, align 8
+  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 2, i1 false)
+  %4 = getelementptr %uint8_uint8__tuple_t, ptr %"$kv", i32 0, i32 0
+  store i8 %key, ptr %4, align 1
+  %5 = getelementptr %uint8_uint8__tuple_t, ptr %"$kv", i32 0, i32 1
+  store i8 %val, ptr %5, align 1
   %"ctx.$var1" = getelementptr %ctx_t, ptr %3, i64 0, i32 0
   %"$var1" = load ptr, ptr %"ctx.$var1", align 8
   %"ctx.$var3" = getelementptr %ctx_t, ptr %3, i64 0, i32 1
@@ -117,8 +117,8 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 attributes #4 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 
-!llvm.dbg.cu = !{!51}
-!llvm.module.flags = !{!53, !54}
+!llvm.dbg.cu = !{!54}
+!llvm.module.flags = !{!56, !57}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -145,47 +145,49 @@ attributes #4 = { nocallback nofree nosync nounwind speculatable willreturn memo
 !22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
 !23 = distinct !DIGlobalVariable(name: "AT_map", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
 !24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !25)
-!25 = !{!11, !26, !18, !21}
+!25 = !{!11, !26, !31, !33}
 !26 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !27, size: 64, offset: 64)
 !27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
 !28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 131072, elements: !29)
 !29 = !{!30}
 !30 = !DISubrange(count: 4096, lowerBound: 0)
-!31 = !DIGlobalVariableExpression(var: !32, expr: !DIExpression())
-!32 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !33, isLocal: false, isDefinition: true)
-!33 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !34)
-!34 = !{!35, !40}
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !36, size: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !38)
-!38 = !{!39}
-!39 = !DISubrange(count: 27, lowerBound: 0)
-!40 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !41, size: 64, offset: 64)
-!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !43)
-!43 = !{!44}
-!44 = !DISubrange(count: 262144, lowerBound: 0)
-!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
-!46 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !47, isLocal: false, isDefinition: true)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 64, elements: !15)
-!48 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!49 = !DIGlobalVariableExpression(var: !50, expr: !DIExpression())
-!50 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
-!52 = !{!0, !7, !22, !31, !45, !49}
-!53 = !{i32 2, !"Debug Info Version", i32 3}
-!54 = !{i32 7, !"uwtable", i32 0}
-!55 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !59)
-!56 = !DISubroutineType(types: !57)
-!57 = !{!20, !58}
-!58 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!59 = !{!60}
-!60 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !58)
-!61 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !62, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !51, retainedNodes: !64)
-!62 = !DISubroutineType(types: !63)
-!63 = !{!20, !58, !58, !58, !58}
-!64 = !{!65, !66, !67, !68}
-!65 = !DILocalVariable(name: "map", arg: 1, scope: !61, file: !2, type: !58)
-!66 = !DILocalVariable(name: "key", arg: 2, scope: !61, file: !2, type: !58)
-!67 = !DILocalVariable(name: "value", arg: 3, scope: !61, file: !2, type: !58)
-!68 = !DILocalVariable(name: "ctx", arg: 4, scope: !61, file: !2, type: !58)
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !32, size: 64, offset: 128)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !32, size: 64, offset: 192)
+!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
+!35 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
+!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !37)
+!37 = !{!38, !43}
+!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
+!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !41)
+!41 = !{!42}
+!42 = !DISubrange(count: 27, lowerBound: 0)
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !44, size: 64, offset: 64)
+!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !46)
+!46 = !{!47}
+!47 = !DISubrange(count: 262144, lowerBound: 0)
+!48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
+!49 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !50, isLocal: false, isDefinition: true)
+!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !51, size: 64, elements: !15)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!52 = !DIGlobalVariableExpression(var: !53, expr: !DIExpression())
+!53 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!54 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !55)
+!55 = !{!0, !7, !22, !34, !48, !52}
+!56 = !{i32 2, !"Debug Info Version", i32 3}
+!57 = !{i32 7, !"uwtable", i32 0}
+!58 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !59, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !54, retainedNodes: !61)
+!59 = !DISubroutineType(types: !60)
+!60 = !{!20, !32}
+!61 = !{!62}
+!62 = !DILocalVariable(name: "ctx", arg: 1, scope: !58, file: !2, type: !32)
+!63 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !64, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !54, retainedNodes: !66)
+!64 = !DISubroutineType(types: !65)
+!65 = !{!20, !32, !32, !32, !32}
+!66 = !{!67, !68, !69, !70}
+!67 = !DILocalVariable(name: "map", arg: 1, scope: !63, file: !2, type: !32)
+!68 = !DILocalVariable(name: "key", arg: 2, scope: !63, file: !2, type: !32)
+!69 = !DILocalVariable(name: "value", arg: 3, scope: !63, file: !2, type: !32)
+!70 = !DILocalVariable(name: "ctx", arg: 4, scope: !63, file: !2, type: !32)

--- a/tests/codegen/llvm/for_map_variables_multiple_loops.ll
+++ b/tests/codegen/llvm/for_map_variables_multiple_loops.ll
@@ -7,12 +7,12 @@ target triple = "bpf"
 %"struct map_internal_repr_t.163" = type { ptr, ptr }
 %ctx_t.164 = type { ptr, ptr }
 %ctx_t = type { ptr }
-%int64_int64__tuple_t = type { i64, i64 }
+%uint8_uint8__tuple_t = type { i8, i8 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !25
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !39
 @__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
 
 ; Function Attrs: nounwind
@@ -29,12 +29,12 @@ entry:
   %"$var1" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$var1")
   store i64 0, ptr %"$var1", align 8
-  %"@_val" = alloca i64, align 8
-  %"@_key" = alloca i64, align 8
+  %"@_val" = alloca i8, align 1
+  %"@_key" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  store i64 0, ptr %"@_key", align 8
+  store i8 0, ptr %"@_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  store i64 0, ptr %"@_val", align 8
+  store i8 0, ptr %"@_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
@@ -66,17 +66,17 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 declare ptr @llvm.preserve.static.offset(ptr readnone %0) #2
 
 ; Function Attrs: nounwind
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !56 {
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !55 {
 for_body:
-  %"$_" = alloca %int64_int64__tuple_t, align 8
-  %key = load i64, ptr %1, align 8
-  %val = load i64, ptr %2, align 8
+  %"$_" = alloca %uint8_uint8__tuple_t, align 8
+  %key = load i8, ptr %1, align 1
+  %val = load i8, ptr %2, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$_")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$_", i8 0, i64 16, i1 false)
-  %4 = getelementptr %int64_int64__tuple_t, ptr %"$_", i32 0, i32 0
-  store i64 %key, ptr %4, align 8
-  %5 = getelementptr %int64_int64__tuple_t, ptr %"$_", i32 0, i32 1
-  store i64 %val, ptr %5, align 8
+  call void @llvm.memset.p0.i64(ptr align 1 %"$_", i8 0, i64 2, i1 false)
+  %4 = getelementptr %uint8_uint8__tuple_t, ptr %"$_", i32 0, i32 0
+  store i8 %key, ptr %4, align 1
+  %5 = getelementptr %uint8_uint8__tuple_t, ptr %"$_", i32 0, i32 1
+  store i8 %val, ptr %5, align 1
   %"ctx.$var1" = getelementptr %ctx_t, ptr %3, i64 0, i32 0
   %"$var1" = load ptr, ptr %"ctx.$var1", align 8
   %6 = load i64, ptr %"$var1", align 8
@@ -92,17 +92,17 @@ for_continue:                                     ; preds = %for_body
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #3
 
 ; Function Attrs: nounwind
-define internal i64 @map_for_each_cb.1(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !64 {
+define internal i64 @map_for_each_cb.1(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !63 {
 for_body:
-  %"$_" = alloca %int64_int64__tuple_t, align 8
-  %key = load i64, ptr %1, align 8
-  %val = load i64, ptr %2, align 8
+  %"$_" = alloca %uint8_uint8__tuple_t, align 8
+  %key = load i8, ptr %1, align 1
+  %val = load i8, ptr %2, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$_")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$_", i8 0, i64 16, i1 false)
-  %4 = getelementptr %int64_int64__tuple_t, ptr %"$_", i32 0, i32 0
-  store i64 %key, ptr %4, align 8
-  %5 = getelementptr %int64_int64__tuple_t, ptr %"$_", i32 0, i32 1
-  store i64 %val, ptr %5, align 8
+  call void @llvm.memset.p0.i64(ptr align 1 %"$_", i8 0, i64 2, i1 false)
+  %4 = getelementptr %uint8_uint8__tuple_t, ptr %"$_", i32 0, i32 0
+  store i8 %key, ptr %4, align 1
+  %5 = getelementptr %uint8_uint8__tuple_t, ptr %"$_", i32 0, i32 1
+  store i8 %val, ptr %5, align 1
   %"ctx.$var1" = getelementptr %ctx_t.164, ptr %3, i64 0, i32 0
   %"$var1" = load ptr, ptr %"ctx.$var1", align 8
   %"ctx.$var2" = getelementptr %ctx_t.164, ptr %3, i64 0, i32 1
@@ -137,7 +137,7 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
@@ -150,50 +150,49 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !20 = !{!21}
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
-!29 = !{!30, !35}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 27, lowerBound: 0)
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
-!38 = !{!39}
-!39 = !DISubrange(count: 262144, lowerBound: 0)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
+!28 = !{!29, !34}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !30, size: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 27, lowerBound: 0)
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !35, size: 64, offset: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 262144, lowerBound: 0)
+!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
+!40 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 64, elements: !15)
 !42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
+!43 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
-!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
 !46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
-!47 = !{!0, !7, !26, !40, !44}
+!47 = !{!0, !7, !25, !39, !44}
 !48 = !{i32 2, !"Debug Info Version", i32 3}
 !49 = !{i32 7, !"uwtable", i32 0}
-!50 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
+!50 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
 !51 = !DISubroutineType(types: !52)
-!52 = !{!24, !53}
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)
-!56 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !46, retainedNodes: !59)
-!57 = !DISubroutineType(types: !58)
-!58 = !{!24, !53, !53, !53, !53}
-!59 = !{!60, !61, !62, !63}
-!60 = !DILocalVariable(name: "map", arg: 1, scope: !56, file: !2, type: !53)
-!61 = !DILocalVariable(name: "key", arg: 2, scope: !56, file: !2, type: !53)
-!62 = !DILocalVariable(name: "value", arg: 3, scope: !56, file: !2, type: !53)
-!63 = !DILocalVariable(name: "ctx", arg: 4, scope: !56, file: !2, type: !53)
-!64 = distinct !DISubprogram(name: "map_for_each_cb_1", linkageName: "map_for_each_cb_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !46, retainedNodes: !65)
-!65 = !{!66, !67, !68, !69}
-!66 = !DILocalVariable(name: "map", arg: 1, scope: !64, file: !2, type: !53)
-!67 = !DILocalVariable(name: "key", arg: 2, scope: !64, file: !2, type: !53)
-!68 = !DILocalVariable(name: "value", arg: 3, scope: !64, file: !2, type: !53)
-!69 = !DILocalVariable(name: "ctx", arg: 4, scope: !64, file: !2, type: !53)
+!52 = !{!43, !23}
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !23)
+!55 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !46, retainedNodes: !58)
+!56 = !DISubroutineType(types: !57)
+!57 = !{!43, !23, !23, !23, !23}
+!58 = !{!59, !60, !61, !62}
+!59 = !DILocalVariable(name: "map", arg: 1, scope: !55, file: !2, type: !23)
+!60 = !DILocalVariable(name: "key", arg: 2, scope: !55, file: !2, type: !23)
+!61 = !DILocalVariable(name: "value", arg: 3, scope: !55, file: !2, type: !23)
+!62 = !DILocalVariable(name: "ctx", arg: 4, scope: !55, file: !2, type: !23)
+!63 = distinct !DISubprogram(name: "map_for_each_cb_1", linkageName: "map_for_each_cb_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !46, retainedNodes: !64)
+!64 = !{!65, !66, !67, !68}
+!65 = !DILocalVariable(name: "map", arg: 1, scope: !63, file: !2, type: !23)
+!66 = !DILocalVariable(name: "key", arg: 2, scope: !63, file: !2, type: !23)
+!67 = !DILocalVariable(name: "value", arg: 3, scope: !63, file: !2, type: !23)
+!68 = !DILocalVariable(name: "ctx", arg: 4, scope: !63, file: !2, type: !23)

--- a/tests/codegen/llvm/for_map_variables_scope.ll
+++ b/tests/codegen/llvm/for_map_variables_scope.ll
@@ -5,12 +5,12 @@ target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.163" = type { ptr, ptr }
-%int64_int64__tuple_t = type { i64, i64 }
+%uint8_uint8__tuple_t = type { i8, i8 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_map = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !25
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !39
 @__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
 
 ; Function Attrs: nounwind
@@ -19,12 +19,12 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !50 {
 entry:
-  %"@map_val" = alloca i64, align 8
-  %"@map_key" = alloca i64, align 8
+  %"@map_val" = alloca i8, align 1
+  %"@map_key" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_key")
-  store i64 16, ptr %"@map_key", align 8
+  store i8 16, ptr %"@map_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_val")
-  store i64 32, ptr %"@map_val", align 8
+  store i8 32, ptr %"@map_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_map, ptr %"@map_key", ptr %"@map_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@map_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@map_key")
@@ -40,21 +40,21 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 ; Function Attrs: nounwind
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !56 {
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !55 {
 for_body:
-  %"$var" = alloca i64, align 8
+  %"$var" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$var")
-  store i64 0, ptr %"$var", align 8
-  %"$kv" = alloca %int64_int64__tuple_t, align 8
-  %key = load i64, ptr %1, align 8
-  %val = load i64, ptr %2, align 8
+  store i8 0, ptr %"$var", align 1
+  %"$kv" = alloca %uint8_uint8__tuple_t, align 8
+  %key = load i8, ptr %1, align 1
+  %val = load i8, ptr %2, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %4 = getelementptr %int64_int64__tuple_t, ptr %"$kv", i32 0, i32 0
-  store i64 %key, ptr %4, align 8
-  %5 = getelementptr %int64_int64__tuple_t, ptr %"$kv", i32 0, i32 1
-  store i64 %val, ptr %5, align 8
-  store i64 1, ptr %"$var", align 8
+  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 2, i1 false)
+  %4 = getelementptr %uint8_uint8__tuple_t, ptr %"$kv", i32 0, i32 0
+  store i8 %key, ptr %4, align 1
+  %5 = getelementptr %uint8_uint8__tuple_t, ptr %"$kv", i32 0, i32 1
+  store i8 %val, ptr %5, align 1
+  store i8 1, ptr %"$var", align 1
   br label %for_continue
 
 for_continue:                                     ; preds = %for_body
@@ -65,21 +65,21 @@ for_continue:                                     ; preds = %for_body
 declare void @llvm.memset.p0.i64(ptr nocapture writeonly %0, i8 %1, i64 %2, i1 immarg %3) #2
 
 ; Function Attrs: nounwind
-define internal i64 @map_for_each_cb.1(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !64 {
+define internal i64 @map_for_each_cb.1(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !63 {
 for_body:
-  %"$var" = alloca i64, align 8
+  %"$var" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$var")
-  store i64 0, ptr %"$var", align 8
-  %"$kv" = alloca %int64_int64__tuple_t, align 8
-  %key = load i64, ptr %1, align 8
-  %val = load i64, ptr %2, align 8
+  store i8 0, ptr %"$var", align 1
+  %"$kv" = alloca %uint8_uint8__tuple_t, align 8
+  %key = load i8, ptr %1, align 1
+  %val = load i8, ptr %2, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %4 = getelementptr %int64_int64__tuple_t, ptr %"$kv", i32 0, i32 0
-  store i64 %key, ptr %4, align 8
-  %5 = getelementptr %int64_int64__tuple_t, ptr %"$kv", i32 0, i32 1
-  store i64 %val, ptr %5, align 8
-  store i64 1, ptr %"$var", align 8
+  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 2, i1 false)
+  %4 = getelementptr %uint8_uint8__tuple_t, ptr %"$kv", i32 0, i32 0
+  store i8 %key, ptr %4, align 1
+  %5 = getelementptr %uint8_uint8__tuple_t, ptr %"$kv", i32 0, i32 1
+  store i8 %val, ptr %5, align 1
+  store i8 1, ptr %"$var", align 1
   br label %for_continue
 
 for_continue:                                     ; preds = %for_body
@@ -103,7 +103,7 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_map", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
@@ -116,50 +116,49 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !20 = !{!21}
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
-!29 = !{!30, !35}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 27, lowerBound: 0)
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
-!38 = !{!39}
-!39 = !DISubrange(count: 262144, lowerBound: 0)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
+!28 = !{!29, !34}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !30, size: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 27, lowerBound: 0)
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !35, size: 64, offset: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 262144, lowerBound: 0)
+!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
+!40 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 64, elements: !15)
 !42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
+!43 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
-!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
 !46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
-!47 = !{!0, !7, !26, !40, !44}
+!47 = !{!0, !7, !25, !39, !44}
 !48 = !{i32 2, !"Debug Info Version", i32 3}
 !49 = !{i32 7, !"uwtable", i32 0}
-!50 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
+!50 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
 !51 = !DISubroutineType(types: !52)
-!52 = !{!24, !53}
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)
-!56 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !46, retainedNodes: !59)
-!57 = !DISubroutineType(types: !58)
-!58 = !{!24, !53, !53, !53, !53}
-!59 = !{!60, !61, !62, !63}
-!60 = !DILocalVariable(name: "map", arg: 1, scope: !56, file: !2, type: !53)
-!61 = !DILocalVariable(name: "key", arg: 2, scope: !56, file: !2, type: !53)
-!62 = !DILocalVariable(name: "value", arg: 3, scope: !56, file: !2, type: !53)
-!63 = !DILocalVariable(name: "ctx", arg: 4, scope: !56, file: !2, type: !53)
-!64 = distinct !DISubprogram(name: "map_for_each_cb_1", linkageName: "map_for_each_cb_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !46, retainedNodes: !65)
-!65 = !{!66, !67, !68, !69}
-!66 = !DILocalVariable(name: "map", arg: 1, scope: !64, file: !2, type: !53)
-!67 = !DILocalVariable(name: "key", arg: 2, scope: !64, file: !2, type: !53)
-!68 = !DILocalVariable(name: "value", arg: 3, scope: !64, file: !2, type: !53)
-!69 = !DILocalVariable(name: "ctx", arg: 4, scope: !64, file: !2, type: !53)
+!52 = !{!43, !23}
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !23)
+!55 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !46, retainedNodes: !58)
+!56 = !DISubroutineType(types: !57)
+!57 = !{!43, !23, !23, !23, !23}
+!58 = !{!59, !60, !61, !62}
+!59 = !DILocalVariable(name: "map", arg: 1, scope: !55, file: !2, type: !23)
+!60 = !DILocalVariable(name: "key", arg: 2, scope: !55, file: !2, type: !23)
+!61 = !DILocalVariable(name: "value", arg: 3, scope: !55, file: !2, type: !23)
+!62 = !DILocalVariable(name: "ctx", arg: 4, scope: !55, file: !2, type: !23)
+!63 = distinct !DISubprogram(name: "map_for_each_cb_1", linkageName: "map_for_each_cb_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !46, retainedNodes: !64)
+!64 = !{!65, !66, !67, !68}
+!65 = !DILocalVariable(name: "map", arg: 1, scope: !63, file: !2, type: !23)
+!66 = !DILocalVariable(name: "key", arg: 2, scope: !63, file: !2, type: !23)
+!67 = !DILocalVariable(name: "value", arg: 3, scope: !63, file: !2, type: !23)
+!68 = !DILocalVariable(name: "ctx", arg: 4, scope: !63, file: !2, type: !23)

--- a/tests/codegen/llvm/if_else_printf.ll
+++ b/tests/codegen/llvm/if_else_printf.ll
@@ -23,16 +23,15 @@ entry:
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #3
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
-  %2 = zext i32 %pid to i64
-  %3 = icmp ugt i64 %2, 10
-  %true_cond = icmp ne i1 %3, false
+  %2 = icmp ugt i32 %pid, 10
+  %true_cond = icmp ne i1 %2, false
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args)
   call void @llvm.memset.p0.i64(ptr align 1 %printf_args, i8 0, i64 8, i1 false)
-  %4 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
-  store i64 0, ptr %4, align 8
+  %3 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
+  store i64 0, ptr %3, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args, i64 8, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
@@ -40,20 +39,20 @@ left:                                             ; preds = %entry
 right:                                            ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args1)
   call void @llvm.memset.p0.i64(ptr align 1 %printf_args1, i8 0, i64 8, i1 false)
-  %5 = getelementptr %printf_t.163, ptr %printf_args1, i32 0, i32 0
-  store i64 1, ptr %5, align 8
+  %4 = getelementptr %printf_t.163, ptr %printf_args1, i32 0, i32 0
+  store i64 1, ptr %4, align 8
   %ringbuf_output2 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args1, i64 8, i64 0)
   %ringbuf_loss5 = icmp slt i64 %ringbuf_output2, 0
   br i1 %ringbuf_loss5, label %event_loss_counter3, label %counter_merge4
 
 event_loss_counter:                               ; preds = %left
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
-  %6 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %6
-  %7 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
-  %8 = load i64, ptr %7, align 8
-  %9 = add i64 %8, 1
-  store i64 %9, ptr %7, align 8
+  %5 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %5
+  %6 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %7 = load i64, ptr %6, align 8
+  %8 = add i64 %7, 1
+  store i64 %8, ptr %6, align 8
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %left
@@ -62,12 +61,12 @@ counter_merge:                                    ; preds = %event_loss_counter,
 
 event_loss_counter3:                              ; preds = %right
   %get_cpu_id6 = call i64 inttoptr (i64 8 to ptr)() #3
-  %10 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded7 = and i64 %get_cpu_id6, %10
-  %11 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded7, i64 0
-  %12 = load i64, ptr %11, align 8
-  %13 = add i64 %12, 1
-  store i64 %13, ptr %11, align 8
+  %9 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded7 = and i64 %get_cpu_id6, %9
+  %10 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded7, i64 0
+  %11 = load i64, ptr %10, align 8
+  %12 = add i64 %11, 1
+  store i64 %12, ptr %10, align 8
   br label %counter_merge4
 
 counter_merge4:                                   ; preds = %event_loss_counter3, %right

--- a/tests/codegen/llvm/if_else_variable.ll
+++ b/tests/codegen/llvm/if_else_variable.ll
@@ -16,20 +16,20 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
-  %"$s1" = alloca i64, align 8
+  %"$s1" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$s1")
-  store i64 0, ptr %"$s1", align 8
-  %"$s" = alloca i64, align 8
+  store i8 0, ptr %"$s1", align 1
+  %"$s" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$s")
-  store i64 0, ptr %"$s", align 8
+  store i8 0, ptr %"$s", align 1
   br i1 true, label %left, label %right
 
 left:                                             ; preds = %entry
-  store i64 10, ptr %"$s", align 8
+  store i8 10, ptr %"$s", align 1
   ret i64 0
 
 right:                                            ; preds = %entry
-  store i64 20, ptr %"$s1", align 8
+  store i8 20, ptr %"$s1", align 1
   ret i64 0
 }
 

--- a/tests/codegen/llvm/if_nested_printf.ll
+++ b/tests/codegen/llvm/if_nested_printf.ll
@@ -24,16 +24,14 @@ entry:
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #3
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
-  %2 = zext i32 %pid to i64
-  %3 = icmp ugt i64 %2, 10000
-  %true_cond = icmp ne i1 %3, false
+  %2 = icmp ugt i32 %pid, 10000
+  %true_cond = icmp ne i1 %2, false
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
   %get_pid_tgid3 = call i64 inttoptr (i64 14 to ptr)() #3
-  %4 = lshr i64 %get_pid_tgid3, 32
-  %pid4 = trunc i64 %4 to i32
-  %5 = zext i32 %pid4 to i64
+  %3 = lshr i64 %get_pid_tgid3, 32
+  %pid4 = trunc i64 %3 to i32
   call void @llvm.lifetime.start.p0(i64 -1, ptr %op_result)
   br i1 false, label %is_zero, label %not_zero
 
@@ -43,8 +41,8 @@ right:                                            ; preds = %entry
 left1:                                            ; preds = %zero_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args)
   call void @llvm.memset.p0.i64(ptr align 1 %printf_args, i8 0, i64 8, i1 false)
-  %6 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
-  store i64 0, ptr %6, align 8
+  %4 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
+  store i64 0, ptr %4, align 8
   %ringbuf_output6 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args, i64 8, i64 0)
   %ringbuf_loss9 = icmp slt i64 %ringbuf_output6, 0
   br i1 %ringbuf_loss9, label %event_loss_counter7, label %counter_merge8
@@ -55,36 +53,36 @@ right2:                                           ; preds = %zero_merge
 is_zero:                                          ; preds = %left
   store i64 1, ptr %op_result, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
-  %7 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
-  store i64 30006, ptr %7, align 8
-  %8 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
-  store i64 0, ptr %8, align 8
-  %9 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
-  store i64 0, ptr %9, align 8
+  %5 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
+  store i64 30006, ptr %5, align 8
+  %6 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
+  store i64 0, ptr %6, align 8
+  %7 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
+  store i64 0, ptr %7, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t, i64 20, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 not_zero:                                         ; preds = %left
-  %10 = urem i64 %5, 2
-  store i64 %10, ptr %op_result, align 8
+  %8 = urem i32 %pid4, 2
+  store i32 %8, ptr %op_result, align 4
   br label %zero_merge
 
 zero_merge:                                       ; preds = %not_zero, %counter_merge
-  %11 = load i64, ptr %op_result, align 8
+  %9 = load i64, ptr %op_result, align 8
   call void @llvm.lifetime.end.p0(i64 -1, ptr %op_result)
-  %12 = icmp eq i64 %11, 0
-  %true_cond5 = icmp ne i1 %12, false
+  %10 = icmp eq i64 %9, 0
+  %true_cond5 = icmp ne i1 %10, false
   br i1 %true_cond5, label %left1, label %right2
 
 event_loss_counter:                               ; preds = %is_zero
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
-  %13 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %13
-  %14 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
-  %15 = load i64, ptr %14, align 8
-  %16 = add i64 %15, 1
-  store i64 %16, ptr %14, align 8
+  %11 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %11
+  %12 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %13 = load i64, ptr %12, align 8
+  %14 = add i64 %13, 1
+  store i64 %14, ptr %12, align 8
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %is_zero
@@ -93,12 +91,12 @@ counter_merge:                                    ; preds = %event_loss_counter,
 
 event_loss_counter7:                              ; preds = %left1
   %get_cpu_id10 = call i64 inttoptr (i64 8 to ptr)() #3
-  %17 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded11 = and i64 %get_cpu_id10, %17
-  %18 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded11, i64 0
-  %19 = load i64, ptr %18, align 8
-  %20 = add i64 %19, 1
-  store i64 %20, ptr %18, align 8
+  %15 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded11 = and i64 %get_cpu_id10, %15
+  %16 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded11, i64 0
+  %17 = load i64, ptr %16, align 8
+  %18 = add i64 %17, 1
+  store i64 %18, ptr %16, align 8
   br label %counter_merge8
 
 counter_merge8:                                   ; preds = %event_loss_counter7, %left1

--- a/tests/codegen/llvm/if_printf.ll
+++ b/tests/codegen/llvm/if_printf.ll
@@ -22,22 +22,21 @@ entry:
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #3
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
-  %2 = zext i32 %pid to i64
-  %3 = icmp ugt i64 %2, 10000
-  %true_cond = icmp ne i1 %3, false
+  %2 = icmp ugt i32 %pid, 10000
+  %true_cond = icmp ne i1 %2, false
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args)
   call void @llvm.memset.p0.i64(ptr align 1 %printf_args, i8 0, i64 16, i1 false)
-  %4 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
-  store i64 0, ptr %4, align 8
-  %5 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 1
+  %3 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
+  store i64 0, ptr %3, align 8
+  %4 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 1
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)() #3
-  %6 = lshr i64 %get_pid_tgid1, 32
-  %pid2 = trunc i64 %6 to i32
-  %7 = getelementptr %printf_args_t, ptr %5, i32 0, i32 0
-  store i32 %pid2, ptr %7, align 4
+  %5 = lshr i64 %get_pid_tgid1, 32
+  %pid2 = trunc i64 %5 to i32
+  %6 = getelementptr %printf_args_t, ptr %4, i32 0, i32 0
+  store i32 %pid2, ptr %6, align 4
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args, i64 16, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
@@ -47,12 +46,12 @@ right:                                            ; preds = %entry
 
 event_loss_counter:                               ; preds = %left
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
-  %8 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %8
-  %9 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
-  %10 = load i64, ptr %9, align 8
-  %11 = add i64 %10, 1
-  store i64 %11, ptr %9, align 8
+  %7 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %7
+  %8 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %9 = load i64, ptr %8, align 8
+  %10 = add i64 %9, 1
+  store i64 %10, ptr %8, align 8
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %left

--- a/tests/codegen/llvm/if_variable.ll
+++ b/tests/codegen/llvm/if_variable.ll
@@ -16,24 +16,24 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
-  %"$y" = alloca i64, align 8
+  %"$y" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$y")
-  store i64 0, ptr %"$y", align 8
-  %"$x" = alloca i64, align 8
+  store i8 0, ptr %"$y", align 1
+  %"$x" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
-  store i64 0, ptr %"$x", align 8
+  store i8 0, ptr %"$x", align 1
   br i1 true, label %left, label %right
 
 left:                                             ; preds = %entry
-  store i64 10, ptr %"$x", align 8
+  store i8 10, ptr %"$x", align 1
   br label %done
 
 right:                                            ; preds = %entry
   br label %done
 
 done:                                             ; preds = %right, %left
-  %1 = load i64, ptr %"$x", align 8
-  store i64 %1, ptr %"$y", align 8
+  %1 = load i8, ptr %"$x", align 1
+  store i8 %1, ptr %"$y", align 1
   ret i64 0
 }
 

--- a/tests/codegen/llvm/int_propagation.ll
+++ b/tests/codegen/llvm/int_propagation.ll
@@ -9,27 +9,27 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !24
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
+@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !26
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
 entry:
-  %"@y_val" = alloca i64, align 8
+  %"@y_val" = alloca i16, align 2
   %"@y_key" = alloca i64, align 8
-  %lookup_elem_val = alloca i64, align 8
+  %lookup_elem_val = alloca i16, align 2
   %"@x_key1" = alloca i64, align 8
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i16, align 2
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 1234, ptr %"@x_val", align 8
+  store i16 1234, ptr %"@x_val", align 2
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -41,22 +41,22 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load ptr, ptr %lookup_elem, align 8
-  store ptr %1, ptr %lookup_elem_val, align 8
+  %1 = load i16, ptr %lookup_elem, align 2
+  store i16 %1, ptr %lookup_elem_val, align 2
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  store i64 0, ptr %lookup_elem_val, align 8
+  store i16 0, ptr %lookup_elem_val, align 2
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %2 = load i64, ptr %lookup_elem_val, align 8
+  %2 = load i16, ptr %lookup_elem_val, align 2
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
-  store i64 %2, ptr %"@y_val", align 8
+  store i16 %2, ptr %"@y_val", align 2
   %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
@@ -72,8 +72,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!44}
-!llvm.module.flags = !{!46, !47}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48, !49}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -96,36 +96,38 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int16", size: 16, encoding: DW_ATE_signed)
 !24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
-!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
-!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
-!27 = !{!28, !33}
-!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
-!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
-!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
-!31 = !{!32}
-!32 = !DISubrange(count: 27, lowerBound: 0)
-!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
-!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
-!36 = !{!37}
-!37 = !DISubrange(count: 262144, lowerBound: 0)
-!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
-!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
-!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
-!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
-!45 = !{!0, !7, !22, !24, !38, !42}
-!46 = !{i32 2, !"Debug Info Version", i32 3}
-!47 = !{i32 7, !"uwtable", i32 0}
-!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
-!49 = !DISubroutineType(types: !50)
-!50 = !{!20, !51}
-!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!52 = !{!53}
-!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)
+!25 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
+!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !7, !24, !26, !40, !44}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = !{i32 7, !"uwtable", i32 0}
+!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
+!51 = !DISubroutineType(types: !52)
+!52 = !{!20, !53}
+!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!54 = !{!55}
+!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)

--- a/tests/codegen/llvm/intcast_retval.ll
+++ b/tests/codegen/llvm/intcast_retval.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kretprobe_f_1(ptr %0) #0 section "s_kretprobe_f_1" !dbg !46 {
+define i64 @kretprobe_f_1(ptr %0) #0 section "s_kretprobe_f_1" !dbg !48 {
 entry:
-  %"@_val" = alloca i64, align 8
+  %"@_val" = alloca i32, align 4
   %"@_key" = alloca i64, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 80
@@ -27,8 +27,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  %3 = sext i32 %cast to i64
-  store i64 %3, ptr %"@_val", align 8
+  store i32 %cast, ptr %"@_val", align 4
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
@@ -48,8 +47,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!44}
+!llvm.module.flags = !{!46, !47}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -72,34 +71,36 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kretprobe_f_1", linkageName: "kretprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
+!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
+!27 = !{!28, !33}
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
+!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
+!31 = !{!32}
+!32 = !DISubrange(count: 27, lowerBound: 0)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 262144, lowerBound: 0)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
+!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
+!45 = !{!0, !7, !24, !38, !42}
+!46 = !{i32 2, !"Debug Info Version", i32 3}
+!47 = !{i32 7, !"uwtable", i32 0}
+!48 = distinct !DISubprogram(name: "kretprobe_f_1", linkageName: "kretprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
+!49 = !DISubroutineType(types: !50)
+!50 = !{!20, !51}
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!52 = !{!53}
+!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)

--- a/tests/codegen/llvm/intptrcast_assign_var.ll
+++ b/tests/codegen/llvm/intptrcast_assign_var.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !37
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kretprobe_f_1(ptr %0) #0 section "s_kretprobe_f_1" !dbg !46 {
+define i64 @kretprobe_f_1(ptr %0) #0 section "s_kretprobe_f_1" !dbg !47 {
 entry:
-  %"@_val" = alloca i64, align 8
+  %"@_val" = alloca i8, align 1
   %"@_key" = alloca i64, align 8
   %deref = alloca i8, align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
@@ -33,8 +33,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  %6 = sext i8 %5 to i64
-  store i64 %6, ptr %"@_val", align 8
+  store i8 %5, ptr %"@_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
@@ -54,8 +53,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!43}
+!llvm.module.flags = !{!45, !46}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -78,34 +77,34 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kretprobe_f_1", linkageName: "kretprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 64, elements: !15)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!43 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !44)
+!44 = !{!0, !7, !23, !37, !41}
+!45 = !{i32 2, !"Debug Info Version", i32 3}
+!46 = !{i32 7, !"uwtable", i32 0}
+!47 = distinct !DISubprogram(name: "kretprobe_f_1", linkageName: "kretprobe_f_1", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !50)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!20, !22}
 !50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !47, file: !2, type: !22)

--- a/tests/codegen/llvm/iter_dereference.ll
+++ b/tests/codegen/llvm/iter_dereference.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !27
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !41
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !45
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @iter_task_file_1(ptr %0) #0 section "s_iter_task_file_1" !dbg !50 {
+define i64 @iter_task_file_1(ptr %0) #0 section "s_iter_task_file_1" !dbg !51 {
 entry:
-  %"@_val" = alloca i64, align 8
+  %"@_val" = alloca i8, align 1
   %"@_key" = alloca i64, align 8
   %"struct bpf_iter_meta.session_id" = alloca i64, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
@@ -40,7 +40,7 @@ pred_true:                                        ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 %6, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  store i64 1, ptr %"@_val", align 8
+  store i8 1, ptr %"@_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
@@ -60,8 +60,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!46}
-!llvm.module.flags = !{!48, !49}
+!llvm.dbg.cu = !{!47}
+!llvm.module.flags = !{!49, !50}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -88,34 +88,34 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
 !23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
 !24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
-!29 = !{!30, !35}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 27, lowerBound: 0)
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
-!38 = !{!39}
-!39 = !DISubrange(count: 262144, lowerBound: 0)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
-!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
-!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
-!47 = !{!0, !7, !26, !40, !44}
-!48 = !{i32 2, !"Debug Info Version", i32 3}
-!49 = !{i32 7, !"uwtable", i32 0}
-!50 = distinct !DISubprogram(name: "iter_task_file_1", linkageName: "iter_task_file_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
-!51 = !DISubroutineType(types: !52)
-!52 = !{!24, !53}
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !26, size: 64, offset: 192)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!27 = !DIGlobalVariableExpression(var: !28, expr: !DIExpression())
+!28 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
+!29 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !30)
+!30 = !{!31, !36}
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !32, size: 64)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !34)
+!34 = !{!35}
+!35 = !DISubrange(count: 27, lowerBound: 0)
+!36 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !37, size: 64, offset: 64)
+!37 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !38, size: 64)
+!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !39)
+!39 = !{!40}
+!40 = !DISubrange(count: 262144, lowerBound: 0)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !44, size: 64, elements: !15)
+!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
+!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
+!46 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!47 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !48)
+!48 = !{!0, !7, !27, !41, !45}
+!49 = !{i32 2, !"Debug Info Version", i32 3}
+!50 = !{i32 7, !"uwtable", i32 0}
+!51 = distinct !DISubprogram(name: "iter_task_file_1", linkageName: "iter_task_file_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !54)
+!52 = !DISubroutineType(types: !53)
+!53 = !{!24, !26}
 !54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)
+!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !26)

--- a/tests/codegen/llvm/late_variable_decl.ll
+++ b/tests/codegen/llvm/late_variable_decl.ll
@@ -5,12 +5,12 @@ target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.163" = type { ptr, ptr }
-%int64_int64__tuple_t = type { i64, i64 }
+%uint8_uint8__tuple_t = type { i8, i8 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_map = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !25
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !39
 @__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
 
 ; Function Attrs: nounwind
@@ -19,59 +19,59 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !50 {
 entry:
-  %"$x3" = alloca i64, align 8
+  %"$x3" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x3")
-  store i64 0, ptr %"$x3", align 8
-  %"@map_val" = alloca i64, align 8
-  %"@map_key" = alloca i64, align 8
-  %"$x2" = alloca i64, align 8
+  store i8 0, ptr %"$x3", align 1
+  %"@map_val" = alloca i8, align 1
+  %"@map_key" = alloca i8, align 1
+  %"$x2" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x2")
-  store i64 0, ptr %"$x2", align 8
+  store i8 0, ptr %"$x2", align 1
   %"$i" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$i")
   store i64 0, ptr %"$i", align 8
-  %"$x1" = alloca i64, align 8
+  %"$x1" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x1")
-  store i64 0, ptr %"$x1", align 8
-  %"$x" = alloca i64, align 8
+  store i8 0, ptr %"$x1", align 1
+  %"$x" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
-  store i64 0, ptr %"$x", align 8
+  store i8 0, ptr %"$x", align 1
   br i1 true, label %left, label %right
 
 left:                                             ; preds = %entry
-  store i64 1, ptr %"$x", align 8
+  store i8 1, ptr %"$x", align 1
   br label %done
 
 right:                                            ; preds = %entry
   br label %done
 
 done:                                             ; preds = %right, %left
-  store i64 2, ptr %"$x1", align 8
+  store i8 2, ptr %"$x1", align 1
   store i64 1, ptr %"$i", align 8
   br label %while_cond
 
 while_cond:                                       ; preds = %while_body, %done
   %1 = load i64, ptr %"$i", align 8
   %true_cond = icmp ne i64 %1, 0
-  br i1 %true_cond, label %while_body, label %while_end, !llvm.loop !56
+  br i1 %true_cond, label %while_body, label %while_end, !llvm.loop !55
 
 while_body:                                       ; preds = %while_cond
   %2 = load i64, ptr %"$i", align 8
   %3 = sub i64 %2, 1
   store i64 %3, ptr %"$i", align 8
-  store i64 3, ptr %"$x2", align 8
+  store i8 3, ptr %"$x2", align 1
   br label %while_cond
 
 while_end:                                        ; preds = %while_cond
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_key")
-  store i64 16, ptr %"@map_key", align 8
+  store i8 16, ptr %"@map_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_val")
-  store i64 32, ptr %"@map_val", align 8
+  store i8 32, ptr %"@map_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_map, ptr %"@map_key", ptr %"@map_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@map_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@map_key")
   %for_each_map_elem = call i64 inttoptr (i64 164 to ptr)(ptr @AT_map, ptr @map_for_each_cb, ptr null, i64 0)
-  store i64 5, ptr %"$x3", align 8
+  store i8 5, ptr %"$x3", align 1
   ret i64 0
 }
 
@@ -82,21 +82,21 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 ; Function Attrs: nounwind
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !58 {
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !57 {
 for_body:
-  %"$x" = alloca i64, align 8
+  %"$x" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
-  store i64 0, ptr %"$x", align 8
-  %"$kv" = alloca %int64_int64__tuple_t, align 8
-  %key = load i64, ptr %1, align 8
-  %val = load i64, ptr %2, align 8
+  store i8 0, ptr %"$x", align 1
+  %"$kv" = alloca %uint8_uint8__tuple_t, align 8
+  %key = load i8, ptr %1, align 1
+  %val = load i8, ptr %2, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %4 = getelementptr %int64_int64__tuple_t, ptr %"$kv", i32 0, i32 0
-  store i64 %key, ptr %4, align 8
-  %5 = getelementptr %int64_int64__tuple_t, ptr %"$kv", i32 0, i32 1
-  store i64 %val, ptr %5, align 8
-  store i64 4, ptr %"$x", align 8
+  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 2, i1 false)
+  %4 = getelementptr %uint8_uint8__tuple_t, ptr %"$kv", i32 0, i32 0
+  store i8 %key, ptr %4, align 1
+  %5 = getelementptr %uint8_uint8__tuple_t, ptr %"$kv", i32 0, i32 1
+  store i8 %val, ptr %5, align 1
+  store i8 4, ptr %"$x", align 1
   br label %for_continue
 
 for_continue:                                     ; preds = %for_body
@@ -123,7 +123,7 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_map", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
@@ -136,46 +136,45 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !20 = !{!21}
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
-!29 = !{!30, !35}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 27, lowerBound: 0)
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
-!38 = !{!39}
-!39 = !DISubrange(count: 262144, lowerBound: 0)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
+!28 = !{!29, !34}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !30, size: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 27, lowerBound: 0)
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !35, size: 64, offset: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 262144, lowerBound: 0)
+!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
+!40 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 64, elements: !15)
 !42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
+!43 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
-!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
 !46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
-!47 = !{!0, !7, !26, !40, !44}
+!47 = !{!0, !7, !25, !39, !44}
 !48 = !{i32 2, !"Debug Info Version", i32 3}
 !49 = !{i32 7, !"uwtable", i32 0}
-!50 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
+!50 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
 !51 = !DISubroutineType(types: !52)
-!52 = !{!24, !53}
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)
-!56 = distinct !{!56, !57}
-!57 = !{!"llvm.loop.unroll.disable"}
-!58 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !59, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !46, retainedNodes: !61)
-!59 = !DISubroutineType(types: !60)
-!60 = !{!24, !53, !53, !53, !53}
-!61 = !{!62, !63, !64, !65}
-!62 = !DILocalVariable(name: "map", arg: 1, scope: !58, file: !2, type: !53)
-!63 = !DILocalVariable(name: "key", arg: 2, scope: !58, file: !2, type: !53)
-!64 = !DILocalVariable(name: "value", arg: 3, scope: !58, file: !2, type: !53)
-!65 = !DILocalVariable(name: "ctx", arg: 4, scope: !58, file: !2, type: !53)
+!52 = !{!43, !23}
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !23)
+!55 = distinct !{!55, !56}
+!56 = !{!"llvm.loop.unroll.disable"}
+!57 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !58, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !46, retainedNodes: !60)
+!58 = !DISubroutineType(types: !59)
+!59 = !{!43, !23, !23, !23, !23}
+!60 = !{!61, !62, !63, !64}
+!61 = !DILocalVariable(name: "map", arg: 1, scope: !57, file: !2, type: !23)
+!62 = !DILocalVariable(name: "key", arg: 2, scope: !57, file: !2, type: !23)
+!63 = !DILocalVariable(name: "value", arg: 3, scope: !57, file: !2, type: !23)
+!64 = !DILocalVariable(name: "ctx", arg: 4, scope: !57, file: !2, type: !23)

--- a/tests/codegen/llvm/license.ll
+++ b/tests/codegen/llvm/license.ll
@@ -8,22 +8,22 @@ target triple = "bpf"
 
 @LICENSE = global [13 x i8] c"Dual BSD/GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !37
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !47 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 1, ptr %"@x_val", align 8
+  store i8 1, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -39,8 +39,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!43}
+!llvm.module.flags = !{!45, !46}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -63,34 +63,34 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 64, elements: !15)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!43 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !44)
+!44 = !{!0, !7, !23, !37, !41}
+!45 = !{i32 2, !"Debug Info Version", i32 3}
+!46 = !{i32 7, !"uwtable", i32 0}
+!47 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !50)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!20, !22}
 !50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !47, file: !2, type: !22)

--- a/tests/codegen/llvm/logical_and.ll
+++ b/tests/codegen/llvm/logical_and.ll
@@ -25,18 +25,16 @@ entry:
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
-  %2 = zext i32 %pid to i64
-  %3 = icmp ne i64 %2, 1234
-  %lhs_true_cond = icmp ne i1 %3, false
+  %2 = icmp ne i32 %pid, 1234
+  %lhs_true_cond = icmp ne i1 %2, false
   br i1 %lhs_true_cond, label %"&&_lhs_true", label %"&&_false"
 
 "&&_lhs_true":                                    ; preds = %entry
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)() #2
-  %4 = lshr i64 %get_pid_tgid1, 32
-  %pid2 = trunc i64 %4 to i32
-  %5 = zext i32 %pid2 to i64
-  %6 = icmp ne i64 %5, 1235
-  %rhs_true_cond = icmp ne i1 %6, false
+  %3 = lshr i64 %get_pid_tgid1, 32
+  %pid2 = trunc i64 %3 to i32
+  %4 = icmp ne i32 %pid2, 1235
+  %rhs_true_cond = icmp ne i1 %4, false
   br i1 %rhs_true_cond, label %"&&_true", label %"&&_false"
 
 "&&_true":                                        ; preds = %"&&_lhs_true"
@@ -48,11 +46,11 @@ entry:
   br label %"&&_merge"
 
 "&&_merge":                                       ; preds = %"&&_false", %"&&_true"
-  %7 = load i1, ptr %"&&_result", align 1
+  %5 = load i1, ptr %"&&_result", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i1 %7, ptr %"@x_val", align 1
+  store i1 %5, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/logical_or.ll
+++ b/tests/codegen/llvm/logical_or.ll
@@ -25,18 +25,16 @@ entry:
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
-  %2 = zext i32 %pid to i64
-  %3 = icmp eq i64 %2, 1234
-  %lhs_true_cond = icmp ne i1 %3, false
+  %2 = icmp eq i32 %pid, 1234
+  %lhs_true_cond = icmp ne i1 %2, false
   br i1 %lhs_true_cond, label %"||_true", label %"||_lhs_false"
 
 "||_lhs_false":                                   ; preds = %entry
   %get_pid_tgid1 = call i64 inttoptr (i64 14 to ptr)() #2
-  %4 = lshr i64 %get_pid_tgid1, 32
-  %pid2 = trunc i64 %4 to i32
-  %5 = zext i32 %pid2 to i64
-  %6 = icmp eq i64 %5, 1235
-  %rhs_true_cond = icmp ne i1 %6, false
+  %3 = lshr i64 %get_pid_tgid1, 32
+  %pid2 = trunc i64 %3 to i32
+  %4 = icmp eq i32 %pid2, 1235
+  %rhs_true_cond = icmp ne i1 %4, false
   br i1 %rhs_true_cond, label %"||_true", label %"||_false"
 
 "||_false":                                       ; preds = %"||_lhs_false"
@@ -48,11 +46,11 @@ entry:
   br label %"||_merge"
 
 "||_merge":                                       ; preds = %"||_true", %"||_false"
-  %7 = load i1, ptr %"||_result", align 1
+  %5 = load i1, ptr %"||_result", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i1 %7, ptr %"@x_val", align 1
+  store i1 %5, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")

--- a/tests/codegen/llvm/macro_definition.ll
+++ b/tests/codegen/llvm/macro_definition.ll
@@ -8,22 +8,22 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !37
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !47 {
 entry:
-  %"@_val" = alloca i64, align 8
+  %"@_val" = alloca i8, align 1
   %"@_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  store i64 100, ptr %"@_val", align 8
+  store i8 100, ptr %"@_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
@@ -39,8 +39,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!43}
+!llvm.module.flags = !{!45, !46}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -63,34 +63,34 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 64, elements: !15)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!43 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !44)
+!44 = !{!0, !7, !23, !37, !41}
+!45 = !{i32 2, !"Debug Info Version", i32 3}
+!46 = !{i32 7, !"uwtable", i32 0}
+!47 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !50)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!20, !22}
 !50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !47, file: !2, type: !22)

--- a/tests/codegen/llvm/map_assign_array.ll
+++ b/tests/codegen/llvm/map_assign_array.ll
@@ -9,8 +9,8 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !29
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !43
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !28
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !42
 @__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !47
 
 ; Function Attrs: nounwind
@@ -24,9 +24,9 @@ entry:
   store i32 0, ptr %"$var", align 4
   %runtime_error_t = alloca %runtime_error_t, align 8
   %lookup_elem_val = alloca [4 x i32], align 4
-  %"@x_key1" = alloca i64, align 8
+  %"@x_key1" = alloca i8, align 1
   %"@x_val" = alloca [4 x i32], align 4
-  %"@x_key" = alloca i64, align 8
+  %"@x_key" = alloca i8, align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
@@ -34,14 +34,14 @@ entry:
   %4 = call ptr @llvm.preserve.static.offset(ptr %3)
   %5 = getelementptr i8, ptr %4, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
-  store i64 0, ptr %"@x_key", align 8
+  store i8 0, ptr %"@x_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"@x_val", i32 16, ptr %5)
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
-  store i64 0, ptr %"@x_key1", align 8
+  store i8 0, ptr %"@x_key1", align 1
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key1")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
@@ -72,7 +72,7 @@ is_oob:                                           ; preds = %lookup_merge
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 oob_merge:                                        ; preds = %counter_merge, %lookup_merge
-  %9 = getelementptr [4 x i32], ptr %lookup_elem_val, i32 0, i64 0
+  %9 = getelementptr [4 x i32], ptr %lookup_elem_val, i32 0, i8 0
   %10 = load volatile i32, ptr %9, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
   store i32 %10, ptr %"$var", align 4
@@ -128,7 +128,7 @@ attributes #5 = { memory(none) }
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
@@ -141,39 +141,38 @@ attributes #5 = { memory(none) }
 !20 = !{!21}
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !26, size: 64, offset: 192)
-!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
-!27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !28, size: 128, elements: !5)
-!28 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
-!29 = !DIGlobalVariableExpression(var: !30, expr: !DIExpression())
-!30 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !31, isLocal: false, isDefinition: true)
-!31 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !32)
-!32 = !{!33, !38}
-!33 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !34, size: 64)
-!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !36)
-!36 = !{!37}
-!37 = !DISubrange(count: 27, lowerBound: 0)
-!38 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !39, size: 64, offset: 64)
-!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !41)
-!41 = !{!42}
-!42 = !DISubrange(count: 262144, lowerBound: 0)
-!43 = !DIGlobalVariableExpression(var: !44, expr: !DIExpression())
-!44 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !45, isLocal: false, isDefinition: true)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !25, size: 64, offset: 192)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !27, size: 128, elements: !5)
+!27 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!28 = !DIGlobalVariableExpression(var: !29, expr: !DIExpression())
+!29 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !30, isLocal: false, isDefinition: true)
+!30 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !31)
+!31 = !{!32, !37}
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !33, size: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 27, lowerBound: 0)
+!37 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !38, size: 64, offset: 64)
+!38 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !39, size: 64)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !40)
+!40 = !{!41}
+!41 = !DISubrange(count: 262144, lowerBound: 0)
+!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
+!43 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !44, isLocal: false, isDefinition: true)
+!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !45, size: 64, elements: !15)
 !45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !46, size: 64, elements: !15)
-!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
+!46 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !47 = !DIGlobalVariableExpression(var: !48, expr: !DIExpression())
-!48 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!48 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !46, isLocal: false, isDefinition: true)
 !49 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !50)
-!50 = !{!0, !7, !29, !43, !47}
+!50 = !{!0, !7, !28, !42, !47}
 !51 = !{i32 2, !"Debug Info Version", i32 3}
 !52 = !{i32 7, !"uwtable", i32 0}
-!53 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !54, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !49, retainedNodes: !57)
+!53 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !54, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !49, retainedNodes: !56)
 !54 = !DISubroutineType(types: !55)
-!55 = !{!24, !56}
-!56 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!57 = !{!58}
-!58 = !DILocalVariable(name: "ctx", arg: 1, scope: !53, file: !2, type: !56)
+!55 = !{!46, !23}
+!56 = !{!57}
+!57 = !DILocalVariable(name: "ctx", arg: 1, scope: !53, file: !2, type: !23)

--- a/tests/codegen/llvm/map_assign_int.ll
+++ b/tests/codegen/llvm/map_assign_int.ll
@@ -8,22 +8,22 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !37
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !47 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 1, ptr %"@x_val", align 8
+  store i8 1, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -39,8 +39,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!43}
+!llvm.module.flags = !{!45, !46}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -63,34 +63,34 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 64, elements: !15)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!43 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !44)
+!44 = !{!0, !7, !23, !37, !41}
+!45 = !{i32 2, !"Debug Info Version", i32 3}
+!46 = !{i32 7, !"uwtable", i32 0}
+!47 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !50)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!20, !22}
 !50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !47, file: !2, type: !22)

--- a/tests/codegen/llvm/map_hash.ll
+++ b/tests/codegen/llvm/map_hash.ll
@@ -8,8 +8,8 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_a = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !25
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !39
 @__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
 
 ; Function Attrs: nounwind
@@ -18,12 +18,12 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !50 {
 entry:
-  %"@a_val" = alloca i64, align 8
-  %"@a_key" = alloca i64, align 8
+  %"@a_val" = alloca i8, align 1
+  %"@a_key" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key")
-  store i64 1, ptr %"@a_key", align 8
+  store i8 1, ptr %"@a_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_val")
-  store i64 1, ptr %"@a_val", align 8
+  store i8 1, ptr %"@a_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key", ptr %"@a_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key")
@@ -52,7 +52,7 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_a", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
@@ -65,36 +65,35 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !20 = !{!21}
 !21 = !DISubrange(count: 10, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
-!29 = !{!30, !35}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 27, lowerBound: 0)
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
-!38 = !{!39}
-!39 = !DISubrange(count: 262144, lowerBound: 0)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
+!28 = !{!29, !34}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !30, size: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 27, lowerBound: 0)
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !35, size: 64, offset: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 262144, lowerBound: 0)
+!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
+!40 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 64, elements: !15)
 !42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
+!43 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
-!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
 !46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
-!47 = !{!0, !7, !26, !40, !44}
+!47 = !{!0, !7, !25, !39, !44}
 !48 = !{i32 2, !"Debug Info Version", i32 3}
 !49 = !{i32 7, !"uwtable", i32 0}
-!50 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
+!50 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
 !51 = !DISubroutineType(types: !52)
-!52 = !{!24, !53}
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)
+!52 = !{!43, !23}
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !23)

--- a/tests/codegen/llvm/map_increment_decrement.ll
+++ b/tests/codegen/llvm/map_increment_decrement.ll
@@ -47,8 +47,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load ptr, ptr %lookup_elem, align 8
-  store ptr %1, ptr %lookup_elem_val, align 8
+  %1 = load i64, ptr %lookup_elem, align 8
+  store i64 %1, ptr %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
@@ -72,8 +72,8 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   br i1 %map_lookup_cond9, label %lookup_success5, label %lookup_failure6
 
 lookup_success5:                                  ; preds = %lookup_merge
-  %4 = load ptr, ptr %lookup_elem4, align 8
-  store ptr %4, ptr %lookup_elem_val8, align 8
+  %4 = load i64, ptr %lookup_elem4, align 8
+  store i64 %4, ptr %lookup_elem_val8, align 8
   br label %lookup_merge7
 
 lookup_failure6:                                  ; preds = %lookup_merge
@@ -98,8 +98,8 @@ lookup_merge7:                                    ; preds = %lookup_failure6, %l
   br i1 %map_lookup_cond18, label %lookup_success14, label %lookup_failure15
 
 lookup_success14:                                 ; preds = %lookup_merge7
-  %8 = load ptr, ptr %lookup_elem13, align 8
-  store ptr %8, ptr %lookup_elem_val17, align 8
+  %8 = load i64, ptr %lookup_elem13, align 8
+  store i64 %8, ptr %lookup_elem_val17, align 8
   br label %lookup_merge16
 
 lookup_failure15:                                 ; preds = %lookup_merge7
@@ -123,8 +123,8 @@ lookup_merge16:                                   ; preds = %lookup_failure15, %
   br i1 %map_lookup_cond27, label %lookup_success23, label %lookup_failure24
 
 lookup_success23:                                 ; preds = %lookup_merge16
-  %11 = load ptr, ptr %lookup_elem22, align 8
-  store ptr %11, ptr %lookup_elem_val26, align 8
+  %11 = load i64, ptr %lookup_elem22, align 8
+  store i64 %11, ptr %lookup_elem_val26, align 8
   br label %lookup_merge25
 
 lookup_failure24:                                 ; preds = %lookup_merge16

--- a/tests/codegen/llvm/map_key_array.ll
+++ b/tests/codegen/llvm/map_key_array.ll
@@ -8,8 +8,8 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !29
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !43
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !28
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !42
 @__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !47
 
 ; Function Attrs: nounwind
@@ -18,7 +18,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !53 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
   %"@x_key" = alloca [4 x i32], align 4
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
@@ -29,7 +29,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"@x_key", i32 16, ptr %5)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 44, ptr %"@x_val", align 8
+  store i8 44, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -79,35 +79,34 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !24 = !DICompositeType(tag: DW_TAG_array_type, baseType: !25, size: 128, elements: !5)
 !25 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !26 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !27, size: 64, offset: 192)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!29 = !DIGlobalVariableExpression(var: !30, expr: !DIExpression())
-!30 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !31, isLocal: false, isDefinition: true)
-!31 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !32)
-!32 = !{!33, !38}
-!33 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !34, size: 64)
-!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !36)
-!36 = !{!37}
-!37 = !DISubrange(count: 27, lowerBound: 0)
-!38 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !39, size: 64, offset: 64)
-!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !41)
-!41 = !{!42}
-!42 = !DISubrange(count: 262144, lowerBound: 0)
-!43 = !DIGlobalVariableExpression(var: !44, expr: !DIExpression())
-!44 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !45, isLocal: false, isDefinition: true)
+!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!28 = !DIGlobalVariableExpression(var: !29, expr: !DIExpression())
+!29 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !30, isLocal: false, isDefinition: true)
+!30 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !31)
+!31 = !{!32, !37}
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !33, size: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 27, lowerBound: 0)
+!37 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !38, size: 64, offset: 64)
+!38 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !39, size: 64)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !40)
+!40 = !{!41}
+!41 = !DISubrange(count: 262144, lowerBound: 0)
+!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
+!43 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !44, isLocal: false, isDefinition: true)
+!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !45, size: 64, elements: !15)
 !45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !46, size: 64, elements: !15)
-!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !28, size: 64, elements: !15)
+!46 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !47 = !DIGlobalVariableExpression(var: !48, expr: !DIExpression())
-!48 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!48 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !46, isLocal: false, isDefinition: true)
 !49 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !50)
-!50 = !{!0, !7, !29, !43, !47}
+!50 = !{!0, !7, !28, !42, !47}
 !51 = !{i32 2, !"Debug Info Version", i32 3}
 !52 = !{i32 7, !"uwtable", i32 0}
-!53 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !54, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !49, retainedNodes: !57)
+!53 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !54, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !49, retainedNodes: !56)
 !54 = !DISubroutineType(types: !55)
-!55 = !{!28, !56}
-!56 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!57 = !{!58}
-!58 = !DILocalVariable(name: "ctx", arg: 1, scope: !53, file: !2, type: !56)
+!55 = !{!46, !27}
+!56 = !{!57}
+!57 = !DILocalVariable(name: "ctx", arg: 1, scope: !53, file: !2, type: !27)

--- a/tests/codegen/llvm/map_key_int.ll
+++ b/tests/codegen/llvm/map_key_int.ll
@@ -5,12 +5,12 @@ target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.163" = type { ptr, ptr }
-%int64_int64_int64__tuple_t = type { i64, i64, i64 }
+%uint8_uint8_uint8__tuple_t = type { i8, i8, i8 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !32
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !46
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !31
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !45
 @__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !50
 
 ; Function Attrs: nounwind
@@ -19,18 +19,18 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !56 {
 entry:
-  %"@x_val" = alloca i64, align 8
-  %tuple = alloca %int64_int64_int64__tuple_t, align 8
+  %"@x_val" = alloca i8, align 1
+  %tuple = alloca %uint8_uint8_uint8__tuple_t, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 24, i1 false)
-  %1 = getelementptr %int64_int64_int64__tuple_t, ptr %tuple, i32 0, i32 0
-  store i64 11, ptr %1, align 8
-  %2 = getelementptr %int64_int64_int64__tuple_t, ptr %tuple, i32 0, i32 1
-  store i64 22, ptr %2, align 8
-  %3 = getelementptr %int64_int64_int64__tuple_t, ptr %tuple, i32 0, i32 2
-  store i64 33, ptr %3, align 8
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 3, i1 false)
+  %1 = getelementptr %uint8_uint8_uint8__tuple_t, ptr %tuple, i32 0, i32 0
+  store i8 11, ptr %1, align 1
+  %2 = getelementptr %uint8_uint8_uint8__tuple_t, ptr %tuple, i32 0, i32 1
+  store i8 22, ptr %2, align 1
+  %3 = getelementptr %uint8_uint8_uint8__tuple_t, ptr %tuple, i32 0, i32 2
+  store i8 33, ptr %3, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 44, ptr %"@x_val", align 8
+  store i8 44, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %tuple, ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
@@ -63,7 +63,7 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !30}
+!10 = !{!11, !17, !22, !29}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
@@ -77,41 +77,40 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
 !23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 192, elements: !25)
-!25 = !{!26, !28, !29}
-!26 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!28 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !27, size: 64, offset: 64)
-!29 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !27, size: 64, offset: 128)
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !31, size: 64, offset: 192)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
-!32 = !DIGlobalVariableExpression(var: !33, expr: !DIExpression())
-!33 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !34, isLocal: false, isDefinition: true)
-!34 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !35)
-!35 = !{!36, !41}
-!36 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !37, size: 64)
-!37 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !38, size: 64)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !39)
-!39 = !{!40}
-!40 = !DISubrange(count: 27, lowerBound: 0)
-!41 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !42, size: 64, offset: 64)
-!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !44)
-!44 = !{!45}
-!45 = !DISubrange(count: 262144, lowerBound: 0)
-!46 = !DIGlobalVariableExpression(var: !47, expr: !DIExpression())
-!47 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !48, isLocal: false, isDefinition: true)
+!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 24, elements: !25)
+!25 = !{!26, !27, !28}
+!26 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !4, size: 8)
+!27 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !4, size: 8, offset: 8)
+!28 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !4, size: 8, offset: 16)
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !30, size: 64, offset: 192)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!31 = !DIGlobalVariableExpression(var: !32, expr: !DIExpression())
+!32 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !33, isLocal: false, isDefinition: true)
+!33 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !34)
+!34 = !{!35, !40}
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !36, size: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 27, lowerBound: 0)
+!40 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !41, size: 64, offset: 64)
+!41 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !42, size: 64)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 262144, lowerBound: 0)
+!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
+!46 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !47, isLocal: false, isDefinition: true)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 64, elements: !15)
 !48 = !DICompositeType(tag: DW_TAG_array_type, baseType: !49, size: 64, elements: !15)
-!49 = !DICompositeType(tag: DW_TAG_array_type, baseType: !27, size: 64, elements: !15)
+!49 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !50 = !DIGlobalVariableExpression(var: !51, expr: !DIExpression())
-!51 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!51 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !49, isLocal: false, isDefinition: true)
 !52 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !53)
-!53 = !{!0, !7, !32, !46, !50}
+!53 = !{!0, !7, !31, !45, !50}
 !54 = !{i32 2, !"Debug Info Version", i32 3}
 !55 = !{i32 7, !"uwtable", i32 0}
-!56 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !52, retainedNodes: !60)
+!56 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !57, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !52, retainedNodes: !59)
 !57 = !DISubroutineType(types: !58)
-!58 = !{!27, !59}
-!59 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!60 = !{!61}
-!61 = !DILocalVariable(name: "ctx", arg: 1, scope: !56, file: !2, type: !59)
+!58 = !{!49, !30}
+!59 = !{!60}
+!60 = !DILocalVariable(name: "ctx", arg: 1, scope: !56, file: !2, type: !30)

--- a/tests/codegen/llvm/map_key_probe.ll
+++ b/tests/codegen/llvm/map_key_probe.ll
@@ -28,8 +28,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load ptr, ptr %lookup_elem, align 8
-  store ptr %1, ptr %lookup_elem_val, align 8
+  %1 = load i64, ptr %lookup_elem, align 8
+  store i64 %1, ptr %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
@@ -64,8 +64,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load ptr, ptr %lookup_elem, align 8
-  store ptr %1, ptr %lookup_elem_val, align 8
+  %1 = load i64, ptr %lookup_elem, align 8
+  store i64 %1, ptr %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry

--- a/tests/codegen/llvm/map_key_scratch_buf.ll
+++ b/tests/codegen/llvm/map_key_scratch_buf.ll
@@ -9,61 +9,61 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !35
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !49
+@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !25
+@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !34
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !48
 @__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !51
-@__bt__map_key_buf = dso_local externally_initialized global [1 x [2 x [8 x i8]]] zeroinitializer, section ".data.map_key_buf", !dbg !55
-@__bt__write_map_val_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.write_map_val_buf", !dbg !64
-@__bt__read_map_val_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.read_map_val_buf", !dbg !68
+@__bt__map_key_buf = dso_local externally_initialized global [1 x [2 x [1 x i8]]] zeroinitializer, section ".data.map_key_buf", !dbg !55
+@__bt__write_map_val_buf = dso_local externally_initialized global [1 x [1 x [1 x i8]]] zeroinitializer, section ".data.write_map_val_buf", !dbg !62
+@__bt__read_map_val_buf = dso_local externally_initialized global [1 x [1 x [1 x i8]]] zeroinitializer, section ".data.read_map_val_buf", !dbg !66
 @yyyy = global [5 x i8] c"yyyy\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !74 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !72 {
 entry:
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #1
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
-  %2 = getelementptr [1 x [2 x [8 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  store i64 1, ptr %2, align 8
+  %2 = getelementptr [1 x [2 x [1 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  store i8 1, ptr %2, align 1
   %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)() #1
   %3 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded2 = and i64 %get_cpu_id1, %3
-  %4 = getelementptr [1 x [1 x [8 x i8]]], ptr @__bt__write_map_val_buf, i64 0, i64 %cpu.id.bounded2, i64 0, i64 0
-  store i64 1, ptr %4, align 8
+  %4 = getelementptr [1 x [1 x [1 x i8]]], ptr @__bt__write_map_val_buf, i64 0, i64 %cpu.id.bounded2, i64 0, i64 0
+  store i8 1, ptr %4, align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %2, ptr %4, i64 0)
   %get_cpu_id3 = call i64 inttoptr (i64 8 to ptr)() #1
   %5 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded4 = and i64 %get_cpu_id3, %5
-  %6 = getelementptr [1 x [2 x [8 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded4, i64 1, i64 0
-  store i64 1, ptr %6, align 8
+  %6 = getelementptr [1 x [2 x [1 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded4, i64 1, i64 0
+  store i8 1, ptr %6, align 1
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %6)
   %get_cpu_id5 = call i64 inttoptr (i64 8 to ptr)() #1
   %7 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded6 = and i64 %get_cpu_id5, %7
-  %8 = getelementptr [1 x [1 x [8 x i8]]], ptr @__bt__read_map_val_buf, i64 0, i64 %cpu.id.bounded6, i64 0, i64 0
+  %8 = getelementptr [1 x [1 x [1 x i8]]], ptr @__bt__read_map_val_buf, i64 0, i64 %cpu.id.bounded6, i64 0, i64 0
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %9 = load ptr, ptr %lookup_elem, align 8
-  store ptr %9, ptr %8, align 8
+  %9 = load i8, ptr %lookup_elem, align 1
+  store i8 %9, ptr %8, align 1
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  store i64 0, ptr %8, align 8
+  store i8 0, ptr %8, align 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %10 = load i64, ptr %8, align 8
+  %10 = load i8, ptr %8, align 1
   %get_cpu_id7 = call i64 inttoptr (i64 8 to ptr)() #1
   %11 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded8 = and i64 %get_cpu_id7, %11
-  %12 = getelementptr [1 x [1 x [8 x i8]]], ptr @__bt__write_map_val_buf, i64 0, i64 %cpu.id.bounded8, i64 0, i64 0
-  store i64 %10, ptr %12, align 8
+  %12 = getelementptr [1 x [1 x [1 x i8]]], ptr @__bt__write_map_val_buf, i64 0, i64 %cpu.id.bounded8, i64 0, i64 0
+  store i8 %10, ptr %12, align 1
   %update_elem9 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr @yyyy, ptr %12, i64 0)
   ret i64 0
 }
@@ -71,8 +71,8 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 attributes #0 = { nounwind }
 attributes #1 = { memory(none) }
 
-!llvm.dbg.cu = !{!70}
-!llvm.module.flags = !{!72, !73}
+!llvm.dbg.cu = !{!68}
+!llvm.module.flags = !{!70, !71}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -84,7 +84,7 @@ attributes #1 = { memory(none) }
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
@@ -97,60 +97,57 @@ attributes #1 = { memory(none) }
 !20 = !{!21}
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !29)
-!29 = !{!11, !17, !30, !25}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 40, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 5, lowerBound: 0)
-!35 = !DIGlobalVariableExpression(var: !36, expr: !DIExpression())
-!36 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !37, isLocal: false, isDefinition: true)
-!37 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !38)
-!38 = !{!39, !44}
-!39 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !40, size: 64)
-!40 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !41, size: 64)
-!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !42)
-!42 = !{!43}
-!43 = !DISubrange(count: 27, lowerBound: 0)
-!44 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !45, size: 64, offset: 64)
-!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
-!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !47)
-!47 = !{!48}
-!48 = !DISubrange(count: 262144, lowerBound: 0)
-!49 = !DIGlobalVariableExpression(var: !50, expr: !DIExpression())
-!50 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !28)
+!28 = !{!11, !17, !29, !24}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !30, size: 64, offset: 128)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 40, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 5, lowerBound: 0)
+!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
+!35 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
+!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !37)
+!37 = !{!38, !43}
+!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
+!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !41)
+!41 = !{!42}
+!42 = !DISubrange(count: 27, lowerBound: 0)
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !44, size: 64, offset: 64)
+!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !46)
+!46 = !{!47}
+!47 = !DISubrange(count: 262144, lowerBound: 0)
+!48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
+!49 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !50, isLocal: false, isDefinition: true)
+!50 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
 !52 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !53, isLocal: false, isDefinition: true)
 !53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !54, size: 64, elements: !15)
-!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
+!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !50, size: 64, elements: !15)
 !55 = !DIGlobalVariableExpression(var: !56, expr: !DIExpression())
 !56 = distinct !DIGlobalVariable(name: "__bt__map_key_buf", linkageName: "global", scope: !2, file: !2, type: !57, isLocal: false, isDefinition: true)
-!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !58, size: 128, elements: !15)
-!58 = !DICompositeType(tag: DW_TAG_array_type, baseType: !59, size: 128, elements: !62)
-!59 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 64, elements: !60)
+!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !58, size: 16, elements: !15)
+!58 = !DICompositeType(tag: DW_TAG_array_type, baseType: !59, size: 16, elements: !60)
+!59 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 8, elements: !15)
 !60 = !{!61}
-!61 = !DISubrange(count: 8, lowerBound: 0)
-!62 = !{!63}
-!63 = !DISubrange(count: 2, lowerBound: 0)
-!64 = !DIGlobalVariableExpression(var: !65, expr: !DIExpression())
-!65 = distinct !DIGlobalVariable(name: "__bt__write_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !66, isLocal: false, isDefinition: true)
-!66 = !DICompositeType(tag: DW_TAG_array_type, baseType: !67, size: 64, elements: !15)
-!67 = !DICompositeType(tag: DW_TAG_array_type, baseType: !59, size: 64, elements: !15)
-!68 = !DIGlobalVariableExpression(var: !69, expr: !DIExpression())
-!69 = distinct !DIGlobalVariable(name: "__bt__read_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !66, isLocal: false, isDefinition: true)
-!70 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !71)
-!71 = !{!0, !7, !26, !35, !49, !51, !55, !64, !68}
-!72 = !{i32 2, !"Debug Info Version", i32 3}
-!73 = !{i32 7, !"uwtable", i32 0}
-!74 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !75, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !70, retainedNodes: !78)
-!75 = !DISubroutineType(types: !76)
-!76 = !{!24, !77}
-!77 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!78 = !{!79}
-!79 = !DILocalVariable(name: "ctx", arg: 1, scope: !74, file: !2, type: !77)
+!61 = !DISubrange(count: 2, lowerBound: 0)
+!62 = !DIGlobalVariableExpression(var: !63, expr: !DIExpression())
+!63 = distinct !DIGlobalVariable(name: "__bt__write_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !64, isLocal: false, isDefinition: true)
+!64 = !DICompositeType(tag: DW_TAG_array_type, baseType: !65, size: 8, elements: !15)
+!65 = !DICompositeType(tag: DW_TAG_array_type, baseType: !59, size: 8, elements: !15)
+!66 = !DIGlobalVariableExpression(var: !67, expr: !DIExpression())
+!67 = distinct !DIGlobalVariable(name: "__bt__read_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !64, isLocal: false, isDefinition: true)
+!68 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !69)
+!69 = !{!0, !7, !25, !34, !48, !51, !55, !62, !66}
+!70 = !{i32 2, !"Debug Info Version", i32 3}
+!71 = !{i32 7, !"uwtable", i32 0}
+!72 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !73, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !68, retainedNodes: !75)
+!73 = !DISubroutineType(types: !74)
+!74 = !{!50, !23}
+!75 = !{!76}
+!76 = !DILocalVariable(name: "ctx", arg: 1, scope: !72, file: !2, type: !23)

--- a/tests/codegen/llvm/map_key_stack.ll
+++ b/tests/codegen/llvm/map_key_stack.ll
@@ -9,9 +9,9 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !35
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !49
+@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !25
+@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !34
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !48
 @__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !53
 @yyyy = global [5 x i8] c"yyyy\00"
 
@@ -21,40 +21,40 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !59 {
 entry:
-  %"@y_val" = alloca i64, align 8
-  %lookup_elem_val = alloca i64, align 8
-  %"@x_key1" = alloca i64, align 8
-  %"@x_val" = alloca i64, align 8
-  %"@x_key" = alloca i64, align 8
+  %"@y_val" = alloca i8, align 1
+  %lookup_elem_val = alloca i8, align 1
+  %"@x_key1" = alloca i8, align 1
+  %"@x_val" = alloca i8, align 1
+  %"@x_key" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
-  store i64 1, ptr %"@x_key", align 8
+  store i8 1, ptr %"@x_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 1, ptr %"@x_val", align 8
+  store i8 1, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
-  store i64 1, ptr %"@x_key1", align 8
+  store i8 1, ptr %"@x_key1", align 1
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key1")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load ptr, ptr %lookup_elem, align 8
-  store ptr %1, ptr %lookup_elem_val, align 8
+  %1 = load i8, ptr %lookup_elem, align 1
+  store i8 %1, ptr %lookup_elem_val, align 1
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  store i64 0, ptr %lookup_elem_val, align 8
+  store i8 0, ptr %lookup_elem_val, align 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %2 = load i64, ptr %lookup_elem_val, align 8
+  %2 = load i8, ptr %lookup_elem_val, align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
-  store i64 %2, ptr %"@y_val", align 8
+  store i8 %2, ptr %"@y_val", align 1
   %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr @yyyy, ptr %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_val")
   ret i64 0
@@ -82,7 +82,7 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
@@ -95,45 +95,44 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !20 = !{!21}
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !29)
-!29 = !{!11, !17, !30, !25}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 40, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 5, lowerBound: 0)
-!35 = !DIGlobalVariableExpression(var: !36, expr: !DIExpression())
-!36 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !37, isLocal: false, isDefinition: true)
-!37 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !38)
-!38 = !{!39, !44}
-!39 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !40, size: 64)
-!40 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !41, size: 64)
-!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !42)
-!42 = !{!43}
-!43 = !DISubrange(count: 27, lowerBound: 0)
-!44 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !45, size: 64, offset: 64)
-!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
-!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !47)
-!47 = !{!48}
-!48 = !DISubrange(count: 262144, lowerBound: 0)
-!49 = !DIGlobalVariableExpression(var: !50, expr: !DIExpression())
-!50 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !51, isLocal: false, isDefinition: true)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !28)
+!28 = !{!11, !17, !29, !24}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !30, size: 64, offset: 128)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 40, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 5, lowerBound: 0)
+!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
+!35 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
+!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !37)
+!37 = !{!38, !43}
+!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
+!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !41)
+!41 = !{!42}
+!42 = !DISubrange(count: 27, lowerBound: 0)
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !44, size: 64, offset: 64)
+!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !46)
+!46 = !{!47}
+!47 = !DISubrange(count: 262144, lowerBound: 0)
+!48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
+!49 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !50, isLocal: false, isDefinition: true)
+!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !51, size: 64, elements: !15)
 !51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !52, size: 64, elements: !15)
-!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
+!52 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !53 = !DIGlobalVariableExpression(var: !54, expr: !DIExpression())
-!54 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!54 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !52, isLocal: false, isDefinition: true)
 !55 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !56)
-!56 = !{!0, !7, !26, !35, !49, !53}
+!56 = !{!0, !7, !25, !34, !48, !53}
 !57 = !{i32 2, !"Debug Info Version", i32 3}
 !58 = !{i32 7, !"uwtable", i32 0}
-!59 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !60, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !55, retainedNodes: !63)
+!59 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !60, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !55, retainedNodes: !62)
 !60 = !DISubroutineType(types: !61)
-!61 = !{!24, !62}
-!62 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!63 = !{!64}
-!64 = !DILocalVariable(name: "ctx", arg: 1, scope: !59, file: !2, type: !62)
+!61 = !{!52, !23}
+!62 = !{!63}
+!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !59, file: !2, type: !23)

--- a/tests/codegen/llvm/map_key_string.ll
+++ b/tests/codegen/llvm/map_key_string.ll
@@ -9,8 +9,8 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !34
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !48
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !33
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !47
 @__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !52
 @a = global [2 x i8] c"a\00"
 @b = global [2 x i8] c"b\00"
@@ -21,7 +21,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !58 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
   %tuple = alloca %"string[2]_string[2]__tuple_t", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
   call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 4, i1 false)
@@ -30,7 +30,7 @@ entry:
   %2 = getelementptr %"string[2]_string[2]__tuple_t", ptr %tuple, i32 0, i32 1
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 @b, i64 2, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 44, ptr %"@x_val", align 8
+  store i8 44, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %tuple, ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
@@ -89,35 +89,34 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !29 = !DISubrange(count: 2, lowerBound: 0)
 !30 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !27, size: 16, offset: 16)
 !31 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !32, size: 64, offset: 192)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!34 = !DIGlobalVariableExpression(var: !35, expr: !DIExpression())
-!35 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !36, isLocal: false, isDefinition: true)
-!36 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !37)
-!37 = !{!38, !43}
-!38 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !39, size: 64)
-!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !41)
-!41 = !{!42}
-!42 = !DISubrange(count: 27, lowerBound: 0)
-!43 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !44, size: 64, offset: 64)
-!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 262144, lowerBound: 0)
-!48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
-!49 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !50, isLocal: false, isDefinition: true)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!33 = !DIGlobalVariableExpression(var: !34, expr: !DIExpression())
+!34 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !35, isLocal: false, isDefinition: true)
+!35 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !36)
+!36 = !{!37, !42}
+!37 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !38, size: 64)
+!38 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !39, size: 64)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !40)
+!40 = !{!41}
+!41 = !DISubrange(count: 27, lowerBound: 0)
+!42 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !43, size: 64, offset: 64)
+!43 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !44, size: 64)
+!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !45)
+!45 = !{!46}
+!46 = !DISubrange(count: 262144, lowerBound: 0)
+!47 = !DIGlobalVariableExpression(var: !48, expr: !DIExpression())
+!48 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !49, isLocal: false, isDefinition: true)
+!49 = !DICompositeType(tag: DW_TAG_array_type, baseType: !50, size: 64, elements: !15)
 !50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !51, size: 64, elements: !15)
-!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !33, size: 64, elements: !15)
+!51 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !52 = !DIGlobalVariableExpression(var: !53, expr: !DIExpression())
-!53 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !33, isLocal: false, isDefinition: true)
+!53 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !51, isLocal: false, isDefinition: true)
 !54 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !55)
-!55 = !{!0, !7, !34, !48, !52}
+!55 = !{!0, !7, !33, !47, !52}
 !56 = !{i32 2, !"Debug Info Version", i32 3}
 !57 = !{i32 7, !"uwtable", i32 0}
-!58 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !59, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !54, retainedNodes: !62)
+!58 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !59, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !54, retainedNodes: !61)
 !59 = !DISubroutineType(types: !60)
-!60 = !{!33, !61}
-!61 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!62 = !{!63}
-!63 = !DILocalVariable(name: "ctx", arg: 1, scope: !58, file: !2, type: !61)
+!60 = !{!51, !32}
+!61 = !{!62}
+!62 = !DILocalVariable(name: "ctx", arg: 1, scope: !58, file: !2, type: !32)

--- a/tests/codegen/llvm/map_key_struct.ll
+++ b/tests/codegen/llvm/map_key_struct.ll
@@ -8,8 +8,8 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !27
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !41
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
 @__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !45
 
 ; Function Attrs: nounwind
@@ -18,7 +18,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !51 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
   %"@x_key" = alloca [4 x i8], align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
@@ -27,7 +27,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"@x_key", i32 4, ptr %3)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 44, ptr %"@x_val", align 8
+  store i8 44, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -75,35 +75,34 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
 !23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !3, size: 64)
 !24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !25, size: 64, offset: 192)
-!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
-!26 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!27 = !DIGlobalVariableExpression(var: !28, expr: !DIExpression())
-!28 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
-!29 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !30)
-!30 = !{!31, !36}
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !32, size: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 27, lowerBound: 0)
-!36 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !37, size: 64, offset: 64)
-!37 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !38, size: 64)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !39)
-!39 = !{!40}
-!40 = !DISubrange(count: 262144, lowerBound: 0)
-!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
-!42 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
 !43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !44, size: 64, elements: !15)
-!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !26, size: 64, elements: !15)
+!44 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
-!46 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!46 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !44, isLocal: false, isDefinition: true)
 !47 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !48)
-!48 = !{!0, !7, !27, !41, !45}
+!48 = !{!0, !7, !26, !40, !45}
 !49 = !{i32 2, !"Debug Info Version", i32 3}
 !50 = !{i32 7, !"uwtable", i32 0}
-!51 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !55)
+!51 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !54)
 !52 = !DISubroutineType(types: !53)
-!53 = !{!26, !54}
-!54 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!55 = !{!56}
-!56 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !54)
+!53 = !{!44, !25}
+!54 = !{!55}
+!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !25)

--- a/tests/codegen/llvm/map_lruhash.ll
+++ b/tests/codegen/llvm/map_lruhash.ll
@@ -8,8 +8,8 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_a = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !25
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !39
 @__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !46
 
 ; Function Attrs: nounwind
@@ -18,12 +18,12 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !52 {
 entry:
-  %"@a_val" = alloca i64, align 8
-  %"@a_key" = alloca i64, align 8
+  %"@a_val" = alloca i8, align 1
+  %"@a_key" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key")
-  store i64 1, ptr %"@a_key", align 8
+  store i8 1, ptr %"@a_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_val")
-  store i64 1, ptr %"@a_val", align 8
+  store i8 1, ptr %"@a_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key", ptr %"@a_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key")
@@ -52,7 +52,7 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_a", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 288, elements: !15)
@@ -65,38 +65,37 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !20 = !{!21}
 !21 = !DISubrange(count: 10, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
-!29 = !{!30, !35}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 27, lowerBound: 0)
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
-!38 = !{!39}
-!39 = !DISubrange(count: 262144, lowerBound: 0)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
+!28 = !{!29, !34}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !30, size: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 27, lowerBound: 0)
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !35, size: 64, offset: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 262144, lowerBound: 0)
+!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
+!40 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 64, elements: !44)
 !42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !44)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !44)
+!43 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !44 = !{!45}
 !45 = !DISubrange(count: 1, lowerBound: 0)
 !46 = !DIGlobalVariableExpression(var: !47, expr: !DIExpression())
-!47 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!47 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
 !48 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !49)
-!49 = !{!0, !7, !26, !40, !46}
+!49 = !{!0, !7, !25, !39, !46}
 !50 = !{i32 2, !"Debug Info Version", i32 3}
 !51 = !{i32 7, !"uwtable", i32 0}
-!52 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !53, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !48, retainedNodes: !56)
+!52 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !53, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !48, retainedNodes: !55)
 !53 = !DISubroutineType(types: !54)
-!54 = !{!24, !55}
-!55 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!56 = !{!57}
-!57 = !DILocalVariable(name: "ctx", arg: 1, scope: !52, file: !2, type: !55)
+!54 = !{!43, !23}
+!55 = !{!56}
+!56 = !DILocalVariable(name: "ctx", arg: 1, scope: !52, file: !2, type: !23)

--- a/tests/codegen/llvm/map_percpuhash.ll
+++ b/tests/codegen/llvm/map_percpuhash.ll
@@ -8,22 +8,22 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_a = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !42
-@__bt__num_cpus = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !48
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !27
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !43
+@__bt__num_cpus = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !49
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !54 {
+define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !55 {
 entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
-  %"@a_key" = alloca i64, align 8
+  %"@a_key" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key")
-  store i64 1, ptr %"@a_key", align 8
+  store i8 1, ptr %"@a_key", align 1
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_a, ptr %"@a_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
@@ -57,8 +57,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!50}
-!llvm.module.flags = !{!52, !53}
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!53, !54}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -70,7 +70,7 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_a", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 160, elements: !15)
@@ -83,40 +83,40 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !20 = !{!21}
 !21 = !DISubrange(count: 10, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
-!29 = !{!30, !35}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 27, lowerBound: 0)
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
-!38 = !{!39}
-!39 = !DISubrange(count: 262144, lowerBound: 0)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
-!43 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !44, isLocal: false, isDefinition: true)
-!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !45, size: 64, elements: !46)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 1, lowerBound: 0)
-!48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
-!49 = distinct !DIGlobalVariable(name: "__bt__num_cpus", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!50 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !51)
-!51 = !{!0, !7, !26, !40, !42, !48}
-!52 = !{i32 2, !"Debug Info Version", i32 3}
-!53 = !{i32 7, !"uwtable", i32 0}
-!54 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !50, retainedNodes: !58)
-!55 = !DISubroutineType(types: !56)
-!56 = !{!24, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !25, size: 64, offset: 192)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!27 = !DIGlobalVariableExpression(var: !28, expr: !DIExpression())
+!28 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
+!29 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !30)
+!30 = !{!31, !36}
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !32, size: 64)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !34)
+!34 = !{!35}
+!35 = !DISubrange(count: 27, lowerBound: 0)
+!36 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !37, size: 64, offset: 64)
+!37 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !38, size: 64)
+!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !39)
+!39 = !{!40}
+!40 = !DISubrange(count: 262144, lowerBound: 0)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!43 = !DIGlobalVariableExpression(var: !44, expr: !DIExpression())
+!44 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !45, isLocal: false, isDefinition: true)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !46, size: 64, elements: !47)
+!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !26, size: 64, elements: !47)
+!47 = !{!48}
+!48 = !DISubrange(count: 1, lowerBound: 0)
+!49 = !DIGlobalVariableExpression(var: !50, expr: !DIExpression())
+!50 = distinct !DIGlobalVariable(name: "__bt__num_cpus", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
+!52 = !{!0, !7, !27, !41, !43, !49}
+!53 = !{i32 2, !"Debug Info Version", i32 3}
+!54 = !{i32 7, !"uwtable", i32 0}
+!55 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
+!56 = !DISubroutineType(types: !57)
+!57 = !{!26, !23}
 !58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
+!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !23)

--- a/tests/codegen/llvm/map_percpulruhash.ll
+++ b/tests/codegen/llvm/map_percpulruhash.ll
@@ -8,22 +8,22 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_a = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !36
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
-@__bt__num_cpus = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !37
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !39
+@__bt__num_cpus = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !45
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !50 {
+define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !51 {
 entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
-  %"@a_key" = alloca i64, align 8
+  %"@a_key" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key")
-  store i64 1, ptr %"@a_key", align 8
+  store i8 1, ptr %"@a_key", align 1
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_a, ptr %"@a_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
@@ -57,8 +57,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!46}
-!llvm.module.flags = !{!48, !49}
+!llvm.dbg.cu = !{!47}
+!llvm.module.flags = !{!49, !50}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -70,7 +70,7 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_a", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !18, !21}
+!10 = !{!11, !17, !18, !20}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 320, elements: !15)
@@ -79,40 +79,40 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !16 = !DISubrange(count: 10, lowerBound: 0)
 !17 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
-!19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
-!20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
-!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !42)
-!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !42)
-!42 = !{!43}
-!43 = !DISubrange(count: 1, lowerBound: 0)
-!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
-!45 = distinct !DIGlobalVariable(name: "__bt__num_cpus", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
-!47 = !{!0, !7, !22, !36, !38, !44}
-!48 = !{i32 2, !"Debug Info Version", i32 3}
-!49 = !{i32 7, !"uwtable", i32 0}
-!50 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
-!51 = !DISubroutineType(types: !52)
-!52 = !{!20, !53}
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !21, size: 64, offset: 192)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!22 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
+!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
+!40 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 64, elements: !43)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 64, elements: !43)
+!43 = !{!44}
+!44 = !DISubrange(count: 1, lowerBound: 0)
+!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
+!46 = distinct !DIGlobalVariable(name: "__bt__num_cpus", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
+!47 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !48)
+!48 = !{!0, !7, !23, !37, !39, !45}
+!49 = !{i32 2, !"Debug Info Version", i32 3}
+!50 = !{i32 7, !"uwtable", i32 0}
+!51 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !54)
+!52 = !DISubroutineType(types: !53)
+!53 = !{!22, !19}
 !54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)
+!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !19)

--- a/tests/codegen/llvm/map_value_int_scratch_buf.ll
+++ b/tests/codegen/llvm/map_value_int_scratch_buf.ll
@@ -9,19 +9,19 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !24
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !38
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
-@__bt__map_key_buf = dso_local externally_initialized global [1 x [3 x [8 x i8]]] zeroinitializer, section ".data.map_key_buf", !dbg !44
-@__bt__write_map_val_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.write_map_val_buf", !dbg !53
-@__bt__read_map_val_buf = dso_local externally_initialized global [1 x [1 x [8 x i8]]] zeroinitializer, section ".data.read_map_val_buf", !dbg !57
+@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !25
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !39
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !41
+@__bt__map_key_buf = dso_local externally_initialized global [1 x [3 x [8 x i8]]] zeroinitializer, section ".data.map_key_buf", !dbg !45
+@__bt__write_map_val_buf = dso_local externally_initialized global [1 x [1 x [1 x i8]]] zeroinitializer, section ".data.write_map_val_buf", !dbg !54
+@__bt__read_map_val_buf = dso_local externally_initialized global [1 x [1 x [1 x i8]]] zeroinitializer, section ".data.read_map_val_buf", !dbg !59
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !63 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !65 {
 entry:
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #1
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
@@ -31,8 +31,8 @@ entry:
   %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)() #1
   %3 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded2 = and i64 %get_cpu_id1, %3
-  %4 = getelementptr [1 x [1 x [8 x i8]]], ptr @__bt__write_map_val_buf, i64 0, i64 %cpu.id.bounded2, i64 0, i64 0
-  store i64 1, ptr %4, align 8
+  %4 = getelementptr [1 x [1 x [1 x i8]]], ptr @__bt__write_map_val_buf, i64 0, i64 %cpu.id.bounded2, i64 0, i64 0
+  store i8 1, ptr %4, align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %2, ptr %4, i64 0)
   %get_cpu_id3 = call i64 inttoptr (i64 8 to ptr)() #1
   %5 = load i64, ptr @__bt__max_cpu_id, align 8
@@ -43,21 +43,21 @@ entry:
   %get_cpu_id5 = call i64 inttoptr (i64 8 to ptr)() #1
   %7 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded6 = and i64 %get_cpu_id5, %7
-  %8 = getelementptr [1 x [1 x [8 x i8]]], ptr @__bt__read_map_val_buf, i64 0, i64 %cpu.id.bounded6, i64 0, i64 0
+  %8 = getelementptr [1 x [1 x [1 x i8]]], ptr @__bt__read_map_val_buf, i64 0, i64 %cpu.id.bounded6, i64 0, i64 0
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %9 = load ptr, ptr %lookup_elem, align 8
-  store ptr %9, ptr %8, align 8
+  %9 = load i8, ptr %lookup_elem, align 1
+  store i8 %9, ptr %8, align 1
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  store i64 0, ptr %8, align 8
+  store i8 0, ptr %8, align 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %10 = load i64, ptr %8, align 8
+  %10 = load i8, ptr %8, align 1
   %get_cpu_id7 = call i64 inttoptr (i64 8 to ptr)() #1
   %11 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded8 = and i64 %get_cpu_id7, %11
@@ -66,8 +66,8 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   %get_cpu_id9 = call i64 inttoptr (i64 8 to ptr)() #1
   %13 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded10 = and i64 %get_cpu_id9, %13
-  %14 = getelementptr [1 x [1 x [8 x i8]]], ptr @__bt__write_map_val_buf, i64 0, i64 %cpu.id.bounded10, i64 0, i64 0
-  store i64 %10, ptr %14, align 8
+  %14 = getelementptr [1 x [1 x [1 x i8]]], ptr @__bt__write_map_val_buf, i64 0, i64 %cpu.id.bounded10, i64 0, i64 0
+  store i8 %10, ptr %14, align 1
   %update_elem11 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %12, ptr %14, i64 0)
   ret i64 0
 }
@@ -75,8 +75,8 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
 attributes #0 = { nounwind }
 attributes #1 = { memory(none) }
 
-!llvm.dbg.cu = !{!59}
-!llvm.module.flags = !{!61, !62}
+!llvm.dbg.cu = !{!61}
+!llvm.module.flags = !{!63, !64}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -99,51 +99,52 @@ attributes #1 = { memory(none) }
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
-!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
-!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
-!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
-!27 = !{!28, !33}
-!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
-!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
-!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
-!31 = !{!32}
-!32 = !DISubrange(count: 27, lowerBound: 0)
-!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
-!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
-!36 = !{!37}
-!37 = !DISubrange(count: 262144, lowerBound: 0)
-!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
-!39 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
-!45 = distinct !DIGlobalVariable(name: "__bt__map_key_buf", linkageName: "global", scope: !2, file: !2, type: !46, isLocal: false, isDefinition: true)
-!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !47, size: 192, elements: !15)
-!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 192, elements: !51)
-!48 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 64, elements: !49)
-!49 = !{!50}
-!50 = !DISubrange(count: 8, lowerBound: 0)
-!51 = !{!52}
-!52 = !DISubrange(count: 3, lowerBound: 0)
-!53 = !DIGlobalVariableExpression(var: !54, expr: !DIExpression())
-!54 = distinct !DIGlobalVariable(name: "__bt__write_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !55, isLocal: false, isDefinition: true)
-!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !56, size: 64, elements: !15)
-!56 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 64, elements: !15)
-!57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
-!58 = distinct !DIGlobalVariable(name: "__bt__read_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !55, isLocal: false, isDefinition: true)
-!59 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !60)
-!60 = !{!0, !7, !22, !24, !38, !40, !44, !53, !57}
-!61 = !{i32 2, !"Debug Info Version", i32 3}
-!62 = !{i32 7, !"uwtable", i32 0}
-!63 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !64, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !59, retainedNodes: !67)
-!64 = !DISubroutineType(types: !65)
-!65 = !{!20, !66}
-!66 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!67 = !{!68}
-!68 = !DILocalVariable(name: "ctx", arg: 1, scope: !63, file: !2, type: !66)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
+!28 = !{!29, !34}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !30, size: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 27, lowerBound: 0)
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !35, size: 64, offset: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 262144, lowerBound: 0)
+!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
+!40 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !44, size: 64, elements: !15)
+!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
+!46 = distinct !DIGlobalVariable(name: "__bt__map_key_buf", linkageName: "global", scope: !2, file: !2, type: !47, isLocal: false, isDefinition: true)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !48, size: 192, elements: !15)
+!48 = !DICompositeType(tag: DW_TAG_array_type, baseType: !49, size: 192, elements: !52)
+!49 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 64, elements: !50)
+!50 = !{!51}
+!51 = !DISubrange(count: 8, lowerBound: 0)
+!52 = !{!53}
+!53 = !DISubrange(count: 3, lowerBound: 0)
+!54 = !DIGlobalVariableExpression(var: !55, expr: !DIExpression())
+!55 = distinct !DIGlobalVariable(name: "__bt__write_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !56, isLocal: false, isDefinition: true)
+!56 = !DICompositeType(tag: DW_TAG_array_type, baseType: !57, size: 8, elements: !15)
+!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !58, size: 8, elements: !15)
+!58 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 8, elements: !15)
+!59 = !DIGlobalVariableExpression(var: !60, expr: !DIExpression())
+!60 = distinct !DIGlobalVariable(name: "__bt__read_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !56, isLocal: false, isDefinition: true)
+!61 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !62)
+!62 = !{!0, !7, !23, !25, !39, !41, !45, !54, !59}
+!63 = !{i32 2, !"Debug Info Version", i32 3}
+!64 = !{i32 7, !"uwtable", i32 0}
+!65 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !66, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !61, retainedNodes: !68)
+!66 = !DISubroutineType(types: !67)
+!67 = !{!20, !22}
+!68 = !{!69}
+!69 = !DILocalVariable(name: "ctx", arg: 1, scope: !65, file: !2, type: !22)

--- a/tests/codegen/llvm/map_value_int_stack.ll
+++ b/tests/codegen/llvm/map_value_int_stack.ll
@@ -9,27 +9,27 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !24
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
+@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !25
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !39
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !43
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !49 {
 entry:
-  %"@y_val" = alloca i64, align 8
+  %"@y_val" = alloca i8, align 1
   %"@y_key" = alloca i64, align 8
-  %lookup_elem_val = alloca i64, align 8
+  %lookup_elem_val = alloca i8, align 1
   %"@x_key1" = alloca i64, align 8
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 1, ptr %"@x_val", align 8
+  store i8 1, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -41,22 +41,22 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load ptr, ptr %lookup_elem, align 8
-  store ptr %1, ptr %lookup_elem_val, align 8
+  %1 = load i8, ptr %lookup_elem, align 1
+  store i8 %1, ptr %lookup_elem_val, align 1
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  store i64 0, ptr %lookup_elem_val, align 8
+  store i8 0, ptr %lookup_elem_val, align 1
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
-  %2 = load i64, ptr %lookup_elem_val, align 8
+  %2 = load i8, ptr %lookup_elem_val, align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key1")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
-  store i64 %2, ptr %"@y_val", align 8
+  store i8 %2, ptr %"@y_val", align 1
   %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %"@y_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@y_key")
@@ -72,8 +72,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!44}
-!llvm.module.flags = !{!46, !47}
+!llvm.dbg.cu = !{!45}
+!llvm.module.flags = !{!47, !48}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -96,36 +96,36 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
-!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
-!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
-!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
-!27 = !{!28, !33}
-!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
-!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
-!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
-!31 = !{!32}
-!32 = !DISubrange(count: 27, lowerBound: 0)
-!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
-!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
-!36 = !{!37}
-!37 = !DISubrange(count: 262144, lowerBound: 0)
-!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
-!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
-!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
-!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
-!45 = !{!0, !7, !22, !24, !38, !42}
-!46 = !{i32 2, !"Debug Info Version", i32 3}
-!47 = !{i32 7, !"uwtable", i32 0}
-!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
-!49 = !DISubroutineType(types: !50)
-!50 = !{!20, !51}
-!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
+!28 = !{!29, !34}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !30, size: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 27, lowerBound: 0)
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !35, size: 64, offset: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 262144, lowerBound: 0)
+!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
+!40 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 64, elements: !15)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!43 = !DIGlobalVariableExpression(var: !44, expr: !DIExpression())
+!44 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!45 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !46)
+!46 = !{!0, !7, !23, !25, !39, !43}
+!47 = !{i32 2, !"Debug Info Version", i32 3}
+!48 = !{i32 7, !"uwtable", i32 0}
+!49 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !50, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !45, retainedNodes: !52)
+!50 = !DISubroutineType(types: !51)
+!51 = !{!20, !22}
 !52 = !{!53}
-!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)
+!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !49, file: !2, type: !22)

--- a/tests/codegen/llvm/map_value_tuple_scratch_buf.ll
+++ b/tests/codegen/llvm/map_value_tuple_scratch_buf.ll
@@ -6,8 +6,8 @@ target triple = "bpf"
 %"struct map_internal_repr_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.163" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.164" = type { ptr, ptr }
-%"string[4]_int64__tuple_t" = type { [4 x i8], i64 }
-%"string[8]_int64__tuple_t" = type { [8 x i8], i64 }
+%"string[4]_uint8__tuple_t" = type { [4 x i8], i8 }
+%"string[8]_uint8__tuple_t" = type { [8 x i8], i8 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
@@ -16,9 +16,9 @@ target triple = "bpf"
 @__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !46
 @__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !48
 @__bt__map_key_buf = dso_local externally_initialized global [1 x [4 x [8 x i8]]] zeroinitializer, section ".data.map_key_buf", !dbg !52
-@__bt__write_map_val_buf = dso_local externally_initialized global [1 x [1 x [16 x i8]]] zeroinitializer, section ".data.write_map_val_buf", !dbg !56
-@__bt__read_map_val_buf = dso_local externally_initialized global [1 x [1 x [16 x i8]]] zeroinitializer, section ".data.read_map_val_buf", !dbg !63
-@__bt__tuple_buf = dso_local externally_initialized global [1 x [2 x [16 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !65
+@__bt__write_map_val_buf = dso_local externally_initialized global [1 x [1 x [9 x i8]]] zeroinitializer, section ".data.write_map_val_buf", !dbg !56
+@__bt__read_map_val_buf = dso_local externally_initialized global [1 x [1 x [9 x i8]]] zeroinitializer, section ".data.read_map_val_buf", !dbg !63
+@__bt__tuple_buf = dso_local externally_initialized global [1 x [2 x [9 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !65
 @xxx = global [4 x i8] c"xxx\00"
 @xxxxxxx = global [8 x i8] c"xxxxxxx\00"
 
@@ -31,12 +31,12 @@ entry:
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
-  %2 = getelementptr [1 x [2 x [16 x i8]]], ptr @__bt__tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
-  %3 = getelementptr %"string[4]_int64__tuple_t", ptr %2, i32 0, i32 0
+  %2 = getelementptr [1 x [2 x [9 x i8]]], ptr @__bt__tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 5, i1 false)
+  %3 = getelementptr %"string[4]_uint8__tuple_t", ptr %2, i32 0, i32 0
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %3, ptr align 1 @xxx, i64 4, i1 false)
-  %4 = getelementptr %"string[4]_int64__tuple_t", ptr %2, i32 0, i32 1
-  store i64 1, ptr %4, align 8
+  %4 = getelementptr %"string[4]_uint8__tuple_t", ptr %2, i32 0, i32 1
+  store i8 1, ptr %4, align 1
   %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)() #3
   %5 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded2 = and i64 %get_cpu_id1, %5
@@ -45,58 +45,59 @@ entry:
   %get_cpu_id3 = call i64 inttoptr (i64 8 to ptr)() #3
   %7 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded4 = and i64 %get_cpu_id3, %7
-  %8 = getelementptr [1 x [1 x [16 x i8]]], ptr @__bt__write_map_val_buf, i64 0, i64 %cpu.id.bounded4, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %8, i8 0, i64 16, i1 false)
-  %9 = getelementptr [16 x i8], ptr %2, i64 0, i64 0
-  %10 = getelementptr %"string[8]_int64__tuple_t", ptr %8, i32 0, i32 0
+  %8 = getelementptr [1 x [1 x [9 x i8]]], ptr @__bt__write_map_val_buf, i64 0, i64 %cpu.id.bounded4, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %8, i8 0, i64 9, i1 false)
+  %9 = getelementptr [5 x i8], ptr %2, i64 0, i64 0
+  %10 = getelementptr %"string[8]_uint8__tuple_t", ptr %8, i32 0, i32 0
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %10, ptr align 1 %9, i64 4, i1 false)
-  %11 = getelementptr [16 x i8], ptr %2, i64 0, i64 8
-  %12 = getelementptr %"string[8]_int64__tuple_t", ptr %8, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %12, ptr align 1 %11, i64 8, i1 false)
+  %11 = getelementptr [5 x i8], ptr %2, i64 0, i64 4
+  %12 = getelementptr %"string[8]_uint8__tuple_t", ptr %8, i32 0, i32 1
+  %13 = load i8, ptr %11, align 1
+  store i8 %13, ptr %12, align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %6, ptr %8, i64 0)
   %get_cpu_id5 = call i64 inttoptr (i64 8 to ptr)() #3
-  %13 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded6 = and i64 %get_cpu_id5, %13
-  %14 = getelementptr [1 x [2 x [16 x i8]]], ptr @__bt__tuple_buf, i64 0, i64 %cpu.id.bounded6, i64 1, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %14, i8 0, i64 16, i1 false)
-  %15 = getelementptr %"string[8]_int64__tuple_t", ptr %14, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %15, ptr align 1 @xxxxxxx, i64 8, i1 false)
-  %16 = getelementptr %"string[8]_int64__tuple_t", ptr %14, i32 0, i32 1
-  store i64 1, ptr %16, align 8
+  %14 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded6 = and i64 %get_cpu_id5, %14
+  %15 = getelementptr [1 x [2 x [9 x i8]]], ptr @__bt__tuple_buf, i64 0, i64 %cpu.id.bounded6, i64 1, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %15, i8 0, i64 9, i1 false)
+  %16 = getelementptr %"string[8]_uint8__tuple_t", ptr %15, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %16, ptr align 1 @xxxxxxx, i64 8, i1 false)
+  %17 = getelementptr %"string[8]_uint8__tuple_t", ptr %15, i32 0, i32 1
+  store i8 1, ptr %17, align 1
   %get_cpu_id7 = call i64 inttoptr (i64 8 to ptr)() #3
-  %17 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded8 = and i64 %get_cpu_id7, %17
-  %18 = getelementptr [1 x [4 x [8 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded8, i64 1, i64 0
-  store i64 0, ptr %18, align 8
-  %update_elem9 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %18, ptr %14, i64 0)
+  %18 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded8 = and i64 %get_cpu_id7, %18
+  %19 = getelementptr [1 x [4 x [8 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded8, i64 1, i64 0
+  store i64 0, ptr %19, align 8
+  %update_elem9 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %19, ptr %15, i64 0)
   %get_cpu_id10 = call i64 inttoptr (i64 8 to ptr)() #3
-  %19 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded11 = and i64 %get_cpu_id10, %19
-  %20 = getelementptr [1 x [4 x [8 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded11, i64 2, i64 0
-  store i64 0, ptr %20, align 8
-  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %20)
+  %20 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded11 = and i64 %get_cpu_id10, %20
+  %21 = getelementptr [1 x [4 x [8 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded11, i64 2, i64 0
+  store i64 0, ptr %21, align 8
+  %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %21)
   %get_cpu_id12 = call i64 inttoptr (i64 8 to ptr)() #3
-  %21 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded13 = and i64 %get_cpu_id12, %21
-  %22 = getelementptr [1 x [1 x [16 x i8]]], ptr @__bt__read_map_val_buf, i64 0, i64 %cpu.id.bounded13, i64 0, i64 0
+  %22 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded13 = and i64 %get_cpu_id12, %22
+  %23 = getelementptr [1 x [1 x [9 x i8]]], ptr @__bt__read_map_val_buf, i64 0, i64 %cpu.id.bounded13, i64 0, i64 0
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %22, ptr align 1 %lookup_elem, i64 16, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %23, ptr align 1 %lookup_elem, i64 9, i1 false)
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  call void @llvm.memset.p0.i64(ptr align 1 %22, i8 0, i64 16, i1 false)
+  call void @llvm.memset.p0.i64(ptr align 1 %23, i8 0, i64 9, i1 false)
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
   %get_cpu_id14 = call i64 inttoptr (i64 8 to ptr)() #3
-  %23 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded15 = and i64 %get_cpu_id14, %23
-  %24 = getelementptr [1 x [4 x [8 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded15, i64 3, i64 0
-  store i64 0, ptr %24, align 8
-  %update_elem16 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %24, ptr %22, i64 0)
+  %24 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded15 = and i64 %get_cpu_id14, %24
+  %25 = getelementptr [1 x [4 x [8 x i8]]], ptr @__bt__map_key_buf, i64 0, i64 %cpu.id.bounded15, i64 3, i64 0
+  store i64 0, ptr %25, align 8
+  %update_elem16 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %25, ptr %23, i64 0)
   ret i64 0
 }
 
@@ -137,13 +138,13 @@ attributes #3 = { memory(none) }
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
 !22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
-!23 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !24)
+!23 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 72, elements: !24)
 !24 = !{!25, !29}
 !25 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !26, size: 64)
 !26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 64, elements: !27)
 !27 = !{!28}
 !28 = !DISubrange(count: 8, lowerBound: 0)
-!29 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !20, size: 64, offset: 64)
+!29 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !4, size: 8, offset: 64)
 !30 = !DIGlobalVariableExpression(var: !31, expr: !DIExpression())
 !31 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !32 = !DIGlobalVariableExpression(var: !33, expr: !DIExpression())
@@ -172,17 +173,17 @@ attributes #3 = { memory(none) }
 !55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !26, size: 256, elements: !5)
 !56 = !DIGlobalVariableExpression(var: !57, expr: !DIExpression())
 !57 = distinct !DIGlobalVariable(name: "__bt__write_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !58, isLocal: false, isDefinition: true)
-!58 = !DICompositeType(tag: DW_TAG_array_type, baseType: !59, size: 128, elements: !15)
-!59 = !DICompositeType(tag: DW_TAG_array_type, baseType: !60, size: 128, elements: !15)
-!60 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 128, elements: !61)
+!58 = !DICompositeType(tag: DW_TAG_array_type, baseType: !59, size: 72, elements: !15)
+!59 = !DICompositeType(tag: DW_TAG_array_type, baseType: !60, size: 72, elements: !15)
+!60 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 72, elements: !61)
 !61 = !{!62}
-!62 = !DISubrange(count: 16, lowerBound: 0)
+!62 = !DISubrange(count: 9, lowerBound: 0)
 !63 = !DIGlobalVariableExpression(var: !64, expr: !DIExpression())
 !64 = distinct !DIGlobalVariable(name: "__bt__read_map_val_buf", linkageName: "global", scope: !2, file: !2, type: !58, isLocal: false, isDefinition: true)
 !65 = !DIGlobalVariableExpression(var: !66, expr: !DIExpression())
 !66 = distinct !DIGlobalVariable(name: "__bt__tuple_buf", linkageName: "global", scope: !2, file: !2, type: !67, isLocal: false, isDefinition: true)
-!67 = !DICompositeType(tag: DW_TAG_array_type, baseType: !68, size: 256, elements: !15)
-!68 = !DICompositeType(tag: DW_TAG_array_type, baseType: !60, size: 256, elements: !69)
+!67 = !DICompositeType(tag: DW_TAG_array_type, baseType: !68, size: 144, elements: !15)
+!68 = !DICompositeType(tag: DW_TAG_array_type, baseType: !60, size: 144, elements: !69)
 !69 = !{!70}
 !70 = !DISubrange(count: 2, lowerBound: 0)
 !71 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !72)

--- a/tests/codegen/llvm/map_value_tuple_stack.ll
+++ b/tests/codegen/llvm/map_value_tuple_stack.ll
@@ -6,8 +6,8 @@ target triple = "bpf"
 %"struct map_internal_repr_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.163" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.164" = type { ptr, ptr }
-%"string[8]_int64__tuple_t" = type { [8 x i8], i64 }
-%"string[4]_int64__tuple_t" = type { [4 x i8], i64 }
+%"string[8]_uint8__tuple_t" = type { [8 x i8], i8 }
+%"string[4]_uint8__tuple_t" = type { [4 x i8], i8 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
@@ -25,39 +25,40 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !56 {
 entry:
   %"@y_key" = alloca i64, align 8
-  %lookup_elem_val = alloca %"string[8]_int64__tuple_t", align 8
+  %lookup_elem_val = alloca %"string[8]_uint8__tuple_t", align 8
   %"@x_key4" = alloca i64, align 8
   %"@x_key2" = alloca i64, align 8
-  %tuple1 = alloca %"string[8]_int64__tuple_t", align 8
-  %"@x_val" = alloca %"string[8]_int64__tuple_t", align 8
+  %tuple1 = alloca %"string[8]_uint8__tuple_t", align 8
+  %"@x_val" = alloca %"string[8]_uint8__tuple_t", align 8
   %"@x_key" = alloca i64, align 8
-  %tuple = alloca %"string[4]_int64__tuple_t", align 8
+  %tuple = alloca %"string[4]_uint8__tuple_t", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %1 = getelementptr %"string[4]_int64__tuple_t", ptr %tuple, i32 0, i32 0
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 5, i1 false)
+  %1 = getelementptr %"string[4]_uint8__tuple_t", ptr %tuple, i32 0, i32 0
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %1, ptr align 1 @xxx, i64 4, i1 false)
-  %2 = getelementptr %"string[4]_int64__tuple_t", ptr %tuple, i32 0, i32 1
-  store i64 1, ptr %2, align 8
+  %2 = getelementptr %"string[4]_uint8__tuple_t", ptr %tuple, i32 0, i32 1
+  store i8 1, ptr %2, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  call void @llvm.memset.p0.i64(ptr align 1 %"@x_val", i8 0, i64 16, i1 false)
-  %3 = getelementptr [16 x i8], ptr %tuple, i64 0, i64 0
-  %4 = getelementptr %"string[8]_int64__tuple_t", ptr %"@x_val", i32 0, i32 0
+  call void @llvm.memset.p0.i64(ptr align 1 %"@x_val", i8 0, i64 9, i1 false)
+  %3 = getelementptr [5 x i8], ptr %tuple, i64 0, i64 0
+  %4 = getelementptr %"string[8]_uint8__tuple_t", ptr %"@x_val", i32 0, i32 0
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %3, i64 4, i1 false)
-  %5 = getelementptr [16 x i8], ptr %tuple, i64 0, i64 8
-  %6 = getelementptr %"string[8]_int64__tuple_t", ptr %"@x_val", i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 %5, i64 8, i1 false)
+  %5 = getelementptr [5 x i8], ptr %tuple, i64 0, i64 4
+  %6 = getelementptr %"string[8]_uint8__tuple_t", ptr %"@x_val", i32 0, i32 1
+  %7 = load i8, ptr %5, align 1
+  store i8 %7, ptr %6, align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple1)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple1, i8 0, i64 16, i1 false)
-  %7 = getelementptr %"string[8]_int64__tuple_t", ptr %tuple1, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %7, ptr align 1 @xxxxxxx, i64 8, i1 false)
-  %8 = getelementptr %"string[8]_int64__tuple_t", ptr %tuple1, i32 0, i32 1
-  store i64 1, ptr %8, align 8
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple1, i8 0, i64 9, i1 false)
+  %8 = getelementptr %"string[8]_uint8__tuple_t", ptr %tuple1, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 @xxxxxxx, i64 8, i1 false)
+  %9 = getelementptr %"string[8]_uint8__tuple_t", ptr %tuple1, i32 0, i32 1
+  store i8 1, ptr %9, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key2")
   store i64 0, ptr %"@x_key2", align 8
   %update_elem3 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key2", ptr %tuple1, i64 0)
@@ -71,11 +72,11 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %lookup_elem_val, ptr align 1 %lookup_elem, i64 16, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %lookup_elem_val, ptr align 1 %lookup_elem, i64 9, i1 false)
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
-  call void @llvm.memset.p0.i64(ptr align 1 %lookup_elem_val, i8 0, i64 16, i1 false)
+  call void @llvm.memset.p0.i64(ptr align 1 %lookup_elem_val, i8 0, i64 9, i1 false)
   br label %lookup_merge
 
 lookup_merge:                                     ; preds = %lookup_failure, %lookup_success
@@ -131,13 +132,13 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
 !22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
-!23 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !24)
+!23 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 72, elements: !24)
 !24 = !{!25, !29}
 !25 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !26, size: 64)
 !26 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 64, elements: !27)
 !27 = !{!28}
 !28 = !DISubrange(count: 8, lowerBound: 0)
-!29 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !20, size: 64, offset: 64)
+!29 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !4, size: 8, offset: 64)
 !30 = !DIGlobalVariableExpression(var: !31, expr: !DIExpression())
 !31 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !32 = !DIGlobalVariableExpression(var: !33, expr: !DIExpression())

--- a/tests/codegen/llvm/max_cast.ll
+++ b/tests/codegen/llvm/max_cast.ll
@@ -66,7 +66,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %me
   br label %while_cond
 
 is_set:                                           ; preds = %lookup_success
-  %7 = icmp sge i64 2, %3
+  %7 = icmp uge i64 2, %3
   br i1 %7, label %min_max, label %merge
 
 min_max:                                          ; preds = %is_set, %lookup_success
@@ -107,7 +107,7 @@ lookup_success2:                                  ; preds = %while_body
   %16 = load i64, ptr %val_2, align 8
   %ret_set_cond = icmp eq i64 %16, 1
   %17 = load i64, ptr %val_1, align 8
-  %max_cond = icmp sgt i64 %13, %17
+  %max_cond = icmp ugt i64 %13, %17
   br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
 lookup_failure3:                                  ; preds = %while_body

--- a/tests/codegen/llvm/max_cast_loop.ll
+++ b/tests/codegen/llvm/max_cast_loop.ll
@@ -6,7 +6,7 @@ target triple = "bpf"
 %"struct map_internal_repr_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.163" = type { ptr, ptr }
 %min_max_val = type { i64, i64 }
-%int64_max_t__tuple_t = type { i64, i64 }
+%uint8_umax_t__tuple_t = type { i8, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
@@ -22,9 +22,9 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !60 {
 entry:
   %mm_struct = alloca %min_max_val, align 8
-  %"@x_key" = alloca i64, align 8
+  %"@x_key" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
-  store i64 1, ptr %"@x_key", align 8
+  store i8 1, ptr %"@x_key", align 1
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
   %lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %lookup_cond, label %lookup_success, label %lookup_failure
@@ -53,7 +53,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %me
   ret i64 0
 
 is_set:                                           ; preds = %lookup_success
-  %7 = icmp sge i64 2, %3
+  %7 = icmp uge i64 2, %3
   br i1 %7, label %min_max, label %merge
 
 min_max:                                          ; preds = %is_set, %lookup_success
@@ -72,16 +72,16 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 ; Function Attrs: nounwind
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !66 {
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !65 {
 for_body:
   %"$res" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$res")
   store i64 0, ptr %"$res", align 8
-  %"$kv" = alloca %int64_max_t__tuple_t, align 8
+  %"$kv" = alloca %uint8_umax_t__tuple_t, align 8
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
-  %key = load i64, ptr %1, align 8
+  %key = load i8, ptr %1, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
@@ -109,11 +109,11 @@ while_end:                                        ; preds = %error_failure, %err
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
   call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %8 = getelementptr %int64_max_t__tuple_t, ptr %"$kv", i32 0, i32 0
-  store i64 %key, ptr %8, align 8
-  %9 = getelementptr %int64_max_t__tuple_t, ptr %"$kv", i32 0, i32 1
+  %8 = getelementptr %uint8_umax_t__tuple_t, ptr %"$kv", i32 0, i32 0
+  store i8 %key, ptr %8, align 1
+  %9 = getelementptr %uint8_umax_t__tuple_t, ptr %"$kv", i32 0, i32 1
   store i64 %7, ptr %9, align 8
-  %10 = getelementptr %int64_max_t__tuple_t, ptr %"$kv", i32 0, i32 1
+  %10 = getelementptr %uint8_umax_t__tuple_t, ptr %"$kv", i32 0, i32 1
   %11 = load i64, ptr %10, align 8
   store i64 %11, ptr %"$res", align 8
   br label %for_continue
@@ -127,7 +127,7 @@ lookup_success:                                   ; preds = %while_body
   %16 = load i64, ptr %val_2, align 8
   %ret_set_cond = icmp eq i64 %16, 1
   %17 = load i64, ptr %val_1, align 8
-  %max_cond = icmp sgt i64 %13, %17
+  %max_cond = icmp ugt i64 %13, %17
   br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
 lookup_failure:                                   ; preds = %while_body
@@ -183,7 +183,7 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 160, elements: !15)
@@ -196,13 +196,13 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !20 = !{!21}
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !26, size: 64, offset: 192)
-!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
-!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
-!28 = !{!29, !30}
-!29 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !24, size: 64)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !25, size: 64, offset: 192)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
+!27 = !{!28, !30}
+!28 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !30 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !31, size: 64, offset: 64)
 !31 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !32 = !DIGlobalVariableExpression(var: !33, expr: !DIExpression())
@@ -220,30 +220,29 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !44 = !{!45}
 !45 = !DISubrange(count: 262144, lowerBound: 0)
 !46 = !DIGlobalVariableExpression(var: !47, expr: !DIExpression())
-!47 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!47 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
 !48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
 !49 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !50, isLocal: false, isDefinition: true)
 !50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !51, size: 64, elements: !52)
-!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !52)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !29, size: 64, elements: !52)
 !52 = !{!53}
 !53 = !DISubrange(count: 1, lowerBound: 0)
 !54 = !DIGlobalVariableExpression(var: !55, expr: !DIExpression())
-!55 = distinct !DIGlobalVariable(name: "__bt__num_cpus", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!55 = distinct !DIGlobalVariable(name: "__bt__num_cpus", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
 !56 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !57)
 !57 = !{!0, !7, !32, !46, !48, !54}
 !58 = !{i32 2, !"Debug Info Version", i32 3}
 !59 = !{i32 7, !"uwtable", i32 0}
-!60 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !61, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !56, retainedNodes: !64)
+!60 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !61, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !56, retainedNodes: !63)
 !61 = !DISubroutineType(types: !62)
-!62 = !{!24, !63}
-!63 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!64 = !{!65}
-!65 = !DILocalVariable(name: "ctx", arg: 1, scope: !60, file: !2, type: !63)
-!66 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !67, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !56, retainedNodes: !69)
-!67 = !DISubroutineType(types: !68)
-!68 = !{!24, !63, !63, !63, !63}
-!69 = !{!70, !71, !72, !73}
-!70 = !DILocalVariable(name: "map", arg: 1, scope: !66, file: !2, type: !63)
-!71 = !DILocalVariable(name: "key", arg: 2, scope: !66, file: !2, type: !63)
-!72 = !DILocalVariable(name: "value", arg: 3, scope: !66, file: !2, type: !63)
-!73 = !DILocalVariable(name: "ctx", arg: 4, scope: !66, file: !2, type: !63)
+!62 = !{!29, !23}
+!63 = !{!64}
+!64 = !DILocalVariable(name: "ctx", arg: 1, scope: !60, file: !2, type: !23)
+!65 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !66, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !56, retainedNodes: !68)
+!66 = !DISubroutineType(types: !67)
+!67 = !{!29, !23, !23, !23, !23}
+!68 = !{!69, !70, !71, !72}
+!69 = !DILocalVariable(name: "map", arg: 1, scope: !65, file: !2, type: !23)
+!70 = !DILocalVariable(name: "key", arg: 2, scope: !65, file: !2, type: !23)
+!71 = !DILocalVariable(name: "value", arg: 3, scope: !65, file: !2, type: !23)
+!72 = !DILocalVariable(name: "ctx", arg: 4, scope: !65, file: !2, type: !23)

--- a/tests/codegen/llvm/min_cast.ll
+++ b/tests/codegen/llvm/min_cast.ll
@@ -66,7 +66,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %me
   br label %while_cond
 
 is_set:                                           ; preds = %lookup_success
-  %7 = icmp sge i64 %3, 2
+  %7 = icmp uge i64 %3, 2
   br i1 %7, label %min_max, label %merge
 
 min_max:                                          ; preds = %is_set, %lookup_success
@@ -107,7 +107,7 @@ lookup_success2:                                  ; preds = %while_body
   %16 = load i64, ptr %val_2, align 8
   %ret_set_cond = icmp eq i64 %16, 1
   %17 = load i64, ptr %val_1, align 8
-  %min_cond = icmp slt i64 %13, %17
+  %max_cond = icmp ult i64 %13, %17
   br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
 lookup_failure3:                                  ; preds = %while_body
@@ -124,7 +124,7 @@ min_max_success:                                  ; preds = %ret_set_success, %v
   br label %min_max_merge
 
 ret_set_success:                                  ; preds = %val_set_success
-  br i1 %min_cond, label %min_max_success, label %min_max_merge
+  br i1 %max_cond, label %min_max_success, label %min_max_merge
 
 min_max_merge:                                    ; preds = %min_max_success, %ret_set_success, %lookup_success2
   %19 = load i32, ptr %i, align 4

--- a/tests/codegen/llvm/min_cast_loop.ll
+++ b/tests/codegen/llvm/min_cast_loop.ll
@@ -6,7 +6,7 @@ target triple = "bpf"
 %"struct map_internal_repr_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.163" = type { ptr, ptr }
 %min_max_val = type { i64, i64 }
-%int64_min_t__tuple_t = type { i64, i64 }
+%uint8_umin_t__tuple_t = type { i8, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
@@ -22,9 +22,9 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !60 {
 entry:
   %mm_struct = alloca %min_max_val, align 8
-  %"@x_key" = alloca i64, align 8
+  %"@x_key" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
-  store i64 1, ptr %"@x_key", align 8
+  store i8 1, ptr %"@x_key", align 1
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
   %lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %lookup_cond, label %lookup_success, label %lookup_failure
@@ -53,7 +53,7 @@ lookup_merge:                                     ; preds = %lookup_failure, %me
   ret i64 0
 
 is_set:                                           ; preds = %lookup_success
-  %7 = icmp sge i64 %3, 2
+  %7 = icmp uge i64 %3, 2
   br i1 %7, label %min_max, label %merge
 
 min_max:                                          ; preds = %is_set, %lookup_success
@@ -72,16 +72,16 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 ; Function Attrs: nounwind
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !66 {
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !65 {
 for_body:
   %"$res" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$res")
   store i64 0, ptr %"$res", align 8
-  %"$kv" = alloca %int64_min_t__tuple_t, align 8
+  %"$kv" = alloca %uint8_umin_t__tuple_t, align 8
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
-  %key = load i64, ptr %1, align 8
+  %key = load i8, ptr %1, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
@@ -109,11 +109,11 @@ while_end:                                        ; preds = %error_failure, %err
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
   call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %8 = getelementptr %int64_min_t__tuple_t, ptr %"$kv", i32 0, i32 0
-  store i64 %key, ptr %8, align 8
-  %9 = getelementptr %int64_min_t__tuple_t, ptr %"$kv", i32 0, i32 1
+  %8 = getelementptr %uint8_umin_t__tuple_t, ptr %"$kv", i32 0, i32 0
+  store i8 %key, ptr %8, align 1
+  %9 = getelementptr %uint8_umin_t__tuple_t, ptr %"$kv", i32 0, i32 1
   store i64 %7, ptr %9, align 8
-  %10 = getelementptr %int64_min_t__tuple_t, ptr %"$kv", i32 0, i32 1
+  %10 = getelementptr %uint8_umin_t__tuple_t, ptr %"$kv", i32 0, i32 1
   %11 = load i64, ptr %10, align 8
   store i64 %11, ptr %"$res", align 8
   br label %for_continue
@@ -127,7 +127,7 @@ lookup_success:                                   ; preds = %while_body
   %16 = load i64, ptr %val_2, align 8
   %ret_set_cond = icmp eq i64 %16, 1
   %17 = load i64, ptr %val_1, align 8
-  %min_cond = icmp slt i64 %13, %17
+  %max_cond = icmp ult i64 %13, %17
   br i1 %val_set_cond, label %val_set_success, label %min_max_merge
 
 lookup_failure:                                   ; preds = %while_body
@@ -144,7 +144,7 @@ min_max_success:                                  ; preds = %ret_set_success, %v
   br label %min_max_merge
 
 ret_set_success:                                  ; preds = %val_set_success
-  br i1 %min_cond, label %min_max_success, label %min_max_merge
+  br i1 %max_cond, label %min_max_success, label %min_max_merge
 
 min_max_merge:                                    ; preds = %min_max_success, %ret_set_success, %lookup_success
   %19 = load i32, ptr %i, align 4
@@ -183,7 +183,7 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 160, elements: !15)
@@ -196,13 +196,13 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !20 = !{!21}
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !26, size: 64, offset: 192)
-!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !27, size: 64)
-!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
-!28 = !{!29, !30}
-!29 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !24, size: 64)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !25, size: 64, offset: 192)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
+!27 = !{!28, !30}
+!28 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !30 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !31, size: 64, offset: 64)
 !31 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !32 = !DIGlobalVariableExpression(var: !33, expr: !DIExpression())
@@ -220,30 +220,29 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !44 = !{!45}
 !45 = !DISubrange(count: 262144, lowerBound: 0)
 !46 = !DIGlobalVariableExpression(var: !47, expr: !DIExpression())
-!47 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!47 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
 !48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
 !49 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !50, isLocal: false, isDefinition: true)
 !50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !51, size: 64, elements: !52)
-!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !52)
+!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !29, size: 64, elements: !52)
 !52 = !{!53}
 !53 = !DISubrange(count: 1, lowerBound: 0)
 !54 = !DIGlobalVariableExpression(var: !55, expr: !DIExpression())
-!55 = distinct !DIGlobalVariable(name: "__bt__num_cpus", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!55 = distinct !DIGlobalVariable(name: "__bt__num_cpus", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
 !56 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !57)
 !57 = !{!0, !7, !32, !46, !48, !54}
 !58 = !{i32 2, !"Debug Info Version", i32 3}
 !59 = !{i32 7, !"uwtable", i32 0}
-!60 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !61, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !56, retainedNodes: !64)
+!60 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !61, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !56, retainedNodes: !63)
 !61 = !DISubroutineType(types: !62)
-!62 = !{!24, !63}
-!63 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!64 = !{!65}
-!65 = !DILocalVariable(name: "ctx", arg: 1, scope: !60, file: !2, type: !63)
-!66 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !67, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !56, retainedNodes: !69)
-!67 = !DISubroutineType(types: !68)
-!68 = !{!24, !63, !63, !63, !63}
-!69 = !{!70, !71, !72, !73}
-!70 = !DILocalVariable(name: "map", arg: 1, scope: !66, file: !2, type: !63)
-!71 = !DILocalVariable(name: "key", arg: 2, scope: !66, file: !2, type: !63)
-!72 = !DILocalVariable(name: "value", arg: 3, scope: !66, file: !2, type: !63)
-!73 = !DILocalVariable(name: "ctx", arg: 4, scope: !66, file: !2, type: !63)
+!62 = !{!29, !23}
+!63 = !{!64}
+!64 = !DILocalVariable(name: "ctx", arg: 1, scope: !60, file: !2, type: !23)
+!65 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !66, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !56, retainedNodes: !68)
+!66 = !DISubroutineType(types: !67)
+!67 = !{!29, !23, !23, !23, !23}
+!68 = !{!69, !70, !71, !72}
+!69 = !DILocalVariable(name: "map", arg: 1, scope: !65, file: !2, type: !23)
+!70 = !DILocalVariable(name: "key", arg: 2, scope: !65, file: !2, type: !23)
+!71 = !DILocalVariable(name: "value", arg: 3, scope: !65, file: !2, type: !23)
+!72 = !DILocalVariable(name: "ctx", arg: 4, scope: !65, file: !2, type: !23)

--- a/tests/codegen/llvm/nested_array_struct.ll
+++ b/tests/codegen/llvm/nested_array_struct.ll
@@ -10,25 +10,25 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@AT_bar = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !37
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !51
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !55
+@AT_bar = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !41
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !55
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !59
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !61 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !65 {
 entry:
-  %"@_val" = alloca i64, align 8
+  %"@_val" = alloca i32, align 4
   %"@_key" = alloca i64, align 8
   %runtime_error_t4 = alloca %runtime_error_t, align 8
   %runtime_error_t = alloca %runtime_error_t, align 8
   %lookup_elem_val = alloca [2 x [2 x [4 x i8]]], align 1
-  %"@bar_key1" = alloca i64, align 8
+  %"@bar_key1" = alloca i8, align 1
   %"@bar_val" = alloca [2 x [2 x [4 x i8]]], align 1
-  %"@bar_key" = alloca i64, align 8
+  %"@bar_key" = alloca i8, align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
@@ -36,14 +36,14 @@ entry:
   %4 = call ptr @llvm.preserve.static.offset(ptr %3)
   %5 = getelementptr i8, ptr %4, i64 0
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@bar_key")
-  store i64 42, ptr %"@bar_key", align 8
+  store i8 42, ptr %"@bar_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@bar_val")
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %"@bar_val", i32 16, ptr %5)
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_bar, ptr %"@bar_key", ptr %"@bar_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@bar_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@bar_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@bar_key1")
-  store i64 42, ptr %"@bar_key1", align 8
+  store i8 42, ptr %"@bar_key1", align 1
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_bar, ptr %"@bar_key1")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
@@ -74,7 +74,7 @@ is_oob:                                           ; preds = %lookup_merge
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 oob_merge:                                        ; preds = %counter_merge, %lookup_merge
-  %9 = getelementptr [2 x [2 x [4 x i8]]], ptr %lookup_elem_val, i32 0, i64 0
+  %9 = getelementptr [2 x [2 x [4 x i8]]], ptr %lookup_elem_val, i32 0, i8 0
   br i1 false, label %is_oob2, label %oob_merge3
 
 event_loss_counter:                               ; preds = %is_oob
@@ -104,15 +104,14 @@ is_oob2:                                          ; preds = %oob_merge
   br i1 %ringbuf_loss8, label %event_loss_counter6, label %counter_merge7
 
 oob_merge3:                                       ; preds = %counter_merge7, %oob_merge
-  %17 = getelementptr [2 x [4 x i8]], ptr %9, i32 0, i64 1
+  %17 = getelementptr [2 x [4 x i8]], ptr %9, i32 0, i8 1
   %18 = getelementptr [4 x i8], ptr %17, i32 0, i64 0
   %19 = load volatile i32, ptr %18, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %lookup_elem_val)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  %20 = sext i32 %19 to i64
-  store i64 %20, ptr %"@_val", align 8
+  store i32 %19, ptr %"@_val", align 4
   %update_elem11 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
@@ -120,12 +119,12 @@ oob_merge3:                                       ; preds = %counter_merge7, %oo
 
 event_loss_counter6:                              ; preds = %is_oob2
   %get_cpu_id9 = call i64 inttoptr (i64 8 to ptr)() #5
-  %21 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded10 = and i64 %get_cpu_id9, %21
-  %22 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded10, i64 0
-  %23 = load i64, ptr %22, align 8
-  %24 = add i64 %23, 1
-  store i64 %24, ptr %22, align 8
+  %20 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded10 = and i64 %get_cpu_id9, %20
+  %21 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded10, i64 0
+  %22 = load i64, ptr %21, align 8
+  %23 = add i64 %22, 1
+  store i64 %23, ptr %21, align 8
   br label %counter_merge7
 
 counter_merge7:                                   ; preds = %event_loss_counter6, %is_oob2
@@ -155,8 +154,8 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 attributes #4 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #5 = { memory(none) }
 
-!llvm.dbg.cu = !{!57}
-!llvm.module.flags = !{!59, !60}
+!llvm.dbg.cu = !{!61}
+!llvm.module.flags = !{!63, !64}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -179,49 +178,52 @@ attributes #5 = { memory(none) }
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "AT_bar", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !25)
-!25 = !{!11, !26, !18, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !27, size: 64, offset: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 131072, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 4096, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !32, size: 64, offset: 192)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !34, size: 128, elements: !35)
-!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !3, size: 64, elements: !35)
-!35 = !{!36}
-!36 = !DISubrange(count: 2, lowerBound: 0)
-!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
-!38 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
-!39 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !40)
-!40 = !{!41, !46}
-!41 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !42, size: 64)
-!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !44)
-!44 = !{!45}
-!45 = !DISubrange(count: 27, lowerBound: 0)
-!46 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !47, size: 64, offset: 64)
-!47 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!48 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !49)
-!49 = !{!50}
-!50 = !DISubrange(count: 262144, lowerBound: 0)
-!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
-!52 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !53, isLocal: false, isDefinition: true)
-!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !54, size: 64, elements: !15)
-!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
+!25 = distinct !DIGlobalVariable(name: "AT_bar", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !27)
+!27 = !{!11, !28, !33, !35}
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !29, size: 64, offset: 64)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
+!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 131072, elements: !31)
+!31 = !{!32}
+!32 = !DISubrange(count: 4096, lowerBound: 0)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !34, size: 64, offset: 128)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !36, size: 64, offset: 192)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !38, size: 128, elements: !39)
+!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !3, size: 64, elements: !39)
+!39 = !{!40}
+!40 = !DISubrange(count: 2, lowerBound: 0)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
+!43 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !44)
+!44 = !{!45, !50}
+!45 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !46, size: 64)
+!46 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !47, size: 64)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !48)
+!48 = !{!49}
+!49 = !DISubrange(count: 27, lowerBound: 0)
+!50 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !51, size: 64, offset: 64)
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !52, size: 64)
+!52 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !53)
+!53 = !{!54}
+!54 = !DISubrange(count: 262144, lowerBound: 0)
 !55 = !DIGlobalVariableExpression(var: !56, expr: !DIExpression())
-!56 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!57 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !58)
-!58 = !{!0, !7, !22, !37, !51, !55}
-!59 = !{i32 2, !"Debug Info Version", i32 3}
-!60 = !{i32 7, !"uwtable", i32 0}
-!61 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !62, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !57, retainedNodes: !65)
-!62 = !DISubroutineType(types: !63)
-!63 = !{!20, !64}
-!64 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!65 = !{!66}
-!66 = !DILocalVariable(name: "ctx", arg: 1, scope: !61, file: !2, type: !64)
+!56 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !57, isLocal: false, isDefinition: true)
+!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !58, size: 64, elements: !15)
+!58 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!59 = !DIGlobalVariableExpression(var: !60, expr: !DIExpression())
+!60 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!61 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !62)
+!62 = !{!0, !7, !24, !41, !55, !59}
+!63 = !{i32 2, !"Debug Info Version", i32 3}
+!64 = !{i32 7, !"uwtable", i32 0}
+!65 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !66, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !61, retainedNodes: !68)
+!66 = !DISubroutineType(types: !67)
+!67 = !{!20, !34}
+!68 = !{!69}
+!69 = !DILocalVariable(name: "ctx", arg: 1, scope: !65, file: !2, type: !34)

--- a/tests/codegen/llvm/nested_tuple_different_sizes.ll
+++ b/tests/codegen/llvm/nested_tuple_different_sizes.ll
@@ -4,10 +4,10 @@ target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr }
-%"int64_(string[13],int64)__tuple_t" = type { i64, %"string[13]_int64__tuple_t" }
-%"string[13]_int64__tuple_t" = type { [13 x i8], i64 }
-%"int64_(string[3],int64)__tuple_t" = type { i64, %"string[3]_int64__tuple_t" }
-%"string[3]_int64__tuple_t" = type { [3 x i8], i64 }
+%"uint8_(string[13],uint8)__tuple_t" = type { i8, %"string[13]_uint8__tuple_t" }
+%"string[13]_uint8__tuple_t" = type { [13 x i8], i8 }
+%"uint8_(string[3],uint8)__tuple_t" = type { i8, %"string[3]_uint8__tuple_t" }
+%"string[3]_uint8__tuple_t" = type { [3 x i8], i8 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @ringbuf = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
@@ -22,53 +22,55 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
-  %tuple3 = alloca %"int64_(string[13],int64)__tuple_t", align 8
-  %tuple2 = alloca %"string[13]_int64__tuple_t", align 8
-  %"$t" = alloca %"int64_(string[13],int64)__tuple_t", align 8
+  %tuple3 = alloca %"uint8_(string[13],uint8)__tuple_t", align 8
+  %tuple2 = alloca %"string[13]_uint8__tuple_t", align 8
+  %"$t" = alloca %"uint8_(string[13],uint8)__tuple_t", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$t")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 32, i1 false)
-  %tuple1 = alloca %"int64_(string[3],int64)__tuple_t", align 8
-  %tuple = alloca %"string[3]_int64__tuple_t", align 8
+  call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 15, i1 false)
+  %tuple1 = alloca %"uint8_(string[3],uint8)__tuple_t", align 8
+  %tuple = alloca %"string[3]_uint8__tuple_t", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %1 = getelementptr %"string[3]_int64__tuple_t", ptr %tuple, i32 0, i32 0
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 4, i1 false)
+  %1 = getelementptr %"string[3]_uint8__tuple_t", ptr %tuple, i32 0, i32 0
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %1, ptr align 1 @hi, i64 3, i1 false)
-  %2 = getelementptr %"string[3]_int64__tuple_t", ptr %tuple, i32 0, i32 1
-  store i64 3, ptr %2, align 8
+  %2 = getelementptr %"string[3]_uint8__tuple_t", ptr %tuple, i32 0, i32 1
+  store i8 3, ptr %2, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple1)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple1, i8 0, i64 24, i1 false)
-  %3 = getelementptr %"int64_(string[3],int64)__tuple_t", ptr %tuple1, i32 0, i32 0
-  store i64 1, ptr %3, align 8
-  %4 = getelementptr %"int64_(string[3],int64)__tuple_t", ptr %tuple1, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %tuple, i64 16, i1 false)
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple1, i8 0, i64 5, i1 false)
+  %3 = getelementptr %"uint8_(string[3],uint8)__tuple_t", ptr %tuple1, i32 0, i32 0
+  store i8 1, ptr %3, align 1
+  %4 = getelementptr %"uint8_(string[3],uint8)__tuple_t", ptr %tuple1, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %tuple, i64 4, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 32, i1 false)
-  %5 = getelementptr [24 x i8], ptr %tuple1, i64 0, i64 0
-  %6 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %"$t", i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 %5, i64 8, i1 false)
-  %7 = getelementptr [24 x i8], ptr %tuple1, i64 0, i64 8
-  %8 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %"$t", i32 0, i32 1
-  %9 = getelementptr [16 x i8], ptr %7, i64 0, i64 0
-  %10 = getelementptr %"string[13]_int64__tuple_t", ptr %8, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %10, ptr align 1 %9, i64 3, i1 false)
-  %11 = getelementptr [16 x i8], ptr %7, i64 0, i64 8
-  %12 = getelementptr %"string[13]_int64__tuple_t", ptr %8, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %12, ptr align 1 %11, i64 8, i1 false)
+  call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 15, i1 false)
+  %5 = getelementptr [5 x i8], ptr %tuple1, i64 0, i64 0
+  %6 = getelementptr %"uint8_(string[13],uint8)__tuple_t", ptr %"$t", i32 0, i32 0
+  %7 = load i8, ptr %5, align 1
+  store i8 %7, ptr %6, align 1
+  %8 = getelementptr [5 x i8], ptr %tuple1, i64 0, i64 1
+  %9 = getelementptr %"uint8_(string[13],uint8)__tuple_t", ptr %"$t", i32 0, i32 1
+  %10 = getelementptr [4 x i8], ptr %8, i64 0, i64 0
+  %11 = getelementptr %"string[13]_uint8__tuple_t", ptr %9, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %11, ptr align 1 %10, i64 3, i1 false)
+  %12 = getelementptr [4 x i8], ptr %8, i64 0, i64 3
+  %13 = getelementptr %"string[13]_uint8__tuple_t", ptr %9, i32 0, i32 1
+  %14 = load i8, ptr %12, align 1
+  store i8 %14, ptr %13, align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple2)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple2, i8 0, i64 24, i1 false)
-  %13 = getelementptr %"string[13]_int64__tuple_t", ptr %tuple2, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %13, ptr align 1 @hellolongstr, i64 13, i1 false)
-  %14 = getelementptr %"string[13]_int64__tuple_t", ptr %tuple2, i32 0, i32 1
-  store i64 4, ptr %14, align 8
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple2, i8 0, i64 14, i1 false)
+  %15 = getelementptr %"string[13]_uint8__tuple_t", ptr %tuple2, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %15, ptr align 1 @hellolongstr, i64 13, i1 false)
+  %16 = getelementptr %"string[13]_uint8__tuple_t", ptr %tuple2, i32 0, i32 1
+  store i8 4, ptr %16, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple3)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple3, i8 0, i64 32, i1 false)
-  %15 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %tuple3, i32 0, i32 0
-  store i64 1, ptr %15, align 8
-  %16 = getelementptr %"int64_(string[13],int64)__tuple_t", ptr %tuple3, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %16, ptr align 1 %tuple2, i64 24, i1 false)
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple3, i8 0, i64 15, i1 false)
+  %17 = getelementptr %"uint8_(string[13],uint8)__tuple_t", ptr %tuple3, i32 0, i32 0
+  store i8 1, ptr %17, align 1
+  %18 = getelementptr %"uint8_(string[13],uint8)__tuple_t", ptr %tuple3, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %18, ptr align 1 %tuple2, i64 14, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple2)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$t", ptr align 1 %tuple3, i64 32, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$t", ptr align 1 %tuple3, i64 15, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple3)
   ret i64 0
 }

--- a/tests/codegen/llvm/nested_while_loop.ll
+++ b/tests/codegen/llvm/nested_while_loop.ll
@@ -8,19 +8,19 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !37
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @interval_s_1_1(ptr %0) #0 section "s_interval_s_1_1" !dbg !46 {
+define i64 @interval_s_1_1(ptr %0) #0 section "s_interval_s_1_1" !dbg !47 {
 entry:
   %"@_newval" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
-  %"@_key" = alloca i64, align 8
+  %"@_key" = alloca i8, align 1
   %"$j" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$j")
   store i64 0, ptr %"$j", align 8
@@ -32,7 +32,7 @@ entry:
 
 while_cond:                                       ; preds = %while_end3, %entry
   %1 = load i64, ptr %"$i", align 8
-  %2 = icmp sle i64 %1, 100
+  %2 = icmp ule i64 %1, 100
   %true_cond = icmp ne i1 %2, false
   br i1 %true_cond, label %while_body, label %while_end, !llvm.loop !52
 
@@ -48,13 +48,13 @@ while_end:                                        ; preds = %while_cond
 
 while_cond1:                                      ; preds = %lookup_merge, %while_body
   %5 = load i64, ptr %"$j", align 8
-  %6 = icmp sle i64 %5, 100
+  %6 = icmp ule i64 %5, 100
   %true_cond4 = icmp ne i1 %6, false
   br i1 %true_cond4, label %while_body2, label %while_end3, !llvm.loop !52
 
 while_body2:                                      ; preds = %while_cond1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  store i64 0, ptr %"@_key", align 8
+  store i8 0, ptr %"@_key", align 1
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_, ptr %"@_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
@@ -64,8 +64,8 @@ while_end3:                                       ; preds = %while_cond1
   br label %while_cond
 
 lookup_success:                                   ; preds = %while_body2
-  %7 = load ptr, ptr %lookup_elem, align 8
-  store ptr %7, ptr %lookup_elem_val, align 8
+  %7 = load i64, ptr %lookup_elem, align 8
+  store i64 %7, ptr %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %while_body2
@@ -96,8 +96,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!43}
+!llvm.module.flags = !{!45, !46}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -109,7 +109,7 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !18, !21}
+!10 = !{!11, !17, !18, !20}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
@@ -118,38 +118,38 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !16 = !DISubrange(count: 1, lowerBound: 0)
 !17 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
-!19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
-!20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "interval_s_1_1", linkageName: "interval_s_1_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !21, size: 64, offset: 192)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!22 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 64, elements: !15)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 64, elements: !15)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
+!43 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !44)
+!44 = !{!0, !7, !23, !37, !41}
+!45 = !{i32 2, !"Debug Info Version", i32 3}
+!46 = !{i32 7, !"uwtable", i32 0}
+!47 = distinct !DISubprogram(name: "interval_s_1_1", linkageName: "interval_s_1_1", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !50)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!22, !19}
 !50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !47, file: !2, type: !19)
 !52 = distinct !{!52, !53}
 !53 = !{!"llvm.loop.unroll.disable"}

--- a/tests/codegen/llvm/optional_positional_parameter.ll
+++ b/tests/codegen/llvm/optional_positional_parameter.ll
@@ -9,25 +9,25 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !29
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !43
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !47
+@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !30
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !44
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !48
 @0 = global [1 x i8] zeroinitializer
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !53 {
+define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !54 {
 entry:
   %"@y_key" = alloca i64, align 8
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
   %"@x_key" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 0, ptr %"@x_val", align 8
+  store i8 0, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -47,8 +47,8 @@ declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!49}
-!llvm.module.flags = !{!51, !52}
+!llvm.dbg.cu = !{!50}
+!llvm.module.flags = !{!52, !53}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -71,41 +71,41 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !25)
-!25 = !{!11, !17, !18, !26}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !27, size: 64, offset: 192)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 8, elements: !15)
-!29 = !DIGlobalVariableExpression(var: !30, expr: !DIExpression())
-!30 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !31, isLocal: false, isDefinition: true)
-!31 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !32)
-!32 = !{!33, !38}
-!33 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !34, size: 64)
-!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !36)
-!36 = !{!37}
-!37 = !DISubrange(count: 27, lowerBound: 0)
-!38 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !39, size: 64, offset: 64)
-!39 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !40, size: 64)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !41)
-!41 = !{!42}
-!42 = !DISubrange(count: 262144, lowerBound: 0)
-!43 = !DIGlobalVariableExpression(var: !44, expr: !DIExpression())
-!44 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !45, isLocal: false, isDefinition: true)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !46, size: 64, elements: !15)
-!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!47 = !DIGlobalVariableExpression(var: !48, expr: !DIExpression())
-!48 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!49 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !50)
-!50 = !{!0, !7, !22, !29, !43, !47}
-!51 = !{i32 2, !"Debug Info Version", i32 3}
-!52 = !{i32 7, !"uwtable", i32 0}
-!53 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !54, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !49, retainedNodes: !57)
-!54 = !DISubroutineType(types: !55)
-!55 = !{!20, !56}
-!56 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !26)
+!26 = !{!11, !17, !18, !27}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !28, size: 64, offset: 192)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 8, elements: !15)
+!30 = !DIGlobalVariableExpression(var: !31, expr: !DIExpression())
+!31 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !32, isLocal: false, isDefinition: true)
+!32 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !33)
+!33 = !{!34, !39}
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !35, size: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 27, lowerBound: 0)
+!39 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !40, size: 64, offset: 64)
+!40 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !41, size: 64)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !42)
+!42 = !{!43}
+!43 = !DISubrange(count: 262144, lowerBound: 0)
+!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
+!45 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !46, isLocal: false, isDefinition: true)
+!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !47, size: 64, elements: !15)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
+!49 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!50 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !51)
+!51 = !{!0, !7, !23, !30, !44, !48}
+!52 = !{i32 2, !"Debug Info Version", i32 3}
+!53 = !{i32 7, !"uwtable", i32 0}
+!54 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !50, retainedNodes: !57)
+!55 = !DISubroutineType(types: !56)
+!56 = !{!20, !22}
 !57 = !{!58}
-!58 = !DILocalVariable(name: "ctx", arg: 1, scope: !53, file: !2, type: !56)
+!58 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !22)

--- a/tests/codegen/llvm/pid_filter.ll
+++ b/tests/codegen/llvm/pid_filter.ll
@@ -16,22 +16,21 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
-  %"$x" = alloca i64, align 8
+  %"$x" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
-  store i64 0, ptr %"$x", align 8
+  store i8 0, ptr %"$x", align 1
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
-  %2 = zext i32 %pid to i64
-  %3 = icmp ne i64 %2, 1
-  %true_cond = icmp ne i1 %3, false
+  %2 = icmp ne i32 %pid, 1
+  %true_cond = icmp ne i1 %2, false
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
   ret i64 0
 
 right:                                            ; preds = %entry
-  store i64 1, ptr %"$x", align 8
+  store i8 1, ptr %"$x", align 1
   ret i64 0
 }
 

--- a/tests/codegen/llvm/pointer_add_int.ll
+++ b/tests/codegen/llvm/pointer_add_int.ll
@@ -19,9 +19,9 @@ entry:
   %"$v" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$v")
   store i0 0, ptr %"$v", align 1
-  store ptr inttoptr (i64 1000 to ptr), ptr %"$v", align 8
+  store ptr inttoptr (i16 1000 to ptr), ptr %"$v", align 8
   %1 = load ptr, ptr %"$v", align 8
-  %2 = getelementptr i16, ptr %1, i64 10
+  %2 = getelementptr i16, ptr %1, i8 10
   store ptr %2, ptr %"$v", align 8
   ret i64 0
 }

--- a/tests/codegen/llvm/pointer_if_condition.ll
+++ b/tests/codegen/llvm/pointer_if_condition.ll
@@ -19,7 +19,7 @@ entry:
   %"$v" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$v")
   store i0 0, ptr %"$v", align 1
-  store ptr inttoptr (i64 1 to ptr), ptr %"$v", align 8
+  store ptr inttoptr (i8 1 to ptr), ptr %"$v", align 8
   %1 = load ptr, ptr %"$v", align 8
   %true_cond = icmp ne ptr %1, null
   br i1 %true_cond, label %left, label %right

--- a/tests/codegen/llvm/pointer_inc_map.ll
+++ b/tests/codegen/llvm/pointer_inc_map.ll
@@ -26,7 +26,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  store ptr inttoptr (i64 1000 to ptr), ptr %"@_val", align 8
+  store ptr inttoptr (i16 1000 to ptr), ptr %"@_val", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")

--- a/tests/codegen/llvm/pointer_inc_var.ll
+++ b/tests/codegen/llvm/pointer_inc_var.ll
@@ -19,7 +19,7 @@ entry:
   %"$v" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$v")
   store i0 0, ptr %"$v", align 1
-  store ptr inttoptr (i64 1000 to ptr), ptr %"$v", align 8
+  store ptr inttoptr (i16 1000 to ptr), ptr %"$v", align 8
   %1 = load ptr, ptr %"$v", align 8
   %2 = getelementptr i16, ptr %1, i32 1
   store ptr %2, ptr %"$v", align 8

--- a/tests/codegen/llvm/pointer_logical_and.ll
+++ b/tests/codegen/llvm/pointer_logical_and.ll
@@ -20,7 +20,7 @@ entry:
   %"$v" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$v")
   store i0 0, ptr %"$v", align 1
-  store ptr inttoptr (i64 1 to ptr), ptr %"$v", align 8
+  store ptr inttoptr (i8 1 to ptr), ptr %"$v", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"&&_result")
   %1 = load ptr, ptr %"$v", align 8
   %lhs_true_cond = icmp ne ptr %1, null

--- a/tests/codegen/llvm/pointer_logical_or.ll
+++ b/tests/codegen/llvm/pointer_logical_or.ll
@@ -20,7 +20,7 @@ entry:
   %"$v" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$v")
   store i0 0, ptr %"$v", align 1
-  store ptr inttoptr (i64 1 to ptr), ptr %"$v", align 8
+  store ptr inttoptr (i8 1 to ptr), ptr %"$v", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"||_result")
   %1 = load ptr, ptr %"$v", align 8
   %lhs_true_cond = icmp ne ptr %1, null

--- a/tests/codegen/llvm/pointer_tenary_expression.ll
+++ b/tests/codegen/llvm/pointer_tenary_expression.ll
@@ -16,13 +16,13 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
-  %"$x" = alloca i64, align 8
+  %"$x" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
-  store i64 0, ptr %"$x", align 8
+  store i8 0, ptr %"$x", align 1
   %"$v" = alloca ptr, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$v")
   store i0 0, ptr %"$v", align 1
-  store ptr inttoptr (i64 1 to ptr), ptr %"$v", align 8
+  store ptr inttoptr (i8 1 to ptr), ptr %"$v", align 8
   %1 = load ptr, ptr %"$v", align 8
   %true_cond = icmp ne ptr %1, null
   br i1 %true_cond, label %left, label %right
@@ -34,8 +34,8 @@ right:                                            ; preds = %entry
   br label %done
 
 done:                                             ; preds = %right, %left
-  %result = phi i64 [ 1, %left ], [ 0, %right ]
-  store i64 %result, ptr %"$x", align 8
+  %result = phi i8 [ 1, %left ], [ 0, %right ]
+  store i8 %result, ptr %"$x", align 1
   ret i64 0
 }
 

--- a/tests/codegen/llvm/pred_binop.ll
+++ b/tests/codegen/llvm/pred_binop.ll
@@ -8,31 +8,30 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !37
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !47 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
   %"@x_key" = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
-  %2 = zext i32 %pid to i64
-  %3 = icmp eq i64 %2, 1234
-  %true_cond = icmp ne i1 %3, false
+  %2 = icmp eq i32 %pid, 1234
+  %true_cond = icmp ne i1 %2, false
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 1, ptr %"@x_val", align 8
+  store i8 1, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -52,8 +51,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { memory(none) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!43}
+!llvm.module.flags = !{!45, !46}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -76,34 +75,34 @@ attributes #2 = { memory(none) }
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 64, elements: !15)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!43 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !44)
+!44 = !{!0, !7, !23, !37, !41}
+!45 = !{i32 2, !"Debug Info Version", i32 3}
+!46 = !{i32 7, !"uwtable", i32 0}
+!47 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !50)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!20, !22}
 !50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !47, file: !2, type: !22)

--- a/tests/codegen/llvm/runtime_error_check_delete.ll
+++ b/tests/codegen/llvm/runtime_error_check_delete.ll
@@ -9,8 +9,8 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !25
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !39
 @__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
 
 ; Function Attrs: nounwind
@@ -20,14 +20,14 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
 entry:
   %runtime_error_t4 = alloca %runtime_error_t, align 8
-  %"@x_key1" = alloca i64, align 8
+  %"@x_key1" = alloca i8, align 1
   %runtime_error_t = alloca %runtime_error_t, align 8
-  %"@x_val" = alloca i64, align 8
-  %"@x_key" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
+  %"@x_key" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
-  store i64 1, ptr %"@x_key", align 8
+  store i8 1, ptr %"@x_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 1, ptr %"@x_val", align 8
+  store i8 1, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   %1 = trunc i64 %update_elem to i32
   %2 = icmp sge i32 %1, 0
@@ -49,7 +49,7 @@ helper_merge:                                     ; preds = %counter_merge, %ent
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key1")
-  store i64 1, ptr %"@x_key1", align 8
+  store i8 1, ptr %"@x_key1", align 1
   %delete_elem = call i64 inttoptr (i64 3 to ptr)(ptr @AT_x, ptr %"@x_key1")
   %6 = trunc i64 %delete_elem to i32
   %7 = icmp sge i32 %6, 0
@@ -124,7 +124,7 @@ attributes #2 = { memory(none) }
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
@@ -137,36 +137,35 @@ attributes #2 = { memory(none) }
 !20 = !{!21}
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
-!29 = !{!30, !35}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 27, lowerBound: 0)
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
-!38 = !{!39}
-!39 = !DISubrange(count: 262144, lowerBound: 0)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
+!28 = !{!29, !34}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !30, size: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 27, lowerBound: 0)
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !35, size: 64, offset: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 262144, lowerBound: 0)
+!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
+!40 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 64, elements: !15)
 !42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
+!43 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
-!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
 !46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
-!47 = !{!0, !7, !26, !40, !44}
+!47 = !{!0, !7, !25, !39, !44}
 !48 = !{i32 2, !"Debug Info Version", i32 3}
 !49 = !{i32 7, !"uwtable", i32 0}
-!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
+!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
 !51 = !DISubroutineType(types: !52)
-!52 = !{!24, !53}
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)
+!52 = !{!43, !23}
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !23)

--- a/tests/codegen/llvm/runtime_error_check_for_map.ll
+++ b/tests/codegen/llvm/runtime_error_check_for_map.ll
@@ -7,29 +7,29 @@ target triple = "bpf"
 %"struct map_internal_repr_t.163" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.164" = type { ptr, ptr }
 %runtime_error_t = type <{ i64, i64, i32 }>
-%int64_int64__tuple_t = type { i64, i64 }
+%uint8_uint8__tuple_t = type { i8, i8 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_map = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@AT_x = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !37
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !51
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !55
+@AT_x = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !25
+@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !39
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !53
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !57
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !61 {
+define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !63 {
 entry:
   %runtime_error_t3 = alloca %runtime_error_t, align 8
   %runtime_error_t = alloca %runtime_error_t, align 8
-  %"@map_val" = alloca i64, align 8
-  %"@map_key" = alloca i64, align 8
+  %"@map_val" = alloca i8, align 1
+  %"@map_key" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_key")
-  store i64 16, ptr %"@map_key", align 8
+  store i8 16, ptr %"@map_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@map_val")
-  store i64 32, ptr %"@map_val", align 8
+  store i8 32, ptr %"@map_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_map, ptr %"@map_key", ptr %"@map_val", i64 0)
   %1 = trunc i64 %update_elem to i32
   %2 = icmp sge i32 %1, 0
@@ -106,19 +106,19 @@ declare void @llvm.lifetime.start.p0(i64 immarg %0, ptr nocapture %1) #1
 declare void @llvm.lifetime.end.p0(i64 immarg %0, ptr nocapture %1) #1
 
 ; Function Attrs: nounwind
-define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !67 {
+define internal i64 @map_for_each_cb(ptr %0, ptr %1, ptr %2, ptr %3) #0 section ".text" !dbg !68 {
 for_body:
   %runtime_error_t = alloca %runtime_error_t, align 8
   %"@x_key" = alloca i64, align 8
-  %"$kv" = alloca %int64_int64__tuple_t, align 8
-  %key = load i64, ptr %1, align 8
-  %val = load i64, ptr %2, align 8
+  %"$kv" = alloca %uint8_uint8__tuple_t, align 8
+  %key = load i8, ptr %1, align 1
+  %val = load i8, ptr %2, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %4 = getelementptr %int64_int64__tuple_t, ptr %"$kv", i32 0, i32 0
-  store i64 %key, ptr %4, align 8
-  %5 = getelementptr %int64_int64__tuple_t, ptr %"$kv", i32 0, i32 1
-  store i64 %val, ptr %5, align 8
+  call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 2, i1 false)
+  %4 = getelementptr %uint8_uint8__tuple_t, ptr %"$kv", i32 0, i32 0
+  store i8 %key, ptr %4, align 1
+  %5 = getelementptr %uint8_uint8__tuple_t, ptr %"$kv", i32 0, i32 1
+  store i8 %val, ptr %5, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"$kv", i64 0)
@@ -168,8 +168,8 @@ attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #3 = { memory(none) }
 
-!llvm.dbg.cu = !{!57}
-!llvm.module.flags = !{!59, !60}
+!llvm.dbg.cu = !{!59}
+!llvm.module.flags = !{!61, !62}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -181,7 +181,7 @@ attributes #3 = { memory(none) }
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_map", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
@@ -194,55 +194,56 @@ attributes #3 = { memory(none) }
 !20 = !{!21}
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !29)
-!29 = !{!11, !30, !22, !31}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !32, size: 64, offset: 192)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !34)
-!34 = !{!35, !36}
-!35 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !24, size: 64)
-!36 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !24, size: 64, offset: 64)
-!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
-!38 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
-!39 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !40)
-!40 = !{!41, !46}
-!41 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !42, size: 64)
-!42 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !43, size: 64)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !44)
-!44 = !{!45}
-!45 = !DISubrange(count: 27, lowerBound: 0)
-!46 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !47, size: 64, offset: 64)
-!47 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
-!48 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !49)
-!49 = !{!50}
-!50 = !DISubrange(count: 262144, lowerBound: 0)
-!51 = !DIGlobalVariableExpression(var: !52, expr: !DIExpression())
-!52 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !53, isLocal: false, isDefinition: true)
-!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !54, size: 64, elements: !15)
-!54 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
-!55 = !DIGlobalVariableExpression(var: !56, expr: !DIExpression())
-!56 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!57 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !58)
-!58 = !{!0, !7, !26, !37, !51, !55}
-!59 = !{i32 2, !"Debug Info Version", i32 3}
-!60 = !{i32 7, !"uwtable", i32 0}
-!61 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !62, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !57, retainedNodes: !65)
-!62 = !DISubroutineType(types: !63)
-!63 = !{!24, !64}
-!64 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!65 = !{!66}
-!66 = !DILocalVariable(name: "ctx", arg: 1, scope: !61, file: !2, type: !64)
-!67 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !68, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !57, retainedNodes: !70)
-!68 = !DISubroutineType(types: !69)
-!69 = !{!24, !64, !64, !64, !64}
-!70 = !{!71, !72, !73, !74}
-!71 = !DILocalVariable(name: "map", arg: 1, scope: !67, file: !2, type: !64)
-!72 = !DILocalVariable(name: "key", arg: 2, scope: !67, file: !2, type: !64)
-!73 = !DILocalVariable(name: "value", arg: 3, scope: !67, file: !2, type: !64)
-!74 = !DILocalVariable(name: "ctx", arg: 4, scope: !67, file: !2, type: !64)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !28)
+!28 = !{!11, !29, !30, !33}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !31, size: 64, offset: 128)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !34, size: 64, offset: 192)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 16, elements: !36)
+!36 = !{!37, !38}
+!37 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !4, size: 8)
+!38 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !4, size: 8, offset: 8)
+!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
+!40 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!41 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !42)
+!42 = !{!43, !48}
+!43 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !44, size: 64)
+!44 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !45, size: 64)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !46)
+!46 = !{!47}
+!47 = !DISubrange(count: 27, lowerBound: 0)
+!48 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !49, size: 64, offset: 64)
+!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !50, size: 64)
+!50 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !51)
+!51 = !{!52}
+!52 = !DISubrange(count: 262144, lowerBound: 0)
+!53 = !DIGlobalVariableExpression(var: !54, expr: !DIExpression())
+!54 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !55, isLocal: false, isDefinition: true)
+!55 = !DICompositeType(tag: DW_TAG_array_type, baseType: !56, size: 64, elements: !15)
+!56 = !DICompositeType(tag: DW_TAG_array_type, baseType: !32, size: 64, elements: !15)
+!57 = !DIGlobalVariableExpression(var: !58, expr: !DIExpression())
+!58 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !32, isLocal: false, isDefinition: true)
+!59 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !60)
+!60 = !{!0, !7, !25, !39, !53, !57}
+!61 = !{i32 2, !"Debug Info Version", i32 3}
+!62 = !{i32 7, !"uwtable", i32 0}
+!63 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !64, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !59, retainedNodes: !66)
+!64 = !DISubroutineType(types: !65)
+!65 = !{!32, !23}
+!66 = !{!67}
+!67 = !DILocalVariable(name: "ctx", arg: 1, scope: !63, file: !2, type: !23)
+!68 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !69, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !59, retainedNodes: !71)
+!69 = !DISubroutineType(types: !70)
+!70 = !{!32, !23, !23, !23, !23}
+!71 = !{!72, !73, !74, !75}
+!72 = !DILocalVariable(name: "map", arg: 1, scope: !68, file: !2, type: !23)
+!73 = !DILocalVariable(name: "key", arg: 2, scope: !68, file: !2, type: !23)
+!74 = !DILocalVariable(name: "value", arg: 3, scope: !68, file: !2, type: !23)
+!75 = !DILocalVariable(name: "ctx", arg: 4, scope: !68, file: !2, type: !23)

--- a/tests/codegen/llvm/runtime_error_check_lookup.ll
+++ b/tests/codegen/llvm/runtime_error_check_lookup.ll
@@ -9,31 +9,31 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !37
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !47 {
 entry:
   %runtime_error_t1 = alloca %runtime_error_t, align 8
   %"@_newval" = alloca i64, align 8
   %runtime_error_t = alloca %runtime_error_t, align 8
   %lookup_elem_val = alloca i64, align 8
-  %"@_key" = alloca i64, align 8
+  %"@_key" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  store i64 0, ptr %"@_key", align 8
+  store i8 0, ptr %"@_key", align 1
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_, ptr %"@_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load ptr, ptr %lookup_elem, align 8
-  store ptr %1, ptr %lookup_elem_val, align 8
+  %1 = load i64, ptr %lookup_elem, align 8
+  store i64 %1, ptr %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
@@ -116,8 +116,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { memory(none) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!43}
+!llvm.module.flags = !{!45, !46}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -129,7 +129,7 @@ attributes #2 = { memory(none) }
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !18, !21}
+!10 = !{!11, !17, !18, !20}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
@@ -138,36 +138,36 @@ attributes #2 = { memory(none) }
 !16 = !DISubrange(count: 1, lowerBound: 0)
 !17 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
-!19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
-!20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !21, size: 64, offset: 192)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!22 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 64, elements: !15)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 64, elements: !15)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
+!43 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !44)
+!44 = !{!0, !7, !23, !37, !41}
+!45 = !{i32 2, !"Debug Info Version", i32 3}
+!46 = !{i32 7, !"uwtable", i32 0}
+!47 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !50)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!22, !19}
 !50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !47, file: !2, type: !19)

--- a/tests/codegen/llvm/runtime_error_check_lookup_no_warning.ll
+++ b/tests/codegen/llvm/runtime_error_check_lookup_no_warning.ll
@@ -9,30 +9,30 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !37
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !47 {
 entry:
   %runtime_error_t = alloca %runtime_error_t, align 8
   %"@_newval" = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
-  %"@_key" = alloca i64, align 8
+  %"@_key" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
-  store i64 0, ptr %"@_key", align 8
+  store i8 0, ptr %"@_key", align 1
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_, ptr %"@_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load ptr, ptr %lookup_elem, align 8
-  store ptr %1, ptr %lookup_elem_val, align 8
+  %1 = load i64, ptr %lookup_elem, align 8
+  store i64 %1, ptr %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
@@ -92,8 +92,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { memory(none) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!43}
+!llvm.module.flags = !{!45, !46}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -105,7 +105,7 @@ attributes #2 = { memory(none) }
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !18, !21}
+!10 = !{!11, !17, !18, !20}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 32, elements: !15)
@@ -114,36 +114,36 @@ attributes #2 = { memory(none) }
 !16 = !DISubrange(count: 1, lowerBound: 0)
 !17 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !12, size: 64, offset: 64)
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
-!19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
-!20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!20 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !21, size: 64, offset: 192)
+!21 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !22, size: 64)
+!22 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 64, elements: !15)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !22, size: 64, elements: !15)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !22, isLocal: false, isDefinition: true)
+!43 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !44)
+!44 = !{!0, !7, !23, !37, !41}
+!45 = !{i32 2, !"Debug Info Version", i32 3}
+!46 = !{i32 7, !"uwtable", i32 0}
+!47 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !50)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!22, !19}
 !50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !47, file: !2, type: !19)

--- a/tests/codegen/llvm/runtime_error_check_pid_tid.ll
+++ b/tests/codegen/llvm/runtime_error_check_pid_tid.ll
@@ -10,22 +10,22 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !24
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
+@AT_y = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@ringbuf = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !26
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
 entry:
   %runtime_error_t5 = alloca %runtime_error_t, align 8
-  %"@y_val" = alloca i64, align 8
+  %"@y_val" = alloca i32, align 4
   %"@y_key" = alloca i64, align 8
   %runtime_error_t = alloca %runtime_error_t, align 8
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i32, align 4
   %"@x_key" = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
@@ -33,21 +33,20 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %2 = zext i32 %pid to i64
-  store i64 %2, ptr %"@x_val", align 8
+  store i32 %pid, ptr %"@x_val", align 4
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
-  %3 = trunc i64 %update_elem to i32
-  %4 = icmp sge i32 %3, 0
-  br i1 %4, label %helper_merge, label %helper_failure
+  %2 = trunc i64 %update_elem to i32
+  %3 = icmp sge i32 %2, 0
+  br i1 %3, label %helper_merge, label %helper_failure
 
 helper_failure:                                   ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t)
-  %5 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
-  store i64 30006, ptr %5, align 8
-  %6 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
-  store i64 0, ptr %6, align 8
-  %7 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
-  store i32 %3, ptr %7, align 4
+  %4 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 0
+  store i64 30006, ptr %4, align 8
+  %5 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 1
+  store i64 0, ptr %5, align 8
+  %6 = getelementptr %runtime_error_t, ptr %runtime_error_t, i64 0, i32 2
+  store i32 %2, ptr %6, align 4
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t, i64 20, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
@@ -60,21 +59,20 @@ helper_merge:                                     ; preds = %counter_merge, %ent
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")
   store i64 0, ptr %"@y_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_val")
-  %8 = zext i32 %tid to i64
-  store i64 %8, ptr %"@y_val", align 8
+  store i32 %tid, ptr %"@y_val", align 4
   %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_y, ptr %"@y_key", ptr %"@y_val", i64 0)
-  %9 = trunc i64 %update_elem2 to i32
-  %10 = icmp sge i32 %9, 0
-  br i1 %10, label %helper_merge4, label %helper_failure3
+  %7 = trunc i64 %update_elem2 to i32
+  %8 = icmp sge i32 %7, 0
+  br i1 %8, label %helper_merge4, label %helper_failure3
 
 event_loss_counter:                               ; preds = %helper_failure
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #2
-  %11 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %11
-  %12 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
-  %13 = load i64, ptr %12, align 8
-  %14 = add i64 %13, 1
-  store i64 %14, ptr %12, align 8
+  %9 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %9
+  %10 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %11 = load i64, ptr %10, align 8
+  %12 = add i64 %11, 1
+  store i64 %12, ptr %10, align 8
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %helper_failure
@@ -83,12 +81,12 @@ counter_merge:                                    ; preds = %event_loss_counter,
 
 helper_failure3:                                  ; preds = %helper_merge
   call void @llvm.lifetime.start.p0(i64 -1, ptr %runtime_error_t5)
-  %15 = getelementptr %runtime_error_t, ptr %runtime_error_t5, i64 0, i32 0
-  store i64 30006, ptr %15, align 8
-  %16 = getelementptr %runtime_error_t, ptr %runtime_error_t5, i64 0, i32 1
-  store i64 1, ptr %16, align 8
-  %17 = getelementptr %runtime_error_t, ptr %runtime_error_t5, i64 0, i32 2
-  store i32 %9, ptr %17, align 4
+  %13 = getelementptr %runtime_error_t, ptr %runtime_error_t5, i64 0, i32 0
+  store i64 30006, ptr %13, align 8
+  %14 = getelementptr %runtime_error_t, ptr %runtime_error_t5, i64 0, i32 1
+  store i64 1, ptr %14, align 8
+  %15 = getelementptr %runtime_error_t, ptr %runtime_error_t5, i64 0, i32 2
+  store i32 %7, ptr %15, align 4
   %ringbuf_output6 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %runtime_error_t5, i64 20, i64 0)
   %ringbuf_loss9 = icmp slt i64 %ringbuf_output6, 0
   br i1 %ringbuf_loss9, label %event_loss_counter7, label %counter_merge8
@@ -100,12 +98,12 @@ helper_merge4:                                    ; preds = %counter_merge8, %he
 
 event_loss_counter7:                              ; preds = %helper_failure3
   %get_cpu_id10 = call i64 inttoptr (i64 8 to ptr)() #2
-  %18 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded11 = and i64 %get_cpu_id10, %18
-  %19 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded11, i64 0
-  %20 = load i64, ptr %19, align 8
-  %21 = add i64 %20, 1
-  store i64 %21, ptr %19, align 8
+  %16 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded11 = and i64 %get_cpu_id10, %16
+  %17 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded11, i64 0
+  %18 = load i64, ptr %17, align 8
+  %19 = add i64 %18, 1
+  store i64 %19, ptr %17, align 8
   br label %counter_merge8
 
 counter_merge8:                                   ; preds = %event_loss_counter7, %helper_failure3
@@ -123,8 +121,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { memory(none) }
 
-!llvm.dbg.cu = !{!44}
-!llvm.module.flags = !{!46, !47}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48, !49}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -147,36 +145,38 @@ attributes #2 = { memory(none) }
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
 !24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
-!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
-!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
-!27 = !{!28, !33}
-!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
-!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
-!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
-!31 = !{!32}
-!32 = !DISubrange(count: 27, lowerBound: 0)
-!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
-!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
-!36 = !{!37}
-!37 = !DISubrange(count: 262144, lowerBound: 0)
-!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
-!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
-!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
-!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
-!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
-!45 = !{!0, !7, !22, !24, !38, !42}
-!46 = !{i32 2, !"Debug Info Version", i32 3}
-!47 = !{i32 7, !"uwtable", i32 0}
-!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
-!49 = !DISubroutineType(types: !50)
-!50 = !{!20, !51}
-!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!52 = !{!53}
-!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)
+!25 = distinct !DIGlobalVariable(name: "AT_y", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
+!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !7, !24, !26, !40, !44}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = !{i32 7, !"uwtable", i32 0}
+!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
+!51 = !DISubroutineType(types: !52)
+!52 = !{!20, !53}
+!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!54 = !{!55}
+!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)

--- a/tests/codegen/llvm/runtime_error_check_printf.ll
+++ b/tests/codegen/llvm/runtime_error_check_printf.ll
@@ -23,7 +23,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %data)
   call void @llvm.memset.p0.i64(ptr align 1 %data, i8 0, i64 8, i1 false)
   %1 = getelementptr [1 x i64], ptr %data, i64 0, i32 0
-  store i64 1, ptr %1, align 8
+  store i8 1, ptr %1, align 1
   %2 = call ptr @llvm.preserve.static.offset(ptr %0)
   %3 = getelementptr i64, ptr %2, i64 0
   %meta = load volatile ptr, ptr %3, align 8

--- a/tests/codegen/llvm/strcontains.ll
+++ b/tests/codegen/llvm/strcontains.ll
@@ -52,28 +52,26 @@ right:                                            ; preds = %entry
   %probe_read_kernel = call i64 inttoptr (i64 113 to ptr)(ptr %array_access, i32 1, ptr %6)
   %7 = load i8, ptr %array_access, align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %array_access)
-  %8 = sext i8 %7 to i64
-  %9 = icmp eq i64 %8, 0
-  %true_cond3 = icmp ne i1 %9, false
+  %8 = icmp eq i8 %7, 0
+  %true_cond3 = icmp ne i1 %8, false
   br i1 %true_cond3, label %left1, label %right2
 
 done:                                             ; preds = %done4, %left
-  %result5 = phi i64 [ 0, %left ], [ %result, %done4 ]
-  %10 = icmp sge i64 %result5, 0
+  %result5 = phi i32 [ 0, %left ], [ %result, %done4 ]
+  %9 = icmp sge i32 %result5, 0
   ret i64 0
 
 left1:                                            ; preds = %right
   br label %done4
 
 right2:                                           ; preds = %right
-  %11 = load i64, ptr %"$$strstr_4_$haystack_size", align 8
-  %12 = load i64, ptr %"$$strstr_4_$needle_size", align 8
-  %__bpf_strnstr = call i32 @__bpf_strnstr(ptr %"$$strstr_2_$haystack", ptr %"$$strstr_3_$needle", i64 %11, i64 %12), !dbg !41
-  %13 = sext i32 %__bpf_strnstr to i64
+  %10 = load i64, ptr %"$$strstr_4_$haystack_size", align 8
+  %11 = load i64, ptr %"$$strstr_4_$needle_size", align 8
+  %__bpf_strnstr = call i32 @__bpf_strnstr(ptr %"$$strstr_2_$haystack", ptr %"$$strstr_3_$needle", i64 %10, i64 %11), !dbg !41
   br label %done4
 
 done4:                                            ; preds = %right2, %left1
-  %result = phi i64 [ 0, %left1 ], [ %13, %right2 ]
+  %result = phi i32 [ 0, %left1 ], [ %__bpf_strnstr, %right2 ]
   br label %done
 }
 

--- a/tests/codegen/llvm/strcontains_no_literals.ll
+++ b/tests/codegen/llvm/strcontains_no_literals.ll
@@ -74,28 +74,26 @@ right:                                            ; preds = %entry
   %probe_read_kernel15 = call i64 inttoptr (i64 113 to ptr)(ptr %array_access, i32 1, ptr %18)
   %19 = load i8, ptr %array_access, align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %array_access)
-  %20 = sext i8 %19 to i64
-  %21 = icmp eq i64 %20, 0
-  %true_cond16 = icmp ne i1 %21, false
+  %20 = icmp eq i8 %19, 0
+  %true_cond16 = icmp ne i1 %20, false
   br i1 %true_cond16, label %left13, label %right14
 
 done:                                             ; preds = %done17, %left
-  %result18 = phi i64 [ 0, %left ], [ %result, %done17 ]
-  %22 = icmp sge i64 %result18, 0
+  %result18 = phi i32 [ 0, %left ], [ %result, %done17 ]
+  %21 = icmp sge i32 %result18, 0
   ret i64 0
 
 left13:                                           ; preds = %right
   br label %done17
 
 right14:                                          ; preds = %right
-  %23 = load i64, ptr %"$$strstr_4_$haystack_size", align 8
-  %24 = load i64, ptr %"$$strstr_4_$needle_size", align 8
-  %__bpf_strnstr = call i32 @__bpf_strnstr(ptr %4, ptr %2, i64 %23, i64 %24), !dbg !54
-  %25 = sext i32 %__bpf_strnstr to i64
+  %22 = load i64, ptr %"$$strstr_4_$haystack_size", align 8
+  %23 = load i64, ptr %"$$strstr_4_$needle_size", align 8
+  %__bpf_strnstr = call i32 @__bpf_strnstr(ptr %4, ptr %2, i64 %22, i64 %23), !dbg !54
   br label %done17
 
 done17:                                           ; preds = %right14, %left13
-  %result = phi i64 [ 0, %left13 ], [ %25, %right14 ]
+  %result = phi i32 [ 0, %left13 ], [ %__bpf_strnstr, %right14 ]
   br label %done
 }
 

--- a/tests/codegen/llvm/strcontains_one_literal.ll
+++ b/tests/codegen/llvm/strcontains_one_literal.ll
@@ -64,28 +64,26 @@ right:                                            ; preds = %entry
   %probe_read_kernel7 = call i64 inttoptr (i64 113 to ptr)(ptr %array_access, i32 1, ptr %12)
   %13 = load i8, ptr %array_access, align 1
   call void @llvm.lifetime.end.p0(i64 -1, ptr %array_access)
-  %14 = sext i8 %13 to i64
-  %15 = icmp eq i64 %14, 0
-  %true_cond8 = icmp ne i1 %15, false
+  %14 = icmp eq i8 %13, 0
+  %true_cond8 = icmp ne i1 %14, false
   br i1 %true_cond8, label %left5, label %right6
 
 done:                                             ; preds = %done9, %left
-  %result10 = phi i64 [ 0, %left ], [ %result, %done9 ]
-  %16 = icmp sge i64 %result10, 0
+  %result10 = phi i32 [ 0, %left ], [ %result, %done9 ]
+  %15 = icmp sge i32 %result10, 0
   ret i64 0
 
 left5:                                            ; preds = %right
   br label %done9
 
 right6:                                           ; preds = %right
-  %17 = load i64, ptr %"$$strstr_4_$haystack_size", align 8
-  %18 = load i64, ptr %"$$strstr_4_$needle_size", align 8
-  %__bpf_strnstr = call i32 @__bpf_strnstr(ptr %2, ptr %"$$strstr_3_$needle", i64 %17, i64 %18), !dbg !54
-  %19 = sext i32 %__bpf_strnstr to i64
+  %16 = load i64, ptr %"$$strstr_4_$haystack_size", align 8
+  %17 = load i64, ptr %"$$strstr_4_$needle_size", align 8
+  %__bpf_strnstr = call i32 @__bpf_strnstr(ptr %2, ptr %"$$strstr_3_$needle", i64 %16, i64 %17), !dbg !54
   br label %done9
 
 done9:                                            ; preds = %right6, %left5
-  %result = phi i64 [ 0, %left5 ], [ %19, %right6 ]
+  %result = phi i32 [ 0, %left5 ], [ %__bpf_strnstr, %right6 ]
   br label %done
 }
 

--- a/tests/codegen/llvm/string_equal_comparison.ll
+++ b/tests/codegen/llvm/string_equal_comparison.ll
@@ -8,18 +8,18 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !27
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !41
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !45
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !25
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !39
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
 @sshd = global [5 x i8] c"sshd\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !51 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
 entry:
-  %"@_val" = alloca i64, align 8
+  %"@_val" = alloca i8, align 1
   %"@_key" = alloca i1, align 1
   %strcmp.result = alloca i64, align 8
   %__builtin_comm = alloca [16 x i8], align 1
@@ -43,7 +43,7 @@ strcmp.false:                                     ; preds = %strcmp.done, %strcm
   %6 = zext i1 %5 to i8
   store i8 %6, ptr %"@_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  store i64 1, ptr %"@_val", align 8
+  store i8 1, ptr %"@_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
@@ -118,8 +118,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!47}
-!llvm.module.flags = !{!49, !50}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48, !49}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -145,35 +145,34 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
 !23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !25, size: 64, offset: 192)
-!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
-!26 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!27 = !DIGlobalVariableExpression(var: !28, expr: !DIExpression())
-!28 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
-!29 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !30)
-!30 = !{!31, !36}
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !32, size: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 27, lowerBound: 0)
-!36 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !37, size: 64, offset: 64)
-!37 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !38, size: 64)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !39)
-!39 = !{!40}
-!40 = !DISubrange(count: 262144, lowerBound: 0)
-!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
-!42 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !44, size: 64, elements: !15)
-!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !26, size: 64, elements: !15)
-!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
-!46 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
-!47 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !48)
-!48 = !{!0, !7, !27, !41, !45}
-!49 = !{i32 2, !"Debug Info Version", i32 3}
-!50 = !{i32 7, !"uwtable", i32 0}
-!51 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !54)
-!52 = !DISubroutineType(types: !53)
-!53 = !{!26, !23}
-!54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !23)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
+!28 = !{!29, !34}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !30, size: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 27, lowerBound: 0)
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !35, size: 64, offset: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 262144, lowerBound: 0)
+!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
+!40 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 64, elements: !15)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
+!43 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
+!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !7, !25, !39, !44}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = !{i32 7, !"uwtable", i32 0}
+!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
+!51 = !DISubroutineType(types: !52)
+!52 = !{!43, !23}
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !23)

--- a/tests/codegen/llvm/string_not_equal_comparison.ll
+++ b/tests/codegen/llvm/string_not_equal_comparison.ll
@@ -8,18 +8,18 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !27
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !41
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !45
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !25
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !39
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
 @sshd = global [5 x i8] c"sshd\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !51 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
 entry:
-  %"@_val" = alloca i64, align 8
+  %"@_val" = alloca i8, align 1
   %"@_key" = alloca i1, align 1
   %strcmp.result = alloca i64, align 8
   %__builtin_comm = alloca [16 x i8], align 1
@@ -43,7 +43,7 @@ strcmp.false:                                     ; preds = %strcmp.done, %strcm
   %6 = zext i1 %5 to i8
   store i8 %6, ptr %"@_key", align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  store i64 1, ptr %"@_val", align 8
+  store i8 1, ptr %"@_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
@@ -118,8 +118,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!47}
-!llvm.module.flags = !{!49, !50}
+!llvm.dbg.cu = !{!46}
+!llvm.module.flags = !{!48, !49}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -145,35 +145,34 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
 !23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !25, size: 64, offset: 192)
-!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
-!26 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!27 = !DIGlobalVariableExpression(var: !28, expr: !DIExpression())
-!28 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
-!29 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !30)
-!30 = !{!31, !36}
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !32, size: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 27, lowerBound: 0)
-!36 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !37, size: 64, offset: 64)
-!37 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !38, size: 64)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !39)
-!39 = !{!40}
-!40 = !DISubrange(count: 262144, lowerBound: 0)
-!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
-!42 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !44, size: 64, elements: !15)
-!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !26, size: 64, elements: !15)
-!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
-!46 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
-!47 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !48)
-!48 = !{!0, !7, !27, !41, !45}
-!49 = !{i32 2, !"Debug Info Version", i32 3}
-!50 = !{i32 7, !"uwtable", i32 0}
-!51 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !54)
-!52 = !DISubroutineType(types: !53)
-!53 = !{!26, !23}
-!54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !23)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
+!25 = !DIGlobalVariableExpression(var: !26, expr: !DIExpression())
+!26 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !27, isLocal: false, isDefinition: true)
+!27 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !28)
+!28 = !{!29, !34}
+!29 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !30, size: 64)
+!30 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !31, size: 64)
+!31 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !32)
+!32 = !{!33}
+!33 = !DISubrange(count: 27, lowerBound: 0)
+!34 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !35, size: 64, offset: 64)
+!35 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !36, size: 64)
+!36 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !37)
+!37 = !{!38}
+!38 = !DISubrange(count: 262144, lowerBound: 0)
+!39 = !DIGlobalVariableExpression(var: !40, expr: !DIExpression())
+!40 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !41, isLocal: false, isDefinition: true)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !42, size: 64, elements: !15)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
+!43 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
+!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
+!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
+!47 = !{!0, !7, !25, !39, !44}
+!48 = !{i32 2, !"Debug Info Version", i32 3}
+!49 = !{i32 7, !"uwtable", i32 0}
+!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !53)
+!51 = !DISubroutineType(types: !52)
+!52 = !{!43, !23}
+!53 = !{!54}
+!54 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !23)

--- a/tests/codegen/llvm/strncmp_no_literals.ll
+++ b/tests/codegen/llvm/strncmp_no_literals.ll
@@ -8,18 +8,18 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
-@__bt__get_str_buf = dso_local externally_initialized global [1 x [1 x [1024 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !42
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !37
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
+@__bt__get_str_buf = dso_local externally_initialized global [1 x [1 x [1024 x i8]]] zeroinitializer, section ".data.get_str_buf", !dbg !43
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @tracepoint_file_filename_1(ptr %0) #0 section "s_tracepoint_file_filename_1" !dbg !53 {
+define i64 @tracepoint_file_filename_1(ptr %0) #0 section "s_tracepoint_file_filename_1" !dbg !54 {
 entry:
-  %"@_val" = alloca i64, align 8
+  %"@_val" = alloca i8, align 1
   %"@_key" = alloca i64, align 8
   %strcmp.result = alloca i64, align 8
   %__builtin_comm = alloca [16 x i8], align 1
@@ -48,7 +48,7 @@ left:                                             ; preds = %strcmp.false
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 0, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  store i64 1, ptr %"@_val", align 8
+  store i8 1, ptr %"@_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
@@ -275,8 +275,8 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 attributes #4 = { memory(none) }
 
-!llvm.dbg.cu = !{!49}
-!llvm.module.flags = !{!51, !52}
+!llvm.dbg.cu = !{!50}
+!llvm.module.flags = !{!52, !53}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -299,41 +299,41 @@ attributes #4 = { memory(none) }
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
-!43 = distinct !DIGlobalVariable(name: "__bt__get_str_buf", linkageName: "global", scope: !2, file: !2, type: !44, isLocal: false, isDefinition: true)
-!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !45, size: 8192, elements: !15)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 64, elements: !15)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!43 = !DIGlobalVariableExpression(var: !44, expr: !DIExpression())
+!44 = distinct !DIGlobalVariable(name: "__bt__get_str_buf", linkageName: "global", scope: !2, file: !2, type: !45, isLocal: false, isDefinition: true)
 !45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !46, size: 8192, elements: !15)
-!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 8192, elements: !47)
-!47 = !{!48}
-!48 = !DISubrange(count: 1024, lowerBound: 0)
-!49 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !50)
-!50 = !{!0, !7, !22, !36, !40, !42}
-!51 = !{i32 2, !"Debug Info Version", i32 3}
-!52 = !{i32 7, !"uwtable", i32 0}
-!53 = distinct !DISubprogram(name: "tracepoint_file_filename_1", linkageName: "tracepoint_file_filename_1", scope: !2, file: !2, type: !54, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !49, retainedNodes: !57)
-!54 = !DISubroutineType(types: !55)
-!55 = !{!20, !56}
-!56 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !47, size: 8192, elements: !15)
+!47 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 8192, elements: !48)
+!48 = !{!49}
+!49 = !DISubrange(count: 1024, lowerBound: 0)
+!50 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !51)
+!51 = !{!0, !7, !23, !37, !41, !43}
+!52 = !{i32 2, !"Debug Info Version", i32 3}
+!53 = !{i32 7, !"uwtable", i32 0}
+!54 = distinct !DISubprogram(name: "tracepoint_file_filename_1", linkageName: "tracepoint_file_filename_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !50, retainedNodes: !57)
+!55 = !DISubroutineType(types: !56)
+!56 = !{!20, !22}
 !57 = !{!58}
-!58 = !DILocalVariable(name: "ctx", arg: 1, scope: !53, file: !2, type: !56)
+!58 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !22)

--- a/tests/codegen/llvm/strncmp_one_literal.ll
+++ b/tests/codegen/llvm/strncmp_one_literal.ll
@@ -8,18 +8,18 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_ = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !44
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !27
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !41
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !45
 @sshd = global [5 x i8] c"sshd\00"
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !50 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !51 {
 entry:
-  %"@_val" = alloca i64, align 8
+  %"@_val" = alloca i8, align 1
   %"@_key" = alloca i64, align 8
   %strcmp.result = alloca i64, align 8
   %__builtin_comm = alloca [16 x i8], align 1
@@ -41,7 +41,7 @@ strcmp.false:                                     ; preds = %strcmp.done, %strcm
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_key")
   store i64 %4, ptr %"@_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@_val")
-  store i64 1, ptr %"@_val", align 8
+  store i8 1, ptr %"@_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_, ptr %"@_key", ptr %"@_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@_key")
@@ -83,8 +83,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!46}
-!llvm.module.flags = !{!48, !49}
+!llvm.dbg.cu = !{!47}
+!llvm.module.flags = !{!49, !50}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -111,34 +111,34 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
 !23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
 !24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
-!29 = !{!30, !35}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 27, lowerBound: 0)
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
-!38 = !{!39}
-!39 = !DISubrange(count: 262144, lowerBound: 0)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
-!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
-!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
-!44 = !DIGlobalVariableExpression(var: !45, expr: !DIExpression())
-!45 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!46 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !47)
-!47 = !{!0, !7, !26, !40, !44}
-!48 = !{i32 2, !"Debug Info Version", i32 3}
-!49 = !{i32 7, !"uwtable", i32 0}
-!50 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !51, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !46, retainedNodes: !54)
-!51 = !DISubroutineType(types: !52)
-!52 = !{!24, !53}
-!53 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !26, size: 64, offset: 192)
+!26 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!27 = !DIGlobalVariableExpression(var: !28, expr: !DIExpression())
+!28 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
+!29 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !30)
+!30 = !{!31, !36}
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !32, size: 64)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !34)
+!34 = !{!35}
+!35 = !DISubrange(count: 27, lowerBound: 0)
+!36 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !37, size: 64, offset: 64)
+!37 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !38, size: 64)
+!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !39)
+!39 = !{!40}
+!40 = !DISubrange(count: 262144, lowerBound: 0)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
+!43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !44, size: 64, elements: !15)
+!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !15)
+!45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
+!46 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
+!47 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !48)
+!48 = !{!0, !7, !27, !41, !45}
+!49 = !{i32 2, !"Debug Info Version", i32 3}
+!50 = !{i32 7, !"uwtable", i32 0}
+!51 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !54)
+!52 = !DISubroutineType(types: !53)
+!53 = !{!24, !26}
 !54 = !{!55}
-!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !50, file: !2, type: !53)
+!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !26)

--- a/tests/codegen/llvm/struct_char_1.ll
+++ b/tests/codegen/llvm/struct_char_1.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !37
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !47 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
   %"@x_key" = alloca i64, align 8
   %"struct Foo.x" = alloca i8, align 1
   %"$foo" = alloca ptr, align 8
@@ -40,8 +40,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %9 = sext i8 %8 to i64
-  store i64 %9, ptr %"@x_val", align 8
+  store i8 %8, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -61,8 +60,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!43}
+!llvm.module.flags = !{!45, !46}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -85,34 +84,34 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 64, elements: !15)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!43 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !44)
+!44 = !{!0, !7, !23, !37, !41}
+!45 = !{i32 2, !"Debug Info Version", i32 3}
+!46 = !{i32 7, !"uwtable", i32 0}
+!47 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !50)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!20, !22}
 !50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !47, file: !2, type: !22)

--- a/tests/codegen/llvm/struct_char_2.ll
+++ b/tests/codegen/llvm/struct_char_2.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !37
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !47 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
   %"@x_key" = alloca i64, align 8
   %"struct Foo.x" = alloca i8, align 1
   %"$foo" = alloca ptr, align 8
@@ -39,8 +39,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %8 = sext i8 %7 to i64
-  store i64 %8, ptr %"@x_val", align 8
+  store i8 %7, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -60,8 +59,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!43}
+!llvm.module.flags = !{!45, !46}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -84,34 +83,34 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 64, elements: !15)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!43 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !44)
+!44 = !{!0, !7, !23, !37, !41}
+!45 = !{i32 2, !"Debug Info Version", i32 3}
+!46 = !{i32 7, !"uwtable", i32 0}
+!47 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !50)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!20, !22}
 !50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !47, file: !2, type: !22)

--- a/tests/codegen/llvm/struct_integer_ptr_1.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_1.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i32, align 4
   %"@x_key" = alloca i64, align 8
   %deref = alloca i32, align 4
   %"struct Foo.x" = alloca ptr, align 8
@@ -45,8 +45,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %10 = sext i32 %9 to i64
-  store i64 %10, ptr %"@x_val", align 8
+  store i32 %9, ptr %"@x_val", align 4
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -66,8 +65,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!44}
+!llvm.module.flags = !{!46, !47}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -90,34 +89,36 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
+!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
+!27 = !{!28, !33}
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
+!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
+!31 = !{!32}
+!32 = !DISubrange(count: 27, lowerBound: 0)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 262144, lowerBound: 0)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
+!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
+!45 = !{!0, !7, !24, !38, !42}
+!46 = !{i32 2, !"Debug Info Version", i32 3}
+!47 = !{i32 7, !"uwtable", i32 0}
+!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
+!49 = !DISubroutineType(types: !50)
+!50 = !{!20, !51}
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!52 = !{!53}
+!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)

--- a/tests/codegen/llvm/struct_integer_ptr_2.ll
+++ b/tests/codegen/llvm/struct_integer_ptr_2.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i32, align 4
   %"@x_key" = alloca i64, align 8
   %deref = alloca i32, align 4
   %"struct Foo.x" = alloca ptr, align 8
@@ -44,8 +44,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %9 = sext i32 %8 to i64
-  store i64 %9, ptr %"@x_val", align 8
+  store i32 %8, ptr %"@x_val", align 4
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -65,8 +64,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!44}
+!llvm.module.flags = !{!46, !47}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -89,34 +88,36 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
+!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
+!27 = !{!28, !33}
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
+!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
+!31 = !{!32}
+!32 = !DISubrange(count: 27, lowerBound: 0)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 262144, lowerBound: 0)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
+!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
+!45 = !{!0, !7, !24, !38, !42}
+!46 = !{i32 2, !"Debug Info Version", i32 3}
+!47 = !{i32 7, !"uwtable", i32 0}
+!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
+!49 = !DISubroutineType(types: !50)
+!50 = !{!20, !51}
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!52 = !{!53}
+!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)

--- a/tests/codegen/llvm/struct_integers_1.ll
+++ b/tests/codegen/llvm/struct_integers_1.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i32, align 4
   %"@x_key" = alloca i64, align 8
   %"struct Foo.x" = alloca i32, align 4
   %"$foo" = alloca ptr, align 8
@@ -40,8 +40,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %9 = sext i32 %8 to i64
-  store i64 %9, ptr %"@x_val", align 8
+  store i32 %8, ptr %"@x_val", align 4
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -61,8 +60,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!44}
+!llvm.module.flags = !{!46, !47}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -85,34 +84,36 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
+!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
+!27 = !{!28, !33}
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
+!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
+!31 = !{!32}
+!32 = !DISubrange(count: 27, lowerBound: 0)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 262144, lowerBound: 0)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
+!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
+!45 = !{!0, !7, !24, !38, !42}
+!46 = !{i32 2, !"Debug Info Version", i32 3}
+!47 = !{i32 7, !"uwtable", i32 0}
+!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
+!49 = !DISubroutineType(types: !50)
+!50 = !{!20, !51}
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!52 = !{!53}
+!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)

--- a/tests/codegen/llvm/struct_integers_2.ll
+++ b/tests/codegen/llvm/struct_integers_2.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i32, align 4
   %"@x_key" = alloca i64, align 8
   %"struct Foo.x" = alloca i32, align 4
   %"$foo" = alloca ptr, align 8
@@ -39,8 +39,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %8 = sext i32 %7 to i64
-  store i64 %8, ptr %"@x_val", align 8
+  store i32 %7, ptr %"@x_val", align 4
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -60,8 +59,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!44}
+!llvm.module.flags = !{!46, !47}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -84,34 +83,36 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
+!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
+!27 = !{!28, !33}
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
+!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
+!31 = !{!32}
+!32 = !DISubrange(count: 27, lowerBound: 0)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 262144, lowerBound: 0)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
+!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
+!45 = !{!0, !7, !24, !38, !42}
+!46 = !{i32 2, !"Debug Info Version", i32 3}
+!47 = !{i32 7, !"uwtable", i32 0}
+!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
+!49 = !DISubroutineType(types: !50)
+!50 = !{!20, !51}
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!52 = !{!53}
+!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)

--- a/tests/codegen/llvm/struct_nested_struct_anon_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_1.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i32, align 4
   %"@x_key" = alloca i64, align 8
   %"struct Foo::(unnamed at definitions.h:2:14).x" = alloca i32, align 4
   %"$foo" = alloca ptr, align 8
@@ -42,8 +42,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %11 = sext i32 %10 to i64
-  store i64 %11, ptr %"@x_val", align 8
+  store i32 %10, ptr %"@x_val", align 4
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -63,8 +62,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!44}
+!llvm.module.flags = !{!46, !47}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -87,34 +86,36 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
+!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
+!27 = !{!28, !33}
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
+!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
+!31 = !{!32}
+!32 = !DISubrange(count: 27, lowerBound: 0)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 262144, lowerBound: 0)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
+!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
+!45 = !{!0, !7, !24, !38, !42}
+!46 = !{i32 2, !"Debug Info Version", i32 3}
+!47 = !{i32 7, !"uwtable", i32 0}
+!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
+!49 = !DISubroutineType(types: !50)
+!50 = !{!20, !51}
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!52 = !{!53}
+!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)

--- a/tests/codegen/llvm/struct_nested_struct_anon_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_anon_2.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i32, align 4
   %"@x_key" = alloca i64, align 8
   %"struct Foo::(unnamed at definitions.h:2:14).x" = alloca i32, align 4
   %"$foo" = alloca ptr, align 8
@@ -41,8 +41,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %10 = sext i32 %9 to i64
-  store i64 %10, ptr %"@x_val", align 8
+  store i32 %9, ptr %"@x_val", align 4
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -62,8 +61,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!44}
+!llvm.module.flags = !{!46, !47}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -86,34 +85,36 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
+!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
+!27 = !{!28, !33}
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
+!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
+!31 = !{!32}
+!32 = !DISubrange(count: 27, lowerBound: 0)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 262144, lowerBound: 0)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
+!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
+!45 = !{!0, !7, !24, !38, !42}
+!46 = !{i32 2, !"Debug Info Version", i32 3}
+!47 = !{i32 7, !"uwtable", i32 0}
+!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
+!49 = !DISubroutineType(types: !50)
+!50 = !{!20, !51}
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!52 = !{!53}
+!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)

--- a/tests/codegen/llvm/struct_nested_struct_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_1.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i32, align 4
   %"@x_key" = alloca i64, align 8
   %"struct Bar.x" = alloca i32, align 4
   %"$foo" = alloca ptr, align 8
@@ -42,8 +42,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %11 = sext i32 %10 to i64
-  store i64 %11, ptr %"@x_val", align 8
+  store i32 %10, ptr %"@x_val", align 4
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -63,8 +62,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!44}
+!llvm.module.flags = !{!46, !47}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -87,34 +86,36 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
+!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
+!27 = !{!28, !33}
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
+!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
+!31 = !{!32}
+!32 = !DISubrange(count: 27, lowerBound: 0)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 262144, lowerBound: 0)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
+!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
+!45 = !{!0, !7, !24, !38, !42}
+!46 = !{i32 2, !"Debug Info Version", i32 3}
+!47 = !{i32 7, !"uwtable", i32 0}
+!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
+!49 = !DISubroutineType(types: !50)
+!50 = !{!20, !51}
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!52 = !{!53}
+!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)

--- a/tests/codegen/llvm/struct_nested_struct_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_named_2.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i32, align 4
   %"@x_key" = alloca i64, align 8
   %"struct Bar.x" = alloca i32, align 4
   %"$foo" = alloca ptr, align 8
@@ -41,8 +41,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %10 = sext i32 %9 to i64
-  store i64 %10, ptr %"@x_val", align 8
+  store i32 %9, ptr %"@x_val", align 4
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -62,8 +61,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!44}
+!llvm.module.flags = !{!46, !47}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -86,34 +85,36 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
+!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
+!27 = !{!28, !33}
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
+!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
+!31 = !{!32}
+!32 = !DISubrange(count: 27, lowerBound: 0)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 262144, lowerBound: 0)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
+!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
+!45 = !{!0, !7, !24, !38, !42}
+!46 = !{i32 2, !"Debug Info Version", i32 3}
+!47 = !{i32 7, !"uwtable", i32 0}
+!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
+!49 = !DISubroutineType(types: !50)
+!50 = !{!20, !51}
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!52 = !{!53}
+!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_1.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i32, align 4
   %"@x_key" = alloca i64, align 8
   %"struct Bar.x" = alloca i32, align 4
   %"struct Foo.bar" = alloca ptr, align 8
@@ -47,8 +47,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %12 = sext i32 %11 to i64
-  store i64 %12, ptr %"@x_val", align 8
+  store i32 %11, ptr %"@x_val", align 4
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -68,8 +67,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!44}
+!llvm.module.flags = !{!46, !47}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -92,34 +91,36 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
+!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
+!27 = !{!28, !33}
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
+!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
+!31 = !{!32}
+!32 = !DISubrange(count: 27, lowerBound: 0)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 262144, lowerBound: 0)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
+!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
+!45 = !{!0, !7, !24, !38, !42}
+!46 = !{i32 2, !"Debug Info Version", i32 3}
+!47 = !{i32 7, !"uwtable", i32 0}
+!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
+!49 = !DISubroutineType(types: !50)
+!50 = !{!20, !51}
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!52 = !{!53}
+!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)

--- a/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
+++ b/tests/codegen/llvm/struct_nested_struct_ptr_named_2.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i32, align 4
   %"@x_key" = alloca i64, align 8
   %"struct Bar.x" = alloca i32, align 4
   %"struct Foo.bar" = alloca ptr, align 8
@@ -46,8 +46,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %11 = sext i32 %10 to i64
-  store i64 %11, ptr %"@x_val", align 8
+  store i32 %10, ptr %"@x_val", align 4
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -67,8 +66,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!44}
+!llvm.module.flags = !{!46, !47}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -91,34 +90,36 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
+!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
+!27 = !{!28, !33}
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
+!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
+!31 = !{!32}
+!32 = !DISubrange(count: 27, lowerBound: 0)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 262144, lowerBound: 0)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
+!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
+!45 = !{!0, !7, !24, !38, !42}
+!46 = !{i32 2, !"Debug Info Version", i32 3}
+!47 = !{i32 7, !"uwtable", i32 0}
+!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
+!49 = !DISubroutineType(types: !50)
+!50 = !{!20, !51}
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!52 = !{!53}
+!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)

--- a/tests/codegen/llvm/struct_save_nested.ll
+++ b/tests/codegen/llvm/struct_save_nested.ll
@@ -12,17 +12,17 @@ target triple = "bpf"
 @AT_bar = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
 @AT_foo = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
 @AT_x = dso_local global %"struct map_internal_repr_t.164" zeroinitializer, section ".maps", !dbg !35
-@ringbuf = dso_local global %"struct map_internal_repr_t.165" zeroinitializer, section ".maps", !dbg !40
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !54
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !58
+@ringbuf = dso_local global %"struct map_internal_repr_t.165" zeroinitializer, section ".maps", !dbg !42
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !56
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !60
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !64 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !66 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i32, align 4
   %"@x_key" = alloca i64, align 8
   %lookup_elem_val8 = alloca [16 x i8], align 1
   %"@foo_key3" = alloca i64, align 8
@@ -89,8 +89,7 @@ lookup_merge7:                                    ; preds = %lookup_failure6, %l
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %8 = sext i32 %7 to i64
-  store i64 %8, ptr %"@x_val", align 8
+  store i32 %7, ptr %"@x_val", align 4
   %update_elem10 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -118,8 +117,8 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite) }
 attributes #4 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!60}
-!llvm.module.flags = !{!62, !63}
+!llvm.dbg.cu = !{!62}
+!llvm.module.flags = !{!64, !65}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -160,34 +159,36 @@ attributes #4 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !36 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !37, isLocal: false, isDefinition: true)
 !37 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !38)
 !38 = !{!11, !17, !18, !39}
-!39 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
-!42 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !43)
-!43 = !{!44, !49}
-!44 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !45, size: 64)
-!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !46, size: 64)
-!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !47)
-!47 = !{!48}
-!48 = !DISubrange(count: 27, lowerBound: 0)
-!49 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !50, size: 64, offset: 64)
-!50 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !51, size: 64)
-!51 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !52)
-!52 = !{!53}
-!53 = !DISubrange(count: 262144, lowerBound: 0)
-!54 = !DIGlobalVariableExpression(var: !55, expr: !DIExpression())
-!55 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !56, isLocal: false, isDefinition: true)
-!56 = !DICompositeType(tag: DW_TAG_array_type, baseType: !57, size: 64, elements: !15)
-!57 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!58 = !DIGlobalVariableExpression(var: !59, expr: !DIExpression())
-!59 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!60 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !61)
-!61 = !{!0, !7, !26, !35, !40, !54, !58}
-!62 = !{i32 2, !"Debug Info Version", i32 3}
-!63 = !{i32 7, !"uwtable", i32 0}
-!64 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !65, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !60, retainedNodes: !68)
-!65 = !DISubroutineType(types: !66)
-!66 = !{!20, !67}
-!67 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!68 = !{!69}
-!69 = !DILocalVariable(name: "ctx", arg: 1, scope: !64, file: !2, type: !67)
+!39 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !40, size: 64, offset: 192)
+!40 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !41, size: 64)
+!41 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
+!43 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !44, isLocal: false, isDefinition: true)
+!44 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !45)
+!45 = !{!46, !51}
+!46 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !47, size: 64)
+!47 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !48, size: 64)
+!48 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !49)
+!49 = !{!50}
+!50 = !DISubrange(count: 27, lowerBound: 0)
+!51 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !52, size: 64, offset: 64)
+!52 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !53, size: 64)
+!53 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !54)
+!54 = !{!55}
+!55 = !DISubrange(count: 262144, lowerBound: 0)
+!56 = !DIGlobalVariableExpression(var: !57, expr: !DIExpression())
+!57 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !58, isLocal: false, isDefinition: true)
+!58 = !DICompositeType(tag: DW_TAG_array_type, baseType: !59, size: 64, elements: !15)
+!59 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!60 = !DIGlobalVariableExpression(var: !61, expr: !DIExpression())
+!61 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!62 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !63)
+!63 = !{!0, !7, !26, !35, !42, !56, !60}
+!64 = !{i32 2, !"Debug Info Version", i32 3}
+!65 = !{i32 7, !"uwtable", i32 0}
+!66 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !67, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !62, retainedNodes: !70)
+!67 = !DISubroutineType(types: !68)
+!68 = !{!20, !69}
+!69 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!70 = !{!71}
+!71 = !DILocalVariable(name: "ctx", arg: 1, scope: !66, file: !2, type: !69)

--- a/tests/codegen/llvm/struct_short_1.ll
+++ b/tests/codegen/llvm/struct_short_1.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i16, align 2
   %"@x_key" = alloca i64, align 8
   %"struct Foo.x" = alloca i16, align 2
   %"$foo" = alloca ptr, align 8
@@ -40,8 +40,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %9 = sext i16 %8 to i64
-  store i64 %9, ptr %"@x_val", align 8
+  store i16 %8, ptr %"@x_val", align 2
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -61,8 +60,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!44}
+!llvm.module.flags = !{!46, !47}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -85,34 +84,36 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int16", size: 16, encoding: DW_ATE_signed)
+!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
+!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
+!27 = !{!28, !33}
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
+!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
+!31 = !{!32}
+!32 = !DISubrange(count: 27, lowerBound: 0)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 262144, lowerBound: 0)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
+!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
+!45 = !{!0, !7, !24, !38, !42}
+!46 = !{i32 2, !"Debug Info Version", i32 3}
+!47 = !{i32 7, !"uwtable", i32 0}
+!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
+!49 = !DISubroutineType(types: !50)
+!50 = !{!20, !51}
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!52 = !{!53}
+!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)

--- a/tests/codegen/llvm/struct_short_2.ll
+++ b/tests/codegen/llvm/struct_short_2.ll
@@ -8,17 +8,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i16, align 2
   %"@x_key" = alloca i64, align 8
   %"struct Foo.x" = alloca i16, align 2
   %"$foo" = alloca ptr, align 8
@@ -39,8 +39,7 @@ entry:
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %8 = sext i16 %7 to i64
-  store i64 %8, ptr %"@x_val", align 8
+  store i16 %7, ptr %"@x_val", align 2
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -60,8 +59,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!44}
+!llvm.module.flags = !{!46, !47}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -84,34 +83,36 @@ attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: re
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int16", size: 16, encoding: DW_ATE_signed)
+!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
+!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
+!27 = !{!28, !33}
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
+!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
+!31 = !{!32}
+!32 = !DISubrange(count: 27, lowerBound: 0)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 262144, lowerBound: 0)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
+!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
+!45 = !{!0, !7, !24, !38, !42}
+!46 = !{i32 2, !"Debug Info Version", i32 3}
+!47 = !{i32 7, !"uwtable", i32 0}
+!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
+!49 = !DISubroutineType(types: !50)
+!50 = !{!20, !51}
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!52 = !{!53}
+!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)

--- a/tests/codegen/llvm/sum_cast_loop.ll
+++ b/tests/codegen/llvm/sum_cast_loop.ll
@@ -5,26 +5,26 @@ target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.163" = type { ptr, ptr }
-%int64_sum_t__tuple_t = type { i64, i64 }
+%uint8_usum_t__tuple_t = type { i8, i64 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !42
-@__bt__num_cpus = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !48
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !27
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !43
+@__bt__num_cpus = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !49
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !54 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !55 {
 entry:
   %initial_value = alloca i64, align 8
   %lookup_elem_val = alloca i64, align 8
-  %"@x_key" = alloca i64, align 8
+  %"@x_key" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
-  store i64 1, ptr %"@x_key", align 8
+  store i8 1, ptr %"@x_key", align 1
   %lookup_elem = call ptr inttoptr (i64 1 to ptr)(ptr @AT_x, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %lookup_elem_val)
   %map_lookup_cond = icmp ne ptr %lookup_elem, null
@@ -62,11 +62,11 @@ for_body:
   %"$res" = alloca i64, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$res")
   store i64 0, ptr %"$res", align 8
-  %"$kv" = alloca %int64_sum_t__tuple_t, align 8
+  %"$kv" = alloca %uint8_usum_t__tuple_t, align 8
   %val_2 = alloca i64, align 8
   %val_1 = alloca i64, align 8
   %i = alloca i32, align 4
-  %key = load i64, ptr %1, align 8
+  %key = load i8, ptr %1, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %i)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %val_1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %val_2)
@@ -94,11 +94,11 @@ while_end:                                        ; preds = %error_failure, %err
   call void @llvm.lifetime.end.p0(i64 -1, ptr %val_2)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$kv")
   call void @llvm.memset.p0.i64(ptr align 1 %"$kv", i8 0, i64 16, i1 false)
-  %8 = getelementptr %int64_sum_t__tuple_t, ptr %"$kv", i32 0, i32 0
-  store i64 %key, ptr %8, align 8
-  %9 = getelementptr %int64_sum_t__tuple_t, ptr %"$kv", i32 0, i32 1
+  %8 = getelementptr %uint8_usum_t__tuple_t, ptr %"$kv", i32 0, i32 0
+  store i8 %key, ptr %8, align 1
+  %9 = getelementptr %uint8_usum_t__tuple_t, ptr %"$kv", i32 0, i32 1
   store i64 %7, ptr %9, align 8
-  %10 = getelementptr %int64_sum_t__tuple_t, ptr %"$kv", i32 0, i32 1
+  %10 = getelementptr %uint8_usum_t__tuple_t, ptr %"$kv", i32 0, i32 1
   %11 = load i64, ptr %10, align 8
   store i64 %11, ptr %"$res", align 8
   br label %for_continue
@@ -136,8 +136,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 
-!llvm.dbg.cu = !{!50}
-!llvm.module.flags = !{!52, !53}
+!llvm.dbg.cu = !{!51}
+!llvm.module.flags = !{!53, !54}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -149,7 +149,7 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !7 = !DIGlobalVariableExpression(var: !8, expr: !DIExpression())
 !8 = distinct !DIGlobalVariable(name: "AT_x", linkageName: "global", scope: !2, file: !2, type: !9, isLocal: false, isDefinition: true)
 !9 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !10)
-!10 = !{!11, !17, !22, !25}
+!10 = !{!11, !17, !22, !24}
 !11 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !12, size: 64)
 !12 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !13, size: 64)
 !13 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 160, elements: !15)
@@ -162,48 +162,48 @@ attributes #2 = { nocallback nofree nounwind willreturn memory(argmem: write) }
 !20 = !{!21}
 !21 = !DISubrange(count: 4096, lowerBound: 0)
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
-!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !24, size: 64)
-!24 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!25 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !23, size: 64, offset: 192)
-!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
-!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
-!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
-!29 = !{!30, !35}
-!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
-!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
-!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
-!33 = !{!34}
-!34 = !DISubrange(count: 27, lowerBound: 0)
-!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
-!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
-!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
-!38 = !{!39}
-!39 = !DISubrange(count: 262144, lowerBound: 0)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
-!43 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !44, isLocal: false, isDefinition: true)
-!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !45, size: 64, elements: !46)
-!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !24, size: 64, elements: !46)
-!46 = !{!47}
-!47 = !DISubrange(count: 1, lowerBound: 0)
-!48 = !DIGlobalVariableExpression(var: !49, expr: !DIExpression())
-!49 = distinct !DIGlobalVariable(name: "__bt__num_cpus", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!50 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !51)
-!51 = !{!0, !7, !26, !40, !42, !48}
-!52 = !{i32 2, !"Debug Info Version", i32 3}
-!53 = !{i32 7, !"uwtable", i32 0}
-!54 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !55, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !50, retainedNodes: !58)
-!55 = !DISubroutineType(types: !56)
-!56 = !{!24, !57}
-!57 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !25, size: 64, offset: 192)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
+!26 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
+!27 = !DIGlobalVariableExpression(var: !28, expr: !DIExpression())
+!28 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
+!29 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !30)
+!30 = !{!31, !36}
+!31 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !32, size: 64)
+!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !34)
+!34 = !{!35}
+!35 = !DISubrange(count: 27, lowerBound: 0)
+!36 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !37, size: 64, offset: 64)
+!37 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !38, size: 64)
+!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !39)
+!39 = !{!40}
+!40 = !DISubrange(count: 262144, lowerBound: 0)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!43 = !DIGlobalVariableExpression(var: !44, expr: !DIExpression())
+!44 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !45, isLocal: false, isDefinition: true)
+!45 = !DICompositeType(tag: DW_TAG_array_type, baseType: !46, size: 64, elements: !47)
+!46 = !DICompositeType(tag: DW_TAG_array_type, baseType: !26, size: 64, elements: !47)
+!47 = !{!48}
+!48 = !DISubrange(count: 1, lowerBound: 0)
+!49 = !DIGlobalVariableExpression(var: !50, expr: !DIExpression())
+!50 = distinct !DIGlobalVariable(name: "__bt__num_cpus", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!51 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !52)
+!52 = !{!0, !7, !27, !41, !43, !49}
+!53 = !{i32 2, !"Debug Info Version", i32 3}
+!54 = !{i32 7, !"uwtable", i32 0}
+!55 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !56, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !51, retainedNodes: !58)
+!56 = !DISubroutineType(types: !57)
+!57 = !{!26, !23}
 !58 = !{!59}
-!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !54, file: !2, type: !57)
-!60 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !61, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !50, retainedNodes: !63)
+!59 = !DILocalVariable(name: "ctx", arg: 1, scope: !55, file: !2, type: !23)
+!60 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !61, flags: DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !51, retainedNodes: !63)
 !61 = !DISubroutineType(types: !62)
-!62 = !{!24, !57, !57, !57, !57}
+!62 = !{!26, !23, !23, !23, !23}
 !63 = !{!64, !65, !66, !67}
-!64 = !DILocalVariable(name: "map", arg: 1, scope: !60, file: !2, type: !57)
-!65 = !DILocalVariable(name: "key", arg: 2, scope: !60, file: !2, type: !57)
-!66 = !DILocalVariable(name: "value", arg: 3, scope: !60, file: !2, type: !57)
-!67 = !DILocalVariable(name: "ctx", arg: 4, scope: !60, file: !2, type: !57)
+!64 = !DILocalVariable(name: "map", arg: 1, scope: !60, file: !2, type: !23)
+!65 = !DILocalVariable(name: "key", arg: 2, scope: !60, file: !2, type: !23)
+!66 = !DILocalVariable(name: "value", arg: 3, scope: !60, file: !2, type: !23)
+!67 = !DILocalVariable(name: "ctx", arg: 4, scope: !60, file: !2, type: !23)

--- a/tests/codegen/llvm/ternary_int.ll
+++ b/tests/codegen/llvm/ternary_int.ll
@@ -8,24 +8,23 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !23
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !37
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !41
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !47 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i8, align 1
   %"@x_key" = alloca i64, align 8
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #2
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
-  %2 = zext i32 %pid to i64
-  %3 = icmp ult i64 %2, 10000
-  %true_cond = icmp ne i1 %3, false
+  %2 = icmp ult i32 %pid, 10000
+  %true_cond = icmp ne i1 %2, false
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
@@ -35,11 +34,11 @@ right:                                            ; preds = %entry
   br label %done
 
 done:                                             ; preds = %right, %left
-  %result = phi i64 [ 1, %left ], [ 2, %right ]
+  %result = phi i8 [ 1, %left ], [ 2, %right ]
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 %result, ptr %"@x_val", align 8
+  store i8 %result, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -56,8 +55,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #2 = { memory(none) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!43}
+!llvm.module.flags = !{!45, !46}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -80,34 +79,34 @@ attributes #2 = { memory(none) }
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!23 = !DIGlobalVariableExpression(var: !24, expr: !DIExpression())
+!24 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !25, isLocal: false, isDefinition: true)
+!25 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !26)
+!26 = !{!27, !32}
+!27 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !28, size: 64)
+!28 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !29, size: 64)
+!29 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !30)
+!30 = !{!31}
+!31 = !DISubrange(count: 27, lowerBound: 0)
+!32 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !33, size: 64, offset: 64)
+!33 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !34, size: 64)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !35)
+!35 = !{!36}
+!36 = !DISubrange(count: 262144, lowerBound: 0)
+!37 = !DIGlobalVariableExpression(var: !38, expr: !DIExpression())
+!38 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !39, isLocal: false, isDefinition: true)
+!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !40, size: 64, elements: !15)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
+!42 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!43 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !44)
+!44 = !{!0, !7, !23, !37, !41}
+!45 = !{i32 2, !"Debug Info Version", i32 3}
+!46 = !{i32 7, !"uwtable", i32 0}
+!47 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !48, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !43, retainedNodes: !50)
+!48 = !DISubroutineType(types: !49)
+!49 = !{!20, !22}
 !50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !47, file: !2, type: !22)

--- a/tests/codegen/llvm/ternary_nested.ll
+++ b/tests/codegen/llvm/ternary_nested.ll
@@ -4,7 +4,7 @@ target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr }
-%print_int_8_t = type <{ i64, i64, [8 x i8] }>
+%print_int_1_t = type <{ i64, i64, [1 x i8] }>
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @ringbuf = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
@@ -17,68 +17,68 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
-  %print_int_8_t = alloca %print_int_8_t, align 8
-  %"$z" = alloca i64, align 8
+  %print_int_1_t = alloca %print_int_1_t, align 8
+  %"$z" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$z")
-  store i64 0, ptr %"$z", align 8
-  %"$y" = alloca i64, align 8
+  store i8 0, ptr %"$z", align 1
+  %"$y" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$y")
-  store i64 0, ptr %"$y", align 8
-  %"$x" = alloca i64, align 8
+  store i8 0, ptr %"$y", align 1
+  %"$x" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
-  store i64 0, ptr %"$x", align 8
-  store i64 1, ptr %"$x", align 8
-  store i64 1, ptr %"$y", align 8
-  store i64 1, ptr %"$z", align 8
-  %1 = load i64, ptr %"$x", align 8
-  %true_cond = icmp ne i64 %1, 0
+  store i8 0, ptr %"$x", align 1
+  store i8 1, ptr %"$x", align 1
+  store i8 1, ptr %"$y", align 1
+  store i8 1, ptr %"$z", align 1
+  %1 = load i8, ptr %"$x", align 1
+  %true_cond = icmp ne i8 %1, 0
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
-  %2 = load i64, ptr %"$y", align 8
-  %true_cond3 = icmp ne i64 %2, 0
+  %2 = load i8, ptr %"$y", align 1
+  %true_cond3 = icmp ne i8 %2, 0
   br i1 %true_cond3, label %left1, label %right2
 
 right:                                            ; preds = %entry
-  %3 = load i64, ptr %"$y", align 8
+  %3 = load i8, ptr %"$y", align 1
   br label %done9
 
 left1:                                            ; preds = %left
-  %4 = load i64, ptr %"$z", align 8
-  %true_cond6 = icmp ne i64 %4, 0
+  %4 = load i8, ptr %"$z", align 1
+  %true_cond6 = icmp ne i8 %4, 0
   br i1 %true_cond6, label %left4, label %right5
 
 right2:                                           ; preds = %left
-  %5 = load i64, ptr %"$z", align 8
+  %5 = load i8, ptr %"$z", align 1
   br label %done7
 
 left4:                                            ; preds = %left1
-  %6 = load i64, ptr %"$x", align 8
+  %6 = load i8, ptr %"$x", align 1
   br label %done
 
 right5:                                           ; preds = %left1
-  %7 = load i64, ptr %"$y", align 8
+  %7 = load i8, ptr %"$y", align 1
   br label %done
 
 done:                                             ; preds = %right5, %left4
-  %result = phi i64 [ %6, %left4 ], [ %7, %right5 ]
+  %result = phi i8 [ %6, %left4 ], [ %7, %right5 ]
   br label %done7
 
 done7:                                            ; preds = %right2, %done
-  %result8 = phi i64 [ %result, %done ], [ %5, %right2 ]
+  %result8 = phi i8 [ %result, %done ], [ %5, %right2 ]
   br label %done9
 
 done9:                                            ; preds = %right, %done7
-  %result10 = phi i64 [ %result8, %done7 ], [ %3, %right ]
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %print_int_8_t)
-  %8 = getelementptr %print_int_8_t, ptr %print_int_8_t, i64 0, i32 0
+  %result10 = phi i8 [ %result8, %done7 ], [ %3, %right ]
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %print_int_1_t)
+  %8 = getelementptr %print_int_1_t, ptr %print_int_1_t, i64 0, i32 0
   store i64 30007, ptr %8, align 8
-  %9 = getelementptr %print_int_8_t, ptr %print_int_8_t, i64 0, i32 1
+  %9 = getelementptr %print_int_1_t, ptr %print_int_1_t, i64 0, i32 1
   store i64 0, ptr %9, align 8
-  %10 = getelementptr %print_int_8_t, ptr %print_int_8_t, i32 0, i32 2
-  call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 8, i1 false)
-  store i64 %result10, ptr %10, align 8
-  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_int_8_t, i64 24, i64 0)
+  %10 = getelementptr %print_int_1_t, ptr %print_int_1_t, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %10, i8 0, i64 1, i1 false)
+  store i8 %result10, ptr %10, align 1
+  %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %print_int_1_t, i64 17, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
@@ -93,7 +93,7 @@ event_loss_counter:                               ; preds = %done9
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %done9
-  call void @llvm.lifetime.end.p0(i64 -1, ptr %print_int_8_t)
+  call void @llvm.lifetime.end.p0(i64 -1, ptr %print_int_1_t)
   ret i64 0
 }
 

--- a/tests/codegen/llvm/ternary_none.ll
+++ b/tests/codegen/llvm/ternary_none.ll
@@ -23,38 +23,37 @@ entry:
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #3
   %1 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %1 to i32
-  %2 = zext i32 %pid to i64
-  %3 = icmp ult i64 %2, 10000
-  %true_cond = icmp ne i1 %3, false
+  %2 = icmp ult i32 %pid, 10000
+  %true_cond = icmp ne i1 %2, false
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %printf_args)
   call void @llvm.memset.p0.i64(ptr align 1 %printf_args, i8 0, i64 8, i1 false)
-  %4 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
-  store i64 0, ptr %4, align 8
+  %3 = getelementptr %printf_t, ptr %printf_args, i32 0, i32 0
+  store i64 0, ptr %3, align 8
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %printf_args, i64 8, i64 0)
   %ringbuf_loss = icmp slt i64 %ringbuf_output, 0
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 right:                                            ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %exit)
-  %5 = getelementptr %exit_t, ptr %exit, i64 0, i32 0
-  store i64 30000, ptr %5, align 8
-  %6 = getelementptr %exit_t, ptr %exit, i64 0, i32 1
-  store i8 0, ptr %6, align 1
+  %4 = getelementptr %exit_t, ptr %exit, i64 0, i32 0
+  store i64 30000, ptr %4, align 8
+  %5 = getelementptr %exit_t, ptr %exit, i64 0, i32 1
+  store i8 0, ptr %5, align 1
   %ringbuf_output1 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %exit, i64 9, i64 0)
   %ringbuf_loss4 = icmp slt i64 %ringbuf_output1, 0
   br i1 %ringbuf_loss4, label %event_loss_counter2, label %counter_merge3
 
 event_loss_counter:                               ; preds = %left
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
-  %7 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %7
-  %8 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
-  %9 = load i64, ptr %8, align 8
-  %10 = add i64 %9, 1
-  store i64 %10, ptr %8, align 8
+  %6 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %6
+  %7 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %8 = load i64, ptr %7, align 8
+  %9 = add i64 %8, 1
+  store i64 %9, ptr %7, align 8
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %left
@@ -63,12 +62,12 @@ counter_merge:                                    ; preds = %event_loss_counter,
 
 event_loss_counter2:                              ; preds = %right
   %get_cpu_id5 = call i64 inttoptr (i64 8 to ptr)() #3
-  %11 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded6 = and i64 %get_cpu_id5, %11
-  %12 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded6, i64 0
-  %13 = load i64, ptr %12, align 8
-  %14 = add i64 %13, 1
-  store i64 %14, ptr %12, align 8
+  %10 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded6 = and i64 %get_cpu_id5, %10
+  %11 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded6, i64 0
+  %12 = load i64, ptr %11, align 8
+  %13 = add i64 %12, 1
+  store i64 %13, ptr %11, align 8
   br label %counter_merge3
 
 counter_merge3:                                   ; preds = %event_loss_counter2, %right

--- a/tests/codegen/llvm/ternary_str.ll
+++ b/tests/codegen/llvm/ternary_str.ll
@@ -30,9 +30,8 @@ entry:
   %get_pid_tgid = call i64 inttoptr (i64 14 to ptr)() #3
   %3 = lshr i64 %get_pid_tgid, 32
   %pid = trunc i64 %3 to i32
-  %4 = zext i32 %pid to i64
-  %5 = icmp ult i64 %4, 10000
-  %true_cond = icmp ne i1 %5, false
+  %4 = icmp ult i32 %pid, 10000
+  %true_cond = icmp ne i1 %4, false
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry

--- a/tests/codegen/llvm/ternary_tuple.ll
+++ b/tests/codegen/llvm/ternary_tuple.ll
@@ -4,8 +4,8 @@ target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr }
-%"string[16]_int64__tuple_t" = type { [16 x i8], i64 }
-%"string[3]_int64__tuple_t" = type { [3 x i8], i64 }
+%"string[16]_uint8__tuple_t" = type { [16 x i8], i8 }
+%"string[3]_uint8__tuple_t" = type { [3 x i8], i8 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @ringbuf = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
@@ -20,52 +20,54 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
-  %"$x" = alloca %"string[16]_int64__tuple_t", align 8
+  %"$x" = alloca %"string[16]_uint8__tuple_t", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$x", i8 0, i64 24, i1 false)
-  %tuple1 = alloca %"string[16]_int64__tuple_t", align 8
-  %tuple = alloca %"string[3]_int64__tuple_t", align 8
-  %1 = alloca %"string[16]_int64__tuple_t", align 8
+  call void @llvm.memset.p0.i64(ptr align 1 %"$x", i8 0, i64 17, i1 false)
+  %tuple1 = alloca %"string[16]_uint8__tuple_t", align 8
+  %tuple = alloca %"string[3]_uint8__tuple_t", align 8
+  %1 = alloca %"string[16]_uint8__tuple_t", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %1)
-  call void @llvm.memset.p0.i64(ptr align 1 %1, i8 0, i64 24, i1 false)
+  call void @llvm.memset.p0.i64(ptr align 1 %1, i8 0, i64 17, i1 false)
   %get_ns = call i64 inttoptr (i64 125 to ptr)()
   %true_cond = icmp ne i64 %get_ns, 0
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %2 = getelementptr %"string[3]_int64__tuple_t", ptr %tuple, i32 0, i32 0
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 4, i1 false)
+  %2 = getelementptr %"string[3]_uint8__tuple_t", ptr %tuple, i32 0, i32 0
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 @hi, i64 3, i1 false)
-  %3 = getelementptr %"string[3]_int64__tuple_t", ptr %tuple, i32 0, i32 1
-  store i64 1, ptr %3, align 8
-  %4 = getelementptr [16 x i8], ptr %tuple, i64 0, i64 0
-  %5 = getelementptr %"string[16]_int64__tuple_t", ptr %1, i32 0, i32 0
+  %3 = getelementptr %"string[3]_uint8__tuple_t", ptr %tuple, i32 0, i32 1
+  store i8 1, ptr %3, align 1
+  %4 = getelementptr [4 x i8], ptr %tuple, i64 0, i64 0
+  %5 = getelementptr %"string[16]_uint8__tuple_t", ptr %1, i32 0, i32 0
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %5, ptr align 1 %4, i64 3, i1 false)
-  %6 = getelementptr [16 x i8], ptr %tuple, i64 0, i64 8
-  %7 = getelementptr %"string[16]_int64__tuple_t", ptr %1, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %7, ptr align 1 %6, i64 8, i1 false)
+  %6 = getelementptr [4 x i8], ptr %tuple, i64 0, i64 3
+  %7 = getelementptr %"string[16]_uint8__tuple_t", ptr %1, i32 0, i32 1
+  %8 = load i8, ptr %6, align 1
+  store i8 %8, ptr %7, align 1
   br label %done
 
 right:                                            ; preds = %entry
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple1)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple1, i8 0, i64 24, i1 false)
-  %8 = getelementptr %"string[16]_int64__tuple_t", ptr %tuple1, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 @extralongstring, i64 16, i1 false)
-  %9 = getelementptr %"string[16]_int64__tuple_t", ptr %tuple1, i32 0, i32 1
-  store i64 2, ptr %9, align 8
-  %10 = getelementptr [24 x i8], ptr %tuple1, i64 0, i64 0
-  %11 = getelementptr %"string[16]_int64__tuple_t", ptr %1, i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %11, ptr align 1 %10, i64 16, i1 false)
-  %12 = getelementptr [24 x i8], ptr %tuple1, i64 0, i64 16
-  %13 = getelementptr %"string[16]_int64__tuple_t", ptr %1, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %13, ptr align 1 %12, i64 8, i1 false)
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple1, i8 0, i64 17, i1 false)
+  %9 = getelementptr %"string[16]_uint8__tuple_t", ptr %tuple1, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %9, ptr align 1 @extralongstring, i64 16, i1 false)
+  %10 = getelementptr %"string[16]_uint8__tuple_t", ptr %tuple1, i32 0, i32 1
+  store i8 2, ptr %10, align 1
+  %11 = getelementptr [17 x i8], ptr %tuple1, i64 0, i64 0
+  %12 = getelementptr %"string[16]_uint8__tuple_t", ptr %1, i32 0, i32 0
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %12, ptr align 1 %11, i64 16, i1 false)
+  %13 = getelementptr [17 x i8], ptr %tuple1, i64 0, i64 16
+  %14 = getelementptr %"string[16]_uint8__tuple_t", ptr %1, i32 0, i32 1
+  %15 = load i8, ptr %13, align 1
+  store i8 %15, ptr %14, align 1
   br label %done
 
 done:                                             ; preds = %right, %left
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple1)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$x", ptr align 1 %1, i64 24, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$x", ptr align 1 %1, i64 17, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %1)
   ret i64 0
 }

--- a/tests/codegen/llvm/tuple.ll
+++ b/tests/codegen/llvm/tuple.ll
@@ -5,7 +5,7 @@ target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.163" = type { ptr, ptr }
-%"int64_int64_string[4]__tuple_t" = type { i64, i64, [4 x i8] }
+%"uint8_uint8_string[4]__tuple_t" = type { i8, i8, [4 x i8] }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_t = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
@@ -21,14 +21,14 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !52 {
 entry:
   %"@t_key" = alloca i64, align 8
-  %tuple = alloca %"int64_int64_string[4]__tuple_t", align 8
+  %tuple = alloca %"uint8_uint8_string[4]__tuple_t", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 24, i1 false)
-  %1 = getelementptr %"int64_int64_string[4]__tuple_t", ptr %tuple, i32 0, i32 0
-  store i64 1, ptr %1, align 8
-  %2 = getelementptr %"int64_int64_string[4]__tuple_t", ptr %tuple, i32 0, i32 1
-  store i64 2, ptr %2, align 8
-  %3 = getelementptr %"int64_int64_string[4]__tuple_t", ptr %tuple, i32 0, i32 2
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 6, i1 false)
+  %1 = getelementptr %"uint8_uint8_string[4]__tuple_t", ptr %tuple, i32 0, i32 0
+  store i8 1, ptr %1, align 1
+  %2 = getelementptr %"uint8_uint8_string[4]__tuple_t", ptr %tuple, i32 0, i32 1
+  store i8 2, ptr %2, align 1
+  %3 = getelementptr %"uint8_uint8_string[4]__tuple_t", ptr %tuple, i32 0, i32 2
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %3, ptr align 1 @str, i64 4, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@t_key")
   store i64 0, ptr %"@t_key", align 8
@@ -81,11 +81,11 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
 !22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
-!23 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 192, elements: !24)
+!23 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 48, elements: !24)
 !24 = !{!25, !26, !27}
-!25 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !20, size: 64)
-!26 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !20, size: 64, offset: 64)
-!27 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !3, size: 32, offset: 128)
+!25 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !4, size: 8)
+!26 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !4, size: 8, offset: 8)
+!27 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !3, size: 32, offset: 16)
 !28 = !DIGlobalVariableExpression(var: !29, expr: !DIExpression())
 !29 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !30, isLocal: false, isDefinition: true)
 !30 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !31)

--- a/tests/codegen/llvm/tuple_bytearray.ll
+++ b/tests/codegen/llvm/tuple_bytearray.ll
@@ -5,7 +5,7 @@ target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.163" = type { ptr, ptr }
-%uint8_usym_t_int64__tuple_t = type { i8, [16 x i8], i64 }
+%uint8_usym_t_uint8__tuple_t = type { i8, [16 x i8], i8 }
 %usym_t = type { i64, i32, i32 }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
@@ -21,7 +21,7 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !55 {
 entry:
   %"@t_key" = alloca i64, align 8
-  %tuple = alloca %uint8_usym_t_int64__tuple_t, align 8
+  %tuple = alloca %uint8_usym_t_uint8__tuple_t, align 8
   %usym = alloca %usym_t, align 8
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 128
@@ -37,13 +37,13 @@ entry:
   store i32 %pid, ptr %5, align 4
   store i32 0, ptr %6, align 4
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 32, i1 false)
-  %7 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %tuple, i32 0, i32 0
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 18, i1 false)
+  %7 = getelementptr %uint8_usym_t_uint8__tuple_t, ptr %tuple, i32 0, i32 0
   store i8 1, ptr %7, align 1
-  %8 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %tuple, i32 0, i32 1
+  %8 = getelementptr %uint8_usym_t_uint8__tuple_t, ptr %tuple, i32 0, i32 1
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 %usym, i64 16, i1 false)
-  %9 = getelementptr %uint8_usym_t_int64__tuple_t, ptr %tuple, i32 0, i32 2
-  store i64 10, ptr %9, align 8
+  %9 = getelementptr %uint8_usym_t_uint8__tuple_t, ptr %tuple, i32 0, i32 2
+  store i8 10, ptr %9, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@t_key")
   store i64 0, ptr %"@t_key", align 8
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_t, ptr %"@t_key", ptr %tuple, i64 0)
@@ -100,14 +100,14 @@ attributes #5 = { memory(none) }
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
 !22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
-!23 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 256, elements: !24)
+!23 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 144, elements: !24)
 !24 = !{!25, !26, !30}
 !25 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !4, size: 8)
 !26 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !27, size: 128, offset: 8)
 !27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 128, elements: !28)
 !28 = !{!29}
 !29 = !DISubrange(count: 16, lowerBound: 0)
-!30 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !20, size: 64, offset: 192)
+!30 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !4, size: 8, offset: 136)
 !31 = !DIGlobalVariableExpression(var: !32, expr: !DIExpression())
 !32 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !33, isLocal: false, isDefinition: true)
 !33 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !34)

--- a/tests/codegen/llvm/tuple_map_val_different_sizes.ll
+++ b/tests/codegen/llvm/tuple_map_val_different_sizes.ll
@@ -5,8 +5,8 @@ target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr, ptr, ptr }
 %"struct map_internal_repr_t.163" = type { ptr, ptr }
-%"int64_string[13]__tuple_t" = type { i64, [13 x i8] }
-%"int64_string[3]__tuple_t" = type { i64, [3 x i8] }
+%"uint8_string[13]__tuple_t" = type { i8, [13 x i8] }
+%"uint8_string[3]__tuple_t" = type { i8, [3 x i8] }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_a = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
@@ -23,36 +23,37 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !54 {
 entry:
   %"@a_key2" = alloca i64, align 8
-  %tuple1 = alloca %"int64_string[13]__tuple_t", align 8
-  %"@a_val" = alloca %"int64_string[13]__tuple_t", align 8
+  %tuple1 = alloca %"uint8_string[13]__tuple_t", align 8
+  %"@a_val" = alloca %"uint8_string[13]__tuple_t", align 8
   %"@a_key" = alloca i64, align 8
-  %tuple = alloca %"int64_string[3]__tuple_t", align 8
+  %tuple = alloca %"uint8_string[3]__tuple_t", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %1 = getelementptr %"int64_string[3]__tuple_t", ptr %tuple, i32 0, i32 0
-  store i64 1, ptr %1, align 8
-  %2 = getelementptr %"int64_string[3]__tuple_t", ptr %tuple, i32 0, i32 1
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 4, i1 false)
+  %1 = getelementptr %"uint8_string[3]__tuple_t", ptr %tuple, i32 0, i32 0
+  store i8 1, ptr %1, align 1
+  %2 = getelementptr %"uint8_string[3]__tuple_t", ptr %tuple, i32 0, i32 1
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 @hi, i64 3, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key")
   store i64 0, ptr %"@a_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_val")
-  call void @llvm.memset.p0.i64(ptr align 1 %"@a_val", i8 0, i64 24, i1 false)
-  %3 = getelementptr [16 x i8], ptr %tuple, i64 0, i64 0
-  %4 = getelementptr %"int64_string[13]__tuple_t", ptr %"@a_val", i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %3, i64 8, i1 false)
-  %5 = getelementptr [16 x i8], ptr %tuple, i64 0, i64 8
-  %6 = getelementptr %"int64_string[13]__tuple_t", ptr %"@a_val", i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 %5, i64 3, i1 false)
+  call void @llvm.memset.p0.i64(ptr align 1 %"@a_val", i8 0, i64 14, i1 false)
+  %3 = getelementptr [4 x i8], ptr %tuple, i64 0, i64 0
+  %4 = getelementptr %"uint8_string[13]__tuple_t", ptr %"@a_val", i32 0, i32 0
+  %5 = load i8, ptr %3, align 1
+  store i8 %5, ptr %4, align 1
+  %6 = getelementptr [4 x i8], ptr %tuple, i64 0, i64 1
+  %7 = getelementptr %"uint8_string[13]__tuple_t", ptr %"@a_val", i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %7, ptr align 1 %6, i64 3, i1 false)
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key", ptr %"@a_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@a_key")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple1)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple1, i8 0, i64 24, i1 false)
-  %7 = getelementptr %"int64_string[13]__tuple_t", ptr %tuple1, i32 0, i32 0
-  store i64 1, ptr %7, align 8
-  %8 = getelementptr %"int64_string[13]__tuple_t", ptr %tuple1, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 @hellolongstr, i64 13, i1 false)
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple1, i8 0, i64 14, i1 false)
+  %8 = getelementptr %"uint8_string[13]__tuple_t", ptr %tuple1, i32 0, i32 0
+  store i8 1, ptr %8, align 1
+  %9 = getelementptr %"uint8_string[13]__tuple_t", ptr %tuple1, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %9, ptr align 1 @hellolongstr, i64 13, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@a_key2")
   store i64 0, ptr %"@a_key2", align 8
   %update_elem3 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_a, ptr %"@a_key2", ptr %tuple1, i64 0)
@@ -104,10 +105,10 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
 !22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
-!23 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 192, elements: !24)
+!23 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 112, elements: !24)
 !24 = !{!25, !26}
-!25 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !20, size: 64)
-!26 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !27, size: 104, offset: 64)
+!25 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !4, size: 8)
+!26 = !DIDerivedType(tag: DW_TAG_member, scope: !2, file: !2, baseType: !27, size: 104, offset: 8)
 !27 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 104, elements: !28)
 !28 = !{!29}
 !29 = !DISubrange(count: 13, lowerBound: 0)

--- a/tests/codegen/llvm/tuple_scratch_buf.ll
+++ b/tests/codegen/llvm/tuple_scratch_buf.ll
@@ -4,13 +4,13 @@ target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr }
-%"int64_string[5]__tuple_t" = type { i64, [5 x i8] }
+%"uint8_string[5]__tuple_t" = type { i8, [5 x i8] }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @ringbuf = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
 @__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !22
 @__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !29
-@__bt__tuple_buf = dso_local externally_initialized global [1 x [1 x [16 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !31
+@__bt__tuple_buf = dso_local externally_initialized global [1 x [1 x [6 x i8]]] zeroinitializer, section ".data.tuple_buf", !dbg !31
 @xxxx = global [5 x i8] c"xxxx\00"
 
 ; Function Attrs: nounwind
@@ -22,11 +22,11 @@ entry:
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %1
-  %2 = getelementptr [1 x [1 x [16 x i8]]], ptr @__bt__tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 16, i1 false)
-  %3 = getelementptr %"int64_string[5]__tuple_t", ptr %2, i32 0, i32 0
-  store i64 1, ptr %3, align 8
-  %4 = getelementptr %"int64_string[5]__tuple_t", ptr %2, i32 0, i32 1
+  %2 = getelementptr [1 x [1 x [6 x i8]]], ptr @__bt__tuple_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  call void @llvm.memset.p0.i64(ptr align 1 %2, i8 0, i64 6, i1 false)
+  %3 = getelementptr %"uint8_string[5]__tuple_t", ptr %2, i32 0, i32 0
+  store i8 1, ptr %3, align 1
+  %4 = getelementptr %"uint8_string[5]__tuple_t", ptr %2, i32 0, i32 1
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 @xxxx, i64 5, i1 false)
   ret i64 0
 }
@@ -78,11 +78,11 @@ attributes #3 = { memory(none) }
 !30 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
 !31 = !DIGlobalVariableExpression(var: !32, expr: !DIExpression())
 !32 = distinct !DIGlobalVariable(name: "__bt__tuple_buf", linkageName: "global", scope: !2, file: !2, type: !33, isLocal: false, isDefinition: true)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !34, size: 128, elements: !27)
-!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !35, size: 128, elements: !27)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 128, elements: !36)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !34, size: 48, elements: !27)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !35, size: 48, elements: !27)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 48, elements: !36)
 !36 = !{!37}
-!37 = !DISubrange(count: 16, lowerBound: 0)
+!37 = !DISubrange(count: 6, lowerBound: 0)
 !38 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !39)
 !39 = !{!0, !7, !22, !29, !31}
 !40 = !{i32 2, !"Debug Info Version", i32 3}

--- a/tests/codegen/llvm/tuple_stack.ll
+++ b/tests/codegen/llvm/tuple_stack.ll
@@ -4,7 +4,7 @@ target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr }
-%"int64_string[5]__tuple_t" = type { i64, [5 x i8] }
+%"uint8_string[5]__tuple_t" = type { i8, [5 x i8] }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @ringbuf = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
@@ -18,12 +18,12 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
-  %tuple = alloca %"int64_string[5]__tuple_t", align 8
+  %tuple = alloca %"uint8_string[5]__tuple_t", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %1 = getelementptr %"int64_string[5]__tuple_t", ptr %tuple, i32 0, i32 0
-  store i64 1, ptr %1, align 8
-  %2 = getelementptr %"int64_string[5]__tuple_t", ptr %tuple, i32 0, i32 1
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 6, i1 false)
+  %1 = getelementptr %"uint8_string[5]__tuple_t", ptr %tuple, i32 0, i32 0
+  store i8 1, ptr %1, align 1
+  %2 = getelementptr %"uint8_string[5]__tuple_t", ptr %tuple, i32 0, i32 1
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 @xxxx, i64 5, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   ret i64 0

--- a/tests/codegen/llvm/tuple_variable_different_sizes.ll
+++ b/tests/codegen/llvm/tuple_variable_different_sizes.ll
@@ -4,8 +4,8 @@ target datalayout = "e-m:e-p:64:64-i64:64-i128:128-n32:64-S128"
 target triple = "bpf"
 
 %"struct map_internal_repr_t" = type { ptr, ptr }
-%"int64_string[13]__tuple_t" = type { i64, [13 x i8] }
-%"int64_string[3]__tuple_t" = type { i64, [3 x i8] }
+%"uint8_string[13]__tuple_t" = type { i8, [13 x i8] }
+%"uint8_string[3]__tuple_t" = type { i8, [3 x i8] }
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @ringbuf = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
@@ -20,32 +20,33 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
-  %tuple1 = alloca %"int64_string[13]__tuple_t", align 8
-  %"$t" = alloca %"int64_string[13]__tuple_t", align 8
+  %tuple1 = alloca %"uint8_string[13]__tuple_t", align 8
+  %"$t" = alloca %"uint8_string[13]__tuple_t", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$t")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 24, i1 false)
-  %tuple = alloca %"int64_string[3]__tuple_t", align 8
+  call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 14, i1 false)
+  %tuple = alloca %"uint8_string[3]__tuple_t", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 16, i1 false)
-  %1 = getelementptr %"int64_string[3]__tuple_t", ptr %tuple, i32 0, i32 0
-  store i64 1, ptr %1, align 8
-  %2 = getelementptr %"int64_string[3]__tuple_t", ptr %tuple, i32 0, i32 1
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple, i8 0, i64 4, i1 false)
+  %1 = getelementptr %"uint8_string[3]__tuple_t", ptr %tuple, i32 0, i32 0
+  store i8 1, ptr %1, align 1
+  %2 = getelementptr %"uint8_string[3]__tuple_t", ptr %tuple, i32 0, i32 1
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %2, ptr align 1 @hi, i64 3, i1 false)
-  call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 24, i1 false)
-  %3 = getelementptr [16 x i8], ptr %tuple, i64 0, i64 0
-  %4 = getelementptr %"int64_string[13]__tuple_t", ptr %"$t", i32 0, i32 0
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %4, ptr align 1 %3, i64 8, i1 false)
-  %5 = getelementptr [16 x i8], ptr %tuple, i64 0, i64 8
-  %6 = getelementptr %"int64_string[13]__tuple_t", ptr %"$t", i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 %5, i64 3, i1 false)
+  call void @llvm.memset.p0.i64(ptr align 1 %"$t", i8 0, i64 14, i1 false)
+  %3 = getelementptr [4 x i8], ptr %tuple, i64 0, i64 0
+  %4 = getelementptr %"uint8_string[13]__tuple_t", ptr %"$t", i32 0, i32 0
+  %5 = load i8, ptr %3, align 1
+  store i8 %5, ptr %4, align 1
+  %6 = getelementptr [4 x i8], ptr %tuple, i64 0, i64 1
+  %7 = getelementptr %"uint8_string[13]__tuple_t", ptr %"$t", i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %7, ptr align 1 %6, i64 3, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %tuple1)
-  call void @llvm.memset.p0.i64(ptr align 1 %tuple1, i8 0, i64 24, i1 false)
-  %7 = getelementptr %"int64_string[13]__tuple_t", ptr %tuple1, i32 0, i32 0
-  store i64 1, ptr %7, align 8
-  %8 = getelementptr %"int64_string[13]__tuple_t", ptr %tuple1, i32 0, i32 1
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %8, ptr align 1 @hellolongstr, i64 13, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$t", ptr align 1 %tuple1, i64 24, i1 false)
+  call void @llvm.memset.p0.i64(ptr align 1 %tuple1, i8 0, i64 14, i1 false)
+  %8 = getelementptr %"uint8_string[13]__tuple_t", ptr %tuple1, i32 0, i32 0
+  store i8 1, ptr %8, align 1
+  %9 = getelementptr %"uint8_string[13]__tuple_t", ptr %tuple1, i32 0, i32 1
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %9, ptr align 1 @hellolongstr, i64 13, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$t", ptr align 1 %tuple1, i64 14, i1 false)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %tuple1)
   ret i64 0
 }

--- a/tests/codegen/llvm/unroll.ll
+++ b/tests/codegen/llvm/unroll.ll
@@ -55,8 +55,8 @@ entry:
   br i1 %map_lookup_cond, label %lookup_success, label %lookup_failure
 
 lookup_success:                                   ; preds = %entry
-  %1 = load ptr, ptr %lookup_elem, align 8
-  store ptr %1, ptr %lookup_elem_val, align 8
+  %1 = load i64, ptr %lookup_elem, align 8
+  store i64 %1, ptr %lookup_elem_val, align 8
   br label %lookup_merge
 
 lookup_failure:                                   ; preds = %entry
@@ -83,8 +83,8 @@ lookup_merge:                                     ; preds = %lookup_failure, %lo
   br i1 %map_lookup_cond11, label %lookup_success7, label %lookup_failure8
 
 lookup_success7:                                  ; preds = %lookup_merge
-  %4 = load ptr, ptr %lookup_elem6, align 8
-  store ptr %4, ptr %lookup_elem_val10, align 8
+  %4 = load i64, ptr %lookup_elem6, align 8
+  store i64 %4, ptr %lookup_elem_val10, align 8
   br label %lookup_merge9
 
 lookup_failure8:                                  ; preds = %lookup_merge
@@ -111,8 +111,8 @@ lookup_merge9:                                    ; preds = %lookup_failure8, %l
   br i1 %map_lookup_cond21, label %lookup_success17, label %lookup_failure18
 
 lookup_success17:                                 ; preds = %lookup_merge9
-  %7 = load ptr, ptr %lookup_elem16, align 8
-  store ptr %7, ptr %lookup_elem_val20, align 8
+  %7 = load i64, ptr %lookup_elem16, align 8
+  store i64 %7, ptr %lookup_elem_val20, align 8
   br label %lookup_merge19
 
 lookup_failure18:                                 ; preds = %lookup_merge9
@@ -139,8 +139,8 @@ lookup_merge19:                                   ; preds = %lookup_failure18, %
   br i1 %map_lookup_cond31, label %lookup_success27, label %lookup_failure28
 
 lookup_success27:                                 ; preds = %lookup_merge19
-  %10 = load ptr, ptr %lookup_elem26, align 8
-  store ptr %10, ptr %lookup_elem_val30, align 8
+  %10 = load i64, ptr %lookup_elem26, align 8
+  store i64 %10, ptr %lookup_elem_val30, align 8
   br label %lookup_merge29
 
 lookup_failure28:                                 ; preds = %lookup_merge19
@@ -167,8 +167,8 @@ lookup_merge29:                                   ; preds = %lookup_failure28, %
   br i1 %map_lookup_cond41, label %lookup_success37, label %lookup_failure38
 
 lookup_success37:                                 ; preds = %lookup_merge29
-  %13 = load ptr, ptr %lookup_elem36, align 8
-  store ptr %13, ptr %lookup_elem_val40, align 8
+  %13 = load i64, ptr %lookup_elem36, align 8
+  store i64 %13, ptr %lookup_elem_val40, align 8
   br label %lookup_merge39
 
 lookup_failure38:                                 ; preds = %lookup_merge29

--- a/tests/codegen/llvm/variable_assign_array.ll
+++ b/tests/codegen/llvm/variable_assign_array.ll
@@ -9,17 +9,17 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !22
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !36
-@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !40
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !24
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !38
+@__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !42
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !46 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !48 {
 entry:
-  %"@x_val" = alloca i64, align 8
+  %"@x_val" = alloca i32, align 4
   %"@x_key" = alloca i64, align 8
   %array_access = alloca i32, align 4
   %runtime_error_t = alloca %runtime_error_t, align 8
@@ -61,8 +61,7 @@ oob_merge:                                        ; preds = %counter_merge, %ent
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
   store i64 0, ptr %"@x_key", align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  %16 = sext i32 %15 to i64
-  store i64 %16, ptr %"@x_val", align 8
+  store i32 %15, ptr %"@x_val", align 4
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"@x_key", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
@@ -70,12 +69,12 @@ oob_merge:                                        ; preds = %counter_merge, %ent
 
 event_loss_counter:                               ; preds = %is_oob
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #3
-  %17 = load i64, ptr @__bt__max_cpu_id, align 8
-  %cpu.id.bounded = and i64 %get_cpu_id, %17
-  %18 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
-  %19 = load i64, ptr %18, align 8
-  %20 = add i64 %19, 1
-  store i64 %20, ptr %18, align 8
+  %16 = load i64, ptr @__bt__max_cpu_id, align 8
+  %cpu.id.bounded = and i64 %get_cpu_id, %16
+  %17 = getelementptr [1 x [1 x i64]], ptr @__bt__event_loss_counter, i64 0, i64 %cpu.id.bounded, i64 0
+  %18 = load i64, ptr %17, align 8
+  %19 = add i64 %18, 1
+  store i64 %19, ptr %17, align 8
   br label %counter_merge
 
 counter_merge:                                    ; preds = %event_loss_counter, %is_oob
@@ -97,8 +96,8 @@ attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memo
 attributes #2 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
 attributes #3 = { memory(none) }
 
-!llvm.dbg.cu = !{!42}
-!llvm.module.flags = !{!44, !45}
+!llvm.dbg.cu = !{!44}
+!llvm.module.flags = !{!46, !47}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -121,34 +120,36 @@ attributes #3 = { memory(none) }
 !18 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !19, size: 64, offset: 128)
 !19 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !20, size: 64)
 !20 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !19, size: 64, offset: 192)
-!22 = !DIGlobalVariableExpression(var: !23, expr: !DIExpression())
-!23 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !24, isLocal: false, isDefinition: true)
-!24 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !25)
-!25 = !{!26, !31}
-!26 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !27, size: 64)
-!27 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !28, size: 64)
-!28 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !29)
-!29 = !{!30}
-!30 = !DISubrange(count: 27, lowerBound: 0)
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !32, size: 64, offset: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 262144, lowerBound: 0)
-!36 = !DIGlobalVariableExpression(var: !37, expr: !DIExpression())
-!37 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !38, isLocal: false, isDefinition: true)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !39, size: 64, elements: !15)
-!39 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
-!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
-!41 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
-!42 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !43)
-!43 = !{!0, !7, !22, !36, !40}
-!44 = !{i32 2, !"Debug Info Version", i32 3}
-!45 = !{i32 7, !"uwtable", i32 0}
-!46 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !47, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !42, retainedNodes: !50)
-!47 = !DISubroutineType(types: !48)
-!48 = !{!20, !49}
-!49 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!50 = !{!51}
-!51 = !DILocalVariable(name: "ctx", arg: 1, scope: !46, file: !2, type: !49)
+!21 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !22, size: 64, offset: 192)
+!22 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !23, size: 64)
+!23 = !DIBasicType(name: "int32", size: 32, encoding: DW_ATE_signed)
+!24 = !DIGlobalVariableExpression(var: !25, expr: !DIExpression())
+!25 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!26 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !27)
+!27 = !{!28, !33}
+!28 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !29, size: 64)
+!29 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !30, size: 64)
+!30 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !31)
+!31 = !{!32}
+!32 = !DISubrange(count: 27, lowerBound: 0)
+!33 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !34, size: 64, offset: 64)
+!34 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !35, size: 64)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !36)
+!36 = !{!37}
+!37 = !DISubrange(count: 262144, lowerBound: 0)
+!38 = !DIGlobalVariableExpression(var: !39, expr: !DIExpression())
+!39 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !40, isLocal: false, isDefinition: true)
+!40 = !DICompositeType(tag: DW_TAG_array_type, baseType: !41, size: 64, elements: !15)
+!41 = !DICompositeType(tag: DW_TAG_array_type, baseType: !20, size: 64, elements: !15)
+!42 = !DIGlobalVariableExpression(var: !43, expr: !DIExpression())
+!43 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !20, isLocal: false, isDefinition: true)
+!44 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !45)
+!45 = !{!0, !7, !24, !38, !42}
+!46 = !{i32 2, !"Debug Info Version", i32 3}
+!47 = !{i32 7, !"uwtable", i32 0}
+!48 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !49, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !44, retainedNodes: !52)
+!49 = !DISubroutineType(types: !50)
+!50 = !{!20, !51}
+!51 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!52 = !{!53}
+!53 = !DILocalVariable(name: "ctx", arg: 1, scope: !48, file: !2, type: !51)

--- a/tests/codegen/llvm/variable_map_key_lifetime.ll
+++ b/tests/codegen/llvm/variable_map_key_lifetime.ll
@@ -8,8 +8,8 @@ target triple = "bpf"
 
 @LICENSE = global [4 x i8] c"GPL\00", section "license", !dbg !0
 @AT_x = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
-@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !27
-@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !41
+@ringbuf = dso_local global %"struct map_internal_repr_t.163" zeroinitializer, section ".maps", !dbg !26
+@__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !40
 @__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !45
 @abc = global [4 x i8] c"abc\00"
 
@@ -19,18 +19,18 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @begin_1(ptr %0) #0 section "s_begin_1" !dbg !51 {
 entry:
-  %"@x_val1" = alloca i64, align 8
-  %"@x_val" = alloca i64, align 8
+  %"@x_val1" = alloca i8, align 1
+  %"@x_val" = alloca i8, align 1
   %"$myvar" = alloca [4 x i8], align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$myvar")
   call void @llvm.memset.p0.i64(ptr align 1 %"$myvar", i8 0, i64 4, i1 false)
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$myvar", ptr align 1 @abc, i64 4, i1 false)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val")
-  store i64 1, ptr %"@x_val", align 8
+  store i8 1, ptr %"@x_val", align 1
   %update_elem = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"$myvar", ptr %"@x_val", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_val1")
-  store i64 1, ptr %"@x_val1", align 8
+  store i8 1, ptr %"@x_val1", align 1
   %update_elem2 = call i64 inttoptr (i64 2 to ptr)(ptr @AT_x, ptr %"$myvar", ptr %"@x_val1", i64 0)
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_val1")
   ret i64 0
@@ -81,35 +81,34 @@ attributes #3 = { nocallback nofree nounwind willreturn memory(argmem: readwrite
 !22 = !DIDerivedType(tag: DW_TAG_member, name: "key", scope: !2, file: !2, baseType: !23, size: 64, offset: 128)
 !23 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !3, size: 64)
 !24 = !DIDerivedType(tag: DW_TAG_member, name: "value", scope: !2, file: !2, baseType: !25, size: 64, offset: 192)
-!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !26, size: 64)
-!26 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
-!27 = !DIGlobalVariableExpression(var: !28, expr: !DIExpression())
-!28 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !29, isLocal: false, isDefinition: true)
-!29 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !30)
-!30 = !{!31, !36}
-!31 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !32, size: 64)
-!32 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !33, size: 64)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !34)
-!34 = !{!35}
-!35 = !DISubrange(count: 27, lowerBound: 0)
-!36 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !37, size: 64, offset: 64)
-!37 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !38, size: 64)
-!38 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !39)
-!39 = !{!40}
-!40 = !DISubrange(count: 262144, lowerBound: 0)
-!41 = !DIGlobalVariableExpression(var: !42, expr: !DIExpression())
-!42 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !43, isLocal: false, isDefinition: true)
+!25 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!26 = !DIGlobalVariableExpression(var: !27, expr: !DIExpression())
+!27 = distinct !DIGlobalVariable(name: "ringbuf", linkageName: "global", scope: !2, file: !2, type: !28, isLocal: false, isDefinition: true)
+!28 = !DICompositeType(tag: DW_TAG_structure_type, scope: !2, file: !2, size: 128, elements: !29)
+!29 = !{!30, !35}
+!30 = !DIDerivedType(tag: DW_TAG_member, name: "type", scope: !2, file: !2, baseType: !31, size: 64)
+!31 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !32, size: 64)
+!32 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 864, elements: !33)
+!33 = !{!34}
+!34 = !DISubrange(count: 27, lowerBound: 0)
+!35 = !DIDerivedType(tag: DW_TAG_member, name: "max_entries", scope: !2, file: !2, baseType: !36, size: 64, offset: 64)
+!36 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !37, size: 64)
+!37 = !DICompositeType(tag: DW_TAG_array_type, baseType: !14, size: 8388608, elements: !38)
+!38 = !{!39}
+!39 = !DISubrange(count: 262144, lowerBound: 0)
+!40 = !DIGlobalVariableExpression(var: !41, expr: !DIExpression())
+!41 = distinct !DIGlobalVariable(name: "__bt__event_loss_counter", linkageName: "global", scope: !2, file: !2, type: !42, isLocal: false, isDefinition: true)
+!42 = !DICompositeType(tag: DW_TAG_array_type, baseType: !43, size: 64, elements: !15)
 !43 = !DICompositeType(tag: DW_TAG_array_type, baseType: !44, size: 64, elements: !15)
-!44 = !DICompositeType(tag: DW_TAG_array_type, baseType: !26, size: 64, elements: !15)
+!44 = !DIBasicType(name: "int64", size: 64, encoding: DW_ATE_signed)
 !45 = !DIGlobalVariableExpression(var: !46, expr: !DIExpression())
-!46 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
+!46 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !44, isLocal: false, isDefinition: true)
 !47 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !48)
-!48 = !{!0, !7, !27, !41, !45}
+!48 = !{!0, !7, !26, !40, !45}
 !49 = !{i32 2, !"Debug Info Version", i32 3}
 !50 = !{i32 7, !"uwtable", i32 0}
-!51 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !55)
+!51 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !52, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !47, retainedNodes: !54)
 !52 = !DISubroutineType(types: !53)
-!53 = !{!26, !54}
-!54 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!55 = !{!56}
-!56 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !54)
+!53 = !{!44, !25}
+!54 = !{!55}
+!55 = !DILocalVariable(name: "ctx", arg: 1, scope: !51, file: !2, type: !25)

--- a/tests/codegen/llvm/variable_scratch_buf.ll
+++ b/tests/codegen/llvm/variable_scratch_buf.ll
@@ -9,24 +9,24 @@ target triple = "bpf"
 @ringbuf = dso_local global %"struct map_internal_repr_t" zeroinitializer, section ".maps", !dbg !7
 @__bt__event_loss_counter = dso_local externally_initialized global [1 x [1 x i64]] zeroinitializer, section ".data.event_loss_counter", !dbg !22
 @__bt__max_cpu_id = dso_local externally_initialized constant i64 0, section ".rodata", !dbg !29
-@__bt__var_buf = dso_local externally_initialized global [1 x [2 x [8 x i8]]] zeroinitializer, section ".data.var_buf", !dbg !31
+@__bt__var_buf = dso_local externally_initialized global [1 x [2 x [1 x i8]]] zeroinitializer, section ".data.var_buf", !dbg !31
 
 ; Function Attrs: nounwind
 declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 
 ; Function Attrs: nounwind
-define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !44 {
+define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !42 {
 entry:
   %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)() #2
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded2 = and i64 %get_cpu_id1, %1
-  %2 = getelementptr [1 x [2 x [8 x i8]]], ptr @__bt__var_buf, i64 0, i64 %cpu.id.bounded2, i64 1, i64 0
-  store i64 0, ptr %2, align 8
+  %2 = getelementptr [1 x [2 x [1 x i8]]], ptr @__bt__var_buf, i64 0, i64 %cpu.id.bounded2, i64 1, i64 0
+  store i8 0, ptr %2, align 1
   %get_cpu_id = call i64 inttoptr (i64 8 to ptr)() #2
   %3 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded = and i64 %get_cpu_id, %3
-  %4 = getelementptr [1 x [2 x [8 x i8]]], ptr @__bt__var_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
-  store i64 0, ptr %4, align 8
+  %4 = getelementptr [1 x [2 x [1 x i8]]], ptr @__bt__var_buf, i64 0, i64 %cpu.id.bounded, i64 0, i64 0
+  store i8 0, ptr %4, align 1
   %5 = call ptr @llvm.preserve.static.offset(ptr %0)
   %6 = getelementptr i8, ptr %5, i64 112
   %arg0 = load volatile i64, ptr %6, align 8
@@ -35,11 +35,11 @@ entry:
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
-  store i64 1, ptr %4, align 8
+  store i8 1, ptr %4, align 1
   ret i64 0
 
 right:                                            ; preds = %entry
-  store i64 2, ptr %2, align 8
+  store i8 2, ptr %2, align 1
   ret i64 0
 }
 
@@ -50,8 +50,8 @@ attributes #0 = { nounwind }
 attributes #1 = { nocallback nofree nosync nounwind speculatable willreturn memory(none) }
 attributes #2 = { memory(none) }
 
-!llvm.dbg.cu = !{!40}
-!llvm.module.flags = !{!42, !43}
+!llvm.dbg.cu = !{!38}
+!llvm.module.flags = !{!40, !41}
 
 !0 = !DIGlobalVariableExpression(var: !1, expr: !DIExpression())
 !1 = distinct !DIGlobalVariable(name: "LICENSE", linkageName: "global", scope: !2, file: !2, type: !3, isLocal: false, isDefinition: true)
@@ -86,20 +86,18 @@ attributes #2 = { memory(none) }
 !30 = distinct !DIGlobalVariable(name: "__bt__max_cpu_id", linkageName: "global", scope: !2, file: !2, type: !26, isLocal: false, isDefinition: true)
 !31 = !DIGlobalVariableExpression(var: !32, expr: !DIExpression())
 !32 = distinct !DIGlobalVariable(name: "__bt__var_buf", linkageName: "global", scope: !2, file: !2, type: !33, isLocal: false, isDefinition: true)
-!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !34, size: 128, elements: !27)
-!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !35, size: 128, elements: !38)
-!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 64, elements: !36)
+!33 = !DICompositeType(tag: DW_TAG_array_type, baseType: !34, size: 16, elements: !27)
+!34 = !DICompositeType(tag: DW_TAG_array_type, baseType: !35, size: 16, elements: !36)
+!35 = !DICompositeType(tag: DW_TAG_array_type, baseType: !4, size: 8, elements: !27)
 !36 = !{!37}
-!37 = !DISubrange(count: 8, lowerBound: 0)
-!38 = !{!39}
-!39 = !DISubrange(count: 2, lowerBound: 0)
-!40 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !41)
-!41 = !{!0, !7, !22, !29, !31}
-!42 = !{i32 2, !"Debug Info Version", i32 3}
-!43 = !{i32 7, !"uwtable", i32 0}
-!44 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !45, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !40, retainedNodes: !48)
-!45 = !DISubroutineType(types: !46)
-!46 = !{!26, !47}
-!47 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
-!48 = !{!49}
-!49 = !DILocalVariable(name: "ctx", arg: 1, scope: !44, file: !2, type: !47)
+!37 = !DISubrange(count: 2, lowerBound: 0)
+!38 = distinct !DICompileUnit(language: DW_LANG_C, file: !2, producer: "bpftrace", isOptimized: false, runtimeVersion: 0, emissionKind: LineTablesOnly, globals: !39)
+!39 = !{!0, !7, !22, !29, !31}
+!40 = !{i32 2, !"Debug Info Version", i32 3}
+!41 = !{i32 7, !"uwtable", i32 0}
+!42 = distinct !DISubprogram(name: "kprobe_f_1", linkageName: "kprobe_f_1", scope: !2, file: !2, type: !43, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !38, retainedNodes: !46)
+!43 = !DISubroutineType(types: !44)
+!44 = !{!26, !45}
+!45 = !DIDerivedType(tag: DW_TAG_pointer_type, baseType: !4, size: 64)
+!46 = !{!47}
+!47 = !DILocalVariable(name: "ctx", arg: 1, scope: !42, file: !2, type: !45)

--- a/tests/codegen/llvm/variable_stack.ll
+++ b/tests/codegen/llvm/variable_stack.ll
@@ -16,12 +16,12 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 ; Function Attrs: nounwind
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
-  %"$x1" = alloca i64, align 8
+  %"$x1" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x1")
-  store i64 0, ptr %"$x1", align 8
-  %"$x" = alloca i64, align 8
+  store i8 0, ptr %"$x1", align 1
+  %"$x" = alloca i8, align 1
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"$x")
-  store i64 0, ptr %"$x", align 8
+  store i8 0, ptr %"$x", align 1
   %1 = call ptr @llvm.preserve.static.offset(ptr %0)
   %2 = getelementptr i8, ptr %1, i64 112
   %arg0 = load volatile i64, ptr %2, align 8
@@ -30,11 +30,11 @@ entry:
   br i1 %true_cond, label %left, label %right
 
 left:                                             ; preds = %entry
-  store i64 1, ptr %"$x", align 8
+  store i8 1, ptr %"$x", align 1
   ret i64 0
 
 right:                                            ; preds = %entry
-  store i64 2, ptr %"$x1", align 8
+  store i8 2, ptr %"$x1", align 1
   ret i64 0
 }
 

--- a/tests/codegen/llvm/while_loop_no_unroll.ll
+++ b/tests/codegen/llvm/while_loop_no_unroll.ll
@@ -28,7 +28,7 @@ entry:
 
 while_cond:                                       ; preds = %while_body, %entry
   %1 = load i64, ptr %"$a", align 8
-  %2 = icmp sle i64 %1, 10
+  %2 = icmp ule i64 %1, 10
   %true_cond = icmp ne i1 %2, false
   br i1 %true_cond, label %while_body, label %while_end, !llvm.loop !52
 

--- a/tests/resource_analyser.cpp
+++ b/tests/resource_analyser.cpp
@@ -69,7 +69,7 @@ TEST(resource_analyser, fmt_string_args_size_ints)
 {
   RequiredResources resources;
   test(R"(begin { printf("%d %d", 3, 4) })", true, &resources);
-  EXPECT_EQ(resources.max_fmtstring_args_size, 24);
+  EXPECT_EQ(resources.max_fmtstring_args_size, 16);
 }
 
 TEST(resource_analyser, fmt_string_args_below_on_stack_limit)
@@ -96,14 +96,14 @@ TEST(resource_analyser, fmt_string_args_size_strings)
       R"(begin { printf("%dst: %sa; %dnd: %sb;; %drd: %sc;;; %dth: %sd;;;;\n", 1, "a", 2, "ab", 3, "abc", 4, "abcd") })",
       true,
       &resources);
-  EXPECT_EQ(resources.max_fmtstring_args_size, 72);
+  EXPECT_EQ(resources.max_fmtstring_args_size, 32);
 }
 
 TEST(resource_analyser, fmt_string_args_non_map_print_int)
 {
   RequiredResources resources;
   test(R"(begin { print(5) })", true, &resources);
-  EXPECT_EQ(resources.max_fmtstring_args_size, 24);
+  EXPECT_EQ(resources.max_fmtstring_args_size, 17);
 }
 
 TEST(resource_analyser, fmt_string_args_non_map_print_arr)

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -355,7 +355,7 @@ WILL_FAIL
 
 NAME has_key error type mismatch
 PROG begin { @g[1, "hi"] = 2; if (has_key(@g, (1, 2))) { printf("ok\n"); }  }
-EXPECT_REGEX .* ERROR: Argument mismatch for @g: trying to access with arguments: '\(int64,int64\)' when map expects arguments: '\(int64,string\[3\]\)'.*
+EXPECT_REGEX .* ERROR: Argument mismatch for @g: trying to access with arguments: '\(uint8,uint8\)' when map expects arguments: '\(uint8,string\[3\]\)'.*
 WILL_FAIL
 
 NAME exit code

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -160,7 +160,7 @@ EXPECT ERROR: failed to open file '/does/not/exist/file': No such file or direct
 
 NAME sizeof
 PROG struct Foo { int x; char c; } begin { $x = 1; printf("%d %d %d %d %d\n", sizeof(struct Foo), sizeof((*(struct Foo*)0).x), sizeof((*(struct Foo*)0).c), sizeof(1 == 1), sizeof($x));  }
-EXPECT 8 4 1 1 8
+EXPECT 8 4 1 1 1
 
 NAME sizeof_ints
 PROG begin { printf("%d %d %d %d %d %d\n", sizeof(uint8), sizeof(int8), sizeof(uint16), sizeof(int16), sizeof(uint32), sizeof(int32));  }

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -694,7 +694,7 @@ EXPECT 12
 TIMEOUT 1
 
 NAME bswap_int64_op
-RUN {{BPFTRACE}} -e 'begin { printf("%llx", bswap(0x12340000 + 0x5678));  }'
+RUN {{BPFTRACE}} -e 'begin { printf("%llx", bswap(0x12340000 + (uint64)0x5678));  }'
 EXPECT 7856341200000000
 TIMEOUT 1
 

--- a/tests/runtime/tuples
+++ b/tests/runtime/tuples
@@ -66,7 +66,7 @@ EXPECT 8
 
 NAME complex tuple 4
 PROG begin { $a = ((int8)-100, (int8) 100, "abcdef", 3, (int32) 1, (int64)-10, (int8)10, (int16)-555, "abc"); print(sizeof($a));  }
-EXPECT 48
+EXPECT 32
 
 NAME struct in tuple
 PROG struct Foo { int m; int n; } u:./testprogs/simple_struct:func { @t = (1, *((struct Foo *)arg0)); exit(); }

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -347,12 +347,12 @@ TEST_F(SemanticAnalyserTest, consistent_map_values)
   test(
       R"(begin { $a = (3, "hello"); @m[1] = $a; $a = (1,"aaaaaaaaaa"); @m[2] = $a; })");
   test("kprobe:f { @x = 0; @x = \"a\"; }", Error{ R"(
-stdin:1:20-28: ERROR: Type mismatch for @x: trying to assign value of type 'string[2]' when map already contains a value of type 'int64'
+stdin:1:20-28: ERROR: Type mismatch for @x: trying to assign value of type 'string[2]' when map already contains a value of type 'uint8'
 kprobe:f { @x = 0; @x = "a"; }
                    ~~~~~~~~
 )" });
   test("kprobe:f { @x = 0; @x = *curtask; }", Error{ R"(
-stdin:1:20-33: ERROR: Type mismatch for @x: trying to assign value of type 'struct task_struct' when map already contains a value of type 'int64'
+stdin:1:20-33: ERROR: Type mismatch for @x: trying to assign value of type 'struct task_struct' when map already contains a value of type 'uint8'
 kprobe:f { @x = 0; @x = *curtask; }
                    ~~~~~~~~~~~~~
 )" });
@@ -381,12 +381,12 @@ begin { @x[1] = 0; @x; }
   test("begin { @x[1, ((int8)2, ((int16)3, 4))] = 0; @x[5, (6, (7, 8))]; }");
 
   test("begin { @x[1,2] = 0; @x[3]; }", Error{ R"(
-stdin:1:25-26: ERROR: Argument mismatch for @x: trying to access with arguments: 'int64' when map expects arguments: '(int64,int64)'
+stdin:1:25-26: ERROR: Argument mismatch for @x: trying to access with arguments: 'uint8' when map expects arguments: '(uint8,uint8)'
 begin { @x[1,2] = 0; @x[3]; }
                         ~
 )" });
   test("begin { @x[1] = 0; @x[2,3]; }", Error{ R"(
-stdin:1:20-27: ERROR: Argument mismatch for @x: trying to access with arguments: '(int64,int64)' when map expects arguments: 'int64'
+stdin:1:20-27: ERROR: Argument mismatch for @x: trying to access with arguments: '(uint8,uint8)' when map expects arguments: 'uint8'
 begin { @x[1] = 0; @x[2,3]; }
                    ~~~~~~~
 )" });
@@ -399,7 +399,7 @@ begin { @x[1] = 0; @x[2,3]; }
       @x["b", 2, kstack];
     })",
        Error{ R"(
-stdin:3:7-25: ERROR: Argument mismatch for @x: trying to access with arguments: '(string[2],int64,kstack)' when map expects arguments: '(int64,string[2],kstack)'
+stdin:3:7-25: ERROR: Argument mismatch for @x: trying to access with arguments: '(string[2],uint8,kstack)' when map expects arguments: '(uint8,string[2],kstack)'
       @x["b", 2, kstack];
       ~~~~~~~~~~~~~~~~~~
 )" });
@@ -413,7 +413,7 @@ kprobe:f { @[1] = 5; @[2] = 10; delete(@); }
 
   test(R"(begin { @map[1, 2] = 1; for ($kv : @map) { @map[$kv.0.0] = 2; } })",
        Error{ R"(
-stdin:1:55-56: ERROR: Argument mismatch for @map: trying to access with arguments: 'int64' when map expects arguments: '(int64,int64)'
+stdin:1:55-56: ERROR: Argument mismatch for @map: trying to access with arguments: 'uint8' when map expects arguments: '(uint8,uint8)'
 begin { @map[1, 2] = 1; for ($kv : @map) { @map[$kv.0.0] = 2; } }
                                                       ~
 )" });
@@ -516,25 +516,25 @@ TEST_F(SemanticAnalyserTest, ternary_expressions)
   // Error location is incorrect: #3063
   test("kprobe:f { $x = pid < 10000 ? 3 : cat(\"/proc/uptime\"); exit(); }",
        Error{ R"(
-stdin:1:17-54: ERROR: Branches must return the same type: have 'int64' and 'none'
+stdin:1:17-54: ERROR: Branches must return the same type: have 'uint8' and 'none'
 kprobe:f { $x = pid < 10000 ? 3 : cat("/proc/uptime"); exit(); }
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
   // Error location is incorrect: #3063
   test("kprobe:f { @x = pid < 10000 ? 1 : \"high\" }", Error{ R"(
-stdin:1:17-41: ERROR: Branches must return the same type: have 'int64' and 'string[5]'
+stdin:1:17-41: ERROR: Branches must return the same type: have 'uint8' and 'string[5]'
 kprobe:f { @x = pid < 10000 ? 1 : "high" }
                 ~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
   // Error location is incorrect: #3063
   test("kprobe:f { @x = pid < 10000 ? \"lo\" : 2 }", Error{ R"(
-stdin:1:17-39: ERROR: Branches must return the same type: have 'string[3]' and 'int64'
+stdin:1:17-39: ERROR: Branches must return the same type: have 'string[3]' and 'uint8'
 kprobe:f { @x = pid < 10000 ? "lo" : 2 }
                 ~~~~~~~~~~~~~~~~~~~~~~
 )" });
   // Error location is incorrect: #3063
   test("kprobe:f { @x = pid < 10000 ? (1, 2) : (\"a\", 4) }", Error{ R"(
-stdin:1:17-48: ERROR: Branches must return the same type: have '(int64,int64)' and '(string[2],int64)'
+stdin:1:17-48: ERROR: Branches must return the same type: have '(uint8,uint8)' and '(string[2],uint8)'
 kprobe:f { @x = pid < 10000 ? (1, 2) : ("a", 4) }
                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
@@ -555,7 +555,7 @@ kprobe:f { @x = pid < 10000 ? kstack(raw) : kstack(perf) }
 TEST_F(SemanticAnalyserTest, mismatched_call_types)
 {
   test("kprobe:f { @x = 1; @x = count(); }", Error{ R"(
-stdin:1:25-32: ERROR: Type mismatch for @x: trying to assign value of type 'count_t' when map already contains a value of type 'int64'
+stdin:1:25-32: ERROR: Type mismatch for @x: trying to assign value of type 'count_t' when map already contains a value of type 'uint8'
 kprobe:f { @x = 1; @x = count(); }
                         ~~~~~~~
 )" });
@@ -567,7 +567,7 @@ kprobe:f { @x = count(); @x = sum(pid); }
                               ~~~~~~~~
 )" });
   test("kprobe:f { @x = 1; @x = hist(0); }", Error{ R"(
-stdin:1:25-32: ERROR: Type mismatch for @x: trying to assign value of type 'hist_t' when map already contains a value of type 'int64'
+stdin:1:25-32: ERROR: Type mismatch for @x: trying to assign value of type 'hist_t' when map already contains a value of type 'uint8'
 kprobe:f { @x = 1; @x = hist(0); }
                         ~~~~~~~
 )" });
@@ -1007,7 +1007,7 @@ TEST_F(SemanticAnalyserTest, call_delete)
   test("kprobe:f { @y[5] = 5; delete(@y, "
        "(int8)5); }");
   test("kprobe:f { @y[5, 4] = 5; delete(@y, "
-       "((int8)5, (int64)4)); }");
+       "((int8)5, (int32)4)); }");
 
   test("kprobe:f { delete(1); }", Error{ R"(
 stdin:1:19-20: ERROR: delete() expects a map argument
@@ -1024,7 +1024,7 @@ kprobe:f { delete(1, 1); }
   test("kprobe:f { @y[(3, 4, 5)] = "
        "5; delete(@y, (1, 2)); }",
        Error{ R"(
-stdin:1:42-48: ERROR: Argument mismatch for @y: trying to access with arguments: '(int64,int64)' when map expects arguments: '(int64,int64,int64)'
+stdin:1:42-48: ERROR: Argument mismatch for @y: trying to access with arguments: '(uint8,uint8)' when map expects arguments: '(uint8,uint8,uint8)'
 kprobe:f { @y[(3, 4, 5)] = 5; delete(@y, (1, 2)); }
                                          ~~~~~~
 )" });
@@ -1059,7 +1059,7 @@ kprobe:f { @x = 1; @y = 5; delete(@x, @y); }
 )" });
 
   test(R"(kprobe:f { @x[1, "hi"] = 1; delete(@x["hi", 1]); })", Error{ R"(
-stdin:1:36-47: ERROR: Argument mismatch for @x: trying to access with arguments: '(string[3],int64)' when map expects arguments: '(int64,string[3])'
+stdin:1:36-47: ERROR: Argument mismatch for @x: trying to access with arguments: '(string[3],uint8)' when map expects arguments: '(uint8,string[3])'
 kprobe:f { @x[1, "hi"] = 1; delete(@x["hi", 1]); }
                                    ~~~~~~~~~~~
 )" });
@@ -1143,7 +1143,7 @@ TEST_F(SemanticAnalyserTest, call_print_map_item)
   test(R"_(begin { @x[1,2] = "asdf"; print((1, 2, @x[1,2])); })_");
 
   test("begin { @x[1] = 1; print(@x[\"asdf\"]); }", Error{ R"(
-stdin:1:34-35: ERROR: Argument mismatch for @x: trying to access with arguments: 'string[5]' when map expects arguments: 'int64'
+stdin:1:34-35: ERROR: Argument mismatch for @x: trying to access with arguments: 'string[5]' when map expects arguments: 'uint8'
 begin { @x[1] = 1; print(@x["asdf"]); }
                                  ~
 )" });
@@ -1263,14 +1263,14 @@ kprobe:f { @x = 1;  if (has_key(@x, 1)) {} }
 )" });
 
   test("kprobe:f { @x[1, 2] = 1;  if (has_key(@x, 1)) {} }", Error{ R"(
-stdin:1:43-44: ERROR: Argument mismatch for @x: trying to access with arguments: 'int64' when map expects arguments: '(int64,int64)'
+stdin:1:43-44: ERROR: Argument mismatch for @x: trying to access with arguments: 'uint8' when map expects arguments: '(uint8,uint8)'
 kprobe:f { @x[1, 2] = 1;  if (has_key(@x, 1)) {} }
                                           ~
 )" });
 
   test(R"(kprobe:f { @x[1, "hi"] = 0; if (has_key(@x, (2, 1))) {} })",
        Error{ R"(
-stdin:1:45-51: ERROR: Argument mismatch for @x: trying to access with arguments: '(int64,int64)' when map expects arguments: '(int64,string[3])'
+stdin:1:45-51: ERROR: Argument mismatch for @x: trying to access with arguments: '(uint8,uint8)' when map expects arguments: '(uint8,string[3])'
 kprobe:f { @x[1, "hi"] = 0; if (has_key(@x, (2, 1))) {} }
                                             ~~~~~~
 )" });
@@ -1737,7 +1737,7 @@ TEST_F(SemanticAnalyserTest, variable_reassignment)
   test(R"(kprobe:f { $b = "hi"; $b = @b; } kprobe:g { @b = "bye"; })");
 
   test(R"(kprobe:f { $b = "hi"; $b = @b; } kprobe:g { @b = 1; })", Error{ R"(
-stdin:1:23-30: ERROR: Type mismatch for $b: trying to assign value of type 'int64' when variable already contains a value of type 'string[3]'
+stdin:1:23-30: ERROR: Type mismatch for $b: trying to assign value of type 'uint8' when variable already contains a value of type 'string[3]'
 kprobe:f { $b = "hi"; $b = @b; } kprobe:g { @b = 1; }
                       ~~~~~~~
 )" });
@@ -1783,7 +1783,10 @@ TEST_F(SemanticAnalyserTest, array_access)
        Error{});
   test("struct MyStruct { int y[4]; } "
        "kprobe:f { $s = (struct MyStruct *) "
-       "arg0; $idx = 0; @x = $s->y[$idx];}",
+       "arg0; $idx = 0; @x = $s->y[$idx];}");
+  test("struct MyStruct { int y[4]; } "
+       "kprobe:f { $s = (struct MyStruct *) "
+       "arg0; $idx = -1; @x = $s->y[$idx];}",
        Error{});
   test("kprobe:f { $s = arg0; @x = $s[0]; }", Error{});
   test("struct MyStruct { void *y; } "
@@ -1795,7 +1798,7 @@ TEST_F(SemanticAnalyserTest, array_access)
                   "arg0; @x = $s->y[0];}");
   auto *assignment =
       ast.root->probes.at(0)->block->stmts.at(1).as<ast::AssignMapStatement>();
-  EXPECT_EQ(CreateInt64(), assignment->map->value_type);
+  EXPECT_EQ(CreateInt32(), assignment->map->value_type);
 
   ast = test("struct MyStruct { int y[4]; "
              "} kprobe:f { $s = ((struct "
@@ -1868,19 +1871,12 @@ TEST_F(SemanticAnalyserTest, array_as_map_key)
   test("struct MyStruct { int x[2]; int y[4]; }"
        "kprobe:f { @x[((struct MyStruct *)arg0)->x, "
        "              ((struct MyStruct *)arg0)->y] = 0; }");
-
-  // Mismatched key types
   test(R"(
     struct MyStruct { int x[2]; int y[4]; }
     begin {
       @x[((struct MyStruct *)0)->x] = 0;
       @x[((struct MyStruct *)0)->y] = 1;
-    })",
-       Error{ R"(
-stdin:4:32-34: ERROR: Argument mismatch for @x: trying to access with arguments: 'int32[4]' when map expects arguments: 'int32[2]'
-      @x[((struct MyStruct *)0)->y] = 1;
-                               ~~
-)" });
+    })");
 }
 
 TEST_F(SemanticAnalyserTest, array_compare)
@@ -1919,7 +1915,7 @@ TEST_F(SemanticAnalyserTest, array_compare)
 TEST_F(SemanticAnalyserTest, variable_type)
 {
   auto ast = test("kprobe:f { $x = 1 }");
-  auto st = CreateInt64();
+  auto st = CreateUInt8();
   auto *assignment =
       ast.root->probes.at(0)->block->stmts.at(0).as<ast::AssignVarStatement>();
   EXPECT_EQ(st, assignment->var()->var_type);
@@ -1956,25 +1952,7 @@ TEST_F(SemanticAnalyserTest, map_integer_sizes)
   auto *map_assignment =
       ast.root->probes.at(0)->block->stmts.at(1).as<ast::AssignMapStatement>();
   EXPECT_EQ(CreateInt32(), var_assignment->var()->var_type);
-  EXPECT_EQ(CreateInt64(), map_assignment->map->value_type);
-}
-
-TEST_F(SemanticAnalyserTest, binop_integer_promotion)
-{
-  auto ast = test("kprobe:f { $x = (int32)5 + (int16)6 }");
-
-  auto *var_assignment =
-      ast.root->probes.at(0)->block->stmts.at(0).as<ast::AssignVarStatement>();
-  EXPECT_EQ(CreateInt32(), var_assignment->var()->var_type);
-}
-
-TEST_F(SemanticAnalyserTest, binop_integer_no_promotion)
-{
-  auto ast = test("kprobe:f { $x = (int8)5 + (int8)6 }");
-
-  auto *var_assignment =
-      ast.root->probes.at(0)->block->stmts.at(0).as<ast::AssignVarStatement>();
-  EXPECT_EQ(CreateInt8(), var_assignment->var()->var_type);
+  EXPECT_EQ(CreateInt32(), map_assignment->map->value_type);
 }
 
 TEST_F(SemanticAnalyserTest, binop_tuple)
@@ -2413,39 +2391,39 @@ kprobe:f { @y = count(); @x = @y; }
 HINT: Add a cast to integer if you want the value of the aggregate, e.g. `@x = (int64)@y;`.
 )" });
   test("kprobe:f { @y = sum(5); @x = @y; }", Error{ R"(
-stdin:1:25-32: ERROR: Map value 'sum_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = sum(retval);`.
+stdin:1:25-32: ERROR: Map value 'usum_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = sum(retval);`.
 kprobe:f { @y = sum(5); @x = @y; }
                         ~~~~~~~
 HINT: Add a cast to integer if you want the value of the aggregate, e.g. `@x = (int64)@y;`.
 )" });
   test("kprobe:f { @y = min(5); @x = @y; }", Error{ R"(
-stdin:1:25-32: ERROR: Map value 'min_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = min(retval);`.
+stdin:1:25-32: ERROR: Map value 'umin_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = min(retval);`.
 kprobe:f { @y = min(5); @x = @y; }
                         ~~~~~~~
 HINT: Add a cast to integer if you want the value of the aggregate, e.g. `@x = (int64)@y;`.
 )" });
   test("kprobe:f { @y = max(5); @x = @y; }", Error{ R"(
-stdin:1:25-32: ERROR: Map value 'max_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = max(retval);`.
+stdin:1:25-32: ERROR: Map value 'umax_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = max(retval);`.
 kprobe:f { @y = max(5); @x = @y; }
                         ~~~~~~~
 HINT: Add a cast to integer if you want the value of the aggregate, e.g. `@x = (int64)@y;`.
 )" });
   test("kprobe:f { @y = avg(5); @x = @y; }", Error{ R"(
-stdin:1:25-32: ERROR: Map value 'avg_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = avg(retval);`.
+stdin:1:25-32: ERROR: Map value 'uavg_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = avg(retval);`.
 kprobe:f { @y = avg(5); @x = @y; }
                         ~~~~~~~
 HINT: Add a cast to integer if you want the value of the aggregate, e.g. `@x = (int64)@y;`.
 )" });
   test("kprobe:f { @y = stats(5); @x = @y; }", Error{ R"(
-stdin:1:27-34: ERROR: Map value 'stats_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = stats(arg2);`.
+stdin:1:27-34: ERROR: Map value 'ustats_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = stats(arg2);`.
 kprobe:f { @y = stats(5); @x = @y; }
                           ~~~~~~~
 )" });
   test("kprobe:f { @x = 1; @y = stats(5); @x = @y; }", Error{ R"(
-stdin:1:35-42: ERROR: Map value 'stats_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = stats(arg2);`.
+stdin:1:35-42: ERROR: Map value 'ustats_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@x = stats(arg2);`.
 kprobe:f { @x = 1; @y = stats(5); @x = @y; }
                                   ~~~~~~~
-stdin:1:35-42: ERROR: Type mismatch for @x: trying to assign value of type 'stats_t' when map already contains a value of type 'int64'
+stdin:1:35-42: ERROR: Type mismatch for @x: trying to assign value of type 'ustats_t' when map already contains a value of type 'uint8'
 kprobe:f { @x = 1; @y = stats(5); @x = @y; }
                                   ~~~~~~~
 )" });
@@ -2457,13 +2435,13 @@ kprobe:f { @x = 1; @y = stats(5); @x = @y; }
   test("kprobe:f { @ = avg(5); if (@ > 0) { print((1)); } }");
 
   test("kprobe:f { @ = hist(5); if (@ > 0) { print((1)); } }", Error{ R"(
-stdin:1:31-32: ERROR: Type mismatch for '>': comparing hist_t with int64
+stdin:1:31-32: ERROR: Type mismatch for '>': comparing hist_t with uint8
 kprobe:f { @ = hist(5); if (@ > 0) { print((1)); } }
                               ~
 stdin:1:29-30: ERROR: left (hist_t)
 kprobe:f { @ = hist(5); if (@ > 0) { print((1)); } }
                             ~
-stdin:1:33-34: ERROR: right (int64)
+stdin:1:33-34: ERROR: right (uint8)
 kprobe:f { @ = hist(5); if (@ > 0) { print((1)); } }
                                 ~
 )" });
@@ -2728,25 +2706,25 @@ TEST_F(SemanticAnalyserTest, per_cpu_map_as_map_key)
   test("begin { @x = avg(1); @y[@x] = 1; }");
 
   test("begin { @x = hist(10); @y[@x] = 1; }", Error{ R"(
-stdin:1:27-29: ERROR: hist_t cannot be used as a map key
+stdin:1:27-29: ERROR: hist_t cannot be part of a map key
 begin { @x = hist(10); @y[@x] = 1; }
                           ~~
 )" });
 
   test("begin { @x = lhist(10, 0, 10, 1); @y[@x] = 1; }", Error{ R"(
-stdin:1:38-40: ERROR: lhist_t cannot be used as a map key
+stdin:1:38-40: ERROR: lhist_t cannot be part of a map key
 begin { @x = lhist(10, 0, 10, 1); @y[@x] = 1; }
                                      ~~
 )" });
 
   test("begin { @x = tseries(10, 1s, 10); @y[@x] = 1; }", Error{ R"(
-stdin:1:38-40: ERROR: tseries_t cannot be used as a map key
+stdin:1:38-40: ERROR: tseries_t cannot be part of a map key
 begin { @x = tseries(10, 1s, 10); @y[@x] = 1; }
                                      ~~
 )" });
 
   test("begin { @x = stats(10); @y[@x] = 1; }", Error{ R"(
-stdin:1:28-30: ERROR: stats_t cannot be used as a map key
+stdin:1:28-30: ERROR: ustats_t cannot be part of a map key
 begin { @x = stats(10); @y[@x] = 1; }
                            ~~
 )" });
@@ -3034,7 +3012,7 @@ TEST_F(SemanticAnalyserTest, binop_arithmetic)
     auto *varB = ast.root->probes.at(0)
                      ->block->stmts.at(2)
                      .as<ast::AssignVarStatement>();
-    EXPECT_EQ(CreateUInt64(), varB->var()->var_type);
+    EXPECT_EQ(CreateInt64(), varB->var()->var_type);
     auto *varC = ast.root->probes.at(0)
                      ->block->stmts.at(3)
                      .as<ast::AssignVarStatement>();
@@ -3142,6 +3120,8 @@ TEST_F(SemanticAnalyserTest, intptr_cast_usage)
 TEST_F(SemanticAnalyserTest, intarray_cast_types)
 {
   test("kprobe:f { @ = (int8[8])1 }");
+  test("kprobe:f { @ = (int8[4])1 }");
+  test("kprobe:f { @ = (int8[2])1 }");
   test("kprobe:f { @ = (int16[4])1 }");
   test("kprobe:f { @ = (int32[2])1 }");
   test("kprobe:f { @ = (int64[1])1 }");
@@ -3152,7 +3132,6 @@ TEST_F(SemanticAnalyserTest, intarray_cast_types)
   test("kprobe:f { @ = (uint8[8])1 }");
   test("kretprobe:f { @ = (int8[8])retval }");
 
-  test("kprobe:f { @ = (int8[4])1 }", Error{});
   test("kprobe:f { @ = (int32[])(int16)1 }", Error{});
   test("kprobe:f { @ = (int8[6])\"hello\" }", Error{});
 
@@ -3162,10 +3141,10 @@ TEST_F(SemanticAnalyserTest, intarray_cast_types)
 TEST_F(SemanticAnalyserTest, bool_array_cast_types)
 {
   test("kprobe:f { @ = (bool[8])1 }");
+  test("kprobe:f { @ = (bool[4])1 }");
   test("kprobe:f { @ = (bool[4])(uint32)1 }");
   test("kprobe:f { @ = (bool[2])(uint16)1 }");
 
-  test("kprobe:f { @ = (bool[4])1 }", Error{});
   test("kprobe:f { @ = (bool[64])1 }", Error{});
 }
 
@@ -3208,71 +3187,47 @@ TEST_F(SemanticAnalyserTest, mixed_int_var_assignments)
   test("kprobe:f { $x = (uint8)1; $x = 200; }");
   test("kprobe:f { $x = (int8)1; $x = -2; }");
   test("kprobe:f { $x = (int16)1; $x = 20000; }");
-  // We'd like the below to work, but
-  // blocked on #3518. TLDR: It looks like a
-  // literal and thus amenable to static
-  // "fits into" checks. But it's not, the
-  // parser has actually desugared it to:
-  //    AssignVarStatement(Variable,
-  //    Binop(Variable, Integer(1)))
-  // test("kprobe:f { $x = (uint32)5; $x +=
-  // 1; }");
+  test("kprobe:f { $x = (uint32)5; $x += 1; }");
+  test("kprobe:f { $x = (uint8)1; $x = -1; }");
+  test("kprobe:f { $x = (int16)1; $x = 100000; }");
+  test("kprobe:f { $a = (uint16)5; $x = (uint8)0; $x = $a; }");
+  test("kprobe:f { $a = (int8)-1; $x = (uint8)0; $x = $a; }");
 
-  test("kprobe:f { $x = (uint8)1; $x = -1; }", Error{ R"(
-stdin:1:27-34: ERROR: Type mismatch for $x: trying to assign value of type 'int64' when variable already contains a value of type 'uint8'
-kprobe:f { $x = (uint8)1; $x = -1; }
-                          ~~~~~~~
-)" });
-  test("kprobe:f { $x = (int16)1; $x = 100000; }", Error{ R"(
-stdin:1:27-38: ERROR: Type mismatch for $x: trying to assign value '100000' which does not fit into the variable of type 'int16'
-kprobe:f { $x = (int16)1; $x = 100000; }
-                          ~~~~~~~~~~~
-)" });
-  test("kprobe:f { $a = (uint16)5; $x = (uint8)0; $x = $a; }", Error{ R"(
-stdin:1:43-50: ERROR: Integer size mismatch. Assignment type 'uint16' is larger than the variable type 'uint8'.
-kprobe:f { $a = (uint16)5; $x = (uint8)0; $x = $a; }
-                                          ~~~~~~~
-)" });
-  test("kprobe:f { $a = (int8)-1; $x = (uint8)0; $x = $a; }", Error{ R"(
-stdin:1:42-49: ERROR: Type mismatch for $x: trying to assign value of type 'int8' when variable already contains a value of type 'uint8'
-kprobe:f { $a = (int8)-1; $x = (uint8)0; $x = $a; }
-                                         ~~~~~~~
-)" });
+  // Errors
+  test("begin { $a = -1; $a = (uint64)2; }", Error{});
+  test("begin { $a = (int64)1; $a = (uint64)2; }", Error{});
+  test("begin { $a = -1; $a = 9223372036854775808; }", Error{});
+  test("begin { $a = 9223372036854775807; $a = -2147483648 }", Error{});
   test("kprobe:f { $x = -1; $x = 10223372036854775807; }", Error{ R"(
-stdin:1:21-46: ERROR: Type mismatch for $x: trying to assign value '10223372036854775807' which does not fit into the variable of type 'int64'
+stdin:1:21-46: ERROR: Type mismatch for $x: trying to assign value of type 'uint64' when variable already contains a value of type 'int8'
 kprobe:f { $x = -1; $x = 10223372036854775807; }
                     ~~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
-  test("kprobe:f { $x = (0, (uint32)123); $x = (0, (int32)-123); }", Error{ R"(
-stdin:1:35-56: ERROR: Type mismatch for $x: trying to assign value of type '(int64,int32)' when variable already contains a value of type '(int64,uint32)'
-kprobe:f { $x = (0, (uint32)123); $x = (0, (int32)-123); }
-                                  ~~~~~~~~~~~~~~~~~~~~~
-)" });
-  test("begin { $x = (uint8)1; $x = 5; }",
-       ExpectedAST{ Program().WithProbe(
-           Probe({ "begin" },
-                 { AssignVarStatement(Variable("$x"),
-                                      Cast(Typeof(SizedType(Type::integer)),
-                                           Integer(1))),
-                   AssignVarStatement(Variable("$x"),
-                                      Cast(Typeof(SizedType(Type::integer)),
-                                           Integer(5))),
-                   Jump(ast::JumpType::RETURN) })) });
+
   test("begin { $x = (int8)1; $x = 5; }",
        ExpectedAST{ Program().WithProbe(
            Probe({ "begin" },
                  { AssignVarStatement(Variable("$x"),
                                       Cast(Typeof(SizedType(Type::integer)),
                                            Integer(1))),
-                   AssignVarStatement(Variable("$x"),
-                                      Cast(Typeof(SizedType(Type::integer)),
-                                           Integer(5))),
+                   AssignVarStatement(Variable("$x"), Integer(5)),
                    Jump(ast::JumpType::RETURN) })) });
+  test("begin { $x = (int8)1; $x = (uint8)5; }",
+       ExpectedAST{ Program().WithProbe(Probe(
+           { "begin" },
+           { AssignVarStatement(Variable("$x"),
+                                Cast(Typeof(SizedType(Type::integer)),
+                                     Cast(Typeof(SizedType(Type::integer)),
+                                          Integer(1)))),
+             AssignVarStatement(Variable("$x"),
+                                Cast(Typeof(SizedType(Type::integer)),
+                                     Cast(Typeof(SizedType(Type::integer)),
+                                          Integer(5)))),
+             Jump(ast::JumpType::RETURN) })) });
 }
 
 TEST_F(SemanticAnalyserTest, mixed_int_like_map_assignments)
 {
-  // Map values are automatically promoted to 64bit ints
   test("kprobe:f { @x = (uint64)0; @x = (uint16)1; }");
   test("kprobe:f { @x = (int8)1; @x = 5; }");
   test("kprobe:f { @x = 1; @x = -1; }");
@@ -3282,40 +3237,41 @@ TEST_F(SemanticAnalyserTest, mixed_int_like_map_assignments)
   test("kprobe:f { @x = (uint16)1; @x = 10223372036854775807; }");
   test("kprobe:f { @x = 1; @x = 9223372036854775807; }");
   test("kprobe:f { @x = 1; @x = -9223372036854775808; }");
+  test("kprobe:f { @x = (uint8)1; @x = -1; }");
+  test("kprobe:f { @x = 1; @x = 10223372036854775807; }");
+  test("kprobe:f { @x = sum(1); @x = sum(-1); }");
+  test("kprobe:f { @x = sum((uint32)1); @x = sum(-1); }");
+  test("kprobe:f { @x = avg(1); @x = avg(-1); }");
+  test("kprobe:f { @x = avg((uint32)1); @x = avg(-1); }");
+  test("kprobe:f { @x = min(1); @x = min(-1); }");
+  test("kprobe:f { @x = min((uint32)1); @x = min(-1); }");
+  test("kprobe:f { @x = max(1); @x = max(-1); }");
+  test("kprobe:f { @x = max((uint32)1); @x = max(-1); }");
+  test("kprobe:f { @x = stats(1); @x = stats(-1); }");
+  test("kprobe:f { @x = stats((uint32)1); @x = stats(-1); }");
 
-  test("kprobe:f { @x = (uint8)1; @x = -1; }", Error{ R"(
-stdin:1:27-34: ERROR: Type mismatch for @x: trying to assign value of type 'int64' when map already contains a value of type 'uint64'
-kprobe:f { @x = (uint8)1; @x = -1; }
-                          ~~~~~~~
-)" });
-
-  test("kprobe:f { @x = 1; @x = 10223372036854775807; }", Error{ R"(
-stdin:1:20-45: ERROR: Type mismatch for @x: trying to assign value '10223372036854775807' which does not fit into the map of type 'int64'
-kprobe:f { @x = 1; @x = 10223372036854775807; }
-                   ~~~~~~~~~~~~~~~~~~~~~~~~~
-)" });
   test("kprobe:f { @x = sum((uint64)1); @x = sum(-1); }", Error{ R"(
-stdin:1:38-45: ERROR: Type mismatch for @x: trying to assign value of type 'sum_t' when map already contains a value of type 'usum_t'
+stdin:1:38-45: ERROR: Type mismatch for @x: trying to assign value of type 'int8' when map already contains a value of type 'uint64'
 kprobe:f { @x = sum((uint64)1); @x = sum(-1); }
                                      ~~~~~~~
 )" });
   test("kprobe:f { @x = min((uint64)1); @x = min(-1); }", Error{ R"(
-stdin:1:38-45: ERROR: Type mismatch for @x: trying to assign value of type 'min_t' when map already contains a value of type 'umin_t'
+stdin:1:38-45: ERROR: Type mismatch for @x: trying to assign value of type 'int8' when map already contains a value of type 'uint64'
 kprobe:f { @x = min((uint64)1); @x = min(-1); }
                                      ~~~~~~~
 )" });
   test("kprobe:f { @x = max((uint64)1); @x = max(-1); }", Error{ R"(
-stdin:1:38-45: ERROR: Type mismatch for @x: trying to assign value of type 'max_t' when map already contains a value of type 'umax_t'
+stdin:1:38-45: ERROR: Type mismatch for @x: trying to assign value of type 'int8' when map already contains a value of type 'uint64'
 kprobe:f { @x = max((uint64)1); @x = max(-1); }
                                      ~~~~~~~
 )" });
   test("kprobe:f { @x = avg((uint64)1); @x = avg(-1); }", Error{ R"(
-stdin:1:38-45: ERROR: Type mismatch for @x: trying to assign value of type 'avg_t' when map already contains a value of type 'uavg_t'
+stdin:1:38-45: ERROR: Type mismatch for @x: trying to assign value of type 'int8' when map already contains a value of type 'uint64'
 kprobe:f { @x = avg((uint64)1); @x = avg(-1); }
                                      ~~~~~~~
 )" });
   test("kprobe:f { @x = stats((uint64)1); @x = stats(-1); }", Error{ R"(
-stdin:1:40-49: ERROR: Type mismatch for @x: trying to assign value of type 'stats_t' when map already contains a value of type 'ustats_t'
+stdin:1:40-49: ERROR: Type mismatch for @x: trying to assign value of type 'int8' when map already contains a value of type 'uint64'
 kprobe:f { @x = stats((uint64)1); @x = stats(-1); }
                                        ~~~~~~~~~
 )" });
@@ -3323,8 +3279,8 @@ kprobe:f { @x = stats((uint64)1); @x = stats(-1); }
 
 TEST_F(SemanticAnalyserTest, mixed_int_map_access)
 {
-  // Map keys are automatically promoted to 64bit ints
   test("kprobe:f { @x[1] = 1; @x[(int16)2] }");
+  test("kprobe:f { @x[-1] = 1; @x[1] }");
   test("kprobe:f { @x[(int16)1] = 1; @x[2] }");
   test("kprobe:f { @x[(int16)1] = 1; @x[(int64)2] }");
   test("kprobe:f { @x[(uint16)1] = 1; @x[(uint64)2] }");
@@ -3333,20 +3289,104 @@ TEST_F(SemanticAnalyserTest, mixed_int_map_access)
   test("kprobe:f { @x[(uint16)1] = 1; @x[10223372036854775807] }");
   test("kprobe:f { @x[1] = 1; @x[9223372036854775807] }");
   test("kprobe:f { @x[1] = 1; @x[-9223372036854775808] }");
+  test("kprobe:f { @x[1] = 1; @x[(uint64)1] }");
+  test("kprobe:f { @x[(uint32)-1] = 1; @x[1] }");
+  test("kprobe:f { @x[-1] = 1; @x[(uint32)1] }");
 
-  test("kprobe:f { @x[1] = 1; @x[10223372036854775807] }", Error{ R"(
-stdin:1:26-46: ERROR: Argument mismatch for @x: trying to access with argument '10223372036854775807' which does not fit into the map of key type 'int64'
-kprobe:f { @x[1] = 1; @x[10223372036854775807] }
-                         ~~~~~~~~~~~~~~~~~~~~
+  test("kprobe:f { @x[-1] = 1; @x[10223372036854775807] }", Error{ R"(
+stdin:1:27-47: ERROR: Argument mismatch for @x: trying to access with arguments: 'uint64' when map expects arguments: 'int8'
+kprobe:f { @x[-1] = 1; @x[10223372036854775807] }
+                          ~~~~~~~~~~~~~~~~~~~~
 )" });
   test("kprobe:f { @x[(uint64)1] = 1; @x[-1] }", Error{ R"(
-stdin:1:34-35: ERROR: Argument mismatch for @x: trying to access with arguments: 'int64' when map expects arguments: 'uint64'
+stdin:1:34-35: ERROR: Argument mismatch for @x: trying to access with arguments: 'int8' when map expects arguments: 'uint64'
 kprobe:f { @x[(uint64)1] = 1; @x[-1] }
                                  ~
 )" });
-  test("kretprobe:f { @x[1] = 1; @x[(uint64)1] }", Error{ R"(
-ERROR: Argument mismatch for @x: trying to access with arguments: 'uint64' when map expects arguments: 'int64'
+  test("kretprobe:f { @x[-1] = 1; @x[(uint64)1] }", Error{ R"(
+ERROR: Argument mismatch for @x: trying to access with arguments: 'uint64' when map expects arguments: 'int8'
 )" });
+}
+
+TEST_F(SemanticAnalyserTest, mixed_int_like_binop)
+{
+  test("kprobe:f { $a = 1 == -1; }", NoWarning{ "comparison of integers" });
+  test("kprobe:f { $a = 1 == (int64)-1; }",
+       NoWarning{ "comparison of integers" });
+  test("kprobe:f { $a = (uint32)1 == (int32)-1; }",
+       NoWarning{ "comparison of integers" });
+  test("kprobe:f { @a = sum(-1); $a = 1 == @a; }",
+       NoWarning{ "comparison of integers" });
+  test("kprobe:f { @a = sum(-1); $a = @a == 1; }",
+       NoWarning{ "comparison of integers" });
+  test("kprobe:f { @a = sum(1); $a = @a == (uint16)1; }",
+       NoWarning{ "comparison of integers" });
+  test("kprobe:f { @a = sum(-1); $a = @a == (uint16)1; }",
+       NoWarning{ "comparison of integers" });
+  test("kprobe:f { @a = sum(1); @b = count(); $a = @a == @b; }",
+       NoWarning{ "comparison of integers" });
+
+  test("kprobe:f { $a = (uint64)1 == (int64)-1; }",
+       Warning{ "comparison of integers" });
+  test("kprobe:f { @a = sum(-1); $a = (uint64)1 == @a; }",
+       Warning{ "comparison of integers" });
+  test("kprobe:f { @a = sum(-1); $a = @a == (uint64)1; }",
+       Warning{ "comparison of integers" });
+  test("kprobe:f { @a = sum(-1); @b = count(); $a = @a == @b; }",
+       Warning{ "comparison of integers" });
+
+  test("kprobe:f { $a = 1 + -1; }", NoWarning{ "arithmetic on integers" });
+  test("kprobe:f { $a = 1 + (int64)-1; }",
+       NoWarning{ "arithmetic on integers" });
+  test("kprobe:f { $a = (uint32)1 + (int32)-1; }",
+       NoWarning{ "arithmetic on integers" });
+  test("kprobe:f { @a = sum(-1); $a = 1 + @a; }",
+       NoWarning{ "arithmetic on integers" });
+  test("kprobe:f { @a = sum(-1); $a = @a + 1; }",
+       NoWarning{ "arithmetic on integers" });
+  test("kprobe:f { @a = sum(1); $a = @a + (uint16)1; }",
+       NoWarning{ "arithmetic on integers" });
+  test("kprobe:f { @a = sum(-1); $a = @a + (uint16)1; }",
+       NoWarning{ "arithmetic on integers" });
+  test("kprobe:f { @a = sum(1); @b = count(); $a = @a + @b; }",
+       NoWarning{ "arithmetic on integers" });
+
+  test("kprobe:f { $a = (uint64)1 + (int64)-1; }",
+       Warning{ "arithmetic on integers" });
+  test("kprobe:f { @a = sum(-1); $a = (uint64)1 + @a; }",
+       Warning{ "arithmetic on integers" });
+  test("kprobe:f { @a = sum(-1); $a = @a + (uint64)1; }",
+       Warning{ "arithmetic on integers" });
+  test("kprobe:f { @a = sum(-1); @b = count(); $a = @a + @b; }",
+       Warning{ "arithmetic on integers" });
+
+  // Both are additionally casted to int16
+  test("kprobe:f { $a = (uint8)1 == (int8)-1; }",
+       ExpectedAST{ Program().WithProbe(Probe(
+           { "kprobe:f" },
+           { AssignVarStatement(
+                 Variable("$a"),
+                 Binop(Operator::EQ,
+                       Cast(Typeof(SizedType(Type::integer)),
+                            Cast(Typeof(SizedType(Type::integer)), Integer(1))),
+                       Cast(Typeof(SizedType(Type::integer)),
+                            Cast(Typeof(SizedType(Type::integer)),
+                                 NegativeInteger(-1))))),
+             Jump(ast::JumpType::RETURN) })) });
+
+  // The left has an additional cast to int64
+  test("kprobe:f { @a = sum(-1); $a = (uint8)1 == @a; }",
+       ExpectedAST{ Program().WithProbe(Probe(
+           { "kprobe:f" },
+           { ExprStatement(
+                 Call("sum", { Map("@a"), Integer(0), NegativeInteger(-1) })),
+             AssignVarStatement(
+                 Variable("$a"),
+                 Binop(Operator::EQ,
+                       Cast(Typeof(SizedType(Type::integer)),
+                            Cast(Typeof(SizedType(Type::integer)), Integer(1))),
+                       MapAccess(Map("@a"), Integer(0)))),
+             Jump(ast::JumpType::RETURN) })) });
 }
 
 TEST_F(SemanticAnalyserTest, signal)
@@ -3837,12 +3877,7 @@ TEST_F(SemanticAnalyserTest, tuple)
   test(R"(begin { @t = (1, kstack()) })");
   test(R"(begin { @t = (1, (2,3)) })");
   test(R"(begin { $t = (1, (int64)2); $t = (2, (int32)3); })");
-
-  test(R"(begin { $t = (1, (int32)2); $t = (2, (int64)3); })", Error{ R"(
-stdin:1:29-47: ERROR: Type mismatch for $t: trying to assign value of type '(int64,int64)' when variable already contains a value of type '(int64,int32)'
-begin { $t = (1, (int32)2); $t = (2, (int64)3); }
-                            ~~~~~~~~~~~~~~~~~~
-)" });
+  test(R"(begin { $t = (1, (int32)2); $t = (2, (int64)3); })");
 
   test(R"(struct task_struct { int x; } begin { $t = (1, curtask); })");
   test(R"(struct task_struct { int x[4]; } begin { $t = (1, curtask->x); })");
@@ -3854,22 +3889,18 @@ begin { $t = (1, (int32)2); $t = (2, (int64)3); }
   test(R"(begin { @t = (1, 2); @t = (4, "other"); })", Error{});
   test(R"(begin { @t = (1, 2); @t = 5; })", Error{});
   test(R"(begin { @t = (1, count()) })", Error{});
+  test(R"(begin { $t = (1, (2, 3)); $t = (4, ((uint8)5, 6)); })");
 
-  test(R"(begin { $t = (1, (2, 3)); $t = (4, ((int8)5, 6)); })");
+  test(R"(begin { $t = (1, (2, 3)); $t = (4, ((int64)5, 6)); })");
 
-  test(R"(begin { $t = (1, ((int8)2, 3)); $t = (4, (5, 6)); })", Error{ R"(
-stdin:1:33-49: ERROR: Type mismatch for $t: trying to assign value of type '(int64,(int64,int64))' when variable already contains a value of type '(int64,(int8,int64))'
-begin { $t = (1, ((int8)2, 3)); $t = (4, (5, 6)); }
-                                ~~~~~~~~~~~~~~~~
-)" });
-
-  test(R"(begin { $t = ((uint8)1, (2, 3)); $t = (4, ((int8)5, 6)); })",
+  test(R"(begin { $t = (1, ((int8)2, 3)); $t = (4, ((uint64)5, 6)); })",
        Error{ R"(
-stdin:1:34-56: ERROR: Type mismatch for $t: trying to assign value of type '(int64,(int8,int64))' when variable already contains a value of type '(uint8,(int64,int64))'
-begin { $t = ((uint8)1, (2, 3)); $t = (4, ((int8)5, 6)); }
-                                 ~~~~~~~~~~~~~~~~~~~~~~
+stdin:1:33-57: ERROR: Type mismatch for $t: trying to assign value of type '(uint8,(uint64,uint8))' when variable already contains a value of type '(uint8,(int8,uint8))'
+begin { $t = (1, ((int8)2, 3)); $t = (4, ((uint64)5, 6)); }
+                                ~~~~~~~~~~~~~~~~~~~~~~~~
 )" });
 
+  test(R"(begin { $t = ((uint8)1, (2, 3)); $t = (4, (5, 6)); })");
   test(R"(begin { @t = (1, 2, "hi"); @t = (3, 4, "hellolongstr"); })");
   test(R"(begin { $t = (1, ("hi", 2)); $t = (3, ("hellolongstr", 4)); })");
 
@@ -3896,7 +3927,7 @@ TEST_F(SemanticAnalyserTest, tuple_indexing)
 TEST_F(SemanticAnalyserTest, tuple_assign_var)
 {
   class SizedType ty = CreateTuple(
-      Struct::CreateTuple({ CreateInt64(), CreateString(6) }));
+      Struct::CreateTuple({ CreateUInt8(), CreateString(6) }));
   auto ast = test(R"(begin { $t = (1, "str"); $t = (4, "other"); })");
   auto &stmts = ast.root->probes.at(0)->block->stmts;
 
@@ -3918,13 +3949,13 @@ TEST_F(SemanticAnalyserTest, tuple_assign_map)
   // $t = (1, 3, 3, 7);
   auto *assignment = stmts.at(0).as<ast::AssignMapStatement>();
   class SizedType ty = CreateTuple(Struct::CreateTuple(
-      { CreateInt64(), CreateInt64(), CreateInt64(), CreateInt64() }));
+      { CreateUInt8(), CreateUInt8(), CreateUInt8(), CreateUInt8() }));
   EXPECT_EQ(ty, assignment->map->value_type);
 
   // $t = (0, 0, 0, 0);
   assignment = stmts.at(1).as<ast::AssignMapStatement>();
   ty = CreateTuple(Struct::CreateTuple(
-      { CreateInt64(), CreateInt64(), CreateInt64(), CreateInt64() }));
+      { CreateUInt8(), CreateUInt8(), CreateUInt8(), CreateUInt8() }));
   EXPECT_EQ(ty, assignment->map->value_type);
 }
 
@@ -3932,9 +3963,9 @@ TEST_F(SemanticAnalyserTest, tuple_assign_map)
 TEST_F(SemanticAnalyserTest, tuple_nested)
 {
   class SizedType ty_inner = CreateTuple(
-      Struct::CreateTuple({ CreateInt64(), CreateInt64() }));
+      Struct::CreateTuple({ CreateUInt8(), CreateUInt8() }));
   class SizedType ty = CreateTuple(
-      Struct::CreateTuple({ CreateInt64(), ty_inner }));
+      Struct::CreateTuple({ CreateUInt8(), ty_inner }));
   auto ast = test(R"(begin { $t = (1,(1,2)); })");
   auto &stmts = ast.root->probes.at(0)->block->stmts;
 
@@ -4093,8 +4124,8 @@ TEST_F(SemanticAnalyserTest, string_size)
   ASSERT_TRUE(map_assign->key.type().GetField(0).type.IsStringTy());
   ASSERT_EQ(map_assign->key.type().GetField(0).type.GetSize(), 3UL);
   ASSERT_EQ(map_assign->map->key_type.GetField(0).type.GetSize(), 6UL);
-  ASSERT_EQ(map_assign->key.type().GetSize(), 16UL);
-  ASSERT_EQ(map_assign->map->key_type.GetSize(), 16UL);
+  ASSERT_EQ(map_assign->key.type().GetSize(), 4UL);
+  ASSERT_EQ(map_assign->map->key_type.GetSize(), 7UL);
 
   ast = test(R"(k:f1 {$x = ("hello", 0);} k:f2 {$x = ("hi", 0); })");
   stmt = ast.root->probes.at(0)->block->stmts.at(0);
@@ -4102,8 +4133,8 @@ TEST_F(SemanticAnalyserTest, string_size)
   ASSERT_TRUE(var_assign->var()->var_type.IsTupleTy());
   ASSERT_TRUE(var_assign->var()->var_type.GetField(0).type.IsStringTy());
   ASSERT_EQ(var_assign->var()->var_type.GetSize(),
-            16UL); // tuples are not
-                   // packed
+            7UL); // tuples are not
+                  // packed
   ASSERT_EQ(var_assign->var()->var_type.GetField(0).type.GetSize(), 6UL);
 }
 
@@ -4144,11 +4175,11 @@ begin { $i = tid(1); }
 TEST_F(SemanticAnalyserTest, subprog_return)
 {
   test("fn f(): void { return; }");
-  test("fn f(): int64 { return 1; }");
+  test("fn f(): uint8 { return 1; }");
 
   // Error location is incorrect: #3063
   test("fn f(): void { return 1; }", Error{ R"(
-stdin:1:16-24: ERROR: Function f is of type void, cannot return int64
+stdin:1:16-24: ERROR: Function f is of type void, cannot return uint8
 fn f(): void { return 1; }
                ~~~~~~~~
 )" });
@@ -4174,15 +4205,15 @@ fn f($a : int64): string { return $a; }
 TEST_F(SemanticAnalyserTest, subprog_map)
 {
   test("fn f(): void { @a = 0; }");
-  test("fn f(): int64 { @a = 0; return @a + 1; }");
+  test("fn f(): uint64 { @a = 0; return @a + 1; }");
   test("fn f(): void { @a[0] = 0; }");
-  test("fn f(): int64 { @a[0] = 0; return @a[0] + 1; }");
+  test("fn f(): uint64 { @a[0] = 0; return @a[0] + 1; }");
 }
 
 TEST_F(SemanticAnalyserTest, subprog_builtin)
 {
   test("fn f(): void { print(\"Hello world\"); }");
-  test("fn f(): uint64 { return sizeof(int64); }");
+  test("fn f(): uint8 { return sizeof(int64); }");
   test("fn f(): uint64 { return nsecs; }");
 }
 
@@ -4496,7 +4527,7 @@ begin { @map[0] = tseries(10, 10s, 10); for ($kv : @map) { } }
                                                    ~~~~
 )" });
   test("begin { @map[0] = stats(10); for ($kv : @map) { } }", Error{ R"(
-stdin:1:41-45: ERROR: Loop expression does not support type: stats_t
+stdin:1:41-45: ERROR: Loop expression does not support type: ustats_t
 begin { @map[0] = stats(10); for ($kv : @map) { } }
                                         ~~~~
 )" });
@@ -4618,7 +4649,7 @@ TEST_F(SemanticAnalyserTest, for_loop_variables_multiple)
       $var2 = "abc";
       $var3 = "def";
       for ($kv : @map) {
-        $var1 = 456;
+        $var1 = 100;
         print($var3);
       }
     })",
@@ -4630,7 +4661,7 @@ TEST_F(SemanticAnalyserTest, for_loop_variables_multiple)
             AssignVarStatement(Variable("$var3"), String("def")),
             For(Variable("$kv"),
                 Map("@map"),
-                { AssignVarStatement(Variable("$var1"), Integer(456)),
+                { AssignVarStatement(Variable("$var1"), Integer(100)),
                   ExprStatement(Block(
                       { ExprStatement(Call("print", { Variable("$var3") })),
                         Jump(ast::JumpType::CONTINUE) })) })
@@ -4777,7 +4808,7 @@ begin { for ($i : 0.."str") { printf("%d", $i); } }
 )" });
 
   test(R"(begin { for ($i : 0.0..5) { printf("%d", $i); } })", Error{ R"(
-stdin:1:21-22: ERROR: Can not access index '0' on expression of type 'int64'
+stdin:1:21-22: ERROR: Can not access index '0' on expression of type 'uint8'
 begin { for ($i : 0.0..5) { printf("%d", $i); } }
                     ~
 stdin:1:19-25: ERROR: Loop range requires an integer for the start value
@@ -4945,31 +4976,25 @@ begin { let $a; let $a; }
 )" });
 
   test("begin { let $a: uint16; $a = -1; }", Error{ R"(
-stdin:1:25-32: ERROR: Type mismatch for $a: trying to assign value of type 'int64' when variable already has a type 'uint16'
+stdin:1:25-32: ERROR: Type mismatch for $a: trying to assign value of type 'int8' when variable already has a type 'uint16'
 begin { let $a: uint16; $a = -1; }
                         ~~~~~~~
 )" });
 
   test("begin { let $a: uint8 = 1; $a = 10000; }", Error{ R"(
-stdin:1:28-38: ERROR: Type mismatch for $a: trying to assign value '10000' which does not fit into the variable of type 'uint8'
+stdin:1:28-38: ERROR: Type mismatch for $a: trying to assign value of type 'uint16' when variable already contains a value of type 'uint8'
 begin { let $a: uint8 = 1; $a = 10000; }
                            ~~~~~~~~~~
 )" });
 
   test("begin { let $a: int8 = 1; $a = -10000; }", Error{ R"(
-stdin:1:27-38: ERROR: Type mismatch for $a: trying to assign value '-10000' which does not fit into the variable of type 'int8'
+stdin:1:27-38: ERROR: Type mismatch for $a: trying to assign value of type 'int16' when variable already contains a value of type 'int8'
 begin { let $a: int8 = 1; $a = -10000; }
                           ~~~~~~~~~~~
 )" });
 
-  test("begin { let $a; $a = (uint8)1; $a = -1; }", Error{ R"(
-stdin:1:32-39: ERROR: Type mismatch for $a: trying to assign value of type 'int64' when variable already contains a value of type 'uint8'
-begin { let $a; $a = (uint8)1; $a = -1; }
-                               ~~~~~~~
-)" });
-
   test("begin { let $a: int8; $a = 10000; }", Error{ R"(
-stdin:1:23-33: ERROR: Type mismatch for $a: trying to assign value '10000' which does not fit into the variable of type 'int8'
+stdin:1:23-33: ERROR: Type mismatch for $a: trying to assign value of type 'uint16' when variable already has a type 'int8'
 begin { let $a: int8; $a = 10000; }
                       ~~~~~~~~~~
 )" });
@@ -4981,7 +5006,7 @@ begin { $a = -1; let $a; }
 )" });
 
   test("begin { let $a: uint16 = -1; }", Error{ R"(
-stdin:1:9-28: ERROR: Type mismatch for $a: trying to assign value of type 'int64' when variable already has a type 'uint16'
+stdin:1:9-28: ERROR: Type mismatch for $a: trying to assign value of type 'int8' when variable already has a type 'uint16'
 begin { let $a: uint16 = -1; }
         ~~~~~~~~~~~~~~~~~~~
 )" });
@@ -5218,7 +5243,7 @@ begin { @a = tseries(10, 10s, 1); let $b = @a; }
 
   test("begin { @a = stats(10); let $b = @a; }",
        Error{ R"(
-stdin:1:25-36: ERROR: Value 'stats_t' cannot be assigned to a scratch variable.
+stdin:1:25-36: ERROR: Value 'ustats_t' cannot be assigned to a scratch variable.
 begin { @a = stats(10); let $b = @a; }
                         ~~~~~~~~~~~
 )" },
@@ -5247,7 +5272,7 @@ begin { @a = tseries(10, 10s, 1); @b = @a; }
 )" });
 
   test("begin { @a = stats(10); @b = @a; }", Error{ R"(
-stdin:1:25-32: ERROR: Map value 'stats_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@b = stats(arg2);`.
+stdin:1:25-32: ERROR: Map value 'ustats_t' cannot be assigned from one map to another. The function that returns this type must be called directly e.g. `@b = stats(arg2);`.
 begin { @a = stats(10); @b = @a; }
                         ~~~~~~~
 )" });
@@ -5365,7 +5390,7 @@ TEST_F(SemanticAnalyserTest, macros)
   test("macro set($x) { $x = 1; $x } begin { $a = \"string\"; set($a); }",
        Mock{ *bpftrace },
        Error{ R"(
-stdin:1:17-23: ERROR: Type mismatch for $a: trying to assign value of type 'int64' when variable already contains a value of type 'string[7]'
+stdin:1:17-23: ERROR: Type mismatch for $a: trying to assign value of type 'uint8' when variable already contains a value of type 'string[7]'
 macro set($x) { $x = 1; $x } begin { $a = "string"; set($a); }
                 ~~~~~~
 stdin:1:53-60: ERROR: expanded from
@@ -5378,13 +5403,13 @@ macro set($x) { $x = 1; $x } begin { $a = "string"; set($a); }
        "begin { $a = \"string\"; add1($a); }",
        Mock{ *bpftrace },
        Error{ R"(
-stdin:1:21-22: ERROR: Type mismatch for '+': comparing string[7] with int64
+stdin:1:21-22: ERROR: Type mismatch for '+': comparing string[7] with uint8
 macro add2($x) { $x + 1 } macro add1($x) { add2($x) } begin { $a = "string"; add1($a); }
                     ~
 stdin:1:18-20: ERROR: left (string[7])
 macro add2($x) { $x + 1 } macro add1($x) { add2($x) } begin { $a = "string"; add1($a); }
                  ~~
-stdin:1:23-24: ERROR: right (int64)
+stdin:1:23-24: ERROR: right (uint8)
 macro add2($x) { $x + 1 } macro add1($x) { add2($x) } begin { $a = "string"; add1($a); }
                       ~
 stdin:1:44-52: ERROR: expanded from
@@ -5516,8 +5541,19 @@ TEST_F(SemanticAnalyserTest, typeof_decls)
   test(R"(kprobe:f { $x = "foo"; let $y : typeof($x); $y = "bar"; })");
   test(
       R"(kprobe:f { $x = "foo"; let $y : typeof($x); $y = "muchmuchlongerstr"; })");
+  test("begin { let $a: uint32 = 1; }");
+  test("begin { let $a: uint32; $a = (uint8)1; }");
+  test("begin { let $a: int8; $a = 1; }");
+  test("begin { let $a; $a = (int32)1; }");
+  test("begin { let $a; $a = (int8)1; }");
+  test("begin { let $a; $a = -1; }");
+  test("begin { let $a: int32 = 0; }");
 
   // These types should be enforced.
+  test("begin { let $a: int8 = 1; $a = (int32)1; }", Error{});
+  test("begin { let $a: uint8; $a = (int8)1; }", Error{});
+  test("begin { $y = (int8)1; let $a: uint8; $a = $y; }", Error{});
+  test("begin { let $a: uint8; $a = -1; }", Error{});
   test(R"(kprobe:f { $x = (uint8)1; let $y : typeof($x); $y = "foo"; })",
        Error{ R"(
 stdin:1:48-58: ERROR: Type mismatch for $y: trying to assign value of type 'string[4]' when variable already has a type 'uint8'
@@ -5525,7 +5561,7 @@ kprobe:f { $x = (uint8)1; let $y : typeof($x); $y = "foo"; }
                                                ~~~~~~~~~~
 )" });
   test(R"(kprobe:f { $x = "foo"; let $y : typeof($x); $y = 2; })", Error{ R"(
-stdin:1:45-51: ERROR: Type mismatch for $y: trying to assign value of type 'int64' when variable already has a type 'string[4]'
+stdin:1:45-51: ERROR: Type mismatch for $y: trying to assign value of type 'uint8' when variable already has a type 'string[4]'
 kprobe:f { $x = "foo"; let $y : typeof($x); $y = 2; }
                                             ~~~~~~
 )" });
@@ -5538,10 +5574,14 @@ kprobe:f { $x = "foo"; let $y : typeof($x); $y = 2; }
 TEST_F(SemanticAnalyserTest, typeof_subprog)
 {
   // Basic subprogram arguments can be defined relatively.
-  test("fn foo($x : int64, $y : typeof($x)) : int64 { return 0; }");
-  test("fn foo($x : typeof($y), $y : int64) : int64 { return 0; }");
+  test("fn foo($x : int64, $y : typeof($x)) : int8 { return 0; }");
+  test("fn foo($x : typeof($y), $y : int64) : int8 { return 0; }");
+  test("fn foo($x : typeof($y), $y : int64) : typeof($x) { return (int64)0; }");
+  test("fn foo($x : typeof($y), $y : int64) : typeof($y) { return (int64)0; }");
   test("fn foo($x : typeof($y), $y : int64) : typeof($x) { return 0; }");
-  test("fn foo($x : typeof($y), $y : int64) : typeof($y) { return 0; }");
+
+  test("fn foo($x : typeof($y), $y : int64) : int64 { return (uint64)0; }",
+       Error{});
 
   // But we can't define using non-existent variables.
   test("fn foo($x : int64, $y : typeof($z)) : int64 { return 0; }", Error{ R"(


### PR DESCRIPTION
This makes several changes to how we handle
the size and up-sizing of integer types.

1. For integer and negative integer literals
make their type the smallest possible type
they can fit into
2. Integer literals will always be unsigned
by default but can be re-created to be signed
if needed (this is in lieu of adding an additional
cast to a signed integer)
3. Negative Integer literals will always be
signed (as expected).
4. Remove automatic integer promotion for map
values and keys (except scalar map keys)
5. Add neccessary casting when comparing integers,
assigning them to variables, map keys, and map
values.

This change also makes sure that tuples
are compatible when their contents contain
integers of different sizes. There will be a
follow-up PR that adds casting earlier, which
will allow us to remove the dependency on codegen
to copy elements individually from one to the other.

The reason for this change is to reduce confusing
logic around integer handling in codegen and
make integer types more robust/flexible.

For example this fails on master:
`begin { $a = (uint32)1; $a = -1; }`
but works fine here as we upcast both sides
to an int64 which safely holds both.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
