### PR TITLE
Remove some error handling in builtins.cpp

### DIFF
--- a/src/ast/passes/builtins.cpp
+++ b/src/ast/passes/builtins.cpp
@@ -36,6 +36,15 @@ private:
 
 std::optional<Expression> Builtins::check(const std::string &ident, Node &node)
 {
+  auto *probe = dynamic_cast<Probe *>(top_level_node_);
+  auto check_probe = [&]() -> bool {
+    if (!probe) {
+      node.addError() << ident << " can only be used inside of a probe.";
+      return false;
+    }
+    return true;
+  };
+
   // N.B. this pass *should* include all the compile-time builtins (probe,
   // provider, etc.) but it presently cannot due to the expansion rules. All
   // builtins should be added here once probes are fully-expanded up front.
@@ -47,20 +56,17 @@ std::optional<Expression> Builtins::check(const std::string &ident, Node &node)
     std::stringstream ss;
     ss << bpftrace::arch::current();
     return ast_.make_node<String>(node.loc, ss.str());
-  }
-  if (ident == "__builtin_safe_mode") {
+  } else if (ident == "__builtin_safe_mode") {
     return ast_.make_node<Boolean>(node.loc, bpftrace_.safe_mode_);
-  }
-  if (ident == "__builtin_probe") {
-    if (auto *probe = dynamic_cast<Probe *>(top_level_node_)) {
+  } else if (ident == "__builtin_probe") {
+    if (check_probe()) {
       return ast_.make_node<String>(node.loc,
                                     probe->attach_points.empty()
                                         ? "none"
                                         : probe->attach_points.front()->name());
     }
-  }
-  if (ident == "__builtin_probetype") {
-    if (auto *probe = dynamic_cast<Probe *>(top_level_node_)) {
+  } else if (ident == "__builtin_probetype") {
+    if (check_probe()) {
       return ast_.make_node<String>(
           node.loc,
           probe->attach_points.empty()
@@ -68,27 +74,18 @@ std::optional<Expression> Builtins::check(const std::string &ident, Node &node)
               : probetypeName(
                     probetype(probe->attach_points.front()->provider)));
     }
-  }
-  if (ident == "__builtin_elf_is_exe" || ident == "__builtin_elf_ino") {
-    auto *probe = dynamic_cast<Probe *>(top_level_node_);
-    if (!probe) {
-      return std::nullopt;
-    }
-    ProbeType type = probetype(probe->attach_points.front()->provider);
-    // Only for uprobe,uretprobe,USDT.
-    if (type != ProbeType::uprobe && type != ProbeType::uretprobe &&
-        type != ProbeType::usdt) {
-      LOG(BUG) << "The " << ident << " can not be used with '"
-               << probe->attach_points.front()->provider << "' probes";
-    }
-    if (ident == "__builtin_elf_is_exe") {
+  } else if (ident == "__builtin_elf_is_exe") {
+    if (check_probe()) {
       return ast_.make_node<Boolean>(
           node.loc, util::is_exe(probe->attach_points.front()->target));
-    } else {
+    }
+  } else if (ident == "__builtin_elf_ino") {
+    if (check_probe()) {
       return ast_.make_node<Integer>(
           node.loc, util::file_ino(probe->attach_points.front()->target));
     }
   }
+
   return std::nullopt;
 }
 

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -1305,8 +1305,8 @@ macro uaddr(sym)
   // There are three types of ELF that use uprobe: PIE, EXEC, and dynamic
   // libraries. Among them, PIE and dynamic libraries need to correct the
   // symbol address according to the actual load address.
-  if comptime (!__builtin_elf_is_exe) {
-    $offset = (uint64)__bpf_task_map_file_min_addr((uint64)__builtin_elf_ino);
+  if comptime (!elf_is_exe) {
+    $offset = (uint64)__bpf_task_map_file_min_addr((uint64)elf_info);
     $addr += $offset;
   }
   $addr

--- a/src/stdlib/meta.bt
+++ b/src/stdlib/meta.bt
@@ -70,3 +70,25 @@ macro usdt_arg(x)
 {
   __usdt_arg((void *)ctx, x)
 }
+
+macro elf_is_exe()
+{
+  if comptime (probetype != "uprobe" && probetype != "uretprobe" &&
+               probetype != "usdt") {
+    fail("elf_is_exe can not be used for this probetype %s", probetype);
+    false
+  } else {
+    __builtin_elf_is_exe
+  }
+}
+
+macro elf_info()
+{
+  if comptime (probetype != "uprobe" && probetype != "uretprobe" &&
+               probetype != "usdt") {
+    fail("elf_info can not be used for this probetype %s", probetype);
+    false
+  } else {
+    __builtin_elf_ino
+  }
+}


### PR DESCRIPTION
Move probetype checks into the stdlib.

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
