### PR TITLE
Add ulong and long int types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@ and this project adheres to
   - [#4715](https://github.com/bpftrace/bpftrace/pull/4715)
 - Add `test` probes as means to improve runtime test latency
   - [#4753](https://github.com/bpftrace/bpftrace/pull/4753)
+- Add `long` and `ulong` int types
+  - [#4849](https://github.com/bpftrace/bpftrace/pull/4849)
 #### Changed
 - `uaddr` support PIE and dynamic library symbols.
   - [#4727](https://github.com/bpftrace/bpftrace/pull/4727)

--- a/docs/language.md
+++ b/docs/language.md
@@ -401,6 +401,8 @@ the type upon declaration.
 | int32 | Signed 32 bit integer |
 | uint64 | Unsigned 64 bit integer |
 | int64 | Signed 64 bit integer |
+| ulong | Unsigned 32 or 64 bit integer (arch dependent) |
+| long | Signed 32 or 64 bit integer (arch dependent) |
 
 ```
 begin { $x = 1<<16; printf("%d %d\n", (uint16)$x, $x); }

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -553,7 +553,7 @@ kprobe:arp_create {
 
 
 ### memcmp
-- `int memcmp(left, right, uint64 count)`
+- `int memcmp(left, right, ulong count)`
 
 Compares the first 'count' bytes of two expressions.
 0 is returned if they are the same.
@@ -1169,9 +1169,9 @@ bpftrace also supports the following format string extensions:
 
 
 ### strlen
-- `int64 strlen(string exp)`
-- `int64 strlen(int8 exp[])`
-- `int64 strlen(int8 *exp)`
+- `uint64 strlen(string exp)`
+- `uint64 strlen(int8 exp[])`
+- `uint64 strlen(int8 *exp)`
 
 Returns the length of a string-like object.
 

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -3308,12 +3308,10 @@ void SemanticAnalyser::reconcile_map_key(Map *map, Expression &key_expr)
 // We can't hint for unsigned types. It is a syntax error,
 // because the word "unsigned" is not allowed in a type name.
 static std::unordered_map<std::string_view, std::string_view>
-    KNOWN_TYPE_ALIASES{
-      { "char", "int8" },   /* { "unsigned char", "uint8" }, */
-      { "short", "int16" }, /* { "unsigned short", "uint16" }, */
-      { "int", "int32" },   /* { "unsigned int", "uint32" }, */
-      { "long", "int64" },  /* { "unsigned long", "uint64" }, */
-    };
+    KNOWN_TYPE_ALIASES{ { "char", "int8" },
+                        { "short", "int16" },
+                        { "int", "int32" },
+                        { "size_t", "ulong" } };
 
 void SemanticAnalyser::visit(Cast &cast)
 {
@@ -3516,7 +3514,7 @@ void SemanticAnalyser::visit(Expression &expr)
         }
         auto *size = ctx_.make_node<Integer>(binop->loc,
                                              updatedTy->GetSize(),
-                                             CreateUInt64());
+                                             CreateULong());
         auto *call = ctx_.make_node<Call>(
             binop->loc,
             "memcmp",

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -48,7 +48,7 @@ path     :(\\.|[_\-\./a-zA-Z0-9#$+\*])+
 /* Most of the builtins are prefixed with __builtin_ as they are exposed to users via macros e.g. macro cpu() { __builtin_cpu } */
 builtin  arg[0-9]+|args|ctx|kstack|nsecs|pid|sarg[0-9]|tid|ustack|__builtin_cgroup|__builtin_comm|__builtin_cpid|__builtin_cpu|__builtin_curtask|__builtin_elapsed|__builtin_func|__builtin_gid|__builtin_jiffies|__builtin_ncpus|__builtin_probe|__builtin_rand|__builtin_retval|__builtin_uid|__builtin_usermode|__builtin_username
 
-int_type        bool|(u)?int(8|16|32|64)
+int_type        bool|(u)?int(8|16|32|64)|(u)?long
 builtin_type    void|(u)?(min|max|sum|avg|stats)_t|count_t|probe_t|username_t|lhist_t|hist_t|usym_t|ksym_t|timestamp|macaddr_t|cgroup_path_t|kstack_t|ustack_t|tseries_t
 sized_type      inet|buffer|string
 subprog         fn

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -343,6 +343,8 @@ int_type:
                         {"int16", CreateInt(16)},
                         {"int32", CreateInt(32)},
                         {"int64", CreateInt(64)},
+                        {"long", CreateLong()},
+                        {"ulong", CreateULong()},
                     };
                     $$ = type_map[$1];
                 }

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -537,7 +537,7 @@ macro len(e) {
 //  */
 // ```
 
-// :variant int memcmp(left, right, uint64 count)
+// :variant int memcmp(left, right, ulong count)
 // Compares the first 'count' bytes of two expressions.
 // 0 is returned if they are the same.
 // negative value if the first differing byte in left is less

--- a/src/stdlib/strings.bt
+++ b/src/stdlib/strings.bt
@@ -34,9 +34,9 @@ macro default_str_length() {
 }
 
 // Returns the length of a string-like object.
-// :variant int64 strlen(string exp)
-// :variant int64 strlen(int8 exp[])
-// :variant int64 strlen(int8 *exp)
+// :variant uint64 strlen(string exp)
+// :variant uint64 strlen(int8 exp[])
+// :variant uint64 strlen(int8 *exp)
 macro strlen($var) {
   assert_str($var);
   let $sz = (int64)0;
@@ -62,7 +62,7 @@ macro strlen(exp) {
 }
 
 macro __strnlen(ptr, max_size) {
-  __bpf_strnlen(ptr, (int64)max_size)
+  __bpf_strnlen(ptr, (ulong)max_size)
 }
 
 // Returns the "capacity" of a string-like object.

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -308,6 +308,23 @@ SizedType CreateUInt64()
   return CreateUInt(64);
 }
 
+SizedType CreateLong()
+{
+  if (sizeof(long) == 4) {
+    return CreateInt32();
+  } else {
+    return CreateInt64();
+  }
+}
+SizedType CreateULong()
+{
+  if (sizeof(long) == 4) {
+    return CreateUInt32();
+  } else {
+    return CreateUInt64();
+  }
+}
+
 SizedType CreateEnum(size_t bits, const std::string &name)
 {
   auto ty = CreateUInt(bits);

--- a/src/types.h
+++ b/src/types.h
@@ -530,6 +530,9 @@ SizedType CreateUInt8();
 SizedType CreateUInt16();
 SizedType CreateUInt32();
 SizedType CreateUInt64();
+// The size of these are based on the architecture
+SizedType CreateLong();
+SizedType CreateULong();
 SizedType CreateEnum(size_t bits, const std::string &name);
 
 // Create a string of `size` bytes, inclusive of NUL terminator.

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -825,3 +825,7 @@ AFTER ./testprogs/syscall nanosleep  1e8
 NAME block expression with map assignment
 PROG begin { @ = { let $a = 100; avg($a) };  }
 EXPECT @: 100
+
+NAME strlen
+PROG begin { $a = "hello"; print(strlen($a)); }
+EXPECT 5

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2587,14 +2587,14 @@ begin { (int)cpu }
         ~~~~~
 HINT: Did you mean "int32"?
 )" });
-  test("begin { (long)cpu }", Error{ R"(
-stdin:1:10-14: ERROR: Cannot resolve unknown type "long"
-begin { (long)cpu }
-         ~~~~
-stdin:1:9-15: ERROR: Cannot cast to "long"
-begin { (long)cpu }
-        ~~~~~~
-HINT: Did you mean "int64"?
+  test("begin { (size_t)cpu }", Error{ R"(
+stdin:1:10-16: ERROR: Cannot resolve unknown type "size_t"
+begin { (size_t)cpu }
+         ~~~~~~
+stdin:1:9-17: ERROR: Cannot cast to "size_t"
+begin { (size_t)cpu }
+        ~~~~~~~~
+HINT: Did you mean "ulong"?
 )" });
 }
 


### PR DESCRIPTION
Stacked PRs:
 * __->__#4849


--- --- ---

### Add ulong and long int types


These are needed to fix the interop with
C types that we can't cast to:
- size_t
- long
- unsigned long (doesn't even parse)

This also fixes strlen and makes sure
calls to stdlib bpf.c functions that are
expecting size_t get an ulong type

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>