### PR TITLE
Add `find` helper function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,8 @@ and this project adheres to
   - [#4912](https://github.com/bpftrace/bpftrace/pull/4912)
 - Add new Record primitive
   - [#4947](https://github.com/bpftrace/bpftrace/pull/4947)
+- Add `find` to get map value if it exists
+  - [#4845](https://github.com/bpftrace/bpftrace/pull/4845)
 #### Changed
 - Add helpers to check if a kfunc exists and is supported for particular probe types.
   - [#4857](https://github.com/bpftrace/bpftrace/pull/4857)

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -302,6 +302,25 @@ BEGIN { if ($1 < 2) { fail("Expected the first positional param to be greater th
 
 
 
+### find
+- `boolean find(map m, mapkey k, mapvalue result)`
+
+Return `true` if the key exists in this map and sets the passed scratch variable (result) to the value of that map key.
+Otherwise return `false` and don't mutate result.
+Use this instead of `has_key` and a map access to avoid an additional map lookup.
+Error if called with a map that has no keys (aka scalar map).
+
+```
+kprobe:dummy {
+  @map[2] = (1, "hello");
+  let $val;
+  if (find(@map, 2, $val)) {
+    print($val); // prints (1, "hello")
+  }
+}
+```
+
+
 ### func
 - `string func()`
 - `string func`

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -337,6 +337,35 @@ macro elapsed()
 // ```
 //
 
+// :variant boolean find(map m, mapkey k, mapvalue result)
+//
+// Return `true` if the key exists in this map and sets the passed scratch variable (result) to the value of that map key.
+// Otherwise return `false` and don't mutate result.
+// Use this instead of `has_key` and a map access to avoid an additional map lookup.
+// Error if called with a map that has no keys (aka scalar map).
+//
+// ```
+// kprobe:dummy {
+//   @map[2] = (1, "hello");
+//   let $val;
+//   if (find(@map, 2, $val)) {
+//     print($val); // prints (1, "hello")
+//   }
+// }
+// ```
+macro find(@map, key, $var) {
+  import "stdlib/map/map.bpf.c";
+  check_key(@map, key, "find");
+  let $key: typeof(@map) = key;
+  $result = __lookup_elem((void *)&@map, (void *)&$key);
+  if ((bool)$result) {
+    $var = *((typeof({ $a = @map[$key]; &$a }))$result);
+    true
+  } else {
+    false
+  }
+}
+
 // :variant string func()
 // Name of the current function being traced (kprobes,uprobes,fentry)
 macro func()
@@ -396,12 +425,11 @@ macro gid()
 //     }
 // }
 // ```
-macro has_key(@map, key)
-{
+macro has_key(@map, key) {
   import "stdlib/map/map.bpf.c";
   check_key(@map, key, "has_key()");
-  let $key : typeof(@map) = key;
-  __has_key((void *)(&@map), (void *)(&$key))
+  let $key: typeof(@map) = key;
+  (bool)__lookup_elem((void *)&@map, (void *)&$key)
 }
 
 // :variant uint64 jiffies()

--- a/src/stdlib/map/map.bpf.c
+++ b/src/stdlib/map/map.bpf.c
@@ -7,11 +7,8 @@
 struct bpf_map;
 extern __s64 bpf_map_sum_elem_count(const struct bpf_map *map) __ksym __weak;
 
-_Bool __has_key(void *map, void *key) {
-    if (bpf_map_lookup_elem(map, key) == NULL) {
-        return 0;
-    }
-    return 1;
+void * __lookup_elem(void *map, void *key) {
+    return bpf_map_lookup_elem(map, key);
 }
 
 long __delete(void *map, void *key) {

--- a/tests/self/find.bt
+++ b/tests/self/find.bt
@@ -1,0 +1,66 @@
+test:find_basic {
+    let $val;
+    @a[1] = 10;
+
+    // key exists
+    if (!find(@a, 1, $val)) {
+        return 1;
+    } else {
+        if ($val != 10) {
+            return 1;
+        }
+    }
+
+    // key doesn't exist
+    if (find(@a, 2, $val)) {
+        return 1;
+    }
+
+    // variable as key
+    @a[2] = 20;
+    $b = 2;
+    if (!find(@a, $b, $val)) {
+        return 1;
+    } else {
+        if ($val != 20) {
+            return 1;
+        }
+    }
+
+    // string as key
+    $val_str = "hello";
+    @b["longerstr"] = "bye";
+    if (find(@b, "byeasdfasdfasdfasdfasdfasdf", $val_str)) {
+        return 1;
+    }
+
+    if (!find(@b, "longerstr", $val_str)) {
+        return 1;
+    } else {
+        if ($val_str != "bye") {
+            return 1;
+        }
+    }
+}
+
+test:find_complex_key {
+    let $val_tpl;
+    @c[1, ("hello", (int8)5)] = (1, "bye");
+    if (!find(@c, (1, ("hello", 5)), $val_tpl)) {
+        return 1;
+    } else {
+        if ($val_tpl != (1, "bye")) {
+            return 1;
+        }
+    }
+
+    if (find(@c, (1, ("bye", (uint16)5)), $val_tpl)) {
+       return 1;
+    }
+
+    @c[2, ("evenlongerstr", 10)] = (2, "hello");
+    $a = (2, ("evenlongerstr", 10));
+    if (!find(@c, $a, $val_tpl)) {
+        return 1;
+    }
+}


### PR DESCRIPTION
Stacked PRs:
 * __->__#4845


--- --- ---

### Add `find` helper function


This is sugar around a map access with a return
value to indicate if the map key was present
in the map. This is to help with cases where
users end up calling `has_key` and then do a map
access. This saves a second map lookup.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>