### PR TITLE
btf: auto char[] => string conversion

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -398,6 +398,7 @@ The following fundamental types are provided by the language.
 | int32 | Signed 32 bit integer |
 | uint64 | Unsigned 64 bit integer |
 | int64 | Signed 64 bit integer |
+| string | See below |
 
 ```
 begin { $x = 1<<16; printf("%d %d\n", (uint16)$x, $x); }
@@ -430,6 +431,13 @@ casting to some of the kernel's fixed integer types:
 ```
 $a = (uint64_t)1; // $a is a uint64
 ```
+
+### String
+
+bpftrace also supports a `string` data type, which it uses for string literals, e.g. `"hello"`.
+Similar to C this is represented as a well formed char array (NULL terminated).
+Additionally, all BTF char arrays (`char[]` or `int8[]`) are automatically converted to a bpftrace string but can be casted back to an int array if needed, e.g. `$a = (int8[])"mystring"`;
+It also may be necessary to utilize the [`str()`](stdlib.md#str) function if bpftrace can't determine the correct address space (user or kernel).
 
 ## Filters/Predicates
 

--- a/src/ast/passes/tracepoint_format_parser.cpp
+++ b/src/ast/passes/tracepoint_format_parser.cpp
@@ -153,7 +153,12 @@ Result<Field> TracepointFormatParser::parse_field(const std::string &line,
   } else {
     auto type = bpftrace_.btf_->get_stype(field_type);
     if (is_array) {
-      field.type = CreateArray(*array_size, type);
+      if (field_type == "char") {
+        // See src/btf.cpp for why this is converted to a string
+        field.type = CreateString(*array_size);
+      } else {
+        field.type = CreateArray(*array_size, type);
+      }
     } else {
       field.type = type;
       field.type.SetSize(std::stoi(*size_str));

--- a/src/dwarf_parser.cpp
+++ b/src/dwarf_parser.cpp
@@ -191,11 +191,12 @@ SizedType Dwarf::get_stype(Dwarf_Die &type_die, bool resolve_structs) const
         ssize_t size = get_array_size(d);
         if (dwarf_tag(&inner_type_die) == DW_TAG_base_type &&
             (inner_enc == DW_ATE_signed_char ||
-             inner_enc == DW_ATE_unsigned_char))
-          // See btf.cpp; we need to signal well-formedness.
-          result = CreateString(size + 1);
-        else
+             inner_enc == DW_ATE_unsigned_char)) {
+          // See src/btf.cpp for why this is converted to a string
+          result = CreateString(size);
+        } else {
           result = CreateArray(size, inner_type);
+        }
         inner_type = result;
       }
       return result;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -205,12 +205,6 @@ bool SizedType::IsStack() const
   return type_ == Type::ustack_t || type_ == Type::kstack_t;
 }
 
-bool SizedType::IsCString() const
-{
-  return IsArrayTy() && GetElementTy()->IsIntegerTy() &&
-         GetElementTy()->GetSize() == 1;
-}
-
 std::string addrspacestr(AddrSpace as)
 {
   switch (as) {

--- a/src/types.h
+++ b/src/types.h
@@ -259,7 +259,6 @@ public:
   bool IsByteArray() const;
   bool IsAggregate() const;
   bool IsStack() const;
-  bool IsCString() const;
 
   bool IsEqual(const SizedType &t) const;
   bool operator==(const SizedType &t) const;

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -141,13 +141,11 @@ TEST_F(field_analyser_btf, btf_arrays)
   EXPECT_EQ(arrs->GetField("int_arr").type.GetSize(), 16U);
   EXPECT_EQ(arrs->GetField("int_arr").offset, 0);
 
-  EXPECT_TRUE(arrs->GetField("char_arr").type.IsArrayTy());
-  EXPECT_EQ(arrs->GetField("char_arr").type.GetNumElements(), 8);
+  EXPECT_TRUE(arrs->GetField("char_arr").type.IsStringTy());
   EXPECT_EQ(arrs->GetField("char_arr").type.GetSize(), 8);
   EXPECT_EQ(arrs->GetField("char_arr").offset, 16);
 
-  EXPECT_TRUE(arrs->GetField("char_arr2").type.IsArrayTy());
-  EXPECT_EQ(arrs->GetField("char_arr2").type.GetNumElements(), 16);
+  EXPECT_TRUE(arrs->GetField("char_arr2").type.IsStringTy());
   EXPECT_EQ(arrs->GetField("char_arr2").type.GetSize(), 16);
   EXPECT_EQ(arrs->GetField("char_arr2").offset, 24);
 

--- a/tests/runtime/array
+++ b/tests/runtime/array
@@ -170,3 +170,8 @@ NAME cast int array to int proberead
 RUN {{BPFTRACE}} --include "stdint.h" -e 'struct A { int x[4]; uint8_t y[4]; } uprobe:./testprogs/array_access:test_arrays { $y = (int32)((struct A *)arg0).y; printf("y: %x\n", $y); exit()}'
 EXPECT y: ddccbbaa
 AFTER ./testprogs/array_access
+
+NAME cast string to int array
+PROG begin { print((int8[])"hello"); }
+EXPECT [104,101,108,108,111,0]
+TIMEOUT 1

--- a/tests/runtime/btf
+++ b/tests/runtime/btf
@@ -94,7 +94,8 @@ PROG begin { let $a: typeof(size_t) = 1; let $b: typeof(size_t*) = &$a; $c = (ui
 EXPECT Attached 1 probe
 REQUIRES_FEATURE btf
 
-NAME printf_btf_char_array
-PROG begin { printf("comm %s\n", curtask.comm); }
+NAME btf_char_array_to_string
+PROG begin { if (curtask.comm == "bpftrace") { print(curtask.comm); printf("comm %s\n", curtask.comm); } }
+EXPECT bpftrace
 EXPECT comm bpftrace
 REQUIRES_FEATURE btf

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -89,11 +89,8 @@ TIMEOUT 3
 
 # The issue this test catches is the verifier doesn't allow multiple ALU ops on ctx pointer.
 # ctx+const is ok, but ctx+const+const is not ok.
-#
-# TODO once we add automatic conversion of `char []` to `SizedType::string`, we
-# should drop the `str` calls here
 NAME access ctx struct field twice
-PROG tracepoint:sched:sched_wakeup { if (str(args.comm) == "asdf") { print(str(args.comm)) } exit(); }
+PROG tracepoint:sched:sched_wakeup { if (args.comm == "asdf") { print(args.comm) } exit(); }
 EXPECT Attached 1 probe
 TIMEOUT 1
 

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2555,7 +2555,7 @@ begin { (struct faketype *)cpu }
 stdin:1:10-18: ERROR: Cannot resolve unknown type "faketype"
 begin { (faketype)cpu }
          ~~~~~~~~
-stdin:1:9-19: ERROR: Cannot cast to "faketype"
+stdin:1:9-19: ERROR: Cannot cast from "uint64" to "faketype"
 begin { (faketype)cpu }
         ~~~~~~~~~~
 )" });
@@ -2570,14 +2570,11 @@ TEST_F(SemanticAnalyserTest, cast_struct)
 stdin:2:36-44: ERROR: Cannot cast from struct type "struct mytype"
 begin { $s = (struct mytype *)cpu; (uint32)*$s; }
                                    ~~~~~~~~
-stdin:2:36-44: ERROR: Cannot cast from "struct mytype" to "uint32"
-begin { $s = (struct mytype *)cpu; (uint32)*$s; }
-                                   ~~~~~~~~
 )" });
   test("struct mytype { int field; } "
        "begin { (struct mytype)cpu }",
        Error{ R"(
-stdin:1:38-53: ERROR: Cannot cast to "struct mytype"
+stdin:1:38-53: ERROR: Cannot cast from "uint64" to "struct mytype"
 struct mytype { int field; } begin { (struct mytype)cpu }
                                      ~~~~~~~~~~~~~~~
 )" });
@@ -3159,9 +3156,11 @@ TEST_F(SemanticAnalyserTest, intarray_cast_types)
   test("kprobe:f { @ = (int8[])1 }");
   test("kprobe:f { @ = (uint8[8])1 }");
   test("kretprobe:f { @ = (int8[8])retval }");
+  test("kprobe:f { @ = (int8[6])\"hello\" }");
+  test("kprobe:f { @ = (int8[])\"hello\" }");
 
   test("kprobe:f { @ = (int32[])(int16)1 }", Error{});
-  test("kprobe:f { @ = (int8[6])\"hello\" }", Error{});
+  test("kprobe:f { @ = (int8[2])\"hello\" }", Error{});
 
   test("struct Foo { int x; } kprobe:f { @ = (struct Foo [2])1 }", Error{});
 }
@@ -5799,7 +5798,7 @@ TEST_F(SemanticAnalyserTest, typeof_casts)
   test(
       R"(struct foo { int x; } kprobe:f { $x = (struct foo*)0; $y = (typeof(*$x))0; })",
       Error{ R"(
-stdin:1:60-73: ERROR: Cannot cast to "struct foo"
+stdin:1:60-73: ERROR: Cannot cast from "uint8" to "struct foo"
 struct foo { int x; } kprobe:f { $x = (struct foo*)0; $y = (typeof(*$x))0; }
                                                            ~~~~~~~~~~~~~
 )" });

--- a/tests/tracepoint_format_parser.cpp
+++ b/tests/tracepoint_format_parser.cpp
@@ -121,7 +121,8 @@ TEST_F(tracepoint_format_parser, array)
 {
   std::string input =
       "	field:char char_array[8];	offset:0;	size:8;	signed:1;\n"
-      "	field:int int_array[2];	offset:8;	size:8;	signed:1;\n";
+      "	field:char uchar_array[8];	offset:8;	size:8;	signed:0;\n"
+      "	field:int int_array[2];	offset:16;	size:8;	signed:1;\n";
 
   std::istringstream format_file(input);
 
@@ -132,22 +133,23 @@ TEST_F(tracepoint_format_parser, array)
   EXPECT_TRUE(bool(result));
 
   Struct *type = result->get();
-  EXPECT_EQ(type->size, 16);
+  EXPECT_EQ(type->size, 24);
 
   EXPECT_TRUE(type->HasField("char_array"));
   auto char_array = type->GetField("char_array");
-  EXPECT_TRUE(char_array.type.IsArrayTy());
-  EXPECT_EQ(char_array.type.GetNumElements(), 8);
+  EXPECT_TRUE(char_array.type.IsStringTy());
   EXPECT_EQ(char_array.offset, 0);
-  const auto *char_array_elem = char_array.type.GetElementTy();
-  EXPECT_TRUE(char_array_elem->IsIntTy());
-  EXPECT_EQ(char_array_elem->GetSize(), 1);
+
+  EXPECT_TRUE(type->HasField("uchar_array"));
+  auto uchar_array = type->GetField("uchar_array");
+  EXPECT_TRUE(uchar_array.type.IsStringTy());
+  EXPECT_EQ(uchar_array.offset, 8);
 
   EXPECT_TRUE(type->HasField("int_array"));
   auto int_array = type->GetField("int_array");
   EXPECT_TRUE(int_array.type.IsArrayTy());
   EXPECT_EQ(int_array.type.GetNumElements(), 2);
-  EXPECT_EQ(int_array.offset, 8);
+  EXPECT_EQ(int_array.offset, 16);
   const auto *int_array_elem = int_array.type.GetElementTy();
   EXPECT_TRUE(int_array_elem->IsIntTy());
   EXPECT_EQ(int_array_elem->GetSize(), 4);


### PR DESCRIPTION
After some additional investigation it seems like
the simplest and least surprising strategy (from a user perspective) is to always convert char arrays in BTF to bpftrace strings. This is because users have grown to rely on being able to print and compare these
as strings. Automatic converstion to a string is also easier because it maintains all the string resizing logic that happens when two strings of different sizes are stored in variables or maps.

This change also adds support for casting strings
to int8[] if, in the hopefully rare case, a char array was not supposed to be a string. The user can just cast it back.

There is also some minor refactoring of the Cast
visitor in semantic analyser to make it more readable.

Partial revert of https://github.com/bpftrace/bpftrace/pull/4861

##### Checklist

- [x] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [x] The new behaviour is covered by tests
