### PR TITLE
Fix llvm verification for external func calls

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -4624,6 +4624,7 @@ llvm::Function *CodegenLLVM::createForCallback(
     std::function<llvm::Value *(llvm::Function *)> decl)
 {
   auto saved_ip = b_.saveIP();
+  auto *saved_scope = scope_;
 
   // All callbacks in BPF will be generated with a standard integer return.
   FunctionType *callback_type = FunctionType::get(b_.getInt64Ty(), args, false);
@@ -4638,7 +4639,7 @@ llvm::Function *CodegenLLVM::createForCallback(
   callback->addFnAttr(Attribute::NoUnwind);
 
   // Add the debug information.
-  debug_.createFunctionDebugInfo(*callback, CreateInt64(), debug_args);
+  scope_ = debug_.createFunctionDebugInfo(*callback, CreateInt64(), debug_args);
 
   // Start our basic function block.
   auto *for_body = BasicBlock::Create(module_->getContext(),
@@ -4727,6 +4728,7 @@ llvm::Function *CodegenLLVM::createForCallback(
   variables_[scope_stack_.back()].erase(f.decl->ident);
 
   b_.restoreIP(saved_ip);
+  scope_ = saved_scope;
   return callback;
 }
 

--- a/tests/runtime/for
+++ b/tests/runtime/for
@@ -135,3 +135,11 @@ EXPECT_REGEX .*\n1\n5\n\n
 NAME range with continue
 PROG begin { for ($i : 1..4) { if ($i == 2) { continue; } print($i); }  }
 EXPECT_REGEX .*\n1\n3\n\n
+
+NAME external function call map
+PROG begin { @map[1] = 1; $x = 1; for ($kv : @map) { print(__has_key((void *)&@map, (void *)&$x)); }  }
+EXPECT true
+
+NAME external function call range
+PROG begin { @map[1] = 1; $x = 1; for ($i : 0..1) { print(__has_key((void *)&@map, (void *)&$x)); }  }
+EXPECT true


### PR DESCRIPTION
Stacked PRs:
 * #4849
 * __->__#4848


--- --- ---

### Fix llvm verification for external func calls


When accessing external functions inside a for
loop that utilizes a callback in codegen, we
weren't setting the debug scope correctly,
which needs to be the callback function itself.

Added runtime tests to validate.

Error:
> LLVM verification failed (--verify-llvm-ir)
!dbg attachment points at wrong subprogram for function
!56048 = distinct !DISubprogram(name: "map_for_each_cb", linkageName: "map_for_each_cb", scope: !2, file: !2, type: !56049, flags:
DIFlagPrototyped, spFlags: DISPFlagLocalToUnit | DISPFlagDefinition, unit: !52, retainedNodes: !56051)
ptr @map_for_each_cb
  %__has_key = call i1 @__has_key(ptr @AT_, ptr %"$has_key_$key"), !dbg !56056
!56056 = !DILocation(line: 388, column: 5, scope: !56043)
!56043 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !56044, flags: DIFlagPrototyped,
spFlags: DISPFlagDefinition, unit: !52, retainedNodes: !56046)
!56043 = distinct !DISubprogram(name: "begin_1", linkageName: "begin_1", scope: !2, file: !2, type: !56044, flags: DIFlagPrototyped,
spFlags: DISPFlagDefinition, unit: !52, retainedNodes: !56046)

Signed-off-by: Jordan Rome <linux@jordanrome.com>