### PR TITLE
ast: change Location ordering

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -171,9 +171,7 @@ AttachPoint *AttachPoint::create_expansion_copy(ASTContext &ctx,
   // Create a new node with the same raw tracepoint. We initialize all the
   // information about the attach point, and then override/reset values
   // depending on the specific probe type.
-  auto *ap = ctx.make_node<AttachPoint>(raw_input,
-                                        ignore_invalid,
-                                        Location(loc));
+  auto *ap = ctx.make_node<AttachPoint>(loc, raw_input, ignore_invalid);
   ap->provider = provider;
   ap->target = target;
   ap->lang = lang;

--- a/src/ast/context.h
+++ b/src/ast/context.h
@@ -51,22 +51,44 @@ public:
 
   // Creates and returns a pointer to an AST node.
   template <NodeType T, typename... Args>
-  constexpr T *make_node(Args &&...args)
+  constexpr T *make_node(Location &&loc, Args... args)
   {
     auto uniq_ptr = std::make_unique<T>(*this,
-                                        wrap(std::forward<Args>(args))...);
+                                        std::move(loc),
+                                        std::forward<Args>(args)...);
     auto *raw_ptr = uniq_ptr.get();
     state_->nodes_.push_back(std::move(uniq_ptr));
     return raw_ptr;
   }
 
+  template <NodeType T, typename... Args>
+  T *make_node(const SourceLocation &loc, Args &&...args)
+  {
+    // Occasionally, the parse default-constructs SourceLocation objects,
+    // which therefore do not reference the original source. We fix up this
+    // case and bound a location to the current from this context.
+    auto bound_loc = loc;
+    if (bound_loc.source_ == nullptr) {
+      bound_loc.source_ = source_;
+    }
+    auto loc_chain = std::make_shared<LocationChain>(std::move(bound_loc));
+    return make_node<T, Args...>(std::move(loc_chain),
+                                 std::forward<Args>(args)...);
+  }
+
+  template <NodeType T, typename... Args>
+  T *make_node(const Location &loc, Args... args)
+  {
+    return make_node<T, Args...>(Location(loc), std::forward<Args>(args)...);
+  }
+
   template <NodeType T>
-  constexpr T *clone_node(const T *other, const Location &loc)
+  T *clone_node(const Location &loc, const T *other)
   {
     if (other == nullptr) {
       return nullptr;
     }
-    auto uniq_ptr = std::make_unique<T>(*this, *other, loc);
+    auto uniq_ptr = std::make_unique<T>(*this, loc, *other);
     auto *raw_ptr = uniq_ptr.get();
     state_->nodes_.push_back(std::move(uniq_ptr));
     return raw_ptr;
@@ -103,22 +125,6 @@ private:
     State();
     std::vector<std::unique_ptr<Node>> nodes_;
     std::unique_ptr<Diagnostics> diagnostics_;
-  };
-
-  // wrap potentially converts external types to internal ones. At the moment,
-  // this automatically converts the parser `location` to the `Location` class
-  // bound to the current source file.
-  template <typename T>
-  auto wrap(T &&t) -> decltype(t)
-  {
-    return std::forward<T>(t);
-  }
-  Location wrap(SourceLocation loc)
-  {
-    // Ensure that this source location refers to the source object in this
-    // context. The parser has a tendency to construct these directly.
-    loc.source_ = source_;
-    return std::make_shared<LocationChain>(std::move(loc));
   };
 
   std::unique_ptr<State> state_;

--- a/src/ast/location.cpp
+++ b/src/ast/location.cpp
@@ -36,7 +36,16 @@ std::ostream &operator<<(std::ostream &out, const SourceLocation &loc)
 
 SourceLocation operator+(const SourceLocation &orig, const SourceLocation &loc)
 {
-  auto result = SourceLocation(orig.source_);
+  // The parser constructs source locations that don't have any source. These
+  // are quickly joined into locations that do have source, so we allow for this
+  // and quickly converge to what is expected.
+  auto source = orig.source_;
+  if (source == nullptr && loc.source_ != nullptr) {
+    source = loc.source_;
+  } else if (loc.source_ != nullptr) {
+    assert(source == loc.source_);
+  }
+  auto result = SourceLocation(source);
   result.begin.line = std::min(orig.begin.line, loc.begin.line);
   result.end.line = std::max(orig.end.line, loc.end.line);
 

--- a/src/ast/location.h
+++ b/src/ast/location.h
@@ -24,9 +24,11 @@ public:
     int column = 1;
   };
 
-  SourceLocation() = default;
+  SourceLocation() = default; // Allowed, but see operator+.
   SourceLocation(const SourceLocation &) = default;
   SourceLocation &operator=(const SourceLocation &other) = default;
+  SourceLocation(SourceLocation &&) = default;
+  SourceLocation &operator=(SourceLocation &&other) = default;
   SourceLocation(std::shared_ptr<ASTSource> source)
       : source_(std::move(source)) {};
 
@@ -150,7 +152,7 @@ public:
     const Location loc;
   };
 
-  LocationChain(const SourceLocation &loc) : current(loc) {};
+  LocationChain(SourceLocation loc) : current(std::move(loc)) {};
 
   // See above.
   std::string filename() const

--- a/src/ast/passes/ap_probe_expansion.cpp
+++ b/src/ast/passes/ap_probe_expansion.cpp
@@ -193,19 +193,18 @@ void SessionExpander::visit(Probe &probe)
 
     AttachPointList attach_points = probe.attach_points;
     auto *expr = ast_.make_node<IfExpr>(
-        ast_.make_node<Call>("__session_is_return",
-                             ExpressionList{},
-                             Location(probe.block->loc)),
+        probe.block->loc,
+        ast_.make_node<Call>(probe.block->loc,
+                             "__session_is_return",
+                             ExpressionList{}),
         retprobe->block,
-        probe.block,
-        Location(probe.block->loc));
-    auto *stmt = ast_.make_node<ExprStatement>(expr,
-                                               Location(probe.block->loc));
+        probe.block);
+    auto *stmt = ast_.make_node<ExprStatement>(probe.block->loc, expr);
 
-    probe.block = ast_.make_node<BlockExpr>(StatementList({ stmt }),
+    probe.block = ast_.make_node<BlockExpr>(probe.block->loc,
+                                            StatementList({ stmt }),
                                             ast_.make_node<None>(
-                                                Location(probe.block->loc)),
-                                            Location(probe.block->loc));
+                                                probe.block->loc));
 
     expansion_result_.set_expansion(*probe.attach_points[0],
                                     ExpansionType::SESSION);
@@ -255,10 +254,10 @@ void ProbeAndApExpander::visit(Program &prog)
     } else {
       for (auto *ap : probe->attach_points) {
         auto *new_probe = ast_.make_node<Probe>(
+            probe->loc,
             AttachPointList{ ap },
-            clone(ast_, probe->block, probe->block->loc),
-            probe->orig_name,
-            Location(probe->loc));
+            clone(ast_, probe->block->loc, probe->block),
+            probe->orig_name);
         new_probe_list.emplace_back(new_probe);
       }
     }

--- a/src/ast/passes/attachpoint_passes.cpp
+++ b/src/ast/passes/attachpoint_passes.cpp
@@ -454,7 +454,7 @@ AttachPointParser::State AttachPointParser::parse_attachpoint(AttachPoint &ap)
       // which raw_input has invalid number of parts will be ignored (instead
       // of throwing an error). These will have the same associated location.
       new_attach_points.push_back(
-          ctx_.make_node<AttachPoint>(raw_input, true, Location(ap.loc)));
+          ctx_.make_node<AttachPoint>(ap.loc, raw_input, true));
     }
     return NEW_APS;
   }

--- a/src/ast/passes/builtins.cpp
+++ b/src/ast/passes/builtins.cpp
@@ -45,27 +45,27 @@ std::optional<Expression> Builtins::check(const std::string &ident, Node &node)
   if (ident == "__builtin_arch") {
     std::stringstream ss;
     ss << bpftrace::arch::current();
-    return ast_.make_node<String>(ss.str(), Location(node.loc));
+    return ast_.make_node<String>(node.loc, ss.str());
   }
   if (ident == "__builtin_safe_mode") {
-    return ast_.make_node<Boolean>(bpftrace_.safe_mode_, Location(node.loc));
+    return ast_.make_node<Boolean>(node.loc, bpftrace_.safe_mode_);
   }
   if (ident == "__builtin_probe") {
     if (auto *probe = dynamic_cast<Probe *>(top_level_node_)) {
-      return ast_.make_node<String>(probe->attach_points.empty()
+      return ast_.make_node<String>(node.loc,
+                                    probe->attach_points.empty()
                                         ? "none"
-                                        : probe->attach_points.front()->name(),
-                                    Location(node.loc));
+                                        : probe->attach_points.front()->name());
     }
   }
   if (ident == "__builtin_probetype") {
     if (auto *probe = dynamic_cast<Probe *>(top_level_node_)) {
       return ast_.make_node<String>(
+          node.loc,
           probe->attach_points.empty()
               ? "none"
               : probetypeName(
-                    probetype(probe->attach_points.front()->provider)),
-          Location(node.loc));
+                    probetype(probe->attach_points.front()->provider)));
     }
   }
   if (ident == "__builtin_elf_is_exe" || ident == "__builtin_elf_ino") {
@@ -81,13 +81,11 @@ std::optional<Expression> Builtins::check(const std::string &ident, Node &node)
                << probe->attach_points.front()->provider << "' probes";
     }
     if (ident == "__builtin_elf_is_exe") {
-      return ast_.make_node<Boolean>(util::is_exe(
-                                         probe->attach_points.front()->target),
-                                     Location(node.loc));
+      return ast_.make_node<Boolean>(
+          node.loc, util::is_exe(probe->attach_points.front()->target));
     } else {
-      return ast_.make_node<Integer>(util::file_ino(
-                                         probe->attach_points.front()->target),
-                                     Location(node.loc));
+      return ast_.make_node<Integer>(
+          node.loc, util::file_ino(probe->attach_points.front()->target));
     }
   }
   return std::nullopt;
@@ -105,7 +103,7 @@ std::optional<Expression> Builtins::visit(Call &call)
         if (signal_num < 1) {
           call.addError() << "Invalid string for signal: " << str->value;
         }
-        return ast_.make_node<Integer>(signal_num, Location(str->loc));
+        return ast_.make_node<Integer>(str->loc, signal_num);
       }
     }
   }

--- a/src/ast/passes/c_macro_expansion.cpp
+++ b/src/ast/passes/c_macro_expansion.cpp
@@ -51,7 +51,7 @@ void CMacroExpander::visit(Expression &expr)
       }
 
       // Expand the macro expression in place.
-      expr.value = clone(ast_, expanded->value, ident->loc);
+      expr.value = clone(ast_, ident->loc, expanded->value);
 
       // Recursively visit the potentially expanded expression, ensuring that
       // we can catch recursive expansion, per above.

--- a/src/ast/passes/fold_literals.cpp
+++ b/src/ast/passes/fold_literals.cpp
@@ -146,7 +146,7 @@ static Expression make_boolean(ASTContext &ast, T left, T right, Binop &op)
       LOG(BUG) << "binary operator is not valid: " << static_cast<int>(op.op);
   }
 
-  return ast.make_node<Boolean>(value, Location(op.loc));
+  return ast.make_node<Boolean>(op.loc, value);
 }
 
 std::optional<bool> LiteralFolder::compare_tuples(Tuple *left_tuple,
@@ -358,8 +358,7 @@ std::optional<Expression> LiteralFolder::visit(Cast &cast)
 {
   visit(cast.expr);
   if (cast.type().IsBoolTy() && cast.expr.is_literal()) {
-    return ast_.make_node<Boolean>(eval_bool(cast.expr),
-                                   Location(cast.expr.loc()));
+    return ast_.make_node<Boolean>(cast.expr.loc(), eval_bool(cast.expr));
   }
   return std::nullopt;
 }
@@ -372,11 +371,9 @@ std::optional<Expression> LiteralFolder::visit(Unop &op)
     bool force_unsigned = !integer->type().IsSigned();
     if (op.op == Operator::BNOT) {
       // Still positive.
-      return ast_.make_node<Integer>(~integer->value,
-                                     Location(op.loc),
-                                     force_unsigned);
+      return ast_.make_node<Integer>(op.loc, ~integer->value, force_unsigned);
     } else if (op.op == Operator::LNOT) {
-      return ast_.make_node<Boolean>(!integer->value, Location(op.loc));
+      return ast_.make_node<Boolean>(op.loc, !integer->value);
     } else if (op.op == Operator::MINUS) {
       // Ensure that it is representable as a negative value.
       if (integer->value >
@@ -390,34 +387,33 @@ std::optional<Expression> LiteralFolder::visit(Unop &op)
         return integer; // Drop the operation.
       } else if (integer->value <= 1) {
         return ast_.make_node<NegativeInteger>(
-            -static_cast<int64_t>(integer->value), Location(op.loc));
+            op.loc, -static_cast<int64_t>(integer->value));
       } else {
         int64_t value = -1;
         value -= static_cast<int64_t>(integer->value - 1);
-        return ast_.make_node<NegativeInteger>(value, Location(op.loc));
+        return ast_.make_node<NegativeInteger>(op.loc, value);
       }
     }
   } else if (auto *integer = op.expr.as<NegativeInteger>()) {
     if (op.op == Operator::BNOT) {
       // Always positive.
-      return ast_.make_node<Integer>(static_cast<uint64_t>(~integer->value),
-                                     Location(op.loc));
+      return ast_.make_node<Integer>(op.loc,
+                                     static_cast<uint64_t>(~integer->value));
     } else if (op.op == Operator::LNOT) {
-      return ast_.make_node<Boolean>(!integer->value, Location(op.loc));
+      return ast_.make_node<Boolean>(op.loc, !integer->value);
     } else if (op.op == Operator::MINUS) {
       // Ensure that it doesn't overflow. We do this by ensuring that is
       // representable as a positive number, casting, and then adding 1 to
       // the unsigned form.
       int64_t value = integer->value + 1;
       value = -value;
-      return ast_.make_node<Integer>(static_cast<uint64_t>(value) + 1,
-                                     Location(op.loc));
+      return ast_.make_node<Integer>(op.loc, static_cast<uint64_t>(value) + 1);
     }
   } else if (auto *boolean = op.expr.as<Boolean>()) {
     // Just supporting logical not for now but we could support other
     // operations like BNOT (e.g. ~false == -1) in the future.
     if (op.op == Operator::LNOT) {
-      return ast_.make_node<Boolean>(!boolean->value, Location(op.loc));
+      return ast_.make_node<Boolean>(op.loc, !boolean->value);
     }
   }
   return std::nullopt;
