### PR TITLE
codegen: Fix tid/pid in non-init namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,8 @@ and this project adheres to
   - [#4714](https://github.com/bpftrace/bpftrace/pull/4714)
 - Fix block expression handling inside print statements
   - [#4704](https://github.com/bpftrace/bpftrace/issues/4704)
+- codegen: Fix tid/pid in non-init namespaces
+  - [#4813](https://github.com/bpftrace/bpftrace/issues/4813)
 #### Security
 #### Docs
 #### Tools

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -75,7 +75,7 @@ Value *IRBuilderBPF::CreateGetPid(const Location &loc, bool force_init)
         getInt64(pidns->st_dev), getInt64(pidns->st_ino), res, loc);
     Value *pid = CreateLoad(
         getInt32Ty(),
-        CreateGEP(BpfPidnsInfoType(), res, { getInt32(0), getInt32(0) }));
+        CreateGEP(BpfPidnsInfoType(), res, { getInt32(0), getInt32(1) }));
     CreateLifetimeEnd(res);
     return pid;
   }
@@ -96,7 +96,7 @@ Value *IRBuilderBPF::CreateGetTid(const Location &loc, bool force_init)
         getInt64(pidns->st_dev), getInt64(pidns->st_ino), res, loc);
     Value *tid = CreateLoad(
         getInt32Ty(),
-        CreateGEP(BpfPidnsInfoType(), res, { getInt32(0), getInt32(1) }));
+        CreateGEP(BpfPidnsInfoType(), res, { getInt32(0), getInt32(0) }));
     CreateLifetimeEnd(res);
     return tid;
   }
@@ -1760,8 +1760,8 @@ llvm::Type *IRBuilderBPF::BpfPidnsInfoType()
 {
   return GetStructType("bpf_pidns_info",
                        {
-                           getInt32Ty(),
-                           getInt32Ty(),
+                           getInt32Ty(), // pid   (TID in userspace)
+                           getInt32Ty(), // tgid  (PID in userspace)
                        },
                        false);
 }

--- a/tests/codegen/llvm/builtin_pid_tid_namespace.ll
+++ b/tests/codegen/llvm/builtin_pid_tid_namespace.ll
@@ -29,7 +29,7 @@ entry:
   %bpf_pidns_info = alloca %bpf_pidns_info, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %bpf_pidns_info)
   %get_ns_pid_tgid = call i64 inttoptr (i64 120 to ptr)(i64 0, i64 4026531857, ptr %bpf_pidns_info, i32 8)
-  %1 = getelementptr %bpf_pidns_info, ptr %bpf_pidns_info, i32 0, i32 0
+  %1 = getelementptr %bpf_pidns_info, ptr %bpf_pidns_info, i32 0, i32 1
   %2 = load i32, ptr %1, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %bpf_pidns_info)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
@@ -41,7 +41,7 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %bpf_pidns_info1)
   %get_ns_pid_tgid2 = call i64 inttoptr (i64 120 to ptr)(i64 0, i64 4026531857, ptr %bpf_pidns_info1, i32 8)
-  %3 = getelementptr %bpf_pidns_info, ptr %bpf_pidns_info1, i32 0, i32 1
+  %3 = getelementptr %bpf_pidns_info, ptr %bpf_pidns_info1, i32 0, i32 0
   %4 = load i32, ptr %3, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %bpf_pidns_info1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")

--- a/tests/codegen/llvm/call_pid_tid_curr_ns_in_child_ns.ll
+++ b/tests/codegen/llvm/call_pid_tid_curr_ns_in_child_ns.ll
@@ -29,7 +29,7 @@ entry:
   %bpf_pidns_info = alloca %bpf_pidns_info, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %bpf_pidns_info)
   %get_ns_pid_tgid = call i64 inttoptr (i64 120 to ptr)(i64 0, i64 4026531857, ptr %bpf_pidns_info, i32 8)
-  %1 = getelementptr %bpf_pidns_info, ptr %bpf_pidns_info, i32 0, i32 0
+  %1 = getelementptr %bpf_pidns_info, ptr %bpf_pidns_info, i32 0, i32 1
   %2 = load i32, ptr %1, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %bpf_pidns_info)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
@@ -41,7 +41,7 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %bpf_pidns_info1)
   %get_ns_pid_tgid2 = call i64 inttoptr (i64 120 to ptr)(i64 0, i64 4026531857, ptr %bpf_pidns_info1, i32 8)
-  %3 = getelementptr %bpf_pidns_info, ptr %bpf_pidns_info1, i32 0, i32 1
+  %3 = getelementptr %bpf_pidns_info, ptr %bpf_pidns_info1, i32 0, i32 0
   %4 = load i32, ptr %3, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %bpf_pidns_info1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")

--- a/tests/codegen/llvm/call_pid_tid_in_child_ns.ll
+++ b/tests/codegen/llvm/call_pid_tid_in_child_ns.ll
@@ -29,7 +29,7 @@ entry:
   %bpf_pidns_info = alloca %bpf_pidns_info, align 8
   call void @llvm.lifetime.start.p0(i64 -1, ptr %bpf_pidns_info)
   %get_ns_pid_tgid = call i64 inttoptr (i64 120 to ptr)(i64 0, i64 4026531857, ptr %bpf_pidns_info, i32 8)
-  %1 = getelementptr %bpf_pidns_info, ptr %bpf_pidns_info, i32 0, i32 0
+  %1 = getelementptr %bpf_pidns_info, ptr %bpf_pidns_info, i32 0, i32 1
   %2 = load i32, ptr %1, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %bpf_pidns_info)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@x_key")
@@ -41,7 +41,7 @@ entry:
   call void @llvm.lifetime.end.p0(i64 -1, ptr %"@x_key")
   call void @llvm.lifetime.start.p0(i64 -1, ptr %bpf_pidns_info1)
   %get_ns_pid_tgid2 = call i64 inttoptr (i64 120 to ptr)(i64 0, i64 4026531857, ptr %bpf_pidns_info1, i32 8)
-  %3 = getelementptr %bpf_pidns_info, ptr %bpf_pidns_info1, i32 0, i32 1
+  %3 = getelementptr %bpf_pidns_info, ptr %bpf_pidns_info1, i32 0, i32 0
   %4 = load i32, ptr %3, align 4
   call void @llvm.lifetime.end.p0(i64 -1, ptr %bpf_pidns_info1)
   call void @llvm.lifetime.start.p0(i64 -1, ptr %"@y_key")


### PR DESCRIPTION
When using the `tid`/`pid` builtins in non-init namespace, we use the `bpf_get_ns_current_pid_tgid` helper which fills a structure of type `struct bpf_pidns_info` with both PID and TGID. Then, we load one of the items based on the builtin used.

Looking at the kernel definition of `struct bpf_pidns_info` [1]:

    struct bpf_pidns_info {
            __u32 pid;
            __u32 tgid;
    };

it turns out, we're accessing the items incorrectly - the first item should be accessed for the `tid` builtin (since kernel PID corresponds to userspace TID) and the second item should be accessed for the `pid` builtin (since kernel TGID corresponds to userspace PID).

We were accessing them in the opposite way, so this commit fixes the indexing.

This should prevent errors such as the one reported in #4807.

[1] https://elixir.bootlin.com/linux/v6.17.6/source/include/uapi/linux/bpf.h#L7469

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
