### PR TITLE
output: drop the infamous double newline

### DIFF
--- a/src/output/json.cpp
+++ b/src/output/json.cpp
@@ -513,9 +513,4 @@ void JsonOutput::benchmark_results(
   emit_data(out_, "benchmark_results", std::nullopt, results);
 }
 
-void JsonOutput::end()
-{
-  // Nothing emitted.
-}
-
 } // namespace bpftrace::output

--- a/src/output/json.h
+++ b/src/output/json.h
@@ -22,7 +22,6 @@ public:
   void runtime_error(int retcode, const RuntimeErrorInfo &info) override;
   void benchmark_results(
       const std::vector<std::pair<std::string, uint32_t>> &results) override;
-  void end() override;
 
 private:
   std::ostream &out_;

--- a/src/output/output.h
+++ b/src/output/output.h
@@ -158,7 +158,6 @@ public:
   virtual void runtime_error(int retcode, const RuntimeErrorInfo& info) = 0;
   virtual void benchmark_results(
       const std::vector<std::pair<std::string, uint32_t>>& results) = 0;
-  virtual void end() = 0;
 };
 
 } // namespace bpftrace::output

--- a/src/output/text.cpp
+++ b/src/output/text.cpp
@@ -689,10 +689,4 @@ void TextOutput::benchmark_results(
   out_ << std::endl;
 }
 
-void TextOutput::end()
-{
-  out_ << std::endl;
-  out_ << std::endl;
-}
-
 } // namespace bpftrace::output

--- a/src/output/text.h
+++ b/src/output/text.h
@@ -24,7 +24,6 @@ public:
   void runtime_error(int retcode, const RuntimeErrorInfo &info) override;
   void benchmark_results(
       const std::vector<std::pair<std::string, uint32_t>> &results) override;
-  void end() override;
 
   // Allows formatting of a specific primitive.
   void primitive(const Primitive &p);