@@ -441,10 +437,9 @@ std::optional<Expression> LiteralFolder::visit(Binop &op)
     if (op.op == Operator::PLUS && integer) {
       if (integer->value >= static_cast<uint64_t>(str->value.size())) {
         op.addWarning() << "literal string will always be empty";
-        return ast_.make_node<String>("", Location(op.loc));
+        return ast_.make_node<String>(op.loc, "");
       }
-      return ast_.make_node<String>(str->value.substr(integer->value),
-                                    Location(op.loc));
+      return ast_.make_node<String>(op.loc, str->value.substr(integer->value));
     }
 
     auto *rb = other.as<Boolean>();
@@ -464,31 +459,27 @@ std::optional<Expression> LiteralFolder::visit(Binop &op)
 
     switch (op.op) {
       case Operator::EQ:
-        return ast_.make_node<Boolean>(str->value == rs->value,
-                                       Location(op.loc));
+        return ast_.make_node<Boolean>(op.loc, str->value == rs->value);
       case Operator::NE:
-        return ast_.make_node<Boolean>(str->value != rs->value,
-                                       Location(op.loc));
+        return ast_.make_node<Boolean>(op.loc, str->value != rs->value);
       case Operator::LE:
-        return ast_.make_node<Boolean>(str->value <= rs->value,
-                                       Location(op.loc));
+        return ast_.make_node<Boolean>(op.loc, str->value <= rs->value);
       case Operator::GE:
-        return ast_.make_node<Boolean>(str->value >= rs->value,
-                                       Location(op.loc));
+        return ast_.make_node<Boolean>(op.loc, str->value >= rs->value);
       case Operator::LT:
-        return ast_.make_node<Boolean>(str->value < rs->value,
-                                       Location(op.loc));
+        return ast_.make_node<Boolean>(op.loc, str->value < rs->value);
       case Operator::GT:
-        return ast_.make_node<Boolean>(str->value > rs->value,
-                                       Location(op.loc));
+        return ast_.make_node<Boolean>(op.loc, str->value > rs->value);
       case Operator::LAND:
-        return ast_.make_node<Boolean>(!str->value.empty() && rs->value.empty(),
-                                       Location(op.loc));
+        return ast_.make_node<Boolean>(op.loc,
+                                       !str->value.empty() &&
+                                           rs->value.empty());
       case Operator::LOR:
-        return ast_.make_node<Boolean>(!str->value.empty() || rs->value.empty(),
-                                       Location(op.loc));
+        return ast_.make_node<Boolean>(op.loc,
+                                       !str->value.empty() ||
+                                           rs->value.empty());
       case Operator::PLUS:
-        return ast_.make_node<String>(str->value + rs->value, Location(op.loc));
+        return ast_.make_node<String>(op.loc, str->value + rs->value);
       default:
         // What are they tring to do?
         op.addError() << "illegal literal operation with strings";
@@ -531,9 +522,9 @@ std::optional<Expression> LiteralFolder::visit(Binop &op)
     auto *right_tuple = op.right.as<Tuple>();
     auto same = compare_tuples(left_tuple, right_tuple);
     if (same) {
-      return ast_.make_node<Boolean>(*same ? op.op == Operator::EQ
-                                           : op.op == Operator::NE,
-                                     Location(op.loc));
+      return ast_.make_node<Boolean>(op.loc,
+                                     *same ? op.op == Operator::EQ
+                                           : op.op == Operator::NE);
     } else {
       // Can't compare here
       return std::nullopt;
@@ -593,9 +584,9 @@ std::optional<Expression> LiteralFolder::visit(Binop &op)
   return std::visit(
       [&](const auto &v) -> Expression {
         if constexpr (std::is_same_v<std::decay_t<decltype(v)>, uint64_t>) {
-          return ast_.make_node<Integer>(v, Location(op.loc), force_unsigned);
+          return ast_.make_node<Integer>(op.loc, v, force_unsigned);
         } else {
-          return ast_.make_node<NegativeInteger>(v, Location(op.loc));
+          return ast_.make_node<NegativeInteger>(op.loc, v);
         }
       },
       result.value());
@@ -627,8 +618,8 @@ std::optional<Expression> LiteralFolder::visit(IfExpr &if_expr)
         }
       } else {
         // At least simplify the conditional expression.
-        if_expr.cond = ast_.make_node<Boolean>(eval_bool(if_expr.cond),
-                                               Location(if_expr.cond.loc()));
+        if_expr.cond = ast_.make_node<Boolean>(if_expr.cond.loc(),
+                                               eval_bool(if_expr.cond));
       }
     }
   }
@@ -642,8 +633,8 @@ std::optional<Expression> LiteralFolder::visit(PositionalParameterCount &param)
     return std::nullopt;
   }
   // This is always an unsigned integer value.
-  return ast_.make_node<Integer>(bpftrace_->get().num_params(),
-                                 Location(param.loc),
+  return ast_.make_node<Integer>(param.loc,
+                                 bpftrace_->get().num_params(),
                                  /*force_unsigned=*/true);
 }
 
@@ -659,23 +650,22 @@ std::optional<Expression> LiteralFolder::visit(PositionalParameter &param)
   if (val.empty()) {
     param.addWarning() << "Positional parameter $" << param.n
                        << " is empty or not provided. ";
-    return ast_.make_node<Integer>(static_cast<uint64_t>(0),
-                                   Location(param.loc));
+    return ast_.make_node<Integer>(param.loc, static_cast<uint64_t>(0));
   }
   if (val[0] == '-') {
     auto v = util::to_int(val);
     if (!v) {
       // Not parsed, treat it as a string.
-      return ast_.make_node<String>(val, Location(param.loc));
+      return ast_.make_node<String>(param.loc, val);
     }
-    return ast_.make_node<NegativeInteger>(*v, Location(param.loc));
+    return ast_.make_node<NegativeInteger>(param.loc, *v);
   } else {
     auto v = util::to_uint(val);
     if (!v) {
       // Not parsed, treat it as a string.
-      return ast_.make_node<String>(val, Location(param.loc));
+      return ast_.make_node<String>(param.loc, val);
     }
-    return ast_.make_node<Integer>(*v, Location(param.loc));
+    return ast_.make_node<Integer>(param.loc, *v);
   }
 }
 
@@ -693,7 +683,7 @@ std::optional<Expression> LiteralFolder::visit(Call &call)
         return std::nullopt; // Can't fold yet.
       }
       call.vargs[0] = ast_.make_node<String>(
-          bpftrace_->get().get_param(param->n), Location(param->loc));
+          param->loc, bpftrace_->get().get_param(param->n));
     } else if (auto *binop = call.vargs.at(0).as<Binop>()) {
       auto *param = binop->left.as<PositionalParameter>();
       if (param && binop->op == Operator::PLUS) {
@@ -701,7 +691,7 @@ std::optional<Expression> LiteralFolder::visit(Call &call)
           return std::nullopt; // Can't fold yet.
         }
         binop->left = ast_.make_node<String>(
-            bpftrace_->get().get_param(param->n), Location(param->loc));
+            param->loc, bpftrace_->get().get_param(param->n));
       }
     }
 
@@ -734,7 +724,7 @@ std::optional<Expression> LiteralFolder::visit(Call &call)
         return std::nullopt;
       }
     }
-    return ast_.make_node<String>(s, Location(call.loc));
+    return ast_.make_node<String>(call.loc, s);
   } else {
     if (!comptime) {
       // Visit normally; we are just simplifying literals.
@@ -771,9 +761,9 @@ std::optional<Expression> LiteralFolder::visit(Builtin &builtin)
         if (!ap->check_available(builtin.ident)) {
           auto probe_type = probetype(ap->provider);
           if (probe_type == ProbeType::special) {
-            return ast_.make_node<Integer>(1, Location(builtin.loc));
+            return ast_.make_node<Integer>(builtin.loc, 1);
           }
-          return ast_.make_node<Integer>(0, Location(builtin.loc));
+          return ast_.make_node<Integer>(builtin.loc, 0);
         }
       }
     }
@@ -808,14 +798,14 @@ std::optional<Expression> LiteralFolder::visit(ArrayAccess &acc)
         return std::nullopt;
       }
       const char *s = str->value.c_str();
-      return ast_.make_node<Integer>(static_cast<uint64_t>(s[index->value]),
-                                     Location(acc.loc));
+      return ast_.make_node<Integer>(acc.loc,
+                                     static_cast<uint64_t>(s[index->value]));
     }
   } else if (acc.expr.type().IsTupleTy()) {
     if (auto *index = acc.indexpr.as<Integer>()) {
-      return ast_.make_node<TupleAccess>(acc.expr,
-                                         static_cast<ssize_t>(index->value),
-                                         Location(acc.loc));
+      return ast_.make_node<TupleAccess>(acc.loc,
+                                         acc.expr,
+                                         static_cast<ssize_t>(index->value));
     } else {
       acc.addError()
           << "Array-style access for tuples only valid for integer literals";

--- a/src/ast/passes/import_scripts.cpp
+++ b/src/ast/passes/import_scripts.cpp
@@ -4,7 +4,7 @@
 
 namespace bpftrace::ast {
 
-static void import_ast(ASTContext &ast, const ASTContext &other)
+static void import_ast(ASTContext &ast, Node &node, const ASTContext &other)
 {
   // Clone all map declarations, subfunctions, etc. into the primary AST.
   // Note that we may choose not to inline all definitions in the future, and
@@ -14,19 +14,19 @@ static void import_ast(ASTContext &ast, const ASTContext &other)
   ast.diagnostics().add(std::move(other.diagnostics()));
   if (other.root) {
     for (const auto &stmt : other.root->c_statements) {
-      ast.root->c_statements.push_back(clone(ast, stmt));
+      ast.root->c_statements.push_back(clone(ast, node.loc, stmt));
     }
     for (const auto &decl : other.root->map_decls) {
-      ast.root->map_decls.push_back(clone(ast, decl));
+      ast.root->map_decls.push_back(clone(ast, node.loc, decl));
     }
     for (const auto &fn : other.root->functions) {
-      ast.root->functions.push_back(clone(ast, fn));
+      ast.root->functions.push_back(clone(ast, node.loc, fn));
     }
     for (const auto &macro : other.root->macros) {
-      ast.root->macros.push_back(clone(ast, macro));
+      ast.root->macros.push_back(clone(ast, node.loc, macro));
     }
     for (const auto &probe : other.root->probes) {
-      ast.root->probes.push_back(clone(ast, probe));
+      ast.root->probes.push_back(clone(ast, node.loc, probe));
     }
   }
 }
@@ -37,7 +37,7 @@ Pass CreateImportExternalScriptsPass()
                       [](ASTContext &ast, Imports &imports) {
                         for (const auto &[name, obj] : imports.scripts) {
                           if (!obj.internal) {
-                            import_ast(ast, obj.ast);
+                            import_ast(ast, obj.node, obj.ast);
                           }
                         }
                       });
@@ -49,7 +49,7 @@ Pass CreateImportInternalScriptsPass()
                       [](ASTContext &ast, Imports &imports) {
                         for (const auto &[name, obj] : imports.scripts) {
                           if (obj.internal) {
-                            import_ast(ast, obj.ast);
+                            import_ast(ast, obj.node, obj.ast);
                           }
                         }
                       });

--- a/src/ast/passes/macro_expansion.cpp
+++ b/src/ast/passes/macro_expansion.cpp
@@ -237,7 +237,7 @@ void MacroExpander::visit(Expression &expr)
 
   if (ident) {
     if (auto it = passed_exprs_.find(ident->ident); it != passed_exprs_.end()) {
-      expr = clone(ast_, it->second, ident->loc);
+      expr = clone(ast_, ident->loc, it->second);
       // Create a new expander because we're visiting an expression passed into
       // the macro so it's not part of the surounding macro code and therefore
       // variables, maps, and idents in this expression shouldn't be modified
@@ -381,7 +381,7 @@ std::optional<BlockExpr *> MacroExpander::expand(const Macro &macro, Call &call)
       if (call.vargs.at(i).is<Variable>() || call.vargs.at(i).is<Map>()) {
         // Wrap variables and maps in a block to avoid mutation.
         passed_exprs_[mident->ident] = ast_.make_node<BlockExpr>(
-            StatementList({}), call.vargs.at(i), Location(call.loc));
+            call.loc, StatementList({}), call.vargs.at(i));
       } else {
         passed_exprs_[mident->ident] = call.vargs.at(i);
       }
@@ -396,7 +396,7 @@ std::optional<BlockExpr *> MacroExpander::expand(const Macro &macro, Call &call)
     }
   }
 
