### PR TITLE
parser: fix location tracking

### DIFF
--- a/src/ast/context.cpp
+++ b/src/ast/context.cpp
@@ -15,6 +15,60 @@ ASTSource::ASTSource(std::string &&filename, std::string &&input)
   }
 }
 
+std::string ASTSource::read(const SourceLocation &loc)
+{
+  std::stringstream ss;
+  for (int line = loc.begin.line; line <= loc.end.line; line++) {
+    auto &srcline = lines_[line - 1];
+    if (line == loc.begin.line && line == loc.end.line) {
+      ss << srcline.substr(loc.begin.column - 1,
+                           loc.end.column - loc.begin.column);
+    } else if (line == loc.begin.line) {
+      ss << srcline.substr(loc.begin.column - 1);
+    } else if (line < loc.end.line - 1) {
+      ss << srcline;
+    } else {
+      ss << srcline.substr(0, loc.end.column - 1);
+    }
+  }
+  return ss.str();
+}
+
+std::vector<MetadataIndex::Variant> MetadataIndex::all()
+{
+  if (map_.empty()) {
+    return {};
+  }
+  std::vector<Variant> result;
+  for (const auto &entry : map_) {
+    if (std::holds_alternative<VspaceSentinel>(entry.second)) {
+      // Just provide the vspace count.
+      result.emplace_back(std::get<VspaceSentinel>(entry.second).amount);
+    } else if (std::holds_alternative<MetadataIndex::CommentSentinel>(
+                   entry.second)) {
+      // Load the comment from the serialized source.
+      result.emplace_back(source_->read(entry.first));
+    }
+  }
+  return result;
+}
+
+MetadataIndex MetadataIndex::before(const SourceLocation::Position &pos)
+{
+  MetadataIndex result(source_);
+  auto it = map_.begin();
+  while (it != map_.end()) {
+    if (it->first.begin.line > pos.line ||
+        (it->first.begin.line == pos.line &&
+         it->first.begin.column > pos.column)) {
+      break;
+    }
+    result.map_.emplace(it->first, it->second);
+    it = map_.erase(it);
+  }
+  return result;
+}
+
 ASTContext::ASTContext(std::string &&filename, std::string &&contents)
     : state_(std::make_unique<State>()),
       source_(

--- a/src/ast/context.h
+++ b/src/ast/context.h
@@ -1,6 +1,8 @@
 #pragma once
 
+#include <map>
 #include <memory>
+#include <variant>
 #include <vector>
 
 #include "ast/diagnostic.h"
@@ -32,10 +34,52 @@ public:
   const std::string filename;
   const std::string contents;
 
+  // Reads the contents of the source corresponding to a specific location.
+  std::string read(const SourceLocation &loc);
+
 private:
   std::vector<std::string> lines_;
 
   friend class SourceLocation;
+};
+
+// MetadataIndex is an index of comments and spacing.
+//
+// It allows for looking up and removing comments associated with specific
+// source locations. It can efficiently claim all comments up until a given
+// location.
+class MetadataIndex {
+public:
+  MetadataIndex() = default; // Allow, map will be empty.
+  MetadataIndex(std::shared_ptr<ASTSource> source)
+      : source_(std::move(source)) {};
+
+  // The Variant describes either comments (strings) or vspace (size_t).
+  using Variant = std::variant<std::string, size_t>;
+
+  // Returns all metadata in this index.
+  std::vector<Variant> all();
+
+  // Finds and removes all metadata that precedes this location, returning
+  // a new index. This new index can be subsequently sliced, or `all` can
+  // be used to retrieve all associated metadata. Note that `all` does not
+  // remove the metadata from the index, this only happens with `before`.
+  MetadataIndex before(const SourceLocation::Position &pos);
+
+private:
+  struct CommentSentinel {};
+  struct VspaceSentinel {
+    size_t amount;
+  };
+  using InternalMap =
+      std::map<SourceLocation,
+               std::variant<CommentSentinel, VspaceSentinel>>;
+  MetadataIndex(std::shared_ptr<ASTSource> source, InternalMap other)
+      : source_(std::move(source)), map_(std::move(other)) {};
+
+  std::shared_ptr<ASTSource> source_;
+  InternalMap map_;
+  friend class ASTContext;
 };
 
 // Manages the lifetime of AST nodes.
