### PR TITLE
Re-add static cast to fix build on 32bit systems

### DIFF
--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2005,7 +2005,9 @@ ScopedExpr CodegenLLVM::visit(Call &call)
     auto &right_arg = call.vargs.at(1);
     auto size_opt = call.vargs.at(2).as<Integer>()->value;
     uint64_t size = std::min(
-        { size_opt, left_arg.type().GetSize(), right_arg.type().GetSize() });
+        { size_opt,
+          static_cast<uint64_t>(left_arg.type().GetSize()),
+          static_cast<uint64_t>(right_arg.type().GetSize()) });
 
     auto left_string = visit(&left_arg);
     auto right_string = visit(&right_arg);


### PR DESCRIPTION
This is because size_t is 32bits which is the type returned by type().GetSize() but an Integer's value is 64bits.


(cherry picked from commit a19d6abaa20ca307d9307ef0d2d58712f26c8e2f)

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