-  auto *cloned_block = clone(ast_, macro.block, call.loc);
+  auto *cloned_block = clone(ast_, call.loc, macro.block);
   visit(cloned_block);
   return cloned_block;
 }
@@ -411,7 +411,7 @@ std::optional<BlockExpr *> MacroExpander::expand(const Macro &macro,
     return std::nullopt;
   }
 
-  auto *cloned_block = clone(ast_, macro.block, ident.loc);
+  auto *cloned_block = clone(ast_, ident.loc, macro.block);
   visit(cloned_block);
   return cloned_block;
 }

--- a/src/ast/passes/named_param.cpp
+++ b/src/ast/passes/named_param.cpp
@@ -50,7 +50,7 @@ void NamedParamPass::visit(Expression &expr)
 
   globalvars::GlobalVarValue np_default;
 
-  auto *map_node = ast_.make_node<Map>(arg_name->value, Location(call->loc));
+  auto *map_node = ast_.make_node<Map>(call->loc, arg_name->value);
   map_node->key_type = CreateInt64();
 
   if (call->vargs.size() == 1) {
@@ -94,10 +94,8 @@ void NamedParamPass::visit(Expression &expr)
     return;
   }
 
-  auto *index = ast_.make_node<Integer>(0, Location(map_node->loc));
-  expr.value = ast_.make_node<MapAccess>(map_node,
-                                         index,
-                                         Location(map_node->loc));
+  auto *index = ast_.make_node<Integer>(map_node->loc, 0);
+  expr.value = ast_.make_node<MapAccess>(map_node->loc, map_node, index);
 
   used_args[arg_name->value] = np_default;
   defaults.defaults[arg_name->value] = std::move(np_default);

--- a/src/ast/passes/pid_filter_pass.cpp
+++ b/src/ast/passes/pid_filter_pass.cpp
@@ -65,17 +65,16 @@ static BlockExpr *create_pid_filter(ASTContext &ast,
                                     BlockExpr *orig_block)
 {
   return ast.make_node<BlockExpr>(
+      orig_block->loc,
       StatementList({}), // All in the expression below.
       ast.make_node<IfExpr>(
-          ast.make_node<Binop>(
-              ast.make_node<Builtin>("pid", Location(orig_block->loc)),
-              Operator::NE,
-              ast.make_node<Integer>(pid, Location(orig_block->loc)),
-              Location(orig_block->loc)),
-          ast.make_node<None>(Location(orig_block->loc)), // Empty.
-          orig_block,
-          Location(orig_block->loc)),
-      Location(orig_block->loc));
+          orig_block->loc,
+          ast.make_node<Binop>(orig_block->loc,
+                               ast.make_node<Builtin>(orig_block->loc, "pid"),
+                               Operator::NE,
+                               ast.make_node<Integer>(orig_block->loc, pid)),
+          ast.make_node<None>(orig_block->loc), // Empty.
+          orig_block));
 }
 
 void PidFilterPass::visit(Probe &probe)

--- a/src/ast/passes/resolve_imports.cpp
+++ b/src/ast/passes/resolve_imports.cpp
@@ -46,7 +46,7 @@ static bool check_permissions(const std::filesystem::path &path)
   }
 }
 
-static Result<OK> import_script([[maybe_unused]] Node &node,
+static Result<OK> import_script(Node &node,
                                 Imports &imports,
                                 const std::string &name,
                                 const std::string &&data,
@@ -60,7 +60,7 @@ static Result<OK> import_script([[maybe_unused]] Node &node,
 
   // Construct our context.
   auto [it, added] = contents.emplace(
-      name, ScriptObject(ASTContext(name, data), internal));
+      name, ScriptObject(node, ASTContext(name, data), internal));
   assert(added);
   auto &ast = it->second.ast;
 

--- a/src/ast/passes/resolve_imports.h
+++ b/src/ast/passes/resolve_imports.h
@@ -52,8 +52,11 @@ public:
 
 class ScriptObject {
 public:
-  ScriptObject(ASTContext &&ast, bool internal)
-      : ast(std::move(ast)), internal(internal) {};
+  ScriptObject(Node &node, ASTContext &&ast, bool internal)
+      : node(node), ast(std::move(ast)), internal(internal) {};
+
+  // Per above, the original node.
+  Node &node;
 
   // The parsed source context.
   ASTContext ast;

--- a/src/ast/passes/tracepoint_format_parser.cpp
+++ b/src/ast/passes/tracepoint_format_parser.cpp
@@ -30,8 +30,8 @@ bool TracepointFormatParser::parse(ast::ASTContext &ctx, BPFtrace &bpftrace)
 
   if (!bpftrace.has_btf_data())
     program->c_statements.emplace_back(
-        ctx.make_node<ast::CStatement>("#include <linux/types.h>",
-                                       ast::Location()));
+        ctx.make_node<ast::CStatement>(ast::Location(),
+                                       "#include <linux/types.h>"));
   for (ast::Probe *probe : probes_with_tracepoint) {
     ast::AttachPointList new_aps;
     for (ast::AttachPoint *ap : probe->attach_points) {
@@ -80,9 +80,9 @@ bool TracepointFormatParser::parse(ast::ASTContext &ctx, BPFtrace &bpftrace)
         std::string struct_name = get_struct_name(*ap);
         if (TracepointFormatParser::struct_list.insert(struct_name).second) {
           program->c_statements.emplace_back(ctx.make_node<ast::CStatement>(
+              ast::Location(),
               get_tracepoint_struct(
-                  format_file, category, event_name, bpftrace),
-              ast::Location()));
+                  format_file, category, event_name, bpftrace)));
         }
       }
       new_aps.push_back(ap);

--- a/src/ast/passes/usdt_arguments.cpp
+++ b/src/ast/passes/usdt_arguments.cpp
@@ -22,19 +22,17 @@ public:
   ast::Variable *var(size_t arg, Node &node)
   {
     std::string ident = "__usdt_arg_" + std::to_string(arg);
-    return ast_.make_node<ast::Variable>(ident, Location(node.loc));
+    return ast_.make_node<ast::Variable>(node.loc, ident);
   }
   ast::AssignVarStatement *var_decl(size_t arg, Node &node)
   {
-    auto *int_arg = ast_.make_node<ast::Integer>(static_cast<uint64_t>(arg),
-                                                 Location(node.loc));
+    auto *int_arg = ast_.make_node<ast::Integer>(node.loc,
+                                                 static_cast<uint64_t>(arg));
     std::vector<Expression> args = { int_arg };
-    Expression expr = ast_.make_node<ast::Call>("usdt_arg",
-                                                std::move(args),
-                                                Location(node.loc));
-    return ast_.make_node<AssignVarStatement>(var(arg, node),
-                                              expr,
-                                              Location(node.loc));
+    Expression expr = ast_.make_node<ast::Call>(node.loc,
+                                                "usdt_arg",
+                                                std::move(args));
+    return ast_.make_node<AssignVarStatement>(node.loc, var(arg, node), expr);
   }
 
 private:

--- a/src/benchmark.cpp
+++ b/src/benchmark.cpp
@@ -69,7 +69,7 @@ Result<> benchmark(std::ostream &out, ast::PassManager &mgr)
     ast::ASTContext saved;
     if (ctx.has<ast::ASTContext>()) {
       auto &ast = ctx.get<ast::ASTContext>();
-      saved.root = saved.clone_node(ast.root, ast::Location());
+      saved.root = saved.clone_node(ast::Location(), ast.root);
     }
 
     // We run the function until we are able to accumulate at least three
@@ -107,7 +107,7 @@ Result<> benchmark(std::ostream &out, ast::PassManager &mgr)
       // Restore the original tree.
       auto &ast = ctx.get<ast::ASTContext>();
       ast.clear();
-      ast.root = clone(ast, saved.root, ast::Location());
+      ast.root = clone(ast, ast::Location(), saved.root);
     }
 
     // Compute the variance of the samples.

--- a/src/driver.cpp
+++ b/src/driver.cpp
@@ -49,7 +49,12 @@ void Driver::error(const ast::SourceLocation &l, const std::string &m)
 {
   // This path is normally not allowed, however we don't yet have nodes
   // constructed. Therefore, we add diagnostics directly via the private field.
-  ctx.state_->diagnostics_->addError(ctx.wrap(l)) << m;
+  ast::SourceLocation valid(loc);
+  valid.begin = l.begin;
+  valid.end = l.end;
+  ctx.state_->diagnostics_->addError(
+      std::make_shared<ast::LocationChain>(std::move(valid)))
+      << m;
 }
 
 ast::Pass CreateParsePass(bool debug)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -674,15 +674,17 @@ bool is_colorize()
 static ast::ASTContext buildListProgram(const std::string& search)
 {
   ast::ASTContext ast("listing", search);
-  auto* ap = ast.make_node<ast::AttachPoint>(search, true, ast::Location());
-  auto* probe = ast.make_node<ast::Probe>(ast::AttachPointList({ ap }),
-                                          nullptr,
-                                          ast::Location());
-  ast.root = ast.make_node<ast::Program>(ast::CStatementList(),
+  auto* ap = ast.make_node<ast::AttachPoint>(ast::SourceLocation(),
+                                             search,
+                                             true);
+  auto* probe = ast.make_node<ast::Probe>(ast::SourceLocation(),
+                                          ast::AttachPointList({ ap }),
+                                          nullptr);
+  ast.root = ast.make_node<ast::Program>(ast::SourceLocation(),
+                                         ast::CStatementList(),
                                          nullptr,
                                          ast::ImportList(),
-                                         ast::RootStatements({ probe }),
-                                         ast::Location());
+                                         ast::RootStatements({ probe }));
   return ast;
 }
 

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -23,35 +23,35 @@ std::vector<T> variants(ASTContext &c, SourceLocation l);
 template <>
 std::vector<Integer *> variants<Integer>(ASTContext &c, SourceLocation l)
 {
-  return { c.make_node<Integer>(42UL, l),
-           c.make_node<Integer>(24UL, l),
-           c.make_node<Integer>(100UL, l),
-           c.make_node<Integer>(0UL, l) };
+  return { c.make_node<Integer>(l, 42UL),
+           c.make_node<Integer>(l, 24UL),
+           c.make_node<Integer>(l, 100UL),
+           c.make_node<Integer>(l, 0UL) };
 }
 
 template <>
 std::vector<NegativeInteger *> variants<NegativeInteger>(ASTContext &c,
                                                          SourceLocation l)
 {
-  return { c.make_node<NegativeInteger>(-42L, l),
-           c.make_node<NegativeInteger>(-24L, l),
-           c.make_node<NegativeInteger>(-100L, l),
-           c.make_node<NegativeInteger>(-1L, l) };
+  return { c.make_node<NegativeInteger>(l, -42L),
+           c.make_node<NegativeInteger>(l, -24L),
+           c.make_node<NegativeInteger>(l, -100L),
+           c.make_node<NegativeInteger>(l, -1L) };
 }
 
 template <>
 std::vector<Boolean *> variants<Boolean>(ASTContext &c, SourceLocation l)
 {
-  return { c.make_node<Boolean>(true, l), c.make_node<Boolean>(false, l) };
+  return { c.make_node<Boolean>(l, true), c.make_node<Boolean>(l, false) };
 }
 
 template <>
 std::vector<String *> variants<String>(ASTContext &c, SourceLocation l)
 {
-  return { c.make_node<String>(std::string("test"), l),
-           c.make_node<String>(std::string("different"), l),
-           c.make_node<String>(std::string("another"), l),
-           c.make_node<String>(std::string(""), l) };
+  return { c.make_node<String>(l, std::string("test")),
+           c.make_node<String>(l, std::string("different")),
+           c.make_node<String>(l, std::string("another")),
+           c.make_node<String>(l, std::string("")) };
 }
 
 template <>
