### PR TITLE
Change prefix for temporary variable names

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -3309,7 +3309,7 @@ void SemanticAnalyser::visit(Expression &expr)
   // Visit and fold all other values.
   Visitor<SemanticAnalyser>::visit(expr);
   fold(ctx_, expr);
-  simplify(ctx_, expr);
+  simplify(ctx_, expr, bpftrace_);
 
   // Inline specific constant expressions.
   if (auto *szof = expr.as<Sizeof>()) {

--- a/src/ast/passes/simplify_types.h
+++ b/src/ast/passes/simplify_types.h
@@ -1,12 +1,13 @@
 #pragma once
 
 #include "ast/pass_manager.h"
+#include "bpftrace.h"
 
 namespace bpftrace::ast {
 
 // No pass exists yet, this just gets called
 // from inside semantic_analyser because this
 // relies on previous and future type resolution
-void simplify(ASTContext &ast, Expression &expr);
+void simplify(ASTContext &ast, Expression &expr, BPFtrace &b);
 
 } // namespace bpftrace::ast

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -238,6 +238,10 @@ public:
   bool run_benchmarks_ = false;
   std::vector<std::pair<std::string, uint32_t>> benchmark_results;
 
+  uint64_t get_temp_variable_prefix() {
+    return temp_prefix_id_++;
+  }
+
 private:
   Ksyms ksyms_;
   Usyms usyms_;
@@ -273,6 +277,7 @@ private:
   struct ring_buffer *ringbuf_ = nullptr;
   struct perf_buffer *skb_perfbuf_ = nullptr;
   uint64_t event_loss_count_ = 0;
+  uint64_t temp_prefix_id_ = 1;
 
   // Mapping traceable functions to modules (or "vmlinux") they appear in.
   // Needs to be mutable to allow lazy loading of the mapping from const lookup

--- a/tests/codegen/llvm/call_signal.ll
+++ b/tests/codegen/llvm/call_signal.ll
@@ -22,16 +22,16 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
   %warnf_args = alloca %warnf_t, align 8
-  %"$$__signal_2_$ret" = alloca i64, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$$__signal_2_$ret")
-  store i64 0, ptr %"$$__signal_2_$ret", align 8
+  %"_1___signal_2_$ret" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"_1___signal_2_$ret")
+  store i64 0, ptr %"_1___signal_2_$ret", align 8
   %errorf_args = alloca %errorf_t, align 8
-  %"$$__signal_2_$sig" = alloca i32, align 4
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$$__signal_2_$sig")
-  store i32 0, ptr %"$$__signal_2_$sig", align 4
-  store i32 0, ptr %"$$__signal_2_$sig", align 4
-  store i32 8, ptr %"$$__signal_2_$sig", align 4
-  %1 = load i32, ptr %"$$__signal_2_$sig", align 4
+  %"_1___signal_2_$sig" = alloca i32, align 4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"_1___signal_2_$sig")
+  store i32 0, ptr %"_1___signal_2_$sig", align 4
+  store i32 0, ptr %"_1___signal_2_$sig", align 4
+  store i32 8, ptr %"_1___signal_2_$sig", align 4
+  %1 = load i32, ptr %"_1___signal_2_$sig", align 4
   %2 = sext i32 %1 to i64
   %3 = icmp slt i64 %2, 1
   %true_cond = icmp ne i1 %3, false
@@ -45,7 +45,7 @@ left:                                             ; preds = %entry
   %5 = getelementptr %errorf_t, ptr %errorf_args, i32 0, i32 1
   %6 = getelementptr %errorf_args_t, ptr %5, i32 0, i32 0
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 @"signal()", i64 9, i1 false)
-  %7 = load i32, ptr %"$$__signal_2_$sig", align 4
+  %7 = load i32, ptr %"_1___signal_2_$sig", align 4
   %8 = getelementptr %errorf_args_t, ptr %5, i32 0, i32 1
   store i32 %7, ptr %8, align 4
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %errorf_args, i64 24, i64 0)
@@ -53,10 +53,10 @@ left:                                             ; preds = %entry
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 right:                                            ; preds = %entry
-  %9 = load i32, ptr %"$$__signal_2_$sig", align 4
+  %9 = load i32, ptr %"_1___signal_2_$sig", align 4
   %__signal_process = call i64 @__signal_process(i32 %9), !dbg !41
