### PR TITLE
Fix comptime expressions

### DIFF
--- a/src/stdlib/process.bt
+++ b/src/stdlib/process.bt
@@ -24,15 +24,17 @@ macro __signal(expr, is_tid) {
   } else if comptime (typeinfo(expr).1 != typeinfo(0).1) {
     fail("%s accepts a string literal or a positive integer",
       is_tid ? "signal_thread()" : "signal()");
-  } else if comptime (expr < 1 || expr > 64) {
-    fail("%s accepts a string literal or a positive integer",
+  } else if comptime (is_literal(expr)) {
+    if comptime (expr < 1 || expr > 64) {
+      fail("%s accepts a string literal or an integer between 1 and 64 (inclusive)",
       is_tid ? "signal_thread()" : "signal()");
+    }
   } else {
     $sig = (int32)expr;
   }
 
-  if ($sig < 1) {
-    errorf("%s expects a positive integer. Got %d",
+  if ($sig < 1 || $sig > 64) {
+    errorf("%s expects an integer between 1 and 64 (inclusive). Got %d",
       is_tid ? "signal_thread()" : "signal()", $sig);
   } else {
     $ret = comptime is_tid ? __signal_thread((uint32)$sig) : __signal_process((uint32)$sig);

--- a/tests/fold_literals.cpp
+++ b/tests/fold_literals.cpp
@@ -530,7 +530,7 @@ TEST(fold_literals, tuple_access)
   test_not("comptime (1,0).0", ComptimeMatcher());
   test_not("comptime (1, 1 + 1).1", ComptimeMatcher());
   // This cannot be evaluated.
-  test_error("comptime ($x, 1 + 1).0", "comptime");
+  test("comptime ($x, 1 + 1).0", ComptimeMatcher());
   // This should be left as is.
   test("{ $x = (1,0); $x.0 };", Block({ _ }, TupleAccess(Variable("$x"), 0)));
   // Left as is, since it is an error.
@@ -546,10 +546,9 @@ TEST(fold_literals, array_access)
 
 TEST(fold_literals, comptime)
 {
-  // This are temporary restrictions, but enough that we error when we hit a
-  // variable or map as part of a comptime expression.
-  test_error("$x = 0; comptime ($x + 1)", "Unable to evaluate at compile time");
-  test_error("@x = 0; comptime (@x + 1)", "Unable to evaluate at compile time");
+  // These can't be evaluated at compile time
+  test("{ $x = 0; comptime ($x + 1) };", Block({ _ }, ComptimeMatcher()));
+  test("{ @x = 0; comptime (@x + 1) };", Block({ _ }, ComptimeMatcher()));
 }
 
 } // namespace bpftrace::test::fold_literals

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -5817,6 +5817,31 @@ stdin:1:44-46: ERROR: @a used as a map without an explicit key (scalar map), pre
 kprobe:f { @a[1] = 1; if (comptime true) { @a = 1; } }
                                            ~~
 )" });
+  test(R"(kprobe:f { @a = 1; if comptime (@a > 1) { print(1); } })", Error{ R"(
+stdin:1:23-40: ERROR: Unable to resolve comptime expression
+kprobe:f { @a = 1; if comptime (@a > 1) { print(1); } }
+                      ~~~~~~~~~~~~~~~~~
+)" });
+}
+
+TEST_F(SemanticAnalyserTest, comptime)
+{
+  test(R"(begin { comptime (1 + 1) })");
+  test(R"(begin { $x = 1; comptime (sizeof($x)) })");
+  test(R"(begin { $x = 1; comptime (typeinfo($x)) })");
+  test(R"(begin { @x = 1; comptime (typeinfo(@x)) })");
+
+  test(R"(begin { $x = 0; comptime ($x + 1) })", Error{ R"(
+stdin:1:17-34: ERROR: Unable to resolve comptime expression.
+begin { $x = 0; comptime ($x + 1) }
+                ~~~~~~~~~~~~~~~~~
+)" });
+  test(R"(begin { @x = 0; comptime (@x + 1) })", Error{ R"(
+stdin:1:17-34: ERROR: Unable to resolve comptime expression.
+begin { @x = 0; comptime (@x + 1) }
+                ~~~~~~~~~~~~~~~~~
+)" });
+  test(R"(begin { @x[1] = 1; comptime (@x[1] + 1) })", Error{});
 }
 
 TEST_F(SemanticAnalyserTest, typeinfo_if_comptime)


### PR DESCRIPTION
In the case where we can't resolve comptime
expressions by the final semantic pass then consider it
an error.

This removes the error handling from fold_literals
because it was both broken and dead (for if comptime
expressions). We don't want to error for all Variable
or Map nodes, e.g. `sizeof($x)` can be evaluated at
compile time where as `$x + 1` can not.

This also fixes the `__signal` macro which was
broken for non-literal integer arguments.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
