### PR TITLE
Add warning for discarded expr statement value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,8 @@ and this project adheres to
   - [#4768](https://github.com/bpftrace/bpftrace/pull/4768)
 - Stabilize macros (remove 'unstable_macro' flag)
   - [#4818](https://github.com/bpftrace/bpftrace/pull/4818)
+- Warn on all discarded expressions
+  - [#4836](https://github.com/bpftrace/bpftrace/pull/4836)
 #### Deprecated
 #### Removed
 - Drop support for LLVM 16

--- a/docs/language.md
+++ b/docs/language.md
@@ -820,6 +820,20 @@ let $a = {
 
 This can be used anywhere an expression can be used.
 
+**Note:** There will be a warning for discarded expressions, e.g.,
+
+```
+{ 1 } // Warning
+$a = { 1 } // No Warning
+has_key(@a, 1); // Warning
+$b = has_key(@a, 1); // No Warning
+```
+The warning can also be silenced by utilizing the Discard Expression:
+
+```
+_ = has_key(@a, 1); // No Warning
+```
+
 ## Preamble
 
 The preamble consists of multiple optional pieces:

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -227,6 +227,7 @@ class VarDeclStatement;
 class AssignScalarMapStatement;
 class AssignMapStatement;
 class AssignVarStatement;
+class DiscardExpr;
 class Unroll;
 class Jump;
 class While;
@@ -237,6 +238,7 @@ class Statement : public VariantNode<ExprStatement,
                                      AssignScalarMapStatement,
                                      AssignMapStatement,
                                      AssignVarStatement,
+                                     DiscardExpr,
                                      Unroll,
                                      Jump,
                                      While,
@@ -625,7 +627,6 @@ public:
   // happens, this number is increased so that later error reporting can
   // correctly account for this.
   size_t injected_args = 0;
-  bool ret_val_discarded = false;
 };
 
 class Sizeof : public Node {
@@ -1512,6 +1513,30 @@ public:
   }
 
   StatementList stmts;
+  Expression expr;
+};
+
+class DiscardExpr : public Node {
+public:
+  explicit DiscardExpr(ASTContext &ctx,
+                              Location &&loc,
+                              Expression expr)
+      : Node(ctx, std::move(loc)), expr(std::move(expr)) {};
+  explicit DiscardExpr(ASTContext &ctx,
+                              const Location &loc,
+                              const DiscardExpr &other)
+      : Node(ctx, loc + other.loc),
+        expr(clone(ctx, loc, other.expr)) {};
+
+  bool operator==(const DiscardExpr &other) const
+  {
+    return expr == other.expr;
+  }
+  std::strong_ordering operator<=>(const DiscardExpr &other) const
+  {
+    return expr <=> other.expr;
+  }
+
   Expression expr;
 };
 

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1141,10 +1141,7 @@ void IRBuilderBPF::CreateMapUpdateElem(const std::string &map_ident,
   CreateHelperErrorCond(call, BPF_FUNC_map_update_elem, loc);
 }
 
-CallInst *IRBuilderBPF::CreateMapDeleteElem(Map &map,
-                                            Value *key,
-                                            bool ret_val_discarded,
-                                            const Location &loc)
+CallInst *IRBuilderBPF::CreateMapDeleteElem(Map &map, Value *key)
 {
   assert(key->getType()->isPointerTy());
   Value *map_ptr = GetMapVar(map.ident);
@@ -1160,8 +1157,6 @@ CallInst *IRBuilderBPF::CreateMapDeleteElem(Map &map,
                                                 delete_func_ptr_type);
   CallInst *call = createCall(
       delete_func_type, delete_func, { map_ptr, key }, "delete_elem");
-  CreateHelperErrorCond(
-      call, BPF_FUNC_map_delete_elem, loc, !ret_val_discarded);
 
   return call;
 }
@@ -2330,10 +2325,9 @@ void IRBuilderBPF::CreateRuntimeError(RuntimeErrorId rte_id,
 
 void IRBuilderBPF::CreateHelperErrorCond(Value *return_value,
                                          bpf_func_id func_id,
-                                         const Location &loc,
-                                         bool suppress_error)
+                                         const Location &loc)
 {
-  if (bpftrace_.warning_level_ == 0 || suppress_error ||
+  if (bpftrace_.warning_level_ == 0 ||
       (bpftrace_.warning_level_ == 1 && return_zero_if_err(func_id)))
     return;
 

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -56,9 +56,7 @@ public:
                            const Location &loc,
                            int64_t flags = 0);
   CallInst *CreateMapDeleteElem(Map &map,
-                                Value *key,
-                                bool ret_val_discarded,
-                                const Location &loc);
+                                Value *key);
   Value *CreateForRange(Value *iters,
                         Value *callback,
                         Value *callback_ctx,
@@ -186,8 +184,7 @@ public:
                           const Location &loc);
   void CreateHelperErrorCond(Value *return_value,
                              bpf_func_id func_id,
-                             const Location &loc,
-                             bool suppress_error = false);
+                             const Location &loc);
   StructType *GetStackStructType(bool is_ustack);
   StructType *GetStructType(const std::string &name,
                             const std::vector<llvm::Type *> &elements,

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1310,8 +1310,7 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     auto &map = *call.vargs.at(0).as<Map>();
     auto scoped_key = getMapKey(map, call.vargs.at(1));
 
-    Value *ret = b_.CreateMapDeleteElem(
-        map, scoped_key.value(), call.ret_val_discarded, call.loc);
+    Value *ret = b_.CreateMapDeleteElem(map, scoped_key.value());
     Value *expr = b_.CreateICmpEQ(ret, b_.getInt64(0), "delete_ret");
     return ScopedExpr(expr);
   } else if (call.func == "str") {

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -135,7 +135,6 @@ struct map_key_spec {
 struct call_spec {
   size_t min_args = 0;
   size_t max_args = 0;
-  bool discard_ret_warn = false;
   // NOLINTBEGIN(readability-redundant-member-init)
   std::vector<std::variant<arg_type_spec, map_type_spec, map_key_spec>>
       arg_types = {};
@@ -326,11 +325,11 @@ static const std::map<std::string, call_spec> CALL_SPEC = {
                              }) },
                      map_key_spec{ .map_index = 0 },
                      arg_type_spec{ .type = Type::integer } } } },
