### PR TITLE
ast: adapt to LLVM setFileManager change

### DIFF
--- a/src/ast/passes/clang_build.cpp
+++ b/src/ast/passes/clang_build.cpp
@@ -129,10 +129,13 @@ static Result<BitcodeModules::Result> build(
   // (works across modern Clang majors, including 21)
   ci.getInvocation() = *inv;
   ci.setDiagnostics(diags.release());
-  ci.setFileManager(new clang::FileManager(clang::FileSystemOptions(), vfs));
+
 #if LLVM_VERSION_MAJOR >= 22
+  ci.setVirtualFileSystem(vfs);
+  ci.createFileManager();
   ci.createSourceManager();
 #else
+  ci.setFileManager(new clang::FileManager(clang::FileSystemOptions(), vfs));
   ci.createSourceManager(ci.getFileManager());
 #endif
 


### PR DESCRIPTION
llvm-project commit 866879f80342 ("[clang] Don't silently inherit the VFS from `FileManager` (#164323)") enforces the explicit setting of the VFS for the instance before FileManager is created.

This change triggers an LLVM assert with the current ast/passes code, and will be in LLVM 22. So, add a conditional for LLVM >= 22 to use the new behavior.