### PR TITLE
Fix MapAddr type

### DIFF
--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -959,8 +959,7 @@ public:
 
   const SizedType &type() const
   {
-    static SizedType voidptr = CreatePointer(CreateVoid());
-    return voidptr;
+    return map_addr_type;
   }
 
   bool operator==(const MapAddr &other) const
@@ -973,6 +972,7 @@ public:
   }
 
   Map *map = nullptr;
+  SizedType map_addr_type;
 };
 
 class Binop : public Node {

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -2165,6 +2165,8 @@ void SemanticAnalyser::visit(MapAddr &map_addr)
     pass_tracker_.inc_num_unresolved();
   } else {
     visit(map_addr.map);
+    map_addr.map_addr_type = CreatePointer(map_addr.map->type(),
+                                           map_addr.map->type().GetAS());
   }
 }
 


### PR DESCRIPTION
Stacked PRs:
 * #4845
 * #4844
 * __->__#4843


--- --- ---

### Fix MapAddr type


We need to set this type from semantic_analyser
after we resolve the type of the map value.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>