### PR TITLE
tools/opensnoop: support mount point

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ and this project adheres to
 #### Security
 #### Docs
 #### Tools
+- opensnoop.bt: support mount points
+  - [#4822](https://github.com/bpftrace/bpftrace/pull/4822)
 - opensnoop.bt: support full file path
   - [#4601](https://github.com/bpftrace/bpftrace/pull/4601)
 - gethostlatency.bt: add more APIs support

--- a/tools/opensnoop.bt
+++ b/tools/opensnoop.bt
@@ -57,22 +57,46 @@ tracepoint:syscalls:sys_enter_openat2
 
 macro getcwd(@paths) {
 	$dentry = curtask->fs->pwd.dentry;
+	$vfsmnt = curtask->fs->pwd.mnt;
+	$mnt = (struct mount *)((uint64)$vfsmnt - offsetof(struct mount, mnt));
+	$mnt_root = $vfsmnt->mnt_root;
 
 	$max_path_depth = getopt("depth", 35);
 
 	for ($j : ((uint64)0)..((uint64)$max_path_depth)) {
-		$parent_dentry = $dentry->d_parent;
-		if ($dentry == $parent_dentry) {
-			break;
-		}
+
 		@paths[$j] = str($dentry->d_name.name);
+		$parent_dentry = $dentry->d_parent;
+
+		if ($dentry == $parent_dentry || $dentry == $mnt_root) {
+			$mnt_parent = (struct mount *)$mnt->mnt_parent;
+
+			/* Real root directory */
+			if ($mnt == $mnt_parent) {
+				break;
+			}
+
+			$dentry = $mnt->mnt_mountpoint;
+			$mnt = $mnt_parent;
+			$mnt_root = $mnt->mnt.mnt_root;
+			continue;
+		}
+
 		$dentry = $parent_dentry;
 	}
 }
 
 macro printcwd(@paths) {
 	for ($j : ((uint64)0)..((uint64)len(@paths))) {
-		printf("/%s", @paths[(uint64)len(@paths) - $j - 1]);
+		let $name = @paths[(uint64)len(@paths) - $j - 1];
+		/**
+		 * If it is a mount point, there will be a '/', because the '/'
+		 * will be added below, so just skip this '/'.
+		 */
+		if ($name == "/") {
+			continue;
+		}
+		printf("/%s", $name);
 	}
 	printf("/");
 	clear(@paths);


### PR DESCRIPTION
Implemented the full path functionality of opensnoop in [2]. However, when there is a mount point in the path, this patch can obtain the full path, including the mount point. Like d_path()/prepend_path() [1] did, get mount parent full-path.

For example, there is a block device mounted at /home/sd/ in my environment. Before this patch, (1) opensnoop could not retrieve path information before the mount point. This patch fixes that issue, see (2).

        $ lsblk
        NAME        MAJ:MIN RM   SIZE RO TYPE MOUNTPOINTS
        sda           8:0    0 447.1G  0 disk /home/sd

        $ cd /home/sd/rongtao/Git/bpftrace/bpftrace/build/
        $ touch a.out && rm a.out

        $ sudo ./opensnoop.bt
        PID    COMM               FD ERR PATH
    (1) 45412  touch               3   0 /rongtao/Git/bpftrace/bpftrace/build/a.out
    (2) 45560  touch               3   0 /home/sd/rongtao/Git/bpftrace/bpftrace/build/a.out
                                         ^^^^^^^^

[1] https://github.com/torvalds/linux/blob/master/fs/d_path.c
[2] https://github.com/bpftrace/bpftrace/pull/4601
