### PR TITLE
tests/opaque: re-arrange includes

### DIFF
--- a/src/util/opaque.h
+++ b/src/util/opaque.h
@@ -6,6 +6,7 @@
 #include <functional>
 #include <memory>
 #include <optional>
+#include <string>
 #include <type_traits>
 #include <utility>
 #include <variant>


### PR DESCRIPTION
Another small fix to satisfy build environments (such as ours) that may not have, or remove, transitive includes pulled in by other includes.
