### PR TITLE
config: Handle missing probes as early as possible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,8 @@ and this project adheres to
 - Drop support for LLVM 16
   - [#4534](https://github.com/bpftrace/bpftrace/pull/4534)
 #### Fixed
+- Respect `missing_probes` config for bad `args` if the probe will be pruned
+  - [#4915](https://github.com/bpftrace/bpftrace/pull/4915)
 - Improved tuple binop comparison
   - [#4523](https://github.com/bpftrace/bpftrace/pull/4523)
 #### Security

--- a/src/ast/passes/attachpoint_passes.h
+++ b/src/ast/passes/attachpoint_passes.h
@@ -14,7 +14,7 @@ class AttachPointParser {
 public:
   AttachPointParser(ASTContext &ctx, BPFtrace &bpftrace, bool listing);
   ~AttachPointParser() = default;
-  int parse();
+  void parse();
 
 private:
   enum State { OK = 0, INVALID, NEW_APS, SKIP };

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -16,8 +16,7 @@ namespace {
 
 class FieldAnalyser : public Visitor<FieldAnalyser> {
 public:
-  explicit FieldAnalyser(BPFtrace &bpftrace, ExpansionResult &expansions)
-      : bpftrace_(bpftrace), expansions_(expansions)
+  explicit FieldAnalyser(BPFtrace &bpftrace) : bpftrace_(bpftrace)
   {
   }
 
@@ -47,7 +46,6 @@ private:
   std::string attach_func_;
   SizedType sized_type_;
   BPFtrace &bpftrace_;
-  ExpansionResult &expansions_;
   bpf_prog_type prog_type_{ BPF_PROG_TYPE_UNSPEC };
   bool has_builtin_args_;
   Probe *probe_ = nullptr;
@@ -293,8 +291,8 @@ void FieldAnalyser::visit(Cast &cast)
 
 Pass CreateFieldAnalyserPass()
 {
-  auto fn = [](ASTContext &ast, BPFtrace &b, ExpansionResult &expansions) {
-    FieldAnalyser analyser(b, expansions);
+  auto fn = [](ASTContext &ast, BPFtrace &b) {
+    FieldAnalyser analyser(b);
     analyser.visit(ast.root);
   };
 

--- a/src/ast/passes/parser.h
+++ b/src/ast/passes/parser.h
@@ -18,6 +18,7 @@
 #include "ast/passes/map_sugar.h"
 #include "ast/passes/named_param.h"
 #include "ast/passes/pid_filter_pass.h"
+#include "ast/passes/probe_prune.h"
 #include "ast/passes/resolve_imports.h"
 #include "ast/passes/unstable_feature.h"
 #include "ast/passes/usdt_arguments.h"
@@ -52,6 +53,7 @@ inline std::vector<Pass> AllParsePasses(
   passes.emplace_back(CreateMacroExpansionPass());
   passes.emplace_back(CreateParseBTFPass());
   passes.emplace_back(CreateProbeAndApExpansionPass());
+  passes.emplace_back(CreateProbePrunePass());
   passes.emplace_back(CreateArgsResolverPass());
   passes.emplace_back(CreateFieldAnalyserPass());
   passes.emplace_back(CreateClangParsePass(std::move(extra_flags)));

--- a/src/ast/passes/probe_prune.cpp
+++ b/src/ast/passes/probe_prune.cpp
@@ -17,7 +17,7 @@ Pass CreateProbePrunePass()
                                "config variable to 'warn'.";
         } else if (missing_config == ConfigMissingProbes::warn) {
           probe->addWarning()
-              << "Probe " << missing_msg
+              << "Probe" << missing_msg
               << " It is being removed which may cause issues with "
                  "program behavior.";
         }

--- a/src/attached_probe.cpp
+++ b/src/attached_probe.cpp
@@ -492,20 +492,7 @@ Result<std::unique_ptr<AttachedKprobeProbe>> AttachedKprobeProbe::make(
       !bpftrace.is_traceable_func(probe.attach_point))
     return make_error<AttachError>();
 
-  // Construct a string containing "module:function."
-  // Also log a warning or throw an error if the module doesn't exist,
-  // before attempting to attach.
-  // Note that we do not pass vmlinux, if it is specified.
   std::string funcname = probe.attach_point;
-  const std::string &modname = probe.path;
-  if ((!modname.empty()) && modname != "vmlinux") {
-    if (!util::is_module_loaded(modname)) {
-      return make_error<AttachError>("specified module " + modname +
-                                     " in probe " + probe.name +
-                                     " is not loaded.");
-    }
-    funcname = modname + ":" + funcname;
-  }
 
   // The kprobe can either be defined by a symbol+offset or an address:
   // For symbol+offset kprobe, we need to check the validity of the offset.

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1374,6 +1374,26 @@ bool BPFtrace::is_traceable_func(const std::string &func_name) const
   return funcs.contains(func_name);
 }
 
+bool BPFtrace::is_module_loaded(const std::string &module) const
+{
+  if (module == "vmlinux") {
+    return true;
+  }
+
+  // This file lists all loaded modules
+  std::ifstream modules_file("/proc/modules");
+
+  for (std::string line; std::getline(modules_file, line);) {
+    if (line.compare(0, module.size() + 1, module + " ") == 0) {
+      modules_file.close();
+      return true;
+    }
+  }
+
+  modules_file.close();
+  return false;
+}
+
 int BPFtrace::resume_tracee(pid_t tracee_pid)
 {
   return ::kill(tracee_pid, SIGCONT);

--- a/src/bpftrace.h
+++ b/src/bpftrace.h
@@ -162,6 +162,7 @@ public:
   void request_finalize();
   std::optional<std::string> get_watchpoint_binary_path() const;
   virtual bool is_traceable_func(const std::string &func_name) const;
+  virtual bool is_module_loaded(const std::string &module) const;
   virtual int resume_tracee(pid_t tracee_pid);
   virtual std::unordered_set<std::string> get_func_modules(
       const std::string &func_name) const;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -29,7 +29,6 @@
 #include "ast/passes/pid_filter_pass.h"
 #include "ast/passes/portability_analyser.h"
 #include "ast/passes/printer.h"
-#include "ast/passes/probe_prune.h"
 #include "ast/passes/recursion_check.h"
 #include "ast/passes/resource_analyser.h"
 #include "ast/passes/semantic_analyser.h"
@@ -345,7 +344,6 @@ void CreateDynamicPasses(std::function<void(ast::Pass&& pass)> add)
   add(ast::CreateClangBuildPass());
   add(ast::CreateTypeSystemPass());
   add(ast::CreateSemanticPass());
-  add(ast::CreateProbePrunePass());
   add(ast::CreateResourcePass());
 }
 
@@ -355,7 +353,6 @@ void CreateAotPasses(std::function<void(ast::Pass&& pass)> add)
   add(ast::CreateClangBuildPass());
   add(ast::CreateTypeSystemPass());
   add(ast::CreateSemanticPass());
-  add(ast::CreateProbePrunePass());
   add(ast::CreateResourcePass());
 }
 

--- a/src/util/kernel.cpp
+++ b/src/util/kernel.cpp
@@ -495,24 +495,4 @@ std::vector<std::string> get_kernel_cflags(const char *uname_machine,
   return cflags;
 }
 
-bool is_module_loaded(const std::string &module)
-{
-  if (module == "vmlinux") {
-    return true;
-  }
-
-  // This file lists all loaded modules
-  std::ifstream modules_file("/proc/modules");
-
-  for (std::string line; std::getline(modules_file, line);) {
-    if (line.compare(0, module.size() + 1, module + " ") == 0) {
-      modules_file.close();
-      return true;
-    }
-  }
-
-  modules_file.close();
-  return false;
-}
-
 } // namespace bpftrace::util

--- a/src/util/kernel.h
+++ b/src/util/kernel.h
@@ -40,6 +40,4 @@ std::vector<std::string> get_kernel_cflags(const char *uname_machine,
                                            const std::string &kobj,
                                            const KConfig &kconfig);
 
-bool is_module_loaded(const std::string &module);
-
 } // namespace bpftrace::util

--- a/tests/bpfbytecode.cpp
+++ b/tests/bpfbytecode.cpp
@@ -37,19 +37,19 @@ BpfBytecode codegen(const std::string &input)
 
 TEST(bpfbytecode, create_programs)
 {
-  auto bytecode = codegen("kprobe:foo { 1 }");
+  auto bytecode = codegen("kprobe:f { 1 }");
 
-  Probe foo;
-  foo.type = ProbeType::kprobe;
-  foo.name = "kprobe:foo";
-  foo.index = 1;
+  Probe f;
+  f.type = ProbeType::kprobe;
+  f.name = "kprobe:f";
+  f.index = 1;
 
-  auto &program = bytecode.getProgramForProbe(foo);
+  auto &program = bytecode.getProgramForProbe(f);
 
   EXPECT_EQ(std::string_view{ bpf_program__name(program.bpf_prog()) },
-            "kprobe_foo_1");
+            "kprobe_f_1");
   EXPECT_EQ(std::string_view{ bpf_program__section_name(program.bpf_prog()) },
-            "s_kprobe_foo_1");
+            "s_kprobe_f_1");
 }
 
 } // namespace bpftrace::test::bpfbytecode

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -28,7 +28,6 @@ static ast::CDefinitions parse(
                 .put(bpftrace)
                 .add(CreateParsePass())
                 .add(ast::CreateParseAttachpointsPass())
-                .add(ast::CreateProbeAndApExpansionPass())
                 .add(ast::CreateArgsResolverPass())
                 .add(ast::CreateFieldAnalyserPass())
                 .add(ast::CreateClangParsePass())

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -283,7 +283,8 @@ TEST_F(field_analyser_btf, btf_types_struct_ptr)
 
 TEST_F(field_analyser_btf, btf_types_arr_access)
 {
-  auto bpftrace = get_mock_bpftrace();
+  auto bpftrace = get_strict_mock_bpftrace();
+  EXPECT_CALL(*bpftrace->mock_probe_matcher, get_fentry_symbols()).Times(1);
   test(*bpftrace,
        "fentry:func_1 {\n"
        "  @foo2 = args.foo3[0].foo2;\n"
@@ -307,7 +308,8 @@ TEST_F(field_analyser_btf, btf_types_arr_access)
 
 TEST_F(field_analyser_btf, btf_types_anon_structs)
 {
-  auto bpftrace = get_mock_bpftrace();
+  auto bpftrace = get_strict_mock_bpftrace();
+  EXPECT_CALL(*bpftrace->mock_probe_matcher, get_fentry_symbols()).Times(1);
   test(*bpftrace,
        "fentry:func_anon_struct {\n"
        "  @ = args.AnonStruct->AnonArray[0];\n"

--- a/tests/mocks.h
+++ b/tests/mocks.h
@@ -113,6 +113,12 @@ public:
     return true;
   }
 
+  bool is_module_loaded(const std::string &module) const override
+  {
+    return (module == "vmlinux" || module == "mock_vmlinux" ||
+            module == "kernel_mod_1" || module == "kernel_mod_2");
+  }
+
   Result<uint64_t> get_buffer_pages(
       bool __attribute__((unused)) /*per_cpu*/) const override
   {

--- a/tests/probe.cpp
+++ b/tests/probe.cpp
@@ -78,7 +78,7 @@ TEST(probe, short_name)
                    "t:sched:sched_one { args }");
   compare_bytecode("kprobe:f { pid }", "k:f { pid }");
   compare_bytecode("kretprobe:f { pid }", "kr:f { pid }");
-  compare_bytecode("uprobe:sh:f { 1 }", "u:sh:f { 1 }");
+  compare_bytecode("uprobe:/bin/sh:f { 1 }", "u:/bin/sh:f { 1 }");
   compare_bytecode("profile:hz:997 { 1 }", "p:hz:997 { 1 }");
   compare_bytecode("hardware:cache-references:1000000 { 1 }",
                    "h:cache-references:1000000 { 1 }");

--- a/tests/runtime/probe
+++ b/tests/runtime/probe
@@ -60,13 +60,13 @@ AFTER ./testprogs/fentry_args 1111 2222
 
 NAME fentry_missing_probes
 PROG fentry:vfs_read,fentry:nonsense { exit(); }
-EXPECT ERROR: No BTF found for nonsense.
+EXPECT_REGEX .* ERROR: No matches for fentry nonsense.
 WILL_FAIL
 REQUIRES_FEATURE btf
 
 NAME fentry_warn_missing_probes
 PROG config = { missing_probes = "warn" } fentry:vfs_read,fentry:nonsense { exit(); }
-EXPECT WARNING: No BTF found for nonsense.
+EXPECT_REGEX .* WARNING: No matches for fentry nonsense. Skipping.
 REQUIRES_FEATURE btf
 
 NAME fentry_ignore_missing_probes
@@ -133,7 +133,8 @@ AFTER ./testprogs/syscall read
 
 NAME kprobe_module_missing
 PROG kprobe:nonsense:vfs_read { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT ERROR: specified module nonsense in probe kprobe:nonsense:vfs_read is not loaded.
+EXPECT_REGEX .* ERROR: specified module nonsense in probe kprobe:nonsense:vfs_read is not loaded.
+EXPECT_REGEX .* ERROR: No matches for kprobe nonsense:vfs_read.
 WILL_FAIL
 
 NAME kprobe_wildcard_all_leading_underscore
@@ -153,7 +154,8 @@ EXPECT 0
 
 NAME kprobe_func_missing
 PROG kprobe:vmlinux:nonsense { printf("SUCCESS %d\n", pid); exit(); }
-EXPECT ERROR: Unable to attach probe: kprobe:vmlinux:nonsense. If this is expected, set the 'missing_probes' config variable to 'warn'.
+EXPECT_REGEX .* ERROR: No matches for kprobe vmlinux:nonsense.
+EXPECT_REGEX .* WARNING: nonsense is not traceable \(either non-existing, inlined, or marked as "notrace"\); attaching to it will likely fail
 WILL_FAIL
 
 NAME kprobe_multi_wildcard
@@ -332,13 +334,13 @@ AFTER ./testprogs/uprobe_test
 
 NAME uprobe_missing_probes
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1,uprobe:./testprogs/uprobe_test:uprobeFunction3 { exit(); }
-EXPECT ERROR: Could not resolve symbol: ./testprogs/uprobe_test:uprobeFunction3
+EXPECT_REGEX .* ERROR: No matches for uprobe ./testprogs/uprobe_test:uprobeFunction3.
 AFTER ./testprogs/uprobe_test
 WILL_FAIL
 
 NAME uprobe_warn_missing_probes
 PROG config = { missing_probes = "warn" } uprobe:./testprogs/uprobe_test:uprobeFunction1,uprobe:./testprogs/uprobe_test:uprobeFunction3 { exit(); }
-EXPECT WARNING: Could not resolve symbol: ./testprogs/uprobe_test:uprobeFunction3
+EXPECT_REGEX .* WARNING: No matches for uprobe ./testprogs/uprobe_test:uprobeFunction3. Skipping.
 AFTER ./testprogs/uprobe_test
 
 NAME uprobe_ignore_missing_probes
@@ -377,12 +379,12 @@ EXPECT hit
 
 NAME tracepoint_missing
 PROG t:syscalls:nonsense { print("hit"); exit(); }
-EXPECT ERROR: Unable to attach probe: tracepoint:syscalls:nonsense. If this is expected, set the 'missing_probes' config variable to 'warn'.
+EXPECT_REGEX .* ERROR: No matches for tracepoint syscalls:nonsense.
 WILL_FAIL
 
 NAME tracepoint_multiattach_missing
 PROG t:syscalls:sys_exit_nanosleep,t:syscalls:nonsense { print("hit"); exit(); }
-EXPECT ERROR: Unable to attach probe: tracepoint:syscalls:nonsense. If this is expected, set the 'missing_probes' config variable to 'warn'.
+EXPECT_REGEX .* ERROR: No matches for tracepoint syscalls:nonsense.
 WILL_FAIL
 
 NAME tracepoint args
@@ -429,7 +431,7 @@ AFTER ./testprogs/syscall nanosleep 1e8
 
 NAME rawtracepoint_module_missing
 PROG rawtracepoint:nonsense:sys_exit { printf("SUCCESS %d\n", gid); exit(); }
-EXPECT ERROR: No BTF found for nonsense:sys_exit.
+EXPECT_REGEX .* ERROR: No matches for rawtracepoint nonsense:sys_exit.
 REQUIRES_FEATURE btf
 WILL_FAIL
 
@@ -531,7 +533,7 @@ TIMEOUT 5
 # only probe that we specify.
 NAME bpf_programs_limit
 PROG k:* { @[probe] = count(); }
-EXPECT_REGEX stdin:1:1-4: ERROR: Your program is trying to generate more than \d+ BPF programs, which exceeds the current limit of 1024\nk:\* { @\[probe\] = count\(\); }\n~~~\nHINT: You can increase the limit through the BPFTRACE_MAX_BPF_PROGS environment variable.
+EXPECT_REGEX .* ERROR: Your program is trying to generate more than \d+ BPF programs, which exceeds the current limit of 1024\nk:\* { @\[probe\] = count\(\); }\n~~~\nHINT: You can increase the limit through the BPFTRACE_MAX_BPF_PROGS environment variable.
 WILL_FAIL
 TIMEOUT 2
 
@@ -598,17 +600,23 @@ EXPECT_REGEX (first)+ second
 
 NAME some_missing_probes_default_error
 PROG kprobe:vfs_read { exit(); } t:syscalls:nonsense { exit(); }
-EXPECT ERROR: Unable to attach probe: tracepoint:syscalls:nonsense. If this is expected, set the 'missing_probes' config variable to 'warn'.
+EXPECT_REGEX .* ERROR: No matches for tracepoint syscalls:nonsense.
 WILL_FAIL
 
 NAME missing_probes_multiple_attach_points_default_error
 PROG kprobe:vfs_read, kprobe:bad { exit(); }
-EXPECT ERROR: Unable to attach probe: kprobe:bad. If this is expected, set the 'missing_probes' config variable to 'warn'.
+EXPECT_REGEX .* ERROR: No matches for kprobe bad.
+EXPECT_REGEX .* WARNING: bad is not traceable \(either non-existing, inlined, or marked as "notrace"\); attaching to it will likely fail
 WILL_FAIL
 
 NAME some_missing_probes_warn
 PROG config = { missing_probes=warn } kprobe:vfs_read { exit(); } t:syscalls:nonsense { exit(); }
-EXPECT WARNING: Unable to attach probe: tracepoint:syscalls:nonsense. Skipping.
+EXPECT_REGEX .* WARNING: No matches for tracepoint syscalls:nonsense. Skipping.
+EXPECT_REGEX .* WARNING: Probe has no valid attach points. It is being removed which may cause issues with program behavior.
+
+NAME some_missing_probes_warn_args
+PROG config = { missing_probes=warn } tracepoint:syscalls:sys_enter_read,tracepoint:nonsense:nonsense { $cnt = args.count; exit(); }
+EXPECT_REGEX .* WARNING: No matches for tracepoint nonsense:nonsense. Skipping.
 
 NAME some_missing_probes_ignore
 PROG config = { missing_probes=ignore } kprobe:vfs_read { exit(); } t:syscalls:nonsense { exit(); }
@@ -616,10 +624,18 @@ EXPECT_NONE WARNING: Unable to attach probe: tracepoint:syscalls:nonsense. Skipp
 
 NAME all_missing_probes_warn
 PROG config = { missing_probes=warn } kprobe:nonsense { exit(); } t:syscalls:nonsense { exit(); } uprobe:./testprogs/uprobe_test:uprobeFunction3 { exit(); }
-EXPECT WARNING: Unable to attach probe: kprobe:nonsense. Skipping.
-EXPECT WARNING: Unable to attach probe: tracepoint:syscalls:nonsense. Skipping.
-EXPECT WARNING: Unable to attach probe: uprobe:./testprogs/uprobe_test:uprobeFunction3. Skipping.
-EXPECT ERROR: Attachment failed for all probes.
+EXPECT_REGEX .* WARNING: nonsense is not traceable \(either non-existing, inlined, or marked as "notrace"\); attaching to it will likely fail
+EXPECT_REGEX .* WARNING: No matches for kprobe nonsense. Skipping.
+EXPECT_REGEX .* WARNING: No matches for tracepoint syscalls:nonsense. Skipping.
+EXPECT_REGEX .* WARNING: No matches for uprobe ./testprogs/uprobe_test:uprobeFunction3. Skipping.
+EXPECT_REGEX .* WARNING: Probe has no valid attach points. It is being removed which may cause issues with program behavior.
+EXPECT_REGEX .* WARNING: Probe has no valid attach points. It is being removed which may cause issues with program behavior.
+EXPECT_REGEX .* WARNING: Probe has no valid attach points. It is being removed which may cause issues with program behavior.
+WILL_FAIL
+
+NAME all_missing_probes_ignore
+PROG config = { missing_probes=ignore } kprobe:nonsense { exit(); } t:syscalls:nonsense { exit(); } uprobe:./testprogs/uprobe_test:uprobeFunction3 { exit(); }
+EXPECT No probes to attach
 WILL_FAIL
 
 # This is hacky because we can't easily run a separate bpftrace program in BEFORE

--- a/tests/semantic_analyser.cpp
+++ b/tests/semantic_analyser.cpp
@@ -1753,11 +1753,12 @@ TEST_F(SemanticAnalyserTest, variable_reassignment)
 {
   test("kprobe:f { $x = 1; $x = 2; }");
   test("kprobe:f { $x = 1; $x = \"foo\"; }", Error{});
-  test(R"(kprobe:f { $b = "hi"; $b = @b; } kprobe:g { @b = "bye"; })");
+  test(R"(kprobe:f { $b = "hi"; $b = @b; } kprobe:func_1 { @b = "bye"; })");
 
-  test(R"(kprobe:f { $b = "hi"; $b = @b; } kprobe:g { @b = 1; })", Error{ R"(
+  test(R"(kprobe:f { $b = "hi"; $b = @b; } kprobe:func_1 { @b = 1; })",
+       Error{ R"(
 stdin:1:23-30: ERROR: Type mismatch for $b: trying to assign value of type 'uint8' when variable already contains a value of type 'string[3]'
-kprobe:f { $b = "hi"; $b = @b; } kprobe:g { @b = 1; }
+kprobe:f { $b = "hi"; $b = @b; } kprobe:func_1 { @b = 1; }
                       ~~~~~~~
 )" });
 }
@@ -1775,14 +1776,14 @@ TEST_F(SemanticAnalyserTest, variable_use_before_assign)
 
 TEST_F(SemanticAnalyserTest, maps_are_global)
 {
-  test("kprobe:f { @x = 1 } kprobe:g { @y = @x }");
-  test("kprobe:f { @x = 1 } kprobe:g { @x = \"abc\" }", Error{});
+  test("kprobe:f { @x = 1 } kprobe:func_1 { @y = @x }");
+  test("kprobe:f { @x = 1 } kprobe:func_1 { @x = \"abc\" }", Error{});
 }
 
 TEST_F(SemanticAnalyserTest, variables_are_local)
 {
-  test("kprobe:f { $x = 1 } kprobe:g { $x = \"abc\"; }");
-  test("kprobe:f { $x = 1 } kprobe:g { @y = $x }", Error{});
+  test("kprobe:f { $x = 1 } kprobe:func_1 { $x = \"abc\"; }");
+  test("kprobe:f { $x = 1 } kprobe:func_1 { @y = $x }", Error{});
 }
 
 TEST_F(SemanticAnalyserTest, array_access)
@@ -2525,7 +2526,7 @@ TEST_F(SemanticAnalyserTest, variable_casts_are_local)
   std::string structs = "struct type1 { int field; } struct "
                         "type2 { int field; }";
   test(structs + "kprobe:f { $x = *(struct type1 *)cpu } "
-                 "kprobe:g { $x = *(struct type2 *)cpu; }");
+                 "kprobe:func_1 { $x = *(struct type2 *)cpu; }");
 }
 
 TEST_F(SemanticAnalyserTest, map_casts_are_global)
@@ -2533,7 +2534,7 @@ TEST_F(SemanticAnalyserTest, map_casts_are_global)
   std::string structs = "struct type1 { int field; } struct "
                         "type2 { int field; }";
   test(structs + "kprobe:f { @x = *(struct type1 *)cpu }"
-                 "kprobe:g { @x = *(struct type2 *)cpu }",
+                 "kprobe:func_1 { @x = *(struct type2 *)cpu }",
        Error{});
 }
 
@@ -2753,8 +2754,8 @@ TEST_F(SemanticAnalyserTest, probe_short_name)
   test("t:sched:sched_one { 1 }");
   test("k:f { pid }");
   test("kr:f { pid }");
-  test("u:sh:f { 1 }");
-  test("ur:sh:f { 1 }");
+  test("u:/bin/sh:f { 1 }");
+  test("ur:/bin/sh:f { 1 }");
   test("p:hz:997 { 1 }");
   test("h:cache-references:1000000 { 1 }");
   test("s:faults:1000 { 1 }");
@@ -4265,14 +4266,14 @@ TEST_F(SemanticAnalyserTest, string_size)
   ASSERT_TRUE(var_assign->var()->var_type.IsStringTy());
   ASSERT_EQ(var_assign->var()->var_type.GetSize(), 6UL);
 
-  ast = test(R"(k:f1 {@ = "hi";} k:f2 {@ = "hello";})");
+  ast = test(R"(k:func_1 {@ = "hi";} k:func_2 {@ = "hello";})");
   stmt = ast.root->probes.at(0)->block->stmts.at(0);
   auto *map_assign = stmt.as<ast::AssignMapStatement>();
   ASSERT_TRUE(map_assign->expr.is<ast::Cast>());
   ASSERT_TRUE(map_assign->map_access->map->value_type.IsStringTy());
   ASSERT_EQ(map_assign->map_access->map->value_type.GetSize(), 6UL);
 
-  ast = test(R"(k:f1 {@["hi"] = 0;} k:f2 {@["hello"] = 1;})");
+  ast = test(R"(k:func_1 {@["hi"] = 0;} k:func_2 {@["hello"] = 1;})");
   stmt = ast.root->probes.at(0)->block->stmts.at(0);
   map_assign = stmt.as<ast::AssignMapStatement>();
   ASSERT_TRUE(map_assign->map_access->key.is<ast::Cast>());
@@ -4280,7 +4281,7 @@ TEST_F(SemanticAnalyserTest, string_size)
   ASSERT_EQ(map_assign->map_access->key.type().GetSize(), 6UL);
   ASSERT_EQ(map_assign->map_access->map->key_type.GetSize(), 6UL);
 
-  ast = test(R"(k:f1 {@["hi", 0] = 0;} k:f2 {@["hello", 1] = 1;})");
+  ast = test(R"(k:func_1 {@["hi", 0] = 0;} k:func_2 {@["hello", 1] = 1;})");
   stmt = ast.root->probes.at(0)->block->stmts.at(0);
   map_assign = stmt.as<ast::AssignMapStatement>();
   ASSERT_TRUE(map_assign->map_access->key.as<ast::Tuple>()
@@ -4294,7 +4295,7 @@ TEST_F(SemanticAnalyserTest, string_size)
   ASSERT_EQ(map_assign->map_access->key.type().GetSize(), 7UL);
   ASSERT_EQ(map_assign->map_access->map->key_type.GetSize(), 7UL);
 
-  ast = test(R"(k:f1 {$x = ("hello", 0);} k:f2 {$x = ("hi", 0); })");
+  ast = test(R"(k:func_1 {$x = ("hello", 0);} k:func_2 {$x = ("hi", 0); })");
   stmt = ast.root->probes.at(0)->block->stmts.at(0);
   var_assign = stmt.as<ast::AssignVarStatement>();
   ASSERT_TRUE(var_assign->var()->var_type.IsTupleTy());

--- a/tools/biolatency-kp.bt
+++ b/tools/biolatency-kp.bt
@@ -50,6 +50,8 @@ config = {
 BEGIN
 {
   printf("Tracing block device I/O... Hit Ctrl-C to end.\n");
+  // If kprobes does not exist, accessing @start in END will result in an error.
+  @start[0] = (uint64)0;
 }
 
 kprobe:blk_account_io_start,


### PR DESCRIPTION
There is an interesting bug: when `config::missing_probes=warn`, if a non-existent tracepoint is used and the built-in variable `args` is called, `args` will be parsed for the non-existent tracepoint, resulting in an error.

For example, `tools/opensnoop.bt` on an aarch64 environment will throw an error because the `open(2)` system call does not exist. This is clearly incorrect.

    $ uname -m
    aarch64

    $ sudo bpftrace opensnoop.bt
    opensnoop.bt:49:1-35: ERROR: Tracepoint not found: syscalls:sys_enter_open
    tracepoint:syscalls:sys_enter_open,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    opensnoop.bt:130:1-34: ERROR: Tracepoint not found: syscalls:sys_exit_open
    tracepoint:syscalls:sys_exit_open,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Simplified analysis example (on aarch64):

  Works fine:
```
    config = { missing_probes = warn; }
    tracepoint:syscalls:sys_enter_open,
    tracepoint:syscalls:sys_enter_openat,
    tracepoint:syscalls:sys_enter_openat2
    {}
    WARNING: Unable to attach probe: tracepoint:syscalls:sys_enter_open. Skipping.
```

  Cannot work:
```
    config = { missing_probes = warn; }
    tracepoint:syscalls:sys_enter_open,
    tracepoint:syscalls:sys_enter_openat,
    tracepoint:syscalls:sys_enter_openat2
    {
      @filename[tid] = args.filename;
    }
    ./tp.bt:7:1-35: ERROR: Tracepoint not found: syscalls:sys_enter_open
    tracepoint:syscalls:sys_enter_open,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

This commit passes through non-existent tracepoints and raw tracepoints in the case of `config::missing_probes!=error`. 

after this commit:

```
    ./tp.bt:7:1-35: WARNING: Skipping non exist tracepoint syscalls:sys_enter_open
    tracepoint:syscalls:sys_enter_open,
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```
