### PR TITLE
Fix constexpr on clang builds

### DIFF
--- a/src/util/elf_parser.cpp
+++ b/src/util/elf_parser.cpp
@@ -236,7 +236,7 @@ Result<std::vector<usdt_probe_entry>> USDTProbeEnumerator::enumerate_probes()
 
   if (notes_shdr.sh_type != SHT_NOTE || !gelf_getehdr(elf, &ehdr)) {
     return make_error<ELFParseError>("invalid USDT notes section (" +
-                                     USDT_NOTE_SEC + ") in '" +
+                                     std::string(USDT_NOTE_SEC) + ") in '" +
                                      std::string(elf_path) + "'");
   }
 

--- a/src/util/elf_parser.h
+++ b/src/util/elf_parser.h
@@ -14,8 +14,8 @@
 namespace bpftrace::util {
 
 constexpr short USDT_NOTE_TYPE = 3;
-constexpr std::string USDT_NOTE_SEC = ".note.stapsdt";
-constexpr std::string USDT_NOTE_NAME = "stapsdt";
+constexpr std::string_view USDT_NOTE_SEC = ".note.stapsdt";
+constexpr std::string_view USDT_NOTE_NAME = "stapsdt";
 
 class ELFParseError : public ErrorInfo<ELFParseError> {
 public:


### PR DESCRIPTION
constexpr should be std::string_view instead
of std::string

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