@@ -63,37 +63,37 @@ std::vector<None *> variants<None>(ASTContext &c, SourceLocation l)
 template <>
 std::vector<Identifier *> variants<Identifier>(ASTContext &c, SourceLocation l)
 {
-  return { c.make_node<Identifier>(std::string("var"), l),
-           c.make_node<Identifier>(std::string("other"), l),
-           c.make_node<Identifier>(std::string("xyz"), l),
-           c.make_node<Identifier>(std::string("_test"), l) };
+  return { c.make_node<Identifier>(l, std::string("var")),
+           c.make_node<Identifier>(l, std::string("other")),
+           c.make_node<Identifier>(l, std::string("xyz")),
+           c.make_node<Identifier>(l, std::string("_test")) };
 }
 
 template <>
 std::vector<Builtin *> variants<Builtin>(ASTContext &c, SourceLocation l)
 {
-  return { c.make_node<Builtin>(std::string("pid"), l),
-           c.make_node<Builtin>(std::string("tid"), l),
-           c.make_node<Builtin>(std::string("uid"), l),
-           c.make_node<Builtin>(std::string("comm"), l) };
+  return { c.make_node<Builtin>(l, std::string("pid")),
+           c.make_node<Builtin>(l, std::string("tid")),
+           c.make_node<Builtin>(l, std::string("uid")),
+           c.make_node<Builtin>(l, std::string("comm")) };
 }
 
 template <>
 std::vector<Variable *> variants<Variable>(ASTContext &c, SourceLocation l)
 {
-  return { c.make_node<Variable>(std::string("$var"), l),
-           c.make_node<Variable>(std::string("$other"), l),
-           c.make_node<Variable>(std::string("$x"), l),
-           c.make_node<Variable>(std::string("$test123"), l) };
+  return { c.make_node<Variable>(l, std::string("$var")),
+           c.make_node<Variable>(l, std::string("$other")),
+           c.make_node<Variable>(l, std::string("$x")),
+           c.make_node<Variable>(l, std::string("$test123")) };
 }
 
 template <>
 std::vector<Map *> variants<Map>(ASTContext &c, SourceLocation l)
 {
-  return { c.make_node<Map>(std::string("@map"), l),
-           c.make_node<Map>(std::string("@other"), l),
-           c.make_node<Map>(std::string("@data"), l),
-           c.make_node<Map>(std::string("@count"), l) };
+  return { c.make_node<Map>(l, std::string("@map")),
+           c.make_node<Map>(l, std::string("@other")),
+           c.make_node<Map>(l, std::string("@data")),
+           c.make_node<Map>(l, std::string("@count")) };
 }
 
 template <>
@@ -101,10 +101,10 @@ std::vector<PositionalParameter *> variants<PositionalParameter>(
     ASTContext &c,
     SourceLocation l)
 {
-  return { c.make_node<PositionalParameter>(1L, l),
-           c.make_node<PositionalParameter>(2L, l),
-           c.make_node<PositionalParameter>(0L, l),
-           c.make_node<PositionalParameter>(10L, l) };
+  return { c.make_node<PositionalParameter>(l, 1L),
+           c.make_node<PositionalParameter>(l, 2L),
+           c.make_node<PositionalParameter>(l, 0L),
+           c.make_node<PositionalParameter>(l, 10L) };
 }
 
 template <>
@@ -119,31 +119,31 @@ template <>
 std::vector<Call *> variants<Call>(ASTContext &c, SourceLocation l)
 {
   ExpressionList args1;
-  args1.emplace_back(c.make_node<Integer>(1UL, l));
+  args1.emplace_back(c.make_node<Integer>(l, 1UL));
 
   ExpressionList args2;
-  args2.emplace_back(c.make_node<String>(std::string("test"), l));
+  args2.emplace_back(c.make_node<String>(l, std::string("test")));
 
   ExpressionList args3;
-  args3.emplace_back(c.make_node<Integer>(2UL, l));
-  args3.emplace_back(c.make_node<String>(std::string("arg"), l));
+  args3.emplace_back(c.make_node<Integer>(l, 2UL));
+  args3.emplace_back(c.make_node<String>(l, std::string("arg")));
 
   ExpressionList args4;
 
-  return { c.make_node<Call>(std::string("printf"), std::move(args1), l),
-           c.make_node<Call>(std::string("count"), std::move(args4), l),
-           c.make_node<Call>(std::string("printf"), std::move(args2), l),
-           c.make_node<Call>(std::string("printf"), std::move(args3), l) };
+  return { c.make_node<Call>(l, std::string("printf"), std::move(args1)),
+           c.make_node<Call>(l, std::string("count"), std::move(args4)),
+           c.make_node<Call>(l, std::string("printf"), std::move(args2)),
+           c.make_node<Call>(l, std::string("printf"), std::move(args3)) };
 }
 
 template <>
 std::vector<Sizeof *> variants<Sizeof>(ASTContext &c, SourceLocation l)
 {
-  Expression expr = c.make_node<Integer>(42UL, l);
-  return { c.make_node<Sizeof>(CreateInt32(), l),
-           c.make_node<Sizeof>(CreateInt64(), l),
-           c.make_node<Sizeof>(CreateUInt32(), l),
-           c.make_node<Sizeof>(std::move(expr), l) };
+  Expression expr = c.make_node<Integer>(l, 42UL);
+  return { c.make_node<Sizeof>(l, CreateInt32()),
+           c.make_node<Sizeof>(l, CreateInt64()),
+           c.make_node<Sizeof>(l, CreateUInt32()),
+           c.make_node<Sizeof>(l, std::move(expr)) };
 }
 
 template <>
@@ -152,89 +152,89 @@ std::vector<Offsetof *> variants<Offsetof>(ASTContext &c, SourceLocation l)
   std::vector<std::string> field1 = { "field" };
   std::vector<std::string> field2 = { "other" };
   std::vector<std::string> field3 = { "field", "nested" };
-  Expression expr = c.make_node<Variable>(std::string("$var"), l);
+  Expression expr = c.make_node<Variable>(l, std::string("$var"));
   std::vector<std::string> field4 = { "member" };
 
-  return { c.make_node<Offsetof>(CreateInteger(32, false), field1, l),
-           c.make_node<Offsetof>(CreateInteger(64, false), field2, l),
-           c.make_node<Offsetof>(CreateString(64), field3, l),
-           c.make_node<Offsetof>(std::move(expr), field4, l) };
+  return { c.make_node<Offsetof>(l, CreateInteger(32, false), field1),
+           c.make_node<Offsetof>(l, CreateInteger(64, false), field2),
+           c.make_node<Offsetof>(l, CreateString(64), field3),
+           c.make_node<Offsetof>(l, std::move(expr), field4) };
 }
 
 template <>
 std::vector<VariableAddr *> variants<VariableAddr>(ASTContext &c,
                                                    SourceLocation l)
 {
-  auto *var1 = c.make_node<Variable>(std::string("$var"), l);
-  auto *var2 = c.make_node<Variable>(std::string("$other"), l);
-  auto *var3 = c.make_node<Variable>(std::string("$x"), l);
+  auto *var1 = c.make_node<Variable>(l, std::string("$var"));
+  auto *var2 = c.make_node<Variable>(l, std::string("$other"));
+  auto *var3 = c.make_node<Variable>(l, std::string("$x"));
 
-  return { c.make_node<VariableAddr>(var1, l),
-           c.make_node<VariableAddr>(var2, l),
-           c.make_node<VariableAddr>(var3, l) };
+  return { c.make_node<VariableAddr>(l, var1),
+           c.make_node<VariableAddr>(l, var2),
+           c.make_node<VariableAddr>(l, var3) };
 }
 
 template <>
 std::vector<MapAddr *> variants<MapAddr>(ASTContext &c, SourceLocation l)
 {
-  auto *map1 = c.make_node<Map>(std::string("@map"), l);
-  auto *map2 = c.make_node<Map>(std::string("@other"), l);
-  auto *map3 = c.make_node<Map>(std::string("@data"), l);
+  auto *map1 = c.make_node<Map>(l, std::string("@map"));
+  auto *map2 = c.make_node<Map>(l, std::string("@other"));
+  auto *map3 = c.make_node<Map>(l, std::string("@data"));
 
-  return { c.make_node<MapAddr>(map1, l),
-           c.make_node<MapAddr>(map2, l),
-           c.make_node<MapAddr>(map3, l) };
+  return { c.make_node<MapAddr>(l, map1),
+           c.make_node<MapAddr>(l, map2),
+           c.make_node<MapAddr>(l, map3) };
 }
 
 template <>
 std::vector<Binop *> variants<Binop>(ASTContext &c, SourceLocation l)
 {
-  Expression left1 = c.make_node<Integer>(1UL, l);
-  Expression right1 = c.make_node<Integer>(2UL, l);
+  Expression left1 = c.make_node<Integer>(l, 1UL);
+  Expression right1 = c.make_node<Integer>(l, 2UL);
 
-  Expression left2 = c.make_node<Integer>(3UL, l);
-  Expression right2 = c.make_node<Integer>(4UL, l);
+  Expression left2 = c.make_node<Integer>(l, 3UL);
+  Expression right2 = c.make_node<Integer>(l, 4UL);
 
-  Expression left3 = c.make_node<Integer>(1UL, l);
-  Expression right3 = c.make_node<Integer>(2UL, l);
+  Expression left3 = c.make_node<Integer>(l, 1UL);
+  Expression right3 = c.make_node<Integer>(l, 2UL);
 
-  Expression left4 = c.make_node<Variable>(std::string("$x"), l);
-  Expression right4 = c.make_node<Integer>(5UL, l);
+  Expression left4 = c.make_node<Variable>(l, std::string("$x"));
+  Expression right4 = c.make_node<Integer>(l, 5UL);
 
   return {
-    c.make_node<Binop>(std::move(left1), Operator::PLUS, std::move(right1), l),
-    c.make_node<Binop>(std::move(left2), Operator::MINUS, std::move(right2), l),
-    c.make_node<Binop>(std::move(left3), Operator::MUL, std::move(right3), l),
-    c.make_node<Binop>(std::move(left4), Operator::PLUS, std::move(right4), l)
+    c.make_node<Binop>(l, std::move(left1), Operator::PLUS, std::move(right1)),
+    c.make_node<Binop>(l, std::move(left2), Operator::MINUS, std::move(right2)),
+    c.make_node<Binop>(l, std::move(left3), Operator::MUL, std::move(right3)),
+    c.make_node<Binop>(l, std::move(left4), Operator::PLUS, std::move(right4))
   };
 }
 
 template <>
 std::vector<Unop *> variants<Unop>(ASTContext &c, SourceLocation l)
 {
-  Expression expr1 = c.make_node<Integer>(42UL, l);
-  Expression expr2 = c.make_node<Integer>(24UL, l);
-  Expression expr3 = c.make_node<Variable>(std::string("$x"), l);
+  Expression expr1 = c.make_node<Integer>(l, 42UL);
+  Expression expr2 = c.make_node<Integer>(l, 24UL);
+  Expression expr3 = c.make_node<Variable>(l, std::string("$x"));
 
-  return { c.make_node<Unop>(std::move(expr1), Operator::LNOT, l),
-           c.make_node<Unop>(std::move(expr2), Operator::BNOT, l),
-           c.make_node<Unop>(std::move(expr3), Operator::LNOT, l) };
+  return { c.make_node<Unop>(l, std::move(expr1), Operator::LNOT),
+           c.make_node<Unop>(l, std::move(expr2), Operator::BNOT),
+           c.make_node<Unop>(l, std::move(expr3), Operator::LNOT) };
 }
 
 template <>
 std::vector<FieldAccess *> variants<FieldAccess>(ASTContext &c,
                                                  SourceLocation l)
 {
-  Expression expr1 = c.make_node<Variable>(std::string("$var"), l);
-  Expression expr2 = c.make_node<Variable>(std::string("$other"), l);
-  Expression expr3 = c.make_node<Variable>(std::string("$var"), l);
-  Expression expr4 = c.make_node<Builtin>(std::string("pid"), l);
+  Expression expr1 = c.make_node<Variable>(l, std::string("$var"));
+  Expression expr2 = c.make_node<Variable>(l, std::string("$other"));
+  Expression expr3 = c.make_node<Variable>(l, std::string("$var"));
+  Expression expr4 = c.make_node<Builtin>(l, std::string("pid"));
 
   return {
-    c.make_node<FieldAccess>(std::move(expr1), std::string("field"), l),
-    c.make_node<FieldAccess>(std::move(expr2), std::string("field"), l),
-    c.make_node<FieldAccess>(std::move(expr3), std::string("other"), l),
-    c.make_node<FieldAccess>(std::move(expr4), std::string("member"), l)
+    c.make_node<FieldAccess>(l, std::move(expr1), std::string("field")),
+    c.make_node<FieldAccess>(l, std::move(expr2), std::string("field")),
+    c.make_node<FieldAccess>(l, std::move(expr3), std::string("other")),
+    c.make_node<FieldAccess>(l, std::move(expr4), std::string("member"))
   };
 }
 
