### PR TITLE
Fix missing lines in stack resolution (#4953)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,6 +84,8 @@ and this project adheres to
   - [#4523](https://github.com/bpftrace/bpftrace/pull/4523)
 - Stack type comparison and compatibility
   - [#4948](https://github.com/bpftrace/bpftrace/pull/4948)
+- Fix missing lines in stack resolution
+  - [#4953] (https://github.com/bpftrace/bpftrace/pull/4953)
 #### Security
 #### Docs
 #### Tools

--- a/src/bpftrace.cpp
+++ b/src/bpftrace.cpp
@@ -1002,11 +1002,10 @@ std::string BPFtrace::get_stack(uint64_t nr_stack_frames,
   std::string padding(indent, ' ');
 
   stack << "\n";
-  for (uint64_t i = 0; i < nr_stack_frames;) {
+  for (uint64_t i = 0; i < nr_stack_frames; ++i) {
     auto addr = raw_stack.bitcast<uint64_t>(i);
     if (stack_type.mode == StackMode::raw) {
       stack << std::hex << addr << std::endl;
-      ++i;
       continue;
     }
     std::vector<std::string> syms;
@@ -1023,9 +1022,7 @@ std::string BPFtrace::get_stack(uint64_t nr_stack_frames,
                                 stack_type.mode == StackMode::perf,
                                 config_->show_debug_info);
 
-    std::string sym;
-    for (size_t sym_idx = 0; i < nr_stack_frames && sym_idx < syms.size();) {
-      sym = syms.at(sym_idx);
+    for (auto const &sym : syms) {
       switch (stack_type.mode) {
         case StackMode::bpftrace:
           stack << padding << sym << std::endl;
@@ -1041,8 +1038,6 @@ std::string BPFtrace::get_stack(uint64_t nr_stack_frames,
                  "symbolication.";
           break;
       }
-      ++i;
-      ++sym_idx;
     }
   }
 


### PR DESCRIPTION
In case of inlined functions, a single addr can resolve to multiple symbols. The current implementation advanced the index in the array of addrs for each resolved symbol. This leads to missing frames in the output.

#4953 did not pick up my updates, so opening the updates in a new PR.