### PR TITLE
Remove stack ids and stack hashing

### DIFF
--- a/src/ast/async_ids.h
+++ b/src/ast/async_ids.h
@@ -6,9 +6,10 @@ namespace bpftrace::ast {
 
 // Add new ids here
 #define FOR_LIST_OF_ASYNC_IDS(DO)                                              \
-  DO(runtime_error)                                                            \
+  DO(call_stack)                                                                 \
   DO(map_key)                                                                  \
   DO(read_map_value)                                                           \
+  DO(runtime_error)                                                            \
   DO(str)                                                                      \
   DO(tuple)                                                                    \
   DO(variable)                                                                 \

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -134,29 +134,25 @@ AllocaInst *IRBuilderBPF::CreateUSym(Value *val,
   return buf;
 }
 
-StructType *IRBuilderBPF::GetStackStructType(bool is_ustack)
+StructType *IRBuilderBPF::GetStackStructType(const StackType &stack_type)
 {
+  std::vector<llvm::Type *> elements;
   // Kernel stacks should not be differentiated by pid, since the kernel
   // address space is the same between pids (and when aggregating you *want*
   // to be able to correlate between pids in most cases). User-space stacks
   // are special because of ASLR, hence we also store the pid; probe id is
   // stored for cases when only ELF resolution works (e.g. ASLR disabled and
   // process exited).
-  if (is_ustack) {
-    std::vector<llvm::Type *> elements{
-      getInt64Ty(), // stack id
-      getInt64Ty(), // nr_stack_frames
-      getInt32Ty(), // pid
-      getInt32Ty(), // probe id
-    };
-    return GetStructType("ustack_key", elements, false);
-  } else {
-    std::vector<llvm::Type *> elements{
-      getInt64Ty(), // stack id
-      getInt64Ty(), // nr_stack_frames
-    };
-    return GetStructType("kstack_key", elements, false);
+  if (!stack_type.kernel) {
+    elements.emplace_back(getInt32Ty()); // pid
+    elements.emplace_back(getInt32Ty()); // probe id
   }
+  // If the offset changes, make sure to also change the codegen for "stack_len"
+  elements.emplace_back(getInt64Ty()); // nr_stack_frames
+  elements.emplace_back(
+      ArrayType::get(getInt64Ty(), stack_type.limit)); // stack of addresses
+
+  return GetStructType(stack_type.name(), elements, false);
 }
 
 StructType *IRBuilderBPF::GetStructType(
@@ -367,7 +363,7 @@ llvm::Type *IRBuilderBPF::GetType(const SizedType &stype)
 
     ty = GetStructType(ty_name, llvm_elems, false);
   } else if (stype.IsStack()) {
-    ty = GetStackStructType(stype.IsUstackTy());
+    ty = GetStackStructType(stype.stack_type);
   } else if (stype.IsPtrTy()) {
     ty = getPtrTy();
   } else if (stype.IsVoidTy()) {
@@ -534,17 +530,6 @@ CallInst *IRBuilderBPF::CreateGetJoinMap(BasicBlock *failure_callback,
       to_string(MapType::Join), "join", loc, failure_callback);
 }
 
-CallInst *IRBuilderBPF::CreateGetStackScratchMap(StackType stack_type,
-                                                 BasicBlock *failure_callback,
-                                                 const Location &loc)
-{
-  SizedType value_type = CreateArray(stack_type.limit, CreateUInt64());
-  return createGetScratchMap(StackType::scratch_name(),
-                             StackType::scratch_name(),
-                             loc,
-                             failure_callback);
-}
-
 Value *IRBuilderBPF::CreateGetStrAllocation(const std::string &name,
                                             const Location &loc,
                                             uint64_t pad)
@@ -576,6 +561,19 @@ Value *IRBuilderBPF::CreateTupleAllocation(const SizedType &tuple_type,
                           loc,
                           [](AsyncIds &async_ids) {
                             return async_ids.tuple();
+                          });
+}
+
+Value *IRBuilderBPF::CreateCallStackAllocation(const SizedType &stack_type,
+                                               const std::string &name,
+                                               const Location &loc)
+{
+  return createAllocation(bpftrace::globalvars::CALL_STACK_BUFFER,
+                          GetType(stack_type),
+                          name,
+                          loc,
+                          [](AsyncIds &async_ids) {
+                            return async_ids.call_stack();
                           });
 }
 
@@ -1807,13 +1805,12 @@ CallInst *IRBuilderBPF::CreateGetRandom(const Location &loc)
 }
 
 CallInst *IRBuilderBPF::CreateGetStack(Value *ctx,
-                                       bool ustack,
                                        Value *buf,
-                                       StackType stack_type,
+                                       const StackType &stack_type,
                                        const Location &loc)
 {
   int flags = 0;
-  if (ustack)
+  if (!stack_type.kernel)
     flags |= (1 << 8);
   Value *flags_val = getInt64(flags);
   Value *stack_size = getInt32(stack_type.limit * sizeof(uint64_t));

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -114,18 +114,14 @@ public:
   CallInst *CreateGetCurrentTask(const Location &loc);
   CallInst *CreateGetRandom(const Location &loc);
   CallInst *CreateGetStack(Value *ctx,
-                           bool ustack,
                            Value *buf,
-                           StackType stack_type,
+                           const StackType& stack_type,
                            const Location &loc);
   CallInst *CreateGetFuncIp(Value *ctx, const Location &loc);
   CallInst *CreatePerCpuPtr(Value *var, Value *cpu, const Location &loc);
   CallInst *CreateThisCpuPtr(Value *var, const Location &loc);
   CallInst *CreateGetSocketCookie(Value *var, const Location &loc);
   CallInst *CreateGetJoinMap(BasicBlock *failure_callback, const Location &loc);
-  CallInst *CreateGetStackScratchMap(StackType stack_type,
-                                     BasicBlock *failure_callback,
-                                     const Location &loc);
   Value *CreateGetStrAllocation(const std::string &name,
                                 const Location &loc,
                                 uint64_t pad = 0);
@@ -133,6 +129,9 @@ public:
                                           const std::string &name,
                                           const Location &loc);
   Value *CreateTupleAllocation(const SizedType &tuple_type,
+                               const std::string &name,
+                               const Location &loc);
+  Value *CreateCallStackAllocation(const SizedType &stack_type,
                                const std::string &name,
                                const Location &loc);
   Value *CreateWriteMapValueAllocation(const SizedType &value_type,
@@ -183,7 +182,7 @@ public:
   void CreateHelperErrorCond(Value *return_value,
                              bpf_func_id func_id,
                              const Location &loc);
-  StructType *GetStackStructType(bool is_ustack);
+  StructType *GetStackStructType(const StackType& stack_type);
   StructType *GetStructType(const std::string &name,
                             const std::vector<llvm::Type *> &elements,
                             bool packed = false);

--- a/src/ast/passes/codegen_resources.cpp
+++ b/src/ast/passes/codegen_resources.cpp
@@ -20,8 +20,6 @@ void CodegenResourceAnalyser::visit(Builtin &builtin)
 {
   if (builtin.ident == "__builtin_elapsed") {
     resources_.needs_elapsed_map = true;
-  } else if (builtin.ident == "kstack" || builtin.ident == "ustack") {
-    resources_.stackid_maps.insert(StackType{ .mode = config_.stack_mode });
   }
 }
 
@@ -31,8 +29,6 @@ void CodegenResourceAnalyser::visit(Call &call)
 
   if (call.func == "join") {
     resources_.needs_join_map = true;
-  } else if (call.func == "kstack" || call.func == "ustack") {
-    resources_.stackid_maps.insert(call.return_type.stack_type);
   }
 }
 

