### PR TITLE
AttachPointParser: Fix uprobe language component handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,8 @@ and this project adheres to
 - Drop support for LLVM 16
   - [#4534](https://github.com/bpftrace/bpftrace/pull/4534)
 #### Fixed
+- Fix language part being overwritten in uprobe attachpoint parser
+  - [#4856](https://github.com/bpftrace/bpftrace/pull/4856)
 - output: prevent crash when printing overflow-only lhist
   - [#4801](https://github.com/bpftrace/bpftrace/pull/4801)
 - join(): Fix wrong index of GEP that was causing truncation

--- a/src/ast/passes/attachpoint_passes.cpp
+++ b/src/ast/passes/attachpoint_passes.cpp
@@ -695,8 +695,7 @@ AttachPointParser::State AttachPointParser::uprobe_parser(bool allow_offset,
       (parts_.size() == 2 ||
        (parts_.size() == 3 && is_supported_lang(parts_[1])))) {
     // For PID, the target may be skipped
-    if (parts_.size() == 2)
-      parts_.insert(parts_.begin() + 1, "");
+    parts_.insert(parts_.begin() + 1, "");
 
     auto target = util::get_pid_exe(*pid);
     parts_[1] = target ? util::path_for_pid_mountns(*pid, *target) : "";


### PR DESCRIPTION
Removed a condition that prevented inserting an empty string into the parts_ vector when PID and language were specified.

Previously, this caused the language part to be overwritten, thus losing the language information later. This could lead to failures in attaching probes correctly, for example, by breaking C++ demangling.

```
$ sudo ./bpftrace --pid '105772' -e 'uprobe:cpp:compute {
print("hello"); }'
ERROR: Could not resolve symbol: /proc/105772/root/home/user/foo:compute
ERROR: Unable to attach probe:
uprobe:/proc/105772/root/home/user/foo:compute. If this is expected, set
the 'missing_probes' config variable to 'warn'.
```

Tested both with and without language specification within the attachpoint string.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
