### PR TITLE
Reduce output of parallel map access test

### DIFF
--- a/tests/runtime/scripts/parallel_map_access.bt
+++ b/tests/runtime/scripts/parallel_map_access.bt
@@ -6,13 +6,13 @@
 // https://github.com/bpftrace/bpftrace/pull/2623
 
 i:us:1 {
-    @data[rand % 100] = count();
+    @data[rand % 5] = count();
     if (rand % 5 == 0) {
         delete(@data, rand % 10);
     }
 }
 
-i:ms:1 {
+i:ms:50 {
     print(@data);
     clear(@data);
     zero(@data);


### PR DESCRIPTION
I see this test failing often on the Latest kernel (LLVM 21 Debug) build. I think it might be due to a flooded ring buffer. Address this by reducing the number of times we call print, clear, and delete. Also reduce the number of keys in the map.

https://github.com/bpftrace/bpftrace/actions/runs/18945574483/job/54096017886

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
