### PR TITLE
bash-completion: add `--no-feature` and `--verify-llvm-ir`

### DIFF
--- a/scripts/bash-completion/bpftrace
+++ b/scripts/bash-completion/bpftrace
@@ -18,9 +18,9 @@ _bpftrace()
   _init_completion -- "$@" || return
 
   local all_args='-B -f -o -e -h --help -I --include -l -p -c
-                  --usdt-file-activation --unsafe -q --info -k
-                  -V --version --no-warnings -v --dry-run -d
-                  --emit-elf --emit-llvm'
+                  --no-feature --usdt-file-activation --unsafe
+                  -q --info -k -V --version --no-warnings -v
+                  --dry-run --verify-llvm-ir -d --emit-elf --emit-llvm'
 
   if [[ $cur == -* ]]; then
     argument=$cur
@@ -52,6 +52,10 @@ _bpftrace()
     COMPREPLY=( $(compgen -W "$PIDS" -- ${cur}) )
     return 0
     ;;
+  --no-feature)
+    COMPREPLY=( $(compgen -W "kprobe_multi kprobe_session uprobe_multi" -- ${cur}) )
+    return 0
+    ;;    
   -d)
     COMPREPLY=( $(compgen -W "all ast codegen codegen-opt dis libbpf verifier" -- ${cur}) )
     return 0


### PR DESCRIPTION
This PR adds `--no-feature` and `--verify-llvm-ir` to the bash completion script.
I also confirmed that the script already covers all other options from usage(). https://github.com/bpftrace/bpftrace/blob/2737cfcf28bf2f10f71700095f003c5571c07aab/src/main.cpp#L108


#### tests
##### before fix
```
# bpftrace -<tab>
--dry-run               --help                  --no-warnings           --version               -V                      -e                      -k                      -p
--emit-elf              --include               --unsafe                -B                      -c                      -f                      -l                      -q
--emit-llvm             --info                  --usdt-file-activation  -I                      -d                      -h                      -o                      -v
```

##### after fix

```
# bpftrace -<tab>
--dry-run               --include               --unsafe                -B                      -d                      -k                      -q                      
--emit-elf              --info                  --usdt-file-activation  -I                      -e                      -l                      -v                      
--emit-llvm             --no-feature            --verify-llvm-ir        -V                      -f                      -o                      
--help                  --no-warnings           --version               -c                      -h                      -p                      
```
```
# bpftrace --no-feature <tab>
kprobe_multi    kprobe_session  uprobe_multi    
```

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