-  store i64 %__signal_process, ptr %"$$__signal_2_$ret", align 8
-  %10 = load i64, ptr %"$$__signal_2_$ret", align 8
+  store i64 %__signal_process, ptr %"_1___signal_2_$ret", align 8
+  %10 = load i64, ptr %"_1___signal_2_$ret", align 8
   %11 = icmp ne i64 %10, 0
   %true_cond3 = icmp ne i1 %11, false
   br i1 %true_cond3, label %left1, label %right2
@@ -84,7 +84,7 @@ left1:                                            ; preds = %right
   %16 = getelementptr %warnf_t, ptr %warnf_args, i32 0, i32 0
   store i64 1, ptr %16, align 8
   %17 = getelementptr %warnf_t, ptr %warnf_args, i32 0, i32 1
-  %18 = load i64, ptr %"$$__signal_2_$ret", align 8
+  %18 = load i64, ptr %"_1___signal_2_$ret", align 8
   %19 = getelementptr %warnf_args_t, ptr %17, i32 0, i32 0
   store i64 %18, ptr %19, align 8
   %ringbuf_output4 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %warnf_args, i64 16, i64 0)

--- a/tests/codegen/llvm/call_signal_string_literal.ll
+++ b/tests/codegen/llvm/call_signal_string_literal.ll
@@ -22,16 +22,16 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
   %warnf_args = alloca %warnf_t, align 8
-  %"$$__signal_2_$ret" = alloca i64, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$$__signal_2_$ret")
-  store i64 0, ptr %"$$__signal_2_$ret", align 8
+  %"_1___signal_2_$ret" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"_1___signal_2_$ret")
+  store i64 0, ptr %"_1___signal_2_$ret", align 8
   %errorf_args = alloca %errorf_t, align 8
-  %"$$__signal_2_$sig" = alloca i32, align 4
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$$__signal_2_$sig")
-  store i32 0, ptr %"$$__signal_2_$sig", align 4
-  store i32 0, ptr %"$$__signal_2_$sig", align 4
-  store i32 9, ptr %"$$__signal_2_$sig", align 4
-  %1 = load i32, ptr %"$$__signal_2_$sig", align 4
+  %"_1___signal_2_$sig" = alloca i32, align 4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"_1___signal_2_$sig")
+  store i32 0, ptr %"_1___signal_2_$sig", align 4
+  store i32 0, ptr %"_1___signal_2_$sig", align 4
+  store i32 9, ptr %"_1___signal_2_$sig", align 4
+  %1 = load i32, ptr %"_1___signal_2_$sig", align 4
   %2 = sext i32 %1 to i64
   %3 = icmp slt i64 %2, 1
   %true_cond = icmp ne i1 %3, false
@@ -45,7 +45,7 @@ left:                                             ; preds = %entry
   %5 = getelementptr %errorf_t, ptr %errorf_args, i32 0, i32 1
   %6 = getelementptr %errorf_args_t, ptr %5, i32 0, i32 0
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 @"signal()", i64 9, i1 false)
-  %7 = load i32, ptr %"$$__signal_2_$sig", align 4
+  %7 = load i32, ptr %"_1___signal_2_$sig", align 4
   %8 = getelementptr %errorf_args_t, ptr %5, i32 0, i32 1
   store i32 %7, ptr %8, align 4
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %errorf_args, i64 24, i64 0)
@@ -53,10 +53,10 @@ left:                                             ; preds = %entry
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 right:                                            ; preds = %entry
-  %9 = load i32, ptr %"$$__signal_2_$sig", align 4
+  %9 = load i32, ptr %"_1___signal_2_$sig", align 4
   %__signal_process = call i64 @__signal_process(i32 %9), !dbg !41
-  store i64 %__signal_process, ptr %"$$__signal_2_$ret", align 8
-  %10 = load i64, ptr %"$$__signal_2_$ret", align 8
+  store i64 %__signal_process, ptr %"_1___signal_2_$ret", align 8
+  %10 = load i64, ptr %"_1___signal_2_$ret", align 8
   %11 = icmp ne i64 %10, 0
   %true_cond3 = icmp ne i1 %11, false
   br i1 %true_cond3, label %left1, label %right2