-  { "bswap", { .min_args = 1, .max_args = 1, .discard_ret_warn = true } },
+  { "bswap", { .min_args = 1, .max_args = 1 } },
   { "buf",
     { .min_args=1,
       .max_args=2,
-      .discard_ret_warn = true,
+
       .arg_types={
         arg_type_spec{ .skip_check=true },
         arg_type_spec{ .type=Type::integer } } } },
@@ -342,13 +341,13 @@ static const std::map<std::string, call_spec> CALL_SPEC = {
   { "cgroupid",
     { .min_args=1,
       .max_args=1,
-      .discard_ret_warn = true,
+
       .arg_types={
         arg_type_spec{ .type=Type::string, .literal=true } } } },
   { "cgroup_path",
     { .min_args=1,
       .max_args=2,
-      .discard_ret_warn = true,
+
       .arg_types={
         arg_type_spec{ .type=Type::integer },
         arg_type_spec{ .type=Type::string } } } },
@@ -411,25 +410,25 @@ static const std::map<std::string, call_spec> CALL_SPEC = {
   { "kaddr",
     { .min_args=1,
       .max_args=1,
-      .discard_ret_warn = true,
+
       .arg_types={
         arg_type_spec{ .type=Type::string, .literal=true } } } },
   { "kptr",
     { .min_args=1,
       .max_args=1,
-      .discard_ret_warn = true, } },
+       } },
   { "kstack",
     { .min_args=0,
       .max_args=2,
-      .discard_ret_warn = true, } },
+       } },
   { "ksym",
     { .min_args=1,
       .max_args=1,
-      .discard_ret_warn = true, } },
+       } },
   { "stack_len",
     { .min_args=1,
       .max_args=1,
-      .discard_ret_warn = true,
+
     } },
   { "lhist",
     { .min_args=6,
@@ -458,7 +457,7 @@ static const std::map<std::string, call_spec> CALL_SPEC = {
   { "macaddr",
     { .min_args=1,
       .max_args=1,
-      .discard_ret_warn = true, } },
+       } },
   { "max",
     { .min_args=3,
       .max_args=3,
@@ -484,28 +483,28 @@ static const std::map<std::string, call_spec> CALL_SPEC = {
   { "nsecs",
     { .min_args=0,
       .max_args=1,
-      .discard_ret_warn = true,
+
       .arg_types={
         arg_type_spec{ .type=Type::timestamp_mode } } } },
   { "ntop",
     { .min_args=1,
       .max_args=2,
-      .discard_ret_warn = true, } },
+       } },
   { "offsetof",
     { .min_args=2,
       .max_args=2,
-      .discard_ret_warn = true, } },
+       } },
   { "path",
     { .min_args=1,
       .max_args=2,
-      .discard_ret_warn = true,
+
       .arg_types={
         arg_type_spec{ .skip_check=true },
         arg_type_spec{ .type=Type::integer, .literal=true } } } },
   { "percpu_kaddr",
     { .min_args=1,
       .max_args=2,
-      .discard_ret_warn = true,
+
       .arg_types={
         arg_type_spec{ .type=Type::string, .literal=true },
         arg_type_spec{ .type=Type::integer } } } },
