### PR TITLE
Don't rely on ast visiting ordering for async ids

### DIFF
--- a/src/ast/async_ids.h
+++ b/src/ast/async_ids.h
@@ -6,20 +6,10 @@ namespace bpftrace::ast {
 
 // Add new ids here
 #define FOR_LIST_OF_ASYNC_IDS(DO)                                              \
-  DO(cat)                                                                      \
-  DO(cgroup_path)                                                              \
   DO(runtime_error)                                                            \
-  DO(join)                                                                     \
-  DO(bpf_print)                                                                \
-  DO(non_map_print)                                                            \
-  DO(printf)                                                                   \
   DO(map_key)                                                                  \
   DO(read_map_value)                                                           \
-  DO(skb_output)                                                               \
-  DO(strftime)                                                                 \
   DO(str)                                                                      \
-  DO(system)                                                                   \
-  DO(time)                                                                     \
   DO(tuple)                                                                    \
   DO(variable)                                                                 \
   DO(watchpoint)

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1490,7 +1490,11 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     cgroupid = util::resolve_cgroupid(path);
     return ScopedExpr(b_.getInt64(cgroupid));
   } else if (call.func == "join") {
-    createJoinCall(call, async_ids_.join());
+    auto found_id = bpftrace_.resources.join_args_id_map.find(&call);
+    if (found_id == bpftrace_.resources.join_args_id_map.end()) {
+      LOG(BUG) << "No id found for join call";
+    }
+    createJoinCall(call, found_id->second);
     return ScopedExpr();
   } else if (call.func == "ksym") {
     // We want to just pass through from the child node.
@@ -1631,9 +1635,13 @@ ScopedExpr CodegenLLVM::visit(Call &call)
       }
 
       // pick the current format string
-      auto print_id = async_ids_.bpf_print();
-      auto *fmt = createFmtString(print_id);
-      const auto &s = bpftrace_.resources.bpf_print_fmts.at(print_id).str();
+      auto found_id = bpftrace_.resources.bpf_print_fmts_id_map.find(&call);
+      if (found_id == bpftrace_.resources.bpf_print_fmts_id_map.end()) {
+        LOG(BUG) << "No id found for printf call";
+      }
+      auto *fmt = createFmtString(found_id->second);
+      const auto &s =
+          bpftrace_.resources.bpf_print_fmts.at(found_id->second).str();
 
       // and finally the seq_printf call
       b_.CreateSeqPrintf(ctx_,
@@ -1645,28 +1653,38 @@ ScopedExpr CodegenLLVM::visit(Call &call)
       return ScopedExpr();
 
     } else {
-      auto async_id = async_ids_.printf();
-      createFormatStringCall(call,
-                             async_id,
-                             std::get<1>(
-                                 bpftrace_.resources.printf_args[async_id]),
-                             "printf",
-                             async_action::AsyncAction::printf);
+      auto found_id = bpftrace_.resources.printf_args_id_map.find(&call);
+      if (found_id == bpftrace_.resources.printf_args_id_map.end()) {
+        LOG(BUG) << "No id found for printf call";
+      }
+      createFormatStringCall(
+          call,
+          found_id->second,
+          std::get<1>(bpftrace_.resources.printf_args[found_id->second]),
+          "printf",
+          async_action::AsyncAction::printf);
       return ScopedExpr();
     }
   } else if (call.func == "errorf" || call.func == "warnf") {
-    auto async_id = async_ids_.printf();
-    createFormatStringCall(call,
-                           async_id,
-                           std::get<1>(
-                               bpftrace_.resources.printf_args[async_id]),
-                           call.func,
-                           async_action::AsyncAction::printf);
+    auto found_id = bpftrace_.resources.printf_args_id_map.find(&call);
+    if (found_id == bpftrace_.resources.printf_args_id_map.end()) {
+      LOG(BUG) << "No id found for errorf/warnf call";
+    }
+    createFormatStringCall(
+        call,
+        found_id->second,
+        std::get<1>(bpftrace_.resources.printf_args[found_id->second]),
+        call.func,
+        async_action::AsyncAction::printf);
     return ScopedExpr();
   } else if (call.func == "debugf") {
-    auto print_id = async_ids_.bpf_print();
-    auto *fmt = createFmtString(print_id);
-    const auto &s = bpftrace_.resources.bpf_print_fmts.at(print_id).str();
+    auto found_id = bpftrace_.resources.bpf_print_fmts_id_map.find(&call);
+    if (found_id == bpftrace_.resources.bpf_print_fmts_id_map.end()) {
+      LOG(BUG) << "No id found for printf call";
+    }
+    auto *fmt = createFmtString(found_id->second);
+    const auto &s =
+        bpftrace_.resources.bpf_print_fmts.at(found_id->second).str();
 
     std::vector<Value *> values;
     std::vector<ScopedExpr> exprs;
@@ -1683,19 +1701,26 @@ ScopedExpr CodegenLLVM::visit(Call &call)
                          call.loc);
     return ScopedExpr();
   } else if (call.func == "system") {
-    auto async_id = async_ids_.system();
-    createFormatStringCall(call,
-                           async_id,
-                           std::get<1>(
-                               bpftrace_.resources.system_args[async_id]),
-                           "system",
-                           async_action::AsyncAction::syscall);
+    auto found_id = bpftrace_.resources.system_args_id_map.find(&call);
+    if (found_id == bpftrace_.resources.system_args_id_map.end()) {
+      LOG(BUG) << "No id found for system call";
+    }
+    createFormatStringCall(
+        call,
+        found_id->second,
+        std::get<1>(bpftrace_.resources.system_args[found_id->second]),
+        "system",
+        async_action::AsyncAction::syscall);
     return ScopedExpr();
   } else if (call.func == "cat") {
-    auto async_id = async_ids_.cat();
+    auto found_id = bpftrace_.resources.cat_args_id_map.find(&call);
+    if (found_id == bpftrace_.resources.cat_args_id_map.end()) {
+      LOG(BUG) << "No id found for cat call";
+    }
     createFormatStringCall(call,
-                           async_id,
-                           std::get<1>(bpftrace_.resources.cat_args[async_id]),
+                           found_id->second,
+                           std::get<1>(
+                               bpftrace_.resources.cat_args[found_id->second]),
                            "cat",
                            async_action::AsyncAction::cat);
     return ScopedExpr();
@@ -1739,7 +1764,11 @@ ScopedExpr CodegenLLVM::visit(Call &call)
                                          call.func + "_args");
 
     // Store cgroup path event id
