### PR TITLE
tools/opensnoop: Fix multi-thread race condition of @paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ and this project adheres to
 #### Security
 #### Docs
 #### Tools
+- opensnoop.bt: Fix multi-thread race condition of @paths
+  - [#4837](https://github.com/bpftrace/bpftrace/pull/4837)
 - syscount.bt: Fix incorrect map printing
   - [#4831](https://github.com/bpftrace/bpftrace/pull/4831)
 - opensnoop.bt: support mount points

--- a/tools/opensnoop.bt
+++ b/tools/opensnoop.bt
@@ -65,7 +65,7 @@ macro getcwd(@paths) {
 
 	for ($j : ((uint64)0)..((uint64)$max_path_depth)) {
 
-		@paths[$j] = str($dentry->d_name.name);
+		@paths[tid, $j] = str($dentry->d_name.name);
 		$parent_dentry = $dentry->d_parent;
 
 		if ($dentry == $parent_dentry || $dentry == $mnt_root) {
@@ -87,19 +87,25 @@ macro getcwd(@paths) {
 }
 
 macro printcwd(@paths) {
-	for ($j : ((uint64)0)..((uint64)len(@paths))) {
-		let $name = @paths[(uint64)len(@paths) - $j - 1];
+	$max_path_depth = getopt("depth", 35);
+
+	for ($j : ((uint64)0)..((uint64)$max_path_depth)) {
+		let $key = (tid, (uint64)$max_path_depth - $j - 1);
+		let $name = @paths[$key];
 		/**
-		 * If it is a mount point, there will be a '/', because the '/'
-		 * will be added below, so just skip this '/'.
+		 * If it is a mount point, there will be a '/', because
+		 * the '/' will be added below, so just skip this '/'.
+		 *
+		 * And, if @paths don't have the $key, just skip the
+		 * empty string.
 		 */
-		if ($name == "/") {
+		if ($name == "/" || $name == "") {
 			continue;
 		}
 		printf("/%s", $name);
+		delete(@paths, $key);
 	}
 	printf("/");
-	clear(@paths);
 }
 
 macro sys_exit(ret, @filename, @paths) {
@@ -123,28 +129,16 @@ macro sys_exit(ret, @filename, @paths) {
 	delete(@filename, tid);
 }
 
-tracepoint:syscalls:sys_exit_open
-/@filename[tid]/
-{
-	sys_exit(args.ret, @filename, @open_paths);
-}
-
-tracepoint:syscalls:sys_exit_openat
-/@filename[tid]/
-{
-	sys_exit(args.ret, @filename, @openat_paths);
-}
-
+tracepoint:syscalls:sys_exit_open,
+tracepoint:syscalls:sys_exit_openat,
 tracepoint:syscalls:sys_exit_openat2
 /@filename[tid]/
 {
-	sys_exit(args.ret, @filename, @openat2_paths);
+	sys_exit(args.ret, @filename, @paths);
 }
 
 END
 {
 	clear(@filename);
-	clear(@open_paths);
-	clear(@openat_paths);
-	clear(@openat2_paths);
+	clear(@paths);
 }


### PR DESCRIPTION
When multiple threads call the open() system call simultaneously, @paths[depth] will be contested between threads, leading to incorrect output data.

This patch adds a change to @paths[depth] to @paths[tid, depth] to resolve this issue.

Issue example (running 'git log' in any git-repo directory):

    Before:
    $ sudo ./opensnoop.bt
    Attached 8 probes
    216793 git                -1   2 ////////.git/objects/info/alternates
    216793 git                 3   0 ////////.git/objects/info/commit-graph
    216793 git                -1   2 /home/sda/git-repos/linux/.git/objects/pack/multi-pack-index
    216793 git                -1   2 ////////.git/objects/pack/multi-pack-index.d/multi-pack-index-chain
    216793 git                 3   0 ////////.git/objects/pack

    After:
    217054 git                -1   2 /home/sda/git-repos/linux/.git/objects/info/alternates
    217054 git                 3   0 /home/sda/git-repos/linux/.git/objects/info/commit-graph
    217054 git                -1   2 /home/sda/git-repos/linux/.git/objects/pack/multi-pack-index
    217054 git                -1   2 /home/sda/git-repos/linux/.git/objects/pack/multi-pack-index.d/multi-pack-index-chain
    217054 git                 3   0 /home/sda/git-repos/linux/.git/objects/pack

Note: This commit also 'revert' commit [1], because [1] only fixed the concurrency issue of multiple system calls to open/openat/openat2, without taking into account multi-threading issues.

[1] bpftrace commit 7bf7724b96a0 ("tools: opensnoop: Fix @paths race condition (#4640)")
