### PR TITLE
tests: fix accidental shadowing issue with ast Matchers

### DIFF
--- a/tests/fold_literals.cpp
+++ b/tests/fold_literals.cpp
@@ -42,7 +42,7 @@ void test(const std::string& input,
     ASSERT_TRUE(ok && ast.diagnostics().ok()) << msg.str() << out.str();
     EXPECT_THAT(ast,
                 Program().WithProbe(
-                    Probe({ "begin" }, { ExprStatement(expr_matcher) })));
+                    Probe({ "begin" }, { ExprStatement(expr_matcher), _ })));
     if (!warn.empty()) {
       EXPECT_THAT(out.str(), HasSubstr(warn)) << msg.str() << out.str();
     }


### PR DESCRIPTION
Stacked PRs:
 * __->__#4788


--- --- ---

### tests: fix accidental shadowing issue with ast Matchers


This was a last minute refactor which causes them to do nothing!
Thankfully the tests are still valid, and will now fail if something
actually breaks underneath them.

Signed-off-by: Adin Scannell <amscanne@meta.com>