### PR TITLE
types: ignore empty C files

### DIFF
--- a/src/ast/passes/clang_build.h
+++ b/src/ast/passes/clang_build.h
@@ -3,14 +3,19 @@
 #include <llvm/IR/LLVMContext.h>
 #include <llvm/IR/Module.h>
 
+#include "ast/location.h"
 #include "ast/pass_manager.h"
 
 namespace bpftrace::ast {
 
 class BitcodeModules : public State<"bitcode"> {
 public:
-  std::vector<std::unique_ptr<llvm::Module>> modules;
-  std::vector<std::string> objects;
+  struct Result {
+    std::unique_ptr<llvm::Module> module;
+    std::string object;
+    Location loc;
+  };
+  std::vector<Result> modules;
 };
 
 class ClangBuildError : public ErrorInfo<ClangBuildError> {

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -4996,10 +4996,14 @@ Pass CreateLinkBitcodePass()
 {
   return Pass::create(
       "LinkBitcode", [](BitcodeModules &bm, CompiledModule &cm) -> Result<> {
-        for (auto &mod : bm.modules) {
+        for (auto &result : bm.modules) {
+          if (!result.module) {
+            continue;
+          }
+
           // Make a copy of the module, to ensure this is not modifying the
           // original. The link step must consume the module below.
-          auto copy = llvm::CloneModule(*mod);
+          auto copy = llvm::CloneModule(*result.module);
 
           // Modify to ensure everything is inlined. Note that this is also
           // marking all these functions for below, which will adjust their

--- a/src/ast/passes/type_system.cpp
+++ b/src/ast/passes/type_system.cpp
@@ -1,14 +1,12 @@
-#include <unordered_map>
-
-#include "ast/ast.h"
-#include "ast/passes/clang_build.h"
 #include "ast/passes/type_system.h"
+#include "ast/context.h"
+#include "ast/passes/clang_build.h"
 
 namespace bpftrace::ast {
 
 Pass CreateTypeSystemPass()
 {
-  auto fn = [](BitcodeModules &bm) -> Result<TypeMetadata> {
+  auto fn = [](ASTContext &ast, BitcodeModules &bm) -> Result<TypeMetadata> {
     TypeMetadata result;
 
     // For now, we simply build a single type system that covers all the
@@ -16,11 +14,27 @@ Pass CreateTypeSystemPass()
     // on top of the individual probe type system (coming from the kernel,
     // module or user binary).
     std::optional<btf::Types> aggregate;
-    for (const auto &s : bm.objects) {
-      auto btf = btf::Types::parse(static_cast<const void *>(s.data()),
-                                   s.size());
+    for (const auto &module : bm.modules) {
+      auto btf = btf::Types::parse(static_cast<const void *>(
+                                       module.object.data()),
+                                   module.object.size());
       if (!btf) {
-        return btf.takeError();
+        // If we encounter some error parsing BTF, add it to the specific
+        // import directly. If there is no BTF (e.g. an empty C file), then
+        // we can just suppress the warning.
+        auto err = handleErrors(std::move(btf),
+                                [&](const btf::ParseError &parse_err) {
+                                  if (parse_err.error_code() != ENODATA) {
+                                    auto &diag = ast.diagnostics().addWarning(
+                                        module.loc);
+                                    diag << "Failed to parse BTF data: "
+                                         << strerror(parse_err.error_code());
+                                  }
+                                });
+        if (!err) {
+          return err.takeError();
+        }
+        continue; // Skip this file.
       }
       if (!aggregate) {
         aggregate.emplace(std::move(*btf));

--- a/src/btf/btf.h
+++ b/src/btf/btf.h
@@ -68,6 +68,7 @@ public:
   static char ID;
   ParseError(int err) : err_(err >= 0 ? err : -err) {};
   void log(llvm::raw_ostream &OS) const override;
+  int error_code() const { return err_; }
 
 private:
   int err_;
@@ -79,6 +80,7 @@ public:
   static char ID;
   TypeError(int err) : err_(err >= 0 ? err : -err) {};
   void log(llvm::raw_ostream &OS) const override;
+  int error_code() const { return err_; }
 
 private:
   int err_;

--- a/tests/bpfbytecode.cpp
+++ b/tests/bpfbytecode.cpp
@@ -25,7 +25,12 @@ BpfBytecode codegen(const std::string &input)
                 .add(ast::CreateSemanticPass())
                 .add(ast::AllCompilePasses())
                 .run();
-  EXPECT_TRUE(ok && ast.diagnostics().ok());
+  if (!ok) {
+    EXPECT_TRUE(bool(ok)) << ok.takeError();
+  }
+  std::stringstream out;
+  ast.diagnostics().emit(out);
+  EXPECT_TRUE(ast.diagnostics().ok()) << out.str();
   auto &output = ok->get<BpfBytecode>();
   return std::move(output);
 }


### PR DESCRIPTION
Stacked PRs:
 * __->__#4776


--- --- ---

### types: ignore empty C files


These currently fail to parse BTF, because there is none. In this case,
associate the error with the node itself, and ignore if it indicates
that there is no BTF for the object.

Signed-off-by: Adin Scannell <adin@scannell.ca>
