### PR TITLE
Replace root user check with capability checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ and this project adheres to
   - [#4688](https://github.com/bpftrace/bpftrace/pull/4688)
 - Increase RLIMIT_NOFILE on startup as needed
   - [#4716](https://github.com/bpftrace/bpftrace/pull/4716)
+- Root user check replaced with check for required capabilities
+  (CAP_BPF, CAP_PERFMON, CAP_DAC_READ_SEARCH, CAP_DAC_OVERRIDE)
+  - [#4773](https://github.com/bpftrace/bpftrace/pull/4773)
 #### Deprecated
 #### Removed
 - Drop support for LLVM 16

--- a/src/aot/aot_main.cpp
+++ b/src/aot/aot_main.cpp
@@ -122,7 +122,7 @@ int main(int argc, char* argv[])
     return 1;
   }
 
-  check_is_root();
+  check_privileges();
 
   libbpf_set_print(libbpf_print);
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -453,7 +453,7 @@ Args parse_args(int argc, char* argv[])
          -1) {
     switch (c) {
       case Options::INFO: // --info
-        check_is_root();
+        check_privileges();
         info(args.no_feature);
         exit(0);
         break;
@@ -761,7 +761,7 @@ int main(int argc, char* argv[])
 
   // Listing probes when there is no program.
   if (args.listing && args.script.empty() && args.filename.empty()) {
-    check_is_root();
+    check_privileges();
 
     if (args.search.find(".") != std::string::npos &&
         args.search.find_first_of(":*") == std::string::npos) {
@@ -845,9 +845,9 @@ int main(int argc, char* argv[])
     bpftrace.add_param(param);
   }
 
-  // If we are not running anything, then we don't require root.
+  // If we are not running anything, then we don't require privileges.
   if (args.test_mode == TestMode::NONE) {
-    check_is_root();
+    check_privileges();
 
     auto lockdown_state = lockdown::detect();
     if (lockdown_state == lockdown::LockdownState::Confidentiality) {

--- a/src/run_bpftrace.h
+++ b/src/run_bpftrace.h
@@ -4,7 +4,7 @@
 #include "output/buffer_mode.h"
 
 int libbpf_print(enum libbpf_print_level level, const char *msg, va_list ap);
-void check_is_root();
+void check_privileges();
 
 int run_bpftrace(bpftrace::BPFtrace &bpftrace,
                  const std::string &output_file,


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

bpftrace is one of those tools where you really don't care what uid/gid it runs as, and if you do you probably want it to be your own uid/gid since you're running it from your home directory and want any generated files to be owned by your user instead of root.

Instead, let's check for the required Linux capabilities so that we can run bpftrace as any user with the required capabilities. This allows running bpftrace as the current user with something like the following:

`systemd-run --uid=$USER --wait --pty --same-dir --collect --property="AmbientCapabilities=~" --quiet -- bpftrace -vl`

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
