### PR TITLE
Use group_leader for pcomm

### DIFF
--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -686,7 +686,7 @@ This function can only be used by functions that are allowed to, these functions
 - `string pcomm`
 - `string pcomm(struct task_struct * task)`
 
-Get the name of the parent process for the passed task or the current task if called without arguments.
+Get the name of the process for the passed task or the current task if called without arguments. This is an alias for (task->group_leader->comm).
 
 
 ### percpu_kaddr

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -687,9 +687,9 @@ macro ppid() {
 
 // :variant string pcomm()
 // :variant string pcomm(struct task_struct * task)
-// Get the name of the parent process for the passed task or the current task if called without arguments.
+// Get the name of the process for the passed task or the current task if called without arguments. This is an alias for (task->group_leader->comm).
 macro pcomm(task) {
-    task->real_parent->comm
+    task->group_leader->comm
 }
 
 macro pcomm() {


### PR DESCRIPTION
This is more correct over 'real_parent'.
Issue:
- https://github.com/bpftrace/bpftrace/issues/782

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
