### PR TITLE
Stabilize macros

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,8 @@ and this project adheres to
   - [#4773](https://github.com/bpftrace/bpftrace/pull/4773)
 - Remove automatic type promotion for integers, making them more flexible
   - [#4768](https://github.com/bpftrace/bpftrace/pull/4768)
+- Stabilize macros (remove 'unstable_macro' flag)
+  - [#4818](https://github.com/bpftrace/bpftrace/pull/4818)
 #### Deprecated
 #### Removed
 - Drop support for LLVM 16

--- a/docs/language.md
+++ b/docs/language.md
@@ -370,7 +370,6 @@ Controls whether maps are printed on exit. Set to `false` in order to change the
 ### unstable features
 
 These are the list of unstable features:
-- `unstable_macro` -  feature flag for bpftrace macros
 - `unstable_map_decl` - feature flag for map declarations
 - `unstable_tseries` - feature flag for time series map type
 - `unstable_addr` - feature flag for address of operator (&)
@@ -616,9 +615,6 @@ interval:s:1 {
 ```
 
 ## Macros
-
-***Warning*** this feature is experimental and may be subject to changes.
-Stabilization is tracked in [#4079](https://github.com/bpftrace/bpftrace/issues/4079).
 
 bpftrace macros (as opposed to C macros) provide a way for you to structure your script.
 They can be useful when you want to factor out code into smaller, more understandable parts.

--- a/src/ast/passes/config_analyser.cpp
+++ b/src/ast/passes/config_analyser.cpp
@@ -27,6 +27,7 @@ private:
 static std::unordered_set<std::string> DEPRECATED_CONFIGS = {
   "symbol_source",
   "max_type_res_iterations",
+  "unstable_macro"
 };
 
 void ConfigAnalyser::visit(AssignConfigVarStatement &assignment)
@@ -36,6 +37,7 @@ void ConfigAnalyser::visit(AssignConfigVarStatement &assignment)
   if (DEPRECATED_CONFIGS.contains(assignment.var)) {
     assignment.addWarning()
         << assignment.var << " is deprecated and has no effect";
+    return;
   }
 
   std::string var(assignment.var);

--- a/src/ast/passes/macro_expansion.cpp
+++ b/src/ast/passes/macro_expansion.cpp
@@ -425,7 +425,6 @@ Pass CreateMacroExpansionPass()
       MacroExpander expander(ast, macros, stack);
       expander.visit(ast.root);
     }
-    return macros;
   };
 
   return Pass::create("MacroExpansion", fn);

--- a/src/config.cpp
+++ b/src/config.cpp
@@ -327,7 +327,6 @@ const std::map<std::string, AnyParser> CONFIG_KEY_MAP = {
   { "use_blazesym", CONFIG_FIELD_PARSER(use_blazesym) },
   { "show_debug_info", CONFIG_FIELD_PARSER(show_debug_info) },
   { UNSTABLE_IMPORT, CONFIG_FIELD_PARSER(unstable_import) },
-  { UNSTABLE_MACRO, CONFIG_FIELD_PARSER(unstable_macro) },
   { UNSTABLE_MAP_DECL, CONFIG_FIELD_PARSER(unstable_map_decl) },
   { UNSTABLE_TSERIES, CONFIG_FIELD_PARSER(unstable_tseries) },
   { UNSTABLE_ADDR, CONFIG_FIELD_PARSER(unstable_addr) },

--- a/src/config.h
+++ b/src/config.h
@@ -31,7 +31,6 @@ enum CompatibleBPFLicense {
 };
 
 static const auto UNSTABLE_IMPORT = "unstable_import";
-static const auto UNSTABLE_MACRO = "unstable_macro";
 static const auto UNSTABLE_MAP_DECL = "unstable_map_decl";
 static const auto UNSTABLE_TSERIES = "unstable_tseries";
 static const auto UNSTABLE_ADDR = "unstable_addr";
@@ -57,7 +56,6 @@ public:
   bool cpp_demangle = true;
   bool lazy_symbolication = true;
   bool print_maps_on_exit = true;
-  ConfigUnstable unstable_macro = ConfigUnstable::warn;
   ConfigUnstable unstable_map_decl = ConfigUnstable::warn;
   ConfigUnstable unstable_import = ConfigUnstable::warn;
   ConfigUnstable unstable_tseries = ConfigUnstable::warn;

--- a/tests/macro_expansion.cpp
+++ b/tests/macro_expansion.cpp
@@ -13,7 +13,6 @@ void test(const std::string& input,
 {
   auto mock_bpftrace = get_mock_bpftrace();
   BPFtrace& bpftrace = *mock_bpftrace;
-  bpftrace.config_->unstable_macro = ConfigUnstable::enable;
 
   // The input provided here is embedded into an expression.
   ast::ASTContext ast("stdin", input);

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -5385,7 +5385,6 @@ let @a = percpuarray(10); begin { @a = count(); }
 TEST_F(SemanticAnalyserTest, macros)
 {
   auto bpftrace = get_mock_bpftrace();
-  bpftrace->config_->unstable_macro = ConfigUnstable::enable;
 
   test("macro set($x) { $x = 1; $x } begin { $a = \"string\"; set($a); }",
        Mock{ *bpftrace },

--- a/tests/unstable_feature.cpp
+++ b/tests/unstable_feature.cpp
@@ -50,24 +50,6 @@ TEST(unstable_feature, check_error)
              "this unstable "
              "feature, "
              "set the config flag to enable. unstable_map_decl=enable");
-  test_error("config = { unstable_macro=0 } macro add_one($x) { $x } begin { "
-             "@a[0] = 0; add_one(1); }",
-             "macros feature is not enabled by default. To enable this "
-             "unstable feature, "
-             "set the config flag to enable. unstable_macro=enable");
-  test_error(
-      "config = { unstable_macro=error } macro add_one($x) { $x } begin { "
-      "@a[0] = 0; add_one(1); }",
-      "macros feature is not enabled by default. To enable this unstable "
-      "feature, "
-      "set the config flag to enable. unstable_macro=enable");
-
-  test("config = { unstable_macro=warn } macro add_one($x) { $x } begin { "
-       "@a[0] = 0; add_one(1); }");
-  // Macros have to be called to get the error/warning
-  test("config = { unstable_macro=error } macro add_one($x) { $x } begin { "
-       "@a[0] = 0; }");
-
   test("config = { unstable_tseries=warn } begin { @ = tseries(4, 1s, 10); }");
   test_error(
       "config = { unstable_tseries=error } begin { @ = tseries(4, 1s, 10); }",

--- a/tools/gethostlatency.bt
+++ b/tools/gethostlatency.bt
@@ -8,9 +8,9 @@
  *
  * This uses dynamic tracing of user-level functions and registers, and may
  * need modifications to match your software and processor architecture.
- * 
+ *
  * Example of usage:
- * 
+ *
  * # ./gethostlatency.bt
  * Attaching 7 probes...
  * Tracing getaddr/gethost calls... Hit Ctrl-C to end.
@@ -19,10 +19,10 @@
  * 02:52:12  19111  curl                 17 www.netflix.com
  * 02:52:19  19116  curl                  9 www.facebook.com
  * 02:52:23  19118  curl                  3 www.facebook.com
- * 
+ *
  * In this example, the first call to lookup "www.netflix.com" took 81 ms, and
  * the second took 17 ms (sounds like some caching).
- * 
+ *
  * This is a bpftrace version of the bcc tool of the same name.
  * The bcc version provides options to customize the output.
  *
@@ -33,7 +33,6 @@
 
 config = {
 	missing_probes = "ignore";
-	unstable_macro = "enable";
 }
 
 BEGIN

--- a/tools/opensnoop.bt
+++ b/tools/opensnoop.bt
@@ -6,7 +6,7 @@
  * USAGE: opensnoop.bt -- [--depth=<N>]
  *
  * Example of usage:
- * 
+ *
  * # ./opensnoop.bt
  * Attached 8 probes
  * Tracing open syscalls... Hit Ctrl-C to end.
@@ -22,10 +22,10 @@
  * 3108   cgroupify           5   0 /Git/bpftrace/bpftrace/rongtao/17355/cgroup.procs
  * 2440   snmp-pass           4   0 /proc/cpuinfo
  * 2440   snmp-pass           4   0 /proc/stat
- * 
+ *
  * While tracing, at "ls" command was launched: the libraries it uses can be seen
  * as they were opened.
- * 
+ *
  * opensnoop can be useful for discovering configuration and log files, if used
  * during application startup.
  *
@@ -40,7 +40,6 @@
 
 config = {
 	missing_probes=warn;
-	unstable_macro=enable;
 }
 
 BEGIN

--- a/tools/syscount.bt
+++ b/tools/syscount.bt
@@ -2,11 +2,11 @@
 /*
  * syscount.bt	Count system calls.
  *		For Linux, uses bpftrace, eBPF.
- * 
+ *
  * USAGE: syscount.bt -- [--sysname]
  *
  * Example of usage:
- * 
+ *
  * # ./syscount.bt
  * Attaching 3 probes...
  * Counting syscalls... Hit Ctrl-C to end.
@@ -22,7 +22,7 @@
  * @syscall[3]: 163269
  * @syscall[2]: 270801
  * @syscall[4]: 326333
- * 
+ *
  * Top 10 processes:
  * @process[rm]: 14360
  * @process[tail]: 16011
@@ -34,7 +34,7 @@
  * @process[sh]: 270515
  * @process[cc1]: 482888
  * @process[make]: 1404065
- * 
+ *
  * The above output was traced during a Linux kernel build, and the process name
  * with the most syscalls was "make" with 1,404,065 syscalls while tracing. The
  * highest syscall ID was 4, which is stat().
@@ -48,10 +48,6 @@
  *
  * 13-Sep-2018	Brendan Gregg	Created this.
  */
-
-config = {
-	unstable_macro=enable;
-}
 
 BEGIN
 {


### PR DESCRIPTION
Macros have become deeply embedded in the stdlib
as well as wrapping mechanism for builtins.
We've made several fixes and improvements over
the past few months and I think it's safe to say
they're a feature that we're going to keep.

https://github.com/bpftrace/bpftrace/issues/4079

##### Checklist

- [x] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
