### PR TITLE
Add new stack mode: build_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to
   - [#4853](https://github.com/bpftrace/bpftrace/pull/4853)
 - Add support for `--fmt` mode (automatic formatting)
   - [#4621](https://github.com/bpftrace/bpftrace/pull/4621)
+- Add `build_id` stack mode for getting build_id and offset
+  - [#4912](https://github.com/bpftrace/bpftrace/pull/4912)
 #### Changed
 - Add helpers to check if a kfunc exists and is supported for particular probe types.
   - [#4857](https://github.com/bpftrace/bpftrace/pull/4857)

--- a/docs/language.md
+++ b/docs/language.md
@@ -350,7 +350,8 @@ Available modes/formats:
 
 * bpftrace
 * perf
-* raw: no symbolication
+* raw: no symbolication (print instruction pointer)
+* build_id: no symbolication (print build_id and file offset) (ustack only)
 
 This can be overwritten at the call site.
 

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -588,8 +588,8 @@ ScopedExpr CodegenLLVM::kstack(const SizedType &stype, const Location &loc)
   b_.CreateBr(merge_block);
   b_.SetInsertPoint(get_stack_success);
 
-  const auto uint64_size = sizeof(uint64_t);
-  Value *num_frames = b_.CreateUDiv(stack_size, b_.getInt64(uint64_size));
+  Value *num_frames = b_.CreateUDiv(stack_size,
+                                    b_.getInt64(stype.stack_type.elem_size()));
   b_.CreateStore(num_frames,
                  b_.CreateGEP(stack_struct_type,
                               stack,
@@ -640,8 +640,8 @@ ScopedExpr CodegenLLVM::ustack(const SizedType &stype, const Location &loc)
   b_.CreateBr(merge_block);
   b_.SetInsertPoint(get_stack_success);
 
-  const auto uint64_size = sizeof(uint64_t);
-  Value *num_frames = b_.CreateUDiv(stack_size, b_.getInt64(uint64_size));
+  Value *num_frames = b_.CreateUDiv(stack_size,
+                                    b_.getInt64(stype.stack_type.elem_size()));
   b_.CreateStore(num_frames,
                  b_.CreateGEP(stack_struct_type,
                               stack,

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -18,6 +18,7 @@
 #include <fcntl.h>
 #include <fstream>
 #include <glob.h>
+#include <iomanip>
 #include <iostream>
 #include <ranges>
 #include <regex>
@@ -1034,8 +1035,10 @@ std::string BPFtrace::get_stack(uint64_t nr_stack_frames,
                 << std::endl;
           break;
         case StackMode::raw:
-          LOG(BUG) << "StackMode::raw should have been processed before "
-                      "symbolication.";
+        case StackMode::build_id:
+          LOG(BUG)
+              << "StackMode::raw or build_id should have been processed before "
+                 "symbolication.";
           break;
       }
       ++i;

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -401,7 +401,7 @@ SizedType CreateStack(bool kernel, StackType stack)
 {
   // These sizes are based on the stack struct (see
   // IRBuilderBPF::GetStackStructType)
-  auto base_size = (stack.limit * 8) + 8;
+  auto base_size = (stack.limit * stack.elem_size()) + 8;
   auto st = SizedType(kernel ? Type::kstack_t : Type::ustack_t,
                       kernel ? base_size : (base_size + 8));
   st.stack_type = stack;

--- a/tests/runtime/call
+++ b/tests/runtime/call
@@ -459,6 +459,11 @@ ENV BPFTRACE_STACK_MODE=perf
 EXPECT_REGEX ^[\da-fA-F]+$
 AFTER ./testprogs/uprobe_loop
 
+NAME ustack_stack_mode_build_id
+PROG u:./testprogs/uprobe_loop:uprobeFunction1 { print(ustack(build_id)); exit(); }
+EXPECT_REGEX ^[\da-fA-F]+ 0x[\da-fA-F]+$
+AFTER ./testprogs/uprobe_loop
+
 NAME ustack_elf_symtable
 ENV BPFTRACE_CACHE_USER_SYMBOLS=PER_PROGRAM
 PROG config = { show_debug_info=0 } uprobe:./testprogs/uprobe_symres_exited_process:test { print(ustack); exit(); }


### PR DESCRIPTION
Stacked PRs:
 * #4922
 * #4921
 * #4929
 * __->__#4912


--- --- ---

### Add new stack mode: build_id


This is so users can get the build_id + file offset
for stacks instead of just the instruction pointer.
This involves utilizing a struct instead of just a
uint64 for the stack elements, defined in the kernel
as "bpf_stack_build_id".

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>