### PR TITLE
Re-add 'has_key' to the stdlib

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1326,16 +1326,6 @@ ScopedExpr CodegenLLVM::visit(Call &call)
       Value *expr = b_.CreateICmpEQ(ret, b_.getInt64(0), "delete_ret");
       return ScopedExpr(expr);
     }
-  } else if (call.func == "has_key") {
-    auto &arg = call.vargs.at(0);
-    auto &map = *arg.as<Map>();
-    auto scoped_key = getMapKey(map, call.vargs.at(1));
-
-    CallInst *lookup = b_.CreateMapLookup(map, scoped_key.value());
-    Value *expr = b_.CreateICmpNE(b_.CreateIntCast(lookup, b_.getPtrTy(), true),
-                                  b_.GetNull(),
-                                  "has_key");
-    return ScopedExpr(expr);
   } else if (call.func == "str") {
     const auto max_strlen = bpftrace_.config_->max_strlen;
     // Largest read we'll allow = our global string buffer size

--- a/src/ast/passes/map_sugar.cpp
+++ b/src/ast/passes/map_sugar.cpp
@@ -90,7 +90,7 @@ private:
 // specific function being called, and potentially respecting annotations on
 // these arguments.
 static std::unordered_set<std::string> RAW_MAP_ARG = {
-  "print", "clear", "zero", "len", "delete", "is_scalar", "has_key"
+  "print", "clear", "zero", "len", "delete", "is_scalar",
 };
 
 void MapDefaultKey::visit(Map &map)
@@ -222,8 +222,6 @@ void MapDefaultKey::visit(Call &call)
           call.addError() << "delete() requires 1 or 2 arguments ("
                           << call.vargs.size() << " provided)";
         }
