### PR TITLE
Runtime tests: add more filtering options

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -20,7 +20,7 @@ These are `test:` probes written to test core functionality, and standard librar
 Runtime tests will call the bpftrace executable. These are located in `tests/runtime` and are managed by a custom framework.
 
 * Run: `sudo <builddir>/tests/runtime-tests.sh`
-* Use the `TEST_FILTER` environment variable (or the `--filter` arg when running `runtime-tests.sh`) to only run a subset of the tests e.g. `sudo <builddir>/tests/runtime-tests.sh --filter=".*uprobe.*"`
+* Use the `TEST_FILTER` environment variable (or the `--filter` arg when running `runtime-tests.sh`) to only run a subset of the tests. The passed value should be a colon-separated list of positive and negative (starting with `-`) regex patterns. Only tests which match any of the positive patterns (by default `.*`) and none of the negative patterns will be executed. For example, `sudo <builddir>/tests/runtime-tests.sh --filter="^uprobe.*:-list"` will run all tests from the `uprobe` suite, except for tests for probe listing.
 * There are environment variables to override paths for the bpftrace executables, if necessary. See runtime-tests.sh for details.
 
 Runtime tests are grouped into "suites". A suite is usually a single file. The

--- a/tests/runtime/engine/main.py
+++ b/tests/runtime/engine/main.py
@@ -28,10 +28,21 @@ def main(test_filter, allowlist_file, run_aot_tests):
         print(fail(f"[  FAILED  ] {str(error)}"))
         exit(1)
 
-    # Apply filter
+    # Apply filters
+    positive_patterns = "|".join([p for p in test_filter.split(':')
+                                  if not p.startswith('-')])
+    negative_patterns = "|".join([p[1:] for p in test_filter.split(':')
+                                  if p.startswith('-')])
+    if len(positive_patterns) == 0:
+        positive_patterns = ".*"
+
     filtered_suites = []
     for fname, tests in test_suite:
-        filtered_tests = [t for t in tests if re.search(test_filter, "{}.{}".format(fname, t.name))]
+        filtered_tests = [t for t in tests if
+                          re.search(positive_patterns, "{}.{}".format(fname, t.name))]
+        if negative_patterns:
+            filtered_tests = [t for t in filtered_tests if
+                              not re.search(negative_patterns, "{}.{}".format(fname, t.name))]
         if len(filtered_tests) != 0:
             filtered_suites.append((fname, filtered_tests))
     test_suite = filtered_suites


### PR DESCRIPTION
Stacked PRs:
 * #4944
 * #4943
 * #4942
 * __->__#4941


--- --- ---

### Runtime tests: add more filtering options


Add two new ways of filtering runtime tests:
- using multiple patterns to match by separating them with ':'
- using negative patterns by using leading '-'

This allows a very granular execution of runtime tests and, among other
things, will allow to skip certain tests in CI jobs.

Signed-off-by: Viktor Malik <viktor.malik@gmail.com>
