### PR TITLE
Rename internal record sized type to c_struct

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -391,9 +391,9 @@ void Program::clear_empty_probes()
   probes.erase(it.begin(), it.end());
 }
 
-SizedType ident_to_record(const std::string &ident, int pointer_level)
+SizedType ident_to_c_struct(const std::string &ident, int pointer_level)
 {
-  SizedType result = CreateRecord(ident);
+  SizedType result = CreateCStruct(ident);
   for (int i = 0; i < pointer_level; i++)
     result = CreatePointer(result);
   return result;
@@ -411,7 +411,7 @@ SizedType ident_to_sized_type(const std::string &ident)
     // if we check the variant values during semantic analysis.
     return CreateEnum(64, enum_name);
   }
-  return ident_to_record(ident);
+  return ident_to_c_struct(ident);
 }
 
 } // namespace bpftrace::ast

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -2182,7 +2182,7 @@ std::string opstr(const Unop &unop);
 std::string opstr(const Jump &jump);
 bool is_comparison_op(Operator op);
 
-SizedType ident_to_record(const std::string &ident, int pointer_level = 0);
+SizedType ident_to_c_struct(const std::string &ident, int pointer_level = 0);
 SizedType ident_to_sized_type(const std::string &ident);
 
 } // namespace bpftrace::ast

--- a/src/ast/codegen_helper.cpp
+++ b/src/ast/codegen_helper.cpp
@@ -23,7 +23,7 @@ bool needAssignMapStatementAllocation(const AssignMapStatement &assignment)
   const auto &expr_type = assignment.expr.type();
   if (shouldBeInBpfMemoryAlready(expr_type)) {
     return false;
-  } else if (map.map->value_type.IsRecordTy() ||
+  } else if (map.map->value_type.IsCStructTy() ||
              map.map->value_type.IsArrayTy()) {
     return !expr_type.is_internal;
   }

