### PR TITLE
probes: allow multiple `begin` and `end` probes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to
   - [#4715](https://github.com/bpftrace/bpftrace/pull/4715)
 - Add `test` probes as means to improve runtime test latency
   - [#4753](https://github.com/bpftrace/bpftrace/pull/4753)
+- Multiple `begin` & `end` probes are now permitted
+  - [#4789](https://github.com/bpftrace/bpftrace/pull/4789)
 #### Changed
 - `uaddr` support PIE and dynamic library symbols.
   - [#4727](https://github.com/bpftrace/bpftrace/pull/4727)

--- a/docs/language.md
+++ b/docs/language.md
@@ -921,6 +921,8 @@ Most providers also support a short name which can be used instead of the full n
 These are special built-in events provided by the bpftrace runtime.
 `begin` is triggered before all other probes are attached.
 `end` is triggered after all other probes are detached.
+Each of these probes can be used any number of times, and they will be executed in the same order they are declared.
+For imports containing `begin` and `end` probes, an effort is made to preserve the partial order implied by the import graph (e.g. if `A` depends on `B`, then `B` will have both its `begin` and `end` probes executed first), but this is not strictly guaranteed.
 
 Note that specifying an `end` probe doesn’t override the printing of 'non-empty' maps at exit.
 To prevent printing all used maps need be cleared in the `end` probe:

--- a/src/ast/passes/attachpoint_passes.cpp
+++ b/src/ast/passes/attachpoint_passes.cpp
@@ -39,8 +39,6 @@ private:
   ASTContext &ast_;
   BPFtrace &bpftrace_;
   bool listing_;
-  bool has_begin_probe_ = false;
-  bool has_end_probe_ = false;
   bool has_child_ = false;
   std::unordered_map<std::string, Location> test_locs_;
   std::unordered_map<std::string, Location> benchmark_locs_;
@@ -276,17 +274,8 @@ void AttachPointChecker::visit(AttachPoint &ap)
     else if (ap.freq < 0)
       ap.addError() << "hardware frequency should be a positive integer";
   } else if (ap.provider == "begin" || ap.provider == "end") {
-    if (!ap.target.empty() || !ap.func.empty())
+    if (!ap.target.empty() || !ap.func.empty()) {
       ap.addError() << "begin/end probes should not have a target";
-    if (ap.provider == "begin") {
-      if (has_begin_probe_)
-        ap.addError() << "More than one begin probe defined";
-      has_begin_probe_ = true;
-    }
-    if (ap.provider == "end") {
-      if (has_end_probe_)
-        ap.addError() << "More than one end probe defined";
-      has_end_probe_ = true;
     }
   } else if (ap.provider == "self") {
     if (ap.target == "signal") {

--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -197,10 +197,8 @@ void BpfBytecode::load_progs(const RequiredResources &resources,
     bpf_program__set_log_buf(prog.bpf_prog(), log_buf.data(), log_buf.size());
   }
 
-  std::vector<Probe> special_probes;
-  for (auto probe : resources.special_probes)
-    special_probes.push_back(probe.second);
-  prepare_progs(special_probes, btf, feature, config);
+  prepare_progs(resources.begin_probes, btf, feature, config);
+  prepare_progs(resources.end_probes, btf, feature, config);
   prepare_progs(resources.test_probes, btf, feature, config);
   prepare_progs(resources.benchmark_probes, btf, feature, config);
   prepare_progs(resources.signal_probes, btf, feature, config);

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -218,16 +218,17 @@ public:
   // Probe metadata that codegen creates. Ideally ResourceAnalyser pass should
   // be collecting this, but it's complex to move the logic.
   std::vector<Probe> probes;
-  std::unordered_map<std::string, Probe> special_probes;
+  std::vector<Probe> begin_probes;
+  std::vector<Probe> end_probes;
   std::vector<Probe> test_probes;
   std::vector<Probe> benchmark_probes;
   std::vector<Probe> signal_probes;
   std::vector<Probe> watchpoint_probes;
 
-  size_t num_probes()
+  size_t num_probes() const
   {
-    return probes.size() + special_probes.size() + test_probes.size() +
-           benchmark_probes.size() + signal_probes.size() +
+    return probes.size() + begin_probes.size() + end_probes.size() +
+           test_probes.size() + benchmark_probes.size() + signal_probes.size() +
            watchpoint_probes.size();
   }
 
@@ -254,7 +255,8 @@ private:
             using_skboutput,
             probes,
             signal_probes,
-            special_probes,
+            begin_probes,
+            end_probes,
             test_probes,
             benchmark_probes);
   }

--- a/tests/attachpoint_passes.cpp
+++ b/tests/attachpoint_passes.cpp
@@ -178,10 +178,10 @@ TEST(attachpoint_checker, usdt)
 TEST(attachpoint_checker, begin_end_probes)
 {
   test("begin { 1 }");
-  test_error("begin { 1 } begin { 2 }");
+  test("begin { 1 } begin { 2 }");
 
   test("end { 1 }");
-  test_error("end { 1 } end { 2 }");
+  test("end { 1 } end { 2 }");
 }
 
 TEST(attachpoint_checker, bench_probes)

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -70,9 +70,13 @@ public:
   {
     return resources.probes;
   }
-  std::unordered_map<std::string, ::bpftrace::Probe> get_special_probes()
+  std::vector<::bpftrace::Probe> get_begin_probes()
   {
-    return resources.special_probes;
+    return resources.begin_probes;
+  }
+  std::vector<::bpftrace::Probe> get_end_probes()
+  {
+    return resources.end_probes;
   }
   std::vector<::bpftrace::Probe> get_test_probes()
   {

--- a/tests/required_resources.cpp
+++ b/tests/required_resources.cpp
@@ -123,7 +123,7 @@ TEST(required_resources, round_trip_probes)
     p.type = ProbeType::hardware;
     p.path = "mypath";
     p.index = 3;
-    r.special_probes["test"] = std::move(p);
+    r.begin_probes.emplace_back(std::move(p));
 
     r.save_state(serialized);
   }
@@ -133,8 +133,8 @@ TEST(required_resources, round_trip_probes)
     RequiredResources r;
     r.load_state(input);
 
-    ASSERT_EQ(r.special_probes.size(), 1UL);
-    auto &probe = r.special_probes["test"];
+    ASSERT_EQ(r.begin_probes.size(), 1UL);
+    auto &probe = r.begin_probes.front();
     EXPECT_EQ(probe.type, ProbeType::hardware);
     EXPECT_EQ(probe.path, "mypath");
     EXPECT_EQ(probe.index, 3);


### PR DESCRIPTION
Stacked PRs:
 * __->__#4789


--- --- ---

### probes: allow multiple `begin` and `end` probes


This removes an arbitrary restriction. Nothing else changes with respect
to the provider parsing or probe semantics. The order will be as
specified.

Signed-off-by: Adin Scannell <amscanne@meta.com>
