### PR TITLE
Add support for casting to common C int types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ and this project adheres to
   - [#4753](https://github.com/bpftrace/bpftrace/pull/4753)
 - Multiple `begin` & `end` probes are now permitted
   - [#4789](https://github.com/bpftrace/bpftrace/pull/4789)
+- Add support for casting to common c integer types
+  - [#4852](https://github.com/bpftrace/bpftrace/pull/4852)
 #### Changed
 - `uaddr` support PIE and dynamic library symbols.
   - [#4727](https://github.com/bpftrace/bpftrace/pull/4727)

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -1169,9 +1169,9 @@ bpftrace also supports the following format string extensions:
 
 
 ### strlen
-- `int64 strlen(string exp)`
-- `int64 strlen(int8 exp[])`
-- `int64 strlen(int8 *exp)`
+- `uint64 strlen(string exp)`
+- `uint64 strlen(int8 exp[])`
+- `uint64 strlen(int8 *exp)`
 
 Returns the length of a string-like object.
 

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -3,6 +3,7 @@
 
 #include "ast/ast.h"
 #include "ast/context.h"
+#include "ast/integer_types.h"
 #include "ast/tracepoint_helpers.h"
 #include "attached_probe.h"
 #include "log.h"
@@ -387,7 +388,8 @@ void Program::clear_empty_probes()
 
 SizedType ident_to_record(const std::string &ident, int pointer_level)
 {
-  SizedType result = CreateRecord(ident);
+  auto c_res = sized_type_from_c_type(ident);
+  SizedType result = c_res ? *c_res : CreateRecord(ident);
   for (int i = 0; i < pointer_level; i++)
     result = CreatePointer(result);
   return result;

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -765,7 +765,16 @@ public:
   explicit Typeof(ASTContext &ctx, Location &&loc, SizedType record)
       : Node(ctx, std::move(loc)), record(record) {};
   explicit Typeof(ASTContext &ctx, Location &&loc, Expression expr)
-      : Node(ctx, std::move(loc)), record(expr) {};
+      : Node(ctx, std::move(loc)) {
+        if (auto *ident = expr.as<Identifier>()) {
+          auto res = sized_type_from_c_type(ident->ident);
+          if (res) {
+            record = *res;
+            return;
+          }
+        }
+        record = expr;
+      };
   explicit Typeof(ASTContext &ctx, const Location &loc, const Typeof &other)
       : Node(ctx, loc + other.loc),
         record(clone(ctx, loc + other.loc, other.record)) {};

--- a/src/ast/integer_types.cpp
+++ b/src/ast/integer_types.cpp
@@ -52,4 +52,29 @@ SizedType get_signed_integer_type(int64_t n)
   }
 }
 
+static std::map<std::string, SizedType> C_INT_TYPES = {
+  { "char", CreateInt8() },       { "int8_t", CreateInt8() },
+  { "uint8_t", CreateUInt8() },   { "short", CreateInt16() },
+  { "int16_t", CreateInt16() },   { "uint16_t", CreateUInt16() },
+  { "int", CreateInt32() },       { "int32_t", CreateInt32() },
+  { "uint32_t", CreateUInt32() }, { "int64_t", CreateInt64() },
+  { "uint64_t", CreateUInt64() },
+};
+
+std::optional<SizedType> sized_type_from_c_type(const std::string& ident)
+{
+  if (ident == "size_t" || ident == "uintptr_t") {
+    return sizeof(long) == 4 ? CreateUInt32() : CreateUInt64();
+  } else if (ident == "long" || ident == "intptr_t") {
+    return sizeof(long) == 4 ? CreateInt32() : CreateInt64();
+  } else {
+    auto found = C_INT_TYPES.find(ident);
+    if (found != C_INT_TYPES.end()) {
+      return found->second;
+    }
+  }
+
+  return std::nullopt;
+}
+
 } // namespace bpftrace::ast

--- a/src/ast/integer_types.h
+++ b/src/ast/integer_types.h
@@ -9,5 +9,6 @@ namespace bpftrace::ast {
 SizedType get_integer_type(uint64_t n);
 std::optional<SizedType> get_signed_integer_type(uint64_t n);
 SizedType get_signed_integer_type(int64_t n);
+std::optional<SizedType> sized_type_from_c_type(const std::string& ident);
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -3278,16 +3278,6 @@ void SemanticAnalyser::reconcile_map_key(Map *map, Expression &key_expr)
   }
 }
 
-// We can't hint for unsigned types. It is a syntax error,
-// because the word "unsigned" is not allowed in a type name.
-static std::unordered_map<std::string_view, std::string_view>
-    KNOWN_TYPE_ALIASES{
-      { "char", "int8" },   /* { "unsigned char", "uint8" }, */
-      { "short", "int16" }, /* { "unsigned short", "uint16" }, */
-      { "int", "int32" },   /* { "unsigned int", "uint32" }, */
-      { "long", "int64" },  /* { "unsigned long", "uint64" }, */
-    };
-
 void SemanticAnalyser::visit(Cast &cast)
 {
   visit(cast.expr);
@@ -3334,12 +3324,6 @@ void SemanticAnalyser::visit(Cast &cast)
       !(ty.IsArrayTy() && ty.GetElementTy()->IsIntTy())) {
     auto &err = cast.addError();
     err << "Cannot cast to \"" << ty << "\"";
-    if (ty.IsRecordTy() || ty.IsEnumTy()) {
-      if (auto it = KNOWN_TYPE_ALIASES.find(ty.GetName());
-          it != KNOWN_TYPE_ALIASES.end()) {
-        err.addHint() << "Did you mean \"" << it->second << "\"?";
-      }
-    }
   }
 
   if (ty.IsArrayTy()) {

--- a/src/stdlib/strings.bt
+++ b/src/stdlib/strings.bt
@@ -14,17 +14,14 @@
 
 // Checks that this value is string-like.
 macro assert_str(exp) {
-  if comptime is_str(exp) {
-    true
-  } else if comptime is_array(exp) {
-    static_assert(typeinfo(exp[0]) == typeinfo(int8), "string-like arrays must contain a char-like type");
-    true
-  } else if comptime is_ptr(exp) {
-    static_assert(typeinfo(exp[0]) == typeinfo(int8), "string-like pointers must point to a char-like type");
-    true
-  } else {
-    static_assert(false, "string-like values must be either strings, arrays or pointers");
-    false
+  if comptime !is_str(exp) {
+    if comptime is_array(exp) {
+      static_assert(typeinfo(exp[0]) == typeinfo(int8), "string-like arrays must contain a char-like type");
+    } else if comptime is_ptr(exp) {
+      static_assert(typeinfo(exp[0]) == typeinfo(int8), "string-like pointers must point to a char-like type");
+    } else {
+      fail("string-like values must be either strings, arrays or pointers");
+    }
   }
 }
 
@@ -34,9 +31,9 @@ macro default_str_length() {
 }
 
 // Returns the length of a string-like object.
-// :variant int64 strlen(string exp)
-// :variant int64 strlen(int8 exp[])
-// :variant int64 strlen(int8 *exp)
+// :variant uint64 strlen(string exp)
+// :variant uint64 strlen(int8 exp[])
+// :variant uint64 strlen(int8 *exp)
 macro strlen($var) {
   assert_str($var);
   let $sz = (int64)0;
@@ -62,7 +59,7 @@ macro strlen(exp) {
 }
 
 macro __strnlen(ptr, max_size) {
-  __bpf_strnlen(ptr, (int64)max_size)
+  __bpf_strnlen(ptr, (size_t)max_size)
 }
 
 // Returns the "capacity" of a string-like object.

--- a/tests/runtime/stdlib
+++ b/tests/runtime/stdlib
@@ -38,3 +38,7 @@ NAME bad delete
 PROG begin { @a[1] = 1; $x = delete(@a, 2); $y = delete(@a, 1); if ($x == false && $y == true) { printf("SUCCESS"); } }
 EXPECT SUCCESS
 TIMEOUT 1
+
+NAME strlen
+PROG begin { $a = "hello"; print(strlen($a)); }
+EXPECT 5

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2568,43 +2568,15 @@ begin { (faketype)cpu }
 
 TEST_F(SemanticAnalyserTest, cast_c_integers)
 {
-  // Casting to a C integer type gives a hint with the correct name
-  test("begin { (char)cpu }", Error{ R"(
-stdin:1:10-14: ERROR: Cannot resolve unknown type "char"
-begin { (char)cpu }
-         ~~~~
-stdin:1:9-15: ERROR: Cannot cast to "char"
-begin { (char)cpu }
-        ~~~~~~
-HINT: Did you mean "int8"?
-)" });
-  test("begin { (short)cpu }", Error{ R"(
-stdin:1:10-15: ERROR: Cannot resolve unknown type "short"
-begin { (short)cpu }
-         ~~~~~
-stdin:1:9-16: ERROR: Cannot cast to "short"
-begin { (short)cpu }
-        ~~~~~~~
-HINT: Did you mean "int16"?
-)" });
-  test("begin { (int)cpu }", Error{ R"(
-stdin:1:10-13: ERROR: Cannot resolve unknown type "int"
-begin { (int)cpu }
-         ~~~
-stdin:1:9-14: ERROR: Cannot cast to "int"
-begin { (int)cpu }
-        ~~~~~
-HINT: Did you mean "int32"?
-)" });
-  test("begin { (long)cpu }", Error{ R"(
-stdin:1:10-14: ERROR: Cannot resolve unknown type "long"
-begin { (long)cpu }
-         ~~~~
-stdin:1:9-15: ERROR: Cannot cast to "long"
-begin { (long)cpu }
-        ~~~~~~
-HINT: Did you mean "int64"?
-)" });
+  std::vector<std::string> c_int_types = { "char",     "short",    "int",
+                                           "long",     "size_t",   "uintptr_t",
+                                           "intptr_t", "int8_t",   "uint8_t",
+                                           "int16_t",  "uint16_t", "int32_t",
+                                           "uint32_t", "int64_t",  "uint64_t" };
+
+  for (const auto &c_type : c_int_types) {
+    test("begin { (" + c_type + ")cpu }");
+  }
 }
 
 TEST_F(SemanticAnalyserTest, cast_struct)


### PR DESCRIPTION
Stacked PRs:
 * __->__#4852


--- --- ---

### Add support for casting to common C int types


Namely: char, short, long, int, size_t,
intX_t, uintX_t, intptr_t, uintptr_t

Also driveby fixes:
- fix strlen macro which was passing
the wrong type to __bpf_strnlen
- fix warning in assert_str

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>