--- a/src/ast/passes/codegen_resources.h
+++ b/src/ast/passes/codegen_resources.h
@@ -10,7 +10,6 @@ namespace bpftrace::ast {
 struct CodegenResources {
   bool needs_elapsed_map = false;
   bool needs_join_map = false;
-  std::unordered_set<StackType> stackid_maps;
 };
 
 // Codegen resource analysis pass

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -98,6 +98,11 @@ RequiredResources ResourceAnalyser::resources()
     resources_.global_vars.add_known(bpftrace::globalvars::TUPLE_BUFFER);
   }
 
+  if (resources_.max_call_stack_size > 0) {
+    assert(resources_.call_stack_buffers > 0);
+    resources_.global_vars.add_known(bpftrace::globalvars::CALL_STACK_BUFFER);
+  }
+
   if (resources_.str_buffers > 0) {
     resources_.global_vars.add_known(bpftrace::globalvars::GET_STR_BUFFER);
   }
@@ -147,8 +152,16 @@ void ResourceAnalyser::visit(Builtin &builtin)
     // mark probe as using usym, so that the symbol table can be pre-loaded
     // and symbols resolved even when unavailable at resolution time
     resources_.probes_using_usym.insert(probe_);
-  } else if (builtin.ident == "__builtin_ncpus") {
+  }
+
+  if (builtin.ident == "__builtin_ncpus") {
     resources_.global_vars.add_known(bpftrace::globalvars::NUM_CPUS);
+  } else if (builtin.ident == "ustack" || builtin.ident == "kstack") {
+    if (exceeds_stack_limit(builtin.builtin_type.GetSize())) {
+      resources_.call_stack_buffers++;
+      resources_.max_call_stack_size = std::max(resources_.max_call_stack_size,
+                                                builtin.builtin_type.GetSize());
+    }
   }
 }
 
