### PR TITLE
maps: use `DiscardExpr` for map desugaring

### DIFF
--- a/src/ast/passes/map_sugar.cpp
+++ b/src/ast/passes/map_sugar.cpp
@@ -298,8 +298,10 @@ void MapAssignmentCall::visit(Statement &stmt)
                           assign->map_access->map,
                           assign->map_access->key);
     if (expr) {
-      // We injected a call, and can flatten the statement.
-      stmt.value = ast_.make_node<ExprStatement>(assign->loc, expr.value());
+      // We injected a call, and can flatten the statement. This discards
+      // the return value, because it is not otherwise useful. We originally
+      // visited as a statement, so this does not affect the semantics.
+      stmt.value = ast_.make_node<DiscardExpr>(assign->loc, expr.value());
     }
   }
   Visitor<MapAssignmentCall>::visit(stmt);

--- a/src/ast/passes/printer.cpp
+++ b/src/ast/passes/printer.cpp
@@ -943,6 +943,14 @@ Buffer Formatter::visit(Unroll& unroll)
       .text("}");
 }
 
+Buffer Formatter::visit(DiscardExpr& discard)
+{
+  return Buffer()
+      .text("_ = ")
+      .append(format(discard.expr, metadata, max_width, true))
+      .text(";");
+}
+
 Buffer Formatter::visit(Range& range)
 {
   Buffer start;

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -95,6 +95,7 @@ public:
   Buffer visit(VarDeclStatement &decl);
   Buffer visit(Jump &jump);
   Buffer visit(Unroll &unroll);
+  Buffer visit(DiscardExpr &discard);
   Buffer visit(While &while_block);
   Buffer visit(Range &range);
   Buffer visit(For &for_loop);

--- a/tests/ast_matchers.h
+++ b/tests/ast_matchers.h
@@ -1157,6 +1157,15 @@ inline ExprStatementMatcher ExprStatement(
   return ExprStatementMatcher().WithExpr(expr_matcher);
 }
 
+class DiscardExprMatcher
+    : public NodeMatcher<DiscardExprMatcher, ast::DiscardExpr> {};
+
+inline DiscardExprMatcher DiscardExpr(
+    const Matcher<const ast::Expression&>& expr_matcher)
+{
+  return DiscardExprMatcher().WithExpr(expr_matcher);
+}
+
 class IfExprMatcher : public NodeMatcher<IfExprMatcher, ast::IfExpr> {};
 
 inline IfExprMatcher If(const Matcher<const ast::Expression&>& cond,

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -3232,4 +3232,9 @@ TEST(Parser, for_loop_unary_condition)
                  { ExprStatement(Call("print", { Variable("$i") })) }) })));
 }
 
+TEST(Parser, discard)
+{
+  test("kprobe:f { _ = 1; }",
+       Program().WithProbe(Probe({ "kprobe:f" }, { DiscardExpr(Integer(1)) })));
+}
 } // namespace bpftrace::test::parser

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -2380,7 +2380,7 @@ TEST_F(SemanticAnalyserTest, map_aggregations_implicit_cast)
        ExpectedAST{ Program().WithProbe(
            Probe({ "kprobe:f" },
                  { AssignMapStatement(Map("@x"), Integer(0), Integer(1)),
-                   ExprStatement(Call("count", { Map("@y"), Integer(0) })),
+                   DiscardExpr(Call("count", { Map("@y"), Integer(0) })),
                    AssignMapStatement(
                        Map("@x"),
                        Integer(0),
@@ -2391,7 +2391,7 @@ TEST_F(SemanticAnalyserTest, map_aggregations_implicit_cast)
        ExpectedAST{ Program().WithProbe(Probe(
            { "kprobe:f" },
            { AssignMapStatement(Map("@x"), Integer(0), Integer(1)),
-             ExprStatement(Call("sum", { Map("@y"), Integer(0), Integer(5) })),
+             DiscardExpr(Call("sum", { Map("@y"), Integer(0), Integer(5) })),
              AssignMapStatement(
                  Map("@x"),
                  Integer(0),
@@ -2402,7 +2402,7 @@ TEST_F(SemanticAnalyserTest, map_aggregations_implicit_cast)
        ExpectedAST{ Program().WithProbe(Probe(
            { "kprobe:f" },
            { AssignMapStatement(Map("@x"), Integer(0), Integer(1)),
-             ExprStatement(Call("min", { Map("@y"), Integer(0), Integer(5) })),
+             DiscardExpr(Call("min", { Map("@y"), Integer(0), Integer(5) })),
              AssignMapStatement(
                  Map("@x"),
                  Integer(0),
@@ -2413,7 +2413,7 @@ TEST_F(SemanticAnalyserTest, map_aggregations_implicit_cast)
        ExpectedAST{ Program().WithProbe(Probe(
            { "kprobe:f" },
            { AssignMapStatement(Map("@x"), Integer(0), Integer(1)),
-             ExprStatement(Call("max", { Map("@y"), Integer(0), Integer(5) })),
+             DiscardExpr(Call("max", { Map("@y"), Integer(0), Integer(5) })),
              AssignMapStatement(
                  Map("@x"),
                  Integer(0),
@@ -2424,7 +2424,7 @@ TEST_F(SemanticAnalyserTest, map_aggregations_implicit_cast)
        ExpectedAST{ Program().WithProbe(Probe(
            { "kprobe:f" },
            { AssignMapStatement(Map("@x"), Integer(0), Integer(1)),
-             ExprStatement(Call("avg", { Map("@y"), Integer(0), Integer(5) })),
+             DiscardExpr(Call("avg", { Map("@y"), Integer(0), Integer(5) })),
              AssignMapStatement(
                  Map("@x"),
                  Integer(0),
@@ -3405,7 +3405,7 @@ TEST_F(SemanticAnalyserTest, mixed_int_like_binop)
   test("kprobe:f { @a = sum(-1); $a = (uint8)1 == @a; }",
        ExpectedAST{ Program().WithProbe(Probe(
            { "kprobe:f" },
-           { ExprStatement(
+           { DiscardExpr(
                  Call("sum", { Map("@a"), Integer(0), NegativeInteger(-1) })),
              AssignVarStatement(
                  Variable("$a"),


### PR DESCRIPTION
Stacked PRs:
 * __->__#4895


--- --- ---

### maps: use `DiscardExpr` for map desugaring


Currently, some map aggregate functions results in a warning, e.g.
`@ = hist(...);`. While this is a result of incorrect return types, it
is also a symptom of the transformation being applied being suboptimal.
Instead, we should transform to `_ = hist(@, ...)` which allows any
return value for the underlying function.

More importantly, this change also fixes up issues on the periphery of
`DiscardExpr`, adding a basic parser test, and ensuring that this is
printed correctly.

Signed-off-by: Adin Scannell <amscanne@meta.com>