@@ -109,6 +153,29 @@ public:
     return source_;
   }
 
+  void add_comment(SourceLocation loc)
+  {
+    // Comments are simply stored as monostate in the map, they are
+    // resolved only when the comment is used.
+    state_->metadata_.emplace(std::move(loc), MetadataIndex::CommentSentinel{});
+  }
+
+  void add_vspace(SourceLocation loc, size_t elems)
+  {
+    // Vspace is stored as a simple unsigned value.
+    state_->metadata_.emplace(std::move(loc),
+                              MetadataIndex::VspaceSentinel{ .amount = elems });
+  }
+
+  // This function returns a unique a metadata object for the AST.
+  //
+  // This object consumed by this call is a copy, and can be used
+  // to iterate over all the available metadata while printing.
+  MetadataIndex metadata() const
+  {
+    return { source_, state_->metadata_ };
+  }
+
   // clears all the nodes and diagnostics, but does not affect the underlying
   // `ASTSource` object. This is useful if you want to e.g. reparse the full
   // syntax tree in place.
@@ -125,6 +192,7 @@ private:
     State();
     std::vector<std::unique_ptr<Node>> nodes_;
     std::unique_ptr<Diagnostics> diagnostics_;
+    MetadataIndex::InternalMap metadata_;
   };
 
   std::unique_ptr<State> state_;

--- a/src/driver.h
+++ b/src/driver.h
@@ -30,6 +30,7 @@ public:
 
   // These are mutable state that can be modified by the lexer.
   ast::SourceLocation loc;
+  ast::SourceLocation orig_loc;
   std::string struct_type;
   std::string buffer;
 

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -44,7 +44,6 @@ map      @{ident}|@
 var      ${ident}
 hspace   [ \t]
 vspace   \n
-space    {hspace}|{vspace}
 path     :(\\.|[_\-\./a-zA-Z0-9#$+\*])+
 /* Most of the builtins are prefixed with __builtin_ as they are exposed to users via macros e.g. macro cpu() { __builtin_cpu } */
 builtin  arg[0-9]+|args|ctx|kstack|nsecs|pid|sarg[0-9]|tid|ustack|__builtin_cgroup|__builtin_comm|__builtin_cpid|__builtin_cpu|__builtin_curtask|__builtin_elapsed|__builtin_func|__builtin_gid|__builtin_jiffies|__builtin_ncpus|__builtin_probe|__builtin_rand|__builtin_retval|__builtin_uid|__builtin_usermode|__builtin_username
@@ -68,6 +67,7 @@ oct_esc  [0-7]{1,3}
 %x CCOMMENTNL
 %x CPPCOMMENT
 %x CPPCOMMENTNL
+%x AFTER_DIV
 %x AFTER_COLON
 %x STRUCT_AFTER_COLON
 
@@ -79,39 +79,51 @@ oct_esc  [0-7]{1,3}
     driver.token.reset();
     return t;
   }
-  driver.loc.reset_meta();
 %}
 