@@ -84,7 +84,7 @@ left1:                                            ; preds = %right
   %16 = getelementptr %warnf_t, ptr %warnf_args, i32 0, i32 0
   store i64 1, ptr %16, align 8
   %17 = getelementptr %warnf_t, ptr %warnf_args, i32 0, i32 1
-  %18 = load i64, ptr %"$$__signal_2_$ret", align 8
+  %18 = load i64, ptr %"_1___signal_2_$ret", align 8
   %19 = getelementptr %warnf_args_t, ptr %17, i32 0, i32 0
   store i64 %18, ptr %19, align 8
   %ringbuf_output4 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %warnf_args, i64 16, i64 0)

--- a/tests/codegen/llvm/call_signal_thread.ll
+++ b/tests/codegen/llvm/call_signal_thread.ll
@@ -22,16 +22,16 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_f_1(ptr %0) #0 section "s_kprobe_f_1" !dbg !35 {
 entry:
   %warnf_args = alloca %warnf_t, align 8
-  %"$$__signal_2_$ret" = alloca i64, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$$__signal_2_$ret")
-  store i64 0, ptr %"$$__signal_2_$ret", align 8
+  %"_1___signal_2_$ret" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"_1___signal_2_$ret")
+  store i64 0, ptr %"_1___signal_2_$ret", align 8
   %errorf_args = alloca %errorf_t, align 8
-  %"$$__signal_2_$sig" = alloca i32, align 4
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$$__signal_2_$sig")
-  store i32 0, ptr %"$$__signal_2_$sig", align 4
-  store i32 0, ptr %"$$__signal_2_$sig", align 4
-  store i32 8, ptr %"$$__signal_2_$sig", align 4
-  %1 = load i32, ptr %"$$__signal_2_$sig", align 4
+  %"_1___signal_2_$sig" = alloca i32, align 4
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"_1___signal_2_$sig")
+  store i32 0, ptr %"_1___signal_2_$sig", align 4
+  store i32 0, ptr %"_1___signal_2_$sig", align 4
+  store i32 8, ptr %"_1___signal_2_$sig", align 4
+  %1 = load i32, ptr %"_1___signal_2_$sig", align 4
   %2 = sext i32 %1 to i64
   %3 = icmp slt i64 %2, 1
   %true_cond = icmp ne i1 %3, false
@@ -45,7 +45,7 @@ left:                                             ; preds = %entry
   %5 = getelementptr %errorf_t, ptr %errorf_args, i32 0, i32 1
   %6 = getelementptr %errorf_args_t, ptr %5, i32 0, i32 0
   call void @llvm.memcpy.p0.p0.i64(ptr align 1 %6, ptr align 1 @"signal_thread()", i64 16, i1 false)
-  %7 = load i32, ptr %"$$__signal_2_$sig", align 4
+  %7 = load i32, ptr %"_1___signal_2_$sig", align 4
   %8 = getelementptr %errorf_args_t, ptr %5, i32 0, i32 1
   store i32 %7, ptr %8, align 4
   %ringbuf_output = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %errorf_args, i64 32, i64 0)
@@ -53,10 +53,10 @@ left:                                             ; preds = %entry
   br i1 %ringbuf_loss, label %event_loss_counter, label %counter_merge
 
 right:                                            ; preds = %entry
-  %9 = load i32, ptr %"$$__signal_2_$sig", align 4
+  %9 = load i32, ptr %"_1___signal_2_$sig", align 4
   %__signal_thread = call i64 @__signal_thread(i32 %9), !dbg !41
-  store i64 %__signal_thread, ptr %"$$__signal_2_$ret", align 8
-  %10 = load i64, ptr %"$$__signal_2_$ret", align 8
+  store i64 %__signal_thread, ptr %"_1___signal_2_$ret", align 8
+  %10 = load i64, ptr %"_1___signal_2_$ret", align 8
   %11 = icmp ne i64 %10, 0
   %true_cond3 = icmp ne i1 %11, false
   br i1 %true_cond3, label %left1, label %right2
@@ -84,7 +84,7 @@ left1:                                            ; preds = %right
   %16 = getelementptr %warnf_t, ptr %warnf_args, i32 0, i32 0
   store i64 1, ptr %16, align 8
   %17 = getelementptr %warnf_t, ptr %warnf_args, i32 0, i32 1