-    b_.CreateStore(b_.GetIntSameSize(async_ids_.cgroup_path(), elements.at(0)),
+    auto found_id = bpftrace_.resources.cgroup_path_args_id_map.find(&call);
+    if (found_id == bpftrace_.resources.cgroup_path_args_id_map.end()) {
+      LOG(BUG) << "No id found for cgroup_path call";
+    }
+    b_.CreateStore(b_.GetIntSameSize(found_id->second, elements.at(0)),
                    b_.CreateGEP(cgroup_path_struct,
                                 buf,
                                 { b_.getInt64(0), b_.getInt32(0) }));
@@ -1815,8 +1844,12 @@ ScopedExpr CodegenLLVM::visit(Call &call)
                           elements.at(0)),
         b_.CreateGEP(time_struct, buf, { b_.getInt64(0), b_.getInt32(0) }));
 
+    auto found_id = bpftrace_.resources.time_args_id_map.find(&call);
+    if (found_id == bpftrace_.resources.time_args_id_map.end()) {
+      LOG(BUG) << "No id found for time call";
+    }
     b_.CreateStore(
-        b_.GetIntSameSize(async_ids_.time(), elements.at(1)),
+        b_.GetIntSameSize(found_id->second, elements.at(1)),
         b_.CreateGEP(time_struct, buf, { b_.getInt64(0), b_.getInt32(1) }));
 
     b_.CreateOutput(buf, getStructSize(time_struct), call.loc);
@@ -1828,8 +1861,12 @@ ScopedExpr CodegenLLVM::visit(Call &call)
                                                    true);
 
     AllocaInst *buf = b_.CreateAllocaBPF(strftime_struct, call.func + "_args");