@@ -526,21 +525,21 @@ static const std::map<std::string, call_spec> CALL_SPEC = {
   { "pton",
     { .min_args=1,
       .max_args=1,
-      .discard_ret_warn = true, } },
+       } },
   { "reg",
     { .min_args=1,
       .max_args=1,
-      .discard_ret_warn = true,
+
       .arg_types={
         arg_type_spec{ .type=Type::string, .literal=true } } } },
   { "sizeof",
     { .min_args=1,
       .max_args=1,
-      .discard_ret_warn = true, } },
+       } },
   { "skboutput",
     { .min_args=4,
       .max_args=4,
-      .discard_ret_warn = true,
+
       .arg_types={
         arg_type_spec{ .type=Type::string, .literal=true }, // pcap file name
         arg_type_spec{ .type=Type::pointer },      // *skb
@@ -563,21 +562,21 @@ static const std::map<std::string, call_spec> CALL_SPEC = {
   { "str",
     { .min_args=1,
       .max_args=2,
-      .discard_ret_warn = true,
+
       .arg_types={
         arg_type_spec{ .skip_check=true },
         arg_type_spec{ .type=Type::integer } } } },
   { "strftime",
     { .min_args=2,
       .max_args=2,
-      .discard_ret_warn = true,
+
       .arg_types={
           arg_type_spec{ .type=Type::string, .literal=true },
           arg_type_spec{ .type=Type::integer } } } },
   { "strncmp",
     { .min_args=3,
       .max_args=3,
-      .discard_ret_warn = true,
+
       .arg_types={
           arg_type_spec{ .type=Type::string },
           arg_type_spec{ .type=Type::string },
@@ -606,7 +605,7 @@ static const std::map<std::string, call_spec> CALL_SPEC = {
   { "__builtin_uaddr",
     { .min_args=1,
       .max_args=1,
-      .discard_ret_warn = true,
+
       .arg_types={
         arg_type_spec{ .type=Type::string, .literal=true } } } },
   { "unwatch",
@@ -617,15 +616,15 @@ static const std::map<std::string, call_spec> CALL_SPEC = {
   { "uptr",
     { .min_args=1,
       .max_args=1,
-      .discard_ret_warn = true, } },
+       } },
   { "ustack",
     { .min_args=0,
       .max_args=2,
-      .discard_ret_warn = true, } },
+       } },
   { "usym",
     { .min_args=1,
       .max_args=1,
-      .discard_ret_warn = true, } },
+       } },
   { "warnf",
     { .min_args=1,
       .max_args=128,
@@ -639,8 +638,7 @@ static const std::map<std::string, call_spec> CALL_SPEC = {
       } } },
   { "pid",
     { .min_args=0,
-      .max_args=1,
-      .discard_ret_warn = true },
+      .max_args=1 },
   },
   { "socket_cookie",
     { .min_args=1,
@@ -1253,19 +1251,10 @@ void SemanticAnalyser::visit(Call &call)
       }
     }
 
-    call.return_type = CreateTSeries();
-  } else if (call.func == "count") {
-    call.return_type = CreateCount();
-  } else if (call.func == "sum") {
-    call.return_type = CreateSum(call.vargs.at(0).type().IsSigned());
-  } else if (call.func == "min") {
-    call.return_type = CreateMin(call.vargs.at(0).type().IsSigned());
-  } else if (call.func == "max") {
-    call.return_type = CreateMax(call.vargs.at(0).type().IsSigned());
-  } else if (call.func == "avg") {
-    call.return_type = CreateAvg(true);
-  } else if (call.func == "stats") {
-    call.return_type = CreateStats(true);
+    call.return_type = CreateVoid();
+  } else if (call.func == "count" || call.func == "sum" || call.func == "min" ||
+             call.func == "max" || call.func == "avg" || call.func == "stats") {
+    call.return_type = CreateVoid();
   } else if (call.func == "delete") {
     call.return_type = CreateUInt8();
   } else if (call.func == "str") {
@@ -3496,17 +3485,12 @@ void SemanticAnalyser::visit(Expression &expr)
 
 void SemanticAnalyser::visit(ExprStatement &expr)
 {
-  if (auto *call = expr.expr.as<Call>()) {
-    // Calls from expression statements are bare, meaning they're not
-    // handling the return value e.g.
-    // delete(@a, 1); <- ExprStatement
-    // vs
-    // $x = delete(@a, 1) <- AssignVarStatement
-    // if (delete(@a, 1)) { <- If
-    call->ret_val_discarded = true;
-  }
-
   visit(expr.expr);
+
+  if (is_final_pass() &&
+      !(expr.expr.type().IsNoneTy() || expr.expr.type().IsVoidTy())) {
+    expr.addWarning() << "Return value discarded.";
+  }
 }
 
 static const std::unordered_map<Type, std::string_view> AGGREGATE_HINTS{
@@ -4033,12 +4017,6 @@ bool SemanticAnalyser::check_call(Call &call)
   auto spec = CALL_SPEC.find(call.func);
   if (spec == CALL_SPEC.end()) {
     return true;
-  }
-
-  if (is_final_pass() && call.ret_val_discarded &&
-      spec->second.discard_ret_warn) {
-    call.addWarning() << "Return value discarded for " << call.func
-                      << ". It should be used.";
   }
 
   auto ret = true;

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -184,6 +184,10 @@ public:
     visitImpl(decl.typeof);
     return default_value();
   }
+  R visit(DiscardExpr &discard_expr)
+  {
+    return visitImpl(discard_expr.expr);
+  }
   R visit(Jump &jump)
   {
     return visitImpl(jump.return_value);

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -253,6 +253,7 @@ oct_esc  [0-7]{1,3}
   "~"                     { return Parser::make_BNOT(driver.loc); }
   "."                     { return Parser::make_DOT(driver.loc); }
   "->"                    { return Parser::make_PTR(driver.loc); }
+  "_"                     { return Parser::make_UNDERSCORE(driver.loc); }
   "$"[0-9]+               { return Parser::make_PARAM(yytext, driver.loc); }
   "$"#                    { return Parser::make_PARAMCOUNT(driver.loc); }
   /* N.B. The C preprocessor directives also span the line. */

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -102,6 +102,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
   PTR        "->"
   STRUCT     "struct"
   UNION      "union"
+  UNDERSCORE "_"
 
   // Pseudo token; see below.
   LOW "low-precedence"
@@ -587,6 +588,7 @@ assign_stmt:
         |       map_expr ASSIGN expr      { $$ = driver.ctx.make_node<ast::AssignMapStatement>(@$, $1, $3); }
         |       var_decl_stmt ASSIGN expr { $$ = driver.ctx.make_node<ast::AssignVarStatement>(@$, $1, $3); }
         |       var ASSIGN expr           { $$ = driver.ctx.make_node<ast::AssignVarStatement>(@$, $1, $3); }
+        |       UNDERSCORE ASSIGN expr    { $$ = driver.ctx.make_node<ast::DiscardExpr>(@$, $3); }
         |       map compound_op expr
                 {
                   auto b = driver.ctx.make_node<ast::Binop>(@2, $1, $2, $3);

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -2253,7 +2253,7 @@ k:f { print(1_1e100); }
 )");
 
   test_parse_failure("k:f { print(1e1_1_); }", R"(
-stdin:1:18-19: ERROR: syntax error, unexpected identifier, expecting ) or ","
+stdin:1:18-19: ERROR: syntax error, unexpected _, expecting ) or ","
 k:f { print(1e1_1_); }
                  ~
 )");
@@ -2265,7 +2265,7 @@ k:f { print(1_1_e100); }
 )");
 
   test_parse_failure("k:f { print(1_1_); }", R"(
-stdin:1:16-17: ERROR: syntax error, unexpected identifier, expecting ) or ","
+stdin:1:16-17: ERROR: syntax error, unexpected _, expecting ) or ","
 k:f { print(1_1_); }
                ~
 )");

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -271,14 +271,9 @@ EXPECT_NONE @a[1]: 1
 EXPECT_NONE @b[2, hi]: 2
 TIMEOUT 1
 
