### PR TITLE
BCC Deprecation: remove bcc_usdt includes

### DIFF
--- a/cmake/FindLibBcc.cmake
+++ b/cmake/FindLibBcc.cmake
@@ -76,6 +76,7 @@ INCLUDE(CheckCXXSourceCompiles)
 SET(CMAKE_REQUIRED_INCLUDES ${LIBBCC_INCLUDE_DIRS})
 SET(CMAKE_REQUIRED_LIBRARIES ${LIBBCC_BPF_LIBRARIES})
 include(CheckSymbolExists)
+# N.B. we don't use bcc_usdt_foreach - it's just a proxy for seeing if the libbcc runtime exists
 check_symbol_exists(bcc_usdt_foreach ${LIBBCC_INCLUDE_DIRS}/bcc/bcc_usdt.h LIBBCC_BPF_CONTAINS_RUNTIME)
 SET(CMAKE_REQUIRED_LIBRARIES)
 SET(CMAKE_REQUIRED_INCLUDES)

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <bcc/bcc_usdt.h>
 #include <llvm/Config/llvm-config.h>
 #include <llvm/IR/IRBuilder.h>
 #include <optional>

--- a/src/usdt.h
+++ b/src/usdt.h
@@ -8,8 +8,6 @@
 
 namespace bpftrace {
 
-// Note this class is fully static because bcc_usdt_foreach takes a function
-// pointer callback without a context variable. So we must keep global state.
 class USDTHelper {
 public:
   virtual ~USDTHelper() = default;

--- a/src/util/kernel.cpp
+++ b/src/util/kernel.cpp
@@ -1,7 +1,6 @@
 #include <algorithm>
 #include <bcc/bcc_elf.h>
 #include <bcc/bcc_syms.h>
-#include <bcc/bcc_usdt.h>
 #include <cstring>
 #include <elf.h>
 #include <fcntl.h>

--- a/src/util/symbols.cpp
+++ b/src/util/symbols.cpp
@@ -1,6 +1,5 @@
 #include <bcc/bcc_elf.h>
 #include <bcc/bcc_syms.h>
-#include <bcc/bcc_usdt.h>
 #include <cstring>
 #include <elf.h>
 #include <fcntl.h>


### PR DESCRIPTION
Stacked PRs:
 * #4928
 * __->__#4927


--- --- ---

### BCC Deprecation: remove bcc_usdt includes


These aren't used anymore.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>