### PR TITLE
docs: explain nix build submodule requirement

### DIFF
--- a/docs/nix.md
+++ b/docs/nix.md
@@ -30,8 +30,12 @@ $ echo "experimental-features = nix-command flakes" >> ~/.config/nix/nix.conf
 
 ### Build bpftrace
 
+When invoking `nix build`, flakes reconstruct the source tree from Git metadata
+but skip submodules, so append `.?submodules=1` (as below) to ensure libbpf is
+present.
+
 ```
-$ nix build
+$ nix build .?submodules=1#
 $ sudo ./result/bin/bpftrace -e 'BEGIN { print("hello world!") }'
 Attached 1 probe
 hello world!
@@ -41,7 +45,7 @@ hello world!
 ### Build bpftrace with a different LLVM version
 
 ```
-$ nix build .#bpftrace-llvm13
+$ nix build .?submodules=1#bpftrace-llvm13
 $ sudo ./result/bin/bpftrace --info 2>&1 | grep LLVM
   LLVM: 13.0.1
 ```
@@ -49,7 +53,7 @@ $ sudo ./result/bin/bpftrace --info 2>&1 | grep LLVM
 ### Build bpftrace as a statically linked binary
 
 ```
-$ nix build .#appimage
+$ nix build .?submodules=1#appimage
 $ ldd ./result
         not a dynamic executable
 $ sudo ./result -e 'BEGIN { print("static!"); exit() }'


### PR DESCRIPTION
Building bpftrace with the documented workflow fails:

    # git clone https://github.com/bpftrace/bpftrace
    # cd bpftrace; git submodule update --init
    # nix build
    -- Found LibBpf: /build/source/build/libbpf/include
    CMake Error at cmake/FindLibBpf.cmake:88 (message):
      Failed to build libbpf, the submodule does not seem to be checked out
    Call Stack (most recent call first):
      CMakeLists.txt:103 (find_package)

This occurs because 'nix build' does not operate on the working
directory.  Instead, Nix flakes reconstruct a source tree from Git
metadata.  Submodules are omitted unless explicitly enabled.  As a
result, libbpf is missing from the build input even though it exists in
the checkout and is available in 'nix develop'.

This commit update docs/nix.md to explain '.?submodules=1' argument in
the build examples, reducing confusion for anyone following the
documented workflow.

Related: #4854

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests