### PR TITLE
Add bpftrace Record type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@ and this project adheres to
   - [#4621](https://github.com/bpftrace/bpftrace/pull/4621)
 - Add `build_id` stack mode for getting build_id and offset
   - [#4912](https://github.com/bpftrace/bpftrace/pull/4912)
+- Add new Record primitive
+  - [#4947](https://github.com/bpftrace/bpftrace/pull/4947)
 #### Changed
 - Add helpers to check if a kfunc exists and is supported for particular probe types.
   - [#4857](https://github.com/bpftrace/bpftrace/pull/4857)

--- a/docs/language.md
+++ b/docs/language.md
@@ -1646,7 +1646,7 @@ kprobe:dummy {
 bpftrace has support for immutable N-tuples.
 A tuple is a sequence type (like an array) where, unlike an array, every element can have a different type.
 
-Tuples are a comma separated list of expressions, enclosed in brackets, `(1,"hello")`.
+Tuples are a comma separated list of expressions, enclosed in parenthesis, `(1,"hello")`.
 Individual fields can be accessed with the `.` operator or via array-style access.
 The array index expression must evaluate to an integer literal at compile time (no variables but this is ok `(1, "hello")[1 - 1]`).
 Tuples are zero indexed like arrays. Examples:
@@ -1664,6 +1664,29 @@ interval:s:1 {
 
 Single-element and empty tuples can be specified using Python-like syntax.
 A single element tuple requires a trailing comma, `(1,)`, while the empty tuple is simply `()`.
+
+## Records
+
+bpftrace has support for immutable N-records.
+A record is a struct-like type where every element has a name and a type.
+
+Records are a comma separated list of named expressions, enclosed in parenthesis, `(color="green", size=2)`.
+Individual fields can be accessed with the `.` operator and the field name.
+Records maintain their initial ordering but maybe assigned to out of order, e.g. `$a = (color="green", size=2); $a = (size=10, color="blue");`. Note that evaluation order is maintained, e.g. `$a = (size={ print("first"); 20 }, color={ print("second"); "pink" });` will print "first" then "second" but `$a` will now contain `(color="pink", size=20)` in that order.
+Examples:
+
+```
+interval:s:1 {
+  $a = (color="green", size=2);
+  print($a);        // { .color = "green", .size = 2 }
+  print($a.size);   // 2
+  $a = (size=10, color="blue");
+  print($a.color);  // blue
+  print($a);        // { .color = "blue", .size = 10 }
+}
+```
+
+
 
 ## Type conversion
 

--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -37,6 +37,11 @@ bool Expression::is_literal() const
       return elem.is_literal();
     });
   }
+  if (auto *record = as<Record>()) {
+    return std::ranges::all_of(record->elems, [](const auto &elem) {
+      return elem->expr.is_literal();
+    });
+  }
   return false;
 }
 

--- a/src/ast/async_ids.h
+++ b/src/ast/async_ids.h
@@ -6,12 +6,12 @@ namespace bpftrace::ast {
 
 // Add new ids here
 #define FOR_LIST_OF_ASYNC_IDS(DO)                                              \
-  DO(call_stack)                                                                 \
+  DO(call_stack)                                                               \
   DO(map_key)                                                                  \
   DO(read_map_value)                                                           \
   DO(runtime_error)                                                            \
   DO(str)                                                                      \
-  DO(tuple)                                                                    \
+  DO(anon_struct)                                                              \
   DO(variable)                                                                 \
   DO(watchpoint)
 

--- a/src/ast/codegen_helper.cpp
+++ b/src/ast/codegen_helper.cpp
@@ -2,9 +2,18 @@
 
 namespace bpftrace::ast {
 
-bool needMapAllocation(const SizedType &ty)
+bool needMapAllocation(const SizedType &src, const SizedType &dst)
 {
-  return !inBpfMemory(ty);
+  // For records (and records inside of tuples) the src and dst might have
+  // fields out of order - for this case we need an allocation to copy
+  // individual fields into so the original field ordering is preserved
+  if (src.IsTupleTy() || src.IsRecordTy()) {
+    if (src != dst) {
+      return true;
+    }
+  }
+
+  return !inBpfMemory(dst);
 }
 
 } // namespace bpftrace::ast

--- a/src/ast/codegen_helper.h
+++ b/src/ast/codegen_helper.h
@@ -18,7 +18,7 @@ inline bool shouldBeInBpfMemoryAlready(const SizedType &type)
 {
   return type.IsStringTy() || type.IsBufferTy() || type.IsInetTy() ||
          type.IsUsymTy() || type.IsKstackTy() || type.IsUstackTy() ||
-         type.IsTupleTy() || type.IsTimestampTy() || type.IsMacAddressTy() ||
+         type.IsTupleTy() || type.IsRecordTy() || type.IsTimestampTy() || type.IsMacAddressTy() ||
          type.IsCgroupPathTy();
 }
 
@@ -33,6 +33,6 @@ inline AddrSpace find_addrspace_stack(const SizedType &ty)
 }
 
 // This applies to both map keys and map values
-bool needMapAllocation(const SizedType &ty);
+bool needMapAllocation(const SizedType &src, const SizedType &dst);
 
 } // namespace bpftrace::ast

--- a/src/ast/dibuilderbpf.h
+++ b/src/ast/dibuilderbpf.h
@@ -33,6 +33,7 @@ public:
 
   DIType *GetType(const SizedType &stype, bool emit_codegen_types = true);
   DIType *CreateTupleType(const SizedType &stype);
+  DIType *CreateRecordType(const SizedType &stype);
   DIType *CreateMapStructType(const SizedType &stype);
   DIType *CreateTSeriesStructType(const SizedType &stype);
   DIType *CreateByteArrayType(uint64_t num_bytes);

--- a/src/ast/irbuilderbpf.h
+++ b/src/ast/irbuilderbpf.h
@@ -126,7 +126,7 @@ public:
   Value *CreateGetFmtStringArgsAllocation(StructType *struct_type,
                                           const std::string &name,
                                           const Location &loc);
-  Value *CreateTupleAllocation(const SizedType &tuple_type,
+  Value *CreateAnonStructAllocation(const SizedType &tuple_type,
                                const std::string &name,
                                const Location &loc);
   Value *CreateCallStackAllocation(const SizedType &stack_type,

--- a/src/ast/passes/printer.h
+++ b/src/ast/passes/printer.h
@@ -87,6 +87,7 @@ public:
   Buffer visit(MapAccess &acc);
   Buffer visit(Cast &cast);
   Buffer visit(Tuple &tuple);
+  Buffer visit(Record &record);
   Buffer visit(ExprStatement &expr);
   Buffer visit(AssignScalarMapStatement &assignment);
   Buffer visit(AssignMapStatement &assignment);
@@ -111,6 +112,7 @@ public:
   Buffer visit(Statement &stmt);
   Buffer visit(RootStatement &root);
   Buffer visit(CStatement &cstmt);
+  Buffer visit(NamedArgument& named_arg);
   Buffer visit(const SizedType &type);
 
 private:

--- a/src/ast/visitor.h
+++ b/src/ast/visitor.h
@@ -155,6 +155,14 @@ public:
   {
     return visitImpl(tuple.elems);
   }
+  R visit(NamedArgument &named_arg)
+  {
+    return visitImpl(named_arg.expr);
+  }
+  R visit(Record &record)
+  {
+    return visitImpl(record.elems);
+  }
   R visit(ExprStatement &expr)
   {
     return visitImpl(expr.expr);

--- a/src/globalvars.cpp
+++ b/src/globalvars.cpp
@@ -227,11 +227,12 @@ SizedType GlobalVars::get_sized_type(const std::string &global_var_name,
         1, CreateArray(resources.max_fmtstring_args_size, CreateInt8()));
   }
 
-  if (global_var_name == TUPLE_BUFFER) {
-    assert(resources.max_tuple_size > 0);
-    assert(resources.tuple_buffers > 0);
-    return make_rw_type(resources.tuple_buffers,
-                        CreateArray(resources.max_tuple_size, CreateInt8()));
+  if (global_var_name == ANON_STRUCT_BUFFER) {
+    assert(resources.max_anon_struct_size > 0);
+    assert(resources.anon_struct_buffers > 0);
+    return make_rw_type(resources.anon_struct_buffers,
+                        CreateArray(resources.max_anon_struct_size,
+                                    CreateInt8()));
   }
 
   if (global_var_name == CALL_STACK_BUFFER) {
@@ -310,8 +311,8 @@ void GlobalVars::check_index(const std::string &global_var_name,
                              const RequiredResources &resources,
                              size_t index) const
 {
-  if (global_var_name == TUPLE_BUFFER) {
-    assert(index < resources.tuple_buffers);
+  if (global_var_name == ANON_STRUCT_BUFFER) {
+    assert(index < resources.anon_struct_buffers);
   } else if (global_var_name == GET_STR_BUFFER) {
     assert(index < resources.str_buffers);
   } else if (global_var_name == READ_MAP_VALUE_BUFFER) {

--- a/src/globalvars.h
+++ b/src/globalvars.h
@@ -102,7 +102,7 @@ using GlobalVarMap = std::unordered_map<std::string, GlobalVarValue>;
 constexpr std::string_view NUM_CPUS = "__bt__num_cpus";
 constexpr std::string_view MAX_CPU_ID = "__bt__max_cpu_id";
 constexpr std::string_view FMT_STRINGS_BUFFER = "__bt__fmt_str_buf";
-constexpr std::string_view TUPLE_BUFFER = "__bt__tuple_buf";
+constexpr std::string_view ANON_STRUCT_BUFFER = "__bt__anon_struct_buf";
 constexpr std::string_view CALL_STACK_BUFFER = "__bt__call_stack_buf";
 constexpr std::string_view GET_STR_BUFFER = "__bt__get_str_buf";
 constexpr std::string_view READ_MAP_VALUE_BUFFER = "__bt__read_map_val_buf";
@@ -116,7 +116,7 @@ constexpr std::string_view JOIN_BUFFER = "__bt__join_buf";
 constexpr std::string_view RO_SECTION_NAME = ".rodata";
 constexpr std::string_view FMT_STRINGS_BUFFER_SECTION_NAME =
     ".data.fmt_str_buf";
-constexpr std::string_view TUPLE_BUFFER_SECTION_NAME = ".data.tuple_buf";
+constexpr std::string_view ANON_STRUCT_BUFFER_SECTION_NAME = ".data.anon_struct_buf";
 constexpr std::string_view CALL_STACK_BUFFER_SECTION_NAME = ".data.call_stack_buf";
 constexpr std::string_view GET_STR_BUFFER_SECTION_NAME = ".data.get_str_buf";
 constexpr std::string_view READ_MAP_VALUE_BUFFER_SECTION_NAME =
@@ -160,7 +160,7 @@ const std::unordered_map<std::string_view, GlobalVarConfig>
           .type = GlobalVarConfig::opt_unsigned } },
       { FMT_STRINGS_BUFFER,
         { .section = std::string(FMT_STRINGS_BUFFER_SECTION_NAME) } },
-      { TUPLE_BUFFER, { .section = std::string(TUPLE_BUFFER_SECTION_NAME) } },
+      { ANON_STRUCT_BUFFER, { .section = std::string(ANON_STRUCT_BUFFER_SECTION_NAME) } },
       { CALL_STACK_BUFFER, { .section = std::string(CALL_STACK_BUFFER_SECTION_NAME) } },
       { GET_STR_BUFFER,
         { .section = std::string(GET_STR_BUFFER_SECTION_NAME) } },

--- a/src/required_resources.h
+++ b/src/required_resources.h
@@ -181,9 +181,9 @@ public:
   // rather than duplicating it in CodegenResources.
   uint64_t max_fmtstring_args_size = 0;
 
-  // Required for sizing of tuple scratch buffer
-  size_t tuple_buffers = 0;
-  size_t max_tuple_size = 0;
+  // Required for sizing of tuple/record scratch buffer
+  size_t anon_struct_buffers = 0;
+  size_t max_anon_struct_size = 0;
 
   // Required for sizing of kstack and ustack scratch buffer
   size_t call_stack_buffers = 0;

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -612,6 +612,15 @@ macro memcmp(left, right, count)
   memcmp($left, $right, count)
 }
 
+macro memcmp_record(left, right, count)
+{
+  let $left = left;
+  // This ensures that the $right variable type has fields
+  // in the exact same order as the $left
+  let $right: typeof($left) = right;
+  memcmp($left, $right, count)
+}
+
 // :variant uint64 ncpus()
 // Number of CPUs
 macro ncpus()

--- a/src/struct.cpp
+++ b/src/struct.cpp
@@ -147,6 +147,15 @@ const Field &Struct::GetField(const std::string &name) const
   throw util::FatalUserException("struct has no field named " + name);
 }
 
+size_t Struct::GetFieldIdx(const std::string &name) const
+{
+  for (size_t i = 0; i < fields.size(); ++i) {
+    if (fields.at(i).name == name)
+      return i;
+  }
+  throw util::FatalUserException("struct has no field named " + name);
+}
+
 void Struct::AddField(const std::string &field_name,
                       const SizedType &type,
                       ssize_t offset,

--- a/src/struct.h
+++ b/src/struct.h
@@ -95,6 +95,7 @@ struct Struct {
 
   bool HasField(const std::string &name) const;
   const Field &GetField(const std::string &name) const;
+  size_t GetFieldIdx(const std::string &name) const;
   void AddField(const std::string &field_name,
                 const SizedType &type,
                 ssize_t offset = 0,

--- a/src/types.h
+++ b/src/types.h
@@ -48,6 +48,7 @@ enum class Type : uint8_t {
   array,
   buffer,
   tuple,
+  record,
   timestamp,
   mac_address,
   cgroup_path_t,
@@ -222,6 +223,7 @@ public:
   std::vector<Field> &GetFields() const;
   bool HasField(const std::string &name) const;
   const Field &GetField(const std::string &name) const;
+  size_t GetFieldIdx(const std::string &name) const;
   Field &GetField(ssize_t n) const;
   ssize_t GetFieldCount() const;
   std::shared_ptr<const Struct> GetStruct() const;
@@ -474,6 +476,10 @@ public:
   {
     return type_ == Type::tuple;
   };
+  bool IsRecordTy() const
+  {
+    return type_ == Type::record;
+  };
   bool IsTimestampTy() const
   {
     return type_ == Type::timestamp;
@@ -531,6 +537,7 @@ public:
                                 std::weak_ptr<Struct> record);
   friend SizedType CreateInteger(size_t bits, bool is_signed);
   friend SizedType CreateTuple(std::shared_ptr<Struct> &&tuple);
+  friend SizedType CreateRecord(std::shared_ptr<Struct> &&record);
 };
 
 // Type helpers
@@ -560,6 +567,7 @@ SizedType CreateCStruct(const std::string &name);
 SizedType CreateCStruct(std::shared_ptr<Struct> &&record);
 SizedType CreateCStruct(const std::string &name, std::weak_ptr<Struct> record);
 SizedType CreateTuple(std::shared_ptr<Struct> &&tuple);
+SizedType CreateRecord(std::shared_ptr<Struct> &&record);
 
 SizedType CreateStack(bool kernel, StackType st = StackType());
 

--- a/src/types_format.cpp
+++ b/src/types_format.cpp
@@ -152,7 +152,8 @@ Result<output::Primitive> format(BPFtrace &bpftrace,
       }
       return array;
     }
-    case Type::c_struct: {
+    case Type::c_struct:
+    case Type::record: {
       output::Primitive::Record record;
       for (auto &field : type.GetFields()) {
         auto elem_data = value.slice(field.offset, field.type.GetSize());

--- a/tests/ast_matchers.h
+++ b/tests/ast_matchers.h
@@ -1558,6 +1558,39 @@ inline TupleMatcher Tuple(
   return TupleMatcher().WithElems(elems);
 }
 
+class NamedArgumentMatcher
+    : public NodeMatcher<NamedArgumentMatcher, ast::NamedArgument> {
+public:
+  NamedArgumentMatcher& WithName(const std::string& name)
+  {
+    return Where(CheckField(&ast::NamedArgument::name, name, "name"));
+  }
+};
+
+inline NamedArgumentMatcher NamedArgument(
+    const std::string& name,
+    const Matcher<const ast::Expression&>& expr)
+{
+  return NamedArgumentMatcher().WithName(name).WithExpr(expr);
+}
+
+class RecordMatcher : public NodeMatcher<RecordMatcher, ast::Record> {
+public:
+  RecordMatcher& WithNamedArgs(
+      const std::vector<Matcher<const ast::NamedArgument&>>& named_args)
+  {
+    return Where([named_args](const ast::Record& record) {
+      return CheckList(record, record.elems, named_args, "named_args");
+    });
+  }
+};
+
+inline RecordMatcher Record(
+    const std::vector<Matcher<const ast::NamedArgument&>>& named_args)
+{
+  return RecordMatcher().WithNamedArgs(named_args);
+}
+
 template <typename Derived, typename NodeType>
 Derived& NodeMatcher<Derived, NodeType>::WithStatements(
     const std::vector<Matcher<const ast::Statement&>>& statements)

--- a/tests/runtime/json-output
+++ b/tests/runtime/json-output
@@ -136,6 +136,10 @@ NAME tuple_with_escaped_string
 RUN {{BPFTRACE}} -q -f json -e 'begin { @ = (1, 2, "string with \"quotes\"");  }'
 EXPECT {"type": "map", "data": {"@": [1,2,"string with \"quotes\""]}}
 
+NAME record
+RUN {{BPFTRACE}} -f json -e 'begin { $v = (x=1, y=2); @a = (a=0, b=1, c="str", d=(5, 6), e=$v);  }'
+EXPECT {"type": "map", "data": {"@a": {"a": 0, "b": 1, "c": "str", "d": [5,6], "e": {"x": 1, "y": 2}}}}
+
 NAME print_non_map
 RUN {{BPFTRACE}} -q -f json -e 'begin { $x = 5; print($x); exit() }'
 EXPECT {"type": "value", "data": 5}

--- a/tests/runtime/record
+++ b/tests/runtime/record
@@ -1,0 +1,19 @@
+NAME basic record
+PROG begin { $v = 99; $t = (a=0, b=1, c="str", d=(5, 6), e=$v); printf("%d %d %s %d %d %d\n", $t.a, $t.b, $t.c, $t.d.0, $t.d.1, $t.e);  }
+EXPECT 0 1 str 5 6 99
+
+NAME record printing
+PROG begin { $v = (x=1, y=2); $t = (a=0, b=1, c="str", d=(5, 6), e=$v); print($t);  }
+EXPECT { .a = 0, .b = 1, .c = str, .d = (5, 6), .e = { .x = 1, .y = 2 } }
+
+NAME record printing complex args
+PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { $args = args; $a = (a=1, b="hello", c=(args, (x=100, y=$args.c))); @[$a] = ("bye", (m=args, n=10)); exit(); }
+EXPECT_REGEX @[{ .a = 1, .b = hello, .c = \({ .n = 0x[0-9a-f]+, .c = 120 }, { .x = 100, .y = 120 }\) }]: \(bye, { .m = { .n = 0x[0-9a-f]+, .c = 120 }, .n = 10 }\)
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+
+NAME record evaluation order
+PROG begin { $a = (foo={ printf("hello"); 1 }, bar={ printf("world"); 2 }); $a = (bar={ printf("hello"); 1 }, foo={ printf("world\n"); 2 }); print($a) }
+EXPECT helloworldhelloworld
+EXPECT { .foo = 2, .bar = 1 }

--- a/tests/self/record.bt
+++ b/tests/self/record.bt
@@ -1,0 +1,235 @@
+config = {
+    unstable_typeinfo=enable
+}
+
+test:record_field_access {
+    $a = (a=1, b="hello");
+    if ($a.b != "hello" || $a.a != 1) {
+        return 1;
+    }
+}
+
+test:record_var_mixed_order {
+    $a = (a=1, b="hello");
+
+    if ($a.b != "hello" || $a.a != 1) {
+        return 1;
+    }
+
+    $a = (b="bye", a=2);
+    if ($a.b != "bye" || $a.a != 2) {
+        return 1;
+    }
+}
+
+test:record_var_mixed_order_nested {
+    $a = (3, (a=(x=1, y=true), b="hello"));
+
+    if ($a.0 != 3 || $a.1.b != "hello" || $a.1.a.x != 1 || $a.1.a.y != true) {
+        return 1;
+    }
+
+    $a = (4, (b="bye", a=(y=false, x=2)));
+
+    if ($a.0 != 4 || $a.1.b != "bye" || $a.1.a.x != 2 || $a.1.a.y != false) {
+        return 1;
+    }
+
+    $b = (a=(3, (x="hello", y=5)), b=5);
+
+    if ($b.a.0 != 3 || $b.a.1.x != "hello" || $b.a.1.y != 5 || $b.b != 5) {
+        return 1;
+    }
+
+    $b = (b=10, a=(20, (y=100, x="bye")));
+
+    if ($b.a.0 != 20 || $b.a.1.x != "bye" || $b.a.1.y != 100 || $b.b != 10) {
+        return 1;
+    }
+}
+
+test:record_map_value_mixed_order {
+    @aaa = (a=1, b="hello");
+
+    if (@aaa.b != "hello" || @aaa.a != 1) {
+        return 1;
+    }
+
+    @aaa = (b="bye", a=2);
+    if (@aaa.b != "bye" || @aaa.a != 2) {
+        return 1;
+    }
+}
+
+test:record_map_value_mixed_order_nested {
+    @bbb = (3, (a=(x=1, y=true), b="hello"));
+
+    if (@bbb.0 != 3 || @bbb.1.b != "hello" || @bbb.1.a.x != 1 || @bbb.1.a.y != true) {
+        return 1;
+    }
+
+    @bbb = (4, (b="bye", a=(y=false, x=2)));
+
+    if (@bbb.0 != 4 || @bbb.1.b != "bye" || @bbb.1.a.x != 2 || @bbb.1.a.y != false) {
+        return 1;
+    }
+
+    @ccc = (a=(3, (x="hello", y=5)), b=5);
+
+    if (@ccc.a.0 != 3 || @ccc.a.1.x != "hello" || @ccc.a.1.y != 5 || @ccc.b != 5) {
+        return 1;
+    }
+
+    @ccc = (b=10, a=(20, (y=100, x="bye")));
+
+    if (@ccc.a.0 != 20 || @ccc.a.1.x != "bye" || @ccc.a.1.y != 100 || @ccc.b != 10) {
+        return 1;
+    }
+}
+
+test:record_map_key_mixed_order {
+    @ddd[(a=1, b="hello")] = 1;
+
+    for ($kv : @ddd) {
+        if ($kv.0.a != 1 || $kv.0.b != "hello" || $kv.1 != 1) {
+            return 1;
+        }
+    }
+
+    // Store the same key but different order
+    @ddd[(b="hello", a=1)] = 2;
+    for ($kv : @ddd) {
+        if ($kv.0.a != 1 || $kv.0.b != "hello" || $kv.1 != 2) {
+            return 1;
+        }
+    }
+}
+
+test:record_map_key_mixed_order_nested {
+    @eee[(3, (a=(x=1, y=true), b="hello"))] = 1;
+
+    for ($kv : @eee) {
+        if ($kv.0.0 != 3 || $kv.0.1.b != "hello" || $kv.0.1.a.x != 1 || $kv.0.1.a.y != true || $kv.1 != 1) {
+            return 1;
+        }
+    }
+
+    // Store the same key but different order
+    @eee[(3, (b="hello", a=(y=true, x=1)))] = 2;
+
+    for ($kv : @eee) {
+        if ($kv.0.0 != 3 || $kv.0.1.b != "hello" || $kv.0.1.a.x != 1 || $kv.0.1.a.y != true || $kv.1 != 2) {
+            return 1;
+        }
+    }
+}
+
+test:record_promotion {
+    $a = (a=1, b="hello");
+    $a = (b="greeting", a=(uint64)2);
+    // Original type order respected
+    if (typeinfo($a.a).2 != "uint64" || typeinfo($a.b).2 != "string[9]") {
+        return 1;
+    }
+
+    if ($a.b != "greeting" || $a.a != 2) {
+        return 1;
+    }
+
+    $b = (a=(uint64)2, b="greeting");
+    $b = (b="hello", a=1);
+    if (typeinfo($b.a).2 != "uint64" || typeinfo($b.b).2 != "string[9]") {
+        return 1;
+    }
+
+    if ($b.b != "hello" || $b.a != 1) {
+        return 1;
+    }
+}
+
+test:record_promotion_nested {
+    $a = (3, (a=(uint64)1, b=(x="bye", y=-1)));
+
+    if ($a.0 != 3 || $a.1.a != 1 || $a.1.b.x != "bye" || $a.1.b.y != -1) {
+        return 1;
+    }
+
+    $a = ((int16)-10, (b=(y=(int64)-100, x="muchlongerstr"), a=5));
+
+    if ($a.0 != -10 || $a.1.a != 5 || $a.1.b.x != "muchlongerstr" || $a.1.b.y != -100) {
+        return 1;
+    }
+
+    $b = ((int64)-50, (b=(x="areallyreallyreallylongstr", y=20), a=500));
+
+    $a = $b;
+
+    if ($a.0 != -50 || $a.1.a != 500 || $a.1.b.x != "areallyreallyreallylongstr" || $a.1.b.y != 20) {
+        return 1;
+    }
+
+    if (typeinfo($a).2 != "(int64,record { .a = uint64, .b = record { .x = string[27], .y = int64 } })") {
+        return 1;
+    }
+}
+
+test:record_binop_literal {
+    if ((a=1, b="hello") != (b="hello", a=1)) {
+        return 1;
+    }
+
+    if ((a=1, b="hello") != (a=1, b="hello")) {
+        return 1;
+    }
+
+    if ((a=(1, "bye"), b=(x="x", y=3)) != (a=(1, "bye"), b=(y=3, x="x"))) {
+        return 1;
+    }
+}
+
+test:record_binop {
+    $a = (a=1, b="hello");
+
+    // Same order on the right
+    if ($a != (a=(uint64)1, b="hello")) {
+        return 1;
+    }
+
+    // Different order on the right
+    if ($a != (b="hello", a=(uint64)1)) {
+        return 1;
+    }
+
+    // Insert in different order but $a field order doesn't change
+    $a = (b="bye", a=2);
+
+    if ($a != (a=(uint64)2, b="bye") || $a != (b="bye", a=(uint64)2)) {
+        return 1;
+    }
+
+    if ($a == (b="muchlongerstr", a=(uint64)1)) {
+        return 1;
+    }
+
+    // Test nested ordering
+    $b = (a=((uint64)1, "bye"), b=(y=3, x="x"));
+
+    if ((a=(1, "bye"), b=(y=3, x="x")) != $b) {
+        return 1;
+    }
+
+    if ((b=(x="x", y=3), a=(1, "bye")) != $b) {
+        return 1;
+    }
+
+    if ((b=(x="x", y=3), a=(1, "hello")) == $b) {
+        return 1;
+    }
+
+    // Test tuples and records
+    $c = (3, "hello", (a=1, b=(10, "bye")));
+
+    if ($c != (3, "hello", (b=(10, "bye"), a=1))) {
+        return 1;
+    }
+}


### PR DESCRIPTION
Stacked PRs:
 * __->__#4947


--- --- ---

### Add bpftrace Record type


This works similar to tuples and uses the same underlying LLVM struct type
except it allows users to specify the names of fields and access these
fields by name. Record assignments are also order insensitive except we
maintain the final order of the first assignment. Example:

```
$a = (color="green", size=1);
$a = (size = 2, color="blue"); // This becomes (color="blue", size=2);
```

This new type is more favorable to adding named fields to the Tuple type so
that users don't have to respect field order. Additionally, mixing named
and unnamed tupes doesn't seem to have a strong usecase and potentially can
be confusing in cases when indicies are used to access named tuples.
This also keeps the Tuple implementation clean.

The syntax `$a = {color="green", size=1};` was considered but conflicts
with block expressions.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>