### PR TITLE
Migrate delete to the standard library

### DIFF
--- a/.github/include/aot_allow.txt
+++ b/.github/include/aot_allow.txt
@@ -1,9 +1,6 @@
 aot.basic.basic while loop
 aot.basic.clear count-map
 aot.basic.clear map
-aot.basic.delete count-map
-aot.basic.delete deprecated
-aot.basic.delete map
 aot.basic.exit code
 aot.basic.has_key exists
 aot.basic.has_key map keys and values
@@ -208,6 +205,9 @@ aot.signed_ints.negative map value
 aot.signed_ints.stats with negative values
 aot.signed_ints.sum negative maps
 aot.signed_ints.sum with negative value
+aot.stdlib.delete count-map
+aot.stdlib.delete deprecated
+aot.stdlib.delete map
 aot.tuples.basic tuple
 aot.uprobe.uprobes - probe function in non-executable library
 aot.variable.32-bit tracepoint arg

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -1141,26 +1141,6 @@ void IRBuilderBPF::CreateMapUpdateElem(const std::string &map_ident,
   CreateHelperErrorCond(call, BPF_FUNC_map_update_elem, loc);
 }
 
-CallInst *IRBuilderBPF::CreateMapDeleteElem(Map &map, Value *key)
-{
-  assert(key->getType()->isPointerTy());
-  Value *map_ptr = GetMapVar(map.ident);
-
-  // long map_delete_elem(&map, &key)
-  // Return: 0 on success or negative error
-  FunctionType *delete_func_type = FunctionType::get(
-      getInt64Ty(), { map_ptr->getType(), key->getType() }, false);
-  PointerType *delete_func_ptr_type = PointerType::get(getContext(), 0);
-  Constant *delete_func = ConstantExpr::getCast(Instruction::IntToPtr,
-                                                getInt64(
-                                                    BPF_FUNC_map_delete_elem),
-                                                delete_func_ptr_type);
-  CallInst *call = createCall(
-      delete_func_type, delete_func, { map_ptr, key }, "delete_elem");
-
-  return call;
-}
-
 Value *IRBuilderBPF::CreateForRange(Value *iters,
                                     Value *callback,
                                     Value *callback_ctx,

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -55,8 +55,6 @@ public:
                            Value *val,
                            const Location &loc,
                            int64_t flags = 0);
