### PR TITLE
macro: Disallow builtin and type idents as macro parameter names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,8 @@ and this project adheres to
 - Add support for more vmlinux BTF types as identifiers
   - [#4853](https://github.com/bpftrace/bpftrace/pull/4853)
 #### Changed
+- Disallow builtin and type idents as macro parameter names
+  - [#4873](https://github.com/bpftrace/bpftrace/pull/4873)
 - Add helpers to check if a kfunc exists and is supported for particular probe types.
   - [#4857](https://github.com/bpftrace/bpftrace/pull/4857)
 - `uaddr` support PIE and dynamic library symbols.

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -405,10 +405,10 @@ macro:
 macro_args:
                 macro_args "," map   { $$ = std::move($1); $$.push_back($3); }
         |       macro_args "," var   { $$ = std::move($1); $$.push_back($3); }
-        |       macro_args "," ident { $$ = std::move($1); $$.push_back(driver.ctx.make_node<ast::Identifier>(@$, $3)); }
+        |       macro_args "," IDENT { $$ = std::move($1); $$.push_back(driver.ctx.make_node<ast::Identifier>(@$, $3)); }
         |       map                  { $$ = ast::ExpressionList{$1}; }
         |       var                  { $$ = ast::ExpressionList{$1}; }
-        |       ident                { $$ = ast::ExpressionList{driver.ctx.make_node<ast::Identifier>(@$, $1)}; }
+        |       IDENT                { $$ = ast::ExpressionList{driver.ctx.make_node<ast::Identifier>(@$, $1)}; }
         |       %empty               { $$ = ast::ExpressionList{}; }
                 ;
 

--- a/tests/macro_expansion.cpp
+++ b/tests/macro_expansion.cpp
@@ -205,6 +205,24 @@ stdin:1:24-33: ERROR: The closest definition of add() has a different number of 
 macro add(x) { x + 1 } macro add(x, y) { x + y } begin { add(1, 1, 1); }
                        ~~~~~~~~~
 )");
+  test_error("macro test(pid) { } begin { }",
+             R"(
+stdin:1:12-15: ERROR: syntax error, unexpected builtin, expecting ) or ","
+macro test(pid) { } begin { }
+           ~~~
+)");
+  test_error("macro test(usym_t) { } begin { }",
+             R"(
+stdin:1:12-18: ERROR: syntax error, unexpected builtin type, expecting ) or ","
+macro test(usym_t) { } begin { }
+           ~~~~~~
+)");
+  test_error("macro test(inet) { } begin { }",
+             R"(
+stdin:1:12-16: ERROR: syntax error, unexpected sized type, expecting ) or ","
+macro test(inet) { } begin { }
+           ~~~~
+)");
 }
 
 } // namespace bpftrace::test::macro_expansion


### PR DESCRIPTION
For built-in types, the parameters of Macro sometimes have parsing errors.

This commit disallow builtin and type idents as macro parameter names

Example 1:

    macro test(pid) {
      printf("%d\n", pid);
    }
    begin { test(1); }

    Expect: 1
    Output: 16614

Example 2:

    macro test(arg0, arg1) {
      printf("%d %d\n", arg0, arg1);
    }
    begin { test(1, 2); }

    Expect: 1 2
    Output: ...
            ERROR: The arg0 builtin can only be used with 'kprobes', 'uprobes' and 'usdt' probes
