### PR TITLE
Remove scratch map infra

### DIFF
--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -121,7 +121,6 @@ public:
   CallInst *CreatePerCpuPtr(Value *var, Value *cpu, const Location &loc);
   CallInst *CreateThisCpuPtr(Value *var, const Location &loc);
   CallInst *CreateGetSocketCookie(Value *var, const Location &loc);
-  CallInst *CreateGetJoinMap(BasicBlock *failure_callback, const Location &loc);
   Value *CreateGetStrAllocation(const std::string &name,
                                 const Location &loc,
                                 uint64_t pad = 0);
@@ -134,6 +133,7 @@ public:
   Value *CreateKUStackAllocation(const SizedType &stack_type,
                                const std::string &name,
                                const Location &loc);
+  Value *CreateJoinAllocation(const Location &loc);
   Value *CreateWriteMapValueAllocation(const SizedType &value_type,
                                        const std::string &name,
                                        const Location &loc);
@@ -284,11 +284,6 @@ private:
       Value *cpu,
       PointerType *val_ptr_ty,
       const std::string &name = "lookup_percpu_elem");
-  CallInst *createGetScratchMap(const std::string &map_name,
-                                const std::string &name,
-                                const Location &loc,
-                                BasicBlock *failure_callback,
-                                int key = 0);
   Value *CreateReadMapValueAllocation(const SizedType &value_type,
                                       const std::string &name,
                                       const Location &loc);

--- a/src/ast/passes/codegen_llvm.cpp
+++ b/src/ast/passes/codegen_llvm.cpp
@@ -3809,7 +3809,7 @@ void CodegenLLVM::createJoinCall(Call &call, int id)
   BasicBlock *failure_callback = BasicBlock::Create(module_->getContext(),
                                                     "failure_callback",
                                                     parent);
-  Value *perfdata = b_.CreateGetJoinMap(failure_callback, call.loc);
+  Value *perfdata = b_.CreateJoinAllocation(call.loc);
 
   uint32_t content_size = bpftrace_.join_argnum_ * bpftrace_.join_argsize_;
 
@@ -3981,18 +3981,6 @@ void CodegenLLVM::generate_maps(const RequiredResources &required_resources,
   }
 
   // bpftrace internal maps
-
-  if (codegen_resources.needs_join_map) {
-    auto value_size = offsetof(AsyncEvent::Join, content) +
-                      (bpftrace_.join_argnum_ * bpftrace_.join_argsize_);
-    SizedType value_type = CreateArray(value_size, CreateInt8());
-    createMapDefinition(to_string(MapType::Join),
-                        BPF_MAP_TYPE_PERCPU_ARRAY,
-                        1,
-                        CreateUInt32(),
-                        value_type);
-  }
-
   if (codegen_resources.needs_elapsed_map) {
     createMapDefinition(to_string(MapType::Elapsed),
                         BPF_MAP_TYPE_HASH,

--- a/src/ast/passes/codegen_resources.cpp
+++ b/src/ast/passes/codegen_resources.cpp
@@ -23,13 +23,4 @@ void CodegenResourceAnalyser::visit(Builtin &builtin)
   }
 }
 
-void CodegenResourceAnalyser::visit(Call &call)
-{
-  Visitor::visit(call);
-
-  if (call.func == "join") {
-    resources_.needs_join_map = true;
-  }
-}
-
 } // namespace bpftrace::ast

--- a/src/ast/passes/codegen_resources.h
+++ b/src/ast/passes/codegen_resources.h
@@ -9,7 +9,6 @@ namespace bpftrace::ast {
 
 struct CodegenResources {
   bool needs_elapsed_map = false;
-  bool needs_join_map = false;
 };
 
 // Codegen resource analysis pass
@@ -24,7 +23,6 @@ public:
 
   using Visitor<CodegenResourceAnalyser>::visit;
   void visit(Builtin &builtin);
-  void visit(Call &call);
 
 private:
   const ::bpftrace::Config &config_;

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -128,6 +128,10 @@ RequiredResources ResourceAnalyser::resources()
     resources_.global_vars.add_known(bpftrace::globalvars::MAP_KEY_BUFFER);
   }
 
