### PR TITLE
types: drop `is_internal` and rely only on the address space

### DIFF
--- a/src/ast/codegen_helper.h
+++ b/src/ast/codegen_helper.h
@@ -24,7 +24,7 @@ inline bool shouldBeInBpfMemoryAlready(const SizedType &type)
 
 inline bool inBpfMemory(const SizedType &type)
 {
-  return type.is_internal || shouldBeInBpfMemoryAlready(type);
+  return type.GetAS() == AddrSpace::none || shouldBeInBpfMemoryAlready(type);
 }
 
 inline AddrSpace find_addrspace_stack(const SizedType &ty)

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2636,8 +2636,7 @@ ScopedExpr CodegenLLVM::visit(Cast &cast)
     if (cast.expr.type().IsArrayTy()) {
       // we need to read the array into the integer
       Value *array = scoped_expr.value();
-      if (cast.expr.type().is_internal ||
-          cast.expr.type().GetAS() == AddrSpace::none) {
+      if (cast.expr.type().GetAS() == AddrSpace::none) {
         // array is on the stack - just cast the pointer
         if (array->getType()->isIntegerTy())
           array = b_.CreateIntToPtr(array, b_.getPtrTy());
@@ -4171,7 +4170,7 @@ ScopedExpr CodegenLLVM::probereadDatastructElem(ScopedExpr &&scoped_src,
     return ScopedExpr(src, std::move(scoped_src));
   } else if (elem_type.IsStringTy() || elem_type.IsBufferTy()) {
     AllocaInst *dst = b_.CreateAllocaBPF(elem_type, temp_name);
-    if (elem_type.IsStringTy() && data_type.is_internal) {
+    if (elem_type.IsStringTy() && elem_type.GetAS() == AddrSpace::none) {
       if (src->getType()->isIntegerTy())
         src = b_.CreateIntToPtr(src, dst->getType());
       b_.CreateMemcpyBPF(dst, src, elem_type.GetSize());

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -513,7 +513,6 @@ SizedType CreateUsername()
 SizedType CreateInet(size_t size)
 {
   auto st = SizedType(Type::inet, size);
-  st.is_internal = true;
   return st;
 }
 
@@ -570,7 +569,6 @@ SizedType CreateRecord(std::shared_ptr<Struct> &&record)
 SizedType CreateMacAddress()
 {
   auto st = SizedType(Type::mac_address, 6);
-  st.is_internal = true;
   return st;
 }
 

--- a/src/types.h
+++ b/src/types.h
@@ -185,7 +185,6 @@ public:
   }
 
   StackType stack_type;
-  bool is_internal = false;
   TimestampMode ts_mode = TimestampMode::boot;
 
 private:
@@ -213,7 +212,6 @@ private:
   {
     archive(type_,
             stack_type,
-            is_internal,
             is_anon_,
             is_signed_,
             element_type_,

--- a/tests/type_checker.cpp
+++ b/tests/type_checker.cpp
@@ -2431,28 +2431,6 @@ TEST_F(TypeCheckerTest, field_access_sub_struct)
        Error{});
 }
 
-TEST_F(TypeCheckerTest, field_access_is_internal)
-{
-  std::string structs = "struct type1 { int x; }";
-
-  {
-    auto ast = test(structs + "kprobe:f { $x = (*(struct type1*)0).x }");
-    auto &stmts = ast.root->probes.at(0)->block->stmts;
-    auto *var_assignment1 = stmts.at(0).as<ast::AssignVarStatement>();
-    EXPECT_FALSE(var_assignment1->var()->var_type.is_internal);
-  }
-
-  {
-    auto ast = test(structs +
-                    "kprobe:f { @type1 = *(struct type1*)0; $x = @type1.x }");
-    auto &stmts = ast.root->probes.at(0)->block->stmts;
-    auto *map_assignment = stmts.at(0).as<ast::AssignMapStatement>();
-    auto *var_assignment2 = stmts.at(1).as<ast::AssignVarStatement>();
-    EXPECT_TRUE(map_assignment->map_access->map->value_type.is_internal);
-    EXPECT_TRUE(var_assignment2->var()->var_type.is_internal);
-  }
-}
-
 TEST_F(TypeCheckerTest, struct_as_map_key)
 {
   test("struct A { int x; } struct B { char x; } "


### PR DESCRIPTION
Stacked PRs:
 * __->__#4891
 * #4887
 * #4894


--- --- ---

### types: drop `is_internal` and rely only on the address space


Signed-off-by: Adin Scannell <amscanne@meta.com>
