### PR TITLE
Move pid filter pass after probe expansion

### DIFF
--- a/src/ast/passes/parser.h
+++ b/src/ast/passes/parser.h
@@ -44,7 +44,6 @@ inline std::vector<Pass> AllParsePasses(
   passes.emplace_back(CreateDeprecatedPass());
   passes.emplace_back(CreateParseAttachpointsPass());
   passes.emplace_back(CreateCheckAttachpointsPass());
-  passes.emplace_back(CreatePidFilterPass());
   passes.emplace_back(CreateUSDTImportPass());
   passes.emplace_back(CreateImportInternalScriptsPass());
   passes.emplace_back(CreateControlFlowPass());
@@ -63,6 +62,7 @@ inline std::vector<Pass> AllParsePasses(
   passes.emplace_back(CreateCMacroExpansionPass());
   passes.emplace_back(CreateMapSugarPass());
   passes.emplace_back(CreateNamedParamsPass());
+  passes.emplace_back(CreatePidFilterPass());
   return passes;
 }
 

--- a/tests/pid_filter_pass.cpp
+++ b/tests/pid_filter_pass.cpp
@@ -104,13 +104,4 @@ TEST(pid_filter_pass, no_add_filter)
   }
 }
 
-TEST(DISABLED_pid_filter_pass, mixed_probes)
-{
-  // FIXME: This functionality is a bit broken, this should be fixed.
-  test("kprobe:f, uprobe:/bin/sh:f", true, { false, true });
-  test("usdt:sh:probe, uprobe:/bin/sh:f, profile:ms:1",
-       true,
-       { true, true, true });
-}
-
 } // namespace bpftrace::test::pid_filter_pass


### PR DESCRIPTION
This makes sure we don't add the filter
for any probes where it doesn't apply.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
