### PR TITLE
flake: ensure submodules are included with nix build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -1,4 +1,6 @@
 {
+  inputs.self.submodules = true;
+
   description = "High-level tracing language for Linux";
 
   inputs = {


### PR DESCRIPTION
Building bpftrace with the documented workflow fails:

    # git clone https://github.com/bpftrace/bpftrace
    # cd bpftrace; git submodule update --init
    # nix build
    -- Found LibBpf: /build/source/build/libbpf/include
    CMake Error at cmake/FindLibBpf.cmake:88 (message):
      Failed to build libbpf, the submodule does not seem to be checked out
    Call Stack (most recent call first):
      CMakeLists.txt:103 (find_package)

This occurs because 'nix build' does not operate on the working
directory.  Instead, Nix flakes reconstruct a source tree from Git
metadata.  Submodules are omitted unless explicitly enabled.  As a
result, libbpf is missing from the build input even though it exists in
the checkout and is available in 'nix develop'.

By enabling 'inputs.self.submodules = true' (from NixOS/nix#12421), 
the flake forwards the Git tree with submodules. This restores 
the expected behavior and allows 'nix build' to succeed without requiring 
the '.?submodules=1#' flag.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests