### PR TITLE
Fix stack type comparisons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,8 @@ and this project adheres to
 #### Fixed
 - Improved tuple binop comparison
   - [#4523](https://github.com/bpftrace/bpftrace/pull/4523)
+- Stack type comparison and compatibility
+  - [#4948](https://github.com/bpftrace/bpftrace/pull/4948)
 #### Security
 #### Docs
 #### Tools

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -926,8 +926,7 @@ void SemanticAnalyser::visit(Builtin &builtin)
     }
   } else if (builtin.ident == "ustack") {
     builtin.builtin_type = CreateStack(
-        false,
-        StackType{ .mode = bpftrace_.config_->stack_mode, .kernel = false });
+        false, StackType{ .mode = bpftrace_.config_->stack_mode });
   } else if (builtin.ident == "__builtin_comm") {
     constexpr int COMM_SIZE = 16;
     builtin.builtin_type = CreateString(COMM_SIZE);
@@ -1996,7 +1995,6 @@ void SemanticAnalyser::check_stack_call(Call &call, bool kernel)
   call.return_type = CreateStack(kernel);
   StackType stack_type;
   stack_type.mode = bpftrace_.config_->stack_mode;
-  stack_type.kernel = kernel;
 
   switch (call.vargs.size()) {
     case 0:
@@ -2762,13 +2760,6 @@ void SemanticAnalyser::visit(IfExpr &if_expr)
     // This assignment is just temporary to prevent errors
     // before the final pass
     if_expr.result_type = lhs;
-    return;
-  }
-
-  if (lhs.IsStack() && lhs.stack_type != rhs.stack_type) {
-    // TODO: fix this for different stack types
-    if_expr.addError() << "Branches must have the same stack type on the right "
-                          "and left sides.";
     return;
   }
 

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -555,7 +555,7 @@ macro len(@map)
 
 macro len(e)
 {
-  if comptime (typeinfo(e) != typeinfo(ustack) && typeinfo(e) != typeinfo(kstack)) {
+  if comptime (typeinfo(e).1 != typeinfo(ustack).1 && typeinfo(e).1 != typeinfo(kstack).1) {
     fail("call to len() expects a map, ustack, or kstack")
   } else {
     // This is handled in codegen for now

--- a/src/types.cpp
+++ b/src/types.cpp
@@ -79,6 +79,9 @@ std::string typestr(const SizedType &type)
       res += ")";
       return res;
     }
+    case Type::kstack_t:
+    case Type::ustack_t:
+      return type.stack_type.name();
     case Type::max_t:
     case Type::min_t:
     case Type::sum_t:
@@ -87,8 +90,6 @@ std::string typestr(const SizedType &type)
       return (type.is_signed_ ? "" : "u") + typestr(type.GetTy());
     case Type::count_t:
     case Type::mac_address:
-    case Type::kstack_t:
-    case Type::ustack_t:
     case Type::timestamp:
     case Type::ksym_t:
     case Type::usym_t:
@@ -133,6 +134,10 @@ bool SizedType::IsSameType(const SizedType &t) const
       if (!GetField(i).type.IsSameType(t.GetField(i).type))
         return false;
     }
+  }
+
+  if (IsStack() && stack_type != t.stack_type) {
+    return false;
   }
 
   return type_ == t.GetTy();
@@ -398,6 +403,7 @@ SizedType CreateStack(bool kernel, StackType stack)
   auto st = SizedType(kernel ? Type::kstack_t : Type::ustack_t,
                       kernel ? base_size : (base_size + 8));
   st.stack_type = stack;
+  st.stack_type.kernel = kernel;
   return st;
 }
 

--- a/tests/runtime/regression
+++ b/tests/runtime/regression
@@ -148,3 +148,9 @@ NAME map key scratch buffer for map aggregates
 PROG config = { on_stack_limit = 0 }  begin { @a[pid, comm, "reallylongstr"] = count(); }
 EXPECT Attached 1 probe
 TIMEOUT 1
+
+# https://github.com/bpftrace/bpftrace/issues/4945
+NAME stack modes and size
+PROG begin { $a = (1, ustack); $b = (1, ustack(build_id)); $c = (1, ustack(build_id, 30)); $d = (1, kstack); $e = (1, kstack(raw)); $f = (1, kstack(raw, 30)); }
+EXPECT Attached 1 probe
+TIMEOUT 1

--- a/tests/types.cpp
+++ b/tests/types.cpp
@@ -59,8 +59,20 @@ TEST(types, to_str)
   EXPECT_EQ(to_str(CreateCount()), "count_t");
 
   EXPECT_EQ(to_str(CreateMacAddress()), "mac_address");
-  EXPECT_EQ(to_str(CreateStack(true)), "kstack");
-  EXPECT_EQ(to_str(CreateStack(false)), "ustack");
+
+  EXPECT_EQ(to_str(CreateStack(true)), "kstack_bpftrace_127");
+  EXPECT_EQ(to_str(CreateStack(false)), "ustack_bpftrace_127");
+
+  StackType stack_type = StackType();
+  stack_type.limit = 10;
+  stack_type.mode = StackMode::raw;
+  EXPECT_EQ(to_str(CreateStack(true, stack_type)), "kstack_raw_10");
+
+  StackType stack_type2 = StackType();
+  stack_type2.limit = 20;
+  stack_type2.mode = StackMode::build_id;
+  EXPECT_EQ(to_str(CreateStack(false, stack_type2)), "ustack_build_id_20");
+
   EXPECT_EQ(to_str(CreateTimestamp()), "timestamp");
   EXPECT_EQ(to_str(CreateKSym()), "ksym_t");
   EXPECT_EQ(to_str(CreateUSym()), "usym_t");


### PR DESCRIPTION
Stacked PRs:
 * #4951
 * __->__#4948


--- --- ---

### Fix stack type comparisons


This makes sure that both kstack and ustack produce the correct struct type
name and are incompatible types unless their stack type structs also match.

https://github.com/bpftrace/bpftrace/issues/4945

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>