### PR TITLE
builtin: Remove additional AST errors 

### DIFF
--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -449,11 +449,15 @@ You can find all kernel symbols at `/proc/kallsyms`.
 
 Determine if a kfunc is supported for particular probe types.
 
+Argument kfunc must be string literal.
+
 
 ### kfunc_exist
 - `boolean kfunc_exist(const string kfunc)`
 
 Determine if a kfunc exists using BTF.
+
+Argument kfunc must be string literal.
 
 
 ### kptr

--- a/src/stdlib/kfunc.bt
+++ b/src/stdlib/kfunc.bt
@@ -1,13 +1,27 @@
 // :variant boolean kfunc_exist(const string kfunc)
 // Determine if a kfunc exists using BTF.
+//
+// Argument kfunc must be string literal.
 macro kfunc_exist(kfunc)
 {
-  __builtin_kfunc_exist(kfunc)
+  if comptime ((is_literal(kfunc)) && (is_str(kfunc))) {
+    __builtin_kfunc_exist(kfunc)
+  } else {
+    fail("kfunc_exist() accepts a string literal only");
+    false
+  }
 }
 
 // :variant boolean kfunc_allowed(const string kfunc)
 // Determine if a kfunc is supported for particular probe types.
+//
+// Argument kfunc must be string literal.
 macro kfunc_allowed(kfunc)
 {
-  __builtin_kfunc_allowed(kfunc)
+  if comptime ((is_literal(kfunc)) && (is_str(kfunc))) {
+    __builtin_kfunc_allowed(kfunc)
+  } else {
+    fail("kfunc_allowed() accepts a string literal only");
+    false
+  }
 }


### PR DESCRIPTION
Fixed the built-in __builtin_signal_num() parameter parsing error that caused __builtin_signal_num() to be undefined, for example:

    begin {
      let $sig = "SIGINT";
      printf("%d\n", __builtin_signal_num($sig));
    }

    signal.bt:5:18-44: ERROR: Unknown function: '__builtin_signal_num'
      printf("%d\n", __builtin_signal_num($sig));
                     ~~~~~~~~~~~~~~~~~~~~~~~~~~