-  %18 = load i64, ptr %"$$__signal_2_$ret", align 8
+  %18 = load i64, ptr %"_1___signal_2_$ret", align 8
   %19 = getelementptr %warnf_args_t, ptr %17, i32 0, i32 0
   store i64 %18, ptr %19, align 8
   %ringbuf_output4 = call i64 inttoptr (i64 130 to ptr)(ptr @ringbuf, ptr %warnf_args, i64 16, i64 0)

--- a/tests/codegen/llvm/strcontains.ll
+++ b/tests/codegen/llvm/strcontains.ll
@@ -19,23 +19,23 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_foo_1(ptr %0) #0 section "s_kprobe_foo_1" !dbg !35 {
 entry:
   %array_access = alloca i8, align 1
-  %"$$strstr_4_$needle_size" = alloca i64, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$$strstr_4_$needle_size")
-  store i64 0, ptr %"$$strstr_4_$needle_size", align 8
-  %"$$strstr_4_$haystack_size" = alloca i64, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$$strstr_4_$haystack_size")
-  store i64 0, ptr %"$$strstr_4_$haystack_size", align 8
-  %"$$strstr_3_$needle" = alloca [5 x i8], align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$$strstr_3_$needle")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$$strstr_3_$needle", i8 0, i64 5, i1 false)
-  %"$$strstr_2_$haystack" = alloca [17 x i8], align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$$strstr_2_$haystack")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$$strstr_2_$haystack", i8 0, i64 17, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$$strstr_2_$haystack", ptr align 1 @hello-test-world, i64 17, i1 false)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$$strstr_3_$needle", ptr align 1 @test, i64 5, i1 false)
-  store i64 17, ptr %"$$strstr_4_$haystack_size", align 8
-  store i64 5, ptr %"$$strstr_4_$needle_size", align 8
-  %1 = load i64, ptr %"$$strstr_4_$needle_size", align 8
+  %"_1_strstr_4_$needle_size" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"_1_strstr_4_$needle_size")
+  store i64 0, ptr %"_1_strstr_4_$needle_size", align 8
+  %"_1_strstr_4_$haystack_size" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"_1_strstr_4_$haystack_size")
+  store i64 0, ptr %"_1_strstr_4_$haystack_size", align 8
+  %"_1_strstr_3_$needle" = alloca [5 x i8], align 1
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"_1_strstr_3_$needle")
+  call void @llvm.memset.p0.i64(ptr align 1 %"_1_strstr_3_$needle", i8 0, i64 5, i1 false)
+  %"_1_strstr_2_$haystack" = alloca [17 x i8], align 1
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"_1_strstr_2_$haystack")
+  call void @llvm.memset.p0.i64(ptr align 1 %"_1_strstr_2_$haystack", i8 0, i64 17, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"_1_strstr_2_$haystack", ptr align 1 @hello-test-world, i64 17, i1 false)
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"_1_strstr_3_$needle", ptr align 1 @test, i64 5, i1 false)
+  store i64 17, ptr %"_1_strstr_4_$haystack_size", align 8
+  store i64 5, ptr %"_1_strstr_4_$needle_size", align 8
+  %1 = load i64, ptr %"_1_strstr_4_$needle_size", align 8
   %2 = icmp eq i64 %1, 0
   %true_cond = icmp ne i1 %2, false
   br i1 %true_cond, label %left, label %right
@@ -44,7 +44,7 @@ left:                                             ; preds = %entry
   br label %done
 
 right:                                            ; preds = %entry
-  %3 = ptrtoint ptr %"$$strstr_3_$needle" to i64
+  %3 = ptrtoint ptr %"_1_strstr_3_$needle" to i64
   %4 = inttoptr i64 %3 to ptr
   %5 = call ptr @llvm.preserve.static.offset(ptr %4)
   %6 = getelementptr i8, ptr %5, i64 0
@@ -66,9 +66,9 @@ left1:                                            ; preds = %right
   br label %done4
 
 right2:                                           ; preds = %right
