### PR TITLE
Fix delayed type propagation for map keys/vals

### DIFF
--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -3258,10 +3258,12 @@ void SemanticAnalyser::reconcile_map_key(Map *map, Expression &key_expr)
       }
     }
     if (type_mismatch_error) {
-      key_expr.node().addError()
-          << "Argument mismatch for " << map->ident << ": "
-          << "trying to access with arguments: '" << new_key_type
-          << "' when map expects arguments: '" << storedTy << "'";
+      if (is_final_pass()) {
+        key_expr.node().addError()
+            << "Argument mismatch for " << map->ident << ": "
+            << "trying to access with arguments: '" << new_key_type
+            << "' when map expects arguments: '" << storedTy << "'";
+      }
     }
   } else {
     if (!new_key_type.IsNoneTy()) {
@@ -4270,10 +4272,12 @@ void SemanticAnalyser::assign_map_type(Map &map,
       }
     }
     if (type_mismatch_error) {
-      loc_node->addError() << "Type mismatch for " << map_ident << ": "
-                           << "trying to assign value of type '" << type
-                           << "' when map already contains a value of type '"
-                           << storedTy << "'";
+      if (is_final_pass()) {
+        loc_node->addError() << "Type mismatch for " << map_ident << ": "
+                             << "trying to assign value of type '" << type
+                             << "' when map already contains a value of type '"
+                             << storedTy << "'";
+      }
     } else {
       map.value_type = storedTy;
       *maptype = storedTy;

--- a/tests/runtime/basic
+++ b/tests/runtime/basic
@@ -339,7 +339,7 @@ WILL_FAIL
 
 NAME has_key error type mismatch
 PROG begin { @g[1, "hi"] = 2; if (has_key(@g, (1, 2))) { printf("ok\n"); }  }
-EXPECT_REGEX .* ERROR: Argument mismatch for @g: trying to access with arguments: '\(uint8,uint8\)' when map expects arguments: '\(uint8,string\[3\]\)'.*
+EXPECT_REGEX .* ERROR: Type mismatch for \$\$has_key_\$key: trying to assign value of type '\(uint8,uint8\)' when variable already has a type '\(uint8,string\[3\]\)'.*
 WILL_FAIL
 
 NAME exit code


### PR DESCRIPTION
Stacked PRs:
 * __->__#4925


--- --- ---

### Fix delayed type propagation for map keys/vals


This matches how we handle variable type mismatches
in that we wait till the final pass before issuing
and error.

Issue: https://github.com/bpftrace/bpftrace/issues/3001

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>