@@ -242,223 +242,223 @@ template <>
 std::vector<ArrayAccess *> variants<ArrayAccess>(ASTContext &c,
                                                  SourceLocation l)
 {
-  Expression expr1 = c.make_node<Variable>(std::string("$arr"), l);
-  Expression index1 = c.make_node<Integer>(0UL, l);
+  Expression expr1 = c.make_node<Variable>(l, std::string("$arr"));
+  Expression index1 = c.make_node<Integer>(l, 0UL);
 
-  Expression expr2 = c.make_node<Variable>(std::string("$other"), l);
-  Expression index2 = c.make_node<Integer>(1UL, l);
+  Expression expr2 = c.make_node<Variable>(l, std::string("$other"));
+  Expression index2 = c.make_node<Integer>(l, 1UL);
 
-  Expression expr3 = c.make_node<Variable>(std::string("$arr"), l);
-  Expression index3 = c.make_node<Integer>(2UL, l);
+  Expression expr3 = c.make_node<Variable>(l, std::string("$arr"));
+  Expression index3 = c.make_node<Integer>(l, 2UL);
 
-  Expression expr4 = c.make_node<Map>(std::string("@data"), l);
-  Expression index4 = c.make_node<Variable>(std::string("$key"), l);
+  Expression expr4 = c.make_node<Map>(l, std::string("@data"));
+  Expression index4 = c.make_node<Variable>(l, std::string("$key"));
 
-  return { c.make_node<ArrayAccess>(std::move(expr1), std::move(index1), l),
-           c.make_node<ArrayAccess>(std::move(expr2), std::move(index2), l),
-           c.make_node<ArrayAccess>(std::move(expr3), std::move(index3), l),
-           c.make_node<ArrayAccess>(std::move(expr4), std::move(index4), l) };
+  return { c.make_node<ArrayAccess>(l, std::move(expr1), std::move(index1)),
+           c.make_node<ArrayAccess>(l, std::move(expr2), std::move(index2)),
+           c.make_node<ArrayAccess>(l, std::move(expr3), std::move(index3)),
+           c.make_node<ArrayAccess>(l, std::move(expr4), std::move(index4)) };
 }
 
 template <>
 std::vector<TupleAccess *> variants<TupleAccess>(ASTContext &c,
                                                  SourceLocation l)
 {
-  Expression expr1 = c.make_node<Variable>(std::string("$tuple"), l);
-  Expression expr2 = c.make_node<Variable>(std::string("$other"), l);
-  Expression expr3 = c.make_node<Variable>(std::string("$tuple"), l);
-  Expression expr4 = c.make_node<Variable>(std::string("$xyz"), l);
+  Expression expr1 = c.make_node<Variable>(l, std::string("$tuple"));
+  Expression expr2 = c.make_node<Variable>(l, std::string("$other"));
+  Expression expr3 = c.make_node<Variable>(l, std::string("$tuple"));
+  Expression expr4 = c.make_node<Variable>(l, std::string("$xyz"));
 
-  return { c.make_node<TupleAccess>(std::move(expr1), 0, l),
-           c.make_node<TupleAccess>(std::move(expr2), 0, l),
-           c.make_node<TupleAccess>(std::move(expr3), 1, l),
-           c.make_node<TupleAccess>(std::move(expr4), 2, l) };
+  return { c.make_node<TupleAccess>(l, std::move(expr1), 0),
+           c.make_node<TupleAccess>(l, std::move(expr2), 0),
+           c.make_node<TupleAccess>(l, std::move(expr3), 1),
+           c.make_node<TupleAccess>(l, std::move(expr4), 2) };
 }
 
 template <>
 std::vector<MapAccess *> variants<MapAccess>(ASTContext &c, SourceLocation l)
 {
-  auto *map1 = c.make_node<Map>(std::string("@map"), l);
-  Expression key1 = c.make_node<Integer>(1UL, l);
+  auto *map1 = c.make_node<Map>(l, std::string("@map"));
+  Expression key1 = c.make_node<Integer>(l, 1UL);
 
-  auto *map2 = c.make_node<Map>(std::string("@other"), l);
-  Expression key2 = c.make_node<Integer>(2UL, l);
+  auto *map2 = c.make_node<Map>(l, std::string("@other"));
+  Expression key2 = c.make_node<Integer>(l, 2UL);
 
-  auto *map3 = c.make_node<Map>(std::string("@map"), l);
-  Expression key3 = c.make_node<String>(std::string("key"), l);
+  auto *map3 = c.make_node<Map>(l, std::string("@map"));
+  Expression key3 = c.make_node<String>(l, std::string("key"));
 
-  auto *map4 = c.make_node<Map>(std::string("@data"), l);
-  Expression key4 = c.make_node<Variable>(std::string("$key"), l);
+  auto *map4 = c.make_node<Map>(l, std::string("@data"));
+  Expression key4 = c.make_node<Variable>(l, std::string("$key"));
 
-  return { c.make_node<MapAccess>(map1, std::move(key1), l),
-           c.make_node<MapAccess>(map2, std::move(key2), l),
-           c.make_node<MapAccess>(map3, std::move(key3), l),
-           c.make_node<MapAccess>(map4, std::move(key4), l) };
+  return { c.make_node<MapAccess>(l, map1, std::move(key1)),
+           c.make_node<MapAccess>(l, map2, std::move(key2)),
+           c.make_node<MapAccess>(l, map3, std::move(key3)),
+           c.make_node<MapAccess>(l, map4, std::move(key4)) };
 }
 
 template <>
 std::vector<Cast *> variants<Cast>(ASTContext &c, SourceLocation l)
 {
-  auto *typeof1 = c.make_node<Typeof>(CreateInt32(), l);
-  Expression expr1 = c.make_node<Integer>(42UL, l);
+  auto *typeof1 = c.make_node<Typeof>(l, CreateInt32());
+  Expression expr1 = c.make_node<Integer>(l, 42UL);
 
-  auto *typeof2 = c.make_node<Typeof>(CreateInt64(), l);
-  Expression expr2 = c.make_node<Integer>(24UL, l);
+  auto *typeof2 = c.make_node<Typeof>(l, CreateInt64());
+  Expression expr2 = c.make_node<Integer>(l, 24UL);
 
-  auto *typeof3 = c.make_node<Typeof>(CreateInt32(), l);
-  Expression expr3 = c.make_node<Variable>(std::string("$x"), l);
+  auto *typeof3 = c.make_node<Typeof>(l, CreateInt32());
+  Expression expr3 = c.make_node<Variable>(l, std::string("$x"));
 
-  auto *typeof4 = c.make_node<Typeof>(CreateUInt32(), l);
-  Expression expr4 = c.make_node<Integer>(42UL, l);
+  auto *typeof4 = c.make_node<Typeof>(l, CreateUInt32());
+  Expression expr4 = c.make_node<Integer>(l, 42UL);
 
-  return { c.make_node<Cast>(typeof1, std::move(expr1), l),
-           c.make_node<Cast>(typeof2, std::move(expr2), l),
-           c.make_node<Cast>(typeof3, std::move(expr3), l),
-           c.make_node<Cast>(typeof4, std::move(expr4), l) };
+  return { c.make_node<Cast>(l, typeof1, std::move(expr1)),
+           c.make_node<Cast>(l, typeof2, std::move(expr2)),
+           c.make_node<Cast>(l, typeof3, std::move(expr3)),
+           c.make_node<Cast>(l, typeof4, std::move(expr4)) };
 }
 
 template <>
 std::vector<Tuple *> variants<Tuple>(ASTContext &c, SourceLocation l)
 {
   ExpressionList elems1;
-  elems1.emplace_back(c.make_node<Integer>(1UL, l));
-  elems1.emplace_back(c.make_node<Integer>(2UL, l));
+  elems1.emplace_back(c.make_node<Integer>(l, 1UL));
+  elems1.emplace_back(c.make_node<Integer>(l, 2UL));
 
   ExpressionList elems2;
-  elems2.emplace_back(c.make_node<Integer>(3UL, l));
-  elems2.emplace_back(c.make_node<Integer>(4UL, l));
+  elems2.emplace_back(c.make_node<Integer>(l, 3UL));
+  elems2.emplace_back(c.make_node<Integer>(l, 4UL));
 
   ExpressionList elems3;
-  elems3.emplace_back(c.make_node<String>(std::string("a"), l));
-  elems3.emplace_back(c.make_node<String>(std::string("b"), l));
+  elems3.emplace_back(c.make_node<String>(l, std::string("a")));
+  elems3.emplace_back(c.make_node<String>(l, std::string("b")));
 
   ExpressionList elems4;
-  elems4.emplace_back(c.make_node<Integer>(1UL, l));
-  elems4.emplace_back(c.make_node<String>(std::string("mixed"), l));
-  elems4.emplace_back(c.make_node<Boolean>(true, l));
+  elems4.emplace_back(c.make_node<Integer>(l, 1UL));
+  elems4.emplace_back(c.make_node<String>(l, std::string("mixed")));
+  elems4.emplace_back(c.make_node<Boolean>(l, true));
 
-  return { c.make_node<Tuple>(std::move(elems1), l),
-           c.make_node<Tuple>(std::move(elems2), l),
-           c.make_node<Tuple>(std::move(elems3), l),
-           c.make_node<Tuple>(std::move(elems4), l) };
+  return { c.make_node<Tuple>(l, std::move(elems1)),
+           c.make_node<Tuple>(l, std::move(elems2)),
+           c.make_node<Tuple>(l, std::move(elems3)),
+           c.make_node<Tuple>(l, std::move(elems4)) };
 }
 
 template <>
 std::vector<IfExpr *> variants<IfExpr>(ASTContext &c, SourceLocation l)
 {
-  Expression cond1 = c.make_node<Boolean>(true, l);
-  Expression left1 = c.make_node<Integer>(1UL, l);
-  Expression right1 = c.make_node<Integer>(2UL, l);
+  Expression cond1 = c.make_node<Boolean>(l, true);
+  Expression left1 = c.make_node<Integer>(l, 1UL);
+  Expression right1 = c.make_node<Integer>(l, 2UL);
 
-  Expression cond2 = c.make_node<Boolean>(false, l);
-  Expression left2 = c.make_node<Integer>(3UL, l);
-  Expression right2 = c.make_node<Integer>(4UL, l);
+  Expression cond2 = c.make_node<Boolean>(l, false);
+  Expression left2 = c.make_node<Integer>(l, 3UL);
+  Expression right2 = c.make_node<Integer>(l, 4UL);
 
-  Expression cond3 = c.make_node<Variable>(std::string("$flag"), l);
-  Expression left3 = c.make_node<String>(std::string("yes"), l);
-  Expression right3 = c.make_node<String>(std::string("no"), l);
+  Expression cond3 = c.make_node<Variable>(l, std::string("$flag"));
+  Expression left3 = c.make_node<String>(l, std::string("yes"));
+  Expression right3 = c.make_node<String>(l, std::string("no"));
 
-  Expression cond4 = c.make_node<Boolean>(true, l);
-  Expression left4 = c.make_node<Integer>(10UL, l);
-  Expression right4 = c.make_node<Integer>(20UL, l);
+  Expression cond4 = c.make_node<Boolean>(l, true);
+  Expression left4 = c.make_node<Integer>(l, 10UL);
+  Expression right4 = c.make_node<Integer>(l, 20UL);
 
   return { c.make_node<IfExpr>(
-               std::move(cond1), std::move(left1), std::move(right1), l),
+               l, std::move(cond1), std::move(left1), std::move(right1)),
            c.make_node<IfExpr>(
-               std::move(cond2), std::move(left2), std::move(right2), l),
+               l, std::move(cond2), std::move(left2), std::move(right2)),
            c.make_node<IfExpr>(
-               std::move(cond3), std::move(left3), std::move(right3), l),
+               l, std::move(cond3), std::move(left3), std::move(right3)),
            c.make_node<IfExpr>(
-               std::move(cond4), std::move(left4), std::move(right4), l) };
+               l, std::move(cond4), std::move(left4), std::move(right4)) };
 }
 
 template <>
 std::vector<BlockExpr *> variants<BlockExpr>(ASTContext &c, SourceLocation l)
 {
   StatementList stmts1;
-  Expression expr1 = c.make_node<Integer>(42UL, l);
+  Expression expr1 = c.make_node<Integer>(l, 42UL);
 
   StatementList stmts2;
-  Expression expr2 = c.make_node<Integer>(24UL, l);
+  Expression expr2 = c.make_node<Integer>(l, 24UL);
 
   StatementList stmts3;
-  Expression stmt_expr = c.make_node<Variable>(std::string("$x"), l);
-  stmts3.emplace_back(c.make_node<ExprStatement>(std::move(stmt_expr), l));
-  Expression expr3 = c.make_node<String>(std::string("result"), l);
+  Expression stmt_expr = c.make_node<Variable>(l, std::string("$x"));
+  stmts3.emplace_back(c.make_node<ExprStatement>(l, std::move(stmt_expr)));
+  Expression expr3 = c.make_node<String>(l, std::string("result"));
 
   StatementList stmts4;
-  Expression expr4 = c.make_node<Boolean>(true, l);
+  Expression expr4 = c.make_node<Boolean>(l, true);
 
-  return { c.make_node<BlockExpr>(std::move(stmts1), std::move(expr1), l),
-           c.make_node<BlockExpr>(std::move(stmts2), std::move(expr2), l),
-           c.make_node<BlockExpr>(std::move(stmts3), std::move(expr3), l),
-           c.make_node<BlockExpr>(std::move(stmts4), std::move(expr4), l) };
+  return { c.make_node<BlockExpr>(l, std::move(stmts1), std::move(expr1)),
+           c.make_node<BlockExpr>(l, std::move(stmts2), std::move(expr2)),
+           c.make_node<BlockExpr>(l, std::move(stmts3), std::move(expr3)),
+           c.make_node<BlockExpr>(l, std::move(stmts4), std::move(expr4)) };
 }
 
 template <>
 std::vector<Typeinfo *> variants<Typeinfo>(ASTContext &c, SourceLocation l)
 {
-  auto *typeof1 = c.make_node<Typeof>(CreateInt32(), l);
-  auto *typeof2 = c.make_node<Typeof>(CreateInt64(), l);
-  auto *typeof3 = c.make_node<Typeof>(CreateUInt32(), l);
-  Expression expr = c.make_node<Variable>(std::string("$x"), l);
-  auto *typeof4 = c.make_node<Typeof>(std::move(expr), l);
+  auto *typeof1 = c.make_node<Typeof>(l, CreateInt32());
+  auto *typeof2 = c.make_node<Typeof>(l, CreateInt64());
+  auto *typeof3 = c.make_node<Typeof>(l, CreateUInt32());
+  Expression expr = c.make_node<Variable>(l, std::string("$x"));
+  auto *typeof4 = c.make_node<Typeof>(l, std::move(expr));
 
-  return { c.make_node<Typeinfo>(typeof1, l),
-           c.make_node<Typeinfo>(typeof2, l),
-           c.make_node<Typeinfo>(typeof3, l),
-           c.make_node<Typeinfo>(typeof4, l) };
+  return { c.make_node<Typeinfo>(l, typeof1),
+           c.make_node<Typeinfo>(l, typeof2),
+           c.make_node<Typeinfo>(l, typeof3),
+           c.make_node<Typeinfo>(l, typeof4) };
 }
 
 template <>
 std::vector<Comptime *> variants<Comptime>(ASTContext &c, SourceLocation l)
 {
-  Expression expr1 = c.make_node<Integer>(42UL, l);
-  Expression expr2 = c.make_node<Integer>(24UL, l);
-  Expression expr3 = c.make_node<String>(std::string("test"), l);
-  Expression expr4 = c.make_node<Variable>(std::string("$x"), l);
+  Expression expr1 = c.make_node<Integer>(l, 42UL);
+  Expression expr2 = c.make_node<Integer>(l, 24UL);
+  Expression expr3 = c.make_node<String>(l, std::string("test"));
+  Expression expr4 = c.make_node<Variable>(l, std::string("$x"));
 
-  return { c.make_node<Comptime>(std::move(expr1), l),
-           c.make_node<Comptime>(std::move(expr2), l),
-           c.make_node<Comptime>(std::move(expr3), l),
-           c.make_node<Comptime>(std::move(expr4), l) };
+  return { c.make_node<Comptime>(l, std::move(expr1)),
+           c.make_node<Comptime>(l, std::move(expr2)),
+           c.make_node<Comptime>(l, std::move(expr3)),
+           c.make_node<Comptime>(l, std::move(expr4)) };
 }
 
 template <>
 std::vector<ExprStatement *> variants<ExprStatement>(ASTContext &c,
                                                      SourceLocation l)
 {
-  Expression expr1 = c.make_node<Integer>(42UL, l);
-  Expression expr2 = c.make_node<Integer>(24UL, l);
-  Expression expr3 = c.make_node<String>(std::string("test"), l);
-  Expression expr4 = c.make_node<Variable>(std::string("$x"), l);
+  Expression expr1 = c.make_node<Integer>(l, 42UL);
+  Expression expr2 = c.make_node<Integer>(l, 24UL);
+  Expression expr3 = c.make_node<String>(l, std::string("test"));
+  Expression expr4 = c.make_node<Variable>(l, std::string("$x"));
 
-  return { c.make_node<ExprStatement>(std::move(expr1), l),
-           c.make_node<ExprStatement>(std::move(expr2), l),
-           c.make_node<ExprStatement>(std::move(expr3), l),
-           c.make_node<ExprStatement>(std::move(expr4), l) };
+  return { c.make_node<ExprStatement>(l, std::move(expr1)),
+           c.make_node<ExprStatement>(l, std::move(expr2)),
+           c.make_node<ExprStatement>(l, std::move(expr3)),
+           c.make_node<ExprStatement>(l, std::move(expr4)) };
 }
 
 template <>
 std::vector<VarDeclStatement *> variants<VarDeclStatement>(ASTContext &c,
                                                            SourceLocation l)
 {
-  auto *var1 = c.make_node<Variable>(std::string("$var"), l);
-  auto *typeof1 = c.make_node<Typeof>(CreateInt32(), l);
+  auto *var1 = c.make_node<Variable>(l, std::string("$var"));
+  auto *typeof1 = c.make_node<Typeof>(l, CreateInt32());
 
-  auto *var2 = c.make_node<Variable>(std::string("$other"), l);
-  auto *typeof2 = c.make_node<Typeof>(CreateInt64(), l);
+  auto *var2 = c.make_node<Variable>(l, std::string("$other"));
+  auto *typeof2 = c.make_node<Typeof>(l, CreateInt64());
 
-  auto *var3 = c.make_node<Variable>(std::string("$x"), l);
-  auto *typeof3 = c.make_node<Typeof>(CreateUInt32(), l);
+  auto *var3 = c.make_node<Variable>(l, std::string("$x"));
+  auto *typeof3 = c.make_node<Typeof>(l, CreateUInt32());
 
-  auto *var4 = c.make_node<Variable>(std::string("$test"), l);
-  auto *typeof4 = c.make_node<Typeof>(CreateInt32(), l);
+  auto *var4 = c.make_node<Variable>(l, std::string("$test"));
+  auto *typeof4 = c.make_node<Typeof>(l, CreateInt32());
 
-  return { c.make_node<VarDeclStatement>(var1, typeof1, l),
-           c.make_node<VarDeclStatement>(var2, typeof2, l),
-           c.make_node<VarDeclStatement>(var3, typeof3, l),
-           c.make_node<VarDeclStatement>(var4, typeof4, l) };
+  return { c.make_node<VarDeclStatement>(l, var1, typeof1),
+           c.make_node<VarDeclStatement>(l, var2, typeof2),
+           c.make_node<VarDeclStatement>(l, var3, typeof3),
+           c.make_node<VarDeclStatement>(l, var4, typeof4) };
 }
 
 template <>
