### PR TITLE
Make typeinfo a record type instead of a tuple

### DIFF
--- a/src/ast/ast.cpp
+++ b/src/ast/ast.cpp
@@ -419,4 +419,18 @@ SizedType ident_to_sized_type(const std::string &ident)
   return ident_to_c_struct(ident);
 }
 
+Record *make_record(ASTContext &ctx,
+                    const Location &loc,
+                    std::vector<std::pair<std::string, Expression>> &&args)
+{
+  NamedArgumentList named_args;
+  named_args.reserve(args.size());
+
+  for (const auto &[name, expr] : args) {
+    named_args.emplace_back(ctx.make_node<NamedArgument>(loc, name, expr));
+  }
+
+  return ctx.make_node<Record>(loc, std::move(named_args));
+}
+
 } // namespace bpftrace::ast

--- a/src/ast/ast.h
+++ b/src/ast/ast.h
@@ -2255,5 +2255,8 @@ bool is_comparison_op(Operator op);
 
 SizedType ident_to_c_struct(const std::string &ident, int pointer_level = 0);
 SizedType ident_to_sized_type(const std::string &ident);
+Record* make_record(ASTContext &ctx,
+                    const Location &loc,
+                    std::vector<std::pair<std::string, Expression>>&& args);
 
 } // namespace bpftrace::ast

--- a/src/ast/passes/semantic_analyser.cpp
+++ b/src/ast/passes/semantic_analyser.cpp
@@ -3528,11 +3528,14 @@ void SemanticAnalyser::visit(Expression &expr)
       // We currently lack a globally-unique enumeration of types. For
       // simplicity, just use the type string with a placeholder identifier.
       auto *id = ctx_.make_node<Integer>(type_id->loc, 0);
-      auto *base_ty = ctx_.make_node<String>(type_id->loc,
-                                             to_string(ty.GetTy()));
-      auto *full_ty = ctx_.make_node<String>(type_id->loc, typestr(ty));
-      expr.value = ctx_.make_node<Tuple>(
-          type_id->loc, ExpressionList{ id, base_ty, full_ty });
+      auto *base_type = ctx_.make_node<String>(type_id->loc,
+                                               to_string(ty.GetTy()));
+      auto *full_type = ctx_.make_node<String>(type_id->loc, typestr(ty));
+      expr.value = make_record(ctx_,
+                               type_id->loc,
+                               { { "btf_id", id },
+                                 { "base_type", base_type },
+                                 { "full_type", full_type } });
     }
   } else if (auto *binop = expr.as<Binop>()) {
     if ((binop->left.type().IsTupleTy() || binop->left.type().IsRecordTy()) &&

--- a/src/stdlib/base.bt
+++ b/src/stdlib/base.bt
@@ -557,7 +557,7 @@ macro len(@map)
 
 macro len(e)
 {
-  if comptime (typeinfo(e).1 != typeinfo(ustack).1 && typeinfo(e).1 != typeinfo(kstack).1) {
+  if comptime (typeinfo(e).base_type != typeinfo(ustack).base_type && typeinfo(e).base_type != typeinfo(kstack).base_type) {
     fail("call to len() expects a map, ustack, or kstack")
   } else {
     // This is handled in codegen for now
@@ -747,8 +747,8 @@ macro override(expr)
     fail("override() can only be used inside kprobes");
   } else if comptime __builtin_safe_mode {
     fail("override() is unsafe. To use you need the --unsafe flag");
-  } else if comptime (typeinfo(expr).1 != typeinfo(0).1) {
-    fail("override() only supports int arguments (%s provided)", typeinfo(expr).1);
+  } else if comptime (typeinfo(expr).base_type != typeinfo(0).base_type) {
+    fail("override() only supports int arguments (%s provided)", typeinfo(expr).base_type);
   } else {
     __override((void *)ctx, (uint64)expr);
   }

--- a/src/stdlib/meta.bt
+++ b/src/stdlib/meta.bt
@@ -2,35 +2,35 @@
 // Determine whether the given expression is a string.
 macro is_str(expr)
 {
-  typeinfo(expr).1 == "string"
+  typeinfo(expr).base_type == "string"
 }
 
 // :variant bool is_ptr(any expression)
 // Determine whether the given expression is a pointer.
 macro is_ptr(expr)
 {
-  typeinfo(expr).1 == "pointer"
+  typeinfo(expr).base_type == "pointer"
 }
 
 // :variant bool is_array(any expression)
 // Determine whether the given expression is an array.
 macro is_array(expr)
 {
-  typeinfo(expr).1 == "array"
+  typeinfo(expr).base_type == "array"
 }
 
 // :variant bool is_integer(any expression)
 // Determine whether the given expression is an integer.
 macro is_integer(expr)
 {
-  typeinfo(expr).1 == "int"
+  typeinfo(expr).base_type == "int"
 }
 
 // :variant bool is_unsigned_integer(any expression)
 // Determine whether the given expression is an unsigned integer.
 macro is_unsigned_integer(expr)
 {
-  typeinfo(expr).1 == typeinfo(0).1 && typeinfo(expr).2[0] == "u"[0]
+  typeinfo(expr).base_type == typeinfo(0).base_type && typeinfo(expr).full_type[0] == "u"[0]
 }
 
 // :variant void static_assert(bool condition, string msg)
@@ -53,7 +53,7 @@ macro check_key(@map, key, func)
     // @c[1, ("hello", (int8)5)] = 0;
     // has_key(@c, (1, ("hello", (uint8)5))) - now the key type is (uint8, (string, int16))
     // Other than that this has no side effects and shouldn't fail
-    if comptime (typeinfo(@map[key]).1 == "__dummy_key_type") {
+    if comptime (typeinfo(@map[key]).base_type == "__dummy_key_type") {
       fail("__dummy_key_type shouldn't exist");
     }
   }

--- a/tests/self/record.bt
+++ b/tests/self/record.bt
@@ -128,7 +128,7 @@ test:record_promotion {
     $a = (a=1, b="hello");
     $a = (b="greeting", a=(uint64)2);
     // Original type order respected
-    if (typeinfo($a.a).2 != "uint64" || typeinfo($a.b).2 != "string[9]") {
+    if (typeinfo($a.a).full_type != "uint64" || typeinfo($a.b).full_type != "string[9]") {
         return 1;
     }
 
@@ -138,7 +138,7 @@ test:record_promotion {
 
     $b = (a=(uint64)2, b="greeting");
     $b = (b="hello", a=1);
-    if (typeinfo($b.a).2 != "uint64" || typeinfo($b.b).2 != "string[9]") {
+    if (typeinfo($b.a).full_type != "uint64" || typeinfo($b.b).full_type != "string[9]") {
         return 1;
     }
 
@@ -168,7 +168,7 @@ test:record_promotion_nested {
         return 1;
     }
 
-    if (typeinfo($a).2 != "(int64,record { .a = uint64, .b = record { .x = string[27], .y = int64 } })") {
+    if (typeinfo($a).full_type != "(int64,record { .a = uint64, .b = record { .x = string[27], .y = int64 } })") {
         return 1;
     }
 }


### PR DESCRIPTION
Stacked PRs:
 * __->__#4962


--- --- ---

### Make typeinfo a record type instead of a tuple


This is so we can name the fields and make them easier to reference.
The fields are:
- btf_id (not yet populated)
- base_type (the string of the base enum sized type)
- full_type (the full type string)

Signed-off-by: Jordan Rome <linux@jordanrome.com>
Signed-off-by: Jordan Rome <linux@jordanrome.com>