### PR TITLE
parser: fix C statement locations

### DIFF
--- a/src/lexer.l
+++ b/src/lexer.l
@@ -255,7 +255,8 @@ oct_esc  [0-7]{1,3}
   "->"                    { return Parser::make_PTR(driver.loc); }
   "$"[0-9]+               { return Parser::make_PARAM(yytext, driver.loc); }
   "$"#                    { return Parser::make_PARAMCOUNT(driver.loc); }
-  "#"[^!].*               { return Parser::make_CPREPROC(yytext, driver.loc); }
+  /* N.B. The C preprocessor directives also span the line. */
+  [#][^!][^\n]*\n         { driver.loc.trim(); auto v = Parser::make_CPREPROC(yytext, driver.loc); driver.loc.advance_lines(1); return v; }
   "if"                    { return Parser::make_IF(yytext, driver.loc); }
   "else"                  { return Parser::make_ELSE(yytext, driver.loc); }
   "?"                     { return Parser::make_QUES(driver.loc); }
@@ -374,8 +375,15 @@ oct_esc  [0-7]{1,3}
                           driver.buffer += yytext[0];
                         }
   "{"                   yy_push_state(BRACE, yyscanner); driver.buffer += '{';
-  "}"|"};"              {
+  [}][;]?[\n]?          {
                           driver.buffer += yytext;
+                          if (yytext[yyleng-1] == '\n') {
+                            driver.loc.trim();
+                          }
+                          auto loc = driver.loc;
+                          if (yytext[yyleng-1] == '\n') {
+                            driver.loc.advance_lines(1);
+                          }
                           yy_pop_state(yyscanner);
                           if (YY_START == STRUCT)
                           {
@@ -384,7 +392,7 @@ oct_esc  [0-7]{1,3}
                             // will go through Clang before we get them back
                             // anyway.
                             yy_pop_state(yyscanner);
-                            return Parser::make_STRUCT_DEFN(driver.struct_type + driver.buffer, driver.loc);
+                            return Parser::make_STRUCT_DEFN(driver.struct_type + driver.buffer, loc);
                           }
                         }
   .                     driver.buffer += yytext[0];

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -35,6 +35,7 @@ class Node;
 #include "ast/context.h"
 #include "ast/location.h"
 #include "util/int_parser.h"
+#include "util/strings.h"
 }
 
 %{
@@ -250,16 +251,21 @@ c_struct:       STRUCT STRUCT_DEFN { $$ = $2; }
                 ;
 
 c_definitions:
-                c_definitions CPREPROC  { $$ = std::move($1); $$.push_back(driver.ctx.make_node<ast::CStatement>(driver.loc, $2)); }
+                c_definitions CPREPROC
+                {
+                    $$ = std::move($1);
+                    auto s = util::rtrim($2);
+                    $$.push_back(driver.ctx.make_node<ast::CStatement>(driver.loc, s));
+                }
         |       c_definitions c_struct  {
                     $$ = std::move($1);
-                    auto s = $2;
-                    if (s.empty() || s.back() != ';') {
-                        s += ";";
+                    auto s = util::rtrim($2);
+                    if (!s.empty() && s.back() != ';') {
+                      s += ";";
                     }
                     $$.push_back(driver.ctx.make_node<ast::CStatement>(driver.loc, s));
                 }
-        |       %empty                           { $$ = ast::CStatementList(); }
+        |       %empty { $$ = ast::CStatementList(); }
                 ;
 
 imports:

--- a/src/util/strings.h
+++ b/src/util/strings.h
@@ -8,14 +8,14 @@ namespace bpftrace::util {
 // trim from end of string (right)
 inline std::string &rtrim(std::string &s)
 {
-  s.erase(s.find_last_not_of(" ") + 1);
+  s.erase(s.find_last_not_of(" \t\r\n") + 1);
   return s;
 }
 
 // trim from beginning of string (left)
 inline std::string &ltrim(std::string &s)
 {
-  s.erase(0, s.find_first_not_of(" "));
+  s.erase(0, s.find_first_not_of(" \t\r\n"));
   return s;
 }
 

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -118,7 +118,7 @@ void test(BPFtrace &bpftrace, const std::string &input, const MatcherT &matcher)
   ASSERT_TRUE(bool(ok));
 
   ast.diagnostics().emit(out);
-  ASSERT_TRUE(ast.diagnostics().ok()) << out.str();
+  ASSERT_TRUE(ast.diagnostics().ok()) << out.str() << input;
 
   EXPECT_THAT(ast, matcher);
 }
@@ -1770,7 +1770,7 @@ TEST(Parser, offsetof_expression)
   test("struct Foo { int x; }; "
        "begin { $foo = (struct Foo *)0; offsetof(*$foo, x); }",
        Program()
-           .WithCStatements({ CStatement("struct Foo { int x; };;") })
+           .WithCStatements({ CStatement("struct Foo { int x; };") })
            .WithProbe(Probe(
                { "begin" },
                { AssignVarStatement(Variable("$foo"),
@@ -1905,7 +1905,7 @@ TEST(Parser, cstruct_semicolon)
   test("struct Foo { int x, y; char *str; }; kprobe:sys_read { 1; }",
        Program()
            .WithCStatements(
-               { CStatement("struct Foo { int x, y; char *str; };;") })
+               { CStatement("struct Foo { int x, y; char *str; };") })
            .WithProbe(
                Probe({ "kprobe:sys_read" }, { ExprStatement(Integer(1)) })));
 }


### PR DESCRIPTION
Stacked PRs:
 * #4797
 * #4621
 * #4620
 * #4787
 * #4784
 * __->__#4783


--- --- ---

### parser: fix C statement locations


These were occasionally consuming a newline, sometimes not. Make the
semantics similar to other traditional line-ending statements, and
attempt to greedily consume the new-line -- as long as the location is
kept accurate.

This change fixes `util::*trim` to actually trim whitespace.

Signed-off-by: Adin Scannell <amscanne@meta.com>
