### PR TITLE
Add support for named tuple fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,6 +49,8 @@ and this project adheres to
   - [#4853](https://github.com/bpftrace/bpftrace/pull/4853)
 - Add support for `--fmt` mode (automatic formatting)
   - [#4621](https://github.com/bpftrace/bpftrace/pull/4621)
+- Add support for named tuple fields
+  - [#4914](https://github.com/bpftrace/bpftrace/pull/4914)
 #### Changed
 - Add helpers to check if a kfunc exists and is supported for particular probe types.
   - [#4857](https://github.com/bpftrace/bpftrace/pull/4857)

--- a/docs/language.md
+++ b/docs/language.md
@@ -1645,7 +1645,9 @@ bpftrace has support for immutable N-tuples.
 A tuple is a sequence type (like an array) where, unlike an array, every element can have a different type.
 
 Tuples are a comma separated list of expressions, enclosed in brackets, `(1,"hello")`.
-Individual fields can be accessed with the `.` operator or via array-style access.
+The fields can also be named: `(age=29, name="hello")`.
+Note: either all fields are named or none of them are and the ordering has to be consistent.
+Individual fields can be accessed with the `.` operator, via array-style access, or via their name if it exists.
 The array index expression must evaluate to an integer literal at compile time (no variables but this is ok `(1, "hello")[1 - 1]`).
 Tuples are zero indexed like arrays. Examples:
 
@@ -1653,10 +1655,13 @@ Tuples are zero indexed like arrays. Examples:
 interval:s:1 {
   $a = (1,"hello");
   $b = (3,4, $a);
-  print($a);     // (1, "hello")
-  print($b);     // (3, 4, (1, "hello"))
-  print($b.0);   // 3
-  print($a[1]);  // "hello"
+  $c = (name="hello", age=29);
+  print($a);      // (1, "hello")
+  print($b);      // (3, 4, (1, "hello"))
+  print($b.0);    // 3
+  print($a[1]);   // "hello"
+  print($c.name); // "hello"
+  print($c.0);    // "hello"
 }
 ```
 

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -33,8 +33,8 @@ bool Expression::is_literal() const
     return true;
   }
   if (auto *tuple = as<Tuple>()) {
-    return std::ranges::all_of(tuple->elems, [](const auto &elem) {
-      return elem.is_literal();
+    return std::ranges::all_of(tuple->named_elems, [](auto *elem) {
+      return elem->expr.is_literal();
     });
   }
   return false;

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -2852,10 +2852,10 @@ ScopedExpr CodegenLLVM::visit(Tuple &tuple)
 
   std::vector<std::pair<llvm::Value *, Location>> vals;
   std::vector<ScopedExpr> scoped_exprs;
-  vals.reserve(tuple.elems.size());
+  vals.reserve(tuple.named_elems.size());
 
-  for (auto &elem : tuple.elems) {
-    auto scoped_expr = visit(elem);
+  for (auto *elem : tuple.named_elems) {
+    auto scoped_expr = visit(elem->expr);
     vals.emplace_back(scoped_expr.value(), tuple.loc);
     scoped_exprs.emplace_back(std::move(scoped_expr));
   }

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -111,6 +111,7 @@ public:
   Buffer visit(Statement &stmt);
   Buffer visit(RootStatement &root);
   Buffer visit(CStatement &cstmt);
+  Buffer visit(NamedArgument& named_arg);
   Buffer visit(const SizedType &type);
 
 private:

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -151,9 +151,13 @@ public:
     visitImpl(cast.typeof);
     return visitImpl(cast.expr);
   }
+  R visit(NamedArgument &named_arg)
+  {
+    return visitImpl(named_arg.expr);
+  }
   R visit(Tuple &tuple)
   {
-    return visitImpl(tuple.elems);
+    return visitImpl(tuple.named_elems);
   }
   R visit(ExprStatement &expr)
   {

--- a/src/output/json.cpp
+++ b/src/output/json.cpp
@@ -194,7 +194,15 @@ template <>
 struct JsonEmitter<Primitive::Tuple> {
   static void emit(std::ostream &out, const Primitive::Tuple &v)
   {
-    JsonEmitter<std::vector<Primitive>>::emit(out, v.values);
+    if (v.is_named) {
+      JsonEmitter<std::decay_t<decltype(v.fields)>>::emit(out, v.fields);
+    } else {
+      std::vector<Primitive> values;
+      for (const auto &[key, elem] : v.fields) {
+        values.emplace_back(elem);
+      }
+      JsonEmitter<std::vector<Primitive>>::emit(out, values);
+    }
   }
 };
 

--- a/src/output/output.cpp
+++ b/src/output/output.cpp
@@ -15,12 +15,12 @@ bool Primitive::Array::operator==(const Array &other) const
 
 std::partial_ordering Primitive::Tuple::operator<=>(const Tuple &other) const
 {
-  return values <=> other.values;
+  return fields <=> other.fields;
 }
 
 bool Primitive::Tuple::operator==(const Tuple &other) const
 {
-  return values == other.values;
+  return fields == other.fields;
 }
 
 std::partial_ordering Primitive::Record::operator<=>(const Record &other) const

--- a/src/output/output.h
+++ b/src/output/output.h
@@ -29,7 +29,8 @@ struct Primitive {
     bool operator==(const Buffer& other) const = default;
   };
   struct Tuple {
-    std::vector<Primitive> values;
+    std::vector<std::pair<std::string, Primitive>> fields;
+    bool is_named = false;
     std::partial_ordering operator<=>(const Tuple& other) const;
     bool operator==(const Tuple& other) const;
   };

--- a/src/output/text.cpp
+++ b/src/output/text.cpp
@@ -124,9 +124,13 @@ struct TextEmitter<Primitive::Tuple> {
   {
     bool first = true;
     out << "(";
-    for (const auto &elem : v.values) {
+    for (const auto &[key, elem] : v.fields) {
       if (!first) {
         out << ", "; // N.B. tuples get spaces, arrays do not.
+      }
+      if (v.is_named) {
+        TextEmitter<std::string>::emit(out, key);
+        out << " = ";
       }
       TextEmitter<Primitive>::emit(out, elem);
       first = false;

--- a/src/struct.cpp
+++ b/src/struct.cpp
@@ -147,6 +147,15 @@ const Field &Struct::GetField(const std::string &name) const
   throw util::FatalUserException("struct has no field named " + name);
 }
 
+size_t Struct::GetFieldIdx(const std::string &name) const
+{
+  for (size_t i = 0; i < fields.size(); ++i) {
+    if (fields.at(i).name == name)
+      return i;
+  }
+  throw util::FatalUserException("struct has no field named " + name);
+}
+
 void Struct::AddField(const std::string &field_name,
                       const SizedType &type,
                       ssize_t offset,

--- a/src/struct.h
+++ b/src/struct.h
@@ -95,6 +95,7 @@ struct Struct {
 
   bool HasField(const std::string &name) const;
   const Field &GetField(const std::string &name) const;
+  size_t GetFieldIdx(const std::string &name) const;
   void AddField(const std::string &field_name,
                 const SizedType &type,
                 ssize_t offset = 0,

--- a/src/types.h
+++ b/src/types.h
@@ -214,6 +214,7 @@ public:
   std::vector<Field> &GetFields() const;
   bool HasField(const std::string &name) const;
   const Field &GetField(const std::string &name) const;
+  size_t GetFieldIdx(const std::string &name) const;
   Field &GetField(ssize_t n) const;
   ssize_t GetFieldCount() const;
   std::shared_ptr<const Struct> GetStruct() const;
@@ -325,7 +326,7 @@ public:
 
   const std::string &GetName() const
   {
-    assert(IsRecordTy() || IsEnumTy());
+    assert(IsRecordTy() || IsEnumTy() || IsTupleTy());
     return name_;
   }
 

--- a/src/types_format.cpp
+++ b/src/types_format.cpp
@@ -131,15 +131,17 @@ Result<output::Primitive> format(BPFtrace &bpftrace,
       return record;
     }
     case Type::tuple: {
+      const auto &fields = type.GetFields();
       output::Primitive::Tuple tuple;
-      for (auto &field : type.GetFields()) {
+      for (const auto &field : fields) {
         auto elem_data = value.slice(field.offset, field.type.GetSize());
         auto val = format(bpftrace, c_definitions, field.type, elem_data, div);
         if (!val) {
           return val.takeError();
         }
-        tuple.values.emplace_back(std::move(*val));
+        tuple.fields.emplace_back(field.name, std::move(*val));
       }
+      tuple.is_named = !fields.empty() && !fields.at(0).name.empty();
       return tuple;
     }
     case Type::count_t: {

--- a/tests/fold_literals.cpp
+++ b/tests/fold_literals.cpp
@@ -109,11 +109,15 @@ TEST(fold_literals, equals)
   test(R"((-1,true,"foo",1) == (1,-1,true,"foo"))", Boolean(false));
   test("(1,-1) == (1,-1,true)", Boolean(false));
   test("($x,-1) == ($x,-1,true)", Boolean(false));
+  test("(hello=1,bye=-1) == (1,-1)", Boolean(true));
+  test("(hello=1,bye=-1) == (hello=-1,bye=-1)", Boolean(false));
+  test("(hello=-1,bye=-1) == (1,-1)", Boolean(false));
 
   // These should be unexpanded.
   test("\"foo\" == 1", Binop(Operator::EQ, String("foo"), Integer(1)));
   test("\"foo\" == true", Binop(Operator::EQ, String("foo"), Boolean(true)));
   test("($x,-1) == ($x,-1)", testing::Not(Boolean(true)));
+  test("(hello=1,bye=-1) == (left=1,right=-1)", testing::Not(Boolean(true)));
 }
 
 TEST(fold_literals, not_equals)

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -136,6 +136,10 @@ NAME tuple_with_escaped_string
 RUN {{BPFTRACE}} -q -f json -e 'begin { @ = (1, 2, "string with \"quotes\"");  }'
 EXPECT {"type": "map", "data": {"@": [1,2,"string with \"quotes\""]}}
 
+NAME tuple_with_named_fields
+RUN {{BPFTRACE}} -q -f json -e 'begin { @ = (hello="string", bye=(4, 5));  }'
+EXPECT {"type": "map", "data": {"@": {"hello": "string", "bye": [4,5]}}}
+
 NAME print_non_map
 RUN {{BPFTRACE}} -q -f json -e 'begin { $x = 5; print($x); exit() }'
 EXPECT {"type": "value", "data": 5}

--- a/tests/runtime/tuples
+++ b/tests/runtime/tuples
@@ -135,3 +135,23 @@ NAME tuple binop not equals
 PROG begin { $x = ("hello", -6); $y = ("hello", -6); $a = (1, true, $x); @b = (1, true, $y); if ($a != @b) { printf("nok\n"); } if ($a != (1, true, ("ello", -6))) { printf("ok\n"); } }
 EXPECT ok
 EXPECT_NONE nok
+
+NAME named tuple field access
+PROG begin { $x = (name="Jordan", age=234, eyes=(left="Red", right="Green")); print($x.eyes.left); }
+EXPECT Red
+
+NAME named tuple field printing
+PROG begin { $x = (name="Jordan", age=234, eyes=(left="Red", right="Green")); print($x); }
+EXPECT (name = Jordan, age = 234, eyes = (left = Red, right = Green))
+
+NAME named tuple field promotion
+PROG begin { $x = (1, "bye"); $x = (age=(uint64)2, greeting="hello"); print($x); }
+EXPECT (age = 2, greeting = hello)
+
+NAME named tuple field late update
+PROG begin { $x = (1, "bye"); print($x.greeting); $x = (age=(uint64)2, greeting="hello"); }
+EXPECT bye
+
+NAME named tuple field in map
+PROG begin { @a[(age=1, greeting="bye")] = (left="Red", right="Green"); }
+EXPECT @a[age = 1, greeting = bye]: (left = Red, right = Green)


### PR DESCRIPTION
Stacked PRs:
 * __->__#4914


--- --- ---

### Add support for named tuple fields


Example:
```
$a = (name="Jordan", age=28);
print($a.name); // prints Jordan
```

This still maintains the type as a
tuple instead of a record so this is
fine.

```
$a = (name="Jordan", age=28);
$a = ("Viktor", 75);
print($a.name); // prints Viktor
```

However if there is a field name mismatch
then it's a type error, e.g.,

```
$a = (name="Jordan", age=28);
$a = (person="Viktor", age=75); // Error
```

Note: that this does require the user
to order the named fields consistently.
I experimented with allowing any order
of named fields but this had all sorts of
unexpected behavior when it came to accessing
or setting tuple fields by index.

When creating a tuple literal all the fields
have to be named or none of them.

Named tuples will have a text ouput like this:

```
$a = (name="Jordan", age=28);
print($a); // prints (name = Jordan, age = 28)
```

However, their JSON output will look like a
record:
```
{"name": "Jordan", "age": 28}
```

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>