-  CallInst *CreateMapDeleteElem(Map &map,
-                                Value *key);
   Value *CreateForRange(Value *iters,
                         Value *callback,
                         Value *callback_ctx,

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -1306,13 +1306,6 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     b_.CreateLifetimeEnd(key_exists);
 
     return ScopedExpr();
-  } else if (call.func == "delete") {
-    auto &map = *call.vargs.at(0).as<Map>();
-    auto scoped_key = getMapKey(map, call.vargs.at(1));
-
-    Value *ret = b_.CreateMapDeleteElem(map, scoped_key.value());
-    Value *expr = b_.CreateICmpEQ(ret, b_.getInt64(0), "delete_ret");
-    return ScopedExpr(expr);
   } else if (call.func == "str") {
     const auto max_strlen = bpftrace_.config_->max_strlen;
     // Largest read we'll allow = our global string buffer size

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -341,13 +341,6 @@ void ResourceAnalyser::visit(Call &call)
 
     resources_.skboutput_args_.emplace_back(file, offset);
     resources_.using_skboutput = true;
-  } else if (call.func == "delete") {
-    auto &arg0 = call.vargs.at(0);
-    auto &map = *arg0.as<Map>();
-    if (exceeds_stack_limit(map.value_type.GetSize())) {
-      resources_.max_write_map_value_size = std::max(
-          resources_.max_write_map_value_size, map.value_type.GetSize());
-    }
   }
 
   if (call.func == "print" || call.func == "clear" || call.func == "zero") {
@@ -371,7 +364,7 @@ void ResourceAnalyser::visit(Call &call)
   // a slightly different type due to type promotion in an earlier pass.
   // This requires us to allocate a new map key (or create a scratch buffer)
   // and copy individual elements of the tuple instead of the whole thing.
-  if (getAssignRewriteFuncs().contains(call.func) || call.func == "delete") {
+  if (getAssignRewriteFuncs().contains(call.func)) {
     if (call.func == "lhist" || call.func == "hist" || call.func == "tseries") {
       auto &map = *call.vargs.at(0).as<Map>();
       // Allocation is always needed for lhist/hist/tseries but we need to

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -188,7 +188,6 @@ macro curtask() {
   __builtin_curtask
 }
 
-// :function delete
 // :variant bool delete(map m, mapkey k)
 // :deprecated_variant bool delete(mapkey k)
 //
@@ -232,6 +231,32 @@ macro curtask() {
 //     delete(@associative[1, 2]);
 // }
 // ```
+macro delete(@map, $key) {
+  check_key(@map, $key, "delete() with two arguments");
+  __delete((void *)&@map, (void *)&$key) == 0
+}
+
+macro delete(@map, key) {
+  check_key(@map, key, "delete() with two arguments");
+  let $key: typeof(@map) = key;
+  __delete((void *)&@map, (void *)&$key) == 0
+}
+
+macro delete(@map) {
+  if comptime !is_scalar(@map) {
+    fail("call to delete() with a single argument expects a map without explicit keys (scalar map)");
+    false
+  } else {
+    let $key: int64 = 0;
+    __delete((void *)&@map, (void *)&$key) == 0
+  }
+}
+
+macro delete(map_access) {
+  // This supports the deprecated delete API, e.g. `delete(@a[1])`
+  // which is handled in the map_sugar pass
+  __deprecated_delete(map_access)
+}
 
 // :variant uint64 elapsed()
 // ktime_get_ns - ktime_get_boot_ns
@@ -345,22 +370,9 @@ macro gid() {
 // }
 // ```
 macro has_key(@map, key) {
-  if comptime is_scalar(@map) {
-    fail("call to has_key() expects a map with explicit keys (non-scalar map)");
-    false
-  } else {
-    // The typeinfo(@map[key]) is a bit of a hack as it both checks if the passed key is compatible
-    // with the map key and it also possibly changes the key type to make them
-    // compatible if possible, e.g.
-    // @c[1, ("hello", (int8)5)] = 0;
-    // has_key(@c, (1, ("hello", (uint8)5))) - now the key type is (uint8, (string, int16))
-    // Other than that this has no side effects and shouldn't fail
-    if comptime (typeinfo(@map[key]).1 == "__dummy_key_type") {
-      fail("__dummy_key_type shouldn't exist")
-    }
-    let $key: typeof(@map) = key;
-    __has_key((void *)&@map, (void *)&$key)
-  }
+  check_key(@map, key, "has_key()");
+  let $key: typeof(@map) = key;
+  __has_key((void *)&@map, (void *)&$key)
 }
 
 // :variant uint64 jiffies()

--- a/src/stdlib/map.bpf.c
+++ b/src/stdlib/map.bpf.c
@@ -14,6 +14,10 @@ _Bool __has_key(void *map, void *key) {
     return 1;
 }
 
+long __delete(void *map, void *key) {
+    return bpf_map_delete_elem(map, key);
+}
+
 static long __empty_map_elem_cb(void *map, const void *key, void *value, void *ctx)
 {
     return 0;

--- a/src/stdlib/meta.bt
+++ b/src/stdlib/meta.bt
@@ -29,3 +29,19 @@ macro static_assert(cond, msg) {
     fail(msg);
   }
 }
+
+macro check_key(@map, key, func) {
+  if comptime is_scalar(@map) {
+    fail("call to %s expects a map with explicit keys (non-scalar map)", func);
+  } else {
+    // The typeinfo(@map[key]) is a bit of a hack as it both checks if the passed key is compatible
+    // with the map key and it also possibly changes the key type to make them
+    // compatible if possible, e.g.
+    // @c[1, ("hello", (int8)5)] = 0;
+    // has_key(@c, (1, ("hello", (uint8)5))) - now the key type is (uint8, (string, int16))
+    // Other than that this has no side effects and shouldn't fail
+    if comptime (typeinfo(@map[key]).1 == "__dummy_key_type") {
+      fail("__dummy_key_type shouldn't exist")
+    }
+  }
+}

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -252,30 +252,6 @@ EXPECT_NONE @: 0
 EXPECT_NONE @a[1]: 1
 TIMEOUT 1
 
-NAME delete map
-PROG begin { @ = 1; @a[1] = 1; @b[1, 2] = 2; if (delete(@)) { printf("ok1\n"); } delete(@a, 1); if (delete(@b, (1, 2))) { printf("ok2\n"); } if (!delete(@b, (5, 6))) { printf("ok3\n"); } }
-EXPECT ok1
-EXPECT ok2
-EXPECT ok3
-TIMEOUT 1
-
-NAME delete count-map
-PROG begin { @ = count(); @a[1] = count(); delete(@); delete(@a, 1); }
-EXPECT_NONE @: 0
-EXPECT_NONE @a[1]: 1
-TIMEOUT 1
-
-NAME delete deprecated
-PROG begin { @a[1] = 1; @b[2, "hi"] = 2; delete(@a[1]); delete(@b[2, "hi"]); }
-EXPECT_NONE @a[1]: 1
-EXPECT_NONE @b[2, hi]: 2
-TIMEOUT 1
-
-NAME bad delete
-PROG begin { @a[1] = 1; $x = delete(@a, 2); $y = delete(@a, 1); if ($x == false && $y == true) { printf("SUCCESS"); } }
-EXPECT SUCCESS
-TIMEOUT 1
-
 NAME increment/decrement map
 PROG begin { @x = 10; printf("%d", @x++); printf(" %d", ++@x); printf(" %d", @x--); printf(" %d\n", --@x); delete(@x); }
 EXPECT 10 12 12 10

--- a/tests/runtime/stdlib
+++ b/tests/runtime/stdlib
@@ -14,3 +14,27 @@ EXPECT Invalid argument
 NAME comm from pid
 PROG iter:task { @ = comm(pid); exit() }
 EXPECT @: bpftrace
+
+NAME delete map
+PROG begin { @ = 1; @a[1] = 1; @b[1, 2] = 2; if (delete(@)) { printf("ok1\n"); } delete(@a, 1); if (delete(@b, (1, 2))) { printf("ok2\n"); } if (!delete(@b, (5, 6))) { printf("ok3\n"); } }
+EXPECT ok1
+EXPECT ok2
+EXPECT ok3
+TIMEOUT 1
+
+NAME delete count-map
+PROG begin { @ = count(); @a[1] = count(); delete(@); delete(@a, 1); }
+EXPECT_NONE @: 0
+EXPECT_NONE @a[1]: 1
+TIMEOUT 1
+
+NAME delete deprecated
+PROG begin { @a[1] = 1; @b[2, "hi"] = 2; delete(@a[1]); delete(@b[2, "hi"]); }
+EXPECT_NONE @a[1]: 1
+EXPECT_NONE @b[2, hi]: 2
+TIMEOUT 1
+
+NAME bad delete
+PROG begin { @a[1] = 1; $x = delete(@a, 2); $y = delete(@a, 1); if ($x == false && $y == true) { printf("SUCCESS"); } }
+EXPECT SUCCESS
+TIMEOUT 1


### PR DESCRIPTION
Stacked PRs:
 * __->__#4840


--- --- ---

### Migrate delete to the standard library


Utilize macro expansion in map_sugar pass
for the deprecated delete API.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>