--- a/src/ast/dibuilderbpf.cpp
+++ b/src/ast/dibuilderbpf.cpp
@@ -271,7 +271,7 @@ DIType *DIBuilderBPF::CreateByteArrayType(uint64_t num_bytes)
 /// name and size (fields are not necessary).
 DIType *DIBuilderBPF::GetType(const SizedType &stype, bool emit_codegen_types)
 {
-  if (!emit_codegen_types && stype.IsRecordTy()) {
+  if (!emit_codegen_types && stype.IsCStructTy()) {
     std::string name = stype.GetName();
     static constexpr std::string_view struct_prefix = "struct ";
     static constexpr std::string_view union_prefix = "union ";
@@ -291,7 +291,7 @@ DIType *DIBuilderBPF::GetType(const SizedType &stype, bool emit_codegen_types)
                             getOrCreateArray({}));
   }
 
-  if (stype.IsByteArray() || stype.IsRecordTy() || stype.IsStack()) {
+  if (stype.IsByteArray() || stype.IsCStructTy() || stype.IsStack()) {
     auto *subrange = getOrCreateSubrange(0, stype.GetSize());
     return createArrayType(
         stype.GetSize() * 8, 0, getInt8Ty(), getOrCreateArray({ subrange }));

--- a/src/ast/irbuilderbpf.cpp
+++ b/src/ast/irbuilderbpf.cpp
@@ -370,11 +370,11 @@ llvm::ConstantInt *IRBuilderBPF::GetIntSameSize(uint64_t C, llvm::Value *expr)
 /// Convert internal SizedType to a corresponding LLVM type.
 ///
 /// Only one type is not converted directly into an LLVM type:
-/// - structs (records) are represented as byte arrays
+/// - C structs (c_struct) are represented as byte arrays
 llvm::Type *IRBuilderBPF::GetType(const SizedType &stype)
 {
   llvm::Type *ty;
-  if (stype.IsByteArray() || stype.IsRecordTy()) {
+  if (stype.IsByteArray() || stype.IsCStructTy()) {
     ty = ArrayType::get(getInt8Ty(), stype.GetSize());
   } else if (stype.IsArrayTy()) {
     ty = ArrayType::get(GetType(*stype.GetElementTy()), stype.GetNumElements());
@@ -2134,7 +2134,7 @@ Value *IRBuilderBPF::CreateRawTracepointArg(Value *ctx,
 Value *IRBuilderBPF::CreateUprobeArgsRecord(Value *ctx,
                                             const SizedType &args_type)
 {
-  assert(args_type.IsRecordTy());
+  assert(args_type.IsCStructTy());
 
   auto *args_t = UprobeArgsType(args_type);
   AllocaInst *result = CreateAllocaBPF(args_t, "args");

--- a/src/ast/passes/clang_parser.cpp
+++ b/src/ast/passes/clang_parser.cpp
@@ -257,7 +257,7 @@ static SizedType get_sized_type(CXType clang_type, StructManager &structs)
       // Struct map entry may not exist for forward declared types so we
       // create it now and fill it later
       auto s = structs.LookupOrAdd(typestr, size / 8);
-      return CreateRecord(typestr, s);
+      return CreateCStruct(typestr, s);
     }
     case CXType_Char_S:
     case CXType_SChar:

--- a/src/ast/passes/field_analyser.cpp
+++ b/src/ast/passes/field_analyser.cpp
@@ -137,7 +137,7 @@ void FieldAnalyser::visit(FieldAccess &acc)
       sized_type_ = arg->type;
 
     has_builtin_args_ = false;
-  } else if (sized_type_.IsRecordTy()) {
+  } else if (sized_type_.IsCStructTy()) {
     SizedType field_type = CreateNone();
     if (sized_type_.HasField(acc.field))
       field_type = sized_type_.GetField(acc.field).type;
@@ -227,7 +227,7 @@ void FieldAnalyser::visit(Unop &unop)
 
 void FieldAnalyser::resolve_fields(SizedType &type)
 {
-  if (!type.IsRecordTy())
+  if (!type.IsCStructTy())
     return;
 
   if (probe_) {
@@ -247,7 +247,7 @@ void FieldAnalyser::resolve_type(SizedType &type)
   const SizedType *inner_type = &type;
   while (inner_type->IsPtrTy())
     inner_type = inner_type->GetPointeeTy();
-  if (!inner_type->IsRecordTy())
+  if (!inner_type->IsCStructTy())
     return;
   const auto &name = inner_type->GetName();
 

--- a/src/btf.cpp
+++ b/src/btf.cpp
@@ -495,7 +495,7 @@ SizedType BTF::get_stype(const BTFId &btf_id, bool resolve_structs)
     auto name = recprefix + rname;
 
     auto record = bpftrace_->structs.LookupOrAdd(name, t->size).lock();
-    stype = CreateRecord(name, record);
+    stype = CreateCStruct(name, record);
     if (is_anon)
       stype.SetAnon();
     if (resolve_structs)
@@ -1197,7 +1197,7 @@ void BTF::resolve_fields(const SizedType &type)
 {
   BTFId type_id;
 
-  if (!type.IsRecordTy())
+  if (!type.IsCStructTy())
     return;
 
   auto const &name = type.GetName();

--- a/src/btf/compat.cpp
+++ b/src/btf/compat.cpp
@@ -67,7 +67,7 @@ Result<SizedType> getCompatType(const Struct &type)
     fields.emplace_back(*ft);
     idents.emplace_back(name);
   }
-  return CreateRecord(bpftrace::Struct::CreateRecord(fields, idents));
+  return CreateCStruct(bpftrace::Struct::CreateRecord(fields, idents));
 }
 
 Result<SizedType> getCompatType(const Enum &type)

--- a/src/dwarf_parser.cpp
+++ b/src/dwarf_parser.cpp
@@ -175,7 +175,7 @@ SizedType Dwarf::get_stype(Dwarf_Die &type_die, bool resolve_structs) const
     case DW_TAG_union_type: {
       std::string name = dwarf_diename(&type_die);
       name = (tag == DW_TAG_structure_type ? "struct " : "union ") + name;
-      auto result = CreateRecord(
+      auto result = CreateCStruct(
           name, bpftrace_->structs.LookupOrAdd(name, bit_size / 8));
       if (resolve_structs)
         resolve_fields(result);
@@ -248,7 +248,7 @@ std::optional<Bitfield> Dwarf::resolve_bitfield(Dwarf_Die &field_die) const
 
 void Dwarf::resolve_fields(const SizedType &type) const
 {
-  if (!type.IsRecordTy())
+  if (!type.IsCStructTy())
     return;
 
   auto str = bpftrace_->structs.Lookup(type.GetName()).lock();

--- a/src/parser.yy
+++ b/src/parser.yy
@@ -764,12 +764,12 @@ cast_expr:
                 LPAREN any_type RPAREN cast_expr           { $$ = driver.ctx.make_node<ast::Cast>(@1 + @3, $2, $4); }
         |       LPAREN any_type RPAREN unary_expr          { $$ = driver.ctx.make_node<ast::Cast>(@1 + @3, $2, $4); }
 /* workaround for typedef types, see https://github.com/bpftrace/bpftrace/pull/2560#issuecomment-1521783935 */
-        |       LPAREN IDENT RPAREN cast_expr          { $$ = driver.ctx.make_node<ast::Cast>(@1 + @3, driver.ctx.make_node<ast::Typeof>(@2, ast::ident_to_record($2, 0)), $4); }
-        |       LPAREN IDENT RPAREN unary_expr         { $$ = driver.ctx.make_node<ast::Cast>(@1 + @3, driver.ctx.make_node<ast::Typeof>(@2, ast::ident_to_record($2, 0)), $4); }
-        |       LPAREN IDENT "*" RPAREN cast_expr      { $$ = driver.ctx.make_node<ast::Cast>(@1 + @4, driver.ctx.make_node<ast::Typeof>(@2, ast::ident_to_record($2, 1)), $5); }
-        |       LPAREN IDENT "*" RPAREN unary_expr     { $$ = driver.ctx.make_node<ast::Cast>(@1 + @4, driver.ctx.make_node<ast::Typeof>(@2, ast::ident_to_record($2, 1)), $5); }
-        |       LPAREN IDENT "*" "*" RPAREN cast_expr  { $$ = driver.ctx.make_node<ast::Cast>(@1 + @5, driver.ctx.make_node<ast::Typeof>(@2, ast::ident_to_record($2, 2)), $6); }
-        |       LPAREN IDENT "*" "*" RPAREN unary_expr { $$ = driver.ctx.make_node<ast::Cast>(@1 + @5, driver.ctx.make_node<ast::Typeof>(@2, ast::ident_to_record($2, 2)), $6); }
+        |       LPAREN IDENT RPAREN cast_expr          { $$ = driver.ctx.make_node<ast::Cast>(@1 + @3, driver.ctx.make_node<ast::Typeof>(@2, ast::ident_to_c_struct($2, 0)), $4); }
+        |       LPAREN IDENT RPAREN unary_expr         { $$ = driver.ctx.make_node<ast::Cast>(@1 + @3, driver.ctx.make_node<ast::Typeof>(@2, ast::ident_to_c_struct($2, 0)), $4); }
+        |       LPAREN IDENT "*" RPAREN cast_expr      { $$ = driver.ctx.make_node<ast::Cast>(@1 + @4, driver.ctx.make_node<ast::Typeof>(@2, ast::ident_to_c_struct($2, 1)), $5); }
+        |       LPAREN IDENT "*" RPAREN unary_expr     { $$ = driver.ctx.make_node<ast::Cast>(@1 + @4, driver.ctx.make_node<ast::Typeof>(@2, ast::ident_to_c_struct($2, 1)), $5); }
+        |       LPAREN IDENT "*" "*" RPAREN cast_expr  { $$ = driver.ctx.make_node<ast::Cast>(@1 + @5, driver.ctx.make_node<ast::Typeof>(@2, ast::ident_to_c_struct($2, 2)), $6); }
+        |       LPAREN IDENT "*" "*" RPAREN unary_expr { $$ = driver.ctx.make_node<ast::Cast>(@1 + @5, driver.ctx.make_node<ast::Typeof>(@2, ast::ident_to_c_struct($2, 2)), $6); }
                 ;
 
 unary_expr:
@@ -831,8 +831,8 @@ offsetof_expr:
 
 typeof_expr:
                 TYPEOF "(" type ")"  { $$ = driver.ctx.make_node<ast::Typeof>(@$, $3); }
-        |       TYPEOF "(" IDENT "*" ")"  { $$ = driver.ctx.make_node<ast::Typeof>(@$, ast::ident_to_record($3, 1)); }
-        |       TYPEOF "(" IDENT "*" "*" ")"  { $$ = driver.ctx.make_node<ast::Typeof>(@$, ast::ident_to_record($3, 2)); }
+        |       TYPEOF "(" IDENT "*" ")"  { $$ = driver.ctx.make_node<ast::Typeof>(@$, ast::ident_to_c_struct($3, 1)); }
+        |       TYPEOF "(" IDENT "*" "*" ")"  { $$ = driver.ctx.make_node<ast::Typeof>(@$, ast::ident_to_c_struct($3, 2)); }
         |       TYPEOF "(" expr ")"  { $$ = driver.ctx.make_node<ast::Typeof>(@$, $3); }
                 ;
 

--- a/src/types.h
+++ b/src/types.h
@@ -28,7 +28,7 @@ enum class Type : uint8_t {
   integer, // int is a protected keyword
   boolean,
   pointer,
-  record, // struct/union, as struct is a protected keyword
+  c_struct, // struct/union from external c programs or the kernel
   hist_t,
   lhist_t,
   tseries_t,
@@ -333,19 +333,19 @@ public:
 
   const std::string &GetName() const
   {
-    assert(IsRecordTy() || IsEnumTy());
+    assert(IsCStructTy() || IsEnumTy());
     return name_;
   }
 
   bool IsAnonTy() const
   {
-    assert(IsRecordTy());
+    assert(IsCStructTy());
     return is_anon_;
   }
 
   void SetAnon()
   {
-    assert(IsRecordTy());
+    assert(IsCStructTy());
     is_anon_ = true;
   }
 
@@ -462,9 +462,9 @@ public:
   {
     return type_ == Type::array;
   };
-  bool IsRecordTy() const
+  bool IsCStructTy() const
   {
-    return type_ == Type::record;
+    return type_ == Type::c_struct;
   };
   bool IsBufferTy() const
   {
@@ -525,9 +525,9 @@ public:
                                const SizedType &element_type);
 
   friend SizedType CreatePointer(const SizedType &pointee_type, AddrSpace as);
-  friend SizedType CreateRecord(const std::string &name);
-  friend SizedType CreateRecord(std::shared_ptr<Struct> &&record);
-  friend SizedType CreateRecord(const std::string &name,
+  friend SizedType CreateCStruct(const std::string &name);
+  friend SizedType CreateCStruct(std::shared_ptr<Struct> &&record);
+  friend SizedType CreateCStruct(const std::string &name,
                                 std::weak_ptr<Struct> record);
   friend SizedType CreateInteger(size_t bits, bool is_signed);
   friend SizedType CreateTuple(std::shared_ptr<Struct> &&tuple);
@@ -556,9 +556,9 @@ SizedType CreateArray(size_t num_elements, const SizedType &element_type);
 SizedType CreatePointer(const SizedType &pointee_type,
                         AddrSpace as = AddrSpace::none);
 
-SizedType CreateRecord(const std::string &name);
-SizedType CreateRecord(std::shared_ptr<Struct> &&record);
-SizedType CreateRecord(const std::string &name, std::weak_ptr<Struct> record);
+SizedType CreateCStruct(const std::string &name);
+SizedType CreateCStruct(std::shared_ptr<Struct> &&record);
+SizedType CreateCStruct(const std::string &name, std::weak_ptr<Struct> record);
 SizedType CreateTuple(std::shared_ptr<Struct> &&tuple);
 
 SizedType CreateStack(bool kernel, StackType st = StackType());

--- a/src/types_format.cpp
+++ b/src/types_format.cpp
@@ -151,7 +151,7 @@ Result<output::Primitive> format(BPFtrace &bpftrace,
       }
       return array;
     }
-    case Type::record: {
+    case Type::c_struct: {
       output::Primitive::Record record;
       for (auto &field : type.GetFields()) {
         auto elem_data = value.slice(field.offset, field.type.GetSize());

--- a/tests/ast_matchers.h
+++ b/tests/ast_matchers.h
@@ -409,7 +409,7 @@ public:
         [field_name, field_type_matcher](const class SizedType& type_obj,
                                          MatchResultListener* listener) {
           // Check if this is a record type (struct/union) or tuple.
-          if (!type_obj.IsRecordTy() && !type_obj.IsTupleTy()) {
+          if (!type_obj.IsCStructTy() && !type_obj.IsTupleTy()) {
             *listener << "type is not a record or tuple, cannot have fields";
             return false;
           }

--- a/tests/clang_parser.cpp
+++ b/tests/clang_parser.cpp
@@ -272,7 +272,7 @@ TEST(clang_parser, nested_struct_named)
   ASSERT_TRUE(foo->HasField("bar"));
 
   const auto &bar = foo->GetField("bar");
-  EXPECT_TRUE(bar.type.IsRecordTy());
+  EXPECT_TRUE(bar.type.IsCStructTy());
   EXPECT_EQ(bar.type.GetName(), "struct Bar");
   EXPECT_EQ(bar.type.GetSize(), 4U);
   EXPECT_EQ(bar.offset, 0);
@@ -293,7 +293,7 @@ TEST(clang_parser, nested_struct_ptr_named)
 
   const auto &bar = foo->GetField("bar");
   EXPECT_TRUE(bar.type.IsPtrTy());
-  EXPECT_TRUE(bar.type.GetPointeeTy()->IsRecordTy());
+  EXPECT_TRUE(bar.type.GetPointeeTy()->IsCStructTy());
   EXPECT_EQ(bar.type.GetPointeeTy()->GetName(), "struct Bar");
   EXPECT_EQ(bar.type.GetPointeeTy()->GetSize(), sizeof(int));
   EXPECT_EQ(bar.offset, 0);
@@ -340,12 +340,12 @@ TEST(clang_parser, nested_struct_no_type)
 
   {
     const auto &bar_field = foo->GetField("bar");
-    EXPECT_TRUE(bar_field.type.IsRecordTy());
+    EXPECT_TRUE(bar_field.type.IsCStructTy());
     EXPECT_EQ(bar_field.type.GetSize(), sizeof(int));
     EXPECT_EQ(bar_field.offset, 0);
 
     const auto &baz_field = foo->GetField("baz");
-    EXPECT_TRUE(baz_field.type.IsRecordTy());
+    EXPECT_TRUE(baz_field.type.IsCStructTy());
     EXPECT_EQ(baz_field.type.GetSize(), sizeof(int));
     EXPECT_EQ(baz_field.offset, 4);
   }
@@ -679,7 +679,7 @@ TEST_F(clang_parser_btf, btf)
   EXPECT_EQ(foo2->GetField("a").type.GetSize(), 4U);
   EXPECT_EQ(foo2->GetField("a").offset, 0);
 
-  EXPECT_TRUE(foo2->GetField("f").type.IsRecordTy());
+  EXPECT_TRUE(foo2->GetField("f").type.IsCStructTy());
   EXPECT_EQ(foo2->GetField("f").type.GetSize(), 16U);
   EXPECT_EQ(foo2->GetField("f").offset, 8);
 
@@ -862,10 +862,10 @@ TEST(clang_parser, struct_qualifiers)
   EXPECT_EQ(SB->fields.size(), 2U);
 
   EXPECT_TRUE(SB->GetField("a").type.IsPtrTy());
-  EXPECT_TRUE(SB->GetField("a").type.GetPointeeTy()->IsRecordTy());
+  EXPECT_TRUE(SB->GetField("a").type.GetPointeeTy()->IsCStructTy());
   EXPECT_EQ(SB->GetField("a").type.GetPointeeTy()->GetName(), "struct a");
 
-  EXPECT_TRUE(SB->GetField("a2").type.IsRecordTy());
+  EXPECT_TRUE(SB->GetField("a2").type.IsCStructTy());
   EXPECT_EQ(SB->GetField("a2").type.GetName(), "struct a");
 }
 

--- a/tests/field_analyser.cpp
+++ b/tests/field_analyser.cpp
@@ -89,7 +89,7 @@ TEST_F(field_analyser_btf, btf_types)
   EXPECT_EQ(foo2->GetField("a").type.GetSize(), 4U);
   EXPECT_EQ(foo2->GetField("a").offset, 0);
 
-  EXPECT_TRUE(foo2->GetField("f").type.IsRecordTy());
+  EXPECT_TRUE(foo2->GetField("f").type.IsCStructTy());
   EXPECT_EQ(foo2->GetField("f").type.GetSize(), 16U);
   EXPECT_EQ(foo2->GetField("f").offset, 8);
 
@@ -233,14 +233,14 @@ void test_arrays_compound_data(BPFtrace &bpftrace)
   ASSERT_TRUE(foo3_ptr_type.IsPtrTy());
 
   const auto &foo3_type = *foo3_ptr_type.GetPointeeTy();
-  ASSERT_TRUE(foo3_type.IsRecordTy());
+  ASSERT_TRUE(foo3_type.IsCStructTy());
   ASSERT_TRUE(foo3_type.HasField("foo1"));
 
   const auto &foo1_ptr_type = foo3_type.GetField("foo1").type;
   ASSERT_TRUE(foo1_ptr_type.IsPtrTy());
 
   const auto &foo1_type = *foo1_ptr_type.GetPointeeTy();
-  ASSERT_TRUE(foo1_type.IsRecordTy());
+  ASSERT_TRUE(foo1_type.IsCStructTy());
   ASSERT_TRUE(foo1_type.HasField("a"));
 }
 
@@ -321,7 +321,7 @@ TEST_F(field_analyser_btf, btf_types_anon_structs)
   EXPECT_TRUE(typedefarray.IsArrayTy());
   EXPECT_EQ(typedefarray.GetNumElements(), 8);
   EXPECT_EQ(typedefarray.GetSize(), 32);
-  EXPECT_TRUE(typedefarray.GetElementTy()->IsRecordTy());
+  EXPECT_TRUE(typedefarray.GetElementTy()->IsCStructTy());
   EXPECT_TRUE(typedefarray.GetElementTy()->IsAnonTy());
   EXPECT_TRUE(typedefarray.GetElementTy()->HasField("a"));
 
@@ -330,7 +330,7 @@ TEST_F(field_analyser_btf, btf_types_anon_structs)
   EXPECT_TRUE(typedefarray.IsArrayTy());
   EXPECT_EQ(structarray.GetSize(), 96);
   EXPECT_EQ(structarray.GetNumElements(), 4);
-  EXPECT_TRUE(structarray.GetElementTy()->IsRecordTy());
+  EXPECT_TRUE(structarray.GetElementTy()->IsCStructTy());
   EXPECT_TRUE(structarray.GetElementTy()->IsAnonTy());
   EXPECT_TRUE(structarray.GetElementTy()->HasField("a"));
   EXPECT_TRUE(structarray.GetElementTy()->HasField("b"));
@@ -338,7 +338,7 @@ TEST_F(field_analyser_btf, btf_types_anon_structs)
   ASSERT_TRUE(structarray.GetElementTy()->HasField("AnonSubArray"));
   auto subarray = structarray.GetElementTy()->GetField("AnonSubArray").type;
   EXPECT_EQ(subarray.GetNumElements(), 2);
-  EXPECT_TRUE(subarray.GetElementTy()->IsRecordTy());
+  EXPECT_TRUE(subarray.GetElementTy()->IsCStructTy());
   EXPECT_TRUE(subarray.GetElementTy()->IsAnonTy());
   EXPECT_TRUE(subarray.GetElementTy()->HasField("c"));
   EXPECT_TRUE(subarray.GetElementTy()->HasField("d"));

--- a/tests/function_registry.cpp
+++ b/tests/function_registry.cpp
@@ -90,7 +90,7 @@ protected:
         "unique_struct",
         CreateNone(),
         {
-            Param{ "a", CreateRecord("unique_struct_arg", unique_struct_arg) },
+            Param{ "a", CreateCStruct("unique_struct_arg", unique_struct_arg) },
         });
 
     takes_c_string_ = reg_.add(Function::Origin::Builtin,
@@ -308,11 +308,11 @@ TEST_F(TestFunctionRegistryPopulated, unique_struct)
   different_struct->AddField("b", CreateInt8(), 0);
 
   test("unique_struct",
-       { CreateRecord("unique_struct_arg", exact_struct) },
+       { CreateCStruct("unique_struct_arg", exact_struct) },
        unique_struct_);
 
   test("unique_struct",
-       { CreateRecord("same_layout_as_unique_struct_arg", compatible_struct) },
+       { CreateCStruct("same_layout_as_unique_struct_arg", compatible_struct) },
        R"(
 ERROR: Cannot call function 'unique_struct' using argument types: (same_layout_as_unique_struct_arg)
 HINT: Candidate function:
@@ -320,8 +320,8 @@ HINT: Candidate function:
 )");
 
   test("unique_struct",
-       { CreateRecord("different_layout_to_unique_struct_arg",
-                      different_struct) },
+       { CreateCStruct("different_layout_to_unique_struct_arg",
+                       different_struct) },
        R"(
 ERROR: Cannot call function 'unique_struct' using argument types: (different_layout_to_unique_struct_arg)
 HINT: Candidate function:

--- a/tests/types.cpp
+++ b/tests/types.cpp
@@ -35,7 +35,7 @@ TEST(types, to_str)
 
   EXPECT_EQ(to_str(CreateArray(2, CreateInt8())), "int8[2]");
 
-  EXPECT_EQ(to_str(CreateRecord("hello")), "hello");
+  EXPECT_EQ(to_str(CreateCStruct("hello")), "hello");
 
   std::shared_ptr<Struct> tuple = Struct::CreateTuple(
       { CreateInt8(), CreateString(10) });


### PR DESCRIPTION
Stacked PRs:
 * #4947
 * __->__#4946


--- --- ---

### Rename internal record sized type to c_struct


This is to make way for a new record type which is a tuple with named
fields but the entire type is still anonymous as opposed to the c_struct
type which (most of the time) has a name.

The name in struct.cpp doesn't change, it is still a record as
`CreateRecord` will be same method we use to create the new record sized
type.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>