### PR TITLE
tools/writeback.bt: Check the validity of @start

### DIFF
--- a/tools/writeback.bt
+++ b/tools/writeback.bt
@@ -63,11 +63,12 @@ tracepoint:writeback:writeback_start
 }
 
 tracepoint:writeback:writeback_written
+/ @start[args.sb_dev] /
 {
 	$sb_dev = args.sb_dev;
 	$s = @start[$sb_dev];
 	delete(@start, $sb_dev);
-	$lat = $s ? (nsecs - $s) / 1000 : 0;
+	$lat = (nsecs - $s) / 1000;
 
 	time("%H:%M:%S  ");
 	printf("%-8s %-8d %-16s %d.%03d\n", args.name,


### PR DESCRIPTION
It is necessary to check the judgment condition for writeback:writeback_written, otherwise incorrect statistical results (0.000) and unnecessary alerts may be obtained.

    WARNING: Can't delete map element because it does not exist.
    17:39:56  8:0      48605    periodic         0.000
