### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to
 - Fix language part being overwritten in uprobe attachpoint parser
   - [#4856](https://github.com/bpftrace/bpftrace/pull/4856)
 - Fix automatic conversion of BTF char arrays to bpftrace strings
-  - [#4861](https://github.com/bpftrace/bpftrace/pull/4861)
+  - [#4871](https://github.com/bpftrace/bpftrace/pull/4871)
 - Fix anonymous struct/unions not resolving correctly from BTF
   - [#4732](https://github.com/bpftrace/bpftrace/pull/4732)
 - Fix getopt support for unsigned integers


### PR DESCRIPTION
Fix link in changelog for auto conversion of BTF int array to string.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