--- a/src/run_bpftrace.cpp
+++ b/src/run_bpftrace.cpp
@@ -232,9 +232,6 @@ int run_bpftrace(BPFtrace &bpftrace,
   if (err)
     return err;
 
-  // Indicate that we are done the main loop.
-  output->end();
-
   // We are now post-processing. If we receive another SIGINT,
   // handle it normally (exit)
   act.sa_handler = SIG_DFL;

--- a/tests/runtime/for
+++ b/tests/runtime/for
@@ -47,7 +47,7 @@ EXPECT (64, 128)
 EXPECT (65, 129)
 
 NAME map nested count
-PROG begin { @mapA[16] = 32; @mapA[17] = 33; @mapB[64] = 128; @mapB[65] = 129; @mapB[66] = 130; for ($kv : @mapA) { printf("A"); for ($kv2 : @mapB) { printf("B"); } }  }
+PROG begin { @mapA[16] = 32; @mapA[17] = 33; @mapB[64] = 128; @mapB[65] = 129; @mapB[66] = 130; for ($kv : @mapA) { printf("A"); for ($kv2 : @mapB) { printf("B"); } } } end { printf("\n"); }
 EXPECT ABBBABBB
 
 NAME map delete
@@ -85,43 +85,43 @@ PROG begin { @map[kstack(raw)] = count(); for ($kv : @map) { print($kv.1); }  }
 EXPECT 1
 
 NAME map with break
-PROG begin { @map["foo"] = 1; @map["bar"] = 2; print("start"); for ($i : @map) { print($i.0); break; } print("done");  }
-EXPECT_REGEX .*start\n(foo|bar)\ndone\n\n
+PROG begin { @map["foo"] = 1; @map["bar"] = 2; print("start"); for ($i : @map) { print($i.0); break; } print("done"); }
+EXPECT_REGEX .*start\n(foo|bar)\ndone
 
 NAME map with continue
-PROG begin { @map["foo"] = 1; @map["bar"] = 2; print("start"); for ($i : @map) { if ($i.0 == "bar") { continue; } print($i.0); }  }
-EXPECT_REGEX .*start\nfoo\n\n
+PROG begin { @map["foo"] = 1; @map["bar"] = 2; print("start"); for ($i : @map) { if ($i.0 == "bar") { continue; } print($i.0); } } end { print("done"); }
+EXPECT_REGEX .*start\nfoo\ndone
 
 NAME range basic
-PROG begin { for ($i : 0..5) { print($i); }  }
-EXPECT_REGEX .*\n0\n1\n2\n3\n4\n\n
+PROG begin { for ($i : 0..5) { print($i); }  } end { print("done"); }
+EXPECT_REGEX .*\n0\n1\n2\n3\n4\ndone
 
 NAME range with variables
-PROG begin { $start = 2; $end = 7; for ($i : $start..$end) { print($i); }  }
-EXPECT_REGEX .*\n2\n3\n4\n5\n6\n\n
+PROG begin { $start = 2; $end = 7; for ($i : $start..$end) { print($i); }  } end { print("done"); }
+EXPECT_REGEX .*\n2\n3\n4\n5\n6\ndone
 
 NAME range with expressions
-PROG begin { for ($i : (1+1)..(2*4)) { print($i); }  }
-EXPECT_REGEX .*\n2\n3\n4\n5\n6\n7\n\n
+PROG begin { for ($i : (1+1)..(2*4)) { print($i); }  } end { print("done"); }
+EXPECT_REGEX .*\n2\n3\n4\n5\n6\n7\ndone
 
 NAME range with map as expression
-PROG begin { @map[5] = 8; for ($i : 0..@map[5]) { print($i); }  }
-EXPECT_REGEX .*\n2\n3\n4\n5\n6\n7\n\n
+PROG begin { @map[5] = 8; for ($i : 0..@map[5]) { print($i); }  } end { print("done"); }
+EXPECT_REGEX .*\n2\n3\n4\n5\n6\n7\ndone
 
 NAME range with zero iterations
 PROG begin { for ($i : 1..0) { print("here"); }  }
 EXPECT_NONE here
 
 NAME range with negative start
-PROG begin { for ($i : (-3)..3) { print($i); }  }
-EXPECT_REGEX .*\n-3\n-2\n-1\n0\n1\n2\n\n
+PROG begin { for ($i : (-3)..3) { print($i); }  } end { print("done"); }
+EXPECT_REGEX .*\n-3\n-2\n-1\n0\n1\n2\ndone
 
 NAME range with same start and end
 PROG begin { for ($i : 5..5) { print("here"); }  }
 EXPECT_NONE here
 
 NAME range with variable modification
-PROG begin { $sum = 0; for ($i : 1..5) { $sum += $i; } print($sum);  }
+PROG begin { $sum = 0; for ($i : 1..5) { $sum += $i; } print($sum); }
 EXPECT_REGEX ^10
 
 NAME range using a map
@@ -129,9 +129,9 @@ PROG begin { @a = 10; for ($i : 0..@a) { print($i); @a += 1; }  }
 EXPECT_REGEX @a: 20
 
 NAME range with break
-PROG begin { for ($i : 1..4) { if ($i == 2) { break; } print($i); } print("5");  }
-EXPECT_REGEX .*\n1\n5\n\n
+PROG begin { for ($i : 1..4) { if ($i == 2) { break; } print($i); } print("5");  } end { print("done"); }
+EXPECT_REGEX .*\n1\n5\ndone
 
 NAME range with continue
-PROG begin { for ($i : 1..4) { if ($i == 2) { continue; } print($i); }  }
-EXPECT_REGEX .*\n1\n3\n\n
+PROG begin { for ($i : 1..4) { if ($i == 2) { continue; } print($i); }  } end { print("done"); }
+EXPECT_REGEX .*\n1\n3\ndone

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -508,7 +508,7 @@ TIMEOUT 2
 NAME bench
 RUN {{BPFTRACE}} --test-mode bench -e 'begin { print("begin\n"); } bench:a { @ = count(); } end { print(@); clear(@); }'
 EXPECT_REGEX begin\n
-             @: 1000000\n\n
+             @: 1000000
              \+-----------\+--------------\+
              \| BENCHMARK \| AVERAGE TIME \|
              \+-----------\+--------------\+
@@ -521,7 +521,7 @@ RUN {{BPFTRACE}} --test-mode bench -e 'begin { printf("begin\n"); } bench:a { @a
 EXPECT_REGEX begin
              @a: 1000000
              @b: 1000000
-             @c: 1000000\n\n
+             @c: 1000000
              \+-----------\+--------------\+
              \| BENCHMARK \| AVERAGE TIME \|
              \+-----------\+--------------\+

--- a/tests/runtime/scripts/struct_array_vars.bt
+++ b/tests/runtime/scripts/struct_array_vars.bt
@@ -42,5 +42,5 @@ uprobe:./testprogs/struct_array:clear {
   printf("%d ", @w[0][4].t.b[1]);
 
   printf("-- ");
-  printf("%d ", @[$c->w]);
+  printf("%d\n", @[$c->w]);
 }


### PR DESCRIPTION
Stacked PRs:
 * #4790
 * #4789
 * __->__#4782


--- --- ---

### output: drop the infamous double newline


For time immemorial, bpftrace has emitted a double newline after output.
There is no real value to this, and we should consider removing this and
allowing the user to more directly control their output.

Signed-off-by: Adin Scannell <adin@scannell.ca>
