### PR TITLE
Don't rely on ast visiting ordering for async ids (#4838)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ and this project adheres to
   - [#4801](https://github.com/bpftrace/bpftrace/pull/4801)
 - codegen: Fix tid/pid in non-init namespaces
   - [#4813](https://github.com/bpftrace/bpftrace/issues/4813)
+- Fix segfault in printf ordering
+  - [#4838](https://github.com/bpftrace/bpftrace/pull/4838)
 ## [0.24.1] 2025-10-03
 
 #### Fixed

--- a/src/ast/async_ids.h
+++ b/src/ast/async_ids.h
@@ -6,20 +6,10 @@ namespace bpftrace::ast {
 
 // Add new ids here
 #define FOR_LIST_OF_ASYNC_IDS(DO)                                              \
-  DO(cat)                                                                      \
-  DO(cgroup_path)                                                              \
   DO(runtime_error)                                                            \
-  DO(join)                                                                     \
-  DO(bpf_print)                                                                \
-  DO(non_map_print)                                                            \
-  DO(printf)                                                                   \
   DO(map_key)                                                                  \
   DO(read_map_value)                                                           \
-  DO(skb_output)                                                               \
-  DO(strftime)                                                                 \
   DO(str)                                                                      \
-  DO(system)                                                                   \
-  DO(time)                                                                     \
   DO(tuple)                                                                    \
   DO(variable)                                                                 \
   DO(watchpoint)

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -148,19 +148,33 @@ public:
   void load_state(const uint8_t *ptr, size_t len);
 
   // Async argument metadata
+  // There is both a vector and a map of AST pointers to vector index.
+  // We only need the latter for a later passes that want to accurately
+  // access the id for a specific node so it can be passed into userspace
+  // when the script is executing.
   std::vector<
       std::tuple<FormatString, std::vector<Field>, PrintfSeverity, SourceInfo>>
       printf_args;
+  std::unordered_map<ast::Call* , size_t> printf_args_id_map;
   std::vector<std::tuple<FormatString, std::vector<Field>>> system_args;
+  std::unordered_map<ast::Call* , size_t> system_args_id_map;
   // fmt strings for BPF helpers (bpf_seq_printf, bpf_trace_printk)
   std::vector<FormatString> bpf_print_fmts;
+  std::unordered_map<ast::Call* , size_t> bpf_print_fmts_id_map;
   std::vector<std::tuple<FormatString, std::vector<Field>>> cat_args;
+  std::unordered_map<ast::Call* , size_t> cat_args_id_map;
   std::vector<std::string> join_args;
+  std::unordered_map<ast::Call* , size_t> join_args_id_map;
   std::vector<std::string> time_args;
+  std::unordered_map<ast::Call* , size_t> time_args_id_map;
   std::vector<std::string> strftime_args;
+  std::unordered_map<ast::Call* , size_t> strftime_args_id_map;
   std::vector<std::string> cgroup_path_args;
+  std::unordered_map<ast::Call* , size_t> cgroup_path_args_id_map;
   std::vector<SizedType> non_map_print_args;
+  std::unordered_map<ast::Call* , size_t> non_map_print_args_id_map;
   std::vector<std::tuple<std::string, long>> skboutput_args_;
+  std::unordered_map<ast::Call* , size_t> skboutput_args_id_map;
   // While max fmtstring args size is not used at runtime, the size
   // calculation requires taking into account struct alignment semantics,
   // and that is tricky enough that we want to minimize repetition of


### PR DESCRIPTION
Matching on the specific order is problematic,
e.g., this led to a segfault:
```
macro name() {
  warnf("tomato");
  "rtoax"
}
begin {
  printf("%s\n", name);
}
```

Instead just make a map of AST pointers to their
index in the vector of args then we don't have to
rely on the AST visitor order being the same
in both resource_analyser and codegen.

This is slightly cheaper than creating two maps
with their keys and values swapped.

AsyncIds could probably be deprecated but that
needs further investigation.

(cherry picked from commit e1d86eaa83bb5adafa45d337d9da0b69d39701de)

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
