### PR TITLE
Add casting for tuples and strings

### DIFF
--- a/src/ast/codegen_helper.cpp
+++ b/src/ast/codegen_helper.cpp
@@ -22,7 +22,7 @@ bool needAssignMapStatementAllocation(const AssignMapStatement &assignment)
   const auto &map = *assignment.map_access;
   const auto &expr_type = assignment.expr.type();
   if (shouldBeInBpfMemoryAlready(expr_type)) {
-    return !expr_type.IsSameSizeRecursive(map.map->value_type);
+    return false;
   } else if (map.map->value_type.IsRecordTy() ||
              map.map->value_type.IsArrayTy()) {
     return !expr_type.is_internal;
@@ -30,12 +30,9 @@ bool needAssignMapStatementAllocation(const AssignMapStatement &assignment)
   return true;
 }
 
-bool needMapKeyAllocation(const Map &map, const Expression &key_expr)
+bool needMapKeyAllocation(const Expression &key_expr)
 {
-  if (inBpfMemory(key_expr.type())) {
-    return !key_expr.type().IsSameSizeRecursive(map.key_type);
-  }
-  return true;
+  return !inBpfMemory(key_expr.type());
 }
 
 } // namespace bpftrace::ast

--- a/src/ast/codegen_helper.h
+++ b/src/ast/codegen_helper.h
@@ -34,6 +34,6 @@ inline AddrSpace find_addrspace_stack(const SizedType &ty)
 
 bool needAssignMapStatementAllocation(const AssignMapStatement &assignment);
 
-bool needMapKeyAllocation(const Map &map, const Expression &key_expr);
+bool needMapKeyAllocation(const Expression &key_expr);
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -568,8 +568,7 @@ void ResourceAnalyser::maybe_allocate_map_key_buffer(const Map &map,
                                                      const Expression &key_expr)
 {
   const auto map_key_size = map.key_type.GetSize();
-  if (needMapKeyAllocation(map, key_expr) &&
-      exceeds_stack_limit(map_key_size)) {
+  if (needMapKeyAllocation(key_expr) && exceeds_stack_limit(map_key_size)) {
     resources_.map_key_buffers++;
     resources_.max_map_key_size = std::max(resources_.max_map_key_size,
                                            map_key_size);

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -578,26 +578,6 @@ std::shared_ptr<const Struct> SizedType::GetStruct() const
   return inner_struct();
 }
 
-bool SizedType::IsSameSizeRecursive(const SizedType &t) const
-{
-  if (GetSize() != t.GetSize()) {
-    return false;
-  }
-
-  if (IsTupleTy() && t.IsTupleTy()) {
-    if (GetFieldCount() != t.GetFieldCount()) {
-      return false;
-    }
-
-    for (ssize_t i = 0; i < GetFieldCount(); i++) {
-      if (!GetField(i).type.IsSameSizeRecursive(t.GetField(i).type))
-        return false;
-    }
-  }
-
-  return true;
-}
-
 bool SizedType::FitsInto(const SizedType &t) const
 {
   if (!IsSameType(t))

--- a/src/types.h
+++ b/src/types.h
@@ -262,9 +262,6 @@ public:
   bool operator==(const SizedType &t) const;
   std::strong_ordering operator<=>(const SizedType &t) const;
   bool IsSameType(const SizedType &t) const;
-  // This is primarily for Tuples which have equal total size (due to padding)
-  // but their individual elements have different sizes.
-  bool IsSameSizeRecursive(const SizedType &t) const;
   bool FitsInto(const SizedType &t) const;
 
   bool IsPrintableTy() const

--- a/tests/ast_matchers.h
+++ b/tests/ast_matchers.h
@@ -350,6 +350,17 @@ public:
         });
   }
 
+  SizedTypeMatcher& WithSigned(bool is_signed)
+  {
+    return Where(
+        [is_signed](const SizedType& type_obj, MatchResultListener* listener) {
+          return type_obj.IsSigned() == is_signed ||
+             (*listener << "has signed " << type_obj.IsSigned() << " instead of "
+                        << is_signed,
+              false);
+        });
+  }
+
   SizedTypeMatcher& WithName(const std::string& name)
   {
     return Where(


### PR DESCRIPTION
Stacked PRs:
 * #4823
 * #4828
 * #4826
 * __->__#4815


--- --- ---

### Add casting for tuples and strings


This is to remove special casing in codegen
where we copy individual tuple elements
or memcpy string elements into variables,
map keys, map values.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>