### PR TITLE
passes: support functions

### DIFF
--- a/src/btf/compat.cpp
+++ b/src/btf/compat.cpp
@@ -116,4 +116,113 @@ Result<SizedType> getCompatType(const Typedef &type)
   return getCompatType(*t);
 }
 
+template <typename T, typename R = T, typename... Args>
+static Result<R> unwrap(Types &btf, const std::string &name, Args &&...args)
+{
+  auto lookup = btf.lookup<T>(name);
+  if (!lookup) {
+    auto create = btf.add<T>(name, std::forward<Args>(args)...);
+    if (!create) {
+      return create.takeError();
+    }
+    return R(*create);
+  }
+  return R(*lookup);
+}
+
+Result<ValueType> convertType(Types &btf, const SizedType &type)
+{
+  if (type.IsVoidTy() || type.IsNoneTy()) {
+    return ValueType(*btf.lookup<Void>("void")); // Require this exists.
+  } else if (type.IsArrayTy()) {
+    auto index = unwrap<Integer>(btf, "uint32_t", 4, 0);
+    if (!index) {
+      return index.takeError();
+    }
+    auto elem = convertType(btf, *type.GetElementTy());
+    if (!elem) {
+      return elem.takeError();
+    }
+    auto array_type = btf.add<Array>(*index, *elem, type.GetNumElements());
+    if (!array_type) {
+      return array_type.takeError();
+    }
+    return ValueType(*array_type);
+  } else if (type.IsPtrTy()) {
+    auto elem = convertType(btf, *type.GetPointeeTy());
+    if (!elem) {
+      return elem.takeError();
+    }
+    auto ptr_type = btf.add<Pointer>(*elem);
+    if (!ptr_type) {
+      return ptr_type.takeError();
+    }
+    return ValueType(*ptr_type);
+  } else if (type.IsBoolTy()) {
+    return unwrap<Integer>(btf, "_Bool", 1, BTF_INT_BOOL);
+  } else if (type.IsBufferTy() || type.IsStringTy()) {
+    auto index = unwrap<Integer>(btf, "uint32_t", 4, 0);
+    if (!index) {
+      return index.takeError();
+    }
+    auto char_type = unwrap<Integer>(btf, "char", 1, BTF_INT_CHAR);
+    if (!char_type) {
+      return char_type.takeError();
+    }
+    auto array_type = btf.add<Array>(*index, *char_type, type.GetSize());
+    if (!array_type) {
+      return array_type.takeError();
+    }
+    return ValueType(*array_type);
+  } else if (type.IsEnumTy()) {
+    // We can't encode all the values, so just claim that this is a
+    // 64-bit integer. This should be fixed in the future.
+    return unwrap<Integer, ValueType>(btf, "int64_t", 8, BTF_INT_SIGNED);
+  } else if (type.IsRecordTy() || type.IsTupleTy()) {
+    auto lookup = btf.lookup<Struct>(type.GetName());
+    if (lookup) {
+      return *lookup;
+    }
+    const auto &fields = type.GetFields();
+    std::vector<std::pair<std::string, ValueType>> btf_fields;
+    for (const auto &field : fields) {
+      auto field_type = convertType(btf, field.type);
+      if (!field_type) {
+        return field_type.takeError();
+      }
+      btf_fields.emplace_back(field.name, *field_type);
+    }
+    auto struct_type = btf.add<Struct>(type.GetName(), btf_fields);
+    if (!struct_type) {
+      return struct_type.takeError();
+    }
+    return ValueType(*struct_type);
+  } else if (type.IsIntegerTy()) {
+    if (type.IsSigned()) {
+      switch (type.GetIntBitWidth()) {
+        case 8:
+          return unwrap<Integer, ValueType>(btf, "int8_t", 1, BTF_INT_SIGNED);
+        case 16:
+          return unwrap<Integer, ValueType>(btf, "int16_t", 2, BTF_INT_SIGNED);
+        case 32:
+          return unwrap<Integer, ValueType>(btf, "int32_t", 4, BTF_INT_SIGNED);
+        case 64:
+          return unwrap<Integer, ValueType>(btf, "int64_t", 8, BTF_INT_SIGNED);
+      }
+    } else {
+      switch (type.GetIntBitWidth()) {
+        case 8:
+          return unwrap<Integer, ValueType>(btf, "uint8_t", 1, 0);
+        case 16:
+          return unwrap<Integer, ValueType>(btf, "uint16_t", 2, 0);
+        case 32:
+          return unwrap<Integer, ValueType>(btf, "uint32_t", 4, 0);
+        case 64:
+          return unwrap<Integer, ValueType>(btf, "uint64_t", 8, 0);
+      }
+    }
+  }
+  return make_error<CompatTypeError>(type);
+}
+
 } // namespace bpftrace::btf

--- a/src/btf/compat.h
+++ b/src/btf/compat.h
@@ -60,4 +60,6 @@ Result<SizedType> getCompatType(const T &type)
   return op(type);
 }
 
+Result<ValueType> convertType(Types &btf, const SizedType &type);
+
 } // namespace bpftrace::btf


### PR DESCRIPTION
Stacked PRs:
 * __->__#4791


--- --- ---

### passes: support functions


The existing functions can be added to the BTF type system via a compat
type layer, then when we generate these functions they are automatically
picked up. This doesn't work currently, but crashes somewhere in LLVM.

Signed-off-by: Adin Scannell <amscanne@meta.com>