-^"#!".*$                {
+^"#!"[^\n]*\n           {
+                          driver.loc.trim();
                           yy_push_state(SCRIPT, yyscanner);
-                          return Parser::make_HEADER(yytext, driver.loc);
+                          auto v = Parser::make_HEADER(yytext, driver.loc);
+                          driver.loc.advance_lines(1);
+                          return v;
                         }
-{vspace}+               { driver.loc.advance_columns(yyleng); }
-\r                      { driver.loc.reset_column(); }
+{vspace}+               {
+                          driver.loc.advance_lines(yyleng);
+                          driver.ctx.add_vspace(driver.loc, yyleng);
+                        }
 .                       {
-                          driver.loc.advance_columns(-1);
+                          driver.loc.rewind_columns();
                           unput(yytext[0]);
                           yy_push_state(SCRIPT, yyscanner);
                         }
 
 <CCOMMENT>{
   "*/"                  yy_pop_state(yyscanner);
-  \n                    { driver.loc.advance_lines(1); yy_pop_state(yyscanner); yy_push_state(CCOMMENTNL, yyscanner); driver.loc.add_comment("\n"); }
-  .                     { driver.loc.add_comment(yytext); }
+  \n                    {
+                          driver.loc.advance_lines(1);
+                          yy_pop_state(yyscanner);
+                          yy_push_state(CCOMMENTNL, yyscanner);
+                        }
+  ([^*\n]|[*][^/\n])+   { driver.ctx.add_comment(driver.loc); }
   <<EOF>>               {
                            yy_pop_state(yyscanner);
                            driver.error(driver.loc, "end of file during comment");
                         }
 }
 <CCOMMENTNL>{
+  [*][/]\n              { driver.loc.advance_lines(1); yy_pop_state(yyscanner); }
   "*/"                  yy_pop_state(yyscanner);
-  " */"                 yy_pop_state(yyscanner);
-  " * "                 { yy_pop_state(yyscanner); yy_push_state(CCOMMENT, yyscanner); }
-  " *"                  { yy_pop_state(yyscanner); yy_push_state(CCOMMENT, yyscanner); }
-  "   "                 { yy_pop_state(yyscanner); yy_push_state(CCOMMENT, yyscanner); }
-  \n                    { driver.loc.advance_lines(1); driver.loc.add_comment("\n"); }
+  "* "                  { yy_pop_state(yyscanner); yy_push_state(CCOMMENT, yyscanner); }
+  "*"                   { }
+  {hspace}+             { }
+  \n                    {
+                          driver.loc.trim();
+                          driver.ctx.add_comment(driver.loc); // Blank comment.
+                          driver.loc.advance_lines(1);
+                        }
   .                     {
-                           driver.loc.advance_columns(-1);
+                           driver.loc.rewind_columns();
                            unput(yytext[0]);
                            yy_pop_state(yyscanner);
                            yy_push_state(CCOMMENT, yyscanner);
@@ -122,7 +134,7 @@ oct_esc  [0-7]{1,3}
                         }
 }
 <CPPCOMMENT>{
-  [^\n]+                { driver.loc.add_comment(yytext); }
+  [^\n]+                { driver.ctx.add_comment(driver.loc); }
   \n                    {
                           driver.loc.advance_lines(1);
                           yy_pop_state(yyscanner);
@@ -131,21 +143,30 @@ oct_esc  [0-7]{1,3}
   <<EOF>>               yy_pop_state(yyscanner);
 }
 <CPPCOMMENTNL>{
-  [/][/][ ]\n           { driver.loc.advance_lines(1); driver.loc.add_comment("\n"); }
-  [/][/]\n              { driver.loc.advance_lines(1); driver.loc.add_comment("\n"); }
-  \n                    { driver.loc.advance_lines(1); driver.loc.add_comment("\n"); }
+  {hspace}+             { }
+  [/][/][ ]\n           {
+                          driver.loc.advance_lines(1);
+                          driver.ctx.add_comment(driver.loc); // Empty.
+                        }
+  [/][/]\n              {
+                          driver.loc.advance_lines(1);
+                          driver.ctx.add_comment(driver.loc); // Empty.
+                        }
   "// "                 {
                           yy_pop_state(yyscanner);
                           yy_push_state(CPPCOMMENT, yyscanner);
-                          driver.loc.add_comment("\n");
                         }
   "//"                  {
                           yy_pop_state(yyscanner);
                           yy_push_state(CPPCOMMENT, yyscanner);
-                          driver.loc.add_comment("\n");
+                        }
+  \n                    {
+                          driver.loc.advance_lines(1);
+                          driver.ctx.add_vspace(driver.loc, 1);
+                          yy_pop_state(yyscanner);
                         }
   .                     {
-                          driver.loc.advance_columns(-1);
+                          driver.loc.rewind_columns();
                           unput(yytext[0]);
                           yy_pop_state(yyscanner);
                         }
@@ -154,8 +175,13 @@ oct_esc  [0-7]{1,3}
 
 <SCRIPT>{
   {hspace}+               { }
-  {vspace}+               { driver.loc.advance_lines(yyleng); driver.loc.advance_vspace(yyleng); }
+  {vspace}+               {
+                            driver.loc.advance_lines(yyleng);
+                            driver.ctx.add_vspace(driver.loc, yyleng);
+                          }
   \r                      { driver.loc.reset_column(); }
+  "/** "                  { yy_push_state(CCOMMENT, yyscanner); }
+  "/**"                   { yy_push_state(CCOMMENT, yyscanner); }
   "/* "                   { yy_push_state(CCOMMENT, yyscanner); }
   "/*"                    { yy_push_state(CCOMMENT, yyscanner); }
   "// "                   { yy_push_state(CPPCOMMENT, yyscanner); }
@@ -180,6 +206,10 @@ oct_esc  [0-7]{1,3}
                             yy_push_state(AFTER_COLON, yyscanner);
                             return Parser::make_COLON(driver.loc);
                           }
+  /* N.B. The newline following semi-colons and braces does not count as explicit vspace. */
+  [;]\n                   { driver.loc.trim(); auto v = Parser::make_SEMI(driver.loc); driver.loc.advance_lines(1); return v; }
+  [{]\n                   { driver.loc.trim(); auto v = Parser::make_LBRACE(driver.loc); driver.loc.advance_lines(1); return v; }
+  [}]\n                   { driver.loc.trim(); auto v = Parser::make_RBRACE(driver.loc); driver.loc.advance_lines(1); return v; }
   ";"                     { return Parser::make_SEMI(driver.loc); }
   "{"                     { return Parser::make_LBRACE(driver.loc); }
   "}"                     { return Parser::make_RBRACE(driver.loc); }
@@ -187,7 +217,6 @@ oct_esc  [0-7]{1,3}
   "]"                     { return Parser::make_RBRACKET(driver.loc); }
   "("                     { return Parser::make_LPAREN(driver.loc); }
   ")"                     { return Parser::make_RPAREN(driver.loc); }
-  \//{space}*[\/\{]       { return Parser::make_ENDPRED(driver.loc); } /* If "/" is followed by "/" or "{", choose ENDPRED, otherwise DIV */
   ","                     { return Parser::make_COMMA(driver.loc); }
   "="                     { return Parser::make_ASSIGN(driver.loc); }
   "<<="                   { return Parser::make_LEFTASSIGN(driver.loc); }
@@ -215,7 +244,7 @@ oct_esc  [0-7]{1,3}
   "++"                    { return Parser::make_INCREMENT(driver.loc); }
   "--"                    { return Parser::make_DECREMENT(driver.loc); }
   "*"                     { return Parser::make_MUL(driver.loc); }
-  "/"                     { return Parser::make_DIV(driver.loc); }
+  "/"                     { driver.orig_loc = driver.loc; yy_push_state(AFTER_DIV, yyscanner); }
   "%"                     { return Parser::make_MOD(driver.loc); }
   "&"                     { return Parser::make_BAND(driver.loc); }
   "|"                     { return Parser::make_BOR(driver.loc); }
@@ -286,6 +315,23 @@ oct_esc  [0-7]{1,3}
   .                     driver.error(driver.loc, "invalid character"); yy_pop_state(yyscanner);
 }
 
+<AFTER_DIV>{
+  {hspace}+             { }
+  {vspace}+             { driver.loc.advance_lines(yyleng); }
+  "{"                   {
+                          driver.loc.rewind_columns();
+                          unput(yytext[0]);
+                          yy_pop_state(yyscanner);
+                          return Parser::make_ENDPRED(driver.orig_loc);
+                        }
+  .                     {
+                          driver.loc.rewind_columns();
+                          unput(yytext[0]);
+                          yy_pop_state(yyscanner);
+                          return Parser::make_DIV(driver.orig_loc);
+                        }
+}
+
 <AFTER_COLON>{
   {hspace}+             { }
   {vspace}+             { driver.loc.advance_lines(yyleng); }
@@ -297,8 +343,9 @@ oct_esc  [0-7]{1,3}
                           driver.struct_type = yytext;
                           return Parser::make_STRUCT(driver.loc);
                         }
-  .                     { driver.loc.advance_columns(-1); unput(yytext[0]); yy_pop_state(yyscanner); }
+  .                     { driver.loc.rewind_columns(); unput(yytext[0]); yy_pop_state(yyscanner); }
 }
+
 <STRUCT_AFTER_COLON>{
   {hspace}+             { }
   {vspace}+             { driver.loc.advance_lines(yyleng); }
@@ -309,6 +356,7 @@ oct_esc  [0-7]{1,3}
                           return Parser::make_IDENT(driver.struct_type + " " + util::trim(driver.buffer), driver.loc);
                         }
 }