@@ -466,49 +466,49 @@ std::vector<AssignScalarMapStatement *> variants<AssignScalarMapStatement>(
     ASTContext &c,
     SourceLocation l)
 {
-  auto *map1 = c.make_node<Map>(std::string("@map"), l);
-  Expression expr1 = c.make_node<Integer>(42UL, l);
+  auto *map1 = c.make_node<Map>(l, std::string("@map"));
+  Expression expr1 = c.make_node<Integer>(l, 42UL);
 
-  auto *map2 = c.make_node<Map>(std::string("@other"), l);
-  Expression expr2 = c.make_node<Integer>(24UL, l);
+  auto *map2 = c.make_node<Map>(l, std::string("@other"));
+  Expression expr2 = c.make_node<Integer>(l, 24UL);
 
-  auto *map3 = c.make_node<Map>(std::string("@map"), l);
-  Expression expr3 = c.make_node<String>(std::string("value"), l);
+  auto *map3 = c.make_node<Map>(l, std::string("@map"));
+  Expression expr3 = c.make_node<String>(l, std::string("value"));
 
-  auto *map4 = c.make_node<Map>(std::string("@data"), l);
-  Expression expr4 = c.make_node<Variable>(std::string("$x"), l);
+  auto *map4 = c.make_node<Map>(l, std::string("@data"));
+  Expression expr4 = c.make_node<Variable>(l, std::string("$x"));
 
-  return { c.make_node<AssignScalarMapStatement>(map1, std::move(expr1), l),
-           c.make_node<AssignScalarMapStatement>(map2, std::move(expr2), l),
-           c.make_node<AssignScalarMapStatement>(map3, std::move(expr3), l),
-           c.make_node<AssignScalarMapStatement>(map4, std::move(expr4), l) };
+  return { c.make_node<AssignScalarMapStatement>(l, map1, std::move(expr1)),
+           c.make_node<AssignScalarMapStatement>(l, map2, std::move(expr2)),
+           c.make_node<AssignScalarMapStatement>(l, map3, std::move(expr3)),
+           c.make_node<AssignScalarMapStatement>(l, map4, std::move(expr4)) };
 }
 
 template <>
 std::vector<AssignMapStatement *> variants<AssignMapStatement>(ASTContext &c,
                                                                SourceLocation l)
 {
-  auto *map1 = c.make_node<Map>(std::string("@map"), l);
-  Expression key1 = c.make_node<Integer>(1UL, l);
-  Expression expr1 = c.make_node<Integer>(42UL, l);
+  auto *map1 = c.make_node<Map>(l, std::string("@map"));
+  Expression key1 = c.make_node<Integer>(l, 1UL);
+  Expression expr1 = c.make_node<Integer>(l, 42UL);
 
-  auto *map2 = c.make_node<Map>(std::string("@other"), l);
-  Expression key2 = c.make_node<Integer>(2UL, l);
-  Expression expr2 = c.make_node<Integer>(24UL, l);
+  auto *map2 = c.make_node<Map>(l, std::string("@other"));
+  Expression key2 = c.make_node<Integer>(l, 2UL);
+  Expression expr2 = c.make_node<Integer>(l, 24UL);
 
-  auto *map3 = c.make_node<Map>(std::string("@map"), l);
-  Expression key3 = c.make_node<String>(std::string("key"), l);
-  Expression expr3 = c.make_node<String>(std::string("value"), l);
+  auto *map3 = c.make_node<Map>(l, std::string("@map"));
+  Expression key3 = c.make_node<String>(l, std::string("key"));
+  Expression expr3 = c.make_node<String>(l, std::string("value"));
 
-  auto *map4 = c.make_node<Map>(std::string("@data"), l);
-  Expression key4 = c.make_node<Variable>(std::string("$k"), l);
-  Expression expr4 = c.make_node<Variable>(std::string("$v"), l);
+  auto *map4 = c.make_node<Map>(l, std::string("@data"));
+  Expression key4 = c.make_node<Variable>(l, std::string("$k"));
+  Expression expr4 = c.make_node<Variable>(l, std::string("$v"));
 
   return {
-    c.make_node<AssignMapStatement>(map1, std::move(key1), std::move(expr1), l),
-    c.make_node<AssignMapStatement>(map2, std::move(key2), std::move(expr2), l),
-    c.make_node<AssignMapStatement>(map3, std::move(key3), std::move(expr3), l),
-    c.make_node<AssignMapStatement>(map4, std::move(key4), std::move(expr4), l)
+    c.make_node<AssignMapStatement>(l, map1, std::move(key1), std::move(expr1)),
+    c.make_node<AssignMapStatement>(l, map2, std::move(key2), std::move(expr2)),
+    c.make_node<AssignMapStatement>(l, map3, std::move(key3), std::move(expr3)),
+    c.make_node<AssignMapStatement>(l, map4, std::move(key4), std::move(expr4))
   };
 }
 