@@ -303,6 +316,12 @@ void ResourceAnalyser::visit(Call &call)
       // Same arguments.
     } else {
       call.addError() << "Different tseries bounds in a single map unsupported";
+    }
+  } else if (call.func == "ustack" || call.func == "kstack") {
+    if (exceeds_stack_limit(call.return_type.GetSize())) {
+      resources_.call_stack_buffers++;
+      resources_.max_call_stack_size = std::max(resources_.max_call_stack_size,
+                                                call.return_type.GetSize());
     }
   } else if (call.func == "time") {
     resources_.time_args_id_map[&call] = resources_.time_args.size();

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -919,7 +919,8 @@ void SemanticAnalyser::visit(Builtin &builtin)
         true, StackType{ .mode = bpftrace_.config_->stack_mode });
   } else if (builtin.ident == "ustack") {
     builtin.builtin_type = CreateStack(
-        false, StackType{ .mode = bpftrace_.config_->stack_mode });
+        false,
+        StackType{ .mode = bpftrace_.config_->stack_mode, .kernel = false });
   } else if (builtin.ident == "__builtin_comm") {
     constexpr int COMM_SIZE = 16;
     builtin.builtin_type = CreateString(COMM_SIZE);
@@ -1988,6 +1989,7 @@ void SemanticAnalyser::check_stack_call(Call &call, bool kernel)
   call.return_type = CreateStack(kernel);
   StackType stack_type;
   stack_type.mode = bpftrace_.config_->stack_mode;
+  stack_type.kernel = kernel;
 
   switch (call.vargs.size()) {
     case 0:

--- a/src/bpfbytecode.cpp
+++ b/src/bpfbytecode.cpp
@@ -310,11 +310,6 @@ bool BpfBytecode::hasMap(MapType internal_type) const
   return maps_.contains(to_string(internal_type));
 }
 
-bool BpfBytecode::hasMap(const StackType &stack_type) const
-{
-  return maps_.contains(stack_type.name());
-}
-
 const BpfMap &BpfBytecode::getMap(const std::string &name) const
 {
   auto map = maps_.find(name);

--- a/src/bpfbytecode.h
+++ b/src/bpfbytecode.h
@@ -46,7 +46,6 @@ public:
   BpfProgram &getProgramForProbe(const Probe &probe);
 
   bool hasMap(MapType internal_type) const;
-  bool hasMap(const StackType &stack_type) const;
   const BpfMap &getMap(const std::string &name) const;
   const BpfMap &getMap(MapType internal_type) const;
   const BpfMap &getMap(int map_id) const;

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -45,11 +45,6 @@ using util::symbol;
 
 const int timeout_ms = 100;
 
-struct stack_key {
-  int64_t stackid;
-  int64_t nr_stack_frames;
-};
-
 enum class DebugStage;
 
 // globals
@@ -129,8 +124,8 @@ public:
       Probe &probe,
       const BpfBytecode &bytecode);
   int run_iter();
-  std::string get_stack(int64_t stackid,
-                        uint32_t nr_stack_frames,
+  std::string get_stack(uint64_t nr_stack_frames,
+                        const OpaqueValue &raw_stack,
                         int32_t pid,
                         int32_t probe_id,
                         bool ustack,

--- a/src/globalvars.cpp
+++ b/src/globalvars.cpp
@@ -234,6 +234,14 @@ SizedType GlobalVars::get_sized_type(const std::string &global_var_name,
                         CreateArray(resources.max_tuple_size, CreateInt8()));
   }
 
+  if (global_var_name == CALL_STACK_BUFFER) {
+    assert(resources.max_call_stack_size > 0);
+    assert(resources.call_stack_buffers > 0);
+    return make_rw_type(resources.call_stack_buffers,
+                        CreateArray(resources.max_call_stack_size,
+                                    CreateInt8()));
+  }
+
   if (global_var_name == GET_STR_BUFFER) {
     assert(resources.str_buffers > 0);
     const auto max_strlen = bpftrace_config.max_strlen;

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -103,6 +103,7 @@ constexpr std::string_view NUM_CPUS = "__bt__num_cpus";
 constexpr std::string_view MAX_CPU_ID = "__bt__max_cpu_id";
 constexpr std::string_view FMT_STRINGS_BUFFER = "__bt__fmt_str_buf";
 constexpr std::string_view TUPLE_BUFFER = "__bt__tuple_buf";
+constexpr std::string_view CALL_STACK_BUFFER = "__bt__call_stack_buf";
 constexpr std::string_view GET_STR_BUFFER = "__bt__get_str_buf";
 constexpr std::string_view READ_MAP_VALUE_BUFFER = "__bt__read_map_val_buf";
 constexpr std::string_view WRITE_MAP_VALUE_BUFFER = "__bt__write_map_val_buf";
@@ -115,6 +116,7 @@ constexpr std::string_view RO_SECTION_NAME = ".rodata";
 constexpr std::string_view FMT_STRINGS_BUFFER_SECTION_NAME =
     ".data.fmt_str_buf";
 constexpr std::string_view TUPLE_BUFFER_SECTION_NAME = ".data.tuple_buf";
+constexpr std::string_view CALL_STACK_BUFFER_SECTION_NAME = ".data.call_stack_buf";
 constexpr std::string_view GET_STR_BUFFER_SECTION_NAME = ".data.get_str_buf";
 constexpr std::string_view READ_MAP_VALUE_BUFFER_SECTION_NAME =
     ".data.read_map_val_buf";
@@ -156,6 +158,7 @@ const std::unordered_map<std::string_view, GlobalVarConfig>
       { FMT_STRINGS_BUFFER,
         { .section = std::string(FMT_STRINGS_BUFFER_SECTION_NAME) } },
       { TUPLE_BUFFER, { .section = std::string(TUPLE_BUFFER_SECTION_NAME) } },
+      { CALL_STACK_BUFFER, { .section = std::string(CALL_STACK_BUFFER_SECTION_NAME) } },
       { GET_STR_BUFFER,
         { .section = std::string(GET_STR_BUFFER_SECTION_NAME) } },
       { READ_MAP_VALUE_BUFFER,

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -185,6 +185,10 @@ public:
   size_t tuple_buffers = 0;
   size_t max_tuple_size = 0;
 
+  // Required for sizing of kstack and ustack scratch buffer
+  size_t call_stack_buffers = 0;
+  size_t max_call_stack_size = 0;
+
   // Required for sizing of string scratch buffer
   size_t str_buffers = 0;
 

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -399,10 +399,11 @@ SizedType CreateRecord(const std::string &name, std::weak_ptr<Struct> record)
 
 SizedType CreateStack(bool kernel, StackType stack)
 {
-  // These sizes are based on the stack key (see
-  // IRBuilderBPF::GetStackStructType) but include struct padding
+  // These sizes are based on the stack struct (see
+  // IRBuilderBPF::GetStackStructType)
+  auto base_size = (stack.limit * 8) + 8;
   auto st = SizedType(kernel ? Type::kstack_t : Type::ustack_t,
-                      kernel ? 16 : 24);
+                      kernel ? base_size : (base_size + 8));
   st.stack_type = stack;
   return st;
 }

--- a/src/types.h
+++ b/src/types.h
@@ -114,6 +114,11 @@ struct StackType {
   // N.B. the limit of 127 defines the default stack size.
   uint16_t limit = 127;
   StackMode mode = StackMode::bpftrace;
+  // This is used to construct the name() below,
+  // which is then used in irbuilder as the struct name.
+  // Since ustacks and kstacks have different structs
+  // we need to make sure the names a different.
+  bool kernel = true;
 
   bool operator==(const StackType &obj) const
   {
@@ -122,14 +127,9 @@ struct StackType {
 
   std::string name() const
   {
-    return "stack_" + STACK_MODE_NAME_MAP.at(mode) + "_" +
+    std::string prefix = kernel ? "k" : "u";
+    return prefix + "stack_" + STACK_MODE_NAME_MAP.at(mode) + "_" +
            std::to_string(limit);
-  }
-
-  static const std::string &scratch_name()
-  {
-    static const std::string scratch_name = "stack_scratch";
-    return scratch_name;
   }
 
 private:


### PR DESCRIPTION
Stacked PRs:
 * #4922
 * #4921
 * #4912
 * __->__#4911


--- --- ---

### Remove stack ids and stack hashing


Now that we don't have to worry about the size
of map keys, we no longer need to hash stacks
into an id that we pass around and then lookup
in userspace.

Instead we can just store the entire stack of
addresses in a struct and use that struct
in print statements as well as map keys.

The struct layouts.
kstack:
```
{
  uint64_t num_frames;
  uint64_t[limit] stack;
}
```

ustack:
```
{
  uint32_t pid;
  uint32_t probe_id;
  uint64_t num_frames;
  uint64_t[limit] stack;
}
```

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>