### PR TITLE
tests: remove kernel-specific type reliance from tests

### DIFF
--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -779,7 +779,7 @@ TEST_F(clang_parser_btf, btf_type_override)
   parse("struct Foo1 { int a; };\n",
         *bpftrace,
         true,
-        "kprobe:sys_read { @x = ((struct Foo1 *)curtask); }");
+        "kprobe:sys_read { @x = ((struct Foo1 *)ctx); }");
 
   ASSERT_TRUE(bpftrace->structs.Has("struct Foo1"));
   auto foo1 = bpftrace->structs.Lookup("struct Foo1").lock();
@@ -792,7 +792,7 @@ TEST_F(clang_parser_btf, btf_type_override)
   parse("struct Foo1 { struct Foo2 foo2; };\n",
         *bpftrace,
         false,
-        "kprobe:sys_read { @x = ((struct Foo1 *)curtask); }");
+        "kprobe:sys_read { @x = ((struct Foo1 *)ctx); }");
 
   // Here, Foo1 redefinition will take place when resolving incomplete types
   // (since Foo3 contains a pointer to Foo1)
@@ -800,7 +800,7 @@ TEST_F(clang_parser_btf, btf_type_override)
   parse("struct Foo1 { struct Foo2 foo2; };\n",
         *bpftrace,
         false,
-        "kprobe:sys_read { @x1 = ((struct Foo3 *)curtask); }");
+        "kprobe:sys_read { @x1 = ((struct Foo3 *)ctx); }");
 }
 
 TEST(clang_parser, struct_typedef)

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -48,9 +48,9 @@ TEST_F(field_analyser_btf, btf_types)
   auto bpftrace = get_mock_bpftrace();
   test(*bpftrace,
        "kprobe:sys_read {\n"
-       "  @x1 = (struct Foo1 *) curtask;\n"
-       "  @x2 = (struct Foo2 *) curtask;\n"
-       "  @x3 = (struct Foo3 *) curtask;\n"
+       "  @x1 = (struct Foo1 *) ctx;\n"
+       "  @x2 = (struct Foo2 *) ctx;\n"
+       "  @x3 = (struct Foo3 *) ctx;\n"
        "}",
        true);
 
@@ -261,7 +261,7 @@ TEST_F(field_analyser_btf, btf_types_struct_ptr)
   auto bpftrace = get_mock_bpftrace();
   test(*bpftrace,
        "kprobe:sys_read {\n"
-       "  @x1 = ((struct Foo3 *) curtask);\n"
+       "  @x1 = ((struct Foo3 *) ctx);\n"
        "  @x3 = @x1->foo2;\n"
        "}",
        true);

--- a/tests/parser.cpp
+++ b/tests/parser.cpp
@@ -184,10 +184,6 @@ TEST(Parser, builtin_variables)
        Program().WithProbe(
            Probe({ "kprobe:f" }, { ExprStatement(Builtin("__builtin_cpu")) })));
 
-  test("kprobe:f { __builtin_curtask }",
-       Program().WithProbe(Probe(
-           { "kprobe:f" }, { ExprStatement(Builtin("__builtin_curtask")) })));
-
   test("kprobe:f { __builtin_rand }",
        Program().WithProbe(Probe(
            { "kprobe:f" }, { ExprStatement(Builtin("__builtin_rand")) })));
@@ -1448,7 +1444,6 @@ TEST(Parser, wildcard_func)
   std::string keywords[] = {
     "arg0",
     "args",
-    "__builtin_curtask",
     "errorf",
     "warnf",
     "func",
@@ -2552,13 +2547,13 @@ TEST(Parser, keywords_as_identifiers)
                                                   .WithName("struct Foo")),
                                        Integer(0))),
                ExprStatement(FieldAccess(keyword, Variable("$x"))) })));
-    test("begin { $x = offsetof(*__builtin_curtask, " + keyword + "); }",
-         Program().WithProbe(Probe(
-             { "begin" },
-             { AssignVarStatement(Variable("$x"),
-                                  Offsetof(Unop(Operator::MUL,
-                                                Builtin("__builtin_curtask")),
-                                           { keyword })) })));
+    test("begin { $x = offsetof(*__builtin_cpu, " + keyword + "); }",
+         Program().WithProbe(
+             Probe({ "begin" },
+                   { AssignVarStatement(Variable("$x"),
+                                        Offsetof(Unop(Operator::MUL,
+                                                      Builtin("__builtin_cpu")),
+                                                 { keyword })) })));
   }
 }
 


### PR DESCRIPTION
Stacked PRs:
 * #4938
 * #4932
 * __->__#4933


--- --- ---

### tests: remove kernel-specific type reliance from tests


Some types (e.g. task_struct, pt_regs) should be defined by the kernel
BTF. Presently, they are defined implicitly by codegen or in a more
ad-hoc way (e.g. for task_struct).

The unit tests should be hermetic, ahead of making these "just another
type", the reliance of some kernel-specific types needs to be removed.
In most cases these tests are not provided any additional coverage, and
the specific builtins (using standard code paths) are covered by runtime
tests. Where there is specific coverage, alternate builtins have been
used instead to replace the existing tests.

Signed-off-by: Adin Scannell <amscanne@meta.com>