-      } else if (call.func == "has_key") {
-        checkCall(*map, true);
       } else if (call.func == "len") {
         checkCall(*map, true);
       } else if (call.func == "is_scalar") {

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -354,8 +354,7 @@ void ResourceAnalyser::visit(Call &call)
   // a slightly different type due to type promotion in an earlier pass.
   // This requires us to allocate a new map key (or create a scratch buffer)
   // and copy individual elements of the tuple instead of the whole thing.
-  if (getAssignRewriteFuncs().contains(call.func) || call.func == "delete" ||
-      call.func == "has_key") {
+  if (getAssignRewriteFuncs().contains(call.func) || call.func == "delete") {
     if (call.func == "lhist" || call.func == "hist" || call.func == "tseries") {
       auto &map = *call.vargs.at(0).as<Map>();
       // Allocation is always needed for lhist/hist/tseries but we need to

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -392,15 +392,6 @@ static const std::map<std::string, call_spec> CALL_SPEC = {
       .max_args=1,
       .arg_types={
         arg_type_spec{ .type=Type::integer } } } },
-  { "has_key",
-    { .min_args=2,
-      .max_args=2,
-      .discard_ret_warn = true,
-      .arg_types={
-        map_type_spec{},
-        map_key_spec{ .map_index=0 },
-      }
-    } },
   { "hist",
     { .min_args=3,
       .max_args=4,
@@ -1277,8 +1268,6 @@ void SemanticAnalyser::visit(Call &call)
     call.return_type = CreateStats(true);
   } else if (call.func == "delete") {
     call.return_type = CreateUInt8();
-  } else if (call.func == "has_key") {
-    call.return_type = CreateBool();
   } else if (call.func == "str") {
     auto &arg = call.vargs.at(0);
     const auto &t = arg.type();

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -325,7 +325,6 @@ macro gid() {
   __builtin_gid
 }
 
-// :function has_key
 // :variant boolean has_key(map m, mapkey k)
 //
 // Return `true` if the key exists in this map.
@@ -345,6 +344,24 @@ macro gid() {
 //     }
 // }
 // ```
+macro has_key(@map, key) {
+  if comptime is_scalar(@map) {
+    fail("call to has_key() expects a map with explicit keys (non-scalar map)");
+    false
+  } else {
+    // The typeinfo(@map[key]) is a bit of a hack as it both checks if the passed key is compatible
+    // with the map key and it also possibly changes the key type to make them
+    // compatible if possible, e.g.
+    // @c[1, ("hello", (int8)5)] = 0;
+    // has_key(@c, (1, ("hello", (uint8)5))) - now the key type is (uint8, (string, int16))
+    // Other than that this has no side effects and shouldn't fail
+    if comptime (typeinfo(@map[key]).1 == "__dummy_key_type") {
+      fail("__dummy_key_type shouldn't exist")
+    }
+    let $key: typeof(@map) = key;
+    __has_key((void *)&@map, (void *)&$key)
+  }
+}
 
 // :variant uint64 jiffies()
 // Jiffies of the kernel

--- a/src/stdlib/map.bpf.c
+++ b/src/stdlib/map.bpf.c
@@ -7,6 +7,13 @@
 struct bpf_map;
 extern __s64 bpf_map_sum_elem_count(const struct bpf_map *map) __ksym __weak;
 
+_Bool __has_key(void *map, void *key) {
+    if (bpf_map_lookup_elem(map, key) == NULL) {
+        return 0;
+    }
+    return 1;
+}
+
 static long __empty_map_elem_cb(void *map, const void *key, void *value, void *ctx)
 {
     return 0;

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -351,7 +351,7 @@ TIMEOUT 1
 
 NAME has_key
 RUN {{BPFTRACE}} runtime/scripts/has_key.bt
-EXPECT 7
+EXPECT 8
 
 NAME has_key error scalar
 PROG begin { @g = 2; if (has_key(@g, 2)) { printf("ok\n"); }  }

--- a/tests/runtime/scripts/has_key.bt
+++ b/tests/runtime/scripts/has_key.bt
@@ -31,7 +31,13 @@ begin {
         ++$count;
     }
 
-    if (!has_key(@c, (1, ("bye", (int8)5)))) {
+    if (!has_key(@c, (1, ("bye", (uint16)5)))) {
+        ++$count;
+    }
+
+    @c[2, ("evenlongerstr", 10)] = 0;
+    $a = (2, ("evenlongerstr", 10));
+    if (has_key(@c, $a)) {
         ++$count;
     }
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -283,7 +283,6 @@ TEST_F(SemanticAnalyserTest, builtin_functions)
   test("kprobe:f { @x = 1; print(@x) }");
   test("kprobe:f { @x = 1; clear(@x) }");
   test("kprobe:f { @x = 1; zero(@x) }");
-  test("kprobe:f { @x[1] = 1; if (has_key(@x, 1)) {} }");
   test("kprobe:f { @x = 1; @y[1] = 1; $a = is_scalar(@x); $b = is_scalar(@y); "
        "}");
   test("kprobe:f { time() }");
@@ -1218,73 +1217,95 @@ TEST_F(SemanticAnalyserTest, call_zero)
 
 TEST_F(SemanticAnalyserTest, call_has_key)
 {
+  ast::TypeMetadata types;
+
+  auto vd_ty = types.global.lookup<btf::Void>("void");
+  ASSERT_TRUE(bool(vd_ty));
+  auto vd_ptr = types.global.add<btf::Pointer>(*vd_ty);
+  ASSERT_TRUE(bool(vd_ptr));
+
+  auto bool_ty = types.global.add<btf::Integer>("int8", 1, 0);
+  ASSERT_TRUE(bool(bool_ty));
+
+  std::vector<std::pair<std::string, btf::ValueType>> args = {
+    { "map", btf::ValueType(*vd_ptr) }, { "key", btf::ValueType(*vd_ptr) }
+  };
+
+  auto has_key_proto = types.global.add<btf::FunctionProto>(
+      btf::ValueType(*bool_ty), args);
+  ASSERT_TRUE(bool(has_key_proto));
+
+  auto has_key_func = types.global.add<btf::Function>(
+      "__has_key", btf::Function::Linkage::Global, *has_key_proto);
+  ASSERT_TRUE(bool(has_key_func));
+
   test("kprobe:f { @x[1] = 0; if "
-       "(has_key(@x, 1)) {} }");
+       "(has_key(@x, 1)) {} }",
+       Types{ types });
   test("kprobe:f { @x[1, 2] = 0; if "
-       "(has_key(@x, (3, 4))) {} }");
+       "(has_key(@x, (3, 4))) {} }",
+       Types{ types });
   test("kprobe:f { @x[1, (int8)2] = 0; if "
-       "(has_key(@x, (3, 4))) {} }");
-  test(R"(kprobe:f { @x[1, "hi"] = 0; if (has_key(@x, (2, "bye"))) {} })");
-  test(
-      R"(kprobe:f { @x[1, "hi"] = 0; if (has_key(@x, (2, "longerstr"))) {} })");
-  test(
-      R"(kprobe:f { @x[1, "longerstr"] = 0; if (has_key(@x, (2, "hi"))) {} })");
+       "(has_key(@x, (3, 4))) {} }",
+       Types{ types });
+  test(R"(kprobe:f { @x[1, "hi"] = 0; if (has_key(@x, (2, "bye"))) {} })",
+       Types{ types });
+  test(R"(kprobe:f { @x[1, "hi"] = 0; if (has_key(@x, (2, "longerstr"))) {} })",
+       Types{ types });
+  test(R"(kprobe:f { @x[1, "longerstr"] = 0; if (has_key(@x, (2, "hi"))) {} })",
+       Types{ types });
   test("kprobe:f { @x[1, 2] = 0; $a = (3, "
-       "4); if (has_key(@x, $a)) {} }");
+       "4); if (has_key(@x, $a)) {} }",
+       Types{ types });
   test("kprobe:f { @x[1, 2] = 0; @a = (3, "
-       "4); if (has_key(@x, @a)) {} }");
+       "4); if (has_key(@x, @a)) {} }",
+       Types{ types });
   test("kprobe:f { @x[1, 2] = 0; @a[1] = "
        "(3, 4); if (has_key(@x, @a[1])) {} "
-       "}");
+       "}",
+       Types{ types });
   test("kprobe:f { @x[1] = 0; @a = "
-       "has_key(@x, 1); }");
+       "has_key(@x, 1); }",
+       Types{ types });
   test("kprobe:f { @x[1] = 0; $a = "
-       "has_key(@x, 1); }");
+       "has_key(@x, 1); }",
+       Types{ types });
   test("kprobe:f { @x[1] = 0; "
-       "@a[has_key(@x, 1)] = 1; }");
+       "@a[has_key(@x, 1)] = 1; }",
+       Types{ types });
 
