### PR TITLE
bpffeature: Check the validity of kfunc btf_id

### DIFF
--- a/src/bpffeature.cpp
+++ b/src/bpffeature.cpp
@@ -201,6 +201,10 @@ bool BPFfeature::kfunc_allowed(const char* kfunc, enum bpf_prog_type prog_type)
     int kfunc_btf_id = btf_.get_btf_id(kfunc, "vmlinux");
     size_t insn_cnt = 0;
 
+    if (kfunc_btf_id <= 0) {
+      return false;
+    }
+
     *insn++ = BPF_CALL_KFUNC(0, kfunc_btf_id);
     *insn++ = BPF_EXIT_INSN();
 


### PR DESCRIPTION
When kfunc does not exist and btf_id is equal to-1, the validity of the btf_id should be checked first.

For example, when kfunc does not exist, kfunc_allowed will always return true:

    tracepoint:syscalls:sys_enter_kill,
    tracepoint:syscalls:sys_enter_tkill,
    tracepoint:syscalls:sys_enter_tgkill,
    kprobe:__x64_sys_kill,
    kprobe:__x64_sys_tgkill,
    kprobe:__x64_sys_tkill
    {
      printf("%s %d\n", probetype, kfunc_allowed("__not_exist_kfunc__"));
    }

kernel logbuf (4294967295 is -1):

    kernel btf_id 4294967295 is not a function
    processed 0 insns (limit 1000000) max_states_per_insn 0 total_states 0 peak_states 0 mark_read 0

Fix: commit b64fc319c93f ("kfunc: Check whether the BPF program type is supported (#4857)")