-NAME bad delete warning
-PROG begin { @a[1] = 1; delete(@a, 2); }
-EXPECT stdin:1:20-33: WARNING: Can't delete map element because it does not exist.
-TIMEOUT 1
-
-NAME bad delete no warning
-PROG begin { @a[1] = 1; $x = delete(@a, 2); if (1 && !delete(@a, 3)) {} }
-EXPECT_NONE stdin:1:20-33: WARNING: Can't delete map element because it does not exist.
+NAME bad delete
+PROG begin { @a[1] = 1; $x = delete(@a, 2); $y = delete(@a, 1); if ($x == false && $y == true) { printf("SUCCESS"); } }
+EXPECT SUCCESS
 TIMEOUT 1
 
 NAME increment/decrement map
@@ -403,3 +398,8 @@ EXPECT @y: 2
 NAME bitwise_not
 PROG begin { @x = ~10; }
 EXPECT @x: 18446744073709551605
+
+NAME discard expression
+PROG begin { _ = { print(1); 1 } }
+EXPECT 1
+EXPECT_REGEX_NONE .*WARNING: Return value discarded..*

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -260,14 +260,6 @@ PROG i:ms:100 { @ = curtask; @a = @; printf("%p\n", @a); exit(); }
 EXPECT_REGEX 0x[0-9a-f]+
 TIMEOUT 1
 
