### PR TITLE
Fix __signal macro

### DIFF
--- a/docs/stdlib.md
+++ b/docs/stdlib.md
@@ -393,6 +393,12 @@ Determine whether the given expression is a pointer.
 Determine whether the given expression is a string.
 
 
+### is_unsigned_integer
+- `bool is_unsigned_integer(any expression)`
+
+Determine whether the given expression is an unsigned integer.
+
+
 ### jiffies
 - `uint64 jiffies()`
 - `uint64 jiffies`

--- a/src/stdlib/meta.bt
+++ b/src/stdlib/meta.bt
@@ -22,6 +22,12 @@ macro is_integer(expr) {
   typeinfo(expr).1 == "int"
 }
 
+// :variant bool is_unsigned_integer(any expression)
+// Determine whether the given expression is an unsigned integer.
+macro is_unsigned_integer(expr) {
+  typeinfo(expr).1 == typeinfo(0).1 && (typeinfo(expr).2)[0] == "u"[0]
+}
+
 // :variant void static_assert(bool condition, string msg)
 // Assert something is true or fail the build.
 macro static_assert(cond, msg) {

--- a/src/stdlib/process.bt
+++ b/src/stdlib/process.bt
@@ -1,6 +1,6 @@
 macro __signal(expr, is_tid) {
   import "stdlib/process/process.bpf.c";
-  let $sig: int32 = 0;
+  let $sig: uint64 = 0;
 
   if comptime (
        probetype != "kprobe"
@@ -20,21 +20,28 @@ macro __signal(expr, is_tid) {
   if comptime (__builtin_safe_mode) {
     fail("%s is unsafe. To use you need the --unsafe flag",
       is_tid ? "signal_thread()" : "signal()");
-  } else if comptime ((is_str(expr) && is_literal(expr))) {
-    $sig = __builtin_signal_num(expr);
-  } else if comptime (typeinfo(expr).1 != typeinfo(0).1) {
-    fail("%s accepts a string literal or a positive integer",
-      is_tid ? "signal_thread()" : "signal()");
   } else if comptime (is_literal(expr)) {
-    if comptime (expr < 1 || expr > 64) {
-      fail("%s accepts a string literal or an integer between 1 and 64 (inclusive)",
+    if comptime (is_str(expr)) {
+      $sig = __builtin_signal_num(expr);
+    } else if comptime (is_integer(expr)) {
+      if comptime (expr < 1 || expr > 64) {
+        fail("%s accepts a string literal or an integer between 1 and 64 (inclusive)",
+        is_tid ? "signal_thread()" : "signal()");
+      } else {
+        $sig = expr;
+      }
+    } else {
+      fail("%s accepts a string literal or a positive integer",
       is_tid ? "signal_thread()" : "signal()");
     }
+  } else if comptime (!is_unsigned_integer(expr)) {
+    fail("%s accepts a string literal or a unsigned integer",
+      is_tid ? "signal_thread()" : "signal()");
   } else {
-    $sig = (int32)expr;
+    $sig = expr;
   }
 
-  if ($sig < 1 || $sig > 64) {
+  if ($sig == 0 || $sig > 64) {
     errorf("%s expects an integer between 1 and 64 (inclusive). Got %d",
       is_tid ? "signal_thread()" : "signal()", $sig);
   } else {

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -3456,7 +3456,7 @@ TEST_F(SemanticAnalyserTest, signal)
 
     // vars
     test("k:f { @=1;" + signal + "(@); }", UnsafeMode::Enable, Types{ types });
-    test("k:f { @=1;" + signal + "((int32)arg0); }",
+    test("k:f { " + signal + "((uint64)arg0); }",
          UnsafeMode::Enable,
          Types{ types });
 
@@ -3503,6 +3503,10 @@ TEST_F(SemanticAnalyserTest, signal)
          Types{ types },
          Error{});
     test("k:f {" + signal + "(100); }",
+         UnsafeMode::Enable,
+         Types{ types },
+         Error{});
+    test("k:f { $a = -1" + signal + "($a); }",
          UnsafeMode::Enable,
          Types{ types },
          Error{});


### PR DESCRIPTION
I broke this in a previous commit in that
if you call signal with a literal integer
it doesn't assign it to the internal `$sig`
variable.

Also made sure that if a user passes a signed
integer that's not a literal that they have
to perform the cast to an unsigned int32.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
