### PR TITLE
Add more long versions of arguments

### DIFF
--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -26,7 +26,7 @@ EXPECT hello world!
 TIMEOUT 1
 
 NAME it lists kprobes
-RUN {{BPFTRACE}} -l | grep kprobes
+RUN {{BPFTRACE}} --list | grep kprobes
 EXPECT_REGEX kprobe:.*
 TIMEOUT 1
 
@@ -174,7 +174,7 @@ EXPECT fentry:vmlinux:vfs_read
 EXPECT_NONE fentry:vmlinux:vfs_write
 
 NAME it lists uprobes in the program
-RUN {{BPFTRACE}} -l -e 'uretprobe:*:uprobeFunction* { exit(); }' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} -l -e 'uretprobe:*:uprobeFunction* { exit(); }' --pid {{BEFORE_PID}}
 EXPECT_REGEX uretprobe:[\S]+uprobe_test:uprobeFunction1
 BEFORE ./testprogs/uprobe_test
 
@@ -295,7 +295,7 @@ EXPECT 10 12 12 10
 TIMEOUT 1
 
 NAME spawn child
-RUN {{BPFTRACE}} -e 'i:ms:500 { printf("%d\n", cpid); }' -c './testprogs/syscall nanosleep 1e9'
+RUN {{BPFTRACE}} -e 'i:ms:500 { printf("%d\n", cpid); }' --cmd './testprogs/syscall nanosleep 1e9'
 EXPECT_REGEX [0-9]+
 TIMEOUT 3
 

--- a/tests/runtime/file-output
+++ b/tests/runtime/file-output
@@ -1,5 +1,5 @@
 NAME printf to file
-RUN {{BPFTRACE}} -e 'i:ms:10 { printf("%s %d\n", "SUCCESS", 1); exit() }' -o /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
+RUN {{BPFTRACE}} -e 'i:ms:10 { printf("%s %d\n", "SUCCESS", 1); exit() }' --output /tmp/bpftrace-file-output-test >/dev/null; cat /tmp/bpftrace-file-output-test; rm /tmp/bpftrace-file-output-test
 EXPECT SUCCESS 1
 
 NAME cat to file

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -261,7 +261,7 @@ EXPECT_REGEX 0x[0-9a-f]+
 TIMEOUT 1
 
 NAME runtime_error_check_delete
-RUN {{BPFTRACE}} -k -e 'i:ms:100 { @[1] = 1; delete(@, 2); exit(); }'
+RUN {{BPFTRACE}} --warnings -e 'i:ms:100 { @[1] = 1; delete(@, 2); exit(); }'
 EXPECT stdin:1:22-34: WARNING: Can't delete map element because it does not exist.
        Additional Info - helper: map_delete_elem, retcode: -2
        i:ms:100 { @[1] = 1; delete(@, 2); exit(); }

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -255,7 +255,7 @@ REQUIRES_FEATURE uprobe_multi
 AFTER ./testprogs/uprobe_test
 
 NAME uprobe_multi_wildcard_target_wildcard
-RUN {{BPFTRACE}} --unsafe -e 'uretprobe:*:uprobeFunction* { printf("link: "); system("bpftool link | grep -E \"uprobe_multi|type 12\" | wc -l"); exit(); }' -p {{BEFORE_PID}}
+RUN {{BPFTRACE}} --unsafe -e 'uretprobe:*:uprobeFunction* { printf("link: "); system("bpftool link | grep -E \"uprobe_multi|type 12\" | wc -l"); exit(); }' --pid {{BEFORE_PID}}
 EXPECT link: 1
 REQUIRES bpftool
 REQUIRES_FEATURE uprobe_multi


### PR DESCRIPTION
Added:
--pid
--warnings
--debug (already half there)
--quiet
--verbose
--cmd
--list
--out

Also re-ordered the long opts alphabetically.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
