### PR TITLE
CMake: Fix ASan build

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,9 +2,12 @@ if(HAVE_BFD_DISASM)
   set(BFD_DISASM_SRC bfd-disasm.cpp)
 endif()
 
+# These add -fsanitize=... to all below compiler invocations, including
+# subdirectories.
+if (BUILD_ASAN)
+  add_compile_options("-fsanitize=address")
+endif()
 if (BUILD_UBSAN)
-  # This adds -fsanitize=undefined to all below compiler invocations, including
-  # subdirectories.
   add_compile_options("-fsanitize=undefined")
 endif()
 
@@ -201,15 +204,13 @@ if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" OR ${CMAKE_CXX_COMPILER_VERSION}
   target_link_libraries(libbpftrace "stdc++fs")
 endif()
 
+# We do not use add_link_options here since it doesn't work for some reason.
+# Instead, just pass -fsanitize=... to the linker when linking the bpftrace
+# target.
 if (BUILD_ASAN)
-  target_compile_options(bpftrace PUBLIC "-fsanitize=address")
   target_link_options(bpftrace PUBLIC "-fsanitize=address")
 endif()
-
 if (BUILD_UBSAN)
-  # We do not use add_link_options here since it doesn't work for some reason.
-  # Instead, just pass -fsanitize=undefined to the linker when linking the
-  # bpftrace target.
   target_link_options(bpftrace PUBLIC "-fsanitize=undefined")
 endif()
 

--- a/src/aot/CMakeLists.txt
+++ b/src/aot/CMakeLists.txt
@@ -31,7 +31,6 @@ endif(STATIC_LINKING)
 
 # ASAN
 if(BUILD_ASAN)
-  target_compile_options(bpftrace-aotrt PUBLIC "-fsanitize=address")
   target_link_options(bpftrace-aotrt PUBLIC "-fsanitize=address")
 endif()
 


### PR DESCRIPTION
Stacked PRs:
 * __->__#4944
 * #4943
 * #4942
 * #4941


--- --- ---

### CMake: Fix ASan build


Using `target_compile_options` applies `-fsanitize=address` only to the
sources of a specific target, not its dependencies. This caused the
option to be missed during the compilation of most source files in the
project, potentially hiding ASAN errors.

Fix the issue by using `add_compile_options` which adds the option to
all compiler invocations within the same CMakeLists.txt, including
sub-directories.

Note that we don't use `add_link_options` to pass `-fsanitize=address`
to the linker since it doesn't work for some reason. Instead, we keep
passing it to the selected targets (`bpftrace` and `bpftrace-aotrt`) via
`target_link_options`.

Signed-off-by: Viktor Malik <viktor.malik@gmail.com>
