### PR TITLE
flake: update BCC to fix SONAME resolution for uprobes

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -1463,6 +1463,14 @@ a full path. The path will be then automatically resolved using `/etc/ld.so.cach
 uprobe:libc:malloc { printf("Allocated %d bytes\n", arg0); }
 ```
 
+If multiple versions of the same shared library exist (e.g. `libssl.so.3` and
+`libssl.so.59`), bpftrace may resolve the wrong one. To fix this, you can specify
+a versioned SONAME to ensure the correct library is traced:
+
+```
+uprobe:libssl.so.3:SSL_write { ... }
+```
+
 If the traced binary has DWARF included, function arguments are available in the `args` struct which can be inspected with verbose listing, see the [Listing Probes](../man/adoc/bpftrace.adoc#listing-probes) section for more details.
 
 ```

--- a/flake.nix
+++ b/flake.nix
@@ -42,7 +42,11 @@
           # Override to specify the bcc build we want.
           # We need a specific patch in BCC which resolves a build failure with
           # LLVM 21 and is not a part of any official release, yet.
-          bccVersion = "8c5c96ad3beeed2fa827017f451a952306826974";
+          # commit: "8c5c96ad3beeed2fa827017f451a952306826974"
+          #
+          # Updated to BCC commit enabling versioned SONAME support in uprobes
+          # (supports attachpoints like uprobe:libssl.so.3:SSL_write)
+          bccVersion = "beb1fe40e1183a9068c93640e4687342d822c4e3";
           bcc = (pkgs.bcc.override {
             llvmPackages = pkgs."llvmPackages_${toString defaultLlvmVersion}";
           }).overridePythonAttrs {
@@ -52,7 +56,7 @@
               repo = "bcc";
               rev = "${bccVersion}";
               # See above
-              sha256 = "sha256-XcTqcsbyUBe83vsjUC70GoffCXaxk32QddBKFEP6LD8=";
+              sha256 = "sha256-9BapcFFVn+4zCDBlt15Wmiwnaj0RAqCOfuByu2n6GAs=";
             };
           };
 

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -308,6 +308,12 @@ EXPECT_REGEX size: [0-9]+
 AFTER ./testprogs/uprobe_library
 REQUIRES_FEATURE libpath_resolv
 
+NAME uprobe_library_soname
+PROG uprobe:libc.so.6:fread { printf("size: %d\n", arg1); exit(); }
+EXPECT_REGEX size: [0-9]+
+AFTER ./testprogs/uprobe_library
+REQUIRES_FEATURE libpath_resolv
+
 NAME uprobe_order
 RUN {{BPFTRACE}} runtime/scripts/uprobe_order.bt
 EXPECT_REGEX (first)+ second


### PR DESCRIPTION
Update bccVersion in flake.nix to commit beb1fe40e118 ("cc: support
versioned SONAME in shared library resolution"). This fixes incorrect
library resolution when multiple SONAMEs exist in /etc/ld.so.cache and
allows using versioned names like libssl.so.3 in uprobe attachpoints.
Tests and documentation updated accordingly.

Fixes: #4760

##### Checklist

- [x] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
