### PR TITLE
tools/statsnoop: Set missing_probes to warn

### DIFF
--- a/tools/statsnoop.bt
+++ b/tools/statsnoop.bt
@@ -64,6 +64,10 @@
 //
 // 08-Sep-2018	Brendan Gregg	Created this.
 
+config = {
+  missing_probes = warn;
+}
+
 BEGIN
 {
   printf("Tracing stat syscalls... Hit Ctrl-C to end.\n");


### PR DESCRIPTION
For example, in the aarch64 architecture, there are no newstat and newlstat system calls.
