### PR TITLE
strerror: Fix: unbounded memory access

### DIFF
--- a/src/stdlib/strings.bpf.c
+++ b/src/stdlib/strings.bpf.c
@@ -68,16 +68,14 @@ int __bpf_strnstr(const char *haystack,
 }
 
 m_str* __strerror(int errno, m_arg *out) {
-  m_str *result;
   if (errno < 0) {
     errno = -errno;
   }
   if (errno >= 0 && errno <= EHWPOISON) {
-    result = &errors[errno];
+    __builtin_memcpy(&out->data, &errors[errno], sizeof(*out));
   } else {
-    result = &unknown_error;
+    __builtin_memcpy(&out->data, &unknown_error, sizeof(*out));
   }
-  __builtin_memcpy(&out->data, result, sizeof(*out));
   return &out->data;
 }
 


### PR DESCRIPTION
Like the bpftrace commit 85dcb3035529 ("stdlib add syscall_name() and apply to tools/syscount.bt (#4746)") do for syscall_name[], if strerror() used as map key, the bpf verifier will complain.

By constraining the range of errno with `&=`, the value of R3 can be constrained.

Test script:

```
#!/bin/env bpftrace

tracepoint:syscalls:sys_exit_write
/ args->ret <= 0 /
{
	@failed[strerror(args->ret)] = count();
}
```

The verifier error:

    ;  @ strings.bpf.c:75
    30: (18) r1 = 0xffffd02b81966010      ; R1_w=map_value(map=22205150.rodata,ks=4,vs=8656,off=16)
    32: (bf) r3 = r2                      ; R2_w=scalar(id=3,smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff)) R3_w=scalar(id
    =3,smin=0,smax=umax=0xffffffff,var_off=(0x0; 0xffffffff))
    33: (67) r3 <<= 6                     ; R3_w=scalar(smin=0,smax=umax=0x3fffffffc0,smax32=0x7fffffc0,umax32=0xffffffc0,var_off=
    (0x0; 0x3fffffffc0))
    34: (0f) r1 += r3                     ; R1_w=map_value(map=22205150.rodata,ks=4,vs=8656,off=16,smin=0,smax=umax=0x3fffffffc0,s
    max32=0x7fffffc0,umax32=0xffffffc0,var_off=(0x0; 0x3fffffffc0)) R3_w=scalar(smin=0,smax=umax=0x3fffffffc0,smax32=0x7fffffc0,um
    ax32=0xffffffc0,var_off=(0x0; 0x3fffffffc0))
    35: (b7) r3 = 134                     ; R3=134
    36: (2d) if r3 > r2 goto pc+2 39: R0=scalar(smin=smin32=0,smax=umax=smax32=umax32=11,var_off=(0x0; 0xf)) R1=map_value(map=2220
    5150.rodata,ks=4,vs=8656,off=16,smin=0,smax=umax=0x3fffffffc0,smax32=0x7fffffc0,umax32=0xffffffc0,var_off=(0x0; 0x3fffffffc0))
     R2=scalar(id=3,smin=smin32=0,smax=umax=smax32=umax32=133,var_off=(0x0; 0xff)) R3=134 R6=map_value(map=.data.var_buf,ks=4,vs=1
    024,smin=smin32=0,smax=umax=smax32=umax32=704,var_off=(0x0; 0x3c0)) R7=ctx() R8=scalar(id=1,smin=smin32=0,smax=umax=smax32=uma
    x32=11,var_off=(0x0; 0xf)) R10=fp0
    39: (71) r2 = *(u8 *)(r1 +63)
    R1 unbounded memory access, make sure to bounds check any such access
