### PR TITLE
Remove unused clang_parser function

### DIFF
--- a/src/ast/passes/clang_parser.cpp
+++ b/src/ast/passes/clang_parser.cpp
@@ -415,31 +415,6 @@ int visitChildren(CXCursor cursor, visitFn fn)
       static_cast<void *>(&fn));
 }
 
-// Get annotation associated with field declaration `c`
-std::optional<std::string> get_field_decl_annotation(CXCursor c)
-{
-  assert(clang_getCursorKind(c) == CXCursor_FieldDecl);
-
-  std::optional<std::string> annotation;
-  visitChildren(c, [&](CXCursor c, CXCursor __attribute__((unused)) parent) {
-    // The header generation code can annotate some struct
-    // fields with additional information for us to parse
-    // here. The annotation looks like:
-    //
-    //    struct Foo {
-    //      __attribute__((annotate("tp_data_loc"))) int
-    //      name;
-    //    };
-    //
-    // Currently only the TracepointFormatParser does this.
-    if (clang_getCursorKind(c) == CXCursor_AnnotateAttr) {
-      annotation = get_clang_string(clang_getCursorSpelling(c));
-    }
-
-    return CXChildVisit_Recurse;
-  });
-  return annotation;
-}
 } // namespace
 
 bool ClangParser::visit_children(CXCursor &cursor, BPFtrace &bpftrace)


### PR DESCRIPTION
##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