+    auto found_id = bpftrace_.resources.strftime_args_id_map.find(&call);
+    if (found_id == bpftrace_.resources.strftime_args_id_map.end()) {
+      LOG(BUG) << "No id found for strftime call";
+    }
     b_.CreateStore(
-        b_.GetIntSameSize(async_ids_.strftime(), elements.at(0)),
+        b_.GetIntSameSize(found_id->second, elements.at(0)),
         b_.CreateGEP(strftime_struct, buf, { b_.getInt64(0), b_.getInt32(0) }));
     b_.CreateStore(
         b_.GetIntSameSize(static_cast<std::underlying_type_t<TimestampMode>>(
@@ -1928,7 +1965,11 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     b_.CreateStore(b_.getInt64(static_cast<int64_t>(
                        async_action::AsyncAction::skboutput)),
                    aid_addr);
-    b_.CreateStore(b_.getInt64(async_ids_.skb_output()), id_addr);
+    auto found_id = bpftrace_.resources.skboutput_args_id_map.find(&call);
+    if (found_id == bpftrace_.resources.skboutput_args_id_map.end()) {
+      LOG(BUG) << "No id found for skboutput call";
+    }
+    b_.CreateStore(b_.getInt64(found_id->second), id_addr);
     b_.CreateStore(b_.CreateGetNs(TimestampMode::boot, call.loc), time_addr);
 
     auto scoped_skb = visit(call.vargs.at(1));
@@ -4016,8 +4057,12 @@ void CodegenLLVM::createPrintNonMapCall(Call &call)
       b_.CreateGEP(print_struct, buf, { b_.getInt64(0), b_.getInt32(0) }));
 
   // Store print id
+  auto found_id = bpftrace_.resources.non_map_print_args_id_map.find(&call);
+  if (found_id == bpftrace_.resources.non_map_print_args_id_map.end()) {
+    LOG(BUG) << "No id found for non_map_print call";
+  }
   b_.CreateStore(
-      b_.getInt64(async_ids_.non_map_print()),
+      b_.getInt64(found_id->second),
       b_.CreateGEP(print_struct, buf, { b_.getInt64(0), b_.getInt32(1) }));
 
   // Store content

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -191,27 +191,37 @@ void ResourceAnalyser::visit(Call &call)
     auto fmtstr = call.vargs.at(0).as<String>()->value;
     if (call.func == "printf") {
       if (probe_ != nullptr && probe_->get_probetype() == ProbeType::iter) {
+        resources_.bpf_print_fmts_id_map[&call] =
+            resources_.bpf_print_fmts.size();
         resources_.bpf_print_fmts.emplace_back(fmtstr);
       } else {
+        resources_.printf_args_id_map[&call] = resources_.printf_args.size();
         resources_.printf_args.emplace_back(
             fmtstr, tuple->fields, PrintfSeverity::NONE, SourceInfo(call.loc));
       }
     } else if (call.func == "errorf") {
+      resources_.printf_args_id_map[&call] = resources_.printf_args.size();
       resources_.printf_args.emplace_back(
           fmtstr, tuple->fields, PrintfSeverity::ERROR, SourceInfo(call.loc));
     } else if (call.func == "warnf") {
+      resources_.printf_args_id_map[&call] = resources_.printf_args.size();
       resources_.printf_args.emplace_back(
           fmtstr, tuple->fields, PrintfSeverity::WARNING, SourceInfo(call.loc));
     } else if (call.func == "debugf") {
+      resources_.bpf_print_fmts_id_map[&call] =
+          resources_.bpf_print_fmts.size();
       resources_.bpf_print_fmts.emplace_back(fmtstr);
     } else if (call.func == "system") {
+      resources_.system_args_id_map[&call] = resources_.system_args.size();
       resources_.system_args.emplace_back(fmtstr, tuple->fields);
     } else {
+      resources_.cat_args_id_map[&call] = resources_.cat_args.size();
       resources_.cat_args.emplace_back(fmtstr, tuple->fields);
     }
   } else if (call.func == "join") {
     auto delim = call.vargs.size() > 1 ? call.vargs.at(1).as<String>()->value
                                        : " ";
+    resources_.join_args_id_map[&call] = resources_.join_args.size();
     resources_.join_args.push_back(delim);
   } else if (call.func == "count" || call.func == "sum" || call.func == "min" ||
              call.func == "max" || call.func == "avg") {
@@ -295,16 +305,20 @@ void ResourceAnalyser::visit(Call &call)
       call.addError() << "Different tseries bounds in a single map unsupported";
     }
   } else if (call.func == "time") {
+    resources_.time_args_id_map[&call] = resources_.time_args.size();
     if (!call.vargs.empty())
       resources_.time_args.push_back(call.vargs.at(0).as<String>()->value);
     else
       resources_.time_args.emplace_back("%H:%M:%S\n");
   } else if (call.func == "strftime") {
+    resources_.strftime_args_id_map[&call] = resources_.strftime_args.size();
     resources_.strftime_args.push_back(call.vargs.at(0).as<String>()->value);
   } else if (call.func == "print") {
     constexpr auto nonmap_headroom = sizeof(AsyncEvent::PrintNonMap);
     auto &arg = call.vargs.at(0);
     if (!arg.is<Map>()) {
+      resources_.non_map_print_args_id_map[&call] =
+          resources_.non_map_print_args.size();
       resources_.non_map_print_args.push_back(arg.type());
       const size_t fmtstring_args_size = nonmap_headroom + arg.type().GetSize();
       if (exceeds_stack_limit(fmtstring_args_size)) {
@@ -313,12 +327,15 @@ void ResourceAnalyser::visit(Call &call)
       }
     }
   } else if (call.func == "cgroup_path") {
+    resources_.cgroup_path_args_id_map[&call] =
+        resources_.cgroup_path_args.size();
     if (call.vargs.size() > 1)
       resources_.cgroup_path_args.push_back(
           call.vargs.at(1).as<String>()->value);
     else
       resources_.cgroup_path_args.emplace_back("*");
   } else if (call.func == "skboutput") {
+    resources_.skboutput_args_id_map[&call] = resources_.skboutput_args_.size();
     const auto &file = call.vargs.at(0).as<String>()->value;
     const auto &offset = call.vargs.at(3).as<Integer>()->value;
 

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -147,19 +147,33 @@ public:
   void load_state(const uint8_t *ptr, size_t len);
 
   // Async argument metadata
+  // There is both a vector and a map of AST pointers to vector index.
+  // We only need the latter for a later passes that want to accurately
+  // access the id for a specific node so it can be passed into userspace
+  // when the script is executing.
   std::vector<
       std::tuple<FormatString, std::vector<Field>, PrintfSeverity, SourceInfo>>
       printf_args;
+  std::unordered_map<ast::Call* , size_t> printf_args_id_map;
   std::vector<std::tuple<FormatString, std::vector<Field>>> system_args;
+  std::unordered_map<ast::Call* , size_t> system_args_id_map;
   // fmt strings for BPF helpers (bpf_seq_printf, bpf_trace_printk)
   std::vector<FormatString> bpf_print_fmts;
+  std::unordered_map<ast::Call* , size_t> bpf_print_fmts_id_map;
   std::vector<std::tuple<FormatString, std::vector<Field>>> cat_args;
+  std::unordered_map<ast::Call* , size_t> cat_args_id_map;
   std::vector<std::string> join_args;
+  std::unordered_map<ast::Call* , size_t> join_args_id_map;
   std::vector<std::string> time_args;
+  std::unordered_map<ast::Call* , size_t> time_args_id_map;
   std::vector<std::string> strftime_args;
+  std::unordered_map<ast::Call* , size_t> strftime_args_id_map;
   std::vector<std::string> cgroup_path_args;
+  std::unordered_map<ast::Call* , size_t> cgroup_path_args_id_map;
   std::vector<SizedType> non_map_print_args;
+  std::unordered_map<ast::Call* , size_t> non_map_print_args_id_map;
   std::vector<std::tuple<std::string, long>> skboutput_args_;
+  std::unordered_map<ast::Call* , size_t> skboutput_args_id_map;
   // While max fmtstring args size is not used at runtime, the size
   // calculation requires taking into account struct alignment semantics,
   // and that is tricky enough that we want to minimize repetition of


### PR DESCRIPTION
Matching on the specific order is problematic,
e.g., this led to a segfault:
```
macro name() {
  warnf("tomato");
  "rtoax"
}
begin {
  printf("%s\n", name);
}
```

Instead just make a map of AST pointers to their
index in the vector of args then we don't have to
rely on the AST visitor order being the same
in both resource_analyser and codegen.

This is slightly cheaper than creating two maps
with their keys and values swapped.

AsyncIds could probably be deprecated but that
needs further investigation.

Co-authored-by: Rong Tao <rongtao@cestc.cn>
Signed-off-by: Jordan Rome <linux@jordanrome.com>

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