@@ -516,177 +516,177 @@ template <>
 std::vector<AssignVarStatement *> variants<AssignVarStatement>(ASTContext &c,
                                                                SourceLocation l)
 {
-  auto *var1 = c.make_node<Variable>(std::string("$var"), l);
-  Expression expr1 = c.make_node<Integer>(42UL, l);
+  auto *var1 = c.make_node<Variable>(l, std::string("$var"));
+  Expression expr1 = c.make_node<Integer>(l, 42UL);
 
-  auto *var2 = c.make_node<Variable>(std::string("$other"), l);
-  Expression expr2 = c.make_node<Integer>(24UL, l);
+  auto *var2 = c.make_node<Variable>(l, std::string("$other"));
+  Expression expr2 = c.make_node<Integer>(l, 24UL);
 
-  auto *var3 = c.make_node<Variable>(std::string("$var"), l);
-  Expression expr3 = c.make_node<String>(std::string("value"), l);
+  auto *var3 = c.make_node<Variable>(l, std::string("$var"));
+  Expression expr3 = c.make_node<String>(l, std::string("value"));
 
-  auto *var4 = c.make_node<Variable>(std::string("$x"), l);
-  Expression expr4 = c.make_node<Boolean>(true, l);
+  auto *var4 = c.make_node<Variable>(l, std::string("$x"));
+  Expression expr4 = c.make_node<Boolean>(l, true);
 
-  return { c.make_node<AssignVarStatement>(var1, std::move(expr1), l),
-           c.make_node<AssignVarStatement>(var2, std::move(expr2), l),
-           c.make_node<AssignVarStatement>(var3, std::move(expr3), l),
-           c.make_node<AssignVarStatement>(var4, std::move(expr4), l) };
+  return { c.make_node<AssignVarStatement>(l, var1, std::move(expr1)),
+           c.make_node<AssignVarStatement>(l, var2, std::move(expr2)),
+           c.make_node<AssignVarStatement>(l, var3, std::move(expr3)),
+           c.make_node<AssignVarStatement>(l, var4, std::move(expr4)) };
 }
 
 template <>
 std::vector<Unroll *> variants<Unroll>(ASTContext &c, SourceLocation l)
 {
-  Expression expr1 = c.make_node<Integer>(10UL, l);
+  Expression expr1 = c.make_node<Integer>(l, 10UL);
   StatementList stmts1;
-  Expression block_expr1 = c.make_node<Integer>(1UL, l);
-  auto *block1 = c.make_node<BlockExpr>(std::move(stmts1),
-                                        std::move(block_expr1),
-                                        l);
+  Expression block_expr1 = c.make_node<Integer>(l, 1UL);
+  auto *block1 = c.make_node<BlockExpr>(l,
+                                        std::move(stmts1),
+                                        std::move(block_expr1));
 
-  Expression expr2 = c.make_node<Integer>(5UL, l);
+  Expression expr2 = c.make_node<Integer>(l, 5UL);
   StatementList stmts2;
-  Expression block_expr2 = c.make_node<Integer>(2UL, l);
-  auto *block2 = c.make_node<BlockExpr>(std::move(stmts2),
-                                        std::move(block_expr2),
-                                        l);
+  Expression block_expr2 = c.make_node<Integer>(l, 2UL);
+  auto *block2 = c.make_node<BlockExpr>(l,
+                                        std::move(stmts2),
+                                        std::move(block_expr2));
 
-  Expression expr3 = c.make_node<Variable>(std::string("$count"), l);
+  Expression expr3 = c.make_node<Variable>(l, std::string("$count"));
   StatementList stmts3;
-  Expression block_expr3 = c.make_node<String>(std::string("loop"), l);
-  auto *block3 = c.make_node<BlockExpr>(std::move(stmts3),
-                                        std::move(block_expr3),
-                                        l);
+  Expression block_expr3 = c.make_node<String>(l, std::string("loop"));
+  auto *block3 = c.make_node<BlockExpr>(l,
+                                        std::move(stmts3),
+                                        std::move(block_expr3));
 
-  Expression expr4 = c.make_node<Integer>(10UL, l);
+  Expression expr4 = c.make_node<Integer>(l, 10UL);
   StatementList stmts4;
-  Expression block_expr4 = c.make_node<Integer>(3UL, l);
-  auto *block4 = c.make_node<BlockExpr>(std::move(stmts4),
-                                        std::move(block_expr4),
-                                        l);
+  Expression block_expr4 = c.make_node<Integer>(l, 3UL);
+  auto *block4 = c.make_node<BlockExpr>(l,
+                                        std::move(stmts4),
+                                        std::move(block_expr4));
 
-  return { c.make_node<Unroll>(std::move(expr1), block1, l),
-           c.make_node<Unroll>(std::move(expr2), block2, l),
-           c.make_node<Unroll>(std::move(expr3), block3, l),
-           c.make_node<Unroll>(std::move(expr4), block4, l) };
+  return { c.make_node<Unroll>(l, std::move(expr1), block1),
+           c.make_node<Unroll>(l, std::move(expr2), block2),
+           c.make_node<Unroll>(l, std::move(expr3), block3),
+           c.make_node<Unroll>(l, std::move(expr4), block4) };
 }
 
 template <>
 std::vector<Jump *> variants<Jump>(ASTContext &c, SourceLocation l)
 {
-  Expression return_val1 = c.make_node<Integer>(42UL, l);
-  Expression return_val2 = c.make_node<String>(std::string("done"), l);
+  Expression return_val1 = c.make_node<Integer>(l, 42UL);
+  Expression return_val2 = c.make_node<String>(l, std::string("done"));
 
-  return { c.make_node<Jump>(JumpType::RETURN, l),
-           c.make_node<Jump>(JumpType::CONTINUE, l),
-           c.make_node<Jump>(JumpType::BREAK, l),
-           c.make_node<Jump>(JumpType::RETURN, std::move(return_val1), l),
-           c.make_node<Jump>(JumpType::RETURN, std::move(return_val2), l) };
+  return { c.make_node<Jump>(l, JumpType::RETURN),
+           c.make_node<Jump>(l, JumpType::CONTINUE),
+           c.make_node<Jump>(l, JumpType::BREAK),
+           c.make_node<Jump>(l, JumpType::RETURN, std::move(return_val1)),
+           c.make_node<Jump>(l, JumpType::RETURN, std::move(return_val2)) };
 }
 
 template <>
 std::vector<While *> variants<While>(ASTContext &c, SourceLocation l)
 {
-  Expression cond1 = c.make_node<Boolean>(true, l);
+  Expression cond1 = c.make_node<Boolean>(l, true);
   StatementList stmts1;
-  Expression block_expr1 = c.make_node<Integer>(42UL, l);
-  auto *block1 = c.make_node<BlockExpr>(std::move(stmts1),
-                                        std::move(block_expr1),
-                                        l);
+  Expression block_expr1 = c.make_node<Integer>(l, 42UL);
+  auto *block1 = c.make_node<BlockExpr>(l,
+                                        std::move(stmts1),
+                                        std::move(block_expr1));
 
-  Expression cond2 = c.make_node<Boolean>(false, l);
+  Expression cond2 = c.make_node<Boolean>(l, false);
   StatementList stmts2;
-  Expression block_expr2 = c.make_node<Integer>(24UL, l);
-  auto *block2 = c.make_node<BlockExpr>(std::move(stmts2),
-                                        std::move(block_expr2),
-                                        l);
+  Expression block_expr2 = c.make_node<Integer>(l, 24UL);
+  auto *block2 = c.make_node<BlockExpr>(l,
+                                        std::move(stmts2),
+                                        std::move(block_expr2));
 
-  Expression cond3 = c.make_node<Variable>(std::string("$flag"), l);
+  Expression cond3 = c.make_node<Variable>(l, std::string("$flag"));
   StatementList stmts3;
-  Expression block_expr3 = c.make_node<String>(std::string("loop"), l);
-  auto *block3 = c.make_node<BlockExpr>(std::move(stmts3),
-                                        std::move(block_expr3),
-                                        l);
+  Expression block_expr3 = c.make_node<String>(l, std::string("loop"));
+  auto *block3 = c.make_node<BlockExpr>(l,
+                                        std::move(stmts3),
+                                        std::move(block_expr3));
 
-  Expression cond4 = c.make_node<Boolean>(true, l);
+  Expression cond4 = c.make_node<Boolean>(l, true);
   StatementList stmts4;
-  Expression block_expr4 = c.make_node<Integer>(100UL, l);
-  auto *block4 = c.make_node<BlockExpr>(std::move(stmts4),
-                                        std::move(block_expr4),
-                                        l);
+  Expression block_expr4 = c.make_node<Integer>(l, 100UL);
+  auto *block4 = c.make_node<BlockExpr>(l,
+                                        std::move(stmts4),
+                                        std::move(block_expr4));
 
-  return { c.make_node<While>(std::move(cond1), block1, l),
-           c.make_node<While>(std::move(cond2), block2, l),
-           c.make_node<While>(std::move(cond3), block3, l),
-           c.make_node<While>(std::move(cond4), block4, l) };
+  return { c.make_node<While>(l, std::move(cond1), block1),
+           c.make_node<While>(l, std::move(cond2), block2),
+           c.make_node<While>(l, std::move(cond3), block3),
+           c.make_node<While>(l, std::move(cond4), block4) };
 }
 
 template <>
 std::vector<For *> variants<For>(ASTContext &c, SourceLocation l)
 {
-  auto *decl1 = c.make_node<Variable>(std::string("$i"), l);
-  auto *map1 = c.make_node<Map>(std::string("@data"), l);
+  auto *decl1 = c.make_node<Variable>(l, std::string("$i"));
+  auto *map1 = c.make_node<Map>(l, std::string("@data"));
   Iterable iterable1 = map1;
   StatementList stmts1;
-  Expression block_expr1 = c.make_node<Integer>(42UL, l);
-  auto *block1 = c.make_node<BlockExpr>(std::move(stmts1),
-                                        std::move(block_expr1),
-                                        l);
+  Expression block_expr1 = c.make_node<Integer>(l, 42UL);
+  auto *block1 = c.make_node<BlockExpr>(l,
+                                        std::move(stmts1),
+                                        std::move(block_expr1));
 
-  auto *decl2 = c.make_node<Variable>(std::string("$j"), l);
-  auto *map2 = c.make_node<Map>(std::string("@other"), l);
+  auto *decl2 = c.make_node<Variable>(l, std::string("$j"));
+  auto *map2 = c.make_node<Map>(l, std::string("@other"));
   Iterable iterable2 = map2;
   StatementList stmts2;
-  Expression block_expr2 = c.make_node<Integer>(24UL, l);
-  auto *block2 = c.make_node<BlockExpr>(std::move(stmts2),
-                                        std::move(block_expr2),
-                                        l);
+  Expression block_expr2 = c.make_node<Integer>(l, 24UL);
+  auto *block2 = c.make_node<BlockExpr>(l,
+                                        std::move(stmts2),
+                                        std::move(block_expr2));
 
-  auto *decl3 = c.make_node<Variable>(std::string("$k"), l);
-  Expression start = c.make_node<Integer>(0UL, l);
-  Expression end = c.make_node<Integer>(10UL, l);
-  auto *range = c.make_node<Range>(std::move(start), std::move(end), l);
+  auto *decl3 = c.make_node<Variable>(l, std::string("$k"));
+  Expression start = c.make_node<Integer>(l, 0UL);
+  Expression end = c.make_node<Integer>(l, 10UL);
+  auto *range = c.make_node<Range>(l, std::move(start), std::move(end));
   Iterable iterable3 = range;
   StatementList stmts3;
-  Expression block_expr3 = c.make_node<String>(std::string("loop"), l);
-  auto *block3 = c.make_node<BlockExpr>(std::move(stmts3),
-                                        std::move(block_expr3),
-                                        l);
+  Expression block_expr3 = c.make_node<String>(l, std::string("loop"));
+  auto *block3 = c.make_node<BlockExpr>(l,
+                                        std::move(stmts3),
+                                        std::move(block_expr3));
 
-  auto *decl4 = c.make_node<Variable>(std::string("$i"), l);
-  auto *map4 = c.make_node<Map>(std::string("@count"), l);
+  auto *decl4 = c.make_node<Variable>(l, std::string("$i"));
+  auto *map4 = c.make_node<Map>(l, std::string("@count"));
   Iterable iterable4 = map4;
   StatementList stmts4;
-  Expression block_expr4 = c.make_node<Integer>(100UL, l);
-  auto *block4 = c.make_node<BlockExpr>(std::move(stmts4),
-                                        std::move(block_expr4),
-                                        l);
+  Expression block_expr4 = c.make_node<Integer>(l, 100UL);
+  auto *block4 = c.make_node<BlockExpr>(l,
+                                        std::move(stmts4),
+                                        std::move(block_expr4));
 
-  return { c.make_node<For>(decl1, std::move(iterable1), block1, l),
-           c.make_node<For>(decl2, std::move(iterable2), block2, l),
-           c.make_node<For>(decl3, std::move(iterable3), block3, l),
-           c.make_node<For>(decl4, std::move(iterable4), block4, l) };
+  return { c.make_node<For>(l, decl1, std::move(iterable1), block1),
+           c.make_node<For>(l, decl2, std::move(iterable2), block2),
+           c.make_node<For>(l, decl3, std::move(iterable3), block3),
+           c.make_node<For>(l, decl4, std::move(iterable4), block4) };
 }
 
 template <>
 std::vector<Range *> variants<Range>(ASTContext &c, SourceLocation l)
 {
-  Expression start1 = c.make_node<Integer>(0UL, l);
-  Expression end1 = c.make_node<Integer>(10UL, l);
+  Expression start1 = c.make_node<Integer>(l, 0UL);
+  Expression end1 = c.make_node<Integer>(l, 10UL);
 
-  Expression start2 = c.make_node<Integer>(1UL, l);
-  Expression end2 = c.make_node<Integer>(5UL, l);
+  Expression start2 = c.make_node<Integer>(l, 1UL);
+  Expression end2 = c.make_node<Integer>(l, 5UL);
 
-  Expression start3 = c.make_node<Variable>(std::string("$start"), l);
-  Expression end3 = c.make_node<Variable>(std::string("$end"), l);
+  Expression start3 = c.make_node<Variable>(l, std::string("$start"));
+  Expression end3 = c.make_node<Variable>(l, std::string("$end"));
 
-  Expression start4 = c.make_node<Integer>(0UL, l);
-  Expression end4 = c.make_node<Integer>(100UL, l);
+  Expression start4 = c.make_node<Integer>(l, 0UL);
+  Expression end4 = c.make_node<Integer>(l, 100UL);
 
-  return { c.make_node<Range>(std::move(start1), std::move(end1), l),
-           c.make_node<Range>(std::move(start2), std::move(end2), l),
-           c.make_node<Range>(std::move(start3), std::move(end3), l),
-           c.make_node<Range>(std::move(start4), std::move(end4), l) };
+  return { c.make_node<Range>(l, std::move(start1), std::move(end1)),
+           c.make_node<Range>(l, std::move(start2), std::move(end2)),
+           c.make_node<Range>(l, std::move(start3), std::move(end3)),
+           c.make_node<Range>(l, std::move(start4), std::move(end4)) };
 }
 
 template <>
@@ -694,12 +694,12 @@ std::vector<Expression> variants<Expression>(ASTContext &c, SourceLocation l)
 {
   // Include same type with different values and different types
   return {
-    c.make_node<Integer>(42UL, l),                 // Primary variant
-    c.make_node<Integer>(24UL, l),                 // Same type, different value
-    c.make_node<String>(std::string("test"), l),   // Different type
-    c.make_node<Boolean>(true, l),                 // Different type
-    c.make_node<Variable>(std::string("$var"), l), // Different type
-    c.make_node<NegativeInteger>(-10L, l)          // Different type
+    c.make_node<Integer>(l, 42UL),                 // Primary variant
+    c.make_node<Integer>(l, 24UL),                 // Same type, different value
+    c.make_node<String>(l, std::string("test")),   // Different type
+    c.make_node<Boolean>(l, true),                 // Different type
+    c.make_node<Variable>(l, std::string("$var")), // Different type
+    c.make_node<NegativeInteger>(l, -10L)          // Different type
   };
 }
 
