### PR TITLE
ast: use `MapAccess` in the `AssignMapStatement`

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1353,36 +1353,28 @@ class AssignMapStatement : public Node {
 public:
   explicit AssignMapStatement(ASTContext &ctx,
                               Location &&loc,
-                              Map *map,
-                              Expression key,
+                              MapAccess *map,
                               Expression expr)
-      : Node(ctx, std::move(loc)),
-        map(map),
-        key(std::move(key)),
-        expr(std::move(expr)) {};
+      : Node(ctx, std::move(loc)), map_access(map), expr(std::move(expr)) {};
   explicit AssignMapStatement(ASTContext &ctx,
                               const Location &loc,
                               const AssignMapStatement &other)
       : Node(ctx, loc + other.loc),
-        map(clone(ctx, loc, other.map)),
-        key(clone(ctx, loc, other.key)),
+        map_access(clone(ctx, loc, other.map_access)),
         expr(clone(ctx, loc, other.expr)) {};
 
   bool operator==(const AssignMapStatement &other) const
   {
-    return *map == *other.map && key == other.key && expr == other.expr;
+    return *map_access == *other.map_access && expr == other.expr;
   }
   std::strong_ordering operator<=>(const AssignMapStatement &other) const
   {
-    if (auto cmp = *map <=> *other.map; cmp != 0)
-      return cmp;
-    if (auto cmp = key <=> other.key; cmp != 0)
+    if (auto cmp = *map_access <=> *other.map_access; cmp != 0)
       return cmp;
     return expr <=> other.expr;
   }
 
-  Map *map = nullptr;
-  Expression key;
+  MapAccess *map_access = nullptr;
   Expression expr;
 };
 

