### PR TITLE
uprobe: Add support for attaching probes to source file statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to
 
 #### Breaking Changes
 #### Added
+- Add `uprobe` support for source location attach points.
+  - [#4867](https://github.com/bpftrace/bpftrace/pull/4867)
 - Add printf specifier `%gr` to print GFP flags in human readable format
   - [#4832](https://github.com/bpftrace/bpftrace/issues/4832)
 #### Changed

--- a/docs/language.md
+++ b/docs/language.md
@@ -1457,6 +1457,7 @@ After the "common" members listed first, the members are specific to the tracepo
 * `uprobe:binary:func`
 * `uprobe:binary:func+offset`
 * `uprobe:binary:offset`
+* `uprobe:binary@file:line[:col]`
 * `uretprobe:binary:func`
 
 **short names**
@@ -1500,6 +1501,14 @@ If the traced binary has DWARF included, function arguments are available in the
 uprobe:/bin/bash:rl_set_prompt
     const char* prompt
 ```
+
+Using DWARF source code location info, bpftrace can also attach uprobes directly to source file statements, similar to setting a breakpoint at a `file:line[:col]` location in a debugger. This avoids manually locating instruction offsets in the ELF when probes are needed inside a function body.
+
+```
+uprobe:/bin/bash@readline.c:362 { ... }
+```
+
+`file` path may be absolute or relative, and `line:col` must refer to a valid statement in that file. Only statements originating from the specified file are considered; statements from included files are ignored.
 
 When tracing C++ programs, it’s possible to turn on automatic symbol demangling by using the `:cpp` prefix:
 

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -189,6 +189,9 @@ AttachPoint *AttachPoint::create_expansion_copy(ASTContext &ctx,
   ap->mode = mode;
   ap->address = address;
   ap->func_offset = func_offset;
+  ap->source_file = source_file;
+  ap->line_num = line_num;
+  ap->col_num = col_num;
 
   switch (probetype(ap->provider)) {
     case ProbeType::kprobe:

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -1941,6 +1941,13 @@ public:
   uint64_t bpf_prog_id = 0;
   bool ignore_invalid = false;
 
+  // Used for attaching probes to statements in userspace programs via DWARF,
+  // specified with source file, line and optionally column.
+  // e.g. uprobe:/dir/foo@main.c:line:[col].
+  std::string source_file;
+  size_t line_num = 0;
+  size_t col_num = 0;
+
   std::string name() const;
 
   AttachPoint *create_expansion_copy(ASTContext &ctx,

--- a/src/ast/passes/attachpoint_passes.cpp
+++ b/src/ast/passes/attachpoint_passes.cpp
@@ -54,9 +54,12 @@ void AttachPointChecker::visit(AttachPoint &ap)
     if (ap.target.empty())
       ap.addError() << ap.provider << " should have a target";
     // --unsafe allows attaching to arbitrary files, and 0 is a valid offset
-    if (ap.func.empty() && ap.address == 0 && bpftrace_.safe_mode_)
-      ap.addError() << ap.provider
-                    << " should be attached to a function and/or address";
+    if (ap.func.empty() && ap.address == 0 && bpftrace_.safe_mode_ &&
+        (ap.source_file.empty() || ap.line_num == 0))
+      ap.addError() << ap.provider << " should be attached to a function"
+                    << (bpftrace_.get_dwarf(ap)
+                            ? ", address, or source file and line (using DWARF)"
+                            : " and/or address");
     if (!ap.lang.empty() && !is_supported_lang(ap.lang))
       ap.addError() << "unsupported language type: " << ap.lang;
 
@@ -525,11 +528,15 @@ AttachPointParser::State AttachPointParser::lex_attachpoint(
   std::string argument;
 
   for (size_t idx = 0; idx < raw.size(); ++idx) {
-    if (raw[idx] == ':' && !in_quotes) {
+    if ((raw[idx] == ':' || raw[idx] == '@') && !in_quotes) {
       parts_.emplace_back(std::move(argument));
       // The standard says an std::string in moved-from state is in
       // valid but unspecified state, so clear() to be safe
       argument.clear();
+
+      if (raw[idx] == '@') {
+        parts_.emplace_back("@");
+      }
     } else if (raw[idx] == '"')
       in_quotes = !in_quotes;
     // Handle escaped characters in a string
@@ -704,7 +711,7 @@ AttachPointParser::State AttachPointParser::kretprobe_parser()
 }
 
 AttachPointParser::State AttachPointParser::uprobe_parser(bool allow_offset,
-                                                          bool allow_abs_addr)
+                                                          bool allow_src_loc)
 {
   const auto pid = bpftrace_.pid();
   if (pid.has_value() &&
@@ -717,7 +724,10 @@ AttachPointParser::State AttachPointParser::uprobe_parser(bool allow_offset,
     parts_[1] = target ? util::path_for_pid_mountns(*pid, *target) : "";
   }
 
-  if (parts_.size() != 3 && parts_.size() != 4) {
+  // uprobe attached by source code location (@source_file:line[:col])
+  const bool source_location = parts_.size() > 2 && parts_[2] == "@";
+
+  if (!source_location && parts_.size() != 3 && parts_.size() != 4) {
     if (ap_->ignore_invalid)
       return SKIP;
 
@@ -744,6 +754,63 @@ AttachPointParser::State AttachPointParser::uprobe_parser(bool allow_offset,
 
   if (ap_->target.empty()) {
     ap_->target = parts_[1];
+  }
+
+  // Handle uprobe:libc@malloc.c:3538 case
+  if (source_location) {
+    if (!allow_src_loc) {
+      errs_ << "Source code location not allowed" << std::endl;
+      return INVALID;
+    }
+
+    if (util::has_wildcard(ap_->target)) {
+      errs_ << "Cannot use wildcards with source code location" << std::endl;
+      return INVALID;
+    }
+
+    if ((parts_.size() != 5 && parts_.size() != 6) || parts_[3].empty() ||
+        parts_[4].empty()) {
+      errs_ << "Invalid uprobe arguments, "
+            << "expected format: uprobe:TARGET@FILE:LINE[:COL]" << std::endl;
+      return INVALID;
+    }
+
+    ap_->source_file = parts_[3];
+
+    auto line = util::to_uint(parts_[4]);
+    if (!line) {
+      errs_ << "Invalid line number: " << line.takeError() << std::endl;
+      return INVALID;
+    }
+    ap_->line_num = *line;
+
+    if (parts_.size() == 6) {
+      auto col = util::to_uint(parts_[5]);
+      if (!col) {
+        errs_ << "Invalid column number: " << col.takeError() << std::endl;
+        return INVALID;
+      }
+      ap_->col_num = *col;
+    }
+
+    Dwarf *dwarf = bpftrace_.get_dwarf(ap_->target);
+    if (dwarf) {
+      auto address = dwarf->line_to_addr(ap_->source_file,
+                                         ap_->line_num,
+                                         ap_->col_num);
+      if (!address) {
+        errs_ << address.takeError() << std::endl;
+        return INVALID;
+      }
+      ap_->address = *address;
+      return OK;
+    }
+
+    errs_ << (ap_->target.empty()
+                  ? "Unspecified target binary"
+                  : "No DWARF debug info found for '" + ap_->target + "'")
+          << ", cannot attach by source code location." << std::endl;
+    return INVALID;
   }
 
   const std::string &func = parts_.back();
@@ -776,20 +843,17 @@ AttachPointParser::State AttachPointParser::uprobe_parser(bool allow_offset,
   }
   // Default case (eg uprobe:[addr][func])
   else {
-    if (allow_abs_addr) {
-      auto res = util::to_uint(func);
-      if (res) {
-        if (util::has_wildcard(ap_->target)) {
-          errs_ << "Cannot use wildcards with absolute address" << std::endl;
-          return INVALID;
-        }
-        ap_->address = *res;
-      } else {
-        ap_->address = 0;
-        ap_->func = func;
+    auto res = util::to_uint(func);
+    if (res) {
+      if (util::has_wildcard(ap_->target)) {
+        errs_ << "Cannot use wildcards with absolute address" << std::endl;
+        return INVALID;
       }
-    } else
+      ap_->address = *res;
+    } else {
+      ap_->address = 0;
       ap_->func = func;
+    }
   }
 
   return OK;
@@ -797,7 +861,7 @@ AttachPointParser::State AttachPointParser::uprobe_parser(bool allow_offset,
 
 AttachPointParser::State AttachPointParser::uretprobe_parser()
 {
-  return uprobe_parser(false);
+  return uprobe_parser(false, false);
 }
 
 AttachPointParser::State AttachPointParser::usdt_parser()

--- a/src/ast/passes/attachpoint_passes.h
+++ b/src/ast/passes/attachpoint_passes.h
@@ -21,8 +21,14 @@ public:
   {
   }
 
-  symbols::KernelInfo &kernel_info() const { return kernel_impl_; }
-  symbols::UserInfo &user_info() const { return user_impl_; }
+  symbols::KernelInfo &kernel_info() const
+  {
+    return kernel_impl_;
+  }
+  symbols::UserInfo &user_info() const
+  {
+    return user_impl_;
+  }
 
 private:
   symbols::KernelInfo &kernel_impl_;
@@ -58,7 +64,7 @@ private:
   State benchmark_parser();
   State kprobe_parser(bool allow_offset = true);
   State kretprobe_parser();
-  State uprobe_parser(bool allow_offset = true, bool allow_abs_addr = true);
+  State uprobe_parser(bool allow_offset = true, bool allow_src_loc = true);
   State uretprobe_parser();
   State usdt_parser();
   State tracepoint_parser();

--- a/src/dwarf_parser.cpp
+++ b/src/dwarf_parser.cpp
@@ -1,9 +1,21 @@
 #include "dwarf_parser.h"
 
+namespace bpftrace {
+
+char DwarfParseError::ID;
+
+void DwarfParseError::log(llvm::raw_ostream &OS) const
+{
+  OS << "DWARF error: " << msg_;
+}
+
+} // namespace bpftrace
+
 #ifdef HAVE_LIBDW
 
 #include "bpftrace.h"
 #include "log.h"
+#include "util/paths.h"
 
 #include <dwarf.h>
 #include <elfutils/libdw.h>
@@ -413,6 +425,122 @@ ssize_t Dwarf::get_bitfield_size(Dwarf_Die &field_die)
       return static_cast<ssize_t>(value);
   }
   return 0;
+}
+
+std::optional<std::filesystem::path> Dwarf::resolve_cu_path(
+    std::string_view cu_name,
+    std::string_view cu_comp_dir)
+{
+  if (cu_name.empty())
+    return std::nullopt;
+
+  // If CU name is relative. According to the DWARF standard, source
+  // file path name should be locatable by combining DW_AT_comp_dir with the
+  // relative CU path name. https://wiki.dwarfstd.org/Best_Practices.md
+  if (cu_name[0] != '/' && !cu_comp_dir.empty())
+    return std::filesystem::path(cu_comp_dir) / std::filesystem::path(cu_name);
+
+  // If CU name is already an absolute path to the source file. Also used as
+  // a fallback, when DW_AT_comp_dir string is empty.
+  return std::filesystem::path(cu_name);
+}
+
+Result<Dwarf::CuInfo> Dwarf::get_cu_info(const std::string &source_file) const
+{
+  Dwarf_Die *cudie = nullptr;
+  Dwarf_Die *matched_cu = nullptr;
+  std::filesystem::path matched_cu_path;
+  Dwarf_Addr cubias;
+
+  while ((cudie = dwfl_nextcu(dwfl, cudie, &cubias)) != nullptr) {
+    const char *cu_name = dwarf_diename(cudie);
+    if (!cu_name) {
+      continue;
+    }
+
+    std::string_view cu_comp_dir;
+    Dwarf_Attribute attr;
+    if (dwarf_attr(cudie, DW_AT_comp_dir, &attr)) {
+      if (const char *dir_str = dwarf_formstring(&attr)) {
+        cu_comp_dir = dir_str;
+      }
+    }
+
+    // Resolve the CU's source file location path.
+    auto cu_path = resolve_cu_path(cu_name, cu_comp_dir);
+    if (!cu_path) {
+      continue;
+    }
+
+    if (util::path_ends_with(*cu_path, source_file)) {
+      if (!matched_cu) {
+        matched_cu = cudie;
+        matched_cu_path = *cu_path;
+      } else {
+        return make_error<DwarfParseError>(
+            "Ambiguous source path, matches multiple files: " +
+            matched_cu_path.string() + ", " + cu_path->string());
+      }
+    }
+  }
+
+  if (!matched_cu) {
+    return make_error<DwarfParseError>("No compilation unit matches " +
+                                       source_file);
+  }
+
+  return CuInfo{ .source = std::move(matched_cu_path), .die = matched_cu };
+}
+
+Result<uint64_t> Dwarf::line_to_addr(const std::string &source_file,
+                                     size_t line_num,
+                                     size_t col_num) const
+{
+  auto cu = get_cu_info(source_file);
+  if (!cu) {
+    return cu.takeError();
+  }
+
+  Dwarf_Lines *lines = nullptr;
+  size_t num_lines = 0;
+
+  if (dwarf_getsrclines(cu->die, &lines, &num_lines) != 0) {
+    return make_error<DwarfParseError>(
+        "Failed to get compilation unit source lines");
+  }
+
+  for (size_t i = 0; i < num_lines; i++) {
+    Dwarf_Line *line = dwarf_onesrcline(lines, i);
+    if (!line) {
+      continue;
+    }
+
+    int lineno, linecol;
+    if (dwarf_lineno(line, &lineno) != 0 ||
+        dwarf_linecol(line, &linecol) != 0) {
+      continue;
+    }
+
+    const char *linesrc = dwarf_linesrc(line, nullptr, nullptr);
+    if (!linesrc) {
+      continue;
+    }
+
+    // Check if the line source matches the CU's source path, to avoid
+    // unintentionally accessing statements from included files.
+    if (util::path_ends_with(linesrc, cu->source) &&
+        line_num == static_cast<size_t>(lineno) &&
+        (col_num == 0 || col_num == static_cast<size_t>(linecol))) {
+      Dwarf_Addr addr;
+      if (dwarf_lineaddr(line, &addr) == 0) {
+        return addr;
+      }
+    }
+  }
+
+  return make_error<DwarfParseError>(
+      "Unable to map '" + source_file + ":" + std::to_string(line_num) +
+      (col_num > 0 ? ":" + std::to_string(col_num) : "") + "' to address");
 }
 
 } // namespace bpftrace

--- a/src/dwarf_parser.h
+++ b/src/dwarf_parser.h
@@ -2,10 +2,33 @@
 
 #include "struct.h"
 #include "types.h"
+#include "util/result.h"
 
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <vector>
+
+namespace bpftrace {
+
+class DwarfParseError : public ErrorInfo<DwarfParseError> {
+public:
+  static char ID;
+  void log(llvm::raw_ostream &OS) const override;
+
+  DwarfParseError(std::string &&msg) : msg_(std::move(msg)) {};
+  DwarfParseError() = default;
+
+  const std::string &msg() const
+  {
+    return msg_;
+  }
+
+private:
+  std::string msg_;
+};
+
+} // namespace bpftrace
 
 #ifdef HAVE_LIBDW
 #include <elfutils/libdwfl.h>
@@ -30,7 +53,16 @@ public:
   SizedType get_stype(const std::string &type_name) const;
   void resolve_fields(const SizedType &type) const;
 
+  Result<uint64_t> line_to_addr(const std::string &source_file,
+                                size_t line_num,
+                                size_t col_num = 0) const;
+
 private:
+  struct CuInfo {
+    std::filesystem::path source;
+    Dwarf_Die *die;
+  };
+
   Dwarf(BPFtrace *bpftrace, const std::string &file_path);
 
   std::vector<Dwarf_Die> function_param_dies(const std::string &function) const;
@@ -46,12 +78,18 @@ private:
 
   SizedType get_stype(Dwarf_Die &type_die, bool resolve_structs = true) const;
 
+  Result<CuInfo> get_cu_info(const std::string &source_file) const;
+
   static std::optional<Dwarf_Die> get_child_with_tagname(
       Dwarf_Die *die,
       int tag,
       const std::string &name);
   static std::vector<Dwarf_Die> get_all_children_with_tag(Dwarf_Die *die,
                                                           int tag);
+
+  static std::optional<std::filesystem::path> resolve_cu_path(
+      std::string_view cu_name,
+      std::string_view cu_comp_dir);
 
   Dwfl *dwfl = nullptr;
   Dwfl_Callbacks callbacks;
@@ -100,6 +138,14 @@ public:
 
   void resolve_fields(const SizedType &type __attribute__((unused))) const
   {
+  }
+
+  Result<uint64_t> line_to_addr(const std::string &source_file
+                                __attribute__((unused)),
+                                size_t line_num __attribute__((unused)),
+                                size_t col_num __attribute__((unused))) const
+  {
+    return make_error<DwarfParseError>();
   }
 };
 

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -40,7 +40,7 @@ hex      0[xX][0-9a-fA-F]+
 exponent {int}[eE]{int}
 
 ident    [_a-zA-Z][_a-zA-Z0-9]*
-map      @{ident}|@
+at_ident @{ident}
 var      ${ident}
 hspace   [ \t]
 vspace   \n
@@ -200,8 +200,9 @@ oct_esc  [0-7]{1,3}
                             return Parser::make_BOOL(false, driver.loc);
                           }
   {path}                  { return Parser::make_PATH(yytext, driver.loc); }
-  {map}                   { return Parser::make_MAP(yytext, driver.loc); }
   {var}                   { return Parser::make_VAR(yytext, driver.loc); }
+  {at_ident}              { return Parser::make_AT_IDENT(yytext, driver.loc); }
+  "@"                     { return Parser::make_AT(driver.loc); }
   ":"                     {
                             /* For handling "struct x" in "fn name(...): struct x {  }" as a type rather than
                               a beginning of a struct definition; see AFTER_COLON rules below */

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -60,6 +60,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
   LPAREN     "("
   RPAREN     ")"
   QUES       "?"
+  AT         "@"
   ENDPRED    "end predicate"
   COMMA      ","
   PARAMCOUNT "$#"
@@ -120,7 +121,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %token <std::string> STRUCT_DEFN "struct definition"
 %token <std::string> ENUM "enum"
 %token <std::string> STRING "string"
-%token <std::string> MAP "map"
+%token <std::string> AT_IDENT "map"
 %token <std::string> VAR "variable"
 %token <std::string> PARAM "positional parameter"
 %token <std::string> UNSIGNED_INT "integer"
@@ -144,7 +145,7 @@ void yyerror(bpftrace::Driver &driver, const char *s);
 %token <bool> BOOL "bool"
 
 %type <ast::Operator> unary_op compound_op
-%type <std::string> attach_point_def attach_point_elem ident keyword external_name
+%type <std::string> attach_point_def attach_point_elem source_path_prefix source_path source_path_def source_path_elem source_path_suffix ident keyword external_name
 %type <std::vector<std::string>> struct_field
 
 %type <ast::ArrayAccess *> array_access_expr
@@ -469,6 +470,7 @@ attach_point_elem:
         |       STRING       { $$ = "\"" + std::regex_replace($1, std::regex("\""), "\\\"") + "\""; }
         |       UNSIGNED_INT { $$ = $1; }
         |       PATH         { $$ = $1; }
+        |       source_path  { $$ = $1; }
         |       COLON        { $$ = ":"; }
         |       DOT          { $$ = "."; }
         |       PLUS         { $$ = "+"; }
@@ -483,6 +485,39 @@ attach_point_elem:
                   // a hack but there doesn't look to be any other way.
                   $$ = "$" + std::to_string($1->n);
                 }
+                ;
+
+source_path_prefix:
+                AT DIV       { $$ = "@/"; }
+        |       AT           { $$ = "@"; }
+        |       AT_IDENT DIV { $$ = $1 + "/"; }
+        |       AT_IDENT     { $$ = $1; }
+                ;
+
+source_path:
+                source_path_prefix source_path_def source_path_suffix %prec LOW { $$ = $1 + $2 + $3; }
+                ;
+
+source_path_def:
+                source_path_elem                           { $$ = $1; }
+        |       source_path_def DIV source_path_elem       { $$ = $1 + "/" + $3; }
+        |       source_path_def source_path_elem %prec LOW { $$ = $1 + $2; }
+                ;
+
+source_path_elem:
+                ident        { $$ = $1; }
+        |       STRING       { $$ = "\"" + std::regex_replace($1, std::regex("\""), "\\\"") + "\""; }
+        |       UNSIGNED_INT { $$ = $1; }
+        |       DOT          { $$ = "."; }
+        |       param
+                {
+                        $$ = "$" + std::to_string($1->n);
+                }
+                ;
+
+source_path_suffix:
+                PATH         { $$ = $1; }
+        |       COLON        { $$ = ":"; }
                 ;
 
 pred:
@@ -617,7 +652,8 @@ assign_stmt:
         ;
 
 map_decl_stmt:
-                LET MAP ASSIGN IDENT LPAREN integer RPAREN ";" { $$ = driver.ctx.make_node<ast::MapDeclStatement>(@$, $2, $4, $6->value); }
+                LET AT_IDENT ASSIGN IDENT LPAREN integer RPAREN ";" { $$ = driver.ctx.make_node<ast::MapDeclStatement>(@$, $2, $4, $6->value); }
+        |       LET AT ASSIGN IDENT LPAREN integer RPAREN ";" { $$ = driver.ctx.make_node<ast::MapDeclStatement>(@$, "@", $4, $6->value); }        
         ;
 
 var_decl_stmt:
@@ -927,7 +963,8 @@ call_expr:
                 ;
 
 map:
-                MAP { $$ = driver.ctx.make_node<ast::Map>(@$, $1); }
+                AT_IDENT { $$ = driver.ctx.make_node<ast::Map>(@$, $1); }
+        |       AT       { $$ = driver.ctx.make_node<ast::Map>(@$, "@"); }
                 ;
 
 map_expr:

--- a/src/util/paths.cpp
+++ b/src/util/paths.cpp
@@ -355,4 +355,42 @@ bool is_archive_path(const std::string &path)
   return std::filesystem::exists(archive, ec);
 }
 
+// Returns true if the given pattern (e.g. file name, relative/absolute path)
+// matches the tail of the path. Comparison order is done from the file name
+// towards the root dir, comparing each path element.
+//
+// Paths passed as parameters are *expected* to be
+// normalised beforehand, i.e. this function doesn't normalise given paths.
+bool path_ends_with(const std::filesystem::path &path,
+                    const std::filesystem::path &pattern)
+{
+  // Early exit on empty paths
+  if (path.empty() && pattern.empty()) {
+    return true;
+  }
+  if (path.empty() || pattern.empty()) {
+    return false;
+  }
+
+  // Iterate backwards, i.e. from file name
+  auto path_it = path.end();
+  auto pattern_it = pattern.end();
+
+  // According to the standard, end() returns an iterator one
+  // past the last element of the path. Dereferencing it is undefined
+  // behavior, so we decrement first.
+  // https://en.cppreference.com/w/cpp/filesystem/path/begin.html
+  --path_it;
+  --pattern_it;
+
+  for (; pattern_it != pattern.begin(); pattern_it--, path_it--) {
+    // Path can't have less elements than pattern
+    if (path_it == path.begin() || *pattern_it != *path_it) {
+      return false;
+    }
+  }
+
+  return *pattern_it == *path_it;
+}
+
 } // namespace bpftrace::util

--- a/src/util/paths.h
+++ b/src/util/paths.h
@@ -28,4 +28,7 @@ std::string path_for_pid_mountns(int pid, const std::string &path);
 
 bool is_archive_path(const std::string &path);
 
+bool path_ends_with(const std::filesystem::path &path,
+                    const std::filesystem::path &pattern);
+
 } // namespace bpftrace::util

--- a/tests/attachpoint_passes.cpp
+++ b/tests/attachpoint_passes.cpp
@@ -5,6 +5,10 @@
 #include "mocks.h"
 #include "gtest/gtest.h"
 
+#ifdef HAVE_LIBDW
+#include "dwarf_common.h"
+#endif // HAVE_LIBDW
+
 namespace bpftrace::test {
 
 namespace attachpoint_parser {
@@ -99,6 +103,73 @@ TEST(attachpoint_parser, uprobe_lang)
   test_uprobe_lang("uprobe:main { 1 }");
   test_uprobe_lang("uprobe:cpp:main { 1 }", "cpp");
 }
+
+#ifdef HAVE_LIBDW
+
+class attachpoint_parser_dwarf : public test_dwarf {};
+
+TEST_F(attachpoint_parser_dwarf, uprobe)
+{
+  // Valid test executable to ensure DWARF function proceeds.
+  // The line numbers used must be mappable to a present, valid statement within
+  // the target executable. If the test executable/source-file is subject to
+  // change, be sure to update these tests. Tests might also fail, if the file
+  // 'data_source.c' is to be compiled elsewhere than in the 'data/' dir.
+  std::string bin = std::string(bin_);
+  std::string ap = "uprobe:" + bin;
+
+  test(ap + "@data_source.c:195 { 1 }");
+  test(ap + "@data_source.c:195:1 { 1 }");
+  test(ap + "@data/data_source.c:195 { 1 }");
+  test(ap + "@data/data_source.c:195:1 { 1 }");
+  test(ap + "@data_source.c:195 / 1 / { 1 }");
+  test(ap + "@data/data_source.c:195 / 1 / { 1 }");
+  test("begin { @x = 1; } " + ap + "@data/data_source.c:195 / @x / { @x/1; }");
+  test("begin { @x = 1; } " + ap + "@data/data_source.c:195 /@x/ { @x/1; }");
+  test("begin { @data_source = 1; } " + ap +
+       "@data_source.c:195 /@data_source/ { @data_source/1; }");
+  test("begin { @data = 1; } " + ap +
+       "@data/data_source.c:195 /@data/ { @data/1; }");
+
+  // Quoted arguments
+  test(ap + R"(@"data_source.c":195 { 1 })");
+  test(ap + R"(@data_source.c:"195" { 1 })");
+  test(ap + R"(@"data_source.c":"195" { 1 })");
+  test(ap + R"(@"data_source.c":"195":"1" { 1 })");
+  test(ap + R"(@data/"data_source.c":195 { 1 })");
+  test(ap + R"(@"data/data_source.c":195 { 1 })");
+  test(R"(uprobe:")" + bin + R"("@data_source.c:195 { 1 })");
+  test(R"(uprobe:")" + bin + R"("@"data_source.c":195 { 1 })");
+  test(R"(uprobe:")" + bin + R"("@"data/data_source.c":195 { 1 })");
+
+  test_error("uretprobe:" + bin + "@data_source.c:195 { 1 }",
+             R"(Source code location not allowed)");
+  test_error("uprobe:*@data_source.c:195 { 1 }",
+             R"(Cannot use wildcards with source code location)");
+  test_error(ap + "@ { 1 }", R"(ERROR: syntax error, unexpected {)");
+  test_error(ap + "@: { 1 }", R"(ERROR: syntax error, unexpected :)");
+  test_error(
+      ap + "@data_source.c: { 1 }",
+      R"(Invalid uprobe arguments, expected format: uprobe:TARGET@FILE:LINE[:COL])");
+  test_error(ap + "@:195 { 1 }", R"(ERROR: syntax error, unexpected path)");
+  test_error(
+      ap + "@data_source.c:195:1:2:3 { 1 }",
+      R"(Invalid uprobe arguments, expected format: uprobe:TARGET@FILE:LINE[:COL])");
+  test_error(ap + "@data_source.c:invalid { 1 }", R"(Invalid line number: )");
+  test_error(ap + "@data_source.c:195:invalid { 1 }",
+             R"(Invalid column number: )");
+  test_error(ap + "@data_source.c:195: { 1 }", R"(Invalid column number: )");
+  test_error(ap + "@invalid.c:195 { 1 }",
+             R"(No compilation unit matches invalid.c)");
+  test_error(
+      "uprobe:no_dwarf@main.c:123 { 1 }",
+      R"(No DWARF debug info found for 'no_dwarf', cannot attach by source code location.)");
+  test_error(
+      "uprobe:@main.c:123 { 1 }",
+      R"(Unspecified target binary, cannot attach by source code location.)");
+}
+
+#endif // HAVE_LIBDW
 
 } // namespace attachpoint_parser
 

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -2944,9 +2944,9 @@ TEST(Parser, map_declarations)
            .WithProbe(Probe({ "begin" }, { ExprStatement(Variable("$x")) })));
 
   test_parse_failure("@a = hash(); begin { $x; }", R"(
-stdin:1:1-3: ERROR: syntax error, unexpected map
+stdin:1:4-5: ERROR: syntax error, unexpected =
 @a = hash(); begin { $x; }
-~~
+   ~
 )");
 
   test_parse_failure("let @a = hash(); begin { $x; }", R"(

--- a/tests/runtime/dwarf
+++ b/tests/runtime/dwarf
@@ -72,3 +72,29 @@ EXPECT foo1.b = 123
 REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
+
+# Attaching probes using source code location
+NAME uprobe source location - attach probe to source line
+PROG uprobe:./testprogs/uprobe_test@uprobe_test.c:16 { printf("0x%lx\n", reg("ip")); exit(); }
+EXPECT_REGEX ^0x[0-9A-Fa-f]+$
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+
+NAME uprobe source location - source line to address validation
+PROG uprobe:./testprogs/uprobe_test@uprobe_test.c:16 { @a = reg("ip"); }
+     uprobe:./testprogs/uprobe_test:uprobeFunction1 { @b = reg("ip"); if (@b == @a) { printf("0x%lx == 0x%lx\n", @a, @b); exit(); } }
+EXPECT_REGEX ^0x[0-9A-Fa-f]+ == 0x[0-9A-Fa-f]+$
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+
+NAME uprobe source location - attach multiple probes
+PROG uprobe:./testprogs/uprobe_test@uprobe_test.c:28 { @a=1; }
+     uprobe:./testprogs/uprobe_test@uprobe_test.c:30 { @b=1; }
+     uprobe:./testprogs/uprobe_test@uprobe_test.c:33 { if (@a == 1 && @b == 1) { print("success"); exit(); } }
+EXPECT success
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+

--- a/tests/testprogs/uprobe_test.c
+++ b/tests/testprogs/uprobe_test.c
@@ -23,6 +23,18 @@ struct Foo *uprobeFunction2(struct Foo *foo1,
   return foo1;
 }
 
+int uprobeFunctionBranching(int n)
+{
+  if (n == 1) {
+   return 1; 
+  } else if (n == 2) {
+    return 2;
+  } else {
+    return 3;
+  }
+  return 0;
+}
+
 // clang-format off
 /*
  * Anonymous types inside parameter lists are not legal until C23 [0][1][2].
@@ -73,6 +85,8 @@ int main(int argc __attribute__((unused)), char **argv __attribute__((unused)))
       .a = 456, .b = "world", .c = { 4, 5, 6 }, .d = 0xFEDCBA9876543210
     };
     uprobeFunction2(&foo1, &foo2);
+
+    uprobeFunctionBranching(n);
 
     __uint128_t x = 0x123456789ABCDEF0;
     __uint128_t y = 0xEFEFEFEFEFEFEFEF;

--- a/tests/utils.cpp
+++ b/tests/utils.cpp
@@ -581,4 +581,31 @@ TEST(utils, gfp_flags_format)
   EXPECT_EQ(GFPFlags::format(0x80000001), "GFP_DMA|0x80000000");
 }
 
+TEST(utils, path_ends_with)
+{
+  EXPECT_TRUE(path_ends_with("", ""));
+  EXPECT_TRUE(path_ends_with("/", "/"));
+  EXPECT_TRUE(path_ends_with("/a", "/a"));
+  EXPECT_TRUE(path_ends_with("/a/b/c", "c"));
+  EXPECT_TRUE(path_ends_with("/a/b/c", "b/c"));
+  EXPECT_TRUE(path_ends_with("/a/b/c", "a/b/c"));
+  EXPECT_TRUE(path_ends_with("/a/b/c", "/a/b/c"));
+  EXPECT_TRUE(path_ends_with("/lib64/libbpf.so", "libbpf.so"));
+  EXPECT_TRUE(path_ends_with(".", "."));
+  EXPECT_TRUE(path_ends_with("..", ".."));
+  EXPECT_TRUE(path_ends_with("/b/./c", "./c"));
+  EXPECT_TRUE(path_ends_with("/b/../c", "../c"));
+  EXPECT_TRUE(path_ends_with("./a/b/c", "./a/b/c"));
+  EXPECT_FALSE(path_ends_with("/", ""));
+  EXPECT_FALSE(path_ends_with("", "/a"));
+  EXPECT_FALSE(path_ends_with("/a/b/c", "x"));
+  EXPECT_FALSE(path_ends_with("/a/b/c", "x/c"));
+  EXPECT_FALSE(path_ends_with("/a/b/c", "x/b/c"));
+  EXPECT_FALSE(path_ends_with("/a/b/c", "/a/x/c"));
+  EXPECT_FALSE(path_ends_with("/lib64/libbpf.so", ""));
+  EXPECT_FALSE(path_ends_with("..", "."));
+  EXPECT_FALSE(path_ends_with(".", ".."));
+  EXPECT_FALSE(path_ends_with("/a", "/a/b/.."));
+}
+
 } // namespace bpftrace::test::utils


### PR DESCRIPTION
<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

It is often useful to place uprobes inside the body of a function. Currently, this typically requires manually locating the instruction offset within the ELF binary, which can be time-consuming and error-prone.

With this change, when DWARF debug information is available in the target binary, bpftrace can attach uprobes directly to source statements by specifying the source file path, line number, and optionally a column.

This is conceptually similar to setting a breakpoint at a specific source location in a conventional debugger.

The new syntax is:

```
uprobe:TARGET@FILE:LINE[:COL]
```

Currently, probes may be attached only to statements whose originating source file matches the file specified in the attach point. This excludes statements originating from included files within the same compilation unit, avoiding accidental matches. However this may be subject to change on demand.

Few examples:

```
uprobe:/bin/foo@foo.c:64
uprobe:/bin/foo@foo.c:64:1
uprobe:/bin/foo@src/foo.c:64
uprobe:/bin/foo@/proj/src/foo.c:64
```

Notes:
- The specified line/column must correspond to a valid, probe-able statement. Non-statement constructs cannot be instrumented.
- The source file must resolve unambiguously. If multiple compilation units contain statements from files with the same name (e.g., test/foo.c and src/foo.c), a sufficiently specific path must be provided. If ambiguity remains, bpftrace exits with an error.

Related issues: [#4537](https://github.com/bpftrace/bpftrace/issues/4537), [#1743](https://github.com/bpftrace/bpftrace/issues/1743)

##### Checklist

- [x] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [x] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