-NAME runtime_error_check_delete
-RUN {{BPFTRACE}} --warnings -e 'i:ms:100 { @[1] = 1; delete(@, 2); exit(); }'
-EXPECT stdin:1:22-34: WARNING: Can't delete map element because it does not exist.
-       Additional Info - helper: map_delete_elem, retcode: -2
-       i:ms:100 { @[1] = 1; delete(@, 2); exit(); }
-                            ~~~~~~~~~~~~
-TIMEOUT 1
-
 NAME runtime_error_check_lookup
 RUN {{BPFTRACE}} -k -e 'i:ms:100 { @[1] = 1; printf("%d\n", @[2]); exit(); }'
 EXPECT stdin:1:37-41: WARNING: Can't lookup map element because it does not exist.

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -5592,21 +5592,19 @@ TEST_F(SemanticAnalyserTest, warning_for_empty_positional_parameters)
        Mock{ *bpftrace });
 }
 
-TEST_F(SemanticAnalyserTest, warning_for_discared_return_value)
+TEST_F(SemanticAnalyserTest, warning_for_discared_expression_statement_value)
 {
   // Non exhaustive testing, just a few examples
-  test("k:f { bswap(arg0); }",
-       Warning{ "Return value discarded for bswap. "
-                "It should be used" });
-  test("k:f { cgroup_path(1); }",
-       Warning{ "Return value discarded for "
-                "cgroup_path. It should be used" });
-  test("k:f { uptr((int8*) arg0); }",
-       Warning{ "Return value discarded for uptr. It "
-                "should be used" });
-  test("k:f { ustack(raw); }",
-       Warning{ "Return value discarded for ustack. "
-                "It should be used" });
+  test("k:f { bswap(arg0); }", Warning{ "Return value discarded" });
+  test("k:f { cgroup_path(1); }", Warning{ "Return value discarded" });
+  test("k:f { uptr((int8*) arg0); }", Warning{ "Return value discarded" });
+  test("k:f { ustack(raw); }", Warning{ "Return value discarded" });
+  test("k:f { { 1 } }", Warning{ "Return value discarded" });
+
+  test("k:f { _ = { 1 } }", NoWarning{ "Return value discarded" });
+  test("k:f { print(1); }", NoWarning{ "Return value discarded" });
+  test("k:f { $a = 1; }", NoWarning{ "Return value discarded" });
+  test("k:f { @a[1] = count(); }", NoWarning{ "Return value discarded" });
 }
 
 TEST_F(SemanticAnalyserTest, external_function)


### PR DESCRIPTION
Stacked PRs:
 * #4840
 * __->__#4836


--- --- ---

### Add warning for discarded expr statement value


Instead of only warning for discarded function
values, let's warn if the expression statement's
expression is not none or void.

This simplifies the implementation and also fixes
incorrect return types for map agg functions
(they all return void).

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>