+  if (resources_.join_value_size > 0) {
+    resources_.global_vars.add_known(bpftrace::globalvars::JOIN_BUFFER);
+  }
+
   resources_.global_vars.add_known(bpftrace::globalvars::MAX_CPU_ID);
   resources_.global_vars.add_known(bpftrace::globalvars::EVENT_LOSS_COUNTER);
 
@@ -375,6 +379,12 @@ void ResourceAnalyser::visit(Call &call)
     const auto max_strlen = bpftrace_.config_->max_strlen;
     if (exceeds_stack_limit(max_strlen))
       resources_.str_buffers++;
+  }
+
+  if (call.func == "join") {
+    resources_.join_value_size = offsetof(AsyncEvent::Join, content) +
+                                 (bpftrace_.join_argnum_ *
+                                  bpftrace_.join_argsize_);
   }
 
   // These functions, some of which are desugared AssignMapStatements (e.g.,

--- a/src/bpfmap.cpp
+++ b/src/bpfmap.cpp
@@ -215,8 +215,6 @@ std::string to_string(MapType t)
   switch (t) {
     case MapType::PerfEvent:
       return "perf_event";
-    case MapType::Join:
-      return "join";
     case MapType::Elapsed:
       return "elapsed";
     case MapType::Ringbuf:

--- a/src/bpfmap.h
+++ b/src/bpfmap.h
@@ -97,7 +97,6 @@ private:
 enum class MapType {
   // Also update to_string
   PerfEvent,
-  Join,
   Elapsed,
   Ringbuf,
   EventLossCounter,

--- a/src/globalvars.cpp
+++ b/src/globalvars.cpp
@@ -280,6 +280,11 @@ SizedType GlobalVars::get_sized_type(const std::string &global_var_name,
     return make_rw_type(1, CreateUInt64());
   }
 
+  if (global_var_name == JOIN_BUFFER) {
+    return make_rw_type(1,
+                        CreateArray(resources.join_value_size, CreateInt8()));
+  }
+
   if (!config.type) {
     LOG(BUG) << "Unknown global variable " << global_var_name;
   }

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -110,6 +110,7 @@ constexpr std::string_view WRITE_MAP_VALUE_BUFFER = "__bt__write_map_val_buf";
 constexpr std::string_view VARIABLE_BUFFER = "__bt__var_buf";
 constexpr std::string_view MAP_KEY_BUFFER = "__bt__map_key_buf";
 constexpr std::string_view EVENT_LOSS_COUNTER = "__bt__event_loss_counter";
+constexpr std::string_view JOIN_BUFFER = "__bt__join_buf";
 
 // Section names
 constexpr std::string_view RO_SECTION_NAME = ".rodata";
@@ -126,6 +127,8 @@ constexpr std::string_view VARIABLE_BUFFER_SECTION_NAME = ".data.var_buf";
 constexpr std::string_view MAP_KEY_BUFFER_SECTION_NAME = ".data.map_key_buf";
 constexpr std::string_view EVENT_LOSS_COUNTER_SECTION_NAME =
     ".data.event_loss_counter";
+constexpr std::string_view JOIN_BUFFER_SECTION_NAME =
+    ".data.join_buf";
 
 struct GlobalVarConfig {
   std::string section;
@@ -169,6 +172,8 @@ const std::unordered_map<std::string_view, GlobalVarConfig>
         { .section = std::string(VARIABLE_BUFFER_SECTION_NAME) } },
       { MAP_KEY_BUFFER,
         { .section = std::string(MAP_KEY_BUFFER_SECTION_NAME) } },
+      { JOIN_BUFFER,
+        { .section = std::string(JOIN_BUFFER_SECTION_NAME) } },
     };
 
 class GlobalVars {

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -205,6 +205,8 @@ public:
   size_t map_key_buffers = 0;
   size_t max_map_key_size = 0;
 
+  size_t join_value_size = 0;
+
   // Async argument metadata that codegen creates. Ideally ResourceAnalyser
   // pass should be collecting this, but it's complex to move the logic.
   //


### PR DESCRIPTION
Remove scratch map infra

Migrate the remaining Join map to a global
variable and remove the scratch map infra.

Signed-off-by: Jordan Rome <linux@jordanrome.com>