--- a/src/ast/codegen_helper.cpp
+++ b/src/ast/codegen_helper.cpp
@@ -19,11 +19,12 @@ namespace bpftrace::ast {
 // IRBuilderBPF::CreateWriteMapValueAllocation
 bool needAssignMapStatementAllocation(const AssignMapStatement &assignment)
 {
-  const auto &map = *assignment.map;
+  const auto &map = *assignment.map_access;
   const auto &expr_type = assignment.expr.type();
   if (shouldBeInBpfMemoryAlready(expr_type)) {
-    return !expr_type.IsSameSizeRecursive(map.value_type);
-  } else if (map.value_type.IsRecordTy() || map.value_type.IsArrayTy()) {
+    return !expr_type.IsSameSizeRecursive(map.map->value_type);
+  } else if (map.map->value_type.IsRecordTy() ||
+             map.map->value_type.IsArrayTy()) {
     return !expr_type.is_internal;
   }
   return true;

--- a/src/ast/passes/control_flow_analyser.cpp
+++ b/src/ast/passes/control_flow_analyser.cpp
@@ -86,9 +86,13 @@ public:
   {
     return visit(acc.expr) || visit(acc.indexpr);
   }
+  bool visit(MapAccess &acc)
+  {
+    return visit(acc.key);
+  }
   bool visit(AssignMapStatement &map_assign)
   {
-    return visit(map_assign.key) || visit(map_assign.expr);
+    return visit(map_assign.map_access) || visit(map_assign.expr);
   }
   bool visit(BlockExpr &block)
   {

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -203,10 +203,9 @@ void FieldAnalyser::visit(Typeof &typeof)
 
 void FieldAnalyser::visit(AssignMapStatement &assignment)
 {
-  visit(assignment.map);
-  visit(assignment.key);
+  visit(assignment.map_access);
   visit(assignment.expr);
-  var_types_.emplace(assignment.map->ident, sized_type_);
+  var_types_.emplace(assignment.map_access->map->ident, sized_type_);
 }
 
 void FieldAnalyser::visit(AssignVarStatement &assignment)

--- a/src/ast/passes/map_sugar.cpp
+++ b/src/ast/passes/map_sugar.cpp
@@ -132,8 +132,8 @@ void MapDefaultKey::visit(AssignScalarMapStatement &assign)
 
 void MapDefaultKey::visit(AssignMapStatement &assign)
 {
-  checkAccess(*assign.map, true);
-  visit(assign.key);
+  checkAccess(*assign.map_access->map, true);
+  visit(assign.map_access);
   visit(assign.expr);
 }
 
@@ -159,8 +159,8 @@ void MapDefaultKey::visit(Statement &stmt)
   // above. This will be type-checked during semantic analysis.
   if (auto *map = stmt.as<AssignScalarMapStatement>()) {
     auto *index = ast_.make_node<Integer>(map->loc, 0, CreateInt64());
-    stmt.value = ast_.make_node<AssignMapStatement>(
-        map->loc, map->map, index, map->expr);
+    auto *acc = ast_.make_node<MapAccess>(map->loc, map->map, index);
+    stmt.value = ast_.make_node<AssignMapStatement>(map->loc, acc, map->expr);
   }
 }
 
@@ -306,7 +306,9 @@ void MapAssignmentCall::visit(Statement &stmt)
   // Any assignments that are direct calls to special functions may
   // be rewritten to simply be the function expression.
   if (auto *assign = stmt.as<AssignMapStatement>()) {
-    auto expr = injectMap(assign->expr, assign->map, assign->key);
+    auto expr = injectMap(assign->expr,
+                          assign->map_access->map,
+                          assign->map_access->key);
     if (expr) {
       // We injected a call, and can flatten the statement.
       stmt.value = ast_.make_node<ExprStatement>(assign->loc, expr.value());

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -354,10 +354,7 @@ void Printer::visit(AssignMapStatement &assignment)
   out_ << indent << "=" << std::endl;
 
   ++depth_;
-  visit(assignment.map);
-  ++depth_;
-  visit(assignment.key);
-  --depth_;
+  visit(assignment.map_access);
   visit(assignment.expr);
   --depth_;
 }

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -468,20 +468,21 @@ void ResourceAnalyser::visit(AssignMapStatement &assignment)
   // an additional read map buffer. Thus to mimic CodegenLLVM, we
   // skip calling ResourceAnalser::visit(a.map) and do the AST traversal
   // ourselves.
-  visit(assignment.map);
-  visit(assignment.key);
+  visit(assignment.map_access->map);
+  visit(assignment.map_access->key);
   visit(assignment.expr);
 
   // The `MapAccess` validated the read limit, we know this to be
   // a write, so we validate the write limit.
   if (needAssignMapStatementAllocation(assignment)) {
-    if (exceeds_stack_limit(assignment.map->value_type.GetSize())) {
+    if (exceeds_stack_limit(assignment.map_access->map->value_type.GetSize())) {
       resources_.max_write_map_value_size = std::max(
           resources_.max_write_map_value_size,
-          assignment.map->value_type.GetSize());
+          assignment.map_access->map->value_type.GetSize());
     }
   }
-  maybe_allocate_map_key_buffer(*assignment.map, assignment.key);
+  maybe_allocate_map_key_buffer(*assignment.map_access->map,
+                                assignment.map_access->key);
 }
 
 void ResourceAnalyser::visit(IfExpr &if_expr)

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -166,8 +166,7 @@ public:
   }
   R visit(AssignMapStatement &assignment)
   {
-    visitImpl(assignment.map);
-    visitImpl(assignment.key);
+    visitImpl(assignment.map_access);
     return visitImpl(assignment.expr);
   }
   R visit(AssignVarStatement &assignment)

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -584,7 +584,7 @@ assign_stmt:
                   YYERROR;
                 }
         |       map ASSIGN expr           { $$ = driver.ctx.make_node<ast::AssignScalarMapStatement>(@$, $1, $3); }
-        |       map_expr ASSIGN expr      { $$ = driver.ctx.make_node<ast::AssignMapStatement>(@$, $1->map, $1->key, $3); }
+        |       map_expr ASSIGN expr      { $$ = driver.ctx.make_node<ast::AssignMapStatement>(@$, $1, $3); }
         |       var_decl_stmt ASSIGN expr { $$ = driver.ctx.make_node<ast::AssignVarStatement>(@$, $1, $3); }
         |       var ASSIGN expr           { $$ = driver.ctx.make_node<ast::AssignVarStatement>(@$, $1, $3); }
         |       map compound_op expr
