### PR TITLE
Add missing include of `<iomanip>`

### DIFF
--- a/src/types_format.cpp
+++ b/src/types_format.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <iomanip>
 #include <string>
 #include <utility>
 


### PR DESCRIPTION
1323d297 ("Add new stack mode: build_id (#4912)") has introduced calls to `std::setfill` but forgot to include the corresponding header. This broke the Fedora build.

<!--
Please provide a description of your change below this comment.

Then please complete the checklist.

Useful contribution guidelines and tips are in docs/developers.md.

Warning: please make sure that you have implemented and tested your
         change against the latest version of bpftrace (unless opening a
         PR for a release branch).
-->

##### Checklist

- [ ] Language changes are updated in `docs/language.md`, `docs/stdlib.md`, or `man/adoc/bpftrace.adoc`
- [ ] User-visible and non-trivial changes updated in `CHANGELOG.md`
- [ ] The new behaviour is covered by tests
