### PR TITLE
builtins: add `__builtin_prog_type` and `__builtin_probe_type`

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -253,7 +253,7 @@ bool AttachPoint::check_available(const std::string &identifier) const
 {
   ProbeType type = probetype(provider);
 
-  if (identifier == "reg" || identifier == "__builtin_usermode") {
+  if (identifier == "reg") {
     switch (type) {
       case ProbeType::kprobe:
       case ProbeType::kretprobe:

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -979,12 +979,6 @@ void SemanticAnalyser::visit(Builtin &builtin)
     builtin.builtin_type.SetAS(addrspace);
   } else if (builtin.ident == "__builtin_username") {
     builtin.builtin_type = CreateUsername();
-  } else if (builtin.ident == "__builtin_usermode") {
-    if (arch::Host::Machine != arch::Machine::X86_64) {
-      builtin.addError() << "'usermode' builtin is only supported on x86_64";
-      return;
-    }
-    builtin.builtin_type = CreateUInt8();
   } else if (builtin.ident == "__builtin_cpid") {
     if (!has_child_) {
       builtin.addError() << "cpid cannot be used without child command";

--- a/src/lexer.l
+++ b/src/lexer.l
@@ -46,7 +46,7 @@ hspace   [ \t]
 vspace   \n
 path     :(\\.|[_\-\./a-zA-Z0-9#$+\*])+
 /* Most of the builtins are prefixed with __builtin_ as they are exposed to users via macros e.g. macro cpu() { __builtin_cpu } */
-builtin  arg[0-9]+|args|ctx|kstack|nsecs|pid|sarg[0-9]|tid|ustack|__builtin_cgroup|__builtin_comm|__builtin_cpid|__builtin_cpu|__builtin_curtask|__builtin_elapsed|__builtin_func|__builtin_gid|__builtin_jiffies|__builtin_ncpus|__builtin_probe|__builtin_rand|__builtin_retval|__builtin_uid|__builtin_usermode|__builtin_username
+builtin  arg[0-9]+|args|ctx|kstack|nsecs|pid|sarg[0-9]|tid|ustack|__builtin_cgroup|__builtin_comm|__builtin_cpid|__builtin_cpu|__builtin_curtask|__builtin_elapsed|__builtin_func|__builtin_gid|__builtin_jiffies|__builtin_ncpus|__builtin_probe|__builtin_rand|__builtin_retval|__builtin_uid|__builtin_username
 
 int_type        bool|(u)?int(8|16|32|64)
 builtin_type    void|(u)?(min|max|sum|avg|stats)_t|count_t|probe_t|username_t|lhist_t|hist_t|usym_t|ksym_t|timestamp|macaddr_t|cgroup_path_t|kstack_t|ustack_t|tseries_t

--- a/src/stdlib/arch.bt
+++ b/src/stdlib/arch.bt
@@ -1,0 +1,24 @@
+// :variant uint8 usermode()
+// Returns 1 if the current process is in user mode, 0 otherwise
+//
+// Currently only available on x86_64.
+macro usermode() {
+  if (arch == "x86_64") {
+    if (__builtin_probe_type == "special") {
+      (uint8)1
+    } else if (__builtin_probe_type == "benchmark") {
+      (uint8)1
+    } else if (__builtin_probe_type == "watchpoint" ||
+               __builtin_probe_type == "asyncwatchpoint" ||
+               __builtin_probe_type == "profile" ||
+               __builtin_probe_type == "interval" ||
+               __builtin_probe_type == "software" ||
+               __builtin_probe_type == "hardware") {
+      (uint8)(ctx.cs & 0x3 == 0x3)
+    } else {
+      (uint8)0
+    }
+  } else {
+    fail("'usermode' builtin is only supported on x86_64")
+  }
+}

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -937,7 +937,7 @@ macro probe() {
 //
 // For example: `kprobe`, `special`, `tracepoint`
 macro probetype() {
-  __builtin_probetype
+  __builtin_probe_type
 }
 
 // :function pton
@@ -1277,14 +1277,6 @@ macro uid() {
 // Marks `ptr` as a user address space pointer.
 // See the address-spaces section for more information on address-spaces.
 // The pointer type is left unchanged.
-
-// :variant uint8 usermode()
-// Returns 1 if the current process is in user mode, 0 otherwise
-//
-// Currently only available on x86_64.
-macro usermode() {
-  __builtin_usermode
-}
 
 // :variant string username()
 // Get the current username

--- a/tests/runtime/macro
+++ b/tests/runtime/macro
@@ -180,11 +180,6 @@ NAME builtin wrapper uid
 PROG begin { if (__builtin_uid == uid() && __builtin_uid == uid) { printf("SUCCESS %d\n", uid); } }
 EXPECT_REGEX SUCCESS [0-9]+
 
-NAME builtin wrapper usermode
-PROG begin { if (__builtin_usermode == usermode() && __builtin_usermode == usermode) { printf("SUCCESS %d\n", usermode); } }
-EXPECT_REGEX SUCCESS 1
-ARCH x86_64
-
 NAME builtin wrapper username
 PROG begin { if (__builtin_username == username() && __builtin_username == username) { printf("SUCCESS %s\n", username); } }
 EXPECT_REGEX SUCCESS .*

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -242,7 +242,7 @@ TEST_F(SemanticAnalyserTest, builtin_variables)
   test("kretprobe:f { retval }");
   test("kprobe:f { func }");
   test("uprobe:/bin/sh:f { func }");
-  test("kprobe:f { probe }");
+  test("kprobe:sys_read { probe }");
   test("kprobe:f { jiffies }");
 
   test("kprobe:f { fake }", Error{ R"(
@@ -1623,8 +1623,10 @@ ERROR: The 'func' builtin is not available for uretprobes on kernels without the
 
 TEST_F(SemanticAnalyserTest, call_probe)
 {
-  test("kprobe:f { @[probe] = count(); }");
-  test("kprobe:f { printf(\"%s\", probe); }");
+  // N.B. This requires a mocked endpoint, since it will fail if
+  // the probe is not successfully expanded to anything.
+  test("kprobe:sys_read { @[probe] = count(); }");
+  test("kprobe:sys_read { printf(\"%s\", probe); }");
 }
 
 TEST_F(SemanticAnalyserTest, call_cat)


### PR DESCRIPTION
Stacked PRs:
 * #4879
 * #4878
 * #4877
 * #4876
 * __->__#4875


--- --- ---

### builtins: add `__builtin_prog_type` and `__builtin_probe_type`


As an examplar, this convers the `__builtin_usermode` macro which was
previously in the constant folder into a macro. These two additional
builtins will enable migration of many provider-dependent builtins.

Note that most of the code in these paths is broken: probes may have
multiple providers, yet checking is often done against only the first.
This change set will not concern itself with these problem; this will be
fixed by doing full up front expansion ahead of semantic analysis, but
doing full expansion requires that these builtins are pulled forward
first. This change should not affect any existing bugs.

Signed-off-by: Adin Scannell <amscanne@meta.com>