@@ -595,7 +595,7 @@ assign_stmt:
         |       map_expr compound_op expr
                 {
                   auto b = driver.ctx.make_node<ast::Binop>(@2, $1, $2, $3);
-                  $$ = driver.ctx.make_node<ast::AssignMapStatement>(@$, $1->map, $1->key, b);
+                  $$ = driver.ctx.make_node<ast::AssignMapStatement>(@$, $1, b);
                 }
         |       var compound_op expr
                 {

--- a/tests/ast.cpp
+++ b/tests/ast.cpp
@@ -505,10 +505,14 @@ std::vector<AssignMapStatement *> variants<AssignMapStatement>(ASTContext &c,
   Expression expr4 = c.make_node<Variable>(l, std::string("$v"));
 
   return {
-    c.make_node<AssignMapStatement>(l, map1, std::move(key1), std::move(expr1)),
-    c.make_node<AssignMapStatement>(l, map2, std::move(key2), std::move(expr2)),
-    c.make_node<AssignMapStatement>(l, map3, std::move(key3), std::move(expr3)),
-    c.make_node<AssignMapStatement>(l, map4, std::move(key4), std::move(expr4))
+    c.make_node<AssignMapStatement>(
+        l, c.make_node<MapAccess>(l, map1, std::move(key1)), std::move(expr1)),
+    c.make_node<AssignMapStatement>(
+        l, c.make_node<MapAccess>(l, map2, std::move(key2)), std::move(expr2)),
+    c.make_node<AssignMapStatement>(
+        l, c.make_node<MapAccess>(l, map3, std::move(key3)), std::move(expr3)),
+    c.make_node<AssignMapStatement>(
+        l, c.make_node<MapAccess>(l, map4, std::move(key4)), std::move(expr4))
   };
 }
 

--- a/tests/ast_matchers.h
+++ b/tests/ast_matchers.h
@@ -1092,7 +1092,7 @@ public:
       const Matcher<const ast::Map&>& map_matcher)
   {
     return Where([map_matcher](const ast::AssignMapStatement& node) {
-      return MatchWith(node, map_matcher, *node.map);
+      return MatchWith(node, map_matcher, *node.map_access->map);
     });
   }
 
@@ -1100,7 +1100,7 @@ public:
       const Matcher<const ast::Expression&>& key_matcher)
   {
     return Where([key_matcher](const ast::AssignMapStatement& node) {
-      return MatchWith(node, key_matcher, node.key);
+      return MatchWith(node, key_matcher, node.map_access->key);
     });
   }
 };

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1798,7 +1798,7 @@ TEST_F(SemanticAnalyserTest, array_access)
                   "arg0; @x = $s->y[0];}");
   auto *assignment =
       ast.root->probes.at(0)->block->stmts.at(1).as<ast::AssignMapStatement>();
-  EXPECT_EQ(CreateInt32(), assignment->map->value_type);
+  EXPECT_EQ(CreateInt32(), assignment->map_access->map->value_type);
 
   ast = test("struct MyStruct { int y[4]; "
              "} kprobe:f { $s = ((struct "
@@ -1816,7 +1816,7 @@ TEST_F(SemanticAnalyserTest, array_access)
   auto *array_map_assignment =
       ast.root->probes.at(0)->block->stmts.at(0).as<ast::AssignMapStatement>();
   EXPECT_EQ(CreateArray(4, CreateInt32()),
-            array_map_assignment->map->value_type);
+            array_map_assignment->map_access->map->value_type);
 
   ast = test("kprobe:f { $s = (int32 *) "
              "arg0; $x = $s[0]; }");
@@ -1952,7 +1952,7 @@ TEST_F(SemanticAnalyserTest, map_integer_sizes)
   auto *map_assignment =
       ast.root->probes.at(0)->block->stmts.at(1).as<ast::AssignMapStatement>();
   EXPECT_EQ(CreateInt32(), var_assignment->var()->var_type);
-  EXPECT_EQ(CreateInt32(), map_assignment->map->value_type);
+  EXPECT_EQ(CreateInt32(), map_assignment->map_access->map->value_type);
 }
 
 TEST_F(SemanticAnalyserTest, binop_tuple)
@@ -2670,7 +2670,7 @@ TEST_F(SemanticAnalyserTest, field_access_is_internal)
     auto &stmts = ast.root->probes.at(0)->block->stmts;
     auto *map_assignment = stmts.at(0).as<ast::AssignMapStatement>();
     auto *var_assignment2 = stmts.at(1).as<ast::AssignVarStatement>();
-    EXPECT_TRUE(map_assignment->map->value_type.is_internal);
+    EXPECT_TRUE(map_assignment->map_access->map->value_type.is_internal);
     EXPECT_TRUE(var_assignment2->var()->var_type.is_internal);
   }
 }