+
 <STRUCT,BRACE>{
   "*"|")"|","           {
                           if (YY_START == STRUCT)
@@ -318,7 +366,7 @@ oct_esc  [0-7]{1,3}
                             // and then inserting a single space.
                             yy_pop_state(yyscanner);
                             for (int i = yyleng - 1; i >= 0; i--) {
-                              driver.loc.advance_columns(-1);
+                              driver.loc.rewind_columns();
                               unput(yytext[i]);
                             }
                             return Parser::make_IDENT(driver.struct_type + " " + util::trim(driver.buffer), driver.loc);

--- a/tests/attachpoint_passes.cpp
+++ b/tests/attachpoint_passes.cpp
@@ -193,9 +193,9 @@ bench: { 1 }
 ~~~~~~
 )");
   test_error("BENCH:a { 1 } BENCH:a { 2 }", R"(
-stdin:1:14-22: ERROR: "a" was used as the name for more than one BENCH probe
+stdin:1:15-22: ERROR: "a" was used as the name for more than one BENCH probe
 BENCH:a { 1 } BENCH:a { 2 }
-             ~~~~~~~~
+              ~~~~~~~
 stdin:1:1-8: ERROR: this is the other instance
 BENCH:a { 1 } BENCH:a { 2 }
 ~~~~~~~

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -3,11 +3,9 @@
 #include <sstream>
 
 #include "ast/ast.h"
-#include "ast/passes/ap_probe_expansion.h"
 #include "ast/passes/attachpoint_passes.h"
 #include "ast/passes/c_macro_expansion.h"
 #include "ast/passes/clang_parser.h"
-#include "ast/passes/printer.h"
 #include "ast_matchers.h"
 #include "driver.h"
 #include "gtest/gtest.h"
@@ -2424,9 +2422,9 @@ TEST(Parser, non_fatal_errors)
   // displayed
   test_parse_failure("uprobe:asdf:Stream {} tracepoint:only_one_arg {}",
                      R"(
-stdin:1:22-46: ERROR: tracepoint probe type requires 2 arguments, found 1
+stdin:1:23-46: ERROR: tracepoint probe type requires 2 arguments, found 1
 uprobe:asdf:Stream {} tracepoint:only_one_arg {}
-                     ~~~~~~~~~~~~~~~~~~~~~~~~
+                      ~~~~~~~~~~~~~~~~~~~~~~~
 )");
 }
 
@@ -2466,7 +2464,7 @@ TEST(Parser, config_error)
 {
   test_parse_failure("i:s:1 { exit(); } config = { BPFTRACE_STACK_MODE=perf }",
                      R"(
-stdin:1:19-25: ERROR: syntax error, unexpected config, expecting {
+stdin:1:19-25: ERROR: syntax error, unexpected config
 i:s:1 { exit(); } config = { BPFTRACE_STACK_MODE=perf }
                   ~~~~~~
 )");
@@ -2486,7 +2484,7 @@ config = { @start = nsecs; } i:s:1 { exit(); }
   test_parse_failure("begin { @start = nsecs; } config = { "
                      "BPFTRACE_STACK_MODE=perf } i:s:1 { exit(); }",
                      R"(
-stdin:1:27-33: ERROR: syntax error, unexpected config, expecting {
+stdin:1:27-33: ERROR: syntax error, unexpected config
 begin { @start = nsecs; } config = { BPFTRACE_STACK_MODE=perf } i:s:1 { exit(); }
                           ~~~~~~
 )");
@@ -2931,7 +2929,7 @@ TEST(Parser, map_declarations)
            .WithProbe(Probe({ "begin" }, { ExprStatement(Variable("$x")) })));
 
   test_parse_failure("@a = hash(); begin { $x; }", R"(
-stdin:1:1-3: ERROR: syntax error, unexpected map, expecting {
+stdin:1:1-3: ERROR: syntax error, unexpected map
 @a = hash(); begin { $x; }
 ~~
 )");
@@ -2995,7 +2993,7 @@ TEST(Parser, imports)
            .WithProbe(Probe({ "begin" }, {})));
 
   test_parse_failure(R"(begin { }; import "foo";)", R"(
-stdin:1:10-11: ERROR: syntax error, unexpected ;, expecting {
+stdin:1:10-11: ERROR: syntax error, unexpected ;
 begin { }; import "foo";
          ~
 )");

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -609,7 +609,7 @@ EXPECT_REGEX (first)+ second
 
 NAME some_missing_probes_default_error
 PROG kprobe:vfs_read { exit(); } t:syscalls:nonsense { exit(); }
-EXPECT stdin:1:28-48: ERROR: Tracepoint not found: syscalls:nonsense
+EXPECT stdin:1:29-48: ERROR: Tracepoint not found: syscalls:nonsense
 EXPECT HINT: If this is expected, set the 'missing_probes' config variable to 'warn' or 'ignore'.
 WILL_FAIL
 
@@ -620,7 +620,7 @@ WILL_FAIL
 
 NAME some_missing_probes_warn
 PROG config = { missing_probes=warn } kprobe:vfs_read { exit(); } t:syscalls:nonsense { exit(); }
-EXPECT stdin:1:61-81: WARNING: Tracepoint not found: syscalls:nonsense
+EXPECT stdin:1:62-81: WARNING: Tracepoint not found: syscalls:nonsense
 
 NAME some_missing_probes_ignore
 PROG config = { missing_probes=ignore } kprobe:vfs_read { exit(); } t:syscalls:nonsense { exit(); }
@@ -629,7 +629,7 @@ EXPECT_NONE WARNING: Unable to attach probe: tracepoint:syscalls:nonsense. Skipp
 NAME all_missing_probes_warn
 PROG config = { missing_probes=warn } kprobe:nonsense { exit(); } t:syscalls:nonsense { exit(); } uprobe:./testprogs/uprobe_test:uprobeFunction3 { exit(); }
 EXPECT WARNING: Unable to attach probe: kprobe:nonsense. Skipping.
-EXPECT stdin:1:61-81: WARNING: Tracepoint not found: syscalls:nonsense
+EXPECT stdin:1:62-81: WARNING: Tracepoint not found: syscalls:nonsense
 EXPECT WARNING: Unable to attach probe: uprobe:./testprogs/uprobe_test:uprobeFunction3. Skipping.
 EXPECT ERROR: Attachment failed for all probes.
 WILL_FAIL


### PR DESCRIPTION
Stacked PRs:
 * #4621
 * #4620
 * #4787
 * #4784
 * #4783
 * __->__#4772


--- --- ---

### parser: fix location tracking


There were several cases of broken location tracking between the lexer
and the parsing. This change addresses most of these, and adds a special
metadata index. Using the metadata index, it is generally possible to
reconstruct the original source (mostly) from the AST.

Signed-off-by: Adin Scannell <adin@scannell.ca>
