### PR TITLE
Remove use of ARRAY maps for user-facing maps

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -1795,7 +1795,6 @@ Currently these are available in bpftrace:
 - lruhash (BPF_MAP_TYPE_LRU_HASH)
 - percpuhash (BPF_MAP_TYPE_PERCPU_HASH)
 - percpulruhash (BPF_MAP_TYPE_LRU_PERCPU_HASH)
-- percpuarray (BPF_MAP_TYPE_PERCPU_ARRAY)
 
 Additionally, map declarations must supply a single argument: ***max entries*** e.g. `let @a = lruhash(100);`
 All maps that are not declared in the global scope utilize the default set in the config variable "max_map_keys".

--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -342,11 +342,6 @@ DIType *DIBuilderBPF::GetMapKeyType(const SizedType &key_type,
                                     const SizedType &value_type,
                                     bpf_map_type map_type)
 {
-  // BPF requires 4-byte keys for array maps.
-  if (map_type == BPF_MAP_TYPE_PERCPU_ARRAY || map_type == BPF_MAP_TYPE_ARRAY) {
-    assert(key_type.IsIntTy());
-    return getInt32Ty();
-  }
   if (map_type == BPF_MAP_TYPE_RINGBUF) {
     assert(key_type.IsNoneTy());
     return getInt64Ty();

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1310,22 +1310,10 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     auto &map = *call.vargs.at(0).as<Map>();
     auto scoped_key = getMapKey(map, call.vargs.at(1));
 
-    if (!is_bpf_map_clearable(map_types_[map.ident])) {
-      // store zero instead of calling bpf_map_delete_elem()
-      auto *val = b_.CreateWriteMapValueAllocation(map.value_type,
-                                                   map.ident + "_zero",
-                                                   call.loc);
-      b_.CreateStore(Constant::getNullValue(b_.GetType(map.value_type)), val);
-      b_.CreateMapUpdateElem(map.ident, scoped_key.value(), val, call.loc);
-      // Assume delete for these kinds of maps always succeeds.
-      Value *expr = b_.getInt8(1);
-      return ScopedExpr(expr);
-    } else {
-      Value *ret = b_.CreateMapDeleteElem(
-          map, scoped_key.value(), call.ret_val_discarded, call.loc);
-      Value *expr = b_.CreateICmpEQ(ret, b_.getInt64(0), "delete_ret");
-      return ScopedExpr(expr);
-    }
+    Value *ret = b_.CreateMapDeleteElem(
+        map, scoped_key.value(), call.ret_val_discarded, call.loc);
+    Value *expr = b_.CreateICmpEQ(ret, b_.getInt64(0), "delete_ret");
+    return ScopedExpr(expr);
   } else if (call.func == "str") {
     const auto max_strlen = bpftrace_.config_->max_strlen;
     // Largest read we'll allow = our global string buffer size
@@ -4815,8 +4803,7 @@ ScopedExpr CodegenLLVM::visit(For &f, Map &map)
 bool CodegenLLVM::canAggPerCpuMapElems(const bpf_map_type map_type,
                                        const SizedType &val_type)
 {
-  return val_type.IsCastableMapTy() && (map_type == BPF_MAP_TYPE_PERCPU_ARRAY ||
-                                        map_type == BPF_MAP_TYPE_PERCPU_HASH);
+  return val_type.IsCastableMapTy() && map_type == BPF_MAP_TYPE_PERCPU_HASH;
 }
 
 // BPF helpers that use fmt strings (bpf_trace_printk, bpf_seq_printf) expect

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -550,8 +550,7 @@ void ResourceAnalyser::update_map_info(Map &map)
     map_info.bpf_type = decl->second.first;
     map_info.max_entries = decl->second.second;
   } else {
-    map_info.bpf_type = get_bpf_map_type(map_info.value_type,
-                                         map_info.is_scalar);
+    map_info.bpf_type = get_bpf_map_type(map_info.value_type);
     // hist() and lhist() transparently create additional elements in whatever
     // map they are assigned to. So even if the map looks like it has no keys,
     // multiple keys are necessary.

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2112,11 +2112,6 @@ void SemanticAnalyser::visit(MapDeclStatement &decl)
     add_bpf_map_types_hint(hint);
   } else {
     bpf_map_type_.insert({ decl.ident, *bpf_type });
-
-    if (decl.max_entries != 1 && *bpf_type == BPF_MAP_TYPE_PERCPU_ARRAY) {
-      decl.addError() << "Max entries can only be 1 for map type "
-                      << decl.bpf_type;
-    }
   }
 
   if (is_final_pass()) {
@@ -2151,11 +2146,8 @@ void SemanticAnalyser::visit(Map &map)
   if (is_final_pass()) {
     auto found_kind = bpf_map_type_.find(map.ident);
     if (found_kind != bpf_map_type_.end()) {
-      if (!bpf_map_types_compatible(map.value_type,
-                                    map_metadata_.scalar[map.ident],
-                                    found_kind->second)) {
-        auto map_type = get_bpf_map_type(map.value_type,
-                                         map_metadata_.scalar[map.ident]);
+      if (!bpf_map_types_compatible(map.value_type, found_kind->second)) {
+        auto map_type = get_bpf_map_type(map.value_type);
         map.addError() << "Incompatible map types. Type from declaration: "
                        << get_bpf_map_type_str(found_kind->second)
                        << ". Type from value/key type: "

--- a/src/async_action.cpp
+++ b/src/async_action.cpp
@@ -133,8 +133,7 @@ void AsyncHandlers::clear_map(const OpaqueValue &data)
 {
   auto mapevent = data.bitcast<AsyncEvent::MapEvent>();
   const auto &map = bpftrace.bytecode_.getMap(mapevent.mapid);
-  uint64_t nvalues = map.is_per_cpu_type() ? bpftrace.ncpus_ : 1;
-  auto ok = map.clear(nvalues);
+  auto ok = map.clear();
   if (!ok) {
     LOG(BUG) << "Could not clear map with ident \"" << map.name()
              << "\", err=" << ok.takeError();

--- a/src/bpfmap.h
+++ b/src/bpfmap.h
@@ -80,7 +80,7 @@ public:
   virtual Result<TSeriesMap> collect_tseries_data(const MapInfo &map_info,
                                                   int nvalues) const;
   Result<> zero_out(int nvalues) const;
-  Result<> clear(int nvalues) const;
+  Result<> clear() const;
   Result<> update_elem(const void *key, const void *value) const;
   Result<> lookup_elem(const void *key, void *value) const;
 
@@ -124,19 +124,11 @@ inline std::string bpftrace_map_name(std::string_view bpf_map_name)
   return name;
 }
 
-inline bool is_bpf_map_clearable(bpf_map_type map_type)
-{
-  return map_type != BPF_MAP_TYPE_ARRAY &&
-         map_type != BPF_MAP_TYPE_PERCPU_ARRAY;
-}
-
-bpf_map_type get_bpf_map_type(const SizedType &val_type, bool scalar);
+bpf_map_type get_bpf_map_type(const SizedType &val_type);
 std::optional<bpf_map_type> get_bpf_map_type(const std::string &name);
 std::string get_bpf_map_type_str(bpf_map_type map_type);
 void add_bpf_map_types_hint(std::stringstream &hint);
-bool is_array_map(const SizedType &val_type, bool scalar);
 bool bpf_map_types_compatible(const SizedType &val_type,
-                              bool scalar,
                               bpf_map_type kind);
 
 } // namespace bpftrace

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -248,7 +248,8 @@ TIMEOUT 1
 
 NAME clear count-map
 PROG begin { @ = count(); @a[1] = count(); clear(@); clear(@a); }
-EXPECT @: 0
+EXPECT_NONE @: 0
+EXPECT_NONE @a[1]: 1
 TIMEOUT 1
 
 NAME delete map
@@ -260,7 +261,8 @@ TIMEOUT 1
 
 NAME delete count-map
 PROG begin { @ = count(); @a[1] = count(); delete(@); delete(@a, 1); }
-EXPECT @: 0
+EXPECT_NONE @: 0
+EXPECT_NONE @a[1]: 1
 TIMEOUT 1
 
 NAME delete deprecated

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -5502,7 +5502,6 @@ TEST_F(SemanticAnalyserTest, map_declarations)
        Mock{ *bpftrace });
   test("let @a = percpulruhash(2); begin { @a[1] = count(); }",
        Mock{ *bpftrace });
-  test("let @a = percpuarray(1); begin { @a = count(); }", Mock{ *bpftrace });
 
   test("let @a = hash(2); begin { print(1); }",
        Mock{ *bpftrace },
@@ -5525,23 +5524,16 @@ let @a = percpulruhash(2); begin { @a = 1; }
   test("let @a = hash(2); begin { @a = count(); }",
        Mock{ *bpftrace },
        Error{ R"(
-stdin:1:27-29: ERROR: Incompatible map types. Type from declaration: hash. Type from value/key type: percpuarray
+stdin:1:27-29: ERROR: Incompatible map types. Type from declaration: hash. Type from value/key type: percpuhash
 let @a = hash(2); begin { @a = count(); }
                           ~~
 )" });
   test("let @a = lruhash(2); begin { @a = count(); }",
        Mock{ *bpftrace },
        Error{ R"(
-stdin:1:30-32: ERROR: Incompatible map types. Type from declaration: lruhash. Type from value/key type: percpuarray
+stdin:1:30-32: ERROR: Incompatible map types. Type from declaration: lruhash. Type from value/key type: percpuhash
 let @a = lruhash(2); begin { @a = count(); }
                              ~~
-)" });
-  test("let @a = percpuarray(1); begin { @a[1] = count(); }",
-       Mock{ *bpftrace },
-       Error{ R"(
-stdin:1:34-36: ERROR: Incompatible map types. Type from declaration: percpuarray. Type from value/key type: percpuhash
-let @a = percpuarray(1); begin { @a[1] = count(); }
-                                 ~~
 )" });
   test("let @a = potato(2); begin { @a[1] = count(); }",
        Mock{ *bpftrace },
@@ -5549,15 +5541,7 @@ let @a = percpuarray(1); begin { @a[1] = count(); }
 stdin:1:1-20: ERROR: Invalid bpf map type: potato
 let @a = potato(2); begin { @a[1] = count(); }
 ~~~~~~~~~~~~~~~~~~~
-HINT: Valid map types: percpulruhash, percpuarray, percpuhash, lruhash, hash
-)" });
-
-  test("let @a = percpuarray(10); begin { @a = count(); }",
-       Mock{ *bpftrace },
-       Error{ R"(
-stdin:1:1-26: ERROR: Max entries can only be 1 for map type percpuarray
-let @a = percpuarray(10); begin { @a = count(); }
-~~~~~~~~~~~~~~~~~~~~~~~~~
+HINT: Valid map types: percpulruhash, percpuhash, lruhash, hash
 )" });
 }
 


### PR DESCRIPTION
Stacked PRs:
 * #4840
 * #4836
 * __->__#4835


--- --- ---

### Remove use of ARRAY maps for user-facing maps


This commit makes two related changes:
1. Remove user access to BPF map type: BPF_MAP_TYPE_PERCPU_ARRAY.
This was only being used, and only could be used,
for count() when the map was scalar (no keys), which doesn't
provide a lot of utility or use

2. Changes `count` (when used with no keys) to use a PERCPU_HASH
instead of a PERCPU_ARRAY. In doing this there was a small regression:

PERCPU_ARRAY: 10.25 ns
PERCPU_HASH: 16.26 ns

Found this using our new bench probes:
```
for i in {1..100}; do sudo ./src/bpftrace -e 'bench:count { @b = count(); }' --test-mode bench; done
```
I think this is a reasonable tradeoff to reduce complexity.

Additionally, it seems like BPF_MAP_TYPE_ARRAY was being
referenced but not used anywhere, so delete that too.
This simplifies the "delete" code path as we no longer have
to "clear" maps instead of "delete" entries.

We can re-add support for PERCPU_ARRAY in the future but
we would need to restrict the keys to int32s and do both compile time
and runtime bounds checking (if we wanted to access them with something
other than integer literals) based on the max entries. We should add
some map introspection (maybe added to typeinfo) so standard library
functions like delete or has_key can detect these map types and act
accordingly. Additionally, we'd have to figure out how we want to
print these maps if different values can be in different CPU slots.
Signed-off-by: Jordan Rome <linux@jordanrome.com>