### PR TITLE
ast: add `RegisterProviders` pass

### DIFF
--- a/src/ast/CMakeLists.txt
+++ b/src/ast/CMakeLists.txt
@@ -40,6 +40,7 @@ add_library(ast STATIC
   passes/args_resolver.cpp
   passes/probe_prune.cpp
   passes/resource_analyser.cpp
+  passes/register_providers.cpp
   passes/semantic_analyser.cpp
   passes/codegen_llvm.cpp
   passes/resolve_imports.cpp

--- a/src/ast/passes/register_providers.cpp
+++ b/src/ast/passes/register_providers.cpp
@@ -1,0 +1,151 @@
+#include <algorithm>
+#include <vector>
+
+#include "ast/passes/register_providers.h"
+#include "providers/benchmark.h"
+#include "providers/fentry.h"
+#include "providers/interval.h"
+#include "providers/kprobe.h"
+#include "providers/perf.h"
+#include "providers/profile.h"
+#include "providers/rawtracepoint.h"
+#include "providers/special.h"
+#include "providers/tracepoint.h"
+#include "providers/uprobe.h"
+#include "providers/usdt.h"
+#include "providers/watchpoint.h"
+#include "util/wildcard.h"
+
+namespace bpftrace::ast {
+using namespace bpftrace::providers;
+
+const Provider *ProviderRegistry::lookup(const std::string &name)
+{
+  auto it = providers_by_name_.find(name);
+  if (it != providers_by_name_.end()) {
+    return it->second.get();
+  }
+  auto aliased_it = aliases_to_provider_.find(name);
+  if (aliased_it != aliases_to_provider_.end()) {
+    return aliased_it->second;
+  }
+  return nullptr; // Nothing.
+}
+
+Result<> ProviderRegistry::add(std::unique_ptr<Provider> &&provider)
+{
+  const std::string primary_name = provider->name();
+  const auto &aliases = provider->aliases();
+
+  // Check for conflicts with primary name.
+  const auto *other = lookup(primary_name);
+  if (other) {
+    return make_error<ProviderConflict>(other, std::move(provider));
+  }
+
+  // Check for conflicts with aliases.
+  for (const auto &alias : aliases) {
+    const auto *other_aliased = lookup(alias);
+    if (other_aliased) {
+      return make_error<ProviderConflict>(other_aliased, std::move(provider));
+    }
+  }
+
+  // Register the provider.
+  Provider *raw_provider = provider.get();
+  providers_by_name_[primary_name] = std::move(provider);
+  for (const auto &alias : aliases) {
+    aliases_to_provider_[alias] = raw_provider;
+  }
+
+  return OK();
+}
+
+Result<std::vector<std::pair<const Provider *, AttachPointList>>> ProviderRegistry::
+    get_all_matching(const std::string &provider_glob,
+                     const std::string &target_glob,
+                     BtfLookup &btf) const
+{
+  bool start_wildcard, end_wildcard;
+  auto tokens = util::get_wildcard_tokens(provider_glob,
+                                          start_wildcard,
+                                          end_wildcard);
+
+  // Collect the set of providers that we will query.
+  std::vector<const Provider *> providers;
+  for (const auto &pair : providers_by_name_) {
+    if (util::wildcard_match(
+            pair.first, tokens, start_wildcard, end_wildcard)) {
+      providers.push_back(pair.second.get());
+    }
+  }
+  for (const auto &pair : aliases_to_provider_) {
+    if (util::wildcard_match(
+            pair.first, tokens, start_wildcard, end_wildcard) &&
+        std::ranges::find(providers, pair.second) == providers.end()) {
+      providers.push_back(pair.second);
+    }
+  }
+
+  // Grab all matching targets.
+  std::vector<std::pair<const Provider *, AttachPointList>> all_results;
+  for (const auto *p : providers) {
+    AttachPointList provider_results;
+    auto targets = p->parse(target_glob, btf);
+    if (!targets) {
+      // Eat any parse errors, since not all providers will support the
+      // glob. However, if other errors occur, then we propagate these.
+      auto ok = handleErrors(std::move(targets), [](const ParseError &) {});
+      if (!ok) {
+        return ok.takeError();
+      }
+      continue;
+    }
+    for (auto &t : *targets) {
+      provider_results.emplace_back(std::move(t));
+    }
+    all_results.emplace_back(p, std::move(provider_results));
+  }
+  return all_results;
+}
+
+Result<ProviderRegistry> DefaultProviderRegistry()
+{
+  std::vector<std::function<std::unique_ptr<Provider>()>> provider_factories = {
+    []() { return std::make_unique<BenchmarkProvider>(); },
+    []() { return std::make_unique<FentryProvider>(); },
+    []() { return std::make_unique<FexitProvider>(); },
+    []() { return std::make_unique<RawTracepointProvider>(); },
+    []() { return std::make_unique<TracepointProvider>(); },
+    []() { return std::make_unique<KprobeProvider>(); },
+    []() { return std::make_unique<KretprobeProvider>(); },
+    []() { return std::make_unique<UprobeProvider>(); },
+    []() { return std::make_unique<UretprobeProvider>(); },
+    []() { return std::make_unique<BeginProvider>(); },
+    []() { return std::make_unique<EndProvider>(); },
+    []() { return std::make_unique<SelfProvider>(); },
+    []() { return std::make_unique<IntervalProvider>(); },
+    []() { return std::make_unique<ProfileProvider>(); },
+    []() { return std::make_unique<PerfProvider>(); },
+    []() { return std::make_unique<UsdtProvider>(); },
+    []() { return std::make_unique<WatchpointProvider>(); },
+  };
+
+  ProviderRegistry registry;
+  for (const auto &factory : provider_factories) {
+    auto result = registry.add(factory());
+    if (!result) {
+      return result.takeError();
+    }
+  }
+  return registry;
+}
+
+Pass CreateRegisterProvidersPass()
+{
+  return Pass::create("RegisterProviders", []() -> Result<ProviderRegistry> {
+    return DefaultProviderRegistry();
+  });
+}
+
+} // namespace bpftrace::ast

--- a/src/ast/passes/register_providers.h
+++ b/src/ast/passes/register_providers.h
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include "ast/pass_manager.h"
+#include "btf/btf.h"
+#include "providers/provider.h"
+#include "util/result.h"
+
+namespace bpftrace::ast {
+
+// Registry for all available providers.
+//
+// This provides a convenient way to register a set of providers.
+class ProviderRegistry : public State<"providers"> {
+public:
+  using Provider = providers::Provider;
+  using AttachPointList = providers::AttachPointList;
+
+  // Register a providers, returning an error if there are
+  // any conflicts or errors.
+  Result<> add(std::unique_ptr<Provider> &&provider);
+
+  // Looks up a provider by name.
+  const Provider *lookup(const std::string &name);
+
+  // Looks up a provider by type.
+  template <typename T>
+  const Provider *lookup()
+  {
+    return lookup(T().name());
+  }
+
+  // Return matching attachpoints, given a glob.
+  //
+  // Note that these attach points could belong to different providers, and
+  // need to be grouped appropriately in order to use multiple attachpoints.
+  // This is left as the responsibility of the caller.
+  Result<std::vector<std::pair<const Provider *, AttachPointList>>> get_all_matching(
+      const std::string &provider_glob,
+      const std::string &target_glob,
+      providers::BtfLookup &btf) const;
+
+private:
+  std::unordered_map<std::string, std::unique_ptr<Provider>> providers_by_name_;
+  std::unordered_map<std::string, Provider *> aliases_to_provider_;
+};
+
+// Returns a registry will all known providers.
+Result<ProviderRegistry> DefaultProviderRegistry();
+
+// Registers known providers.
+Pass CreateRegisterProvidersPass();
+
+} // namespace bpftrace::ast


### PR DESCRIPTION
Stacked PRs:
 * #4879
 * __->__#4878
 * #4877
 * #4876
 * #4875


--- --- ---

### ast: add `RegisterProviders` pass


This registers a provider registry to be used in subsequent passes.

Signed-off-by: Adin Scannell <amscanne@meta.com>