-  %11 = load i64, ptr %"$$strstr_4_$haystack_size", align 8
-  %12 = load i64, ptr %"$$strstr_4_$needle_size", align 8
-  %__bpf_strnstr = call i32 @__bpf_strnstr(ptr %"$$strstr_2_$haystack", ptr %"$$strstr_3_$needle", i64 %11, i64 %12), !dbg !41
+  %11 = load i64, ptr %"_1_strstr_4_$haystack_size", align 8
+  %12 = load i64, ptr %"_1_strstr_4_$needle_size", align 8
+  %__bpf_strnstr = call i32 @__bpf_strnstr(ptr %"_1_strstr_2_$haystack", ptr %"_1_strstr_3_$needle", i64 %11, i64 %12), !dbg !41
   %13 = sext i32 %__bpf_strnstr to i64
   br label %done4
 

--- a/tests/codegen/llvm/strcontains_no_literals.ll
+++ b/tests/codegen/llvm/strcontains_no_literals.ll
@@ -19,12 +19,12 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_foo_1(ptr %0) #0 section "s_kprobe_foo_1" !dbg !48 {
 entry:
   %array_access = alloca i8, align 1
-  %"$$strstr_4_$needle_size" = alloca i64, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$$strstr_4_$needle_size")
-  store i64 0, ptr %"$$strstr_4_$needle_size", align 8
-  %"$$strstr_4_$haystack_size" = alloca i64, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$$strstr_4_$haystack_size")
-  store i64 0, ptr %"$$strstr_4_$haystack_size", align 8
+  %"_1_strstr_4_$needle_size" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"_1_strstr_4_$needle_size")
+  store i64 0, ptr %"_1_strstr_4_$needle_size", align 8
+  %"_1_strstr_4_$haystack_size" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"_1_strstr_4_$haystack_size")
+  store i64 0, ptr %"_1_strstr_4_$haystack_size", align 8
   %get_cpu_id9 = call i64 inttoptr (i64 8 to ptr)() #4
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded10 = and i64 %get_cpu_id9, %1
@@ -55,9 +55,9 @@ entry:
   %arg1 = load volatile i64, ptr %12, align 8
   %probe_read_kernel_str8 = call i64 inttoptr (i64 115 to ptr)(ptr %10, i32 1024, i64 %arg1)
   %probe_read_kernel12 = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 1024, ptr %10)
-  store i64 1024, ptr %"$$strstr_4_$haystack_size", align 8
-  store i64 1024, ptr %"$$strstr_4_$needle_size", align 8
-  %13 = load i64, ptr %"$$strstr_4_$needle_size", align 8
+  store i64 1024, ptr %"_1_strstr_4_$haystack_size", align 8
+  store i64 1024, ptr %"_1_strstr_4_$needle_size", align 8
+  %13 = load i64, ptr %"_1_strstr_4_$needle_size", align 8
   %14 = icmp eq i64 %13, 0
   %true_cond = icmp ne i1 %14, false
   br i1 %true_cond, label %left, label %right
@@ -88,8 +88,8 @@ left13:                                           ; preds = %right
   br label %done17
 
 right14:                                          ; preds = %right
-  %23 = load i64, ptr %"$$strstr_4_$haystack_size", align 8
-  %24 = load i64, ptr %"$$strstr_4_$needle_size", align 8
+  %23 = load i64, ptr %"_1_strstr_4_$haystack_size", align 8
+  %24 = load i64, ptr %"_1_strstr_4_$needle_size", align 8
   %__bpf_strnstr = call i32 @__bpf_strnstr(ptr %4, ptr %2, i64 %23, i64 %24), !dbg !54
   %25 = sext i32 %__bpf_strnstr to i64
   br label %done17

--- a/tests/codegen/llvm/strcontains_one_literal.ll
+++ b/tests/codegen/llvm/strcontains_one_literal.ll
@@ -20,15 +20,15 @@ declare i64 @llvm.bpf.pseudo(i64 %0, i64 %1) #0
 define i64 @kprobe_foo_1(ptr %0) #0 section "s_kprobe_foo_1" !dbg !48 {
 entry:
   %array_access = alloca i8, align 1
