### PR TITLE
ast: ResourceAnalyser: Re-order the initialization sequence of printf_args[]

### DIFF
--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -154,8 +154,6 @@ void ResourceAnalyser::visit(Builtin &builtin)
 
 void ResourceAnalyser::visit(Call &call)
 {
-  Visitor<ResourceAnalyser>::visit(call);
-
   if (call.func == "printf" || call.func == "errorf" || call.func == "warnf" ||
       call.func == "system" || call.func == "cat" || call.func == "debugf") {
     std::vector<SizedType> args;
@@ -379,6 +377,8 @@ void ResourceAnalyser::visit(Call &call)
     // and symbols resolved even when unavailable at resolution time
     resources_.probes_using_usym.insert(probe_);
   }
+
+  Visitor<ResourceAnalyser>::visit(call);
 }
 
 void ResourceAnalyser::visit(MapDeclStatement &decl)


### PR DESCRIPTION
When `printf/errorf/warnf` is called within a macro, and this macro is directly used as an argument to `printf/errorf/warnf`, the initialization order of `printf_args[]` differs between ResourceAnalyser and CodegenLLVM. This will cause a segmentation fault in `CodegenLLVM::createFormatStringCall()`.

For example:

    macro name() {
        warnf("");
        "Rong Tao"
    }
    BEGIN {
        printf("%s\n", name);
    }

SemanticAnalyser and CodegenLLVM handle `printf` first, however, ResourceAnalyser handle `warnf` first, this will cause CodegenLLVM to use the wrong printf_args[].

    (gdb) bt
    #0  0x00007fffecbf7d8f in llvm::Type::isScalableTy(llvm::SmallPtrSetImpl<llvm::Type const*>&) const ()
      from /lib64/libLLVM.so.21.1
    #1  0x00007fffecc09d58 in llvm::ConstantFolder::FoldGEP(llvm::Type*, llvm::Value*, llvm::ArrayRef<llvm::Value*>, llvm::GEPNoWrapFlags) const () from /lib64/libLLVM.so.21.1
    #2  0x00000000009e7189 in llvm::IRBuilderBase::CreateGEP (this=0x7fffffff9940, Ty=0x0, Ptr=0x0, IdxList=..., Name=...,
        NW=...) at /usr/include/llvm/IR/IRBuilder.h:1931
    #3  0x00000000009c2ac3 in bpftrace::ast::(anonymous namespace)::CodegenLLVM::createFormatStringCall (this=0x7fffffff98c0,
        call=..., id=2, call_args=std::vector of length 0, capacity 0, call_name="printf",
        async_action=bpftrace::async_action::AsyncAction::printf)
        at /home/rongtao/Git/bpftrace/bpftrace/src/ast/passes/codegen_llvm.cpp:3888
    #4  0x00000000009af8de in bpftrace::ast::(anonymous namespace)::CodegenLLVM::visit (this=0x7fffffff98c0, call=...)
        at /home/rongtao/Git/bpftrace/bpftrace/src/ast/passes/codegen_llvm.cpp:1642

Therefore, we should ensure that ResourceAnalyser and other analysers like CodegenLLVM follow the same processing order.
