### PR TITLE
CI: Run sanitizers in a separate job

### DIFF
--- a/.github/include/ci.py
+++ b/.github/include/ci.py
@@ -46,6 +46,8 @@ TOOLS_TEST_OLDVERSION = os.environ.get("TOOLS_TEST_OLDVERSION", "")
 TOOLS_TEST_DISABLE = os.environ.get("TOOLS_TEST_DISABLE", "")
 AOT_ALLOWLIST_FILE = os.environ.get("AOT_ALLOWLIST_FILE", "")
 RUNTIME_TESTS_FILTER = os.environ.get("RUNTIME_TESTS_FILTER", "")
+BUILD_ASAN = os.environ.get("BUILD_ASAN", "0")
+BUILD_UBSAN = os.environ.get("BUILD_UBSAN", "0")
 
 
 class TestStatus(Enum):
@@ -187,12 +189,13 @@ def configure():
             f"-DCMAKE_C_COMPILER={CC}",
             f"-DCMAKE_CXX_COMPILER={CXX}",
             f"-DCMAKE_BUILD_TYPE={CMAKE_BUILD_TYPE}",
+            f"-DBUILD_ASAN={BUILD_ASAN}",
+            f"-DBUILD_UBSAN={BUILD_UBSAN}",
 
             # Static configs
             f"-DCMAKE_VERBOSE_MAKEFILE=1",
             f"-DBUILD_TESTING=1",
             f"-DENABLE_SKB_OUTPUT=1",
-            f"-DBUILD_ASAN=1",
             f"-DHARDENED_STDLIB=1",
         ]
         # fmt: on

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,13 @@ jobs:
           CC: clang
           CXX: clang++
           TOOLS_TEST_DISABLE: runqlen.bt
+        - NAME: LLVM 21 + sanitizers
+          CMAKE_BUILD_TYPE: Debug
+          NIX_TARGET: .#bpftrace-llvm21
+          BUILD_ASAN: 1
+          BUILD_UBSAN: 1
+          TOOLS_TEST_DISABLE: runqlen.bt
+          RUNTIME_TESTS_FILTER: "-btf.user_supplied_c_def_using_btf"
         - NAME: Fuzzing
           CMAKE_BUILD_TYPE: Debug
           NIX_TARGET: .#bpftrace-fuzz


### PR DESCRIPTION
Stacked PRs:
 * #4944
 * __->__#4943
 * #4942
 * #4941


--- --- ---

### CI: Run sanitizers in a separate job


Instead of running all the CI jobs with just address sanitizer turned
on, turn it off by default and add a new dedicated job with all
sanitizers (ASan and UBSan) on.

The main reason is that the sanitizers add quite a large overhead so it
doesn't make much sense to run them all the time. In addition, with
UBSan enabled, the "btf.user_supplied_c_def_using_btf" runtime test
times out, so we can disable it in the dedicated job only.

N.B.: the overhead is also large with ASan but until now, we haven't
noticed b/c we're only compiling a small subset of .cpp files with ASan.
This is going to be fixed in the following commit.

Signed-off-by: Viktor Malik <viktor.malik@gmail.com>