-  test("kprobe:f { @x[1] = 1;  if (has_key(@x)) {} }", Error{ R"(
-stdin:1:28-39: ERROR: has_key() requires 2 arguments (1 provided)
-kprobe:f { @x[1] = 1;  if (has_key(@x)) {} }
-                           ~~~~~~~~~~~
-)" });
+  test("kprobe:f { @x[1] = 1;  if (has_key(@x)) {} }", Error{}, Types{ types });
+  test("kprobe:f { @x[1] = 1;  if (has_key(@x[1], 1)) {} }",
+       Error{},
+       Types{ types });
+  test("kprobe:f { @x = 1;  if (has_key(@x, 1)) {} }", Error{}, Types{ types });
+  test("kprobe:f { @x[1] = 1; $a = 1; if (has_key($a, 1)) {} }",
+       Error{},
+       Types{ types });
 
-  test("kprobe:f { @x[1] = 1;  if (has_key(@x[1], 1)) {} }", Error{ R"(
-stdin:1:36-41: ERROR: has_key() expects a map argument
-kprobe:f { @x[1] = 1;  if (has_key(@x[1], 1)) {} }
-                                   ~~~~~
-)" });
-
-  test("kprobe:f { @x = 1;  if (has_key(@x, 1)) {} }", Error{ R"(
-stdin:1:33-35: ERROR: call to has_key() expects a map with explicit keys (non-scalar map)
-kprobe:f { @x = 1;  if (has_key(@x, 1)) {} }
-                                ~~
-)" });
-
-  test("kprobe:f { @x[1, 2] = 1;  if (has_key(@x, 1)) {} }", Error{ R"(
+  test("kprobe:f { @x[1, 2] = 1;  if (has_key(@x, 1)) {} }",
+       Error{ R"(
 stdin:1:43-44: ERROR: Argument mismatch for @x: trying to access with arguments: 'uint8' when map expects arguments: '(uint8,uint8)'
 kprobe:f { @x[1, 2] = 1;  if (has_key(@x, 1)) {} }
                                           ~
-)" });
+)" },
+       Types{ types });
 
   test(R"(kprobe:f { @x[1, "hi"] = 0; if (has_key(@x, (2, 1))) {} })",
        Error{ R"(
 stdin:1:45-51: ERROR: Argument mismatch for @x: trying to access with arguments: '(uint8,uint8)' when map expects arguments: '(uint8,string[3])'
 kprobe:f { @x[1, "hi"] = 0; if (has_key(@x, (2, 1))) {} }
                                             ~~~~~~
-)" });
+)" },
+       Types{ types });
 
-  test("kprobe:f { @x[1] = 1; $a = 1; if (has_key($a, 1)) {} }", Error{ R"(
-stdin:1:43-45: ERROR: has_key() expects a map argument
-kprobe:f { @x[1] = 1; $a = 1; if (has_key($a, 1)) {} }
-                                          ~~
-)" });
-
-  test("kprobe:f { @a[1] = 1; has_key(@a, @a); }", Error{ R"(
+  test("kprobe:f { @a[1] = 1; has_key(@a, @a); }",
+       Error{ R"(
 stdin:1:35-37: ERROR: @a used as a map without an explicit key (scalar map), previously used with an explicit key (non-scalar map)
 kprobe:f { @a[1] = 1; has_key(@a, @a); }
                                   ~~
-)" });
+)" },
+       Types{ types });
 }
 
 TEST_F(SemanticAnalyserTest, call_time)
@@ -5021,7 +5042,6 @@ TEST_F(SemanticAnalyserTest, castable_map_missing_feature)
   test("k:f {  @a = count(); clear(@a) }", NoFeatures::Enable);
   test("k:f {  @a = count(); zero(@a) }", NoFeatures::Enable);
   test("k:f {  @a[1] = count(); delete(@a, 1) }", NoFeatures::Enable);
-  test("k:f { @a[1] = count(); has_key(@a, 1) }", NoFeatures::Enable);
 
   test("begin { @a = count(); print((uint64)@a) }",
        NoFeatures::Enable,
@@ -5602,9 +5622,6 @@ TEST_F(SemanticAnalyserTest, warning_for_discared_return_value)
                 "should be used" });
   test("k:f { ustack(raw); }",
        Warning{ "Return value discarded for ustack. "
-                "It should be used" });
-  test("k:f { @x[1] = 0; has_key(@x, 1); }",
-       Warning{ "Return value discarded for has_key. "
                 "It should be used" });
 }
 


### PR DESCRIPTION
Stacked PRs:
 * #4823
 * __->__#4828


--- --- ---

### Re-add 'has_key' to the stdlib


With the updates to how we handle tuples
and integers, we can safely re-add this.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>