### PR TITLE
Close possible leaky perf_event_fds

### DIFF
--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -965,6 +965,7 @@ Result<std::unique_ptr<AttachedProfileProbe>> AttachedProfileProbe::make(
 
     auto *link = bpf_program__attach_perf_event(prog.bpf_prog(), perf_event_fd);
     if (!link) {
+      close(perf_event_fd);
       has_error = true;
       break;
     }
@@ -1052,6 +1053,7 @@ Result<std::unique_ptr<AttachedIntervalProbe>> AttachedIntervalProbe::make(
 
   auto *link = bpf_program__attach_perf_event(prog.bpf_prog(), perf_event_fd);
   if (!link) {
+    close(perf_event_fd);
     return make_error<AttachError>();
   }
 
@@ -1130,6 +1132,7 @@ Result<std::unique_ptr<AttachedSoftwareProbe>> AttachedSoftwareProbe::make(
 
     auto *link = bpf_program__attach_perf_event(prog.bpf_prog(), perf_event_fd);
     if (!link) {
+      close(perf_event_fd);
       has_error = true;
       break;
     }
@@ -1221,6 +1224,7 @@ Result<std::unique_ptr<AttachedHardwareProbe>> AttachedHardwareProbe::make(
 
     auto *link = bpf_program__attach_perf_event(prog.bpf_prog(), perf_event_fd);
     if (!link) {
+      close(perf_event_fd);
       has_error = true;
       break;
     }


### PR DESCRIPTION
If we fail to create a link we need to close
the perf_event_fd ourselves.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
