### PR TITLE
Fix probe return values

### DIFF
--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -403,3 +403,7 @@ NAME discard expression
 PROG begin { _ = { print(1); 1 } }
 EXPECT 1
 EXPECT_REGEX_NONE .*WARNING: Return value discarded..*
+
+NAME probe return
+PROG begin { $a = 1; print($a); return $a; }
+EXPECT 1


### PR DESCRIPTION
Check to make sure these are always ints
and make them 64bits because it's easier up-cast
in semantic analyser than attempt to reconcile
the different possible return integer sizes
when creating the debug info in codegen.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
