### PR TITLE
util: fix `exec_system`

### DIFF
--- a/src/ast/passes/clang_parser.cpp
+++ b/src/ast/passes/clang_parser.cpp
@@ -836,9 +836,14 @@ std::string ClangParser::get_arch_include_path()
 
 static void query_clang_include_dirs(std::vector<std::string> &result)
 {
-  auto clang = "clang-" + std::to_string(LLVM_VERSION_MAJOR);
-  auto cmd = clang + " -Wp,-v -x c -fsyntax-only /dev/null 2>&1";
-  auto check = util::exec_system(cmd.c_str());
+  std::vector<std::string> args;
+  args.emplace_back("clang-" + std::to_string(LLVM_VERSION_MAJOR));
+  args.emplace_back("-Wp,-v");
+  args.emplace_back("-x");
+  args.emplace_back("c");
+  args.emplace_back("-fsyntax-only");
+  args.emplace_back("/dev/null");
+  auto check = util::exec_system(args);
   if (!check) {
     // Exec failed, ignore and move on.
     return;

--- a/src/async_action.cpp
+++ b/src/async_action.cpp
@@ -239,7 +239,12 @@ void AsyncHandlers::syscall(const OpaqueValue &data)
     LOG(BUG) << "Error processing syscall arguments: " << vals.takeError();
   }
 
-  auto result = util::exec_system(fmt.format(*vals).c_str());
+  // Always execute via a shell, if available.
+  std::vector<std::string> system_args;
+  system_args.emplace_back("sh");
+  system_args.emplace_back("-c");
+  system_args.emplace_back(fmt.format(*vals));
+  auto result = util::exec_system(system_args);
   if (!result) {
     LOG(ERROR) << "Error executing program: " << result.takeError();
     return;

--- a/src/util/system.h
+++ b/src/util/system.h
@@ -12,7 +12,7 @@ Result<std::string> get_pid_exe(const std::string &pid);
 Result<std::string> get_proc_maps(const std::string &pid);
 Result<std::string> get_proc_maps(pid_t pid);
 
-Result<std::string> exec_system(const char *cmd);
+Result<std::string> exec_system(const std::vector<std::string> &args);
 
 Result<std::vector<std::string>> get_mapped_paths_for_pid(pid_t pid);
 Result<std::vector<std::string>> get_mapped_paths_for_running_pids();


### PR DESCRIPTION
Stacked PRs:
 * __->__#4804


--- --- ---

### util: fix `exec_system`


AppImages are currently broken, and will SEGV on startup. This is
because we have code paths that attempt to invoke a shell, and the shell
is not included in the appimage. When invoking the shell, we have
`-ENOENT` from the `execvp`, because it does not exist.

This hits this section of code:

```
  std::shared_ptr<FILE> pipe(popen(cmd, "r"), pclose);
  if (!pipe) {
    return make_error<SystemError>("popen() failed");
```

Unfortunately, the `Deleter` for a `std::shared_ptr` is always run, even
if NULL. There's generally a shell, so this is probably never NULL on
most systems. It's not clear why this was made a `std::shared_ptr` and
not `std::unique_ptr`, as a `std::unique_ptr` distinctly does not have
this same property and will **not** call the Deleter for null.

Just to avoid this subtletly, change `exec_system` to control the actual
subprocess execution, and provide extra protection against the death of
the process, to avoid stranding anything on the system.

Signed-off-by: Adin Scannell <amscanne@meta.com>