@@ -707,41 +707,41 @@ template <>
 std::vector<Statement> variants<Statement>(ASTContext &c, SourceLocation l)
 {
   // Include same type with different values and different types
-  Expression expr1 = c.make_node<Integer>(42UL, l);
-  Expression expr2 = c.make_node<Integer>(24UL, l);
-  auto *var = c.make_node<Variable>(std::string("$var"), l);
-  auto *typeof_node = c.make_node<Typeof>(CreateInt32(), l);
-  auto *map = c.make_node<Map>(std::string("@map"), l);
-  Expression expr3 = c.make_node<String>(std::string("value"), l);
+  Expression expr1 = c.make_node<Integer>(l, 42UL);
+  Expression expr2 = c.make_node<Integer>(l, 24UL);
+  auto *var = c.make_node<Variable>(l, std::string("$var"));
+  auto *typeof_node = c.make_node<Typeof>(l, CreateInt32());
+  auto *map = c.make_node<Map>(l, std::string("@map"));
+  Expression expr3 = c.make_node<String>(l, std::string("value"));
 
   return {
-    c.make_node<ExprStatement>(std::move(expr1), l),    // Primary variant
-    c.make_node<ExprStatement>(std::move(expr2), l),    // Same type, different
+    c.make_node<ExprStatement>(l, std::move(expr1)),    // Primary variant
+    c.make_node<ExprStatement>(l, std::move(expr2)),    // Same type, different
                                                         // value
-    c.make_node<VarDeclStatement>(var, typeof_node, l), // Different type
-    c.make_node<AssignScalarMapStatement>(map,
-                                          std::move(expr3),
-                                          l), // Different
-                                              // type
-    c.make_node<Jump>(JumpType::RETURN, l),   // Different type
+    c.make_node<VarDeclStatement>(l, var, typeof_node), // Different type
+    c.make_node<AssignScalarMapStatement>(l,
+                                          map,
+                                          std::move(expr3)), // Different
+                                                             // type
+    c.make_node<Jump>(l, JumpType::RETURN),                  // Different type
   };
 }
 
 template <>
 std::vector<Iterable> variants<Iterable>(ASTContext &c, SourceLocation l)
 {
-  auto *map1 = c.make_node<Map>(std::string("@map"), l);
-  auto *map2 = c.make_node<Map>(std::string("@other"), l);
+  auto *map1 = c.make_node<Map>(l, std::string("@map"));
+  auto *map2 = c.make_node<Map>(l, std::string("@other"));
 
-  Expression start1 = c.make_node<Integer>(0UL, l);
-  Expression end1 = c.make_node<Integer>(10UL, l);
-  auto *range1 = c.make_node<Range>(std::move(start1), std::move(end1), l);
+  Expression start1 = c.make_node<Integer>(l, 0UL);
+  Expression end1 = c.make_node<Integer>(l, 10UL);
+  auto *range1 = c.make_node<Range>(l, std::move(start1), std::move(end1));
 
-  auto *map3 = c.make_node<Map>(std::string("@data"), l);
+  auto *map3 = c.make_node<Map>(l, std::string("@data"));
 
-  Expression start2 = c.make_node<Integer>(5UL, l);
-  Expression end2 = c.make_node<Integer>(15UL, l);
-  auto *range2 = c.make_node<Range>(std::move(start2), std::move(end2), l);
+  Expression start2 = c.make_node<Integer>(l, 5UL);
+  Expression end2 = c.make_node<Integer>(l, 15UL);
+  auto *range2 = c.make_node<Range>(l, std::move(start2), std::move(end2));
 
   return {
     map1,   // Primary variant
@@ -816,7 +816,7 @@ TYPED_TEST(ASTTest, Cloning)
   ASSERT_FALSE(nodes.empty());
 
   for (size_t i = 0; i < nodes.size(); ++i) {
-    auto *cloned = clone(this->ctx, nodes[i], nullptr);
+    auto *cloned = clone(this->ctx, Location(), nodes[i]);
     for (size_t j = 0; j < nodes.size(); ++j) {
       if (j == i) {
         EXPECT_EQ(deref(cloned), deref(nodes[j]));

--- a/tests/collect_nodes.cpp
+++ b/tests/collect_nodes.cpp
@@ -22,7 +22,7 @@ void test(const std::vector<std::reference_wrapper<T>> &expected,
 TEST(CollectNodes, direct)
 {
   ASTContext ctx;
-  auto &var = *ctx.make_node<Variable>("myvar", Location());
+  auto &var = *ctx.make_node<Variable>(Location(), "myvar");
 
   CollectNodes<Variable> visitor;
   visitor.visit(var);
@@ -33,8 +33,8 @@ TEST(CollectNodes, direct)
 TEST(CollectNodes, indirect)
 {
   ASTContext ctx;
-  auto &var = *ctx.make_node<Variable>("myvar", Location());
-  auto &unop = *ctx.make_node<Unop>(&var, Operator::PRE_INCREMENT, Location());
+  auto &var = *ctx.make_node<Variable>(Location(), "myvar");
+  auto &unop = *ctx.make_node<Unop>(Location(), &var, Operator::PRE_INCREMENT);
 
   CollectNodes<Variable> visitor;
   visitor.visit(unop);
@@ -45,8 +45,8 @@ TEST(CollectNodes, indirect)
 TEST(CollectNodes, none)
 {
   ASTContext ctx;
-  auto &map = *ctx.make_node<Map>("myvar", Location());
-  auto &unop = *ctx.make_node<Unop>(&map, Operator::PRE_INCREMENT, Location());
+  auto &map = *ctx.make_node<Map>(Location(), "myvar");
+  auto &unop = *ctx.make_node<Unop>(Location(), &map, Operator::PRE_INCREMENT);
 
   CollectNodes<Variable> visitor;
   visitor.visit(unop);
@@ -57,15 +57,15 @@ TEST(CollectNodes, none)
 TEST(CollectNodes, multiple_runs)
 {
   ASTContext ctx;
-  auto &var1 = *ctx.make_node<Variable>("myvar1", Location());
-  auto &unop1 = *ctx.make_node<Unop>(&var1,
-                                     Operator::PRE_INCREMENT,
-                                     Location());
+  auto &var1 = *ctx.make_node<Variable>(Location(), "myvar1");
+  auto &unop1 = *ctx.make_node<Unop>(Location(),
+                                     &var1,
+                                     Operator::PRE_INCREMENT);
 
-  auto &var2 = *ctx.make_node<Variable>("myvar2", Location());
-  auto &unop2 = *ctx.make_node<Unop>(&var2,
-                                     Operator::PRE_INCREMENT,
-                                     Location());
+  auto &var2 = *ctx.make_node<Variable>(Location(), "myvar2");
+  auto &unop2 = *ctx.make_node<Unop>(Location(),
+                                     &var2,
+                                     Operator::PRE_INCREMENT);
 
   CollectNodes<Variable> visitor;
   visitor.visit(unop1);
@@ -77,9 +77,9 @@ TEST(CollectNodes, multiple_runs)
 TEST(CollectNodes, multiple_children)
 {
   ASTContext ctx;
-  auto &var1 = *ctx.make_node<Variable>("myvar1", Location());
-  auto &var2 = *ctx.make_node<Variable>("myvar2", Location());
-  auto &binop = *ctx.make_node<Binop>(&var1, Operator::PLUS, &var2, Location());
+  auto &var1 = *ctx.make_node<Variable>(Location(), "myvar1");
+  auto &var2 = *ctx.make_node<Variable>(Location(), "myvar2");
+  auto &binop = *ctx.make_node<Binop>(Location(), &var1, Operator::PLUS, &var2);
 
   CollectNodes<Variable> visitor;
   visitor.visit(binop);
@@ -90,9 +90,9 @@ TEST(CollectNodes, multiple_children)
 TEST(CollectNodes, predicate)
 {
   ASTContext ctx;
-  auto &var1 = *ctx.make_node<Variable>("myvar1", Location());
-  auto &var2 = *ctx.make_node<Variable>("myvar2", Location());
-  auto &binop = *ctx.make_node<Binop>(&var1, Operator::PLUS, &var2, Location());
+  auto &var1 = *ctx.make_node<Variable>(Location(), "myvar1");
+  auto &var2 = *ctx.make_node<Variable>(Location(), "myvar2");
+  auto &binop = *ctx.make_node<Binop>(Location(), &var1, Operator::PLUS, &var2);
 
   CollectNodes<Variable> visitor;
   visitor.visit(binop, [](const auto &var) { return var.ident == "myvar2"; });
@@ -103,13 +103,13 @@ TEST(CollectNodes, predicate)
 TEST(CollectNodes, nested)
 {
   ASTContext ctx;
-  auto &var1 = *ctx.make_node<Variable>("myvar1", Location());
-  auto &var2 = *ctx.make_node<Variable>("myvar2", Location());
-  auto &var3 = *ctx.make_node<Variable>("myvar3", Location());
+  auto &var1 = *ctx.make_node<Variable>(Location(), "myvar1");
+  auto &var2 = *ctx.make_node<Variable>(Location(), "myvar2");
+  auto &var3 = *ctx.make_node<Variable>(Location(), "myvar3");
   auto &binop1 = *ctx.make_node<Binop>(
-      &var1, Operator::PLUS, &var2, Location());
+      Location(), &var1, Operator::PLUS, &var2);
   auto &binop2 = *ctx.make_node<Binop>(
-      &binop1, Operator::MINUS, &var3, Location());
+      Location(), &binop1, Operator::MINUS, &var3);
 
   CollectNodes<Binop> visitor;
   visitor.visit(binop2,

--- a/tests/function_registry.cpp
+++ b/tests/function_registry.cpp
@@ -145,9 +145,9 @@ void TestFunctionRegistryPopulated::test(
     const Function *expected_result)
 {
   ast::ASTContext ast;
-  auto &call = *ast.make_node<ast::Call>(func_name,
-                                         ast::ExpressionList({}),
-                                         ast::Location());
+  auto &call = *ast.make_node<ast::Call>(ast::Location(),
+                                         func_name,
+                                         ast::ExpressionList({}));
   EXPECT_EQ(expected_result, reg_.get("", func_name, arg_types, call));
   EXPECT_TRUE(ast.diagnostics().ok());
 }
@@ -158,9 +158,9 @@ void TestFunctionRegistryPopulated::test(
     std::string_view expected_error)
 {
   ast::ASTContext ast;
-  auto &call = *ast.make_node<ast::Call>(func_name,
-                                         ast::ExpressionList({}),
-                                         ast::Location());
+  auto &call = *ast.make_node<ast::Call>(ast::Location(),
+                                         func_name,
+                                         ast::ExpressionList({}));
   EXPECT_EQ(nullptr, reg_.get("", func_name, arg_types, call));
   EXPECT_FALSE(ast.diagnostics().ok());
 
@@ -346,9 +346,9 @@ TEST(TestFunctionRegistry, add_namespaced)
   const auto *foo = reg.add(
       Function::Origin::Script, "ns", "foo", CreateNone(), {});
   ast::ASTContext ast;
-  auto &call = *ast.make_node<ast::Call>("foo",
-                                         ast::ExpressionList({}),
-                                         ast::Location());
+  auto &call = *ast.make_node<ast::Call>(ast::Location(),
+                                         "foo",
+                                         ast::ExpressionList({}));
   EXPECT_EQ(nullptr, reg.get("", "foo", {}, call));
   EXPECT_EQ(foo, reg.get("ns", "foo", {}, call));
 }

--- a/tests/location.cpp
+++ b/tests/location.cpp
@@ -20,7 +20,7 @@ TEST(Location, single_line)
   ast::SourceLocation loc(ast.source());
   loc.begin = { .line = 3, .column = 9 };
   loc.end = { .line = 3, .column = 13 };
-  auto &call = *ast.make_node<ast::Call>("foo", ast::ExpressionList({}), loc);
+  auto &call = *ast.make_node<ast::Call>(loc, "foo", ast::ExpressionList({}));
   auto &err = call.addError();
 
   EXPECT_EQ(err.loc()->source_location(), "testfile:3:9-13");
@@ -39,7 +39,7 @@ TEST(Location, multi_line)
   ast::SourceLocation loc(ast.source());
   loc.begin = { .line = 3, .column = 3 };
   loc.end = { .line = 4, .column = 19 };
-  auto &call = *ast.make_node<ast::Call>("foo", ast::ExpressionList({}), loc);
+  auto &call = *ast.make_node<ast::Call>(loc, "foo", ast::ExpressionList({}));
   auto &err = call.addError();
 
   EXPECT_EQ(err.loc()->source_location(), "testfile:3-4");


### PR DESCRIPTION
Stacked PRs:
 * #4621
 * #4620
 * #4784
 * #4783
 * #4772
 * #4771
 * __->__#4770


--- --- ---

### ast: change Location ordering


Since the location is rqeuired, make this the earlier parameter for
construction, cloning, etc. This allows us to remove some templating
complexity and also support different location types directly.

We no longer need to call `Location(...)` to construct the movable
type, and can have this happen automatically.

Signed-off-by: Adin Scannell <amscanne@meta.com>
