### PR TITLE
tools/undump: support dgram packet capture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,8 @@ and this project adheres to
 #### Security
 #### Docs
 #### Tools
+- undump.bt: Support dgram packet capture
+  - [#4846](https://github.com/bpftrace/bpftrace/pull/4846)
 - opensnoop.bt: Fix multi-thread race condition of @paths
   - [#4837](https://github.com/bpftrace/bpftrace/pull/4837)
 - syscount.bt: Fix incorrect map printing

--- a/tools/undump.bt
+++ b/tools/undump.bt
@@ -40,6 +40,7 @@
  * Copyright 2022 CESTC, Inc.
  *
  * 22-May-2022	Rong Tao	Created this.
+ * 13-Nov-2025	Rong Tao	Support dgram packet capture.
  */
 #ifndef BPFTRACE_HAVE_BTF
 #include <linux/skbuff.h>
@@ -51,13 +52,39 @@ BEGIN
 	printf("%-8s %-16s %-8s %-8s %-s\n", "TIME", "COMM", "PID", "SIZE", "DATA");
 }
 
-kprobe:unix_stream_read_actor
+kprobe:unix_dgram_recvmsg,
+kprobe:unix_stream_recvmsg
 {
-	$skb = (struct sk_buff *)arg0;
-	time("%H:%M:%S ");
-	printf("%-16s %-8d %-8d %r\n", comm, pid, $skb->len, buf($skb->data, $skb->len));
+	@start_recv[tid] = nsecs;
+}
+
+kretprobe:unix_dgram_recvmsg,
+kretprobe:unix_stream_recvmsg
+{
+	delete(@start_recv, tid);
+}
+
+/* Both unix_{dgram,stream}_recvmsg() call skb_copy_datagram_iter */
+kprobe:skb_copy_datagram_iter
+/ has_key(@start_recv, tid) /
+{
+	@skbs[tid] = (struct sk_buff *)arg0;
+}
+
+kretprobe:skb_copy_datagram_iter
+/ has_key(@skbs, tid) /
+{
+	if (retval == 0) {
+		$skb = @skbs[tid];
+		time("%H:%M:%S ");
+		printf("%-16s %-8d %-8d %r\n", comm, pid, $skb->len,
+			buf($skb->data, $skb->len));
+	}
+	delete(@skbs, tid);
 }
 
 END
 {
+	clear(@start_recv);
+	clear(@skbs);
 }


### PR DESCRIPTION
Supports packet capture for receiving datagram type Unix sockets.

For example, 1-2-3-4-5-6-7-8-9:

    1)  $ sudo ./undump.bt | grep -w nc
        Attached 8 probes
    5)  17:15:53 nc               939271   24       this is a stream packet\x0a
    9)  17:16:12 nc               939284   23       this is a dgram packet\x0a

        # listen on stream socket
    2)  $ nc -lU /var/tmp/unixsocket.tcp
    5)  this is a stream packet

        # listen on dgram socket
    6)  $ nc -luU /var/tmp/unixsocket.udp
    9)  this is a dgram message

    3)  $ nc -U /var/tmp/unixsocket.tcp
    4)  this is a stream packet[enter]
    7)  $ nc -uU /var/tmp/unixsocket.udp
    8)  this is a dgram message[enter]

