### PR TITLE
build: remove accidental files

### DIFF
--- a/src/async/CMakeLists.txt
+++ b/src/async/CMakeLists.txt
@@ -1,7 +1,0 @@
-add_library(async STATIC
-  functions.cpp
-  memory.cpp
-  relocations.cpp
-  )
-
-target_link_libraries(async arch util)


### PR DESCRIPTION
Stacked PRs:
 * __->__#4937


--- --- ---

### build: remove accidental files


During the large-scale formatting change, this file was added
accidentally. It is from a separate branch & development effort.

Signed-off-by: Adin Scannell <amscanne@meta.com>