@@ -3950,13 +3950,13 @@ TEST_F(SemanticAnalyserTest, tuple_assign_map)
   auto *assignment = stmts.at(0).as<ast::AssignMapStatement>();
   class SizedType ty = CreateTuple(Struct::CreateTuple(
       { CreateUInt8(), CreateUInt8(), CreateUInt8(), CreateUInt8() }));
-  EXPECT_EQ(ty, assignment->map->value_type);
+  EXPECT_EQ(ty, assignment->map_access->map->value_type);
 
   // $t = (0, 0, 0, 0);
   assignment = stmts.at(1).as<ast::AssignMapStatement>();
   ty = CreateTuple(Struct::CreateTuple(
       { CreateUInt8(), CreateUInt8(), CreateUInt8(), CreateUInt8() }));
-  EXPECT_EQ(ty, assignment->map->value_type);
+  EXPECT_EQ(ty, assignment->map_access->map->value_type);
 }
 
 // More in depth inspection of AST
@@ -4107,25 +4107,26 @@ TEST_F(SemanticAnalyserTest, string_size)
   ast = test(R"(k:f1 {@ = "hi";} k:f2 {@ = "hello";})");
   stmt = ast.root->probes.at(0)->block->stmts.at(0);
   auto *map_assign = stmt.as<ast::AssignMapStatement>();
-  ASSERT_TRUE(map_assign->map->value_type.IsStringTy());
-  ASSERT_EQ(map_assign->map->value_type.GetSize(), 6UL);
+  ASSERT_TRUE(map_assign->map_access->map->value_type.IsStringTy());
+  ASSERT_EQ(map_assign->map_access->map->value_type.GetSize(), 6UL);
 
   ast = test(R"(k:f1 {@["hi"] = 0;} k:f2 {@["hello"] = 1;})");
   stmt = ast.root->probes.at(0)->block->stmts.at(0);
   map_assign = stmt.as<ast::AssignMapStatement>();
-  ASSERT_TRUE(map_assign->key.type().IsStringTy());
-  ASSERT_EQ(map_assign->key.type().GetSize(), 3UL);
-  ASSERT_EQ(map_assign->map->key_type.GetSize(), 6UL);
+  ASSERT_TRUE(map_assign->map_access->key.type().IsStringTy());
+  ASSERT_EQ(map_assign->map_access->key.type().GetSize(), 3UL);
+  ASSERT_EQ(map_assign->map_access->map->key_type.GetSize(), 6UL);
 
   ast = test(R"(k:f1 {@["hi", 0] = 0;} k:f2 {@["hello", 1] = 1;})");
   stmt = ast.root->probes.at(0)->block->stmts.at(0);
   map_assign = stmt.as<ast::AssignMapStatement>();
-  ASSERT_TRUE(map_assign->key.type().IsTupleTy());
-  ASSERT_TRUE(map_assign->key.type().GetField(0).type.IsStringTy());
-  ASSERT_EQ(map_assign->key.type().GetField(0).type.GetSize(), 3UL);
-  ASSERT_EQ(map_assign->map->key_type.GetField(0).type.GetSize(), 6UL);
-  ASSERT_EQ(map_assign->key.type().GetSize(), 4UL);
-  ASSERT_EQ(map_assign->map->key_type.GetSize(), 7UL);
+  ASSERT_TRUE(map_assign->map_access->key.type().IsTupleTy());
+  ASSERT_TRUE(map_assign->map_access->key.type().GetField(0).type.IsStringTy());
+  ASSERT_EQ(map_assign->map_access->key.type().GetField(0).type.GetSize(), 3UL);
+  ASSERT_EQ(map_assign->map_access->map->key_type.GetField(0).type.GetSize(),
+            6UL);
+  ASSERT_EQ(map_assign->map_access->key.type().GetSize(), 4UL);
+  ASSERT_EQ(map_assign->map_access->map->key_type.GetSize(), 7UL);
 
   ast = test(R"(k:f1 {$x = ("hello", 0);} k:f2 {$x = ("hi", 0); })");
   stmt = ast.root->probes.at(0)->block->stmts.at(0);


### PR DESCRIPTION
Stacked PRs:
 * #4797
 * #4621
 * #4620
 * __->__#4787


--- --- ---

### ast: use `MapAccess` in the `AssignMapStatement`


This simplifies the respresentation and allows the AST to use the node
created directly by the parser.

Signed-off-by: Adin Scannell <amscanne@meta.com>
