### PR TITLE
getopt: support unsigned integers

### DIFF
--- a/src/ast/passes/named_param.cpp
+++ b/src/ast/passes/named_param.cpp
@@ -66,11 +66,11 @@ void NamedParamPass::visit(Expression &expr)
     map_node->value_type = CreateString(bpftrace_.config_->max_strlen);
     np_default = default_value->value;
   } else if (auto *default_value = call->vargs.at(1).as<Integer>()) {
-    // integer
-    map_node->value_type = CreateInt64();
-    np_default = static_cast<int64_t>(default_value->value);
+    // unsigned integer
+    map_node->value_type = CreateUInt64();
+    np_default = default_value->value;
   } else if (auto *default_value = call->vargs.at(1).as<NegativeInteger>()) {
-    // integer
+    // signed integer
     map_node->value_type = CreateInt64();
     np_default = default_value->value;
   }
@@ -83,6 +83,10 @@ void NamedParamPass::visit(Expression &expr)
     } else if (std::holds_alternative<int64_t>(used_args.at(arg_name->value))) {
       pre_value = std::to_string(
           std::get<int64_t>(used_args.at(arg_name->value)));
+    } else if (std::holds_alternative<uint64_t>(
+                   used_args.at(arg_name->value))) {
+      pre_value = std::to_string(
+          std::get<uint64_t>(used_args.at(arg_name->value)));
     } else {
       pre_value = std::get<bool>(used_args.at(arg_name->value)) ? "true"
                                                                 : "false";

--- a/src/ast/passes/named_param.h
+++ b/src/ast/passes/named_param.h
@@ -2,7 +2,6 @@
 
 #include "ast/pass_manager.h"
 #include "globalvars.h"
-#include "types.h"
 
 namespace bpftrace::ast {
 

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -79,7 +79,7 @@ private:
   std::vector<std::string> expected_;
 };
 
-using GlobalVarValue = std::variant<std::string, int64_t, bool>;
+using GlobalVarValue = std::variant<std::string, int64_t, uint64_t, bool>;
 
 using GlobalVarMap = std::unordered_map<std::string, GlobalVarValue>;
 
@@ -112,7 +112,13 @@ constexpr std::string_view EVENT_LOSS_COUNTER_SECTION_NAME =
 
 struct GlobalVarConfig {
   std::string section;
-  Type type = Type::none;
+  enum Type {
+    opt_bool,
+    opt_string,
+    opt_signed,
+    opt_unsigned,
+  };
+  std::optional<Type> type = std::nullopt;
 
 private:
   friend class cereal::access;
@@ -126,12 +132,12 @@ private:
 const std::unordered_map<std::string_view, GlobalVarConfig>
     GLOBAL_VAR_CONFIGS = {
       { NUM_CPUS,
-        { .section = std::string(RO_SECTION_NAME), .type = Type::integer } },
+        { .section = std::string(RO_SECTION_NAME), .type = GlobalVarConfig::opt_unsigned } },
       { MAX_CPU_ID,
-        { .section = std::string(RO_SECTION_NAME), .type = Type::integer } },
+        { .section = std::string(RO_SECTION_NAME), .type = GlobalVarConfig::opt_unsigned } },
       { EVENT_LOSS_COUNTER,
         { .section = std::string(EVENT_LOSS_COUNTER_SECTION_NAME),
-          .type = Type::integer } },
+          .type = GlobalVarConfig::opt_unsigned } },
       { FMT_STRINGS_BUFFER,
         { .section = std::string(FMT_STRINGS_BUFFER_SECTION_NAME) } },
       { TUPLE_BUFFER, { .section = std::string(TUPLE_BUFFER_SECTION_NAME) } },
@@ -177,8 +183,8 @@ public:
       const struct bpf_object *bpf_object,
       const std::unordered_map<std::string, struct bpf_map *> &global_vars_map,
       GlobalVarMap &&global_var_vals,
-      int ncpus,
-      int max_cpu_id);
+      uint64_t ncpus,
+      uint64_t max_cpu_id);
 
   std::unordered_set<std::string> get_global_vars_for_section(
       std::string_view target_section);

--- a/tests/runtime/other
+++ b/tests/runtime/other
@@ -369,13 +369,13 @@ EXPECT_REGEX .*ERROR: Invalid value for license. Found: Potato. Valid values: Du
 WILL_FAIL
 
 NAME named command line params
-RUN {{BPFTRACE}} -e 'begin { print((getopt("aa", 10), getopt("cc", true), getopt("dd"), getopt("ee", "hello")));  }' -- --dd --aa=20 --cc=False
-EXPECT (20, false, true, hello)
+RUN {{BPFTRACE}} -e 'begin { print((getopt("aa", 20), getopt("bb", -1), getopt("cc", true), getopt("dd"), getopt("ee", "hello")));  }' -- --dd --aa=0xffffffffffffffff --bb=-10 --cc=False
+EXPECT (18446744073709551615, -10, false, true, hello)
 TIMEOUT 1
 
 NAME named and positional params
-RUN {{BPFTRACE}} -e 'begin { print(($1, getopt("aa", 10), $2, getopt("bb", "hello"), getopt("cc")));  }' pos1 -- --aa=20 --bb=bye pos2 --cc
-EXPECT (pos1, 20, pos2, bye, true)
+RUN {{BPFTRACE}} -e 'begin { print(($1, getopt("aa", 10), getopt("bb", -1), $2, getopt("cc", "hello"), getopt("dd")));  }' pos1 -- --aa=20 --bb=5 --cc=bye pos2 --dd
+EXPECT (pos1, 20, 5, pos2, bye, true)
 TIMEOUT 1
 
 # Can't run through the standard AOT path because we need to pass CLI args


### PR DESCRIPTION
Stacked PRs:
 * __->__#4881


--- --- ---

### getopt: support unsigned integers


Default to unsigned integers for arguments, in order to support parsing
full 64-bit values. This may be common, as it is required for passing a
kernel address as a parameter.

Signed-off-by: Adin Scannell <amscanne@meta.com>