-  %"$$strstr_4_$needle_size" = alloca i64, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$$strstr_4_$needle_size")
-  store i64 0, ptr %"$$strstr_4_$needle_size", align 8
-  %"$$strstr_4_$haystack_size" = alloca i64, align 8
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$$strstr_4_$haystack_size")
-  store i64 0, ptr %"$$strstr_4_$haystack_size", align 8
-  %"$$strstr_3_$needle" = alloca [5 x i8], align 1
-  call void @llvm.lifetime.start.p0(i64 -1, ptr %"$$strstr_3_$needle")
-  call void @llvm.memset.p0.i64(ptr align 1 %"$$strstr_3_$needle", i8 0, i64 5, i1 false)
+  %"_1_strstr_4_$needle_size" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"_1_strstr_4_$needle_size")
+  store i64 0, ptr %"_1_strstr_4_$needle_size", align 8
+  %"_1_strstr_4_$haystack_size" = alloca i64, align 8
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"_1_strstr_4_$haystack_size")
+  store i64 0, ptr %"_1_strstr_4_$haystack_size", align 8
+  %"_1_strstr_3_$needle" = alloca [5 x i8], align 1
+  call void @llvm.lifetime.start.p0(i64 -1, ptr %"_1_strstr_3_$needle")
+  call void @llvm.memset.p0.i64(ptr align 1 %"_1_strstr_3_$needle", i8 0, i64 5, i1 false)
   %get_cpu_id1 = call i64 inttoptr (i64 8 to ptr)() #6
   %1 = load i64, ptr @__bt__max_cpu_id, align 8
   %cpu.id.bounded2 = and i64 %get_cpu_id1, %1
@@ -44,10 +44,10 @@ entry:
   %arg0 = load volatile i64, ptr %6, align 8
   %probe_read_kernel_str = call i64 inttoptr (i64 115 to ptr)(ptr %4, i32 1024, i64 %arg0)
   %probe_read_kernel4 = call i64 inttoptr (i64 113 to ptr)(ptr %2, i32 1024, ptr %4)
-  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"$$strstr_3_$needle", ptr align 1 @test, i64 5, i1 false)
-  store i64 1024, ptr %"$$strstr_4_$haystack_size", align 8
-  store i64 5, ptr %"$$strstr_4_$needle_size", align 8
-  %7 = load i64, ptr %"$$strstr_4_$needle_size", align 8
+  call void @llvm.memcpy.p0.p0.i64(ptr align 1 %"_1_strstr_3_$needle", ptr align 1 @test, i64 5, i1 false)
+  store i64 1024, ptr %"_1_strstr_4_$haystack_size", align 8
+  store i64 5, ptr %"_1_strstr_4_$needle_size", align 8
+  %7 = load i64, ptr %"_1_strstr_4_$needle_size", align 8
   %8 = icmp eq i64 %7, 0
   %true_cond = icmp ne i1 %8, false
   br i1 %true_cond, label %left, label %right
@@ -56,7 +56,7 @@ left:                                             ; preds = %entry
   br label %done
 
 right:                                            ; preds = %entry
-  %9 = ptrtoint ptr %"$$strstr_3_$needle" to i64
+  %9 = ptrtoint ptr %"_1_strstr_3_$needle" to i64
   %10 = inttoptr i64 %9 to ptr
   %11 = call ptr @llvm.preserve.static.offset(ptr %10)
   %12 = getelementptr i8, ptr %11, i64 0
@@ -78,9 +78,9 @@ left5:                                            ; preds = %right
   br label %done9
 
 right6:                                           ; preds = %right
-  %17 = load i64, ptr %"$$strstr_4_$haystack_size", align 8
-  %18 = load i64, ptr %"$$strstr_4_$needle_size", align 8
-  %__bpf_strnstr = call i32 @__bpf_strnstr(ptr %2, ptr %"$$strstr_3_$needle", i64 %17, i64 %18), !dbg !54
+  %17 = load i64, ptr %"_1_strstr_4_$haystack_size", align 8
+  %18 = load i64, ptr %"_1_strstr_4_$needle_size", align 8
+  %__bpf_strnstr = call i32 @__bpf_strnstr(ptr %2, ptr %"_1_strstr_3_$needle", i64 %17, i64 %18), !dbg !54
   %19 = sext i32 %__bpf_strnstr to i64
   br label %done9
 


### PR DESCRIPTION
Have bpftrace object return a prefix id (uint64)
for each pass that creates temporary variables to prevent possible conflicts in the future.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
