### PR TITLE
Add 'is_literal' to the standard library

### DIFF
--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -375,6 +375,12 @@ Determine whether the given expression is an array.
 Determine whether the given expression is an integer.
 
 
+### is_literal
+- `bool is_literal(Expression expr)`
+
+Returns true if the passed expression is a literal, e.g. 1, true, "hello"
+
+
 ### is_ptr
 - `bool is_ptr(any expression)`
 

--- a/src/ast/passes/builtins.cpp
+++ b/src/ast/passes/builtins.cpp
@@ -131,6 +131,13 @@ std::optional<Expression> Builtins::visit(Call &call)
           kfunc->loc,
           bpftrace_.feature_->kfunc_allowed(kfunc->value.c_str(), prog_type));
     }
+  } else if (call.func == "__builtin_is_literal") {
+    if (call.vargs.size() != 1) {
+      call.addError() << call.func << " expects 1 argument";
+    } else {
+      return ast_.make_node<Boolean>(call.vargs.at(0).loc(),
+                                     call.vargs.at(0).is_literal());
+    }
   }
   return std::nullopt;
 }

--- a/src/ast/passes/parser.h
+++ b/src/ast/passes/parser.h
@@ -11,6 +11,7 @@
 #include "ast/passes/control_flow_analyser.h"
 #include "ast/passes/deprecated.h"
 #include "ast/passes/field_analyser.h"
+#include "ast/passes/fold_literals.h"
 #include "ast/passes/import_scripts.h"
 #include "ast/passes/macro_expansion.h"
 #include "ast/passes/map_sugar.h"
@@ -54,6 +55,7 @@ inline std::vector<Pass> AllParsePasses(
   passes.emplace_back(CreateArgsResolverPass());
   passes.emplace_back(CreateFieldAnalyserPass());
   passes.emplace_back(CreateClangParsePass(std::move(extra_flags)));
+  passes.emplace_back(CreateFoldLiteralsPass());
   passes.emplace_back(CreateBuiltinsPass());
   passes.emplace_back(CreateCMacroExpansionPass());
   passes.emplace_back(CreateMapSugarPass());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -22,7 +22,6 @@
 #include "ast/passes/clang_parser.h"
 #include "ast/passes/codegen_llvm.h"
 #include "ast/passes/control_flow_analyser.h"
-#include "ast/passes/fold_literals.h"
 #include "ast/passes/macro_expansion.h"
 #include "ast/passes/map_sugar.h"
 #include "ast/passes/named_param.h"
@@ -341,7 +340,6 @@ struct Args {
 
 void CreateDynamicPasses(std::function<void(ast::Pass&& pass)> add)
 {
-  add(ast::CreateFoldLiteralsPass());
   add(ast::CreateClangBuildPass());
   add(ast::CreateTypeSystemPass());
   add(ast::CreateSemanticPass());
@@ -352,7 +350,6 @@ void CreateDynamicPasses(std::function<void(ast::Pass&& pass)> add)
 void CreateAotPasses(std::function<void(ast::Pass&& pass)> add)
 {
   add(ast::CreatePortabilityPass());
-  add(ast::CreateFoldLiteralsPass());
   add(ast::CreateClangBuildPass());
   add(ast::CreateTypeSystemPass());
   add(ast::CreateSemanticPass());

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -1001,13 +1001,6 @@ macro retval() {
 // $ ls
 // Trace/breakpoint trap (core dumped)
 // ```
-macro signal($var) {
-  if comptime (is_str($var)) {
-    fail("this first argument to signal() must be a string literal or a positive integer");
-  }
-  __signal($var, false);
-}
-
 macro signal(expr) {
   __signal(expr, false);
 }
@@ -1024,13 +1017,6 @@ macro signal(expr) {
 // Send a signal to the thread being traced.
 // Use `signal` to send to the process being traced (any thread).
 // The signal can either be identified by name, e.g. `SIGSTOP` or by ID, e.g. `19` as found in `kill -l`.
-macro signal_thread($var) {
-  if comptime (is_str($var)) {
-    fail("this first argument to signal_thread() must be a string literal or a positive integer");
-  }
-  __signal($var, true);
-}
-
 macro signal_thread(expr) {
   __signal(expr, true);
 }

--- a/src/stdlib/meta.bt
+++ b/src/stdlib/meta.bt
@@ -45,3 +45,9 @@ macro check_key(@map, key, func) {
     }
   }
 }
+
+// :variant bool is_literal(Expression expr)
+// Returns true if the passed expression is a literal, e.g. 1, true, "hello"
+macro is_literal(expr) {
+  __builtin_is_literal(expr)
+}

--- a/src/stdlib/process.bt
+++ b/src/stdlib/process.bt
@@ -19,7 +19,7 @@ macro __signal(expr, is_tid) {
   if comptime (__builtin_safe_mode) {
     fail("%s is unsafe. To use you need the --unsafe flag",
       is_tid ? "signal_thread()" : "signal()");
-  } else if comptime (is_str(expr)) {
+  } else if comptime ((is_str(expr) && is_literal(expr))) {
     $sig = __builtin_signal_num(expr);
   } else if comptime (typeinfo(expr).1 != typeinfo(0).1) {
     fail("%s accepts a string literal or a positive integer",

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -170,9 +170,9 @@ public:
                   .add(ast::CreateArgsResolverPass())
                   .add(ast::CreateFieldAnalyserPass())
                   .add(ast::CreateClangParsePass())
+                  .add(ast::CreateFoldLiteralsPass())
                   .add(ast::CreateBuiltinsPass())
                   .add(ast::CreateCMacroExpansionPass())
-                  .add(ast::CreateFoldLiteralsPass())
                   .add(ast::CreateMapSugarPass())
                   .add(ast::CreateNamedParamsPass())
                   .add(ast::CreateSemanticPass())
@@ -3473,6 +3473,9 @@ TEST_F(SemanticAnalyserTest, signal)
     test("k:f {" + signal + "(\"SIGKILL\"); }",
          UnsafeMode::Enable,
          Types{ types });
+    test("k:f {" + signal + "({ \"SIGKILL\" }); }",
+         UnsafeMode::Enable,
+         Types{ types });
 
     // Not allowed for:
     test("hardware:pcm:1000 {" + signal + "(1); }",
@@ -3514,6 +3517,14 @@ TEST_F(SemanticAnalyserTest, signal)
          Types{ types },
          Error{});
     test("k:f {" + signal + "(\"ABC\"); }",
+         UnsafeMode::Enable,
+         Types{ types },
+         Error{});
+    test("k:f { $a = \"SIGKILL\"" + signal + "($a); }",
+         UnsafeMode::Enable,
+         Types{ types },
+         Error{});
+    test("k:f { $a = \"SIGKILL\"" + signal + "({ $a }); }",
          UnsafeMode::Enable,
          Types{ types },
          Error{});


### PR DESCRIPTION
This is so we can move literal detection
into stdlib functions.

Currently we use macro argument handling
as a way to detect literals but this has
and issue with block expressions that
have a single final expression e.g.
```
$a = "hello";
signal({ $a });
```
This is not caught by this signal macro
because macro expansion happens much
earlier.
```
macro signal($var) {
  if comptime (is_str($var)) {
    fail("this first argument to signal() must be a string literal or a positive integer");
  }
  __signal($var, false);
}
```
It's also a little more explicit if
we utilize this helper rather than this
macro method.

##### Checklist

- [x] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
