### PR TITLE
OpaqueValue: Fix out-of-scope usage error

### DIFF
--- a/src/types_format.cpp
+++ b/src/types_format.cpp
@@ -118,8 +118,9 @@ Result<output::Primitive> format(BPFtrace &bpftrace,
       size_t length = buf.length;
       output::Primitive::Buffer v;
       v.data.resize(buf.length);
-      const auto *content = value.slice(sizeof(AsyncEvent::Buf), length).data();
-      memcpy(v.data.data(), content, length);
+      memcpy(v.data.data(),
+             value.slice(sizeof(AsyncEvent::Buf), length).data(),
+             length);
       return v;
     }
     case Type::string: {


### PR DESCRIPTION
Stacked PRs:
 * #4944
 * #4943
 * #4942
 * #4941
 * __->__#4940


--- --- ---

### OpaqueValue: Fix out-of-scope usage error


Taking a pointer to the memory stored by a temporary OpaqueValue object
(created by OpaqueValue::slice) and storing it in a variable results in
a stack-use-after-scope from ASAN when that variable is used in memcpy.

Move the creation temporary object directly to the memcpy argument to
avoid the error.

Signed-off-by: Viktor Malik <viktor.malik@gmail.com>
