### PR TITLE
FormatString: Fix use-after-move

### DIFF
--- a/src/format_string.cpp
+++ b/src/format_string.cpp
@@ -44,7 +44,7 @@ FormatSpec::FormatSpec(const std::smatch& match)
 
 FormatString::FormatString() = default;
 
-FormatString::FormatString(const std::string& fmt) : fmt_(std::move(fmt))
+FormatString::FormatString(std::string fmt) : fmt_(std::move(fmt))
 {
   parse();
 }

--- a/src/format_string.h
+++ b/src/format_string.h
@@ -47,7 +47,7 @@ private:
 class FormatString {
 public:
   FormatString();
-  FormatString(const std::string &fmt);
+  FormatString(std::string fmt);
   ~FormatString();
 
   // check can be used to check if the format is valid, given a set of arguments


### PR DESCRIPTION
Stacked PRs:
 * #4944
 * #4943
 * #4942
 * #4941
 * #4940
 * __->__#4939


--- --- ---

### FormatString: Fix use-after-move


Change to FormatString constructor to accept `std::string` rather than a
reference since it moves the value into a private field.

This removes a use-after-move warning reported by Coverity:

    Returning while reference parameter "fmt" is in a moved state.

Signed-off-by: Viktor Malik <viktor.malik@gmail.com>
