### PR TITLE
Consolidate map key and value allocations

### DIFF
--- a/src/ast/codegen_helper.cpp
+++ b/src/ast/codegen_helper.cpp
@@ -2,37 +2,9 @@
 
 namespace bpftrace::ast {
 
-// needAssignMapStatementAllocation determines if a map assignment requires a
-// new memory allocation. This happens only in a few cases e.g. if there are
-// two map assignments of tuples of different sizes e.g.
-//   @x = ("xxx", 1); @x = ("xxxxxxx", 1);
-// which requires a 0 memsetting and copying of each tuple element into the
-// new allocation before calling bpf_map_update_elem.
-//
-// Another case when we need an allocation is for a external struct e.g.
-//   $v = (struct task_struct *)arg1; @ = *$v;.
-//
-// Most cases we can reuse existing BPF memory and not create a new allocation.
-//
-// Note this function does NOT determine if an allocation should use scratch
-// buffer or the stack, that logic is in
-// IRBuilderBPF::CreateWriteMapValueAllocation
-bool needAssignMapStatementAllocation(const AssignMapStatement &assignment)
+bool needMapAllocation(const SizedType &ty)
 {
-  const auto &map = *assignment.map_access;
-  const auto &expr_type = assignment.expr.type();
-  if (shouldBeInBpfMemoryAlready(expr_type)) {
-    return false;
-  } else if (map.map->value_type.IsCStructTy() ||
-             map.map->value_type.IsArrayTy()) {
-    return !expr_type.is_internal;
-  }
-  return true;
-}
-
-bool needMapKeyAllocation(const Expression &key_expr)
-{
-  return !inBpfMemory(key_expr.type());
+  return !inBpfMemory(ty);
 }
 
 } // namespace bpftrace::ast

--- a/src/ast/codegen_helper.h
+++ b/src/ast/codegen_helper.h
@@ -32,8 +32,7 @@ inline AddrSpace find_addrspace_stack(const SizedType &ty)
   return (shouldBeInBpfMemoryAlready(ty)) ? AddrSpace::kernel : ty.GetAS();
 }
 
-bool needAssignMapStatementAllocation(const AssignMapStatement &assignment);
-
-bool needMapKeyAllocation(const Expression &key_expr);
+// This applies to both map keys and map values
+bool needMapAllocation(const SizedType &ty);
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/resource_analyser.cpp
+++ b/src/ast/passes/resource_analyser.cpp
@@ -514,7 +514,7 @@ void ResourceAnalyser::visit(AssignMapStatement &assignment)
 
   // The `MapAccess` validated the read limit, we know this to be
   // a write, so we validate the write limit.
-  if (needAssignMapStatementAllocation(assignment)) {
+  if (needMapAllocation(assignment.expr.type())) {
     if (exceeds_stack_limit(assignment.map_access->map->value_type.GetSize())) {
       resources_.max_write_map_value_size = std::max(
           resources_.max_write_map_value_size,
@@ -607,7 +607,7 @@ void ResourceAnalyser::maybe_allocate_map_key_buffer(const Map &map,
                                                      const Expression &key_expr)
 {
   const auto map_key_size = map.key_type.GetSize();
-  if (needMapKeyAllocation(key_expr) && exceeds_stack_limit(map_key_size)) {
+  if (needMapAllocation(key_expr.type()) && exceeds_stack_limit(map_key_size)) {
     resources_.map_key_buffers++;
     resources_.max_map_key_size = std::max(resources_.max_map_key_size,
                                            map_key_size);

--- a/tests/runtime/builtin
+++ b/tests/runtime/builtin
@@ -235,6 +235,13 @@ REQUIRES_FEATURE dwarf
 TIMEOUT 5
 BEFORE ./testprogs/uprobe_test
 
+NAME args in a tuple in map
+PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { $a = (1, "hello", args); @[$a] = (args, "bye"); exit(); }
+EXPECT_REGEX @[1, hello, { .n = 0x[0-9a-f]+, .c = 120 }]: \({ .n = 0x[0-9a-f]+, .c = 120 }, bye\)
+REQUIRES_FEATURE dwarf
+TIMEOUT 5
+BEFORE ./testprogs/uprobe_test
+
 NAME args in uprobe store in map and access field
 PROG uprobe:./testprogs/uprobe_test:uprobeFunction1 { @ = args; print(@.c); exit(); }
 EXPECT 120


### PR DESCRIPTION
Stacked PRs:
 * #4947
 * __->__#4954


--- --- ---

### Consolidate map key and value allocations


These should work in the exact same way and therefore the logic in codegen
should be the same.

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>