### PR TITLE
kfunc: Check whether the BPF program type is supported

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,8 @@ and this project adheres to
 - Add support for more vmlinux BTF types as identifiers
   - [#4853](https://github.com/bpftrace/bpftrace/pull/4853)
 #### Changed
+- Add helpers to check if a kfunc exists and is supported for particular probe types.
+  - [#4857](https://github.com/bpftrace/bpftrace/pull/4857)
 - `uaddr` support PIE and dynamic library symbols.
   - [#4727](https://github.com/bpftrace/bpftrace/pull/4727)
 - Apply `-B` buffering semantics to file outputs.

--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -432,6 +432,18 @@ interval:s:1 {
 You can find all kernel symbols at `/proc/kallsyms`.
 
 
+### kfunc_allowed
+- `boolean kfunc_allowed(const string kfunc)`
+
+Determine if a kfunc is supported for particular probe types.
+
+
+### kfunc_exist
+- `boolean kfunc_exist(const string kfunc)`
+
+Determine if a kfunc exists using BTF.
+
+
 ### kptr
 - `T * kptr(T * ptr)`
 

--- a/src/bpf_assembler.h
+++ b/src/bpf_assembler.h
@@ -145,6 +145,16 @@
 		.off   = OFF,					\
 		.imm   = IMM })
 
+/* Kfunc call */
+
+#define BPF_CALL_KFUNC(OFF, IMM)				\
+	((struct bpf_insn) {					\
+		.code  = BPF_JMP | BPF_CALL,			\
+		.dst_reg = 0,					\
+		.src_reg = BPF_PSEUDO_KFUNC_CALL,		\
+		.off   = OFF,					\
+		.imm   = IMM })
+
 /* Raw code statement block */
 
 #define BPF_RAW_INSN(CODE, DST, SRC, OFF, IMM)			\

--- a/src/bpffeature.h
+++ b/src/bpffeature.h
@@ -72,6 +72,9 @@ public:
   DEFINE_HELPER_TEST(map_lookup_percpu_elem, BPF_PROG_TYPE_KPROBE);
   DEFINE_HELPER_TEST(loop, BPF_PROG_TYPE_KPROBE); // Added in 5.17.
 
+  bool has_kfunc(std::string kfunc);
+  bool kfunc_allowed(const char* kfunc, enum bpf_prog_type prog_type);
+
 protected:
   std::optional<bool> has_d_path_;
   std::optional<int> insns_limit_;

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -145,17 +145,20 @@ macro comm($pid) {
     }
 
     let $name : string[64];
-    let $ret = (int32)__bpf_task_comm_from_pid((int32)$pid, &$name);
-    // EOPNOTSUPP: Operation not supported
-    if ($ret == (int32)-95) {
-      warnf("'bpf_task_from_pid kfunc', which is used for getting the process comm, is not supported on your system.");
-      $name = "[unknown]";
-    // ESRCH: No such process
-    } else if ($ret == (int32)-3) {
-      warnf("No such process (pid=%d)", $pid);
-      $name = "N/A";
+    if comptime kfunc_allowed("bpf_task_from_pid") {
+      let $ret = (int32)__bpf_task_comm_from_pid((int32)$pid, &$name);
+      // EOPNOTSUPP: Operation not supported
+      if ($ret == (int32)-95) {
+        warnf("'bpf_task_from_pid kfunc', which is used for getting the process comm, is not supported on your system.");
+        $name = "[unknown]";
+      // ESRCH: No such process
+      } else if ($ret == (int32)-3) {
+        warnf("No such process (pid=%d)", $pid);
+        $name = "N/A";
+      }
+    } else {
+      fail("Syntax comm(PID) is not supported in this probe type yet. Type: %s", probetype);
     }
-
     $name
 }
 

--- a/src/stdlib/kfunc.bt
+++ b/src/stdlib/kfunc.bt
@@ -1,0 +1,11 @@
+// :variant boolean kfunc_exist(const string kfunc)
+// Determine if a kfunc exists using BTF.
+macro kfunc_exist(kfunc) {
+  __builtin_kfunc_exist(kfunc)
+}
+
+// :variant boolean kfunc_allowed(const string kfunc)
+// Determine if a kfunc is supported for particular probe types.
+macro kfunc_allowed(kfunc) {
+  __builtin_kfunc_allowed(kfunc)
+}


### PR DESCRIPTION
A large number of kfuncs have been introduced into the kernel, and these kfuncs have different support for BPF program types across different kernel versions. This commit adds a built-in function __builtin_kfunc_avail(), which is used to determine at compile time whether a certain kfunc is supported in the current program type.

For example, kfunc bpf_task_from_pid() was introduced in linux v6.1, its support for tracepoint is in v6.12 [1]. We support comm(pid) in [2], but there is a problem: when calling comm(pid) in kprobe, the verifier will complain.

    tracepoint:syscalls:sys_enter_kill,
    tracepoint:syscalls:sys_enter_tkill,
    tracepoint:syscalls:sys_enter_tgkill,
    kprobe:__x64_sys_kill,
    kprobe:__x64_sys_tgkill,
    kprobe:__x64_sys_tkill
    {
      printf("kprobe %s\n", comm(pid));
    }

    ;  @ task.bpf.c:13
    28: (bf) r1 = r0
    29: (85) call bpf_task_from_pid#89392
    calling kernel function bpf_task_from_pid is not allowed

Therefore, we can optimize the script as follows:

    {
      if comptime  __builtin_kfunc_avail("bpf_task_from_pid") {
        printf("comm %s from %s\n", comm(pid), probe);
      } else {
        warnf("not support comm(pid) in %s\n", probe);
      }
    }

[1] https://docs.ebpf.io/linux/kfuncs/bpf_task_from_pid/
[2] commit 57dec2a8480a ("stdlib: comm(): support PID argument (#4799)")
