### PR TITLE
RM special casing for old clang and gcc versions

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -194,11 +194,6 @@ if (LIBDW_FOUND)
   endif()
 endif()
 
-# Support for std::filesystem
-# GCC version <9 and Clang (all versions) require -lstdc++fs
-target_link_libraries(runtime $<$<OR:$<CXX_COMPILER_ID:Clang>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9>>:stdc++fs>)
-target_link_libraries(libbpftrace $<$<OR:$<CXX_COMPILER_ID:Clang>,$<VERSION_LESS:$<CXX_COMPILER_VERSION>,9>>:stdc++fs>)
-
 # We do not use add_link_options here since it doesn't work for some reason.
 # Instead, just pass -fsanitize=... to the linker when linking the bpftrace
 # target.


### PR DESCRIPTION
Stacked PRs:
 * __->__#4931


--- --- ---

### RM special casing for old clang and gcc versions


Both GCC 8 and Clang 9 are now 7 and 6 years old
respectively. We don't need to explicitly add the
stdc++fs library.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>