### PR TITLE
use getNullValue to initialize variables

### DIFF
--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -238,7 +238,7 @@ void IRBuilderBPF::CreateAllocationInit(const SizedType &stype, Value *alloc)
   if (needMemcpy(stype)) {
     CreateMemsetBPF(alloc, getInt8(0), stype.GetSize());
   } else {
-    CreateStore(ConstantInt::get(GetType(stype), 0), alloc);
+    CreateStore(Constant::getNullValue(GetType(stype)), alloc);
   }
 }
 


### PR DESCRIPTION
A small fix to avoid an assertion failure when using LLVM with assertions enabled.