### PR TITLE
fix generic build fatal

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,6 +89,7 @@ add_custom_target(version_h
     -Dbpftrace_SOURCE_DIR=${CMAKE_SOURCE_DIR}
     -P ${CMAKE_SOURCE_DIR}/cmake/Version.cmake
 )
+add_dependencies(runtime version_h)
 add_dependencies(bpftrace version_h)
 add_dependencies(libbpftrace version_h)
 


### PR DESCRIPTION
should add deps to runtime

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist
to fix issue: https://github.com/bpftrace/bpftrace/issues/4805


- [x ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ x] The new behaviour is covered by tests
